### PR TITLE
scripts: Fix extracted ECDSA signature padding

### DIFF
--- a/scripts/bootloader/asn1parse.py
+++ b/scripts/bootloader/asn1parse.py
@@ -29,7 +29,7 @@ def get_ecdsa_signature(der, clength):
     # Disable pylint error as 'input' keyword has specific handling in 'check_output'
     # pylint: disable=unexpected-keyword-arg
     stdout = check_output(['openssl', 'asn1parse', '-inform', 'der'], input=der)
-    sig = b''.join([bytes.fromhex(re.search(r'(?<=\:)([0-9A-F]+)', num)[0]).ljust(clength, b'\0') \
+    sig = b''.join([bytes.fromhex(re.search(r'(?<=\:)([0-9A-F]+)', num)[0]).rjust(clength, b'\0') \
                     for num in re.findall(r'INTEGER *\:[0-9A-F]+', stdout.decode())])
 
     assert len(sig) == 2*clength


### PR DESCRIPTION
As the comments of `get_ecdsa_signature()` suggest, ECDSA r/s values can be short and require left-padding with zeroes. However, [this change](https://github.com/nrfconnect/sdk-nrf/commit/df0171a3d4832dc365a0ec6a8800b07bd92fd7c2) replaced the `leftpad()` function with `ljust()`, which provides right-padding. This can cause signature verification to occasionally fail when `SB_CONFIG_SECURE_BOOT_SIGNING_OPENSSL` is used:
```
[203/205] Creating validation for zephyr.hex, storing to
Traceback (most recent call last):
  File "/ncs/nrf/scripts/bootloader/validation_data.py", line 109, in <module>
    main()
  File "/ncs/nrf/scripts/bootloader/validation_data.py", line 99, in main
    append_validation_data(signature=args.signature.read(),
  File "/ncs/nrf/scripts/bootloader/validation_data.py", line 48, in append_validation_data
    validation_data = get_validation_data(signature_bytes=signature,
  File "/ncs/nrf/scripts/bootloader/validation_data.py", line 26, in get_validation_data
    public_key.verify(signature_bytes, hash_bytes, hashfunc=hashlib.sha256)
  File "/usr/local/lib/python3.9/site-packages/ecdsa/keys.py", line 685, in verify
    return self.verify_digest(signature, digest, sigdecode, allow_truncate)
  File "/usr/local/lib/python3.9/site-packages/ecdsa/keys.py", line 741, in verify_digest
    raise BadSignatureError("Signature verification failed")
ecdsa.keys.BadSignatureError: Signature verification failed
```

I presume this went uncaught for so long since `SB_CONFIG_SECURE_BOOT_SIGNING_OPENSSL` is rarely used and signature validation only occasionally fails when it is set.