### PR TITLE
lib: nrf_modem_lib: Use debug logs of expected errnos on backend write

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_lib_trace.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib_trace.c
@@ -261,7 +261,10 @@ static int trace_fragment_write(struct nrf_modem_trace_data *frag)
 		}
 
 		if (ret < 0) {
-			if (ret != -ENOSPC) {
+			if ((ret == -ENOSPC) || (ret == -ENOSR)) {
+				LOG_DBG("trace_backend.write returned with %d", ret);
+				LOG_DBG("Please make sure that the backend is properly connected.");
+			} else {
 				LOG_ERR("trace_backend.write failed with err: %d", ret);
 			}
 


### PR DESCRIPTION
We use -ENOSPC and -ENOSPC to signal from the backend that there is no space in backend or it is not properly connected. This can occur from time to time and is not always an error. Though, it can be noisy in log output. This commit replaces the error logs with debug level and adds a hint that the backend should be properly connected.