### PR TITLE
tests: psa_crypto: Clean up configs

### DIFF
--- a/tests/psa_crypto/prj.conf
+++ b/tests/psa_crypto/prj.conf
@@ -13,7 +13,6 @@ CONFIG_HEAP_MEM_POOL_SIZE=8192
 
 # Enable logging
 CONFIG_CONSOLE=y
-CONFIG_LOG=n
 
 # Enable nordic security backend and PSA APIs
 CONFIG_NRF_SECURITY=y

--- a/tests/psa_crypto/tests/test_ikg_identity_key_sign_verify.c
+++ b/tests/psa_crypto/tests/test_ikg_identity_key_sign_verify.c
@@ -27,8 +27,9 @@ static psa_key_id_t identity_key_id = TFM_BUILTIN_KEY_ID_IAK;
 static psa_key_id_t identity_key_id = CRACEN_BUILTIN_IDENTITY_KEY_ID;
 #endif
 
-/* ====================================================================== */
-/*			Global variables/defines for the IKG signing tests		  */
+/* ======================================================================
+ *			Global variables/defines for the IKG signing tests
+ */
 
 #define NRF_CRYPTO_TEST_IKG_TEXT_SIZE (68)
 #define NRF_CRYPTO_TEST_IKG_SIGNATURE_SIZE (64)

--- a/tests/psa_crypto/tests/test_kmu_write.c
+++ b/tests/psa_crypto/tests/test_kmu_write.c
@@ -21,14 +21,15 @@
 #endif
 
 LOG_MODULE_DECLARE(app, LOG_LEVEL_DBG);
-/* ====================================================================== */
-/*			Global variables/defines for the kmu write test				  */
+/* ======================================================================
+ *		Global variables/defines for the kmu write test
+ */
 
 static psa_key_handle_t key_handle;
 #define KMU_SLOT_NUM 125
 /*
  *This is a sample public key for testing purposes only.
- *Uses sample key to ensure key generation is causing issues.
+ *Uses sample key to ensure key generation is not the cause of an issue.
  */
 static uint8_t m_pub_key[32] = {
 	0x29, 0x06, 0xA6, 0xA5, 0x5F, 0x9E, 0xB0, 0x5E,


### PR DESCRIPTION
Removed redundant config from psa_crypto tests
Cleaned up comment