### PR TITLE
sdfw_services: psa_crypto: use new tags for pointer-to-const members

### DIFF
--- a/subsys/sdfw_services/services/echo/zcbor_generated/CMakeLists.txt
+++ b/subsys/sdfw_services/services/echo/zcbor_generated/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2025 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #

--- a/subsys/sdfw_services/services/echo/zcbor_generated/echo_service_decode.c
+++ b/subsys/sdfw_services/services/echo/zcbor_generated/echo_service_decode.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -22,6 +22,17 @@
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
 
+#define log_result(state, result, func)                                                            \
+	do {                                                                                       \
+		if (!result) {                                                                     \
+			zcbor_trace_file(state);                                                   \
+			zcbor_log("%s error: %s\r\n", func,                                        \
+				  zcbor_error_str(zcbor_peek_error(state)));                       \
+		} else {                                                                           \
+			zcbor_log("%s success\r\n", func);                                         \
+		}                                                                                  \
+	} while (0)
+
 static bool decode_echo_service_rsp(zcbor_state_t *state, struct echo_service_rsp *result);
 static bool decode_echo_service_req(zcbor_state_t *state, struct zcbor_string *result);
 
@@ -29,40 +40,27 @@ static bool decode_echo_service_rsp(zcbor_state_t *state, struct echo_service_rs
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((zcbor_list_start_decode(state) &&
-		   ((((zcbor_int32_decode(state, (&(*result).echo_service_rsp_ret)))) &&
-		     ((zcbor_tstr_decode(state, (&(*result).echo_service_rsp_str_out))))) ||
-		    (zcbor_list_map_end_force_decode(state), false)) &&
-		   zcbor_list_end_decode(state))));
+	bool res = (((zcbor_list_start_decode(state) &&
+		      ((((zcbor_int32_decode(state, (&(*result).echo_service_rsp_ret)))) &&
+			((zcbor_tstr_decode(state, (&(*result).echo_service_rsp_str_out))))) ||
+		       (zcbor_list_map_end_force_decode(state), false)) &&
+		      zcbor_list_end_decode(state))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_echo_service_req(zcbor_state_t *state, struct zcbor_string *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((zcbor_list_start_decode(state) &&
-			     ((((zcbor_tstr_decode(state, (&(*result)))))) ||
-			      (zcbor_list_map_end_force_decode(state), false)) &&
-			     zcbor_list_end_decode(state))));
+	bool res = (((zcbor_list_start_decode(state) &&
+		      ((((zcbor_tstr_decode(state, (&(*result)))))) ||
+		       (zcbor_list_map_end_force_decode(state), false)) &&
+		      zcbor_list_end_decode(state))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 int cbor_decode_echo_service_req(const uint8_t *payload, size_t payload_len,

--- a/subsys/sdfw_services/services/echo/zcbor_generated/echo_service_decode.h
+++ b/subsys/sdfw_services/services/echo/zcbor_generated/echo_service_decode.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/echo/zcbor_generated/echo_service_encode.c
+++ b/subsys/sdfw_services/services/echo/zcbor_generated/echo_service_encode.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -22,6 +22,17 @@
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
 
+#define log_result(state, result, func)                                                            \
+	do {                                                                                       \
+		if (!result) {                                                                     \
+			zcbor_trace_file(state);                                                   \
+			zcbor_log("%s error: %s\r\n", func,                                        \
+				  zcbor_error_str(zcbor_peek_error(state)));                       \
+		} else {                                                                           \
+			zcbor_log("%s success\r\n", func);                                         \
+		}                                                                                  \
+	} while (0)
+
 static bool encode_echo_service_rsp(zcbor_state_t *state, const struct echo_service_rsp *input);
 static bool encode_echo_service_req(zcbor_state_t *state, const struct zcbor_string *input);
 
@@ -29,40 +40,27 @@ static bool encode_echo_service_rsp(zcbor_state_t *state, const struct echo_serv
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((zcbor_list_start_encode(state, 2) &&
-		   ((((zcbor_int32_encode(state, (&(*input).echo_service_rsp_ret)))) &&
-		     ((zcbor_tstr_encode(state, (&(*input).echo_service_rsp_str_out))))) ||
-		    (zcbor_list_map_end_force_encode(state), false)) &&
-		   zcbor_list_end_encode(state, 2))));
+	bool res = (((zcbor_list_start_encode(state, 2) &&
+		      ((((zcbor_int32_encode(state, (&(*input).echo_service_rsp_ret)))) &&
+			((zcbor_tstr_encode(state, (&(*input).echo_service_rsp_str_out))))) ||
+		       (zcbor_list_map_end_force_encode(state), false)) &&
+		      zcbor_list_end_encode(state, 2))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_echo_service_req(zcbor_state_t *state, const struct zcbor_string *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((zcbor_list_start_encode(state, 1) &&
-			     ((((zcbor_tstr_encode(state, (&(*input)))))) ||
-			      (zcbor_list_map_end_force_encode(state), false)) &&
-			     zcbor_list_end_encode(state, 1))));
+	bool res = (((zcbor_list_start_encode(state, 1) &&
+		      ((((zcbor_tstr_encode(state, (&(*input)))))) ||
+		       (zcbor_list_map_end_force_encode(state), false)) &&
+		      zcbor_list_end_encode(state, 1))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 int cbor_encode_echo_service_req(uint8_t *payload, size_t payload_len,

--- a/subsys/sdfw_services/services/echo/zcbor_generated/echo_service_encode.h
+++ b/subsys/sdfw_services/services/echo/zcbor_generated/echo_service_encode.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/echo/zcbor_generated/echo_service_types.h
+++ b/subsys/sdfw_services/services/echo/zcbor_generated/echo_service_types.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/psa_crypto/Kconfig
+++ b/subsys/sdfw_services/services/psa_crypto/Kconfig
@@ -7,7 +7,7 @@
 service_name = PSA_CRYPTO
 service_default_enabled = n
 service_id = 0x71
-service_version = 1
+service_version = 2
 service_buffer_size = 128
 service_name_str = PSA Crypto
 rsource "../Kconfig.template.service"

--- a/subsys/sdfw_services/services/psa_crypto/psa_crypto_service.cddl
+++ b/subsys/sdfw_services/services/psa_crypto/psa_crypto_service.cddl
@@ -9,6 +9,12 @@ ptr_attr = #6.32772(uint)
 ptr_key = #6.32773(uint)
 ptr_uint = #6.32774(uint)
 ptr_cipher = #6.32775(uint)
+ptr_const_buf = #6.32776(uint)
+ptr_const_attr = #6.32777(uint)
+ptr_const_key = #6.32778(uint)
+ptr_const_uint = #6.32779(uint)
+ptr_const_cipher = #6.32780(uint)
+
 
 
 psa_crypto_init_req = (
@@ -34,7 +40,7 @@ psa_purge_key_req = (
 psa_copy_key_req = (
     14,
     source_key: uint,
-    p_attributes: ptr_attr,
+    p_attributes: ptr_const_attr,
     p_target_key: ptr_key,
 )
 
@@ -45,8 +51,8 @@ psa_destroy_key_req = (
 
 psa_import_key_req = (
     16,
-    p_attributes: ptr_attr,
-    p_data: ptr_buf,
+    p_attributes: ptr_const_attr,
+    p_data: ptr_const_buf,
     data_length: buf_len,
     p_key: ptr_key,
 )
@@ -70,7 +76,7 @@ psa_export_public_key_req = (
 psa_hash_compute_req = (
     19,
     alg: uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
     p_hash: ptr_buf,
     hash_size: buf_len,
@@ -80,9 +86,9 @@ psa_hash_compute_req = (
 psa_hash_compare_req = (
     20,
     alg: uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
-    p_hash: ptr_buf,
+    p_hash: ptr_const_buf,
     hash_length: buf_len,
 )
 
@@ -95,7 +101,7 @@ psa_hash_setup_req = (
 psa_hash_update_req = (
     22,
     p_handle: ptr_uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
 )
 
@@ -110,7 +116,7 @@ psa_hash_finish_req = (
 psa_hash_verify_req = (
     24,
     p_handle: ptr_uint,
-    p_hash: ptr_buf,
+    p_hash: ptr_const_buf,
     hash_length: buf_len,
 )
 
@@ -129,7 +135,7 @@ psa_mac_compute_req = (
     27,
     key: uint,
     alg: uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
     p_mac: ptr_buf,
     mac_size: buf_len,
@@ -140,9 +146,9 @@ psa_mac_verify_req = (
     28,
     key: uint,
     alg: uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
-    p_mac: ptr_buf,
+    p_mac: ptr_const_buf,
     mac_length: buf_len,
 )
 
@@ -163,7 +169,7 @@ psa_mac_verify_setup_req = (
 psa_mac_update_req = (
     31,
     p_handle: ptr_uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
 )
 
@@ -178,7 +184,7 @@ psa_mac_sign_finish_req = (
 psa_mac_verify_finish_req = (
     33,
     p_handle: ptr_uint,
-    p_mac: ptr_buf,
+    p_mac: ptr_const_buf,
     mac_length: buf_len,
 )
 
@@ -191,7 +197,7 @@ psa_cipher_encrypt_req = (
     35,
     key: uint,
     alg: uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
     p_output: ptr_buf,
     output_size: buf_len,
@@ -202,7 +208,7 @@ psa_cipher_decrypt_req = (
     36,
     key: uint,
     alg: uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
     p_output: ptr_buf,
     output_size: buf_len,
@@ -234,14 +240,14 @@ psa_cipher_generate_iv_req = (
 psa_cipher_set_iv_req = (
     40,
     p_handle: ptr_uint,
-    p_iv: ptr_buf,
+    p_iv: ptr_const_buf,
     iv_length: buf_len,
 )
 
 psa_cipher_update_req = (
     41,
     p_handle: ptr_uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
     p_output: ptr_buf,
     output_size: buf_len,
@@ -265,11 +271,11 @@ psa_aead_encrypt_req = (
     44,
     key: uint,
     alg: uint,
-    p_nonce: ptr_buf,
+    p_nonce: ptr_const_buf,
     nonce_length: buf_len,
-    p_additional_data: ptr_buf,
+    p_additional_data: ptr_const_buf,
     additional_data_length: buf_len,
-    p_plaintext: ptr_buf,
+    p_plaintext: ptr_const_buf,
     plaintext_length: buf_len,
     p_ciphertext: ptr_buf,
     ciphertext_size: buf_len,
@@ -280,11 +286,11 @@ psa_aead_decrypt_req = (
     45,
     key: uint,
     alg: uint,
-    p_nonce: ptr_buf,
+    p_nonce: ptr_const_buf,
     nonce_length: buf_len,
-    p_additional_data: ptr_buf,
+    p_additional_data: ptr_const_buf,
     additional_data_length: buf_len,
-    p_ciphertext: ptr_buf,
+    p_ciphertext: ptr_const_buf,
     ciphertext_length: buf_len,
     p_plaintext: ptr_buf,
     plaintext_size: buf_len,
@@ -316,28 +322,28 @@ psa_aead_generate_nonce_req = (
 psa_aead_set_nonce_req = (
     49,
     p_handle: ptr_uint,
-    p_nonce: ptr_buf,
+    p_nonce: ptr_const_buf,
     nonce_length: buf_len,
 )
 
 psa_aead_set_lengths_req = (
     50,
     p_handle: ptr_uint,
-    ad_length: buf_len,
-    plaintext_length: buf_len,
+    ad_length: uint,
+    plaintext_length: uint,
 )
 
 psa_aead_update_ad_req = (
     51,
     p_handle: ptr_uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
 )
 
 psa_aead_update_req = (
     52,
     p_handle: ptr_uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
     p_output: ptr_buf,
     output_size: buf_len,
@@ -361,7 +367,7 @@ psa_aead_verify_req = (
     p_plaintext: ptr_buf,
     plaintext_size: buf_len,
     p_plaintext_length: ptr_uint,
-    p_tag: ptr_buf,
+    p_tag: ptr_const_buf,
     tag_length: buf_len,
 )
 
@@ -374,7 +380,7 @@ psa_sign_message_req = (
     56,
     key: uint,
     alg: uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
     p_signature: ptr_buf,
     signature_size: buf_len,
@@ -385,9 +391,9 @@ psa_verify_message_req = (
     57,
     key: uint,
     alg: uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
-    p_signature: ptr_buf,
+    p_signature: ptr_const_buf,
     signature_length: buf_len,
 )
 
@@ -395,7 +401,7 @@ psa_sign_hash_req = (
     58,
     key: uint,
     alg: uint,
-    p_hash: ptr_buf,
+    p_hash: ptr_const_buf,
     hash_length: buf_len,
     p_signature: ptr_buf,
     signature_size: buf_len,
@@ -406,9 +412,9 @@ psa_verify_hash_req = (
     59,
     key: uint,
     alg: uint,
-    p_hash: ptr_buf,
+    p_hash: ptr_const_buf,
     hash_length: buf_len,
-    p_signature: ptr_buf,
+    p_signature: ptr_const_buf,
     signature_length: buf_len,
 )
 
@@ -416,9 +422,9 @@ psa_asymmetric_encrypt_req = (
     60,
     key: uint,
     alg: uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
-    p_salt: ptr_buf,
+    p_salt: ptr_const_buf,
     salt_length: buf_len,
     p_output: ptr_buf,
     output_size: buf_len,
@@ -429,9 +435,9 @@ psa_asymmetric_decrypt_req = (
     61,
     key: uint,
     alg: uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
-    p_salt: ptr_buf,
+    p_salt: ptr_const_buf,
     salt_length: buf_len,
     p_output: ptr_buf,
     output_size: buf_len,
@@ -460,7 +466,7 @@ psa_key_derivation_input_bytes_req = (
     65,
     p_handle: ptr_uint,
     step: uint,
-    p_data: ptr_buf,
+    p_data: ptr_const_buf,
     data_length: buf_len,
 )
 
@@ -483,7 +489,7 @@ psa_key_derivation_key_agreement_req = (
     p_handle: ptr_uint,
     step: uint,
     private_key: uint,
-    p_peer_key: ptr_buf,
+    p_peer_key: ptr_const_buf,
     peer_key_length: buf_len,
 )
 
@@ -496,7 +502,7 @@ psa_key_derivation_output_bytes_req = (
 
 psa_key_derivation_output_key_req = (
     70,
-    p_attributes: ptr_attr,
+    p_attributes: ptr_const_attr,
     p_handle: ptr_uint,
     p_key: ptr_key,
 )
@@ -510,7 +516,7 @@ psa_raw_key_agreement_req = (
     72,
     alg: uint,
     private_key: uint,
-    p_peer_key: ptr_buf,
+    p_peer_key: ptr_const_buf,
     peer_key_length: buf_len,
     p_output: ptr_buf,
     output_size: buf_len,
@@ -525,7 +531,7 @@ psa_generate_random_req = (
 
 psa_generate_key_req = (
     74,
-    p_attributes: ptr_attr,
+    p_attributes: ptr_const_attr,
     p_key: ptr_key,
 )
 
@@ -533,7 +539,7 @@ psa_pake_setup_req = (
     79,
     p_handle: ptr_uint,
     password_key: uint,
-    p_cipher_suite: ptr_cipher,
+    p_cipher_suite: ptr_const_cipher,
 )
 
 psa_pake_set_role_req = (
@@ -545,21 +551,21 @@ psa_pake_set_role_req = (
 psa_pake_set_user_req = (
     81,
     p_handle: ptr_uint,
-    p_user_id: ptr_buf,
+    p_user_id: ptr_const_buf,
     user_id_len: buf_len,
 )
 
 psa_pake_set_peer_req = (
     82,
     p_handle: ptr_uint,
-    p_peer_id: ptr_buf,
+    p_peer_id: ptr_const_buf,
     peer_id_len: buf_len,
 )
 
 psa_pake_set_context_req = (
     83,
     p_handle: ptr_uint,
-    p_context: ptr_buf,
+    p_context: ptr_const_buf,
     context_len: buf_len,
 )
 
@@ -576,14 +582,14 @@ psa_pake_input_req = (
     85,
     p_handle: ptr_uint,
     step: uint,
-    p_input: ptr_buf,
+    p_input: ptr_const_buf,
     input_length: buf_len,
 )
 
 psa_pake_get_shared_key_req = (
     86,
     p_handle: ptr_uint,
-    p_attributes: ptr_attr,
+    p_attributes: ptr_const_attr,
     p_key: ptr_key,
 )
 

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/CMakeLists.txt
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Nordic Semiconductor
+# Copyright (c) 2025 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_decode.c
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_decode.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.99
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -21,6 +21,17 @@
 #if DEFAULT_MAX_QTY != 3
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
+
+#define log_result(state, result, func)                                                            \
+	do {                                                                                       \
+		if (!result) {                                                                     \
+			zcbor_trace_file(state);                                                   \
+			zcbor_log("%s error: %s\r\n", func,                                        \
+				  zcbor_error_str(zcbor_peek_error(state)));                       \
+		} else {                                                                           \
+			zcbor_log("%s success\r\n", func);                                         \
+		}                                                                                  \
+	} while (0)
 
 static bool decode_ptr_attr(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_get_key_attributes_req(zcbor_state_t *state,
@@ -157,17 +168,10 @@ static bool decode_ptr_attr(zcbor_state_t *state, uint32_t *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		((zcbor_tag_expect(state, 32772) && (zcbor_uint32_decode(state, (&(*result))))));
+	bool res = ((zcbor_tag_expect(state, 32772) && (zcbor_uint32_decode(state, (&(*result))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_get_key_attributes_req(zcbor_state_t *state,
@@ -175,19 +179,13 @@ static bool decode_psa_get_key_attributes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		((zcbor_uint32_expect(state, (11)))) &&
 		((zcbor_uint32_decode(state, (&(*result).psa_get_key_attributes_req_key)))) &&
 		((decode_ptr_attr(state, (&(*result).psa_get_key_attributes_req_p_attributes)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_reset_key_attributes_req(zcbor_state_t *state,
@@ -195,184 +193,115 @@ static bool decode_psa_reset_key_attributes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (12)))) &&
-		   ((decode_ptr_attr(state,
-				     (&(*result).psa_reset_key_attributes_req_p_attributes)))))));
+	bool res = (((((zcbor_uint32_expect(state, (12)))) &&
+		      ((decode_ptr_attr(
+			      state, (&(*result).psa_reset_key_attributes_req_p_attributes)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_purge_key_req(zcbor_state_t *state, struct psa_purge_key_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((((zcbor_uint32_expect(state, (13)))) &&
-			     ((zcbor_uint32_decode(state, (&(*result).psa_purge_key_req_key)))))));
+	bool res = (((((zcbor_uint32_expect(state, (13)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_purge_key_req_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_ptr_key(zcbor_state_t *state, uint32_t *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		((zcbor_tag_expect(state, 32773) && (zcbor_uint32_decode(state, (&(*result))))));
+	bool res = ((zcbor_tag_expect(state, 32773) && (zcbor_uint32_decode(state, (&(*result))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_copy_key_req(zcbor_state_t *state, struct psa_copy_key_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (14)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_copy_key_req_source_key)))) &&
-		   ((decode_ptr_attr(state, (&(*result).psa_copy_key_req_p_attributes)))) &&
-		   ((decode_ptr_key(state, (&(*result).psa_copy_key_req_p_target_key)))))));
+	bool res = (((((zcbor_uint32_expect(state, (14)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_copy_key_req_source_key)))) &&
+		      ((decode_ptr_attr(state, (&(*result).psa_copy_key_req_p_attributes)))) &&
+		      ((decode_ptr_key(state, (&(*result).psa_copy_key_req_p_target_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_destroy_key_req(zcbor_state_t *state, struct psa_destroy_key_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (15)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_destroy_key_req_key)))))));
+	bool res = (((((zcbor_uint32_expect(state, (15)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_destroy_key_req_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_ptr_buf(zcbor_state_t *state, uint32_t *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		((zcbor_tag_expect(state, 32770) && (zcbor_uint32_decode(state, (&(*result))))));
+	bool res = ((zcbor_tag_expect(state, 32770) && (zcbor_uint32_decode(state, (&(*result))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_buf_len(zcbor_state_t *state, uint32_t *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		((zcbor_tag_expect(state, 32771) && (zcbor_uint32_decode(state, (&(*result))))));
+	bool res = ((zcbor_tag_expect(state, 32771) && (zcbor_uint32_decode(state, (&(*result))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_import_key_req(zcbor_state_t *state, struct psa_import_key_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (16)))) &&
-		   ((decode_ptr_attr(state, (&(*result).psa_import_key_req_p_attributes)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_import_key_req_p_data)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_import_key_req_data_length)))) &&
-		   ((decode_ptr_key(state, (&(*result).psa_import_key_req_p_key)))))));
+	bool res = (((((zcbor_uint32_expect(state, (16)))) &&
+		      ((decode_ptr_attr(state, (&(*result).psa_import_key_req_p_attributes)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_import_key_req_p_data)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_import_key_req_data_length)))) &&
+		      ((decode_ptr_key(state, (&(*result).psa_import_key_req_p_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_ptr_uint(zcbor_state_t *state, uint32_t *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		((zcbor_tag_expect(state, 32774) && (zcbor_uint32_decode(state, (&(*result))))));
+	bool res = ((zcbor_tag_expect(state, 32774) && (zcbor_uint32_decode(state, (&(*result))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_export_key_req(zcbor_state_t *state, struct psa_export_key_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (17)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_export_key_req_key)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_export_key_req_p_data)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_export_key_req_data_size)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_export_key_req_p_data_length)))))));
+	bool res = (((((zcbor_uint32_expect(state, (17)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_export_key_req_key)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_export_key_req_p_data)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_export_key_req_data_size)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_export_key_req_p_data_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_export_public_key_req(zcbor_state_t *state,
@@ -380,28 +309,22 @@ static bool decode_psa_export_public_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		((zcbor_uint32_expect(state, (18)))) &&
 		((zcbor_uint32_decode(state, (&(*result).psa_export_public_key_req_key)))) &&
 		((decode_ptr_buf(state, (&(*result).psa_export_public_key_req_p_data)))) &&
 		((decode_buf_len(state, (&(*result).psa_export_public_key_req_data_size)))) &&
 		((decode_ptr_uint(state, (&(*result).psa_export_public_key_req_p_data_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_hash_compute_req(zcbor_state_t *state, struct psa_hash_compute_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (19)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_alg)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_hash_compute_req_p_input)))) &&
@@ -410,199 +333,131 @@ static bool decode_psa_hash_compute_req(zcbor_state_t *state, struct psa_hash_co
 		   ((decode_buf_len(state, (&(*result).psa_hash_compute_req_hash_size)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_hash_compute_req_p_hash_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_hash_compare_req(zcbor_state_t *state, struct psa_hash_compare_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (20)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_alg)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_hash_compare_req_p_input)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_hash_compare_req_input_length)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_hash_compare_req_p_hash)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_hash_compare_req_hash_length)))))));
+	bool res = (((((zcbor_uint32_expect(state, (20)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_alg)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_hash_compare_req_p_input)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_hash_compare_req_input_length)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_hash_compare_req_p_hash)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_hash_compare_req_hash_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_hash_setup_req(zcbor_state_t *state, struct psa_hash_setup_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((((zcbor_uint32_expect(state, (21)))) &&
-			     ((decode_ptr_uint(state, (&(*result).psa_hash_setup_req_p_handle)))) &&
-			     ((zcbor_uint32_decode(state, (&(*result).psa_hash_setup_req_alg)))))));
+	bool res = (((((zcbor_uint32_expect(state, (21)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_hash_setup_req_p_handle)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_hash_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_hash_update_req(zcbor_state_t *state, struct psa_hash_update_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (22)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_hash_update_req_p_handle)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_hash_update_req_p_input)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_hash_update_req_input_length)))))));
+	bool res = (((((zcbor_uint32_expect(state, (22)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_hash_update_req_p_handle)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_hash_update_req_p_input)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_hash_update_req_input_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_hash_finish_req(zcbor_state_t *state, struct psa_hash_finish_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (23)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_hash_finish_req_p_handle)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_hash_finish_req_p_hash)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_hash_finish_req_hash_size)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_hash_finish_req_p_hash_length)))))));
+	bool res = (((((zcbor_uint32_expect(state, (23)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_hash_finish_req_p_handle)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_hash_finish_req_p_hash)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_hash_finish_req_hash_size)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_hash_finish_req_p_hash_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_hash_verify_req(zcbor_state_t *state, struct psa_hash_verify_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (24)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_hash_verify_req_p_handle)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_hash_verify_req_p_hash)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_hash_verify_req_hash_length)))))));
+	bool res = (((((zcbor_uint32_expect(state, (24)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_hash_verify_req_p_handle)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_hash_verify_req_p_hash)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_hash_verify_req_hash_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_hash_abort_req(zcbor_state_t *state, struct psa_hash_abort_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (25)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_hash_abort_req_p_handle)))))));
+	bool res = (((((zcbor_uint32_expect(state, (25)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_hash_abort_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_hash_clone_req(zcbor_state_t *state, struct psa_hash_clone_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (26)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_clone_req_handle)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_hash_clone_req_p_handle)))))));
+	bool res = (((((zcbor_uint32_expect(state, (26)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_hash_clone_req_handle)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_hash_clone_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_mac_compute_req(zcbor_state_t *state, struct psa_mac_compute_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (27)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_key)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_alg)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_mac_compute_req_p_input)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_mac_compute_req_input_length)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_mac_compute_req_p_mac)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_mac_compute_req_mac_size)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_mac_compute_req_p_mac_length)))))));
+	bool res = (((((zcbor_uint32_expect(state, (27)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_key)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_alg)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_mac_compute_req_p_input)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_mac_compute_req_input_length)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_mac_compute_req_p_mac)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_mac_compute_req_mac_size)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_mac_compute_req_p_mac_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_mac_verify_req(zcbor_state_t *state, struct psa_mac_verify_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (28)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_key)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_alg)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_mac_verify_req_p_input)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_mac_verify_req_input_length)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_mac_verify_req_p_mac)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_mac_verify_req_mac_length)))))));
+	bool res = (((((zcbor_uint32_expect(state, (28)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_key)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_alg)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_mac_verify_req_p_input)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_mac_verify_req_input_length)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_mac_verify_req_p_mac)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_mac_verify_req_mac_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_mac_sign_setup_req(zcbor_state_t *state,
@@ -610,20 +465,13 @@ static bool decode_psa_mac_sign_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (29)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_mac_sign_setup_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_setup_req_key)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_setup_req_alg)))))));
+	bool res = (((((zcbor_uint32_expect(state, (29)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_mac_sign_setup_req_p_handle)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_setup_req_key)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_mac_sign_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_mac_verify_setup_req(zcbor_state_t *state,
@@ -631,40 +479,26 @@ static bool decode_psa_mac_verify_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (30)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_mac_verify_setup_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_setup_req_key)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_setup_req_alg)))))));
+	bool res = (((((zcbor_uint32_expect(state, (30)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_mac_verify_setup_req_p_handle)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_setup_req_key)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_mac_update_req(zcbor_state_t *state, struct psa_mac_update_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (31)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_mac_update_req_p_handle)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_mac_update_req_p_input)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_mac_update_req_input_length)))))));
+	bool res = (((((zcbor_uint32_expect(state, (31)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_mac_update_req_p_handle)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_mac_update_req_p_input)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_mac_update_req_input_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_mac_sign_finish_req(zcbor_state_t *state,
@@ -672,21 +506,15 @@ static bool decode_psa_mac_sign_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (32)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_mac_sign_finish_req_p_handle)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_mac_sign_finish_req_p_mac)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_mac_sign_finish_req_mac_size)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_mac_sign_finish_req_p_mac_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_mac_verify_finish_req(zcbor_state_t *state,
@@ -694,37 +522,25 @@ static bool decode_psa_mac_verify_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (33)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_mac_verify_finish_req_p_handle)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_mac_verify_finish_req_p_mac)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_mac_verify_finish_req_mac_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_mac_abort_req(zcbor_state_t *state, struct psa_mac_abort_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((((zcbor_uint32_expect(state, (34)))) &&
-			     ((decode_ptr_uint(state, (&(*result).psa_mac_abort_req_p_handle)))))));
+	bool res = (((((zcbor_uint32_expect(state, (34)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_mac_abort_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_cipher_encrypt_req(zcbor_state_t *state,
@@ -732,7 +548,7 @@ static bool decode_psa_cipher_encrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (35)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_alg)))) &&
@@ -742,14 +558,8 @@ static bool decode_psa_cipher_encrypt_req(zcbor_state_t *state,
 		 ((decode_buf_len(state, (&(*result).psa_cipher_encrypt_req_output_size)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_cipher_encrypt_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_cipher_decrypt_req(zcbor_state_t *state,
@@ -757,7 +567,7 @@ static bool decode_psa_cipher_decrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (36)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_alg)))) &&
@@ -767,14 +577,8 @@ static bool decode_psa_cipher_decrypt_req(zcbor_state_t *state,
 		 ((decode_buf_len(state, (&(*result).psa_cipher_decrypt_req_output_size)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_cipher_decrypt_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_cipher_encrypt_setup_req(zcbor_state_t *state,
@@ -782,20 +586,14 @@ static bool decode_psa_cipher_encrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (37)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_cipher_encrypt_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_setup_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_cipher_decrypt_setup_req(zcbor_state_t *state,
@@ -803,20 +601,14 @@ static bool decode_psa_cipher_decrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (38)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_cipher_decrypt_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_setup_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_cipher_generate_iv_req(zcbor_state_t *state,
@@ -824,48 +616,35 @@ static bool decode_psa_cipher_generate_iv_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (39)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_cipher_generate_iv_req_p_handle)))) &&
 		 ((decode_ptr_buf(state, (&(*result).psa_cipher_generate_iv_req_p_iv)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_cipher_generate_iv_req_iv_size)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_cipher_generate_iv_req_p_iv_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_cipher_set_iv_req(zcbor_state_t *state, struct psa_cipher_set_iv_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (40)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_cipher_set_iv_req_p_handle)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_cipher_set_iv_req_p_iv)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_cipher_set_iv_req_iv_length)))))));
+	bool res = (((((zcbor_uint32_expect(state, (40)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_cipher_set_iv_req_p_handle)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_cipher_set_iv_req_p_iv)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_cipher_set_iv_req_iv_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_cipher_update_req(zcbor_state_t *state, struct psa_cipher_update_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (41)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_cipher_update_req_p_handle)))) &&
 		 ((decode_ptr_buf(state, (&(*result).psa_cipher_update_req_p_input)))) &&
@@ -874,60 +653,41 @@ static bool decode_psa_cipher_update_req(zcbor_state_t *state, struct psa_cipher
 		 ((decode_buf_len(state, (&(*result).psa_cipher_update_req_output_size)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_cipher_update_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_cipher_finish_req(zcbor_state_t *state, struct psa_cipher_finish_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (42)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_cipher_finish_req_p_handle)))) &&
 		 ((decode_ptr_buf(state, (&(*result).psa_cipher_finish_req_p_output)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_cipher_finish_req_output_size)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_cipher_finish_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_cipher_abort_req(zcbor_state_t *state, struct psa_cipher_abort_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (43)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_cipher_abort_req_p_handle)))))));
+	bool res = (((((zcbor_uint32_expect(state, (43)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_cipher_abort_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_aead_encrypt_req(zcbor_state_t *state, struct psa_aead_encrypt_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (44)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_alg)))) &&
@@ -943,21 +703,15 @@ static bool decode_psa_aead_encrypt_req(zcbor_state_t *state, struct psa_aead_en
 		   ((decode_ptr_uint(state,
 				     (&(*result).psa_aead_encrypt_req_p_ciphertext_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_aead_decrypt_req(zcbor_state_t *state, struct psa_aead_decrypt_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		((zcbor_uint32_expect(state, (45)))) &&
 		((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_key)))) &&
 		((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_alg)))) &&
@@ -972,14 +726,8 @@ static bool decode_psa_aead_decrypt_req(zcbor_state_t *state, struct psa_aead_de
 		((decode_buf_len(state, (&(*result).psa_aead_decrypt_req_plaintext_size)))) &&
 		((decode_ptr_uint(state, (&(*result).psa_aead_decrypt_req_p_plaintext_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_aead_encrypt_setup_req(zcbor_state_t *state,
@@ -987,20 +735,14 @@ static bool decode_psa_aead_encrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (46)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_aead_encrypt_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_setup_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_aead_decrypt_setup_req(zcbor_state_t *state,
@@ -1008,20 +750,14 @@ static bool decode_psa_aead_decrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (47)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_aead_decrypt_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_setup_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_aead_generate_nonce_req(zcbor_state_t *state,
@@ -1029,7 +765,7 @@ static bool decode_psa_aead_generate_nonce_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (48)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_aead_generate_nonce_req_p_handle)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_aead_generate_nonce_req_p_nonce)))) &&
@@ -1037,14 +773,8 @@ static bool decode_psa_aead_generate_nonce_req(zcbor_state_t *state,
 		   ((decode_ptr_uint(state,
 				     (&(*result).psa_aead_generate_nonce_req_p_nonce_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_aead_set_nonce_req(zcbor_state_t *state,
@@ -1052,20 +782,14 @@ static bool decode_psa_aead_set_nonce_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (49)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_aead_set_nonce_req_p_handle)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_aead_set_nonce_req_p_nonce)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_aead_set_nonce_req_nonce_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_aead_set_lengths_req(zcbor_state_t *state,
@@ -1073,21 +797,14 @@ static bool decode_psa_aead_set_lengths_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (50)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_aead_set_lengths_req_p_handle)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_aead_set_lengths_req_ad_length)))) &&
-		   ((decode_buf_len(state,
-				    (&(*result).psa_aead_set_lengths_req_plaintext_length)))))));
+	bool res = (((((zcbor_uint32_expect(state, (50)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_aead_set_lengths_req_p_handle)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_aead_set_lengths_req_ad_length)))) &&
+		      ((decode_buf_len(state,
+				       (&(*result).psa_aead_set_lengths_req_plaintext_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_aead_update_ad_req(zcbor_state_t *state,
@@ -1095,27 +812,21 @@ static bool decode_psa_aead_update_ad_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (51)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_aead_update_ad_req_p_handle)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_aead_update_ad_req_p_input)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_aead_update_ad_req_input_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_aead_update_req(zcbor_state_t *state, struct psa_aead_update_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (52)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_aead_update_req_p_handle)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_aead_update_req_p_input)))) &&
@@ -1124,21 +835,15 @@ static bool decode_psa_aead_update_req(zcbor_state_t *state, struct psa_aead_upd
 		   ((decode_buf_len(state, (&(*result).psa_aead_update_req_output_size)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_aead_update_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_aead_finish_req(zcbor_state_t *state, struct psa_aead_finish_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (53)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_aead_finish_req_p_handle)))) &&
 		 ((decode_ptr_buf(state, (&(*result).psa_aead_finish_req_p_ciphertext)))) &&
@@ -1148,21 +853,15 @@ static bool decode_psa_aead_finish_req(zcbor_state_t *state, struct psa_aead_fin
 		 ((decode_buf_len(state, (&(*result).psa_aead_finish_req_tag_size)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_aead_finish_req_p_tag_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_aead_verify_req(zcbor_state_t *state, struct psa_aead_verify_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (54)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_aead_verify_req_p_handle)))) &&
 		 ((decode_ptr_buf(state, (&(*result).psa_aead_verify_req_p_plaintext)))) &&
@@ -1171,39 +870,26 @@ static bool decode_psa_aead_verify_req(zcbor_state_t *state, struct psa_aead_ver
 		 ((decode_ptr_buf(state, (&(*result).psa_aead_verify_req_p_tag)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_aead_verify_req_tag_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_aead_abort_req(zcbor_state_t *state, struct psa_aead_abort_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (55)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_aead_abort_req_p_handle)))))));
+	bool res = (((((zcbor_uint32_expect(state, (55)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_aead_abort_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_sign_message_req(zcbor_state_t *state, struct psa_sign_message_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		((zcbor_uint32_expect(state, (56)))) &&
 		((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_key)))) &&
 		((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_alg)))) &&
@@ -1213,14 +899,8 @@ static bool decode_psa_sign_message_req(zcbor_state_t *state, struct psa_sign_me
 		((decode_buf_len(state, (&(*result).psa_sign_message_req_signature_size)))) &&
 		((decode_ptr_uint(state, (&(*result).psa_sign_message_req_p_signature_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_verify_message_req(zcbor_state_t *state,
@@ -1228,7 +908,7 @@ static bool decode_psa_verify_message_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (57)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_alg)))) &&
@@ -1237,21 +917,15 @@ static bool decode_psa_verify_message_req(zcbor_state_t *state,
 		 ((decode_ptr_buf(state, (&(*result).psa_verify_message_req_p_signature)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_verify_message_req_signature_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_sign_hash_req(zcbor_state_t *state, struct psa_sign_hash_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (58)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_alg)))) &&
@@ -1261,21 +935,15 @@ static bool decode_psa_sign_hash_req(zcbor_state_t *state, struct psa_sign_hash_
 		   ((decode_buf_len(state, (&(*result).psa_sign_hash_req_signature_size)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_sign_hash_req_p_signature_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_verify_hash_req(zcbor_state_t *state, struct psa_verify_hash_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (59)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_alg)))) &&
@@ -1284,14 +952,8 @@ static bool decode_psa_verify_hash_req(zcbor_state_t *state, struct psa_verify_h
 		   ((decode_ptr_buf(state, (&(*result).psa_verify_hash_req_p_signature)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_verify_hash_req_signature_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_asymmetric_encrypt_req(zcbor_state_t *state,
@@ -1299,7 +961,7 @@ static bool decode_psa_asymmetric_encrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (60)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_alg)))) &&
@@ -1312,14 +974,8 @@ static bool decode_psa_asymmetric_encrypt_req(zcbor_state_t *state,
 		 ((decode_ptr_uint(state,
 				   (&(*result).psa_asymmetric_encrypt_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_asymmetric_decrypt_req(zcbor_state_t *state,
@@ -1327,7 +983,7 @@ static bool decode_psa_asymmetric_decrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (61)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_alg)))) &&
@@ -1340,14 +996,8 @@ static bool decode_psa_asymmetric_decrypt_req(zcbor_state_t *state,
 		 ((decode_ptr_uint(state,
 				   (&(*result).psa_asymmetric_decrypt_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_key_derivation_setup_req(zcbor_state_t *state,
@@ -1355,19 +1005,13 @@ static bool decode_psa_key_derivation_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (62)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_key_derivation_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_key_derivation_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1376,21 +1020,15 @@ decode_psa_key_derivation_get_capacity_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (63)))) &&
 		   ((zcbor_uint32_decode(
 			   state, (&(*result).psa_key_derivation_get_capacity_req_handle)))) &&
 		   ((decode_ptr_uint(
 			   state, (&(*result).psa_key_derivation_get_capacity_req_p_capacity)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1399,21 +1037,15 @@ decode_psa_key_derivation_set_capacity_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (64)))) &&
 		   ((decode_ptr_uint(state,
 				     (&(*result).psa_key_derivation_set_capacity_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(
 			   state, (&(*result).psa_key_derivation_set_capacity_req_capacity)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1422,7 +1054,7 @@ decode_psa_key_derivation_input_bytes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		((zcbor_uint32_expect(state, (65)))) &&
 		((decode_ptr_uint(state,
 				  (&(*result).psa_key_derivation_input_bytes_req_p_handle)))) &&
@@ -1432,14 +1064,8 @@ decode_psa_key_derivation_input_bytes_req(zcbor_state_t *state,
 		((decode_buf_len(state,
 				 (&(*result).psa_key_derivation_input_bytes_req_data_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1448,7 +1074,7 @@ decode_psa_key_derivation_input_integer_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (66)))) &&
 		   ((decode_ptr_uint(
 			   state, (&(*result).psa_key_derivation_input_integer_req_p_handle)))) &&
@@ -1457,14 +1083,8 @@ decode_psa_key_derivation_input_integer_req(zcbor_state_t *state,
 		   ((zcbor_uint32_decode(
 			   state, (&(*result).psa_key_derivation_input_integer_req_value)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_key_derivation_input_key_req(zcbor_state_t *state,
@@ -1472,23 +1092,16 @@ static bool decode_psa_key_derivation_input_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (67)))) &&
-		   ((decode_ptr_uint(state,
-				     (&(*result).psa_key_derivation_input_key_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_key_derivation_input_key_req_step)))) &&
-		   ((zcbor_uint32_decode(state,
-					 (&(*result).psa_key_derivation_input_key_req_key)))))));
+	bool res = (((((zcbor_uint32_expect(state, (67)))) &&
+		      ((decode_ptr_uint(state,
+					(&(*result).psa_key_derivation_input_key_req_p_handle)))) &&
+		      ((zcbor_uint32_decode(state,
+					    (&(*result).psa_key_derivation_input_key_req_step)))) &&
+		      ((zcbor_uint32_decode(state,
+					    (&(*result).psa_key_derivation_input_key_req_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1497,7 +1110,7 @@ decode_psa_key_derivation_key_agreement_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (68)))) &&
 		 ((decode_ptr_uint(state,
 				   (&(*result).psa_key_derivation_key_agreement_req_p_handle)))) &&
@@ -1511,14 +1124,8 @@ decode_psa_key_derivation_key_agreement_req(zcbor_state_t *state,
 			 state,
 			 (&(*result).psa_key_derivation_key_agreement_req_peer_key_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1527,7 +1134,7 @@ decode_psa_key_derivation_output_bytes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		((zcbor_uint32_expect(state, (69)))) &&
 		((decode_ptr_uint(state,
 				  (&(*result).psa_key_derivation_output_bytes_req_p_handle)))) &&
@@ -1536,14 +1143,8 @@ decode_psa_key_derivation_output_bytes_req(zcbor_state_t *state,
 		((decode_buf_len(
 			state, (&(*result).psa_key_derivation_output_bytes_req_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1552,7 +1153,7 @@ decode_psa_key_derivation_output_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (70)))) &&
 		 ((decode_ptr_attr(state,
 				   (&(*result).psa_key_derivation_output_key_req_p_attributes)))) &&
@@ -1560,14 +1161,8 @@ decode_psa_key_derivation_output_key_req(zcbor_state_t *state,
 				   (&(*result).psa_key_derivation_output_key_req_p_handle)))) &&
 		 ((decode_ptr_key(state, (&(*result).psa_key_derivation_output_key_req_p_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_key_derivation_abort_req(zcbor_state_t *state,
@@ -1575,18 +1170,12 @@ static bool decode_psa_key_derivation_abort_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_expect(state, (71)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_key_derivation_abort_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_raw_key_agreement_req(zcbor_state_t *state,
@@ -1594,7 +1183,7 @@ static bool decode_psa_raw_key_agreement_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		((zcbor_uint32_expect(state, (72)))) &&
 		((zcbor_uint32_decode(state, (&(*result).psa_raw_key_agreement_req_alg)))) &&
 		((zcbor_uint32_decode(state,
@@ -1606,14 +1195,8 @@ static bool decode_psa_raw_key_agreement_req(zcbor_state_t *state,
 		((decode_ptr_uint(state,
 				  (&(*result).psa_raw_key_agreement_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_generate_random_req(zcbor_state_t *state,
@@ -1621,134 +1204,87 @@ static bool decode_psa_generate_random_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (73)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_generate_random_req_p_output)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_generate_random_req_output_size)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_generate_key_req(zcbor_state_t *state, struct psa_generate_key_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (74)))) &&
-		   ((decode_ptr_attr(state, (&(*result).psa_generate_key_req_p_attributes)))) &&
-		   ((decode_ptr_key(state, (&(*result).psa_generate_key_req_p_key)))))));
+	bool res = (((((zcbor_uint32_expect(state, (74)))) &&
+		      ((decode_ptr_attr(state, (&(*result).psa_generate_key_req_p_attributes)))) &&
+		      ((decode_ptr_key(state, (&(*result).psa_generate_key_req_p_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_ptr_cipher(zcbor_state_t *state, uint32_t *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		((zcbor_tag_expect(state, 32775) && (zcbor_uint32_decode(state, (&(*result))))));
+	bool res = ((zcbor_tag_expect(state, 32775) && (zcbor_uint32_decode(state, (&(*result))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_pake_setup_req(zcbor_state_t *state, struct psa_pake_setup_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (79)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_pake_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_setup_req_password_key)))) &&
 		   ((decode_ptr_cipher(state, (&(*result).psa_pake_setup_req_p_cipher_suite)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_pake_set_role_req(zcbor_state_t *state, struct psa_pake_set_role_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (80)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_role_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_role_req_role)))))));
+	bool res = (((((zcbor_uint32_expect(state, (80)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_pake_set_role_req_p_handle)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_pake_set_role_req_role)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_pake_set_user_req(zcbor_state_t *state, struct psa_pake_set_user_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (81)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_user_req_p_handle)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_pake_set_user_req_p_user_id)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_pake_set_user_req_user_id_len)))))));
+	bool res = (((((zcbor_uint32_expect(state, (81)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_pake_set_user_req_p_handle)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_pake_set_user_req_p_user_id)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_pake_set_user_req_user_id_len)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_pake_set_peer_req(zcbor_state_t *state, struct psa_pake_set_peer_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (82)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_peer_req_p_handle)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_pake_set_peer_req_p_peer_id)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_pake_set_peer_req_peer_id_len)))))));
+	bool res = (((((zcbor_uint32_expect(state, (82)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_pake_set_peer_req_p_handle)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_pake_set_peer_req_p_peer_id)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_pake_set_peer_req_peer_id_len)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_pake_set_context_req(zcbor_state_t *state,
@@ -1756,27 +1292,21 @@ static bool decode_psa_pake_set_context_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (83)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_context_req_p_handle)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_pake_set_context_req_p_context)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_pake_set_context_req_context_len)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_pake_output_req(zcbor_state_t *state, struct psa_pake_output_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_expect(state, (84)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_pake_output_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_output_req_step)))) &&
@@ -1784,35 +1314,22 @@ static bool decode_psa_pake_output_req(zcbor_state_t *state, struct psa_pake_out
 		   ((decode_buf_len(state, (&(*result).psa_pake_output_req_output_size)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_pake_output_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_pake_input_req(zcbor_state_t *state, struct psa_pake_input_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (85)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_pake_input_req_p_handle)))) &&
-		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_input_req_step)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_pake_input_req_p_input)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_pake_input_req_input_length)))))));
+	bool res = (((((zcbor_uint32_expect(state, (85)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_pake_input_req_p_handle)))) &&
+		      ((zcbor_uint32_decode(state, (&(*result).psa_pake_input_req_step)))) &&
+		      ((decode_ptr_buf(state, (&(*result).psa_pake_input_req_p_input)))) &&
+		      ((decode_buf_len(state, (&(*result).psa_pake_input_req_input_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_pake_get_shared_key_req(zcbor_state_t *state,
@@ -1820,58 +1337,39 @@ static bool decode_psa_pake_get_shared_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		((zcbor_uint32_expect(state, (86)))) &&
 		((decode_ptr_uint(state, (&(*result).psa_pake_get_shared_key_req_p_handle)))) &&
 		((decode_ptr_attr(state, (&(*result).psa_pake_get_shared_key_req_p_attributes)))) &&
 		((decode_ptr_key(state, (&(*result).psa_pake_get_shared_key_req_p_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_pake_abort_req(zcbor_state_t *state, struct psa_pake_abort_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_expect(state, (87)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_pake_abort_req_p_handle)))))));
+	bool res = (((((zcbor_uint32_expect(state, (87)))) &&
+		      ((decode_ptr_uint(state, (&(*result).psa_pake_abort_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_crypto_rsp(zcbor_state_t *state, struct psa_crypto_rsp *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((zcbor_list_start_decode(state) &&
-			     ((((zcbor_uint32_decode(state, (&(*result).psa_crypto_rsp_id)))) &&
-			       ((zcbor_int32_decode(state, (&(*result).psa_crypto_rsp_status))))) ||
-			      (zcbor_list_map_end_force_decode(state), false)) &&
-			     zcbor_list_end_decode(state))));
+	bool res = (((zcbor_list_start_decode(state) &&
+		      ((((zcbor_uint32_decode(state, (&(*result).psa_crypto_rsp_id)))) &&
+			((zcbor_int32_decode(state, (&(*result).psa_crypto_rsp_status))))) ||
+		       (zcbor_list_map_end_force_decode(state), false)) &&
+		      zcbor_list_end_decode(state))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_psa_crypto_req(zcbor_state_t *state, struct psa_crypto_req *result)
@@ -1879,7 +1377,7 @@ static bool decode_psa_crypto_req(zcbor_state_t *state, struct psa_crypto_req *r
 	zcbor_log("%s\r\n", __func__);
 	bool int_res;
 
-	bool tmp_result = (((
+	bool res = (((
 		zcbor_list_start_decode(state) &&
 		((((zcbor_union_start_code(state) &&
 		    (int_res =
@@ -1887,14 +1385,13 @@ static bool decode_psa_crypto_req(zcbor_state_t *state, struct psa_crypto_req *r
 			       (((*result).psa_crypto_req_msg_choice =
 					 psa_crypto_req_msg_psa_crypto_init_req_m_c),
 				true)) ||
-			      (zcbor_union_elem_code(state) &&
-			       (((decode_psa_get_key_attributes_req(
-					state,
-					(&(*result)
-						  .psa_crypto_req_msg_psa_get_key_attributes_req_m)))) &&
-				(((*result).psa_crypto_req_msg_choice =
-					  psa_crypto_req_msg_psa_get_key_attributes_req_m_c),
-				 true))) ||
+			      (((decode_psa_get_key_attributes_req(
+				       state,
+				       (&(*result)
+						 .psa_crypto_req_msg_psa_get_key_attributes_req_m)))) &&
+			       (((*result).psa_crypto_req_msg_choice =
+					 psa_crypto_req_msg_psa_get_key_attributes_req_m_c),
+				true)) ||
 			      (zcbor_union_elem_code(state) &&
 			       (((decode_psa_reset_key_attributes_req(
 					state,
@@ -2443,14 +1940,8 @@ static bool decode_psa_crypto_req(zcbor_state_t *state, struct psa_crypto_req *r
 		 (zcbor_list_map_end_force_decode(state), false)) &&
 		zcbor_list_end_decode(state))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 int cbor_decode_psa_crypto_req(const uint8_t *payload, size_t payload_len,

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_decode.c
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_decode.c
@@ -39,12 +39,14 @@ static bool decode_psa_get_key_attributes_req(zcbor_state_t *state,
 static bool decode_psa_reset_key_attributes_req(zcbor_state_t *state,
 						struct psa_reset_key_attributes_req *result);
 static bool decode_psa_purge_key_req(zcbor_state_t *state, struct psa_purge_key_req *result);
+static bool decode_ptr_const_attr(zcbor_state_t *state, uint32_t *result);
 static bool decode_ptr_key(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_copy_key_req(zcbor_state_t *state, struct psa_copy_key_req *result);
 static bool decode_psa_destroy_key_req(zcbor_state_t *state, struct psa_destroy_key_req *result);
-static bool decode_ptr_buf(zcbor_state_t *state, uint32_t *result);
+static bool decode_ptr_const_buf(zcbor_state_t *state, uint32_t *result);
 static bool decode_buf_len(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_import_key_req(zcbor_state_t *state, struct psa_import_key_req *result);
+static bool decode_ptr_buf(zcbor_state_t *state, uint32_t *result);
 static bool decode_ptr_uint(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_export_key_req(zcbor_state_t *state, struct psa_export_key_req *result);
 static bool decode_psa_export_public_key_req(zcbor_state_t *state,
@@ -146,7 +148,7 @@ static bool decode_psa_raw_key_agreement_req(zcbor_state_t *state,
 static bool decode_psa_generate_random_req(zcbor_state_t *state,
 					   struct psa_generate_random_req *result);
 static bool decode_psa_generate_key_req(zcbor_state_t *state, struct psa_generate_key_req *result);
-static bool decode_ptr_cipher(zcbor_state_t *state, uint32_t *result);
+static bool decode_ptr_const_cipher(zcbor_state_t *state, uint32_t *result);
 static bool decode_psa_pake_setup_req(zcbor_state_t *state, struct psa_pake_setup_req *result);
 static bool decode_psa_pake_set_role_req(zcbor_state_t *state,
 					 struct psa_pake_set_role_req *result);
@@ -212,6 +214,16 @@ static bool decode_psa_purge_key_req(zcbor_state_t *state, struct psa_purge_key_
 	return res;
 }
 
+static bool decode_ptr_const_attr(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = ((zcbor_tag_expect(state, 32777) && (zcbor_uint32_decode(state, (&(*result))))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
 static bool decode_ptr_key(zcbor_state_t *state, uint32_t *result)
 {
 	zcbor_log("%s\r\n", __func__);
@@ -226,10 +238,11 @@ static bool decode_psa_copy_key_req(zcbor_state_t *state, struct psa_copy_key_re
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((((zcbor_uint32_expect(state, (14)))) &&
-		      ((zcbor_uint32_decode(state, (&(*result).psa_copy_key_req_source_key)))) &&
-		      ((decode_ptr_attr(state, (&(*result).psa_copy_key_req_p_attributes)))) &&
-		      ((decode_ptr_key(state, (&(*result).psa_copy_key_req_p_target_key)))))));
+	bool res =
+		(((((zcbor_uint32_expect(state, (14)))) &&
+		   ((zcbor_uint32_decode(state, (&(*result).psa_copy_key_req_source_key)))) &&
+		   ((decode_ptr_const_attr(state, (&(*result).psa_copy_key_req_p_attributes)))) &&
+		   ((decode_ptr_key(state, (&(*result).psa_copy_key_req_p_target_key)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -246,11 +259,11 @@ static bool decode_psa_destroy_key_req(zcbor_state_t *state, struct psa_destroy_
 	return res;
 }
 
-static bool decode_ptr_buf(zcbor_state_t *state, uint32_t *result)
+static bool decode_ptr_const_buf(zcbor_state_t *state, uint32_t *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = ((zcbor_tag_expect(state, 32770) && (zcbor_uint32_decode(state, (&(*result))))));
+	bool res = ((zcbor_tag_expect(state, 32776) && (zcbor_uint32_decode(state, (&(*result))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -270,11 +283,22 @@ static bool decode_psa_import_key_req(zcbor_state_t *state, struct psa_import_ke
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((((zcbor_uint32_expect(state, (16)))) &&
-		      ((decode_ptr_attr(state, (&(*result).psa_import_key_req_p_attributes)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_import_key_req_p_data)))) &&
-		      ((decode_buf_len(state, (&(*result).psa_import_key_req_data_length)))) &&
-		      ((decode_ptr_key(state, (&(*result).psa_import_key_req_p_key)))))));
+	bool res =
+		(((((zcbor_uint32_expect(state, (16)))) &&
+		   ((decode_ptr_const_attr(state, (&(*result).psa_import_key_req_p_attributes)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_import_key_req_p_data)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_import_key_req_data_length)))) &&
+		   ((decode_ptr_key(state, (&(*result).psa_import_key_req_p_key)))))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool decode_ptr_buf(zcbor_state_t *state, uint32_t *result)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = ((zcbor_tag_expect(state, 32770) && (zcbor_uint32_decode(state, (&(*result))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -327,7 +351,7 @@ static bool decode_psa_hash_compute_req(zcbor_state_t *state, struct psa_hash_co
 	bool res =
 		(((((zcbor_uint32_expect(state, (19)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_hash_compute_req_alg)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_hash_compute_req_p_input)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_hash_compute_req_p_input)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_hash_compute_req_input_length)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_hash_compute_req_p_hash)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_hash_compute_req_hash_size)))) &&
@@ -343,9 +367,9 @@ static bool decode_psa_hash_compare_req(zcbor_state_t *state, struct psa_hash_co
 
 	bool res = (((((zcbor_uint32_expect(state, (20)))) &&
 		      ((zcbor_uint32_decode(state, (&(*result).psa_hash_compare_req_alg)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_hash_compare_req_p_input)))) &&
+		      ((decode_ptr_const_buf(state, (&(*result).psa_hash_compare_req_p_input)))) &&
 		      ((decode_buf_len(state, (&(*result).psa_hash_compare_req_input_length)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_hash_compare_req_p_hash)))) &&
+		      ((decode_ptr_const_buf(state, (&(*result).psa_hash_compare_req_p_hash)))) &&
 		      ((decode_buf_len(state, (&(*result).psa_hash_compare_req_hash_length)))))));
 
 	log_result(state, res, __func__);
@@ -370,7 +394,7 @@ static bool decode_psa_hash_update_req(zcbor_state_t *state, struct psa_hash_upd
 
 	bool res = (((((zcbor_uint32_expect(state, (22)))) &&
 		      ((decode_ptr_uint(state, (&(*result).psa_hash_update_req_p_handle)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_hash_update_req_p_input)))) &&
+		      ((decode_ptr_const_buf(state, (&(*result).psa_hash_update_req_p_input)))) &&
 		      ((decode_buf_len(state, (&(*result).psa_hash_update_req_input_length)))))));
 
 	log_result(state, res, __func__);
@@ -397,7 +421,7 @@ static bool decode_psa_hash_verify_req(zcbor_state_t *state, struct psa_hash_ver
 
 	bool res = (((((zcbor_uint32_expect(state, (24)))) &&
 		      ((decode_ptr_uint(state, (&(*result).psa_hash_verify_req_p_handle)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_hash_verify_req_p_hash)))) &&
+		      ((decode_ptr_const_buf(state, (&(*result).psa_hash_verify_req_p_hash)))) &&
 		      ((decode_buf_len(state, (&(*result).psa_hash_verify_req_hash_length)))))));
 
 	log_result(state, res, __func__);
@@ -434,7 +458,7 @@ static bool decode_psa_mac_compute_req(zcbor_state_t *state, struct psa_mac_comp
 	bool res = (((((zcbor_uint32_expect(state, (27)))) &&
 		      ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_key)))) &&
 		      ((zcbor_uint32_decode(state, (&(*result).psa_mac_compute_req_alg)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_mac_compute_req_p_input)))) &&
+		      ((decode_ptr_const_buf(state, (&(*result).psa_mac_compute_req_p_input)))) &&
 		      ((decode_buf_len(state, (&(*result).psa_mac_compute_req_input_length)))) &&
 		      ((decode_ptr_buf(state, (&(*result).psa_mac_compute_req_p_mac)))) &&
 		      ((decode_buf_len(state, (&(*result).psa_mac_compute_req_mac_size)))) &&
@@ -451,9 +475,9 @@ static bool decode_psa_mac_verify_req(zcbor_state_t *state, struct psa_mac_verif
 	bool res = (((((zcbor_uint32_expect(state, (28)))) &&
 		      ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_key)))) &&
 		      ((zcbor_uint32_decode(state, (&(*result).psa_mac_verify_req_alg)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_mac_verify_req_p_input)))) &&
+		      ((decode_ptr_const_buf(state, (&(*result).psa_mac_verify_req_p_input)))) &&
 		      ((decode_buf_len(state, (&(*result).psa_mac_verify_req_input_length)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_mac_verify_req_p_mac)))) &&
+		      ((decode_ptr_const_buf(state, (&(*result).psa_mac_verify_req_p_mac)))) &&
 		      ((decode_buf_len(state, (&(*result).psa_mac_verify_req_mac_length)))))));
 
 	log_result(state, res, __func__);
@@ -494,7 +518,7 @@ static bool decode_psa_mac_update_req(zcbor_state_t *state, struct psa_mac_updat
 
 	bool res = (((((zcbor_uint32_expect(state, (31)))) &&
 		      ((decode_ptr_uint(state, (&(*result).psa_mac_update_req_p_handle)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_mac_update_req_p_input)))) &&
+		      ((decode_ptr_const_buf(state, (&(*result).psa_mac_update_req_p_input)))) &&
 		      ((decode_buf_len(state, (&(*result).psa_mac_update_req_input_length)))))));
 
 	log_result(state, res, __func__);
@@ -525,7 +549,7 @@ static bool decode_psa_mac_verify_finish_req(zcbor_state_t *state,
 	bool res =
 		(((((zcbor_uint32_expect(state, (33)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_mac_verify_finish_req_p_handle)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_mac_verify_finish_req_p_mac)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_mac_verify_finish_req_p_mac)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_mac_verify_finish_req_mac_length)))))));
 
 	log_result(state, res, __func__);
@@ -552,7 +576,7 @@ static bool decode_psa_cipher_encrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (35)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_encrypt_req_alg)))) &&
-		 ((decode_ptr_buf(state, (&(*result).psa_cipher_encrypt_req_p_input)))) &&
+		 ((decode_ptr_const_buf(state, (&(*result).psa_cipher_encrypt_req_p_input)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_cipher_encrypt_req_input_length)))) &&
 		 ((decode_ptr_buf(state, (&(*result).psa_cipher_encrypt_req_p_output)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_cipher_encrypt_req_output_size)))) &&
@@ -571,7 +595,7 @@ static bool decode_psa_cipher_decrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (36)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_cipher_decrypt_req_alg)))) &&
-		 ((decode_ptr_buf(state, (&(*result).psa_cipher_decrypt_req_p_input)))) &&
+		 ((decode_ptr_const_buf(state, (&(*result).psa_cipher_decrypt_req_p_input)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_cipher_decrypt_req_input_length)))) &&
 		 ((decode_ptr_buf(state, (&(*result).psa_cipher_decrypt_req_p_output)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_cipher_decrypt_req_output_size)))) &&
@@ -633,7 +657,7 @@ static bool decode_psa_cipher_set_iv_req(zcbor_state_t *state, struct psa_cipher
 
 	bool res = (((((zcbor_uint32_expect(state, (40)))) &&
 		      ((decode_ptr_uint(state, (&(*result).psa_cipher_set_iv_req_p_handle)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_cipher_set_iv_req_p_iv)))) &&
+		      ((decode_ptr_const_buf(state, (&(*result).psa_cipher_set_iv_req_p_iv)))) &&
 		      ((decode_buf_len(state, (&(*result).psa_cipher_set_iv_req_iv_length)))))));
 
 	log_result(state, res, __func__);
@@ -647,7 +671,7 @@ static bool decode_psa_cipher_update_req(zcbor_state_t *state, struct psa_cipher
 	bool res = ((
 		(((zcbor_uint32_expect(state, (41)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_cipher_update_req_p_handle)))) &&
-		 ((decode_ptr_buf(state, (&(*result).psa_cipher_update_req_p_input)))) &&
+		 ((decode_ptr_const_buf(state, (&(*result).psa_cipher_update_req_p_input)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_cipher_update_req_input_length)))) &&
 		 ((decode_ptr_buf(state, (&(*result).psa_cipher_update_req_p_output)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_cipher_update_req_output_size)))) &&
@@ -691,12 +715,13 @@ static bool decode_psa_aead_encrypt_req(zcbor_state_t *state, struct psa_aead_en
 		(((((zcbor_uint32_expect(state, (44)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_aead_encrypt_req_alg)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_aead_encrypt_req_p_nonce)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_aead_encrypt_req_p_nonce)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_aead_encrypt_req_nonce_length)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_aead_encrypt_req_p_additional_data)))) &&
+		   ((decode_ptr_const_buf(state,
+					  (&(*result).psa_aead_encrypt_req_p_additional_data)))) &&
 		   ((decode_buf_len(state,
 				    (&(*result).psa_aead_encrypt_req_additional_data_length)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_aead_encrypt_req_p_plaintext)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_aead_encrypt_req_p_plaintext)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_aead_encrypt_req_plaintext_length)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_aead_encrypt_req_p_ciphertext)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_aead_encrypt_req_ciphertext_size)))) &&
@@ -715,12 +740,13 @@ static bool decode_psa_aead_decrypt_req(zcbor_state_t *state, struct psa_aead_de
 		((zcbor_uint32_expect(state, (45)))) &&
 		((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_key)))) &&
 		((zcbor_uint32_decode(state, (&(*result).psa_aead_decrypt_req_alg)))) &&
-		((decode_ptr_buf(state, (&(*result).psa_aead_decrypt_req_p_nonce)))) &&
+		((decode_ptr_const_buf(state, (&(*result).psa_aead_decrypt_req_p_nonce)))) &&
 		((decode_buf_len(state, (&(*result).psa_aead_decrypt_req_nonce_length)))) &&
-		((decode_ptr_buf(state, (&(*result).psa_aead_decrypt_req_p_additional_data)))) &&
+		((decode_ptr_const_buf(state,
+				       (&(*result).psa_aead_decrypt_req_p_additional_data)))) &&
 		((decode_buf_len(state,
 				 (&(*result).psa_aead_decrypt_req_additional_data_length)))) &&
-		((decode_ptr_buf(state, (&(*result).psa_aead_decrypt_req_p_ciphertext)))) &&
+		((decode_ptr_const_buf(state, (&(*result).psa_aead_decrypt_req_p_ciphertext)))) &&
 		((decode_buf_len(state, (&(*result).psa_aead_decrypt_req_ciphertext_length)))) &&
 		((decode_ptr_buf(state, (&(*result).psa_aead_decrypt_req_p_plaintext)))) &&
 		((decode_buf_len(state, (&(*result).psa_aead_decrypt_req_plaintext_size)))) &&
@@ -785,7 +811,7 @@ static bool decode_psa_aead_set_nonce_req(zcbor_state_t *state,
 	bool res =
 		(((((zcbor_uint32_expect(state, (49)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_aead_set_nonce_req_p_handle)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_aead_set_nonce_req_p_nonce)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_aead_set_nonce_req_p_nonce)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_aead_set_nonce_req_nonce_length)))))));
 
 	log_result(state, res, __func__);
@@ -797,10 +823,11 @@ static bool decode_psa_aead_set_lengths_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((((zcbor_uint32_expect(state, (50)))) &&
-		      ((decode_ptr_uint(state, (&(*result).psa_aead_set_lengths_req_p_handle)))) &&
-		      ((decode_buf_len(state, (&(*result).psa_aead_set_lengths_req_ad_length)))) &&
-		      ((decode_buf_len(state,
+	bool res = ((
+		(((zcbor_uint32_expect(state, (50)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_aead_set_lengths_req_p_handle)))) &&
+		 ((zcbor_uint32_decode(state, (&(*result).psa_aead_set_lengths_req_ad_length)))) &&
+		 ((zcbor_uint32_decode(state,
 				       (&(*result).psa_aead_set_lengths_req_plaintext_length)))))));
 
 	log_result(state, res, __func__);
@@ -815,7 +842,7 @@ static bool decode_psa_aead_update_ad_req(zcbor_state_t *state,
 	bool res =
 		(((((zcbor_uint32_expect(state, (51)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_aead_update_ad_req_p_handle)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_aead_update_ad_req_p_input)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_aead_update_ad_req_p_input)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_aead_update_ad_req_input_length)))))));
 
 	log_result(state, res, __func__);
@@ -829,7 +856,7 @@ static bool decode_psa_aead_update_req(zcbor_state_t *state, struct psa_aead_upd
 	bool res =
 		(((((zcbor_uint32_expect(state, (52)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_aead_update_req_p_handle)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_aead_update_req_p_input)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_aead_update_req_p_input)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_aead_update_req_input_length)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_aead_update_req_p_output)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_aead_update_req_output_size)))) &&
@@ -867,7 +894,7 @@ static bool decode_psa_aead_verify_req(zcbor_state_t *state, struct psa_aead_ver
 		 ((decode_ptr_buf(state, (&(*result).psa_aead_verify_req_p_plaintext)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_aead_verify_req_plaintext_size)))) &&
 		 ((decode_ptr_uint(state, (&(*result).psa_aead_verify_req_p_plaintext_length)))) &&
-		 ((decode_ptr_buf(state, (&(*result).psa_aead_verify_req_p_tag)))) &&
+		 ((decode_ptr_const_buf(state, (&(*result).psa_aead_verify_req_p_tag)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_aead_verify_req_tag_length)))))));
 
 	log_result(state, res, __func__);
@@ -893,7 +920,7 @@ static bool decode_psa_sign_message_req(zcbor_state_t *state, struct psa_sign_me
 		((zcbor_uint32_expect(state, (56)))) &&
 		((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_key)))) &&
 		((zcbor_uint32_decode(state, (&(*result).psa_sign_message_req_alg)))) &&
-		((decode_ptr_buf(state, (&(*result).psa_sign_message_req_p_input)))) &&
+		((decode_ptr_const_buf(state, (&(*result).psa_sign_message_req_p_input)))) &&
 		((decode_buf_len(state, (&(*result).psa_sign_message_req_input_length)))) &&
 		((decode_ptr_buf(state, (&(*result).psa_sign_message_req_p_signature)))) &&
 		((decode_buf_len(state, (&(*result).psa_sign_message_req_signature_size)))) &&
@@ -912,9 +939,9 @@ static bool decode_psa_verify_message_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (57)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_verify_message_req_alg)))) &&
-		 ((decode_ptr_buf(state, (&(*result).psa_verify_message_req_p_input)))) &&
+		 ((decode_ptr_const_buf(state, (&(*result).psa_verify_message_req_p_input)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_verify_message_req_input_length)))) &&
-		 ((decode_ptr_buf(state, (&(*result).psa_verify_message_req_p_signature)))) &&
+		 ((decode_ptr_const_buf(state, (&(*result).psa_verify_message_req_p_signature)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_verify_message_req_signature_length)))))));
 
 	log_result(state, res, __func__);
@@ -929,7 +956,7 @@ static bool decode_psa_sign_hash_req(zcbor_state_t *state, struct psa_sign_hash_
 		(((((zcbor_uint32_expect(state, (58)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_sign_hash_req_alg)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_sign_hash_req_p_hash)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_sign_hash_req_p_hash)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_sign_hash_req_hash_length)))) &&
 		   ((decode_ptr_buf(state, (&(*result).psa_sign_hash_req_p_signature)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_sign_hash_req_signature_size)))) &&
@@ -947,9 +974,9 @@ static bool decode_psa_verify_hash_req(zcbor_state_t *state, struct psa_verify_h
 		(((((zcbor_uint32_expect(state, (59)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_key)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_verify_hash_req_alg)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_verify_hash_req_p_hash)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_verify_hash_req_p_hash)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_verify_hash_req_hash_length)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_verify_hash_req_p_signature)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_verify_hash_req_p_signature)))) &&
 		   ((decode_buf_len(state, (&(*result).psa_verify_hash_req_signature_length)))))));
 
 	log_result(state, res, __func__);
@@ -965,9 +992,9 @@ static bool decode_psa_asymmetric_encrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (60)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_encrypt_req_alg)))) &&
-		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_encrypt_req_p_input)))) &&
+		 ((decode_ptr_const_buf(state, (&(*result).psa_asymmetric_encrypt_req_p_input)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_asymmetric_encrypt_req_input_length)))) &&
-		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_encrypt_req_p_salt)))) &&
+		 ((decode_ptr_const_buf(state, (&(*result).psa_asymmetric_encrypt_req_p_salt)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_asymmetric_encrypt_req_salt_length)))) &&
 		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_encrypt_req_p_output)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_asymmetric_encrypt_req_output_size)))) &&
@@ -987,9 +1014,9 @@ static bool decode_psa_asymmetric_decrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_expect(state, (61)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_key)))) &&
 		 ((zcbor_uint32_decode(state, (&(*result).psa_asymmetric_decrypt_req_alg)))) &&
-		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_decrypt_req_p_input)))) &&
+		 ((decode_ptr_const_buf(state, (&(*result).psa_asymmetric_decrypt_req_p_input)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_asymmetric_decrypt_req_input_length)))) &&
-		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_decrypt_req_p_salt)))) &&
+		 ((decode_ptr_const_buf(state, (&(*result).psa_asymmetric_decrypt_req_p_salt)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_asymmetric_decrypt_req_salt_length)))) &&
 		 ((decode_ptr_buf(state, (&(*result).psa_asymmetric_decrypt_req_p_output)))) &&
 		 ((decode_buf_len(state, (&(*result).psa_asymmetric_decrypt_req_output_size)))) &&
@@ -1054,15 +1081,16 @@ decode_psa_key_derivation_input_bytes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((
-		((zcbor_uint32_expect(state, (65)))) &&
-		((decode_ptr_uint(state,
-				  (&(*result).psa_key_derivation_input_bytes_req_p_handle)))) &&
-		((zcbor_uint32_decode(state,
-				      (&(*result).psa_key_derivation_input_bytes_req_step)))) &&
-		((decode_ptr_buf(state, (&(*result).psa_key_derivation_input_bytes_req_p_data)))) &&
-		((decode_buf_len(state,
-				 (&(*result).psa_key_derivation_input_bytes_req_data_length)))))));
+	bool res =
+		(((((zcbor_uint32_expect(state, (65)))) &&
+		   ((decode_ptr_uint(state,
+				     (&(*result).psa_key_derivation_input_bytes_req_p_handle)))) &&
+		   ((zcbor_uint32_decode(state,
+					 (&(*result).psa_key_derivation_input_bytes_req_step)))) &&
+		   ((decode_ptr_const_buf(
+			   state, (&(*result).psa_key_derivation_input_bytes_req_p_data)))) &&
+		   ((decode_buf_len(
+			   state, (&(*result).psa_key_derivation_input_bytes_req_data_length)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1118,8 +1146,8 @@ decode_psa_key_derivation_key_agreement_req(zcbor_state_t *state,
 				       (&(*result).psa_key_derivation_key_agreement_req_step)))) &&
 		 ((zcbor_uint32_decode(
 			 state, (&(*result).psa_key_derivation_key_agreement_req_private_key)))) &&
-		 ((decode_ptr_buf(state,
-				  (&(*result).psa_key_derivation_key_agreement_req_p_peer_key)))) &&
+		 ((decode_ptr_const_buf(
+			 state, (&(*result).psa_key_derivation_key_agreement_req_p_peer_key)))) &&
 		 ((decode_buf_len(
 			 state,
 			 (&(*result).psa_key_derivation_key_agreement_req_peer_key_length)))))));
@@ -1155,8 +1183,8 @@ decode_psa_key_derivation_output_key_req(zcbor_state_t *state,
 
 	bool res = ((
 		(((zcbor_uint32_expect(state, (70)))) &&
-		 ((decode_ptr_attr(state,
-				   (&(*result).psa_key_derivation_output_key_req_p_attributes)))) &&
+		 ((decode_ptr_const_attr(
+			 state, (&(*result).psa_key_derivation_output_key_req_p_attributes)))) &&
 		 ((decode_ptr_uint(state,
 				   (&(*result).psa_key_derivation_output_key_req_p_handle)))) &&
 		 ((decode_ptr_key(state, (&(*result).psa_key_derivation_output_key_req_p_key)))))));
@@ -1188,7 +1216,8 @@ static bool decode_psa_raw_key_agreement_req(zcbor_state_t *state,
 		((zcbor_uint32_decode(state, (&(*result).psa_raw_key_agreement_req_alg)))) &&
 		((zcbor_uint32_decode(state,
 				      (&(*result).psa_raw_key_agreement_req_private_key)))) &&
-		((decode_ptr_buf(state, (&(*result).psa_raw_key_agreement_req_p_peer_key)))) &&
+		((decode_ptr_const_buf(state,
+				       (&(*result).psa_raw_key_agreement_req_p_peer_key)))) &&
 		((decode_buf_len(state, (&(*result).psa_raw_key_agreement_req_peer_key_length)))) &&
 		((decode_ptr_buf(state, (&(*result).psa_raw_key_agreement_req_p_output)))) &&
 		((decode_buf_len(state, (&(*result).psa_raw_key_agreement_req_output_size)))) &&
@@ -1217,19 +1246,20 @@ static bool decode_psa_generate_key_req(zcbor_state_t *state, struct psa_generat
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((((zcbor_uint32_expect(state, (74)))) &&
-		      ((decode_ptr_attr(state, (&(*result).psa_generate_key_req_p_attributes)))) &&
-		      ((decode_ptr_key(state, (&(*result).psa_generate_key_req_p_key)))))));
+	bool res = ((
+		(((zcbor_uint32_expect(state, (74)))) &&
+		 ((decode_ptr_const_attr(state, (&(*result).psa_generate_key_req_p_attributes)))) &&
+		 ((decode_ptr_key(state, (&(*result).psa_generate_key_req_p_key)))))));
 
 	log_result(state, res, __func__);
 	return res;
 }
 
-static bool decode_ptr_cipher(zcbor_state_t *state, uint32_t *result)
+static bool decode_ptr_const_cipher(zcbor_state_t *state, uint32_t *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = ((zcbor_tag_expect(state, 32775) && (zcbor_uint32_decode(state, (&(*result))))));
+	bool res = ((zcbor_tag_expect(state, 32780) && (zcbor_uint32_decode(state, (&(*result))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1243,7 +1273,8 @@ static bool decode_psa_pake_setup_req(zcbor_state_t *state, struct psa_pake_setu
 		(((((zcbor_uint32_expect(state, (79)))) &&
 		   ((decode_ptr_uint(state, (&(*result).psa_pake_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_decode(state, (&(*result).psa_pake_setup_req_password_key)))) &&
-		   ((decode_ptr_cipher(state, (&(*result).psa_pake_setup_req_p_cipher_suite)))))));
+		   ((decode_ptr_const_cipher(state,
+					     (&(*result).psa_pake_setup_req_p_cipher_suite)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1265,10 +1296,11 @@ static bool decode_psa_pake_set_user_req(zcbor_state_t *state, struct psa_pake_s
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((((zcbor_uint32_expect(state, (81)))) &&
-		      ((decode_ptr_uint(state, (&(*result).psa_pake_set_user_req_p_handle)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_pake_set_user_req_p_user_id)))) &&
-		      ((decode_buf_len(state, (&(*result).psa_pake_set_user_req_user_id_len)))))));
+	bool res =
+		(((((zcbor_uint32_expect(state, (81)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_user_req_p_handle)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_pake_set_user_req_p_user_id)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_pake_set_user_req_user_id_len)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1278,10 +1310,11 @@ static bool decode_psa_pake_set_peer_req(zcbor_state_t *state, struct psa_pake_s
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((((zcbor_uint32_expect(state, (82)))) &&
-		      ((decode_ptr_uint(state, (&(*result).psa_pake_set_peer_req_p_handle)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_pake_set_peer_req_p_peer_id)))) &&
-		      ((decode_buf_len(state, (&(*result).psa_pake_set_peer_req_peer_id_len)))))));
+	bool res =
+		(((((zcbor_uint32_expect(state, (82)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_peer_req_p_handle)))) &&
+		   ((decode_ptr_const_buf(state, (&(*result).psa_pake_set_peer_req_p_peer_id)))) &&
+		   ((decode_buf_len(state, (&(*result).psa_pake_set_peer_req_peer_id_len)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1292,11 +1325,11 @@ static bool decode_psa_pake_set_context_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res =
-		(((((zcbor_uint32_expect(state, (83)))) &&
-		   ((decode_ptr_uint(state, (&(*result).psa_pake_set_context_req_p_handle)))) &&
-		   ((decode_ptr_buf(state, (&(*result).psa_pake_set_context_req_p_context)))) &&
-		   ((decode_buf_len(state, (&(*result).psa_pake_set_context_req_context_len)))))));
+	bool res = ((
+		(((zcbor_uint32_expect(state, (83)))) &&
+		 ((decode_ptr_uint(state, (&(*result).psa_pake_set_context_req_p_handle)))) &&
+		 ((decode_ptr_const_buf(state, (&(*result).psa_pake_set_context_req_p_context)))) &&
+		 ((decode_buf_len(state, (&(*result).psa_pake_set_context_req_context_len)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1325,7 +1358,7 @@ static bool decode_psa_pake_input_req(zcbor_state_t *state, struct psa_pake_inpu
 	bool res = (((((zcbor_uint32_expect(state, (85)))) &&
 		      ((decode_ptr_uint(state, (&(*result).psa_pake_input_req_p_handle)))) &&
 		      ((zcbor_uint32_decode(state, (&(*result).psa_pake_input_req_step)))) &&
-		      ((decode_ptr_buf(state, (&(*result).psa_pake_input_req_p_input)))) &&
+		      ((decode_ptr_const_buf(state, (&(*result).psa_pake_input_req_p_input)))) &&
 		      ((decode_buf_len(state, (&(*result).psa_pake_input_req_input_length)))))));
 
 	log_result(state, res, __func__);
@@ -1337,11 +1370,12 @@ static bool decode_psa_pake_get_shared_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((
-		((zcbor_uint32_expect(state, (86)))) &&
-		((decode_ptr_uint(state, (&(*result).psa_pake_get_shared_key_req_p_handle)))) &&
-		((decode_ptr_attr(state, (&(*result).psa_pake_get_shared_key_req_p_attributes)))) &&
-		((decode_ptr_key(state, (&(*result).psa_pake_get_shared_key_req_p_key)))))));
+	bool res =
+		(((((zcbor_uint32_expect(state, (86)))) &&
+		   ((decode_ptr_uint(state, (&(*result).psa_pake_get_shared_key_req_p_handle)))) &&
+		   ((decode_ptr_const_attr(
+			   state, (&(*result).psa_pake_get_shared_key_req_p_attributes)))) &&
+		   ((decode_ptr_key(state, (&(*result).psa_pake_get_shared_key_req_p_key)))))));
 
 	log_result(state, res, __func__);
 	return res;

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_decode.h
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_decode.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.99
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_encode.c
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_encode.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.99
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -21,6 +21,17 @@
 #if DEFAULT_MAX_QTY != 3
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
+
+#define log_result(state, result, func)                                                            \
+	do {                                                                                       \
+		if (!result) {                                                                     \
+			zcbor_trace_file(state);                                                   \
+			zcbor_log("%s error: %s\r\n", func,                                        \
+				  zcbor_error_str(zcbor_peek_error(state)));                       \
+		} else {                                                                           \
+			zcbor_log("%s success\r\n", func);                                         \
+		}                                                                                  \
+	} while (0)
 
 static bool encode_ptr_attr(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_get_key_attributes_req(zcbor_state_t *state,
@@ -172,17 +183,10 @@ static bool encode_ptr_attr(zcbor_state_t *state, const uint32_t *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		((zcbor_tag_put(state, 32772) && (zcbor_uint32_encode(state, (&(*input))))));
+	bool res = ((zcbor_tag_put(state, 32772) && (zcbor_uint32_encode(state, (&(*input))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_get_key_attributes_req(zcbor_state_t *state,
@@ -190,19 +194,13 @@ static bool encode_psa_get_key_attributes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (11)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_get_key_attributes_req_key)))) &&
 		 ((encode_ptr_attr(state, (&(*input).psa_get_key_attributes_req_p_attributes)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_reset_key_attributes_req(zcbor_state_t *state,
@@ -210,73 +208,46 @@ static bool encode_psa_reset_key_attributes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (12)))) &&
-		   ((encode_ptr_attr(state,
-				     (&(*input).psa_reset_key_attributes_req_p_attributes)))))));
+	bool res = (((((zcbor_uint32_put(state, (12)))) &&
+		      ((encode_ptr_attr(state,
+					(&(*input).psa_reset_key_attributes_req_p_attributes)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_purge_key_req(zcbor_state_t *state, const struct psa_purge_key_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((((zcbor_uint32_put(state, (13)))) &&
-			     ((zcbor_uint32_encode(state, (&(*input).psa_purge_key_req_key)))))));
+	bool res = (((((zcbor_uint32_put(state, (13)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_purge_key_req_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_ptr_key(zcbor_state_t *state, const uint32_t *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		((zcbor_tag_put(state, 32773) && (zcbor_uint32_encode(state, (&(*input))))));
+	bool res = ((zcbor_tag_put(state, 32773) && (zcbor_uint32_encode(state, (&(*input))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_copy_key_req(zcbor_state_t *state, const struct psa_copy_key_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (14)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_copy_key_req_source_key)))) &&
-		   ((encode_ptr_attr(state, (&(*input).psa_copy_key_req_p_attributes)))) &&
-		   ((encode_ptr_key(state, (&(*input).psa_copy_key_req_p_target_key)))))));
+	bool res = (((((zcbor_uint32_put(state, (14)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_copy_key_req_source_key)))) &&
+		      ((encode_ptr_attr(state, (&(*input).psa_copy_key_req_p_attributes)))) &&
+		      ((encode_ptr_key(state, (&(*input).psa_copy_key_req_p_target_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_destroy_key_req(zcbor_state_t *state,
@@ -284,110 +255,69 @@ static bool encode_psa_destroy_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((((zcbor_uint32_put(state, (15)))) &&
-			     ((zcbor_uint32_encode(state, (&(*input).psa_destroy_key_req_key)))))));
+	bool res = (((((zcbor_uint32_put(state, (15)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_destroy_key_req_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_ptr_buf(zcbor_state_t *state, const uint32_t *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		((zcbor_tag_put(state, 32770) && (zcbor_uint32_encode(state, (&(*input))))));
+	bool res = ((zcbor_tag_put(state, 32770) && (zcbor_uint32_encode(state, (&(*input))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_buf_len(zcbor_state_t *state, const uint32_t *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		((zcbor_tag_put(state, 32771) && (zcbor_uint32_encode(state, (&(*input))))));
+	bool res = ((zcbor_tag_put(state, 32771) && (zcbor_uint32_encode(state, (&(*input))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_import_key_req(zcbor_state_t *state, const struct psa_import_key_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (16)))) &&
-		   ((encode_ptr_attr(state, (&(*input).psa_import_key_req_p_attributes)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_import_key_req_p_data)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_import_key_req_data_length)))) &&
-		   ((encode_ptr_key(state, (&(*input).psa_import_key_req_p_key)))))));
+	bool res = (((((zcbor_uint32_put(state, (16)))) &&
+		      ((encode_ptr_attr(state, (&(*input).psa_import_key_req_p_attributes)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_import_key_req_p_data)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_import_key_req_data_length)))) &&
+		      ((encode_ptr_key(state, (&(*input).psa_import_key_req_p_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_ptr_uint(zcbor_state_t *state, const uint32_t *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		((zcbor_tag_put(state, 32774) && (zcbor_uint32_encode(state, (&(*input))))));
+	bool res = ((zcbor_tag_put(state, 32774) && (zcbor_uint32_encode(state, (&(*input))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_export_key_req(zcbor_state_t *state, const struct psa_export_key_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (17)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_export_key_req_key)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_export_key_req_p_data)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_export_key_req_data_size)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_export_key_req_p_data_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (17)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_export_key_req_key)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_export_key_req_p_data)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_export_key_req_data_size)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_export_key_req_p_data_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_export_public_key_req(zcbor_state_t *state,
@@ -395,21 +325,15 @@ static bool encode_psa_export_public_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (18)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_export_public_key_req_key)))) &&
 		 ((encode_ptr_buf(state, (&(*input).psa_export_public_key_req_p_data)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_export_public_key_req_data_size)))) &&
 		 ((encode_ptr_uint(state, (&(*input).psa_export_public_key_req_p_data_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_hash_compute_req(zcbor_state_t *state,
@@ -417,23 +341,16 @@ static bool encode_psa_hash_compute_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (19)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_alg)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_hash_compute_req_p_input)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_hash_compute_req_input_length)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_hash_compute_req_p_hash)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_hash_compute_req_hash_size)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_hash_compute_req_p_hash_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (19)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_alg)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_hash_compute_req_p_input)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_hash_compute_req_input_length)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_hash_compute_req_p_hash)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_hash_compute_req_hash_size)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_hash_compute_req_p_hash_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_hash_compare_req(zcbor_state_t *state,
@@ -441,40 +358,27 @@ static bool encode_psa_hash_compare_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (20)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_alg)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_hash_compare_req_p_input)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_hash_compare_req_input_length)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_hash_compare_req_p_hash)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_hash_compare_req_hash_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (20)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_alg)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_hash_compare_req_p_input)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_hash_compare_req_input_length)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_hash_compare_req_p_hash)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_hash_compare_req_hash_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_hash_setup_req(zcbor_state_t *state, const struct psa_hash_setup_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((((zcbor_uint32_put(state, (21)))) &&
-			     ((encode_ptr_uint(state, (&(*input).psa_hash_setup_req_p_handle)))) &&
-			     ((zcbor_uint32_encode(state, (&(*input).psa_hash_setup_req_alg)))))));
+	bool res = (((((zcbor_uint32_put(state, (21)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_hash_setup_req_p_handle)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_hash_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_hash_update_req(zcbor_state_t *state,
@@ -482,20 +386,13 @@ static bool encode_psa_hash_update_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (22)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_hash_update_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_hash_update_req_p_input)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_hash_update_req_input_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (22)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_hash_update_req_p_handle)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_hash_update_req_p_input)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_hash_update_req_input_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_hash_finish_req(zcbor_state_t *state,
@@ -503,21 +400,14 @@ static bool encode_psa_hash_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (23)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_hash_finish_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_hash_finish_req_p_hash)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_hash_finish_req_hash_size)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_hash_finish_req_p_hash_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (23)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_hash_finish_req_p_handle)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_hash_finish_req_p_hash)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_hash_finish_req_hash_size)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_hash_finish_req_p_hash_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_hash_verify_req(zcbor_state_t *state,
@@ -525,56 +415,36 @@ static bool encode_psa_hash_verify_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (24)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_hash_verify_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_hash_verify_req_p_hash)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_hash_verify_req_hash_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (24)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_hash_verify_req_p_handle)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_hash_verify_req_p_hash)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_hash_verify_req_hash_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_hash_abort_req(zcbor_state_t *state, const struct psa_hash_abort_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((((zcbor_uint32_put(state, (25)))) &&
-			     ((encode_ptr_uint(state, (&(*input).psa_hash_abort_req_p_handle)))))));
+	bool res = (((((zcbor_uint32_put(state, (25)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_hash_abort_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_hash_clone_req(zcbor_state_t *state, const struct psa_hash_clone_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (26)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_hash_clone_req_handle)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_hash_clone_req_p_handle)))))));
+	bool res = (((((zcbor_uint32_put(state, (26)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_hash_clone_req_handle)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_hash_clone_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_mac_compute_req(zcbor_state_t *state,
@@ -582,47 +452,33 @@ static bool encode_psa_mac_compute_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (27)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_alg)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_mac_compute_req_p_input)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_mac_compute_req_input_length)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_mac_compute_req_p_mac)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_mac_compute_req_mac_size)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_mac_compute_req_p_mac_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (27)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_key)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_alg)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_mac_compute_req_p_input)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_mac_compute_req_input_length)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_mac_compute_req_p_mac)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_mac_compute_req_mac_size)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_mac_compute_req_p_mac_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_mac_verify_req(zcbor_state_t *state, const struct psa_mac_verify_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (28)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_alg)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_mac_verify_req_p_input)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_mac_verify_req_input_length)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_mac_verify_req_p_mac)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_mac_verify_req_mac_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (28)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_key)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_alg)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_mac_verify_req_p_input)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_mac_verify_req_input_length)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_mac_verify_req_p_mac)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_mac_verify_req_mac_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_mac_sign_setup_req(zcbor_state_t *state,
@@ -630,20 +486,13 @@ static bool encode_psa_mac_sign_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (29)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_mac_sign_setup_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_setup_req_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_setup_req_alg)))))));
+	bool res = (((((zcbor_uint32_put(state, (29)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_mac_sign_setup_req_p_handle)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_setup_req_key)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_mac_sign_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_mac_verify_setup_req(zcbor_state_t *state,
@@ -651,40 +500,26 @@ static bool encode_psa_mac_verify_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (30)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_mac_verify_setup_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_setup_req_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_setup_req_alg)))))));
+	bool res = (((((zcbor_uint32_put(state, (30)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_mac_verify_setup_req_p_handle)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_setup_req_key)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_mac_update_req(zcbor_state_t *state, const struct psa_mac_update_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (31)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_mac_update_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_mac_update_req_p_input)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_mac_update_req_input_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (31)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_mac_update_req_p_handle)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_mac_update_req_p_input)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_mac_update_req_input_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_mac_sign_finish_req(zcbor_state_t *state,
@@ -692,21 +527,15 @@ static bool encode_psa_mac_sign_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (32)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_mac_sign_finish_req_p_handle)))) &&
 		   ((encode_ptr_buf(state, (&(*input).psa_mac_sign_finish_req_p_mac)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_mac_sign_finish_req_mac_size)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_mac_sign_finish_req_p_mac_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_mac_verify_finish_req(zcbor_state_t *state,
@@ -714,37 +543,25 @@ static bool encode_psa_mac_verify_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (33)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_mac_verify_finish_req_p_handle)))) &&
 		   ((encode_ptr_buf(state, (&(*input).psa_mac_verify_finish_req_p_mac)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_mac_verify_finish_req_mac_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_mac_abort_req(zcbor_state_t *state, const struct psa_mac_abort_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((((zcbor_uint32_put(state, (34)))) &&
-			     ((encode_ptr_uint(state, (&(*input).psa_mac_abort_req_p_handle)))))));
+	bool res = (((((zcbor_uint32_put(state, (34)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_mac_abort_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_cipher_encrypt_req(zcbor_state_t *state,
@@ -752,7 +569,7 @@ static bool encode_psa_cipher_encrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (35)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_alg)))) &&
@@ -762,14 +579,8 @@ static bool encode_psa_cipher_encrypt_req(zcbor_state_t *state,
 		 ((encode_buf_len(state, (&(*input).psa_cipher_encrypt_req_output_size)))) &&
 		 ((encode_ptr_uint(state, (&(*input).psa_cipher_encrypt_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_cipher_decrypt_req(zcbor_state_t *state,
@@ -777,7 +588,7 @@ static bool encode_psa_cipher_decrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (36)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_alg)))) &&
@@ -787,14 +598,8 @@ static bool encode_psa_cipher_decrypt_req(zcbor_state_t *state,
 		 ((encode_buf_len(state, (&(*input).psa_cipher_decrypt_req_output_size)))) &&
 		 ((encode_ptr_uint(state, (&(*input).psa_cipher_decrypt_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_cipher_encrypt_setup_req(zcbor_state_t *state,
@@ -802,20 +607,14 @@ static bool encode_psa_cipher_encrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (37)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_cipher_encrypt_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_setup_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_cipher_decrypt_setup_req(zcbor_state_t *state,
@@ -823,20 +622,14 @@ static bool encode_psa_cipher_decrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (38)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_cipher_decrypt_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_setup_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_cipher_generate_iv_req(zcbor_state_t *state,
@@ -844,21 +637,15 @@ static bool encode_psa_cipher_generate_iv_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (39)))) &&
 		 ((encode_ptr_uint(state, (&(*input).psa_cipher_generate_iv_req_p_handle)))) &&
 		 ((encode_ptr_buf(state, (&(*input).psa_cipher_generate_iv_req_p_iv)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_cipher_generate_iv_req_iv_size)))) &&
 		 ((encode_ptr_uint(state, (&(*input).psa_cipher_generate_iv_req_p_iv_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_cipher_set_iv_req(zcbor_state_t *state,
@@ -866,20 +653,13 @@ static bool encode_psa_cipher_set_iv_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (40)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_cipher_set_iv_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_cipher_set_iv_req_p_iv)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_cipher_set_iv_req_iv_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (40)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_cipher_set_iv_req_p_handle)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_cipher_set_iv_req_p_iv)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_cipher_set_iv_req_iv_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_cipher_update_req(zcbor_state_t *state,
@@ -887,7 +667,7 @@ static bool encode_psa_cipher_update_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (41)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_cipher_update_req_p_handle)))) &&
 		   ((encode_ptr_buf(state, (&(*input).psa_cipher_update_req_p_input)))) &&
@@ -896,14 +676,8 @@ static bool encode_psa_cipher_update_req(zcbor_state_t *state,
 		   ((encode_buf_len(state, (&(*input).psa_cipher_update_req_output_size)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_cipher_update_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_cipher_finish_req(zcbor_state_t *state,
@@ -911,21 +685,15 @@ static bool encode_psa_cipher_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (42)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_cipher_finish_req_p_handle)))) &&
 		   ((encode_ptr_buf(state, (&(*input).psa_cipher_finish_req_p_output)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_cipher_finish_req_output_size)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_cipher_finish_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_cipher_abort_req(zcbor_state_t *state,
@@ -933,18 +701,11 @@ static bool encode_psa_cipher_abort_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (43)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_cipher_abort_req_p_handle)))))));
+	bool res = (((((zcbor_uint32_put(state, (43)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_cipher_abort_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_aead_encrypt_req(zcbor_state_t *state,
@@ -952,7 +713,7 @@ static bool encode_psa_aead_encrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		((zcbor_uint32_put(state, (44)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_key)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_alg)))) &&
@@ -967,14 +728,8 @@ static bool encode_psa_aead_encrypt_req(zcbor_state_t *state,
 		((encode_buf_len(state, (&(*input).psa_aead_encrypt_req_ciphertext_size)))) &&
 		((encode_ptr_uint(state, (&(*input).psa_aead_encrypt_req_p_ciphertext_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_aead_decrypt_req(zcbor_state_t *state,
@@ -982,7 +737,7 @@ static bool encode_psa_aead_decrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (45)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_alg)))) &&
@@ -997,14 +752,8 @@ static bool encode_psa_aead_decrypt_req(zcbor_state_t *state,
 		 ((encode_buf_len(state, (&(*input).psa_aead_decrypt_req_plaintext_size)))) &&
 		 ((encode_ptr_uint(state, (&(*input).psa_aead_decrypt_req_p_plaintext_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_aead_encrypt_setup_req(zcbor_state_t *state,
@@ -1012,20 +761,13 @@ static bool encode_psa_aead_encrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (46)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_aead_encrypt_setup_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_alg)))))));
+	bool res = (((((zcbor_uint32_put(state, (46)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_aead_encrypt_setup_req_p_handle)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_key)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_aead_decrypt_setup_req(zcbor_state_t *state,
@@ -1033,20 +775,13 @@ static bool encode_psa_aead_decrypt_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (47)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_aead_decrypt_setup_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_alg)))))));
+	bool res = (((((zcbor_uint32_put(state, (47)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_aead_decrypt_setup_req_p_handle)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_key)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_aead_generate_nonce_req(zcbor_state_t *state,
@@ -1054,7 +789,7 @@ static bool encode_psa_aead_generate_nonce_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (48)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_aead_generate_nonce_req_p_handle)))) &&
 		   ((encode_ptr_buf(state, (&(*input).psa_aead_generate_nonce_req_p_nonce)))) &&
@@ -1062,14 +797,8 @@ static bool encode_psa_aead_generate_nonce_req(zcbor_state_t *state,
 		   ((encode_ptr_uint(state,
 				     (&(*input).psa_aead_generate_nonce_req_p_nonce_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_aead_set_nonce_req(zcbor_state_t *state,
@@ -1077,20 +806,13 @@ static bool encode_psa_aead_set_nonce_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (49)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_aead_set_nonce_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_aead_set_nonce_req_p_nonce)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_aead_set_nonce_req_nonce_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (49)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_aead_set_nonce_req_p_handle)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_aead_set_nonce_req_p_nonce)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_aead_set_nonce_req_nonce_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_aead_set_lengths_req(zcbor_state_t *state,
@@ -1098,20 +820,14 @@ static bool encode_psa_aead_set_lengths_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		((zcbor_uint32_put(state, (50)))) &&
 		((encode_ptr_uint(state, (&(*input).psa_aead_set_lengths_req_p_handle)))) &&
 		((encode_buf_len(state, (&(*input).psa_aead_set_lengths_req_ad_length)))) &&
 		((encode_buf_len(state, (&(*input).psa_aead_set_lengths_req_plaintext_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_aead_update_ad_req(zcbor_state_t *state,
@@ -1119,20 +835,13 @@ static bool encode_psa_aead_update_ad_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (51)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_aead_update_ad_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_aead_update_ad_req_p_input)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_aead_update_ad_req_input_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (51)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_aead_update_ad_req_p_handle)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_aead_update_ad_req_p_input)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_aead_update_ad_req_input_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_aead_update_req(zcbor_state_t *state,
@@ -1140,7 +849,7 @@ static bool encode_psa_aead_update_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (52)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_aead_update_req_p_handle)))) &&
 		   ((encode_ptr_buf(state, (&(*input).psa_aead_update_req_p_input)))) &&
@@ -1149,14 +858,8 @@ static bool encode_psa_aead_update_req(zcbor_state_t *state,
 		   ((encode_buf_len(state, (&(*input).psa_aead_update_req_output_size)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_aead_update_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_aead_finish_req(zcbor_state_t *state,
@@ -1164,7 +867,7 @@ static bool encode_psa_aead_finish_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (53)))) &&
 		 ((encode_ptr_uint(state, (&(*input).psa_aead_finish_req_p_handle)))) &&
 		 ((encode_ptr_buf(state, (&(*input).psa_aead_finish_req_p_ciphertext)))) &&
@@ -1174,14 +877,8 @@ static bool encode_psa_aead_finish_req(zcbor_state_t *state,
 		 ((encode_buf_len(state, (&(*input).psa_aead_finish_req_tag_size)))) &&
 		 ((encode_ptr_uint(state, (&(*input).psa_aead_finish_req_p_tag_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_aead_verify_req(zcbor_state_t *state,
@@ -1189,7 +886,7 @@ static bool encode_psa_aead_verify_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (54)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_aead_verify_req_p_handle)))) &&
 		   ((encode_ptr_buf(state, (&(*input).psa_aead_verify_req_p_plaintext)))) &&
@@ -1198,31 +895,19 @@ static bool encode_psa_aead_verify_req(zcbor_state_t *state,
 		   ((encode_ptr_buf(state, (&(*input).psa_aead_verify_req_p_tag)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_aead_verify_req_tag_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_aead_abort_req(zcbor_state_t *state, const struct psa_aead_abort_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((((zcbor_uint32_put(state, (55)))) &&
-			     ((encode_ptr_uint(state, (&(*input).psa_aead_abort_req_p_handle)))))));
+	bool res = (((((zcbor_uint32_put(state, (55)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_aead_abort_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_sign_message_req(zcbor_state_t *state,
@@ -1230,7 +915,7 @@ static bool encode_psa_sign_message_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (56)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_alg)))) &&
@@ -1240,14 +925,8 @@ static bool encode_psa_sign_message_req(zcbor_state_t *state,
 		 ((encode_buf_len(state, (&(*input).psa_sign_message_req_signature_size)))) &&
 		 ((encode_ptr_uint(state, (&(*input).psa_sign_message_req_p_signature_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_verify_message_req(zcbor_state_t *state,
@@ -1255,7 +934,7 @@ static bool encode_psa_verify_message_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (57)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_alg)))) &&
@@ -1264,21 +943,15 @@ static bool encode_psa_verify_message_req(zcbor_state_t *state,
 		 ((encode_ptr_buf(state, (&(*input).psa_verify_message_req_p_signature)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_verify_message_req_signature_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_sign_hash_req(zcbor_state_t *state, const struct psa_sign_hash_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (58)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_alg)))) &&
@@ -1288,14 +961,8 @@ static bool encode_psa_sign_hash_req(zcbor_state_t *state, const struct psa_sign
 		   ((encode_buf_len(state, (&(*input).psa_sign_hash_req_signature_size)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_sign_hash_req_p_signature_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_verify_hash_req(zcbor_state_t *state,
@@ -1303,7 +970,7 @@ static bool encode_psa_verify_hash_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (59)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_alg)))) &&
@@ -1312,14 +979,8 @@ static bool encode_psa_verify_hash_req(zcbor_state_t *state,
 		   ((encode_ptr_buf(state, (&(*input).psa_verify_hash_req_p_signature)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_verify_hash_req_signature_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_asymmetric_encrypt_req(zcbor_state_t *state,
@@ -1327,7 +988,7 @@ static bool encode_psa_asymmetric_encrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (60)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_alg)))) &&
@@ -1340,14 +1001,8 @@ static bool encode_psa_asymmetric_encrypt_req(zcbor_state_t *state,
 		   ((encode_ptr_uint(state,
 				     (&(*input).psa_asymmetric_encrypt_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_asymmetric_decrypt_req(zcbor_state_t *state,
@@ -1355,7 +1010,7 @@ static bool encode_psa_asymmetric_decrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (61)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_alg)))) &&
@@ -1368,14 +1023,8 @@ static bool encode_psa_asymmetric_decrypt_req(zcbor_state_t *state,
 		   ((encode_ptr_uint(state,
 				     (&(*input).psa_asymmetric_decrypt_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_key_derivation_setup_req(zcbor_state_t *state,
@@ -1383,19 +1032,13 @@ static bool encode_psa_key_derivation_setup_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (62)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_key_derivation_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_setup_req_alg)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1404,21 +1047,15 @@ encode_psa_key_derivation_get_capacity_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (63)))) &&
 		   ((zcbor_uint32_encode(
 			   state, (&(*input).psa_key_derivation_get_capacity_req_handle)))) &&
 		   ((encode_ptr_uint(
 			   state, (&(*input).psa_key_derivation_get_capacity_req_p_capacity)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1427,21 +1064,14 @@ encode_psa_key_derivation_set_capacity_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (64)))) &&
-		   ((encode_ptr_uint(state,
-				     (&(*input).psa_key_derivation_set_capacity_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_set_capacity_req_capacity)))))));
+	bool res = (((((zcbor_uint32_put(state, (64)))) &&
+		      ((encode_ptr_uint(
+			      state, (&(*input).psa_key_derivation_set_capacity_req_p_handle)))) &&
+		      ((zcbor_uint32_encode(
+			      state, (&(*input).psa_key_derivation_set_capacity_req_capacity)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1450,7 +1080,7 @@ encode_psa_key_derivation_input_bytes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (65)))) &&
 		 ((encode_ptr_uint(state,
 				   (&(*input).psa_key_derivation_input_bytes_req_p_handle)))) &&
@@ -1460,14 +1090,8 @@ encode_psa_key_derivation_input_bytes_req(zcbor_state_t *state,
 		 ((encode_buf_len(state,
 				  (&(*input).psa_key_derivation_input_bytes_req_data_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_key_derivation_input_integer_req(
@@ -1475,23 +1099,16 @@ static bool encode_psa_key_derivation_input_integer_req(
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (66)))) &&
-		   ((encode_ptr_uint(state,
-				     (&(*input).psa_key_derivation_input_integer_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state,
-					 (&(*input).psa_key_derivation_input_integer_req_step)))) &&
-		   ((zcbor_uint32_encode(
-			   state, (&(*input).psa_key_derivation_input_integer_req_value)))))));
+	bool res = (((((zcbor_uint32_put(state, (66)))) &&
+		      ((encode_ptr_uint(
+			      state, (&(*input).psa_key_derivation_input_integer_req_p_handle)))) &&
+		      ((zcbor_uint32_encode(
+			      state, (&(*input).psa_key_derivation_input_integer_req_step)))) &&
+		      ((zcbor_uint32_encode(
+			      state, (&(*input).psa_key_derivation_input_integer_req_value)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1500,20 +1117,14 @@ encode_psa_key_derivation_input_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		((zcbor_uint32_put(state, (67)))) &&
 		((encode_ptr_uint(state, (&(*input).psa_key_derivation_input_key_req_p_handle)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_input_key_req_step)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_key_derivation_input_key_req_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_key_derivation_key_agreement_req(
@@ -1521,7 +1132,7 @@ static bool encode_psa_key_derivation_key_agreement_req(
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (68)))) &&
 		   ((encode_ptr_uint(state,
 				     (&(*input).psa_key_derivation_key_agreement_req_p_handle)))) &&
@@ -1535,14 +1146,8 @@ static bool encode_psa_key_derivation_key_agreement_req(
 			   state,
 			   (&(*input).psa_key_derivation_key_agreement_req_peer_key_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1551,7 +1156,7 @@ encode_psa_key_derivation_output_bytes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (69)))) &&
 		 ((encode_ptr_uint(state,
 				   (&(*input).psa_key_derivation_output_bytes_req_p_handle)))) &&
@@ -1560,14 +1165,8 @@ encode_psa_key_derivation_output_bytes_req(zcbor_state_t *state,
 		 ((encode_buf_len(
 			 state, (&(*input).psa_key_derivation_output_bytes_req_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool
@@ -1576,7 +1175,7 @@ encode_psa_key_derivation_output_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (70)))) &&
 		 ((encode_ptr_attr(state,
 				   (&(*input).psa_key_derivation_output_key_req_p_attributes)))) &&
@@ -1584,14 +1183,8 @@ encode_psa_key_derivation_output_key_req(zcbor_state_t *state,
 				   (&(*input).psa_key_derivation_output_key_req_p_handle)))) &&
 		 ((encode_ptr_key(state, (&(*input).psa_key_derivation_output_key_req_p_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_key_derivation_abort_req(zcbor_state_t *state,
@@ -1599,18 +1192,12 @@ static bool encode_psa_key_derivation_abort_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (71)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_key_derivation_abort_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_raw_key_agreement_req(zcbor_state_t *state,
@@ -1618,7 +1205,7 @@ static bool encode_psa_raw_key_agreement_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		((zcbor_uint32_put(state, (72)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_alg)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_private_key)))) &&
@@ -1629,14 +1216,8 @@ static bool encode_psa_raw_key_agreement_req(zcbor_state_t *state,
 		((encode_ptr_uint(state,
 				  (&(*input).psa_raw_key_agreement_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_generate_random_req(zcbor_state_t *state,
@@ -1644,19 +1225,12 @@ static bool encode_psa_generate_random_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (73)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_generate_random_req_p_output)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_generate_random_req_output_size)))))));
+	bool res = (((((zcbor_uint32_put(state, (73)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_generate_random_req_p_output)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_generate_random_req_output_size)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_generate_key_req(zcbor_state_t *state,
@@ -1664,56 +1238,36 @@ static bool encode_psa_generate_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (74)))) &&
-		   ((encode_ptr_attr(state, (&(*input).psa_generate_key_req_p_attributes)))) &&
-		   ((encode_ptr_key(state, (&(*input).psa_generate_key_req_p_key)))))));
+	bool res = (((((zcbor_uint32_put(state, (74)))) &&
+		      ((encode_ptr_attr(state, (&(*input).psa_generate_key_req_p_attributes)))) &&
+		      ((encode_ptr_key(state, (&(*input).psa_generate_key_req_p_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_ptr_cipher(zcbor_state_t *state, const uint32_t *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		((zcbor_tag_put(state, 32775) && (zcbor_uint32_encode(state, (&(*input))))));
+	bool res = ((zcbor_tag_put(state, 32775) && (zcbor_uint32_encode(state, (&(*input))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_pake_setup_req(zcbor_state_t *state, const struct psa_pake_setup_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (79)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_pake_setup_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_setup_req_password_key)))) &&
 		   ((encode_ptr_cipher(state, (&(*input).psa_pake_setup_req_p_cipher_suite)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_pake_set_role_req(zcbor_state_t *state,
@@ -1721,19 +1275,12 @@ static bool encode_psa_pake_set_role_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (80)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_role_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_role_req_role)))))));
+	bool res = (((((zcbor_uint32_put(state, (80)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_pake_set_role_req_p_handle)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_pake_set_role_req_role)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_pake_set_user_req(zcbor_state_t *state,
@@ -1741,20 +1288,13 @@ static bool encode_psa_pake_set_user_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (81)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_user_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_pake_set_user_req_p_user_id)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_pake_set_user_req_user_id_len)))))));
+	bool res = (((((zcbor_uint32_put(state, (81)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_pake_set_user_req_p_handle)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_pake_set_user_req_p_user_id)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_pake_set_user_req_user_id_len)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_pake_set_peer_req(zcbor_state_t *state,
@@ -1762,20 +1302,13 @@ static bool encode_psa_pake_set_peer_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (82)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_peer_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_pake_set_peer_req_p_peer_id)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_pake_set_peer_req_peer_id_len)))))));
+	bool res = (((((zcbor_uint32_put(state, (82)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_pake_set_peer_req_p_handle)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_pake_set_peer_req_p_peer_id)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_pake_set_peer_req_peer_id_len)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_pake_set_context_req(zcbor_state_t *state,
@@ -1783,20 +1316,14 @@ static bool encode_psa_pake_set_context_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (83)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_context_req_p_handle)))) &&
 		   ((encode_ptr_buf(state, (&(*input).psa_pake_set_context_req_p_context)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_pake_set_context_req_context_len)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_pake_output_req(zcbor_state_t *state,
@@ -1804,7 +1331,7 @@ static bool encode_psa_pake_output_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
+	bool res =
 		(((((zcbor_uint32_put(state, (84)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_pake_output_req_p_handle)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_output_req_step)))) &&
@@ -1812,35 +1339,22 @@ static bool encode_psa_pake_output_req(zcbor_state_t *state,
 		   ((encode_buf_len(state, (&(*input).psa_pake_output_req_output_size)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_pake_output_req_p_output_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_pake_input_req(zcbor_state_t *state, const struct psa_pake_input_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((((zcbor_uint32_put(state, (85)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_pake_input_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_input_req_step)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_pake_input_req_p_input)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_pake_input_req_input_length)))))));
+	bool res = (((((zcbor_uint32_put(state, (85)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_pake_input_req_p_handle)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_pake_input_req_step)))) &&
+		      ((encode_ptr_buf(state, (&(*input).psa_pake_input_req_p_input)))) &&
+		      ((encode_buf_len(state, (&(*input).psa_pake_input_req_input_length)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_pake_get_shared_key_req(zcbor_state_t *state,
@@ -1848,64 +1362,46 @@ static bool encode_psa_pake_get_shared_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(((zcbor_uint32_put(state, (86)))) &&
 		 ((encode_ptr_uint(state, (&(*input).psa_pake_get_shared_key_req_p_handle)))) &&
 		 ((encode_ptr_attr(state, (&(*input).psa_pake_get_shared_key_req_p_attributes)))) &&
 		 ((encode_ptr_key(state, (&(*input).psa_pake_get_shared_key_req_p_key)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_pake_abort_req(zcbor_state_t *state, const struct psa_pake_abort_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((((zcbor_uint32_put(state, (87)))) &&
-			     ((encode_ptr_uint(state, (&(*input).psa_pake_abort_req_p_handle)))))));
+	bool res = (((((zcbor_uint32_put(state, (87)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_pake_abort_req_p_handle)))))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_crypto_rsp(zcbor_state_t *state, const struct psa_crypto_rsp *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((zcbor_list_start_encode(state, 2) &&
-			     ((((zcbor_uint32_encode(state, (&(*input).psa_crypto_rsp_id)))) &&
-			       ((zcbor_int32_encode(state, (&(*input).psa_crypto_rsp_status))))) ||
-			      (zcbor_list_map_end_force_encode(state), false)) &&
-			     zcbor_list_end_encode(state, 2))));
+	bool res = (((zcbor_list_start_encode(state, 2) &&
+		      ((((zcbor_uint32_encode(state, (&(*input).psa_crypto_rsp_id)))) &&
+			((zcbor_int32_encode(state, (&(*input).psa_crypto_rsp_status))))) ||
+		       (zcbor_list_map_end_force_encode(state), false)) &&
+		      zcbor_list_end_encode(state, 2))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_psa_crypto_req(zcbor_state_t *state, const struct psa_crypto_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((zcbor_list_start_encode(state, 12) && ((((((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_crypto_init_req_m_c) ? ((zcbor_uint32_put(state, (10))))
+	bool res = (((zcbor_list_start_encode(state, 12) && ((((((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_crypto_init_req_m_c) ? ((zcbor_uint32_put(state, (10))))
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_get_key_attributes_req_m_c) ? ((encode_psa_get_key_attributes_req(state, (&(*input).psa_crypto_req_msg_psa_get_key_attributes_req_m))))
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_reset_key_attributes_req_m_c) ? ((encode_psa_reset_key_attributes_req(state, (&(*input).psa_crypto_req_msg_psa_reset_key_attributes_req_m))))
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_purge_key_req_m_c) ? ((encode_psa_purge_key_req(state, (&(*input).psa_crypto_req_msg_psa_purge_key_req_m))))
@@ -1981,14 +1477,8 @@ static bool encode_psa_crypto_req(zcbor_state_t *state, const struct psa_crypto_
 	: (((*input).psa_crypto_req_msg_choice == psa_crypto_req_msg_psa_pake_abort_req_m_c) ? ((encode_psa_pake_abort_req(state, (&(*input).psa_crypto_req_msg_psa_pake_abort_req_m))))
 	: false)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) || (zcbor_list_map_end_force_encode(state), false)) && zcbor_list_end_encode(state, 12))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 int cbor_encode_psa_crypto_req(uint8_t *payload, size_t payload_len,

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_encode.c
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_encode.c
@@ -39,13 +39,15 @@ static bool encode_psa_get_key_attributes_req(zcbor_state_t *state,
 static bool encode_psa_reset_key_attributes_req(zcbor_state_t *state,
 						const struct psa_reset_key_attributes_req *input);
 static bool encode_psa_purge_key_req(zcbor_state_t *state, const struct psa_purge_key_req *input);
+static bool encode_ptr_const_attr(zcbor_state_t *state, const uint32_t *input);
 static bool encode_ptr_key(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_copy_key_req(zcbor_state_t *state, const struct psa_copy_key_req *input);
 static bool encode_psa_destroy_key_req(zcbor_state_t *state,
 				       const struct psa_destroy_key_req *input);
-static bool encode_ptr_buf(zcbor_state_t *state, const uint32_t *input);
+static bool encode_ptr_const_buf(zcbor_state_t *state, const uint32_t *input);
 static bool encode_buf_len(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_import_key_req(zcbor_state_t *state, const struct psa_import_key_req *input);
+static bool encode_ptr_buf(zcbor_state_t *state, const uint32_t *input);
 static bool encode_ptr_uint(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_export_key_req(zcbor_state_t *state, const struct psa_export_key_req *input);
 static bool encode_psa_export_public_key_req(zcbor_state_t *state,
@@ -160,7 +162,7 @@ static bool encode_psa_generate_random_req(zcbor_state_t *state,
 					   const struct psa_generate_random_req *input);
 static bool encode_psa_generate_key_req(zcbor_state_t *state,
 					const struct psa_generate_key_req *input);
-static bool encode_ptr_cipher(zcbor_state_t *state, const uint32_t *input);
+static bool encode_ptr_const_cipher(zcbor_state_t *state, const uint32_t *input);
 static bool encode_psa_pake_setup_req(zcbor_state_t *state, const struct psa_pake_setup_req *input);
 static bool encode_psa_pake_set_role_req(zcbor_state_t *state,
 					 const struct psa_pake_set_role_req *input);
@@ -227,6 +229,16 @@ static bool encode_psa_purge_key_req(zcbor_state_t *state, const struct psa_purg
 	return res;
 }
 
+static bool encode_ptr_const_attr(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = ((zcbor_tag_put(state, 32777) && (zcbor_uint32_encode(state, (&(*input))))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
 static bool encode_ptr_key(zcbor_state_t *state, const uint32_t *input)
 {
 	zcbor_log("%s\r\n", __func__);
@@ -243,7 +255,7 @@ static bool encode_psa_copy_key_req(zcbor_state_t *state, const struct psa_copy_
 
 	bool res = (((((zcbor_uint32_put(state, (14)))) &&
 		      ((zcbor_uint32_encode(state, (&(*input).psa_copy_key_req_source_key)))) &&
-		      ((encode_ptr_attr(state, (&(*input).psa_copy_key_req_p_attributes)))) &&
+		      ((encode_ptr_const_attr(state, (&(*input).psa_copy_key_req_p_attributes)))) &&
 		      ((encode_ptr_key(state, (&(*input).psa_copy_key_req_p_target_key)))))));
 
 	log_result(state, res, __func__);
@@ -262,11 +274,11 @@ static bool encode_psa_destroy_key_req(zcbor_state_t *state,
 	return res;
 }
 
-static bool encode_ptr_buf(zcbor_state_t *state, const uint32_t *input)
+static bool encode_ptr_const_buf(zcbor_state_t *state, const uint32_t *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = ((zcbor_tag_put(state, 32770) && (zcbor_uint32_encode(state, (&(*input))))));
+	bool res = ((zcbor_tag_put(state, 32776) && (zcbor_uint32_encode(state, (&(*input))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -286,11 +298,22 @@ static bool encode_psa_import_key_req(zcbor_state_t *state, const struct psa_imp
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((((zcbor_uint32_put(state, (16)))) &&
-		      ((encode_ptr_attr(state, (&(*input).psa_import_key_req_p_attributes)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_import_key_req_p_data)))) &&
-		      ((encode_buf_len(state, (&(*input).psa_import_key_req_data_length)))) &&
-		      ((encode_ptr_key(state, (&(*input).psa_import_key_req_p_key)))))));
+	bool res =
+		(((((zcbor_uint32_put(state, (16)))) &&
+		   ((encode_ptr_const_attr(state, (&(*input).psa_import_key_req_p_attributes)))) &&
+		   ((encode_ptr_const_buf(state, (&(*input).psa_import_key_req_p_data)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_import_key_req_data_length)))) &&
+		   ((encode_ptr_key(state, (&(*input).psa_import_key_req_p_key)))))));
+
+	log_result(state, res, __func__);
+	return res;
+}
+
+static bool encode_ptr_buf(zcbor_state_t *state, const uint32_t *input)
+{
+	zcbor_log("%s\r\n", __func__);
+
+	bool res = ((zcbor_tag_put(state, 32770) && (zcbor_uint32_encode(state, (&(*input))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -343,7 +366,7 @@ static bool encode_psa_hash_compute_req(zcbor_state_t *state,
 
 	bool res = (((((zcbor_uint32_put(state, (19)))) &&
 		      ((zcbor_uint32_encode(state, (&(*input).psa_hash_compute_req_alg)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_hash_compute_req_p_input)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_hash_compute_req_p_input)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_hash_compute_req_input_length)))) &&
 		      ((encode_ptr_buf(state, (&(*input).psa_hash_compute_req_p_hash)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_hash_compute_req_hash_size)))) &&
@@ -360,9 +383,9 @@ static bool encode_psa_hash_compare_req(zcbor_state_t *state,
 
 	bool res = (((((zcbor_uint32_put(state, (20)))) &&
 		      ((zcbor_uint32_encode(state, (&(*input).psa_hash_compare_req_alg)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_hash_compare_req_p_input)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_hash_compare_req_p_input)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_hash_compare_req_input_length)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_hash_compare_req_p_hash)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_hash_compare_req_p_hash)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_hash_compare_req_hash_length)))))));
 
 	log_result(state, res, __func__);
@@ -388,7 +411,7 @@ static bool encode_psa_hash_update_req(zcbor_state_t *state,
 
 	bool res = (((((zcbor_uint32_put(state, (22)))) &&
 		      ((encode_ptr_uint(state, (&(*input).psa_hash_update_req_p_handle)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_hash_update_req_p_input)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_hash_update_req_p_input)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_hash_update_req_input_length)))))));
 
 	log_result(state, res, __func__);
@@ -417,7 +440,7 @@ static bool encode_psa_hash_verify_req(zcbor_state_t *state,
 
 	bool res = (((((zcbor_uint32_put(state, (24)))) &&
 		      ((encode_ptr_uint(state, (&(*input).psa_hash_verify_req_p_handle)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_hash_verify_req_p_hash)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_hash_verify_req_p_hash)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_hash_verify_req_hash_length)))))));
 
 	log_result(state, res, __func__);
@@ -455,7 +478,7 @@ static bool encode_psa_mac_compute_req(zcbor_state_t *state,
 	bool res = (((((zcbor_uint32_put(state, (27)))) &&
 		      ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_key)))) &&
 		      ((zcbor_uint32_encode(state, (&(*input).psa_mac_compute_req_alg)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_mac_compute_req_p_input)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_mac_compute_req_p_input)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_mac_compute_req_input_length)))) &&
 		      ((encode_ptr_buf(state, (&(*input).psa_mac_compute_req_p_mac)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_mac_compute_req_mac_size)))) &&
@@ -472,9 +495,9 @@ static bool encode_psa_mac_verify_req(zcbor_state_t *state, const struct psa_mac
 	bool res = (((((zcbor_uint32_put(state, (28)))) &&
 		      ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_key)))) &&
 		      ((zcbor_uint32_encode(state, (&(*input).psa_mac_verify_req_alg)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_mac_verify_req_p_input)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_mac_verify_req_p_input)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_mac_verify_req_input_length)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_mac_verify_req_p_mac)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_mac_verify_req_p_mac)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_mac_verify_req_mac_length)))))));
 
 	log_result(state, res, __func__);
@@ -515,7 +538,7 @@ static bool encode_psa_mac_update_req(zcbor_state_t *state, const struct psa_mac
 
 	bool res = (((((zcbor_uint32_put(state, (31)))) &&
 		      ((encode_ptr_uint(state, (&(*input).psa_mac_update_req_p_handle)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_mac_update_req_p_input)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_mac_update_req_p_input)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_mac_update_req_input_length)))))));
 
 	log_result(state, res, __func__);
@@ -546,7 +569,7 @@ static bool encode_psa_mac_verify_finish_req(zcbor_state_t *state,
 	bool res =
 		(((((zcbor_uint32_put(state, (33)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_mac_verify_finish_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_mac_verify_finish_req_p_mac)))) &&
+		   ((encode_ptr_const_buf(state, (&(*input).psa_mac_verify_finish_req_p_mac)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_mac_verify_finish_req_mac_length)))))));
 
 	log_result(state, res, __func__);
@@ -573,7 +596,7 @@ static bool encode_psa_cipher_encrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (35)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_encrypt_req_alg)))) &&
-		 ((encode_ptr_buf(state, (&(*input).psa_cipher_encrypt_req_p_input)))) &&
+		 ((encode_ptr_const_buf(state, (&(*input).psa_cipher_encrypt_req_p_input)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_cipher_encrypt_req_input_length)))) &&
 		 ((encode_ptr_buf(state, (&(*input).psa_cipher_encrypt_req_p_output)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_cipher_encrypt_req_output_size)))) &&
@@ -592,7 +615,7 @@ static bool encode_psa_cipher_decrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (36)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_cipher_decrypt_req_alg)))) &&
-		 ((encode_ptr_buf(state, (&(*input).psa_cipher_decrypt_req_p_input)))) &&
+		 ((encode_ptr_const_buf(state, (&(*input).psa_cipher_decrypt_req_p_input)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_cipher_decrypt_req_input_length)))) &&
 		 ((encode_ptr_buf(state, (&(*input).psa_cipher_decrypt_req_p_output)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_cipher_decrypt_req_output_size)))) &&
@@ -655,7 +678,7 @@ static bool encode_psa_cipher_set_iv_req(zcbor_state_t *state,
 
 	bool res = (((((zcbor_uint32_put(state, (40)))) &&
 		      ((encode_ptr_uint(state, (&(*input).psa_cipher_set_iv_req_p_handle)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_cipher_set_iv_req_p_iv)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_cipher_set_iv_req_p_iv)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_cipher_set_iv_req_iv_length)))))));
 
 	log_result(state, res, __func__);
@@ -670,7 +693,7 @@ static bool encode_psa_cipher_update_req(zcbor_state_t *state,
 	bool res =
 		(((((zcbor_uint32_put(state, (41)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_cipher_update_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_cipher_update_req_p_input)))) &&
+		   ((encode_ptr_const_buf(state, (&(*input).psa_cipher_update_req_p_input)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_cipher_update_req_input_length)))) &&
 		   ((encode_ptr_buf(state, (&(*input).psa_cipher_update_req_p_output)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_cipher_update_req_output_size)))) &&
@@ -717,12 +740,13 @@ static bool encode_psa_aead_encrypt_req(zcbor_state_t *state,
 		((zcbor_uint32_put(state, (44)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_key)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_aead_encrypt_req_alg)))) &&
-		((encode_ptr_buf(state, (&(*input).psa_aead_encrypt_req_p_nonce)))) &&
+		((encode_ptr_const_buf(state, (&(*input).psa_aead_encrypt_req_p_nonce)))) &&
 		((encode_buf_len(state, (&(*input).psa_aead_encrypt_req_nonce_length)))) &&
-		((encode_ptr_buf(state, (&(*input).psa_aead_encrypt_req_p_additional_data)))) &&
+		((encode_ptr_const_buf(state,
+				       (&(*input).psa_aead_encrypt_req_p_additional_data)))) &&
 		((encode_buf_len(state,
 				 (&(*input).psa_aead_encrypt_req_additional_data_length)))) &&
-		((encode_ptr_buf(state, (&(*input).psa_aead_encrypt_req_p_plaintext)))) &&
+		((encode_ptr_const_buf(state, (&(*input).psa_aead_encrypt_req_p_plaintext)))) &&
 		((encode_buf_len(state, (&(*input).psa_aead_encrypt_req_plaintext_length)))) &&
 		((encode_ptr_buf(state, (&(*input).psa_aead_encrypt_req_p_ciphertext)))) &&
 		((encode_buf_len(state, (&(*input).psa_aead_encrypt_req_ciphertext_size)))) &&
@@ -741,12 +765,13 @@ static bool encode_psa_aead_decrypt_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (45)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_aead_decrypt_req_alg)))) &&
-		 ((encode_ptr_buf(state, (&(*input).psa_aead_decrypt_req_p_nonce)))) &&
+		 ((encode_ptr_const_buf(state, (&(*input).psa_aead_decrypt_req_p_nonce)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_aead_decrypt_req_nonce_length)))) &&
-		 ((encode_ptr_buf(state, (&(*input).psa_aead_decrypt_req_p_additional_data)))) &&
+		 ((encode_ptr_const_buf(state,
+					(&(*input).psa_aead_decrypt_req_p_additional_data)))) &&
 		 ((encode_buf_len(state,
 				  (&(*input).psa_aead_decrypt_req_additional_data_length)))) &&
-		 ((encode_ptr_buf(state, (&(*input).psa_aead_decrypt_req_p_ciphertext)))) &&
+		 ((encode_ptr_const_buf(state, (&(*input).psa_aead_decrypt_req_p_ciphertext)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_aead_decrypt_req_ciphertext_length)))) &&
 		 ((encode_ptr_buf(state, (&(*input).psa_aead_decrypt_req_p_plaintext)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_aead_decrypt_req_plaintext_size)))) &&
@@ -808,7 +833,7 @@ static bool encode_psa_aead_set_nonce_req(zcbor_state_t *state,
 
 	bool res = (((((zcbor_uint32_put(state, (49)))) &&
 		      ((encode_ptr_uint(state, (&(*input).psa_aead_set_nonce_req_p_handle)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_aead_set_nonce_req_p_nonce)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_aead_set_nonce_req_p_nonce)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_aead_set_nonce_req_nonce_length)))))));
 
 	log_result(state, res, __func__);
@@ -820,11 +845,12 @@ static bool encode_psa_aead_set_lengths_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((
-		((zcbor_uint32_put(state, (50)))) &&
-		((encode_ptr_uint(state, (&(*input).psa_aead_set_lengths_req_p_handle)))) &&
-		((encode_buf_len(state, (&(*input).psa_aead_set_lengths_req_ad_length)))) &&
-		((encode_buf_len(state, (&(*input).psa_aead_set_lengths_req_plaintext_length)))))));
+	bool res =
+		(((((zcbor_uint32_put(state, (50)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_aead_set_lengths_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state, (&(*input).psa_aead_set_lengths_req_ad_length)))) &&
+		   ((zcbor_uint32_encode(
+			   state, (&(*input).psa_aead_set_lengths_req_plaintext_length)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -837,7 +863,7 @@ static bool encode_psa_aead_update_ad_req(zcbor_state_t *state,
 
 	bool res = (((((zcbor_uint32_put(state, (51)))) &&
 		      ((encode_ptr_uint(state, (&(*input).psa_aead_update_ad_req_p_handle)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_aead_update_ad_req_p_input)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_aead_update_ad_req_p_input)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_aead_update_ad_req_input_length)))))));
 
 	log_result(state, res, __func__);
@@ -852,7 +878,7 @@ static bool encode_psa_aead_update_req(zcbor_state_t *state,
 	bool res =
 		(((((zcbor_uint32_put(state, (52)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_aead_update_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_aead_update_req_p_input)))) &&
+		   ((encode_ptr_const_buf(state, (&(*input).psa_aead_update_req_p_input)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_aead_update_req_input_length)))) &&
 		   ((encode_ptr_buf(state, (&(*input).psa_aead_update_req_p_output)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_aead_update_req_output_size)))) &&
@@ -892,7 +918,7 @@ static bool encode_psa_aead_verify_req(zcbor_state_t *state,
 		   ((encode_ptr_buf(state, (&(*input).psa_aead_verify_req_p_plaintext)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_aead_verify_req_plaintext_size)))) &&
 		   ((encode_ptr_uint(state, (&(*input).psa_aead_verify_req_p_plaintext_length)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_aead_verify_req_p_tag)))) &&
+		   ((encode_ptr_const_buf(state, (&(*input).psa_aead_verify_req_p_tag)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_aead_verify_req_tag_length)))))));
 
 	log_result(state, res, __func__);
@@ -919,7 +945,7 @@ static bool encode_psa_sign_message_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (56)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_sign_message_req_alg)))) &&
-		 ((encode_ptr_buf(state, (&(*input).psa_sign_message_req_p_input)))) &&
+		 ((encode_ptr_const_buf(state, (&(*input).psa_sign_message_req_p_input)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_sign_message_req_input_length)))) &&
 		 ((encode_ptr_buf(state, (&(*input).psa_sign_message_req_p_signature)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_sign_message_req_signature_size)))) &&
@@ -938,9 +964,9 @@ static bool encode_psa_verify_message_req(zcbor_state_t *state,
 		(((zcbor_uint32_put(state, (57)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_key)))) &&
 		 ((zcbor_uint32_encode(state, (&(*input).psa_verify_message_req_alg)))) &&
-		 ((encode_ptr_buf(state, (&(*input).psa_verify_message_req_p_input)))) &&
+		 ((encode_ptr_const_buf(state, (&(*input).psa_verify_message_req_p_input)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_verify_message_req_input_length)))) &&
-		 ((encode_ptr_buf(state, (&(*input).psa_verify_message_req_p_signature)))) &&
+		 ((encode_ptr_const_buf(state, (&(*input).psa_verify_message_req_p_signature)))) &&
 		 ((encode_buf_len(state, (&(*input).psa_verify_message_req_signature_length)))))));
 
 	log_result(state, res, __func__);
@@ -955,7 +981,7 @@ static bool encode_psa_sign_hash_req(zcbor_state_t *state, const struct psa_sign
 		(((((zcbor_uint32_put(state, (58)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_sign_hash_req_alg)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_sign_hash_req_p_hash)))) &&
+		   ((encode_ptr_const_buf(state, (&(*input).psa_sign_hash_req_p_hash)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_sign_hash_req_hash_length)))) &&
 		   ((encode_ptr_buf(state, (&(*input).psa_sign_hash_req_p_signature)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_sign_hash_req_signature_size)))) &&
@@ -974,9 +1000,9 @@ static bool encode_psa_verify_hash_req(zcbor_state_t *state,
 		(((((zcbor_uint32_put(state, (59)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_key)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).psa_verify_hash_req_alg)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_verify_hash_req_p_hash)))) &&
+		   ((encode_ptr_const_buf(state, (&(*input).psa_verify_hash_req_p_hash)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_verify_hash_req_hash_length)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_verify_hash_req_p_signature)))) &&
+		   ((encode_ptr_const_buf(state, (&(*input).psa_verify_hash_req_p_signature)))) &&
 		   ((encode_buf_len(state, (&(*input).psa_verify_hash_req_signature_length)))))));
 
 	log_result(state, res, __func__);
@@ -988,18 +1014,18 @@ static bool encode_psa_asymmetric_encrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res =
-		(((((zcbor_uint32_put(state, (60)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_alg)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_encrypt_req_p_input)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_asymmetric_encrypt_req_input_length)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_encrypt_req_p_salt)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_asymmetric_encrypt_req_salt_length)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_encrypt_req_p_output)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_asymmetric_encrypt_req_output_size)))) &&
-		   ((encode_ptr_uint(state,
-				     (&(*input).psa_asymmetric_encrypt_req_p_output_length)))))));
+	bool res = ((
+		(((zcbor_uint32_put(state, (60)))) &&
+		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_key)))) &&
+		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_encrypt_req_alg)))) &&
+		 ((encode_ptr_const_buf(state, (&(*input).psa_asymmetric_encrypt_req_p_input)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_asymmetric_encrypt_req_input_length)))) &&
+		 ((encode_ptr_const_buf(state, (&(*input).psa_asymmetric_encrypt_req_p_salt)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_asymmetric_encrypt_req_salt_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_asymmetric_encrypt_req_p_output)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_asymmetric_encrypt_req_output_size)))) &&
+		 ((encode_ptr_uint(state,
+				   (&(*input).psa_asymmetric_encrypt_req_p_output_length)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1010,18 +1036,18 @@ static bool encode_psa_asymmetric_decrypt_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res =
-		(((((zcbor_uint32_put(state, (61)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_key)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_alg)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_decrypt_req_p_input)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_asymmetric_decrypt_req_input_length)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_decrypt_req_p_salt)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_asymmetric_decrypt_req_salt_length)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_asymmetric_decrypt_req_p_output)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_asymmetric_decrypt_req_output_size)))) &&
-		   ((encode_ptr_uint(state,
-				     (&(*input).psa_asymmetric_decrypt_req_p_output_length)))))));
+	bool res = ((
+		(((zcbor_uint32_put(state, (61)))) &&
+		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_key)))) &&
+		 ((zcbor_uint32_encode(state, (&(*input).psa_asymmetric_decrypt_req_alg)))) &&
+		 ((encode_ptr_const_buf(state, (&(*input).psa_asymmetric_decrypt_req_p_input)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_asymmetric_decrypt_req_input_length)))) &&
+		 ((encode_ptr_const_buf(state, (&(*input).psa_asymmetric_decrypt_req_p_salt)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_asymmetric_decrypt_req_salt_length)))) &&
+		 ((encode_ptr_buf(state, (&(*input).psa_asymmetric_decrypt_req_p_output)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_asymmetric_decrypt_req_output_size)))) &&
+		 ((encode_ptr_uint(state,
+				   (&(*input).psa_asymmetric_decrypt_req_p_output_length)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1080,15 +1106,16 @@ encode_psa_key_derivation_input_bytes_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = ((
-		(((zcbor_uint32_put(state, (65)))) &&
-		 ((encode_ptr_uint(state,
-				   (&(*input).psa_key_derivation_input_bytes_req_p_handle)))) &&
-		 ((zcbor_uint32_encode(state,
-				       (&(*input).psa_key_derivation_input_bytes_req_step)))) &&
-		 ((encode_ptr_buf(state, (&(*input).psa_key_derivation_input_bytes_req_p_data)))) &&
-		 ((encode_buf_len(state,
-				  (&(*input).psa_key_derivation_input_bytes_req_data_length)))))));
+	bool res =
+		(((((zcbor_uint32_put(state, (65)))) &&
+		   ((encode_ptr_uint(state,
+				     (&(*input).psa_key_derivation_input_bytes_req_p_handle)))) &&
+		   ((zcbor_uint32_encode(state,
+					 (&(*input).psa_key_derivation_input_bytes_req_step)))) &&
+		   ((encode_ptr_const_buf(
+			   state, (&(*input).psa_key_derivation_input_bytes_req_p_data)))) &&
+		   ((encode_buf_len(
+			   state, (&(*input).psa_key_derivation_input_bytes_req_data_length)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1140,7 +1167,7 @@ static bool encode_psa_key_derivation_key_agreement_req(
 					 (&(*input).psa_key_derivation_key_agreement_req_step)))) &&
 		   ((zcbor_uint32_encode(
 			   state, (&(*input).psa_key_derivation_key_agreement_req_private_key)))) &&
-		   ((encode_ptr_buf(
+		   ((encode_ptr_const_buf(
 			   state, (&(*input).psa_key_derivation_key_agreement_req_p_peer_key)))) &&
 		   ((encode_buf_len(
 			   state,
@@ -1177,8 +1204,8 @@ encode_psa_key_derivation_output_key_req(zcbor_state_t *state,
 
 	bool res = ((
 		(((zcbor_uint32_put(state, (70)))) &&
-		 ((encode_ptr_attr(state,
-				   (&(*input).psa_key_derivation_output_key_req_p_attributes)))) &&
+		 ((encode_ptr_const_attr(
+			 state, (&(*input).psa_key_derivation_output_key_req_p_attributes)))) &&
 		 ((encode_ptr_uint(state,
 				   (&(*input).psa_key_derivation_output_key_req_p_handle)))) &&
 		 ((encode_ptr_key(state, (&(*input).psa_key_derivation_output_key_req_p_key)))))));
@@ -1209,7 +1236,7 @@ static bool encode_psa_raw_key_agreement_req(zcbor_state_t *state,
 		((zcbor_uint32_put(state, (72)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_alg)))) &&
 		((zcbor_uint32_encode(state, (&(*input).psa_raw_key_agreement_req_private_key)))) &&
-		((encode_ptr_buf(state, (&(*input).psa_raw_key_agreement_req_p_peer_key)))) &&
+		((encode_ptr_const_buf(state, (&(*input).psa_raw_key_agreement_req_p_peer_key)))) &&
 		((encode_buf_len(state, (&(*input).psa_raw_key_agreement_req_peer_key_length)))) &&
 		((encode_ptr_buf(state, (&(*input).psa_raw_key_agreement_req_p_output)))) &&
 		((encode_buf_len(state, (&(*input).psa_raw_key_agreement_req_output_size)))) &&
@@ -1238,19 +1265,20 @@ static bool encode_psa_generate_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((((zcbor_uint32_put(state, (74)))) &&
-		      ((encode_ptr_attr(state, (&(*input).psa_generate_key_req_p_attributes)))) &&
-		      ((encode_ptr_key(state, (&(*input).psa_generate_key_req_p_key)))))));
+	bool res = ((
+		(((zcbor_uint32_put(state, (74)))) &&
+		 ((encode_ptr_const_attr(state, (&(*input).psa_generate_key_req_p_attributes)))) &&
+		 ((encode_ptr_key(state, (&(*input).psa_generate_key_req_p_key)))))));
 
 	log_result(state, res, __func__);
 	return res;
 }
 
-static bool encode_ptr_cipher(zcbor_state_t *state, const uint32_t *input)
+static bool encode_ptr_const_cipher(zcbor_state_t *state, const uint32_t *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = ((zcbor_tag_put(state, 32775) && (zcbor_uint32_encode(state, (&(*input))))));
+	bool res = ((zcbor_tag_put(state, 32780) && (zcbor_uint32_encode(state, (&(*input))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1260,11 +1288,11 @@ static bool encode_psa_pake_setup_req(zcbor_state_t *state, const struct psa_pak
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res =
-		(((((zcbor_uint32_put(state, (79)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_pake_setup_req_p_handle)))) &&
-		   ((zcbor_uint32_encode(state, (&(*input).psa_pake_setup_req_password_key)))) &&
-		   ((encode_ptr_cipher(state, (&(*input).psa_pake_setup_req_p_cipher_suite)))))));
+	bool res = (((((zcbor_uint32_put(state, (79)))) &&
+		      ((encode_ptr_uint(state, (&(*input).psa_pake_setup_req_p_handle)))) &&
+		      ((zcbor_uint32_encode(state, (&(*input).psa_pake_setup_req_password_key)))) &&
+		      ((encode_ptr_const_cipher(state,
+						(&(*input).psa_pake_setup_req_p_cipher_suite)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1288,10 +1316,11 @@ static bool encode_psa_pake_set_user_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((((zcbor_uint32_put(state, (81)))) &&
-		      ((encode_ptr_uint(state, (&(*input).psa_pake_set_user_req_p_handle)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_pake_set_user_req_p_user_id)))) &&
-		      ((encode_buf_len(state, (&(*input).psa_pake_set_user_req_user_id_len)))))));
+	bool res =
+		(((((zcbor_uint32_put(state, (81)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_user_req_p_handle)))) &&
+		   ((encode_ptr_const_buf(state, (&(*input).psa_pake_set_user_req_p_user_id)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_pake_set_user_req_user_id_len)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1302,10 +1331,11 @@ static bool encode_psa_pake_set_peer_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((((zcbor_uint32_put(state, (82)))) &&
-		      ((encode_ptr_uint(state, (&(*input).psa_pake_set_peer_req_p_handle)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_pake_set_peer_req_p_peer_id)))) &&
-		      ((encode_buf_len(state, (&(*input).psa_pake_set_peer_req_peer_id_len)))))));
+	bool res =
+		(((((zcbor_uint32_put(state, (82)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_peer_req_p_handle)))) &&
+		   ((encode_ptr_const_buf(state, (&(*input).psa_pake_set_peer_req_p_peer_id)))) &&
+		   ((encode_buf_len(state, (&(*input).psa_pake_set_peer_req_peer_id_len)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1316,11 +1346,11 @@ static bool encode_psa_pake_set_context_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res =
-		(((((zcbor_uint32_put(state, (83)))) &&
-		   ((encode_ptr_uint(state, (&(*input).psa_pake_set_context_req_p_handle)))) &&
-		   ((encode_ptr_buf(state, (&(*input).psa_pake_set_context_req_p_context)))) &&
-		   ((encode_buf_len(state, (&(*input).psa_pake_set_context_req_context_len)))))));
+	bool res = ((
+		(((zcbor_uint32_put(state, (83)))) &&
+		 ((encode_ptr_uint(state, (&(*input).psa_pake_set_context_req_p_handle)))) &&
+		 ((encode_ptr_const_buf(state, (&(*input).psa_pake_set_context_req_p_context)))) &&
+		 ((encode_buf_len(state, (&(*input).psa_pake_set_context_req_context_len)))))));
 
 	log_result(state, res, __func__);
 	return res;
@@ -1350,7 +1380,7 @@ static bool encode_psa_pake_input_req(zcbor_state_t *state, const struct psa_pak
 	bool res = (((((zcbor_uint32_put(state, (85)))) &&
 		      ((encode_ptr_uint(state, (&(*input).psa_pake_input_req_p_handle)))) &&
 		      ((zcbor_uint32_encode(state, (&(*input).psa_pake_input_req_step)))) &&
-		      ((encode_ptr_buf(state, (&(*input).psa_pake_input_req_p_input)))) &&
+		      ((encode_ptr_const_buf(state, (&(*input).psa_pake_input_req_p_input)))) &&
 		      ((encode_buf_len(state, (&(*input).psa_pake_input_req_input_length)))))));
 
 	log_result(state, res, __func__);
@@ -1362,11 +1392,12 @@ static bool encode_psa_pake_get_shared_key_req(zcbor_state_t *state,
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = ((
-		(((zcbor_uint32_put(state, (86)))) &&
-		 ((encode_ptr_uint(state, (&(*input).psa_pake_get_shared_key_req_p_handle)))) &&
-		 ((encode_ptr_attr(state, (&(*input).psa_pake_get_shared_key_req_p_attributes)))) &&
-		 ((encode_ptr_key(state, (&(*input).psa_pake_get_shared_key_req_p_key)))))));
+	bool res =
+		(((((zcbor_uint32_put(state, (86)))) &&
+		   ((encode_ptr_uint(state, (&(*input).psa_pake_get_shared_key_req_p_handle)))) &&
+		   ((encode_ptr_const_attr(
+			   state, (&(*input).psa_pake_get_shared_key_req_p_attributes)))) &&
+		   ((encode_ptr_key(state, (&(*input).psa_pake_get_shared_key_req_p_key)))))));
 
 	log_result(state, res, __func__);
 	return res;

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_encode.h
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_encode.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.99
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_types.h
+++ b/subsys/sdfw_services/services/psa_crypto/zcbor_generated/psa_crypto_service_types.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.99
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/reset_evt/zcbor_generated/CMakeLists.txt
+++ b/subsys/sdfw_services/services/reset_evt/zcbor_generated/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2025 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #

--- a/subsys/sdfw_services/services/reset_evt/zcbor_generated/reset_evt_service_decode.c
+++ b/subsys/sdfw_services/services/reset_evt/zcbor_generated/reset_evt_service_decode.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -22,6 +22,17 @@
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
 
+#define log_result(state, result, func)                                                            \
+	do {                                                                                       \
+		if (!result) {                                                                     \
+			zcbor_trace_file(state);                                                   \
+			zcbor_log("%s error: %s\r\n", func,                                        \
+				  zcbor_error_str(zcbor_peek_error(state)));                       \
+		} else {                                                                           \
+			zcbor_log("%s success\r\n", func);                                         \
+		}                                                                                  \
+	} while (0)
+
 static bool decode_reset_evt_notif(zcbor_state_t *state, struct reset_evt_notif *result);
 static bool decode_reset_evt_sub_rsp(zcbor_state_t *state, int32_t *result);
 static bool decode_reset_evt_sub_req(zcbor_state_t *state, bool *result);
@@ -30,59 +41,40 @@ static bool decode_reset_evt_notif(zcbor_state_t *state, struct reset_evt_notif 
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((zcbor_list_start_decode(state) &&
-		   ((((zcbor_uint32_decode(state, (&(*result).reset_evt_notif_domains)))) &&
-		     ((zcbor_uint32_decode(state, (&(*result).reset_evt_notif_delay_ms))))) ||
-		    (zcbor_list_map_end_force_decode(state), false)) &&
-		   zcbor_list_end_decode(state))));
+	bool res = (((zcbor_list_start_decode(state) &&
+		      ((((zcbor_uint32_decode(state, (&(*result).reset_evt_notif_domains)))) &&
+			((zcbor_uint32_decode(state, (&(*result).reset_evt_notif_delay_ms))))) ||
+		       (zcbor_list_map_end_force_decode(state), false)) &&
+		      zcbor_list_end_decode(state))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_reset_evt_sub_rsp(zcbor_state_t *state, int32_t *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((zcbor_list_start_decode(state) &&
-			     ((((zcbor_int32_decode(state, (&(*result)))))) ||
-			      (zcbor_list_map_end_force_decode(state), false)) &&
-			     zcbor_list_end_decode(state))));
+	bool res = (((zcbor_list_start_decode(state) &&
+		      ((((zcbor_int32_decode(state, (&(*result)))))) ||
+		       (zcbor_list_map_end_force_decode(state), false)) &&
+		      zcbor_list_end_decode(state))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_reset_evt_sub_req(zcbor_state_t *state, bool *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((zcbor_list_start_decode(state) &&
-			     ((((zcbor_bool_decode(state, (&(*result)))))) ||
-			      (zcbor_list_map_end_force_decode(state), false)) &&
-			     zcbor_list_end_decode(state))));
+	bool res = (((zcbor_list_start_decode(state) &&
+		      ((((zcbor_bool_decode(state, (&(*result)))))) ||
+		       (zcbor_list_map_end_force_decode(state), false)) &&
+		      zcbor_list_end_decode(state))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 int cbor_decode_reset_evt_sub_req(const uint8_t *payload, size_t payload_len, bool *result,

--- a/subsys/sdfw_services/services/reset_evt/zcbor_generated/reset_evt_service_decode.h
+++ b/subsys/sdfw_services/services/reset_evt/zcbor_generated/reset_evt_service_decode.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/reset_evt/zcbor_generated/reset_evt_service_encode.c
+++ b/subsys/sdfw_services/services/reset_evt/zcbor_generated/reset_evt_service_encode.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -22,6 +22,17 @@
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
 
+#define log_result(state, result, func)                                                            \
+	do {                                                                                       \
+		if (!result) {                                                                     \
+			zcbor_trace_file(state);                                                   \
+			zcbor_log("%s error: %s\r\n", func,                                        \
+				  zcbor_error_str(zcbor_peek_error(state)));                       \
+		} else {                                                                           \
+			zcbor_log("%s success\r\n", func);                                         \
+		}                                                                                  \
+	} while (0)
+
 static bool encode_reset_evt_notif(zcbor_state_t *state, const struct reset_evt_notif *input);
 static bool encode_reset_evt_sub_rsp(zcbor_state_t *state, const int32_t *input);
 static bool encode_reset_evt_sub_req(zcbor_state_t *state, const bool *input);
@@ -30,59 +41,40 @@ static bool encode_reset_evt_notif(zcbor_state_t *state, const struct reset_evt_
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result =
-		(((zcbor_list_start_encode(state, 2) &&
-		   ((((zcbor_uint32_encode(state, (&(*input).reset_evt_notif_domains)))) &&
-		     ((zcbor_uint32_encode(state, (&(*input).reset_evt_notif_delay_ms))))) ||
-		    (zcbor_list_map_end_force_encode(state), false)) &&
-		   zcbor_list_end_encode(state, 2))));
+	bool res = (((zcbor_list_start_encode(state, 2) &&
+		      ((((zcbor_uint32_encode(state, (&(*input).reset_evt_notif_domains)))) &&
+			((zcbor_uint32_encode(state, (&(*input).reset_evt_notif_delay_ms))))) ||
+		       (zcbor_list_map_end_force_encode(state), false)) &&
+		      zcbor_list_end_encode(state, 2))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_reset_evt_sub_rsp(zcbor_state_t *state, const int32_t *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((zcbor_list_start_encode(state, 1) &&
-			     ((((zcbor_int32_encode(state, (&(*input)))))) ||
-			      (zcbor_list_map_end_force_encode(state), false)) &&
-			     zcbor_list_end_encode(state, 1))));
+	bool res = (((zcbor_list_start_encode(state, 1) &&
+		      ((((zcbor_int32_encode(state, (&(*input)))))) ||
+		       (zcbor_list_map_end_force_encode(state), false)) &&
+		      zcbor_list_end_encode(state, 1))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_reset_evt_sub_req(zcbor_state_t *state, const bool *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((zcbor_list_start_encode(state, 1) &&
-			     ((((zcbor_bool_encode(state, (&(*input)))))) ||
-			      (zcbor_list_map_end_force_encode(state), false)) &&
-			     zcbor_list_end_encode(state, 1))));
+	bool res = (((zcbor_list_start_encode(state, 1) &&
+		      ((((zcbor_bool_encode(state, (&(*input)))))) ||
+		       (zcbor_list_map_end_force_encode(state), false)) &&
+		      zcbor_list_end_encode(state, 1))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 int cbor_encode_reset_evt_sub_req(uint8_t *payload, size_t payload_len, const bool *input,

--- a/subsys/sdfw_services/services/reset_evt/zcbor_generated/reset_evt_service_encode.h
+++ b/subsys/sdfw_services/services/reset_evt/zcbor_generated/reset_evt_service_encode.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/reset_evt/zcbor_generated/reset_evt_service_types.h
+++ b/subsys/sdfw_services/services/reset_evt/zcbor_generated/reset_evt_service_types.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/sdfw_update/zcbor_generated/CMakeLists.txt
+++ b/subsys/sdfw_services/services/sdfw_update/zcbor_generated/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2025 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #

--- a/subsys/sdfw_services/services/sdfw_update/zcbor_generated/sdfw_update_service_decode.c
+++ b/subsys/sdfw_services/services/sdfw_update/zcbor_generated/sdfw_update_service_decode.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -22,6 +22,17 @@
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
 
+#define log_result(state, result, func)                                                            \
+	do {                                                                                       \
+		if (!result) {                                                                     \
+			zcbor_trace_file(state);                                                   \
+			zcbor_log("%s error: %s\r\n", func,                                        \
+				  zcbor_error_str(zcbor_peek_error(state)));                       \
+		} else {                                                                           \
+			zcbor_log("%s success\r\n", func);                                         \
+		}                                                                                  \
+	} while (0)
+
 static bool decode_sdfw_update_rsp(zcbor_state_t *state, int32_t *result);
 static bool decode_sdfw_update_req(zcbor_state_t *state, struct sdfw_update_req *result);
 
@@ -29,26 +40,20 @@ static bool decode_sdfw_update_rsp(zcbor_state_t *state, int32_t *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((zcbor_list_start_decode(state) &&
-			     ((((zcbor_int32_decode(state, (&(*result)))))) ||
-			      (zcbor_list_map_end_force_decode(state), false)) &&
-			     zcbor_list_end_decode(state))));
+	bool res = (((zcbor_list_start_decode(state) &&
+		      ((((zcbor_int32_decode(state, (&(*result)))))) ||
+		       (zcbor_list_map_end_force_decode(state), false)) &&
+		      zcbor_list_end_decode(state))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool decode_sdfw_update_req(zcbor_state_t *state, struct sdfw_update_req *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((
+	bool res = (((
 		zcbor_list_start_decode(state) &&
 		((((zcbor_uint32_decode(state, (&(*result).sdfw_update_req_tbs_addr)))) &&
 		  ((zcbor_uint32_decode(state, (&(*result).sdfw_update_req_dl_max)))) &&
@@ -58,14 +63,8 @@ static bool decode_sdfw_update_req(zcbor_state_t *state, struct sdfw_update_req 
 		 (zcbor_list_map_end_force_decode(state), false)) &&
 		zcbor_list_end_decode(state))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 int cbor_decode_sdfw_update_req(const uint8_t *payload, size_t payload_len,

--- a/subsys/sdfw_services/services/sdfw_update/zcbor_generated/sdfw_update_service_decode.h
+++ b/subsys/sdfw_services/services/sdfw_update/zcbor_generated/sdfw_update_service_decode.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/sdfw_update/zcbor_generated/sdfw_update_service_encode.c
+++ b/subsys/sdfw_services/services/sdfw_update/zcbor_generated/sdfw_update_service_encode.c
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -22,6 +22,17 @@
 #error "The type file was generated with a different default_max_qty than this file"
 #endif
 
+#define log_result(state, result, func)                                                            \
+	do {                                                                                       \
+		if (!result) {                                                                     \
+			zcbor_trace_file(state);                                                   \
+			zcbor_log("%s error: %s\r\n", func,                                        \
+				  zcbor_error_str(zcbor_peek_error(state)));                       \
+		} else {                                                                           \
+			zcbor_log("%s success\r\n", func);                                         \
+		}                                                                                  \
+	} while (0)
+
 static bool encode_sdfw_update_rsp(zcbor_state_t *state, const int32_t *input);
 static bool encode_sdfw_update_req(zcbor_state_t *state, const struct sdfw_update_req *input);
 
@@ -29,26 +40,20 @@ static bool encode_sdfw_update_rsp(zcbor_state_t *state, const int32_t *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = (((zcbor_list_start_encode(state, 1) &&
-			     ((((zcbor_int32_encode(state, (&(*input)))))) ||
-			      (zcbor_list_map_end_force_encode(state), false)) &&
-			     zcbor_list_end_encode(state, 1))));
+	bool res = (((zcbor_list_start_encode(state, 1) &&
+		      ((((zcbor_int32_encode(state, (&(*input)))))) ||
+		       (zcbor_list_map_end_force_encode(state), false)) &&
+		      zcbor_list_end_encode(state, 1))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 static bool encode_sdfw_update_req(zcbor_state_t *state, const struct sdfw_update_req *input)
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool tmp_result = ((
+	bool res = ((
 		(zcbor_list_start_encode(state, 5) &&
 		 ((((zcbor_uint32_encode(state, (&(*input).sdfw_update_req_tbs_addr)))) &&
 		   ((zcbor_uint32_encode(state, (&(*input).sdfw_update_req_dl_max)))) &&
@@ -58,14 +63,8 @@ static bool encode_sdfw_update_req(zcbor_state_t *state, const struct sdfw_updat
 		  (zcbor_list_map_end_force_encode(state), false)) &&
 		 zcbor_list_end_encode(state, 5))));
 
-	if (!tmp_result) {
-		zcbor_trace_file(state);
-		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
-	} else {
-		zcbor_log("%s success\r\n", __func__);
-	}
-
-	return tmp_result;
+	log_result(state, res, __func__);
+	return res;
 }
 
 int cbor_encode_sdfw_update_req(uint8_t *payload, size_t payload_len,

--- a/subsys/sdfw_services/services/sdfw_update/zcbor_generated/sdfw_update_service_encode.h
+++ b/subsys/sdfw_services/services/sdfw_update/zcbor_generated/sdfw_update_service_encode.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/subsys/sdfw_services/services/sdfw_update/zcbor_generated/sdfw_update_service_types.h
+++ b/subsys/sdfw_services/services/sdfw_update/zcbor_generated/sdfw_update_service_types.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /*
- * Generated using zcbor version 0.8.1
+ * Generated using zcbor version 0.9.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */


### PR DESCRIPTION
Relevant changes are in the second commit.

The first commit is just regenerating zcbor code.