### PR TITLE
tests: drivers: Add test for SDP ASM

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -805,6 +805,7 @@
 /tests/drivers/nrfx_integration_test/     @nrfconnect/ncs-co-drivers
 /tests/drivers/pwm/gpio_loopback/         @nrfconnect/ncs-low-level-test
 /tests/drivers/sensor/multicore_temp/     @nrfconnect/ncs-low-level-test
+/tests/drivers/sdp_asm/                   @nrfconnect/ncs-low-level-test @nrfconnect/ncs-ll-ursus
 /tests/lib/at_cmd_parser/                 @nrfconnect/ncs-modem
 /tests/lib/at_cmd_custom/                 @nrfconnect/ncs-modem
 /tests/lib/at_parser/                     @nrfconnect/ncs-modem

--- a/tests/drivers/sdp_asm/CMakeLists.txt
+++ b/tests/drivers/sdp_asm/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(hello_world)
+
+sdp_assembly_generate("${CMAKE_CURRENT_SOURCE_DIR}/src/add_1.c;${CMAKE_CURRENT_SOURCE_DIR}/src/add_10.c;${CMAKE_CURRENT_SOURCE_DIR}/src/add_100.c")
+sdp_assembly_check("${CMAKE_CURRENT_SOURCE_DIR}/src/add_1.c;${CMAKE_CURRENT_SOURCE_DIR}/src/add_10.c;${CMAKE_CURRENT_SOURCE_DIR}/src/add_100.c")
+sdp_assembly_prepare_install("${CMAKE_CURRENT_SOURCE_DIR}/src/add_1.c;${CMAKE_CURRENT_SOURCE_DIR}/src/add_10.c;${CMAKE_CURRENT_SOURCE_DIR}/src/add_100.c")
+
+target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE src/add_1.s)
+target_sources(app PRIVATE src/add_10.s)
+target_sources(app PRIVATE src/add_100.s)
+
+add_dependencies(app asm_check)

--- a/tests/drivers/sdp_asm/prj.conf
+++ b/tests/drivers/sdp_asm/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/tests/drivers/sdp_asm/pytest/test_sdp_asm.py
+++ b/tests/drivers/sdp_asm/pytest/test_sdp_asm.py
@@ -1,0 +1,72 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+import logging
+import os
+import subprocess
+
+from twister_harness import DeviceAdapter
+
+logger = logging.getLogger(__name__)
+
+
+def execute_shell_cmd(cmd, work_dir: str):
+    os.chdir(work_dir)
+    try:
+        logger.info(f"Executing:\n{cmd}")
+        proc = subprocess.run(
+            cmd, shell=False,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        logger.info(f'out: {proc.stdout}\n')
+        logger.info(f'err: {proc.stderr}\n')
+    except OSError as exc:
+        logger.error(f"Command has failed:\n{cmd}\n{exc}")
+
+
+def test_sdp_asm(dut: DeviceAdapter):
+    BUILD_DIR = str(dut.device_config.build_dir)
+    build_log_file = f"{BUILD_DIR}/build.log"
+    OUTPUT1 = """initial: 0, 0, 0
+after add_1: 1, 2, 3
+after add_10: 11, 22, 33
+after add_100: 111, 222, 333"""
+    OUTPUT2 = """initial: 0, 0, 0
+after add_1: 2, 3, 4
+after add_10: 12, 23, 34
+after add_100: 212, 323, 434"""
+
+    logger.info("# Get output from serial port")
+    output = "\n".join(dut.readlines_until(regex='Test completed', timeout=5.0))
+
+    logger.info("# Confirm that precompiled .S files were linked in the build")
+    assert OUTPUT1 in output, f"Unexpected output: {output}"
+
+    logger.info("# Confirm that build log contains warnings")
+    with open(f"{build_log_file}", errors="ignore") as log_file:
+        log_file_content = log_file.read()
+        assert "add_1.s ASM file content has changed" in log_file_content
+        assert "File add_10.s has not changed" in log_file_content
+        assert "add_100.s ASM file content has changed" in log_file_content
+
+    for _ in range(2):
+        logger.info("# Install newly compiled .S files")
+        cmd = ['ninja', 'asm_install']
+        execute_shell_cmd(cmd, f"{BUILD_DIR}/sdp_asm")
+
+        logger.info("# Recompile")
+        cmd = ['ninja']
+        execute_shell_cmd(cmd, f"{BUILD_DIR}")
+
+    logger.info("# Reflash")
+    cmd = ['west', 'flash', '--erase']
+    execute_shell_cmd(cmd, f"{BUILD_DIR}")
+
+    logger.info("# Get output from serial port")
+    output = "\n".join(dut.readlines_until(regex='Test completed', timeout=5.0))
+
+    logger.info("# Confirm that new .S files were linked in the build")
+    assert OUTPUT2 in output, f"Unexpected output: {output}"

--- a/tests/drivers/sdp_asm/src/add_1.c
+++ b/tests/drivers/sdp_asm/src/add_1.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+
+extern volatile uint8_t arg_uint8_t;
+extern volatile uint16_t arg_uint16_t;
+extern volatile uint32_t arg_uint32_t;
+
+void hrt_add_1(void)
+{
+	arg_uint8_t += 2;
+	arg_uint16_t += 3;
+	arg_uint32_t += 4;
+}

--- a/tests/drivers/sdp_asm/src/add_1.h
+++ b/tests/drivers/sdp_asm/src/add_1.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+void hrt_add_1(void);

--- a/tests/drivers/sdp_asm/src/add_1.s
+++ b/tests/drivers/sdp_asm/src/add_1.s
@@ -1,0 +1,28 @@
+	.file	"add_1.c"
+	.option nopic
+	.attribute arch, "rv32e1p9_m2p0_c2p0_zicsr2p0"
+	.attribute unaligned_access, 0
+	.attribute stack_align, 4
+	.text
+	.section	.text.hrt_add_1,"ax",@progbits
+	.align	1
+	.globl	hrt_add_1
+	.type	hrt_add_1, @function
+hrt_add_1:
+	lui	a4,%hi(arg_uint8_t)
+	lbu	a5,%lo(arg_uint8_t)(a4)
+	addi	a5,a5,1
+	andi	a5,a5,0xff
+	sb	a5,%lo(arg_uint8_t)(a4)
+	lui	a4,%hi(arg_uint16_t)
+	lhu	a5,%lo(arg_uint16_t)(a4)
+	addi	a5,a5,2
+	slli	a5,a5,16
+	srli	a5,a5,16
+	sh	a5,%lo(arg_uint16_t)(a4)
+	lui	a4,%hi(arg_uint32_t)
+	lw	a5,%lo(arg_uint32_t)(a4)
+	addi	a5,a5,3
+	sw	a5,%lo(arg_uint32_t)(a4)
+	ret
+	.size	hrt_add_1, .-hrt_add_1

--- a/tests/drivers/sdp_asm/src/add_10.c
+++ b/tests/drivers/sdp_asm/src/add_10.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+
+extern volatile uint8_t arg_uint8_t;
+extern volatile uint16_t arg_uint16_t;
+extern volatile uint32_t arg_uint32_t;
+
+void hrt_add_10(void)
+{
+	arg_uint8_t += 10;
+	arg_uint16_t += 20;
+	arg_uint32_t += 30;
+}

--- a/tests/drivers/sdp_asm/src/add_10.h
+++ b/tests/drivers/sdp_asm/src/add_10.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+void hrt_add_10(void);

--- a/tests/drivers/sdp_asm/src/add_10.s
+++ b/tests/drivers/sdp_asm/src/add_10.s
@@ -1,0 +1,28 @@
+	.file	"add_10.c"
+	.option nopic
+	.attribute arch, "rv32e1p9_m2p0_c2p0_zicsr2p0"
+	.attribute unaligned_access, 0
+	.attribute stack_align, 4
+	.text
+	.section	.text.hrt_add_10,"ax",@progbits
+	.align	1
+	.globl	hrt_add_10
+	.type	hrt_add_10, @function
+hrt_add_10:
+	lui	a4,%hi(arg_uint8_t)
+	lbu	a5,%lo(arg_uint8_t)(a4)
+	addi	a5,a5,10
+	andi	a5,a5,0xff
+	sb	a5,%lo(arg_uint8_t)(a4)
+	lui	a4,%hi(arg_uint16_t)
+	lhu	a5,%lo(arg_uint16_t)(a4)
+	addi	a5,a5,20
+	slli	a5,a5,16
+	srli	a5,a5,16
+	sh	a5,%lo(arg_uint16_t)(a4)
+	lui	a4,%hi(arg_uint32_t)
+	lw	a5,%lo(arg_uint32_t)(a4)
+	addi	a5,a5,30
+	sw	a5,%lo(arg_uint32_t)(a4)
+	ret
+	.size	hrt_add_10, .-hrt_add_10

--- a/tests/drivers/sdp_asm/src/add_100.c
+++ b/tests/drivers/sdp_asm/src/add_100.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+
+extern volatile uint8_t arg_uint8_t;
+extern volatile uint16_t arg_uint16_t;
+extern volatile uint32_t arg_uint32_t;
+
+void hrt_add_100(void)
+{
+	arg_uint8_t += 200;
+	arg_uint16_t += 300;
+	arg_uint32_t += 400;
+}

--- a/tests/drivers/sdp_asm/src/add_100.h
+++ b/tests/drivers/sdp_asm/src/add_100.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+void hrt_add_100(void);

--- a/tests/drivers/sdp_asm/src/add_100.s
+++ b/tests/drivers/sdp_asm/src/add_100.s
@@ -1,0 +1,28 @@
+	.file	"add_100.c"
+	.option nopic
+	.attribute arch, "rv32e1p9_m2p0_c2p0_zicsr2p0"
+	.attribute unaligned_access, 0
+	.attribute stack_align, 4
+	.text
+	.section	.text.hrt_add_100,"ax",@progbits
+	.align	1
+	.globl	hrt_add_100
+	.type	hrt_add_100, @function
+hrt_add_100:
+	lui	a4,%hi(arg_uint8_t)
+	lbu	a5,%lo(arg_uint8_t)(a4)
+	addi	a5,a5,100
+	andi	a5,a5,0xff
+	sb	a5,%lo(arg_uint8_t)(a4)
+	lui	a4,%hi(arg_uint16_t)
+	lhu	a5,%lo(arg_uint16_t)(a4)
+	addi	a5,a5,200
+	slli	a5,a5,16
+	srli	a5,a5,16
+	sh	a5,%lo(arg_uint16_t)(a4)
+	lui	a4,%hi(arg_uint32_t)
+	lw	a5,%lo(arg_uint32_t)(a4)
+	addi	a5,a5,300
+	sw	a5,%lo(arg_uint32_t)(a4)
+	ret
+	.size	hrt_add_100, .-hrt_add_100

--- a/tests/drivers/sdp_asm/src/main.c
+++ b/tests/drivers/sdp_asm/src/main.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdio.h>
+#include "./add_1.h"
+#include "./add_10.h"
+#include "./add_100.h"
+
+volatile uint8_t arg_uint8_t;
+volatile uint16_t arg_uint16_t;
+volatile uint32_t arg_uint32_t;
+
+int main(void)
+{
+	printf("SDP ASM test on %s\n", CONFIG_BOARD_TARGET);
+	printf("initial: %u, %u, %u\n", arg_uint8_t, arg_uint16_t, arg_uint32_t);
+	hrt_add_1();
+	printf("after add_1: %u, %u, %u\n", arg_uint8_t, arg_uint16_t, arg_uint32_t);
+	hrt_add_10();
+	printf("after add_10: %u, %u, %u\n", arg_uint8_t, arg_uint16_t, arg_uint32_t);
+	hrt_add_100();
+	printf("after add_100: %u, %u, %u\n", arg_uint8_t, arg_uint16_t, arg_uint32_t);
+	printf("Test completed.\n");
+
+	return 0;
+}

--- a/tests/drivers/sdp_asm/testcase.yaml
+++ b/tests/drivers/sdp_asm/testcase.yaml
@@ -1,0 +1,16 @@
+common:
+  tags:
+    - sdp_asm
+    - ci_tests_drivers_egpio
+  platform_allow:
+    - nrf54l15dk/nrf54l15/cpuflpr
+  integration_platforms:
+    - nrf54l15dk/nrf54l15/cpuflpr
+
+tests:
+  drivers.sdp_asm.basic:
+    harness: pytest
+    harness_config:
+      pytest_dut_scope: session
+      pytest_root:
+        - "pytest/test_sdp_asm.py::test_sdp_asm"


### PR DESCRIPTION
Add test that confirms operation of Software Defined Peripherals Assembly Management.