### PR TITLE
bluetooth: Add required heap to the gatt_dm

### DIFF
--- a/subsys/bluetooth/Kconfig.discovery
+++ b/subsys/bluetooth/Kconfig.discovery
@@ -67,6 +67,10 @@ config BT_GATT_DM_DATA_PRINT
 	help
 	  Enable functions for printing discovery related data
 
+config HEAP_MEM_POOL_ADD_SIZE_BT_GATT_DM
+	int
+	default 512
+
 module = BT_GATT_DM
 module-str = GATT database discovery
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/subsys/bluetooth/services/ras/rreq/Kconfig.ras_rreq
+++ b/subsys/bluetooth/services/ras/rreq/Kconfig.ras_rreq
@@ -23,9 +23,4 @@ config BT_RAS_RREQ_MAX_ACTIVE_CONN
 	help
 	  The number of simultaneous connections with an instance of RAS RREQ
 
-# GATT DM module requires heap
-config HEAP_MEM_POOL_ADD_SIZE_RAS_RREQ_GATT_DM
-	int
-	default 512
-
 endif # BT_RAS_RREQ


### PR DESCRIPTION
Add heap requirement to gatt_dm.
Make use of HEAP_MEM_POOL_ADD_SIZE_* Kconfig
to increase required heap for gatt_dm module.

Remove the requirement from ras service, since
the requirement is added to gatt_dm itself.

Jira: NCSDK-31002