### PR TITLE
actions: Limit Toolchain Sync execution

### DIFF
--- a/.github/workflows/enforce-toolchain-synchronization.yml
+++ b/.github/workflows/enforce-toolchain-synchronization.yml
@@ -15,8 +15,9 @@ name: Enforce rebasing Pull Requests if Toolchain was modified on target branch
 
 on:
   push:
-    branches:
-      - '**'  # Triggers on pushes to any branch
+    branches: # Trigger on push to main and release branches
+      - main
+      - 'v*-branch'
 jobs:
   check-prs:
     if: ${{ github.repository_owner == 'nrfconnect' && !github.event.created }}  # Skip for new branches or forks


### PR DESCRIPTION
Action should be run only on branches which are targets of PRs.