### PR TITLE
logging: rpc: disable overwriting while history transfer

### DIFF
--- a/subsys/logging/log_backend_rpc.c
+++ b/subsys/logging/log_backend_rpc.c
@@ -518,6 +518,7 @@ static void history_transfer_task(struct k_work *work)
 	} else {
 		log_rpc_history_free(history_cur_msg);
 		history_cur_msg = NULL;
+		log_rpc_history_set_overwriting(true);
 	}
 
 	k_mutex_unlock(&history_transfer_mtx);
@@ -541,6 +542,7 @@ static void log_rpc_fetch_history_handler(const struct nrf_rpc_group *group,
 
 	k_mutex_lock(&history_transfer_mtx, K_FOREVER);
 	history_transfer_id = transfer_id;
+	log_rpc_history_set_overwriting(false);
 	k_work_submit_to_queue(&history_transfer_workq, &history_transfer_work);
 	k_mutex_unlock(&history_transfer_mtx);
 

--- a/subsys/logging/log_backend_rpc_history.h
+++ b/subsys/logging/log_backend_rpc_history.h
@@ -12,6 +12,7 @@
 void log_rpc_history_init(void);
 
 void log_rpc_history_push(const union log_msg_generic *msg);
+void log_rpc_history_set_overwriting(bool overwriting);
 
 union log_msg_generic *log_rpc_history_pop(void);
 void log_rpc_history_free(const union log_msg_generic *msg);

--- a/subsys/logging/log_backend_rpc_history_ram.c
+++ b/subsys/logging/log_backend_rpc_history_ram.c
@@ -47,6 +47,19 @@ void log_rpc_history_push(const union log_msg_generic *msg)
 	mpsc_pbuf_commit(&log_history_pbuf, &copy->buf);
 }
 
+void log_rpc_history_set_overwriting(bool overwriting)
+{
+	k_sched_lock();
+
+	if (overwriting) {
+		log_history_pbuf.flags |= MPSC_PBUF_MODE_OVERWRITE;
+	} else {
+		log_history_pbuf.flags &= (~MPSC_PBUF_MODE_OVERWRITE);
+	}
+
+	k_sched_unlock();
+}
+
 union log_msg_generic *log_rpc_history_pop(void)
 {
 	return (union log_msg_generic *)mpsc_pbuf_claim(&log_history_pbuf);


### PR DESCRIPTION
While the log history is being transferred to the logging RPC client, do not overwrite the least recent logs in the log history, so that the history being transferred doesn't have gaps.