### PR TITLE
suit: increase synchronous invoke timeout

### DIFF
--- a/config/suit/templates/nrf54h20/default/v1/app_recovery_local_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/app_recovery_local_envelope.yaml.jinja2
@@ -69,7 +69,7 @@ SUIT_Envelope_Tagged:
     - suit-directive-override-parameters:
         suit-parameter-invoke-args:
           suit-synchronous-invoke: True
-          suit-timeout: 1000
+          suit-timeout: 5000
 {%- endif %}
     - suit-directive-invoke:
       - suit-send-record-failure


### PR DESCRIPTION
If recovery was run with external flash the initialization took too long, resulting in recovery not booting.