### PR TITLE
samples: matter: align extra args in sample yamls

### DIFF
--- a/applications/matter_bridge/sample.yaml
+++ b/applications/matter_bridge/sample.yaml
@@ -158,7 +158,8 @@ tests:
   applications.matter_bridge.lto.smart_plug:
     sysbuild: true
     build_only: true
-    extra_args: matter_bridge_SNIPPET=onoff_plug
+    extra_args:
+      - matter_bridge_SNIPPET=onoff_plug
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     platform_allow: nrf5340dk/nrf5340/cpuapp

--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -82,7 +82,8 @@ tests:
   sample.matter.light_bulb.debug.nrf21540ek:
     sysbuild: true
     build_only: true
-    extra_args: light_bulb_SHIELD=nrf21540ek
+    extra_args:
+      - light_bulb_SHIELD=nrf21540ek
     integration_platforms:
       - nrf52840dk/nrf52840
     platform_allow: nrf52840dk/nrf52840
@@ -138,7 +139,8 @@ tests:
   sample.matter.light_bulb.aws:
     sysbuild: true
     build_only: true
-    extra_args: EXTRA_CONF_FILE="overlay-aws-iot-integration.conf"
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-aws-iot-integration.conf"
     platform_allow: nrf7002dk/nrf5340/cpuapp
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp

--- a/samples/matter/light_switch/sample.yaml
+++ b/samples/matter/light_switch/sample.yaml
@@ -62,7 +62,8 @@ tests:
   sample.matter.light_switch.lit_icd:
     sysbuild: true
     build_only: true
-    extra_args: light_switch_SNIPPET=lit_icd
+    extra_args:
+      - light_switch_SNIPPET=lit_icd
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -27,7 +27,8 @@ tests:
   sample.matter.lock.release:
     sysbuild: true
     build_only: true
-    extra_args: FILE_SUFFIX=release
+    extra_args:
+      - FILE_SUFFIX=release
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -69,7 +70,8 @@ tests:
   sample.matter.lock.smp_dfu:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_CHIP_DFU_OVER_BT_SMP=y
+    extra_args:
+      - CONFIG_CHIP_DFU_OVER_BT_SMP=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -88,7 +90,8 @@ tests:
   sample.matter.lock.no_dfu.no_fd:
     sysbuild: true
     build_only: true
-    extra_args: SB_CONFIG_MATTER_OTA=n
+    extra_args:
+      - SB_CONFIG_MATTER_OTA=n
     integration_platforms:
       - nrf21540dk/nrf52840
     platform_allow: nrf21540dk/nrf52840

--- a/samples/matter/smoke_co_alarm/sample.yaml
+++ b/samples/matter/smoke_co_alarm/sample.yaml
@@ -78,7 +78,8 @@ tests:
     build_only: true
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
-    extra_args: smoke_co_alarm_SNIPPET="diagnostic-logs"
+    extra_args:
+      - smoke_co_alarm_SNIPPET="diagnostic-logs"
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
     tags:
       - sysbuild

--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -5,7 +5,8 @@ tests:
   sample.matter.template.debug:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
+    extra_args:
+      - CONFIG_NCS_SAMPLE_MATTER_OPERATIONAL_KEYS_MIGRATION_TO_ITS=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -94,7 +95,8 @@ tests:
   sample.matter.template.smp_dfu.nrf54h20:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_CHIP_DFU_OVER_BT_SMP=y
+    extra_args:
+      - CONFIG_CHIP_DFU_OVER_BT_SMP=y
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
@@ -135,7 +137,8 @@ tests:
   sample.matter.template.cc3xx_backend:
     sysbuild: true
     build_only: true
-    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
+    extra_args:
+      - CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp


### PR DESCRIPTION
Change unifies the way of extra args definition in sample yamls in matter objects