### PR TITLE
esb: Add ESB events queuing

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -125,7 +125,11 @@ DECT NR+
 Enhanced ShockBurst (ESB)
 -------------------------
 
-* Added loading of radio trims and a fix of a hardware errata for the nRF54H20 SoC to improve the RF performance.
+* Added:
+
+  * Loading of radio trims and a fix of a hardware errata for the nRF54H20 SoC to improve the RF performance.
+  * Queuing for ESB events.
+    Events are handled using the ``System Workqueue``.
 
 Gazell
 ------


### PR DESCRIPTION
Added queuing for ESB events.
The handling of these events is now processed using the system workqueue, reducing the interrupt handling time
when a packet is received.
This approach prevents the loss of ESB_EVENT_RX_RECEIVED events that could occur while the event callback is still being processed.
