### PR TITLE
doc: j-link: update version to 8.10f

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -33,7 +33,10 @@ The following sections provide detailed lists of changes by component.
 IDE, OS, and tool support
 =========================
 
-* Updated the :ref:`installing_vsc` section on the :ref:`installation` page with the Windows-only requirement to install SEGGER USB Driver for J-Link.
+* Updated:
+
+  * The required `SEGGER J-Link`_ version to v8.10f.
+  * The :ref:`installing_vsc` section on the :ref:`installation` page with the Windows-only requirement to install SEGGER USB Driver for J-Link.
 
 Board support
 =============

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -6,7 +6,7 @@
 .. |release_tt| replace:: ``v2.9.0-nRF54H20-rc1``
 .. |release_number_tt| replace:: ``2.9.0-nRF54H20-rc1``
 
-.. |jlink_ver| replace:: v7.94i
+.. |jlink_ver| replace:: v8.10f
 .. |jlink_ver_vsc| replace:: v7.94i
 
 .. ### Config shortcuts


### PR DESCRIPTION
Updated the required version of SEGGER J-Link in docs to v8.10f. NRFU-1388.