### PR TITLE
[Backport v2.9-nRF54H20-branch] manifest: update sdk-zephyr revision with custom jlink script removal

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: da1f133c5df6a507941690478b94f0b60bf42bdb
+      revision: 38b89183e59c4c42349bf9e6fd15d101b6038079
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Backport of #19527.