### PR TITLE
samples: cellular: modem_shell: Add socket options commands

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -291,6 +291,8 @@ Cellular samples
 
 * :ref:`modem_shell_application` sample:
 
+  * Added support for saving and loading DTLS connection.
+
   * Removed the ``CONFIG_MOSH_LINK`` Kconfig option.
     The link control functionality is now always enabled and cannot be disabled.
 

--- a/samples/cellular/modem_shell/src/sock/sock.h
+++ b/samples/cellular/modem_shell/src/sock/sock.h
@@ -37,6 +37,8 @@ int sock_recv(
 	enum sock_recv_print_format print_format);
 
 int sock_close(int socket_id);
+int sock_connection_save(int socket_id);
+int sock_connection_load(int socket_id);
 int sock_rai(
 	int socket_id, bool rai_last, bool rai_no_data, bool rai_one_resp,
 	bool rai_ongoing, bool rai_wait_more);


### PR DESCRIPTION
Add support for save and load DTLS connection.