### PR TITLE
subsys: net: lib: downloader: make sure at least one transport enabled

### DIFF
--- a/subsys/net/lib/downloader/dl_transports.ld
+++ b/subsys/net/lib/downloader/dl_transports.ld
@@ -3,3 +3,6 @@
 _dl_transport_entry_list_start = .;
 KEEP(*(SORT_BY_NAME("._dl_transport_entry.*")));
 _dl_transport_entry_list_end = .;
+
+ASSERT(_dl_transport_entry_list_end != _dl_transport_entry_list_start,
+       "No transport enabled for the downloader library. See downloader library Kconfig options.");


### PR DESCRIPTION
The downloader library require at least one transport to be enabled. Add build assert when downloader library is enabled without any transport.