### PR TITLE
scripts: remove a sample from quarantine integration.yaml

### DIFF
--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -347,7 +347,6 @@
     - sample.matter.template.smp_dfu
   platforms:
     - nrf52840dk/nrf52840
-    - nrf7002dk/nrf5340/cpuapp
     - nrf5340dk/nrf5340/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
 


### PR DESCRIPTION
As switching to testing template with smp_dfu on nRF7002 in integration, we need it to be built there.