### PR TITLE
openthread: remove 1.3 prebuilt libraries

### DIFF
--- a/subsys/net/openthread/Kconfig.defconfig
+++ b/subsys/net/openthread/Kconfig.defconfig
@@ -20,7 +20,7 @@ config OPENTHREAD_LIBRARY_AVAILABLE
 	# - To `y` when libraries for the current OpenThread revision are provided
 	# - To `n` on the next OpenThread upmerge
 	default y
-	depends on OPENTHREAD_THREAD_VERSION_1_3 || OPENTHREAD_THREAD_VERSION_1_4
+	depends on OPENTHREAD_THREAD_VERSION_1_4
 	depends on (OPENTHREAD_NORDIC_LIBRARY_MASTER && (SOC_NRF52840 || SOC_NRF54L15_CPUAPP)) || \
 		    OPENTHREAD_NORDIC_LIBRARY_FTD || OPENTHREAD_NORDIC_LIBRARY_MTD
 	depends on !OPENTHREAD_COPROCESSOR

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 41c282bf92550109d1ad80365550465bccf6b839
+      revision: 3189339e38f52a92098945a3c7f070810a067390
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
1.4 is now a default Thread version, 1.3 libraries are not needed anymore.