### PR TITLE
doc: release notes: Add note about fixed flash driver and ble coop

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -110,7 +110,7 @@ Amazon Sidewalk
 Bluetooth® LE
 -------------
 
-|no_changes_yet_note|
+* Fixed an issue where a flash operation executed on the system workqueue might result in ``-ETIMEDOUT``, if there is an active Bluetooth LE connection.
 
 Bluetooth Mesh
 --------------


### PR DESCRIPTION
Add a note about fixed issue where a flash operation executed on the system workqueue might result in `-ETIMEDOUT` if there is an active Bluetooth LE connection.

Ref: https://github.com/nrfconnect/sdk-nrf/pull/18953