### PR TITLE
[Backport v2.9-nRF54H20-branch] suit: Fix Nordic top candidate verification seq

### DIFF
--- a/config/suit/templates/nrf54h20/default/v1/root_with_binary_nordic_top.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/root_with_binary_nordic_top.yaml.jinja2
@@ -465,6 +465,7 @@ SUIT_Envelope_Tagged:
 {%- endif %}
 
 {%- if nordic_top %}
+    - suit-directive-set-component-index: 0
     - suit-directive-override-parameters:
         suit-parameter-uri: '#top'
         suit-parameter-image-digest:


### PR DESCRIPTION
Backport 5ae88098dfb7279a30f153eb9b7f06ff691ba60c from #19867.