### PR TITLE
Bluetooth: gatt_pool: Supress -Waddress in EL_IN_POOL_VERIFY

### DIFF
--- a/subsys/bluetooth/gatt_pool.c
+++ b/subsys/bluetooth/gatt_pool.c
@@ -79,7 +79,10 @@ static struct bt_uuid const * const uuid_ccc = BT_UUID_GATT_CCC;
 
 #define EL_IN_POOL_VERIFY(pool, el)                                            \
 	do {                                                                   \
+		_Pragma("GCC diagnostic push");                                \
+		_Pragma("GCC diagnostic ignored \"-Waddress\"");               \
 		__ASSERT(pool != NULL, "Pool is uninitialized");               \
+		_Pragma("GCC diagnostic pop");                                 \
 		__ASSERT(((uint32_t)el >= (uint32_t)pool) &&                         \
 			     (((uint32_t)el) < (((uint32_t)pool) + sizeof(pool))),   \
 			 "Element does not belong to the pool");               \


### PR DESCRIPTION
GCC13 will complain here with:

gatt_pool.c:165:69: warning: the comparison will always evaluate as 'true' for the address of 'chrc_tab' will never be NULL [-Waddress]

when CONFIG_ASSERT is set. Since the problem is harmless add warning supression pragmas to avoid build failures with -Werror.