### PR TITLE
doc: nrf util: usb driver prerequisite for win

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_gs.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_gs.rst
@@ -46,27 +46,8 @@ You also need the following:
 
 * `Git`_ or `Git for Windows`_ (on Linux and Mac, or Windows, respectively)
 * `curl`_
-* SEGGER J-Link |jlink_ver| and, on Windows, also the SEGGER USB Driver for J-Link from `SEGGER J-Link`_ |jlink_ver|
-
-   .. note::
-      To install the SEGGER USB Driver for J-Link on Windows, manually install J-Link |jlink_ver| from the command line using the ``-InstUSBDriver=1`` parameter:
-
-      1. Navigate to the download location of the J-Link executable and run one of the following commands:
-
-         * From the Command Prompt::
-
-            JLink_Windows_V794i_x86_64.exe -InstUSBDriver=1
-
-         * From PowerShell::
-
-            .\JLink_Windows_V794i_x86_64.exe -InstUSBDriver=1
-
-      #. Follow the on-screen instructions.
-      #. After installing, ensure the J-Link executable can be run from anywhere on your system:
-
-         * For Linux and MacOS, add it to the system path.
-         * For Windows, add it to the environment variables.
-
+* SEGGER J-Link |jlink_ver| and, on Windows, also the SEGGER USB Driver for J-Link from `SEGGER J-Link`_ |jlink_ver|.
+  For information on how to install the USB Driver, see the `nRF Util prerequisites`_ documentation.
 * The latest version of |VSC| for your operating system from the `Visual Studio Code download page`_
 * In |VSC|, the latest version of the `nRF Connect for VS Code Extension Pack`_
 * On Linux, the `nrf-udev`_ module with udev rules required to access USB ports on Nordic Semiconductor devices and program the firmware

--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -51,10 +51,13 @@ Depending on your preferred development environment, install the following requi
           Check :ref:`operating system versions that support this tool <additional_nordic_sw_tools>` and download the installer from the `nRF Command Line Tools`_ page.
         * The |jlink_ver_vsc| of :ref:`SEGGER J-Link <requirements_jlink>`.
           Download it from the `J-Link Software and Documentation Pack`_ page.
+          On Windows, `install it manually together with SEGGER USB Driver for J-Link <nRF Util prerequisites_>`_.
         * The latest version of |VSC| for your operating system from the `Visual Studio Code download page`_.
         * In |VSC|, the latest version of the `nRF Connect for VS Code Extension Pack`_.
 
-      * Additionally for Linux users: the `nrf-udev`_ module with udev rules required to access USB ports on Nordic Semiconductor devices and program the firmware.
+      * Additionally, for Windows users: SEGGER USB Driver for J-Link, required for support of older Nordic Semiconductor devices in nRF Util.
+        For information on how to install the USB Driver, see the `nRF Util prerequisites`_ documentation.
+      * Additionally, for Linux users: the `nrf-udev`_ module with udev rules required to access USB ports on Nordic Semiconductor devices and program the firmware.
 
    .. group-tab:: Command line
 
@@ -75,8 +78,11 @@ Depending on your preferred development environment, install the following requi
 
         * The |jlink_ver| of :ref:`SEGGER J-Link <requirements_jlink>`.
           Download it from the `J-Link Software and Documentation Pack`_ page.
+          On Windows, `install it manually together with SEGGER USB Driver for J-Link <nRF Util prerequisites_>`_.
 
-      * Additionally for Linux users: the `nrf-udev`_ module with udev rules required to access USB ports on Nordic Semiconductor devices and program the firmware.
+      * Additionally, for Windows users: SEGGER USB Driver for J-Link, required for support of older Nordic Semiconductor devices in nRF Util.
+        For information on how to install the USB Driver, see the `nRF Util prerequisites`_ documentation.
+      * Additionally, for Linux users: the `nrf-udev`_ module with udev rules required to access USB ports on Nordic Semiconductor devices and program the firmware.
 
 .. _gs_installing_toolchain:
 .. _gs_installing_tools:

--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -287,6 +287,9 @@ Among others, this package includes the J-Link RTT Viewer, which can be used for
 
 It is recommended to use the |jlink_ver| of the package when you :ref:`installing_vsc`.
 
+On Windows, you also need to install SEGGER USB Driver for J-Link, which is required for support of older Nordic Semiconductor devices in :ref:`requirements_nrf_util`.
+For information on how to install the USB Driver, see the `nRF Util prerequisites`_ documentation.
+
 .. _toolchain_management_tools:
 .. _additional_nordic_sw_tools:
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -836,6 +836,7 @@
 
 .. _`nRF Util`: https://docs.nordicsemi.com/bundle/nrfutil/page/README.html
 .. _`Installing nRF Util`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html
+.. _`nRF Util prerequisites`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html#prerequisites
 .. _`Installing and upgrading nRF Util commands`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing_commands.html
 .. _`Installing nRF Util for nRF5 SDK`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides-nrf5sdk/installing.html
 .. _`DFU over Zigbee`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides-nrf5sdk/dfu_performing.html#dfu-over-zigbee

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -33,7 +33,7 @@ The following sections provide detailed lists of changes by component.
 IDE, OS, and tool support
 =========================
 
-|no_changes_yet_note|
+* Updated the :ref:`installing_vsc` section on the :ref:`installation` page with the Windows-only requirement to install SEGGER USB Driver for J-Link.
 
 Board support
 =============
@@ -63,7 +63,8 @@ Developing with nRF70 Series
 Working with nRF54H Series
 ==========================
 
-|no_changes_yet_note|
+* Removed the note on installing SEGGER USB Driver for J-Link on Windows from the :ref:`ug_nrf54h20_gs` page and moved its contents to the `nRF Util prerequisites`_ documentation.
+  The Windows-only requirement to install the SEGGER USB Driver for J-Link is now mentioned in the :ref:`installing_vsc` section on the :ref:`installation` page.
 
 Developing with nRF54L Series
 =============================


### PR DESCRIPTION
Added information about the required installation of USB Driver for J-Link on Windows. Moved installation instructions to nRF Util docs and removed them from the nRF54H20 Getting Started Guide. NCD-909.

----

Related nRF Util PR https://github.com/NordicSemiconductor/nrfutil-rs/pull/2563 

----

- [x] Changelog entry