### PR TITLE
suit: Fix Nordic top candidate verification seq

### DIFF
--- a/config/suit/templates/nrf54h20/default/v1/root_with_binary_nordic_top.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/root_with_binary_nordic_top.yaml.jinja2
@@ -465,6 +465,7 @@ SUIT_Envelope_Tagged:
 {%- endif %}
 
 {%- if nordic_top %}
+    - suit-directive-set-component-index: 0
     - suit-directive-override-parameters:
         suit-parameter-uri: '#top'
         suit-parameter-image-digest:


### PR DESCRIPTION
Since the set of selected components is local for each run-sequence and try-each sequences, the active component must be set to CAND_MFST before fetching and processing of Nordic top candidate manifest.

Ref: NCSDK-31295