### PR TITLE
net: lib: nrfcloud_pgps_utils: Ignore error on canceling download

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
@@ -581,7 +581,7 @@ static int downloader_callback(const struct downloader_evt *event)
 
 	ret = downloader_cancel(&dl);
 
-	if (ret) {
+	if (ret && (ret != -EPERM)) {
 		LOG_ERR("Error disconnecting from download client:%d", ret);
 	}
 #endif


### PR DESCRIPTION
Remove error log when canceling completed downloads.