### PR TITLE
samples: psa_tls: Fix typo in chip name

### DIFF
--- a/samples/crypto/psa_tls/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/crypto/psa_tls/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -10,7 +10,7 @@ CONFIG_MBEDTLS_PSA_CRYPTO_C=y
 
 # The ECDSA CA certificate is stored persistently with Protected Storage,
 # which internally uses Internal Trusted Storage. Since ITS encryption is
-# enabled by default for nRF54L20, the sample must be configured with a
+# enabled by default for nRF54L15, the sample must be configured with a
 # larger ITS asset size than the default 500 bytes. This is because
 # encrypted ITS assets must be stored in a single chunk.
 CONFIG_TFM_ITS_MAX_ASSET_SIZE_OVERRIDE=y


### PR DESCRIPTION
The chip name was wrongly mentioned as nRF54L20.
Since this is overlay file for the nRF54L15DK, this needs to be nRF54L15.