### PR TITLE
[Backport v2.9-nRF54H20-branch] suit: Remove legacy implementation

### DIFF
--- a/subsys/mgmt/suitfu/src/suitfu_mgmt_suit.c
+++ b/subsys/mgmt/suitfu/src/suitfu_mgmt_suit.c
@@ -55,26 +55,11 @@ static const struct mgmt_handler suit_mgmt_handlers[] = {
 #endif
 };
 
-#ifdef CONFIG_MGMT_SUITFU_GRP_OS
-static const struct mgmt_handler suit_mgmt_os_handlers[] = {
-	[OS_MGMT_ID_BOOTLOADER_INFO] = {.mh_read = suitfu_mgmt_suit_bootloader_info_read,
-					.mh_write = NULL},
-};
-#endif
-
 static struct mgmt_group suit_mgmt_group = {
 	.mg_handlers = (struct mgmt_handler *)suit_mgmt_handlers,
 	.mg_handlers_count = ARRAY_SIZE(suit_mgmt_handlers),
 	.mg_group_id = CONFIG_MGMT_GROUP_ID_SUIT,
 };
-
-#ifdef CONFIG_MGMT_SUITFU_GRP_OS
-static struct mgmt_group suit_mgmt_os_group = {
-	.mg_handlers = (struct mgmt_handler *)suit_mgmt_os_handlers,
-	.mg_handlers_count = ARRAY_SIZE(suit_mgmt_os_handlers),
-	.mg_group_id = MGMT_GROUP_ID_OS,
-};
-#endif
 
 void suit_mgmt_register_group(void)
 {
@@ -82,17 +67,11 @@ void suit_mgmt_register_group(void)
 	suitfu_mgmt_suit_image_fetch_init();
 #endif
 	mgmt_register_group(&suit_mgmt_group);
-#ifdef CONFIG_MGMT_SUITFU_GRP_OS
-	mgmt_register_group(&suit_mgmt_os_group);
-#endif
 }
 
 void suit_mgmt_unregister_group(void)
 {
 	mgmt_unregister_group(&suit_mgmt_group);
-#ifdef CONFIG_MGMT_SUITFU_GRP_OS
-	mgmt_unregister_group(&suit_mgmt_os_group);
-#endif
 }
 
 #ifdef CONFIG_MGMT_SUITFU_AUTO_REGISTER_HANDLERS

--- a/subsys/suit/memory_layout/src/suit_memory_layout.c
+++ b/subsys/suit/memory_layout/src/suit_memory_layout.c
@@ -17,9 +17,6 @@
 #elif (DT_NODE_EXISTS(DT_NODELABEL(flash0))) /* nrf52 or flash simulator */
 #define INTERNAL_NVM_START DT_REG_ADDR(DT_NODELABEL(flash0))
 #define INTERNAL_NVM_SIZE  DT_REG_SIZE(DT_NODELABEL(flash0))
-#elif (DT_NODE_EXISTS(DT_NODELABEL(rram0))) /* nrf54l15 */
-#define INTERNAL_NVM_START DT_REG_ADDR(DT_NODELABEL(rram0))
-#define INTERNAL_NVM_SIZE  DT_REG_SIZE(DT_NODELABEL(rram0))
 #else
 #error "No recognizable internal nvm nodes found."
 #endif

--- a/subsys/suit/storage/Kconfig
+++ b/subsys/suit/storage/Kconfig
@@ -51,15 +51,13 @@ config SUIT_STORAGE_N_ENVELOPES
 	    - SecDom: firmware + recovery
 	    - SysCtlr: firmware
 	    - Radio: recovery
-	    * Radio: firmware (A)
-	    * Radio: firmware (B)
+	    - Radio: firmware (A)
+	    - Radio: firmware (B)
 	    - ROOT
 	    - Application: recovery
 	    - Application: firmware (A)
 	    - Application: firmware (B)
-	    * Application: user data
-
-	  Manifests marked with (*) are not available in legacy SUIT storage format.
+	    - Application: user data
 
 	  For debug and test platforms (POSIX, nRF52840) the following envelopes may be defined:
 	    - ROOT

--- a/subsys/suit/storage/include/suit_storage_internal.h
+++ b/subsys/suit/storage/include/suit_storage_internal.h
@@ -30,9 +30,7 @@
 extern "C" {
 #endif
 
-#define SUIT_STORAGE_NVM_NODE                                                                      \
-	COND_CODE_1(DT_NODE_EXISTS(DT_NODELABEL(secdom_nvs)), (DT_NODELABEL(secdom_nvs)),          \
-		    (DT_CHOSEN(zephyr_flash)))
+#define SUIT_STORAGE_NVM_NODE DT_CHOSEN(zephyr_flash)
 #define SUIT_STORAGE_WRITE_SIZE DT_PROP(SUIT_STORAGE_NVM_NODE, write_block_size)
 #define SUIT_STORAGE_EB_SIZE	DT_PROP(SUIT_STORAGE_NVM_NODE, erase_block_size)
 #define SUIT_STORAGE_ACCESS_BLOCK_SIZE                                                             \

--- a/subsys/suit/storage/src/suit_storage_update.c
+++ b/subsys/suit/storage/src/suit_storage_update.c
@@ -8,7 +8,6 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/logging/log.h>
 
-#define UPDATE_MAGIC_VALUE_AVAILABLE_RAW  0x5555AAAA
 #define UPDATE_MAGIC_VALUE_AVAILABLE_CBOR 0x55AA55AA
 #define UPDATE_MAGIC_VALUE_EMPTY	  0xFFFFFFFF
 

--- a/subsys/suit/utils/src/suit_plat_mem_util.c
+++ b/subsys/suit/utils/src/suit_plat_mem_util.c
@@ -75,8 +75,6 @@ uintptr_t suit_plat_mem_nvm_offset_get(uint8_t *ptr)
 
 #if (DT_NODE_EXISTS(DT_NODELABEL(mram1x)))
 	address = (((address) & 0xEFFFFFFFUL) - (DT_REG_ADDR(DT_NODELABEL(mram1x)) & 0xEFFFFFFFUL));
-#elif (DT_NODE_EXISTS(DT_NODELABEL(mram10)))
-	address = (((address) & 0xEFFFFFFFUL) - (DT_REG_ADDR(DT_NODELABEL(mram10)) & 0xEFFFFFFFUL));
 #endif
 
 	return address;
@@ -88,8 +86,6 @@ uint8_t *suit_plat_mem_nvm_ptr_get(uintptr_t offset)
 
 #if (DT_NODE_EXISTS(DT_NODELABEL(mram1x)))
 	address = (((offset) & 0xEFFFFFFFUL) + (DT_REG_ADDR(DT_NODELABEL(mram1x)) & 0xEFFFFFFFUL));
-#elif (DT_NODE_EXISTS(DT_NODELABEL(mram10)))
-	address = (((offset) & 0xEFFFFFFFUL) + (DT_REG_ADDR(DT_NODELABEL(mram10)) & 0xEFFFFFFFUL));
 #else
 	address = offset;
 #endif


### PR DESCRIPTION
Backport b777188d6a29f037b8990b110a6d4f1f0ff2a61b from #19776.