### PR TITLE
doc: add-ons: add information about the index

### DIFF
--- a/doc/nrf/app_dev/create_application.rst
+++ b/doc/nrf/app_dev/create_application.rst
@@ -100,6 +100,7 @@ This application type is suitable for the following development cases:
 * You want to make changes to one or more of the repositories of the |NCS| when working on the application.
 * You want to develop a project that involves more than one board target, for example using a mesh networking protocol like :ref:`ug_matter` or :ref:`ug_bt_mesh`.
 * You want to run a big project that lets you develop most features without having to patch the |NCS| tree, for example with out-of-tree boards, drivers, SoCs, and so on.
+* You want to use out-of-tree applications from the `nRF Connect SDK Add-ons`_ index.
 
 For more information about applications placed in workspace in the |NCS|, see the :ref:`workflow 4 on the development model page <dm_workflow_4>`.
 
@@ -291,3 +292,34 @@ Use the following steps depending on the application type:
          This allows CMake to automatically load the boilerplate code required for building |NCS| applications.
 
 You can now start :ref:`configuring and building <configuration_and_build>` the application using the command line.
+
+.. _creating_add_on_index:
+
+Creating application from add-ons
+=================================
+
+You can create a :ref:`workspace application <create_application_types_workspace>` also by browsing and copying reference applications from the `nRF Connect SDK Add-ons`_ index.
+The index is a collection of publicly available |NCS| supplementary components that extend the SDK's functionality.
+In addition to applications, it includes drivers, libraries, and protocol implementations.
+
+To create an application from the add-on index, complete the following steps:
+
+.. tabs::
+
+   .. tab:: nRF Connect for VS Code (recommended)
+
+      Complete the following steps in the |nRFVSC|:
+
+      1. In the :guilabel:`Welcome View`, click :guilabel:`Create a new application`.
+      #. Select :guilabel:`Browse nRF Connect SDK Add-on Index`.
+      #. Browse through the available add-ons and select one that matches your needs.
+      #. Follow the creation wizard to set up your workspace application.
+
+   .. tab:: Command line
+
+      When creating add-on applications from the command line, follow the instructions provided in the `nRF Connect SDK Add-ons`_ repository.
+      These instructions guide you through the process of copying and configuring the add-on application in your workspace.
+
+The add-on is copied to your workspace and automatically configured with a west workspace, allowing you to start development right away.
+
+For more information, including how to contribute your own add-on to the index, read :file:`README.md` and :file:`CONTRIBUTING.md` in the `ncs-app-index repository <ncs-app-index_>`_.

--- a/doc/nrf/glossary.rst
+++ b/doc/nrf/glossary.rst
@@ -603,6 +603,13 @@ Glossary
       It includes a public REST API that can be used for building IoT solutions.
       See `nRF Cloud`_.
 
+   nRF Connect SDK Add-ons
+      An index of publicly available supplementary components that extend the |NCS|'s functionality.
+      The index can be accessed from the |nRFVSC|, and can also be browsed on `add-on webpage <nRF Connect SDK Add-ons_>`_.
+      Add-ons in the index follow specific contribution guidelines and are maintained by their respective owners.
+      The workspace applications listed there can be used to create out-of-tree :ref:`workspace applications <creating_add_on_index>`.
+      For more information, including how to contribute your own add-on to the index, read :file:`README.md` and :file:`CONTRIBUTING.md` in the `ncs-app-index repository <ncs-app-index_>`_.
+
    nRF repository
       An |NCS| repository, hosted in the `nrfconnect GitHub organization`_, that does not have an externally maintained, open-source upstream.
       It is exclusive to Nordic development.

--- a/doc/nrf/integrations.rst
+++ b/doc/nrf/integrations.rst
@@ -11,6 +11,10 @@ Integrations of the following third-party products are documented in their priva
 
 In the case of Find My, MFi licensees can get access to the repository by issuing a Nordic `DevZone`_ private ticket.
 
+.. note::
+    Integrations are available also through the `nRF Connect SDK Add-ons`_, a curated collection of supplementary |NCS| components.
+    For more information, including how to contribute your own add-on to the index, read :file:`README.md` and :file:`CONTRIBUTING.md` in the `ncs-app-index repository <ncs-app-index_>`_.
+
 The following user guides describe available integrations:
 
 .. toctree::

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -225,6 +225,7 @@
 .. _`Memfault WebBluetooth Client`: https://memfault.github.io/web-ble-example/
 
 .. _`nRF Connect SDK Add-ons`: https://nrfconnect.github.io/ncs-app-index/
+.. _`ncs-app-index`: https://github.com/nrfconnect/ncs-app-index
 
 .. ### Source: githubusercontent.com
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -664,5 +664,6 @@ Documentation
   * New page :ref:`thingy53_precompiled` under :ref:`ug_thingy53`.
     This page includes some of the information previously located on the standalone page for getting started with Nordic Thingy:53.
 
+* Updated the :ref:`create_application` page with the :ref:`creating_add_on_index` section.
 * Removed the standalone page for getting started with Nordic Thingy:53.
   The contents of this page have been moved to the :ref:`thingy53_precompiled` page and to the `Programmer app <Programming Nordic Thingy:53_>`_ documentation.


### PR DESCRIPTION
Added mentions of the nRF Connect SDK Add-ons page and the ncs-app-index repository to the pages Create an application and Integrations. Added a glossary entry.
VSC-2765.