### PR TITLE
lib: lte_link_control: Send NEIGHBOR_CELL_MEAS event in case of error

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -495,6 +495,7 @@ Modem libraries
 * :ref:`lte_lc_readme` library:
 
   * Fixed handling of ``%NCELLMEAS`` notification with status 2 (measurement interrupted) and no cells.
+  * Added sending of ``LTE_LC_EVT_NEIGHBOR_CELL_MEAS`` event with ``current_cell`` set to ``LTE_LC_CELL_EUTRAN_ID_INVALID`` in case an error occurs while parsing the ``%NCELLMEAS`` notification.
 
 * :ref:`modem_key_mgmt` library:
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -283,7 +283,10 @@ enum lte_lc_evt_type {
 	 * Neighbor cell measurement results.
 	 *
 	 * The associated payload is the @c lte_lc_evt.cells_info member of type
-	 * @ref lte_lc_cells_info in the event.
+	 * @ref lte_lc_cells_info in the event. In case of an error or if no cells were found,
+	 * the @c lte_lc_cells_info.current_cell member is set to
+	 * @ref LTE_LC_CELL_EUTRAN_ID_INVALID, and @c lte_lc_cells_info.ncells_count and
+	 * @c lte_lc_cells_info.gci_cells_count members are set to zero.
 	 */
 	LTE_LC_EVT_NEIGHBOR_CELL_MEAS		= 7,
 #endif /* CONFIG_LTE_LC_NEIGHBOR_CELL_MEAS_MODULE */
@@ -1688,7 +1691,8 @@ int lte_lc_lte_mode_get(enum lte_lc_lte_mode *mode);
  * @ref LTE_LC_EVT_NEIGHBOR_CELL_MEAS, meaning that an event handler must be registered to receive
  * the information. Depending on the network conditions, LTE connection state and requested search
  * type, it may take a while before the measurement result is ready and reported back. After the
- * event is received, the neighbor cell measurements are automatically stopped.
+ * event is received, the neighbor cell measurements are automatically stopped. If the
+ * function returns successfully, the @ref LTE_LC_EVT_NEIGHBOR_CELL_MEAS event is always reported.
  *
  * @note This feature is only supported by modem firmware versions >= 1.3.0.
  *

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -961,7 +961,7 @@ struct lte_lc_conn_eval_params {
  *
  * When using search types up to @ref LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE, the result
  * contains parameters from current/serving cell and optionally up to
- * @kconfig{CONFIG_LTE_NEIGHBOR_CELLS_MAX} neighbor cells.
+ * `CONFIG_LTE_NEIGHBOR_CELLS_MAX` neighbor cells.
  *
  * Result notification for Global Cell ID (GCI) search types include Cell ID, PLMN and TAC for up to
  * @c gci_count (@ref lte_lc_ncellmeas_params) surrounding cells.
@@ -1373,7 +1373,7 @@ int lte_lc_normal(void);
  * For encoding of the variables, see nRF AT Commands Reference Guide, 3GPP 27.007 Ch. 7.38., and
  * 3GPP 24.008 Ch. 10.5.7.4a and Ch. 10.5.7.3.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_PSM_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_PSM_MODULE` to be enabled.
  *
  * @param[in] rptau
  * @parblock
@@ -1435,7 +1435,7 @@ int lte_lc_psm_param_set(const char *rptau, const char *rat);
  * For more information about the encodings, see the description of the
  * lte_lc_psm_param_set() function.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_PSM_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_PSM_MODULE` to be enabled.
  *
  * @param[in] rptau
  * @parblock
@@ -1468,18 +1468,18 @@ int lte_lc_psm_param_set_seconds(int rptau, int rat);
 /**
  * Request modem to enable or disable Power Saving Mode (PSM).
  *
- * PSM parameters can be set using @kconfig{CONFIG_LTE_PSM_REQ_FORMAT},
- * @kconfig{CONFIG_LTE_PSM_REQ_RPTAU}, @kconfig{CONFIG_LTE_PSM_REQ_RAT},
- * @kconfig{CONFIG_LTE_PSM_REQ_RPTAU_SECONDS} and @kconfig{CONFIG_LTE_PSM_REQ_RAT_SECONDS},
+ * PSM parameters can be set using `CONFIG_LTE_PSM_REQ_FORMAT`,
+ * `CONFIG_LTE_PSM_REQ_RPTAU`, `CONFIG_LTE_PSM_REQ_RAT`,
+ * `CONFIG_LTE_PSM_REQ_RPTAU_SECONDS` and `CONFIG_LTE_PSM_REQ_RAT_SECONDS`,
  * or by calling lte_lc_psm_param_set() or lte_lc_psm_param_set_seconds().
  *
- * @note @kconfig{CONFIG_LTE_PSM_REQ} can be set to enable PSM, which is generally sufficient. This
+ * @note `CONFIG_LTE_PSM_REQ` can be set to enable PSM, which is generally sufficient. This
  *       option allows explicit disabling/enabling of PSM requesting after modem initialization.
  *       Calling this function for run-time control is possible, but it should be noted that
- *       conflicts may arise with the value set by @kconfig{CONFIG_LTE_PSM_REQ} if it is called
+ *       conflicts may arise with the value set by `CONFIG_LTE_PSM_REQ` if it is called
  *       during modem initialization.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_PSM_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_PSM_MODULE` to be enabled.
  *
  * @param[in] enable @c true to enable PSM, @c false to disable PSM.
  *
@@ -1491,7 +1491,7 @@ int lte_lc_psm_req(bool enable);
 /**
  * Get the current PSM (Power Saving Mode) configuration.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_PSM_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_PSM_MODULE` to be enabled.
  *
  * @param[out] tau Periodic TAU interval in seconds. A non-negative integer.
  * @param[out] active_time Active time in seconds. A non-negative integer,
@@ -1513,20 +1513,20 @@ int lte_lc_psm_get(int *tau, int *active_time);
  * would do if network allowed to use PSM. Sending of MO data or MO SMS will automatically wake up
  * the modem just like if modem was in normal PSM sleep.
  *
- * To use the feature, also PSM request must be enabled using @kconfig{CONFIG_LTE_PSM_REQ} or
+ * To use the feature, also PSM request must be enabled using `CONFIG_LTE_PSM_REQ` or
  * lte_lc_psm_req().
  *
  * Refer to the AT command guide for guidance and limitations of this feature.
  *
- * @note @kconfig{CONFIG_LTE_PROPRIETARY_PSM_REQ} can be set to enable proprietary PSM, which is
+ * @note `CONFIG_LTE_PROPRIETARY_PSM_REQ` can be set to enable proprietary PSM, which is
  *       generally sufficient. This option allows to enable or disable proprietary PSM after modem
  *       initialization. Calling this function for run-time control is possible, but it should be
  *       noted that conflicts may arise with the value set by
- *       @kconfig{CONFIG_LTE_PROPRIETARY_PSM_REQ} if it is called during modem initialization.
+ *       `CONFIG_LTE_PROPRIETARY_PSM_REQ` if it is called during modem initialization.
  *
  * @note This feature is only supported by modem firmware versions >= v2.0.0.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_PSM_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_PSM_MODULE` to be enabled.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if AT command failed.
@@ -1544,7 +1544,7 @@ int lte_lc_proprietary_psm_req(bool enable);
  *
  * For reference to which values can be set, see subclause 10.5.5.32 of 3GPP TS 24.008.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_EDRX_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_EDRX_MODULE` to be enabled.
  *
  * @param[in] mode LTE mode to which the PTW value applies.
  * @param[in] ptw Paging Time Window value as a null-terminated string.
@@ -1563,7 +1563,7 @@ int lte_lc_ptw_set(enum lte_lc_lte_mode mode, const char *ptw);
  *
  * For reference see 3GPP 27.007 Ch. 7.40.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_EDRX_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_EDRX_MODULE` to be enabled.
  *
  * @param[in] mode LTE mode to which the eDRX value applies.
  * @param[in] edrx eDRX value as a null-terminated string.
@@ -1577,20 +1577,20 @@ int lte_lc_edrx_param_set(enum lte_lc_lte_mode mode, const char *edrx);
 /**
  * Request modem to enable or disable use of eDRX.
  *
- * eDRX parameters can be set using @kconfig{CONFIG_LTE_EDRX_REQ_VALUE_LTE_M},
- * @kconfig{CONFIG_LTE_EDRX_REQ_VALUE_NBIOT}, @kconfig{CONFIG_LTE_PTW_VALUE_LTE_M} and
- * @kconfig{CONFIG_LTE_PTW_VALUE_NBIOT}, or by calling lte_lc_edrx_param_set() and
+ * eDRX parameters can be set using `CONFIG_LTE_EDRX_REQ_VALUE_LTE_M`,
+ * `CONFIG_LTE_EDRX_REQ_VALUE_NBIOT`, `CONFIG_LTE_PTW_VALUE_LTE_M` and
+ * `CONFIG_LTE_PTW_VALUE_NBIOT`, or by calling lte_lc_edrx_param_set() and
  * lte_lc_ptw_set().
  *
  * For reference see 3GPP 27.007 Ch. 7.40.
  *
- * @note @kconfig{CONFIG_LTE_EDRX_REQ} can be set to enable eDRX, which is generally sufficient.
+ * @note `CONFIG_LTE_EDRX_REQ` can be set to enable eDRX, which is generally sufficient.
  *       This option allows explicit disabling/enabling of eDRX requesting after modem
  *       initialization. Calling this function for run-time control is possible, but it should be
- *       noted that conflicts may arise with the value set by @kconfig{CONFIG_LTE_EDRX_REQ} if it is
+ *       noted that conflicts may arise with the value set by `CONFIG_LTE_EDRX_REQ` if it is
  *       called during modem initialization.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_EDRX_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_EDRX_MODULE` to be enabled.
  *
  * @param[in] enable @c true to enable eDRX, @c false to disable eDRX.
  *
@@ -1604,7 +1604,7 @@ int lte_lc_edrx_req(bool enable);
  *
  * @param[out] edrx_cfg eDRX configuration.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_EDRX_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_EDRX_MODULE` to be enabled.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if input argument was invalid.
@@ -1696,7 +1696,7 @@ int lte_lc_lte_mode_get(enum lte_lc_lte_mode *mode);
  *
  * @note This feature is only supported by modem firmware versions >= 1.3.0.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_NEIGHBOR_CELL_MEAS_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_NEIGHBOR_CELL_MEAS_MODULE` to be enabled.
  *
  * @param[in] params Search type parameters or @c NULL to initiate a measurement with the default
  *                   parameters. See @ref lte_lc_ncellmeas_params for more information.
@@ -1711,7 +1711,7 @@ int lte_lc_neighbor_cell_measurement(struct lte_lc_ncellmeas_params *params);
 /**
  * Cancel an ongoing neighbor cell measurement.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_NEIGHBOR_CELL_MEAS_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_NEIGHBOR_CELL_MEAS_MODULE` to be enabled.
  *
  * @retval 0 if neighbor cell measurement was cancelled.
  * @retval -EFAULT if AT command failed.
@@ -1724,7 +1724,7 @@ int lte_lc_neighbor_cell_measurement_cancel(void);
  * Connection evaluation parameters can be used to determine the energy efficiency of data
  * transmission before the actual data transmission.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_CONN_EVAL_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_CONN_EVAL_MODULE` to be enabled.
  *
  * @param[out] params Connection evaluation parameters.
  *
@@ -1776,7 +1776,7 @@ int lte_lc_modem_events_disable(void);
  * "nRF91 AT Commands - Command Reference Guide" for more information and in-depth explanations of
  * periodic search configuration.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_PERIODIC_SEARCH_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_PERIODIC_SEARCH_MODULE` to be enabled.
  *
  * @param[in] cfg Periodic search configuration.
  *
@@ -1790,7 +1790,7 @@ int lte_lc_periodic_search_set(const struct lte_lc_periodic_search_cfg *const cf
 /**
  * Get the configured periodic search parameters.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_PERIODIC_SEARCH_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_PERIODIC_SEARCH_MODULE` to be enabled.
  *
  * @param[out] cfg Periodic search configuration.
  *
@@ -1806,7 +1806,7 @@ int lte_lc_periodic_search_get(struct lte_lc_periodic_search_cfg *const cfg);
 /**
  * Clear the configured periodic search parameters.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_PERIODIC_SEARCH_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_PERIODIC_SEARCH_MODULE` to be enabled.
  *
  * @retval 0 if the configuration was cleared.
  * @retval -EFAULT if an AT command could not be sent to the modem.
@@ -1820,7 +1820,7 @@ int lte_lc_periodic_search_clear(void);
  * This can be used for example when modem is in sleep state between periodic searches. The search
  * is performed only when the modem is in sleep state between periodic searches.
  *
- * @note Requires @kconfig{CONFIG_LTE_LC_PERIODIC_SEARCH_MODULE} to be enabled.
+ * @note Requires `CONFIG_LTE_LC_PERIODIC_SEARCH_MODULE` to be enabled.
  *
  * @retval 0 if the search request was successfully delivered to the modem.
  * @retval -EFAULT if an AT command could not be sent to the modem.

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -16,7 +16,7 @@
 #include "cmock_nrf_modem_at.h"
 #include "cmock_nrf_modem.h"
 
-#define TEST_EVENT_MAX_COUNT 10
+#define TEST_EVENT_MAX_COUNT 20
 
 static struct lte_lc_evt test_event_data[TEST_EVENT_MAX_COUNT];
 static struct lte_lc_ncell test_neighbor_cells[CONFIG_LTE_NEIGHBOR_CELLS_MAX];
@@ -2746,6 +2746,14 @@ void test_lte_lc_neighbor_cell_measurement_cell_id_missing_fail(void)
 	       "%NCELLMEAS:0,,\"98712\",\"0AB9\",4800,7,63,31,456,4800,"
 	       "8,60,29,4,3500,9,99,18,5,5300,11\r\n");
 
+	lte_lc_callback_count_expected = 1;
+
+	/* In case of an error, we're expected to receive an empty event. */
+	test_event_data[0].type = LTE_LC_EVT_NEIGHBOR_CELL_MEAS;
+	test_event_data[0].cells_info.current_cell.id = LTE_LC_CELL_EUTRAN_ID_INVALID;
+	test_event_data[0].cells_info.ncells_count = 0;
+	test_event_data[0].cells_info.gci_cells_count = 0;
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%NCELLMEAS", EXIT_SUCCESS);
 
 	ret = lte_lc_neighbor_cell_measurement(NULL);
@@ -2762,6 +2770,14 @@ void test_lte_lc_neighbor_cell_measurement_cell_id_too_big_fail(void)
 	       "%NCELLMEAS:0,\"FFFFFFFF\",\"98712\",\"0AB9\",4800,7,63,31,456,4800,"
 	       "8,60,29,4,3500,9,99,18,5,5300,11\r\n");
 
+	lte_lc_callback_count_expected = 1;
+
+	/* In case of an error, we're expected to receive an empty event. */
+	test_event_data[0].type = LTE_LC_EVT_NEIGHBOR_CELL_MEAS;
+	test_event_data[0].cells_info.current_cell.id = LTE_LC_CELL_EUTRAN_ID_INVALID;
+	test_event_data[0].cells_info.ncells_count = 0;
+	test_event_data[0].cells_info.gci_cells_count = 0;
+
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%NCELLMEAS", EXIT_SUCCESS);
 
 	ret = lte_lc_neighbor_cell_measurement(NULL);
@@ -2777,6 +2793,14 @@ void test_lte_lc_neighbor_cell_measurement_malformed_fail(void)
 	strcpy(at_notif,
 	       "%NCELLMEAS:0,\"00112233\",\"98712\",\"0AB9\",4800,7,63,31,456,4800,"
 	       "8,60,29,4,35 00,9,99,18,5,5300,11\r\n");
+
+	lte_lc_callback_count_expected = 1;
+
+	/* In case of an error, we're expected to receive an empty event. */
+	test_event_data[0].type = LTE_LC_EVT_NEIGHBOR_CELL_MEAS;
+	test_event_data[0].cells_info.current_cell.id = LTE_LC_CELL_EUTRAN_ID_INVALID;
+	test_event_data[0].cells_info.ncells_count = 0;
+	test_event_data[0].cells_info.gci_cells_count = 0;
 
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%NCELLMEAS", EXIT_SUCCESS);
 
@@ -3506,6 +3530,16 @@ void test_lte_lc_neighbor_cell_measurement_normal_invalid_field_format_fail(void
 		.gci_count = 0,
 	};
 
+	lte_lc_callback_count_expected = 16;
+
+	/* In case of an error, we're expected to receive an empty event. */
+	for (int i = 0; i < lte_lc_callback_count_expected; i++) {
+		test_event_data[i].type = LTE_LC_EVT_NEIGHBOR_CELL_MEAS;
+		test_event_data[i].cells_info.current_cell.id = LTE_LC_CELL_EUTRAN_ID_INVALID;
+		test_event_data[i].cells_info.ncells_count = 0;
+		test_event_data[i].cells_info.gci_cells_count = 0;
+	}
+
 	/* Syntax:
 	 * %NCELLMEAS: status
 	 * [,<cell_id>,<plmn>,<tac>,<ta>,<earfcn>,<phys_cell_id>,<rsrp>,<rsrq>,<meas_time>
@@ -3670,6 +3704,16 @@ void test_lte_lc_neighbor_cell_measurement_gci_invalid_field_format_fail(void)
 		.search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_DEFAULT,
 		.gci_count = 10,
 	};
+
+	lte_lc_callback_count_expected = 18;
+
+	/* In case of an error, we're expected to receive an empty event. */
+	for (int i = 0; i < lte_lc_callback_count_expected; i++) {
+		test_event_data[i].type = LTE_LC_EVT_NEIGHBOR_CELL_MEAS;
+		test_event_data[i].cells_info.current_cell.id = LTE_LC_CELL_EUTRAN_ID_INVALID;
+		test_event_data[i].cells_info.ncells_count = 0;
+		test_event_data[i].cells_info.gci_cells_count = 0;
+	}
 
 	/* Syntax for GCI search types:
 	 * High level:
@@ -3881,6 +3925,16 @@ void test_lte_lc_neighbor_cell_measurement_normal_invalid_mccmnc_fail(void)
 {
 	int ret;
 
+	lte_lc_callback_count_expected = 2;
+
+	/* In case of an error, we're expected to receive an empty event. */
+	for (int i = 0; i < lte_lc_callback_count_expected; i++) {
+		test_event_data[i].type = LTE_LC_EVT_NEIGHBOR_CELL_MEAS;
+		test_event_data[i].cells_info.current_cell.id = LTE_LC_CELL_EUTRAN_ID_INVALID;
+		test_event_data[i].cells_info.ncells_count = 0;
+		test_event_data[i].cells_info.gci_cells_count = 0;
+	}
+
 	/* Invalid MCC */
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%NCELLMEAS", EXIT_SUCCESS);
 	ret = lte_lc_neighbor_cell_measurement(NULL);
@@ -3907,6 +3961,16 @@ void test_lte_lc_neighbor_cell_measurement_gci_invalid_mccmnc_fail(void)
 		.search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_EXTENDED_COMPLETE,
 		.gci_count = 2,
 	};
+
+	lte_lc_callback_count_expected = 2;
+
+	/* In case of an error, we're expected to receive an empty event. */
+	for (int i = 0; i < lte_lc_callback_count_expected; i++) {
+		test_event_data[i].type = LTE_LC_EVT_NEIGHBOR_CELL_MEAS;
+		test_event_data[i].cells_info.current_cell.id = LTE_LC_CELL_EUTRAN_ID_INVALID;
+		test_event_data[i].cells_info.ncells_count = 0;
+		test_event_data[i].cells_info.gci_cells_count = 0;
+	}
 
 	/* Invalid MCC */
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%NCELLMEAS=5,2", EXIT_SUCCESS);


### PR DESCRIPTION
Earlier, no `LTE_LC_EVT_NEIGHBOR_CELL_MEAS` event was sent in case an error occurred during parsing of the `%NCELLMEAS` notification. Because of this, the user of the library did not have any way to determine when the operation had been completed. The implementation has been changed so, that an `LTE_LC_EVT_NEIGHBOR_CELL_MEAS` event is always sent, if `lte_lc_neighbor_cell_measurement()` has returned `0`. In case of an error, an empty `LTE_LC_EVT_NEIGHBOR_CELL_MEAS` (`current_cell` set to `LTE_LC_CELL_EUTRAN_ID_INVALID`) is sent.

Removed Kconfig links from the library header. The reason behind the change is that Breathe is no longer used when generating the documentation, and without Breathe the links do not work and only cause the generated documentation to look bad.