### PR TITLE
samples: psa_tls: Add TLS 1.3 tests for cracen

### DIFF
--- a/samples/crypto/psa_tls/sample.yaml
+++ b/samples/crypto/psa_tls/sample.yaml
@@ -299,6 +299,50 @@ tests:
       - cracen
       - sysbuild
       - ci_samples_crypto
+  sample.psa_tls.tls_1_3_server.ecdsa.cracen:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      OVERLAY_CONFIG="overlays/server.conf;overlays/ecdsa.conf;overlays/cracen-psa.conf;overlays/tls_1_3.conf"
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    tags:
+      - ci_build
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
+  sample.psa_tls.tls_1_3_client.ecdsa.cracen:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      OVERLAY_CONFIG="overlays/client.conf;overlays/ecdsa.conf;overlays/cracen-psa.conf;overlays/tls_1_3.conf"
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    tags:
+      - ci_build
+      - cracen
+      - sysbuild
+      - ci_samples_crypto
   ################################################################################
   ## PSA APIs with Cracen and Oberon
   ################################################################################


### PR DESCRIPTION
Added test cases for cracen backend to run TLS 1.3 tests

