### PR TITLE
nrf_security: Fix data cache buffer size in Cracen

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/blkcipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/blkcipher.c
@@ -444,7 +444,7 @@ int sx_blkcipher_ecb_simple(uint8_t *key, size_t key_size, uint8_t *input, size_
 #if CONFIG_DCACHE
 	sys_cache_data_flush_range(in_descs, sizeof(in_descs));
 	sys_cache_data_flush_range(&out_desc, sizeof(out_desc));
-	sys_cache_data_flush_range(input, sizeof(input));
+	sys_cache_data_flush_range(input, input_size);
 	sys_cache_data_flush_range(output, output_size);
 #endif
 


### PR DESCRIPTION
The input variable in the function sx_blkcipher_ecb_simple is a pointer and not an array. So sizeof cannot be used to determine the array size. Replace this with the input_size variable which contains the correct iput size of the buffer.