### PR TITLE
[Backport v2.9-nRF54H20-branch] tests: benchmarks: multicore: Fix core synchronization in idle_pwm_lo…

### DIFF
--- a/tests/benchmarks/multicore/idle_pwm_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/benchmarks/multicore/idle_pwm_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -13,7 +13,6 @@
  */
 
 / {
-
 	aliases {
 		led = &led0;
 		/delete-property/ led1;

--- a/tests/benchmarks/multicore/idle_pwm_loopback/src/main.c
+++ b/tests/benchmarks/multicore/idle_pwm_loopback/src/main.c
@@ -102,15 +102,14 @@ int main(void)
 	ret = gpio_is_ready_dt(&led);
 	__ASSERT(ret, "Error: GPIO Device not ready");
 
-#if defined(CONFIG_CLOCK_CONTROL)
-	ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_INACTIVE);
-	__ASSERT(ret == 0, "Could not configure led GPIO");
-	k_msleep(1000);
-	gpio_pin_set_dt(&led, 1);
-	set_global_domain_frequency();
-#else
 	ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
 	__ASSERT(ret == 0, "Could not configure led GPIO");
+
+	/* Wait a bit to solve NRFS request timeout issue. */
+	k_msleep(100);
+
+#if defined(CONFIG_CLOCK_CONTROL)
+	set_global_domain_frequency();
 #endif
 
 	/* Set PWM fill ratio to 50% */

--- a/tests/benchmarks/multicore/idle_pwm_loopback/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_pwm_loopback/testcase.yaml
@@ -94,7 +94,7 @@ tests:
     harness_config:
       fixture: spi_loopback
       pytest_root:
-        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_pwm_and_s2ram"
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_pwm_and_s2ram_with_clock_control"
 
   benchmarks.multicore.idle_pwm_loopback.nrf54h20dk_cpuapp_cpurad.s2ram_fast.gd_freq_256MHz:
     tags: ppk_power_measure
@@ -108,7 +108,7 @@ tests:
     harness_config:
       fixture: spi_loopback
       pytest_root:
-        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_pwm_and_s2ram"
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_pwm_and_s2ram_with_clock_control"
 
   benchmarks.multicore.idle_pwm_loopback.nrf54h20dk_cpuapp_cpurad.s2ram_fast.gd_freq_128MHz:
     tags: ppk_power_measure
@@ -122,7 +122,7 @@ tests:
     harness_config:
       fixture: spi_loopback
       pytest_root:
-        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_pwm_and_s2ram"
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_pwm_and_s2ram_with_clock_control"
 
   benchmarks.multicore.idle_pwm_loopback.nrf54h20dk_cpuapp_cpurad.s2ram_fast.gd_freq_64MHz:
     tags: ppk_power_measure
@@ -136,4 +136,4 @@ tests:
     harness_config:
       fixture: spi_loopback
       pytest_root:
-        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_pwm_and_s2ram"
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_pwm_and_s2ram_with_clock_control"


### PR DESCRIPTION
Backport 2e0fec201f8c8f3e87585a140514f8c14a6e7f5e from #19912.