### PR TITLE
sts: benchmarks: multicore: idle_outside_of_main: add cooperative thread

### DIFF
--- a/tests/benchmarks/multicore/idle_outside_of_main/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_outside_of_main/testcase.yaml
@@ -17,3 +17,18 @@ tests:
       fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_s2ram_outside_of_main"
+
+  benchmarks.multicore.idle_outside_of_main.nrf54h20dk_cpuapp_cpurad.s2ram.cooperative:
+    harness: pytest
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+      - CONFIG_MAIN_THREAD_PRIORITY=-1
+      - remote_CONFIG_MAIN_THREAD_PRIORITY=-1
+    harness_config:
+      fixture: ppk_power_measure
+      pytest_root:
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_s2ram_outside_of_main"


### PR DESCRIPTION


Verify current consumption when cooperative thread is used.