### PR TITLE
[Backport v2.9-nRF54H20-branch] tests: benchmarks: power_consumption: i2c: Fix increased power consumpion

### DIFF
--- a/boards/shields/pca63566/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/boards/shields/pca63566/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -55,6 +55,7 @@
 	pinctrl-1 = <&i2c130_sleep>;
 	pinctrl-names = "default", "sleep";
 	zephyr,concat-buf-size = <255>;
+	zephyr,pm-device-runtime-auto;
 
 	bme688: bme688@76 {
 		compatible = "bosch,bme680";
@@ -82,6 +83,7 @@
 	pinctrl-1 = <&spi131_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
+	zephyr,pm-device-runtime-auto;
 	cs-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>,
 				<&gpio1 2 GPIO_ACTIVE_LOW>;
 

--- a/tests/benchmarks/power_consumption/i2c/src/driver_test.c
+++ b/tests/benchmarks/power_consumption/i2c/src/driver_test.c
@@ -9,6 +9,13 @@
 
 static const struct device *i2c = DEVICE_DT_GET(DT_ALIAS(sensor_bme688));
 
+static bool suspend_req;
+
+bool self_suspend_req(void)
+{
+	suspend_req = true;
+	return true;
+}
 
 void thread_definition(void)
 {
@@ -17,6 +24,10 @@ void thread_definition(void)
 
 	while (1) {
 		ret = i2c_reg_read_byte(i2c, 0x76, 0x75, &value);
+		if (suspend_req) {
+			suspend_req = false;
+			k_thread_suspend(k_current_get());
+		}
 		if (ret < 0) {
 			printk("Failure in reading byte %d", ret);
 			return;


### PR DESCRIPTION
Backport 6dd7041c44f61e808133384d87069e842ae678ce~3..6dd7041c44f61e808133384d87069e842ae678ce from #19861.