### PR TITLE
tests: benchmarks: power_consumption: i2c: Fix increased power consumpion

### DIFF
--- a/boards/shields/pca63566/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/boards/shields/pca63566/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -55,6 +55,7 @@
 	pinctrl-1 = <&i2c130_sleep>;
 	pinctrl-names = "default", "sleep";
 	zephyr,concat-buf-size = <255>;
+	zephyr,pm-device-runtime-auto;
 
 	bme688: bme688@76 {
 		compatible = "bosch,bme680";
@@ -82,6 +83,7 @@
 	pinctrl-1 = <&spi131_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
+	zephyr,pm-device-runtime-auto;
 	cs-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>,
 				<&gpio1 2 GPIO_ACTIVE_LOW>;
 

--- a/tests/benchmarks/power_consumption/common/main.c
+++ b/tests/benchmarks/power_consumption/common/main.c
@@ -12,6 +12,16 @@ const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(DT_ALIAS(led2), gpios);
 static bool state = true;
 extern void thread_definition(void);
 
+/* Some tests require that test thread controls the moment when it is
+ * suspended. In that case test implements this function and returns true to
+ * indicated that test thread will take case of the suspension and it can
+ * be skipped in the common code.
+ */
+__weak bool self_suspend_req(void)
+{
+	return false;
+}
+
 K_THREAD_DEFINE(thread_id, 500, thread_definition, NULL, NULL, NULL,
 				5, 0, 0);
 
@@ -24,7 +34,9 @@ void timer_handler(struct k_timer *dummy)
 	} else {
 		state = true;
 		gpio_pin_set_dt(&led, 0);
-		k_thread_suspend(thread_id);
+		if (self_suspend_req() == false) {
+			k_thread_suspend(thread_id);
+		}
 	}
 }
 

--- a/tests/benchmarks/power_consumption/i2c/src/driver_test.c
+++ b/tests/benchmarks/power_consumption/i2c/src/driver_test.c
@@ -9,6 +9,13 @@
 
 static const struct device *i2c = DEVICE_DT_GET(DT_ALIAS(sensor_bme688));
 
+static bool suspend_req;
+
+bool self_suspend_req(void)
+{
+	suspend_req = true;
+	return true;
+}
 
 void thread_definition(void)
 {
@@ -17,6 +24,10 @@ void thread_definition(void)
 
 	while (1) {
 		ret = i2c_reg_read_byte(i2c, 0x76, 0x75, &value);
+		if (suspend_req) {
+			suspend_req = false;
+			k_thread_suspend(k_current_get());
+		}
 		if (ret < 0) {
 			printk("Failure in reading byte %d", ret);
 			return;


### PR DESCRIPTION
Test was suspending test thread from the timer interrupt at random (but periodic) point. I2c driver handles power management in the thread context. Randomly suspending the test thread could lead to a case where driver did not finish requested operation and system goes to s2ram in the middle of the driver operation.

PR extends framework to allow optional requesting of the test thread suspension (instead of forcing) and test thread suspends itself when requested. It is done after driver operation is finished.

Additionally, added enabling of the runtime power management to the i2c instance used by the shield used in the test.