### PR TITLE
actions: Bump limit of listed PRs

### DIFF
--- a/.github/workflows/enforce-toolchain-synchronization.yml
+++ b/.github/workflows/enforce-toolchain-synchronization.yml
@@ -69,7 +69,7 @@ jobs:
         if: env.modified == 'true'
         id: find_prs
         run: |
-          PRs=$(gh pr list --base ${{ github.ref_name }} --state open --json url,headRefName,files --jq '[.[] | select(.files[]? | .path as $file | [$file] | inside([env.TOOLCHAIN_FILES]))]')
+          PRs=$(gh pr list --limit 500 --base ${{ github.ref_name }} --state open --json url,headRefName,files --jq '[.[] | select(.files[]? | .path as $file | [$file] | inside([env.TOOLCHAIN_FILES]))]')
           echo "Found PRs: $PRs"
           echo "prs=$PRs" >> $GITHUB_ENV
         env:


### PR DESCRIPTION
By default `gh pr list` limits output to 30 found PRs. `--jq` expressions  filters JSON output, not PRs, which means it is evaluated after PRs number is reduced by `--limit` .