### PR TITLE
lib: location: skip A-GNSS data request when no ephe/alm requested

### DIFF
--- a/lib/location/method_gnss.c
+++ b/lib/location/method_gnss.c
@@ -425,19 +425,27 @@ static void method_gnss_pgps_request_work_fn(struct k_work *item)
 static bool method_gnss_agnss_required(void)
 {
 	int32_t time_since_agnss_req;
-	bool ephe_or_alm_required = false;
+	bool ephe_requested = false;
+	bool alm_requested = false;
 
 	/* Check if A-GNSS data is needed. */
 	for (int i = 0; i < agnss_request.system_count; i++) {
-		if (agnss_request.system[i].sv_mask_ephe != 0 ||
-		    agnss_request.system[i].sv_mask_alm != 0) {
-			ephe_or_alm_required = true;
-			break;
+		if (agnss_request.system[i].sv_mask_ephe != 0) {
+			ephe_requested = true;
+		}
+		if (agnss_request.system[i].sv_mask_alm != 0) {
+			alm_requested = true;
 		}
 	}
 
-	if (agnss_request.data_flags == 0 && !ephe_or_alm_required) {
+	if (!ephe_requested && !alm_requested && agnss_request.data_flags == 0) {
 		LOG_DBG("No A-GNSS data types requested");
+		return false;
+	} else if (!IS_ENABLED(CONFIG_NRF_CLOUD_PGPS) && !ephe_requested) {
+		/* No ephemerides requested and A-GNSS is used to provide ephemerides.
+		 * Skip this request and download all data with the next ephemeris request.
+		 */
+		LOG_DBG("Skipping A-GNSS request, no ephemerides requested");
 		return false;
 	}
 
@@ -551,12 +559,8 @@ static void method_gnss_assistance_request(void)
 	 * QZSS satellites always as expired.
 	 */
 	if (agnss_request.system_count > 1) {
-		if (agnss_request.data_flags != 0 ||
-		    agnss_request.system[0].sv_mask_ephe != 0 ||
-		    agnss_request.system[0].sv_mask_alm != 0) {
-			/* QZSS ephemerides are requested always when other assistance data is
-			 * needed.
-			 */
+		if (agnss_request.system[0].sv_mask_ephe != 0) {
+			/* QZSS ephemerides are requested whenever GPS ephemerides are requested. */
 			agnss_request.system[1].sv_mask_ephe = 0x3ff;
 		} else {
 			/* No other assistance is needed. Request QZSS ephemerides anyway if
@@ -1172,7 +1176,7 @@ static void method_gnss_agnss_expiry_process(const struct nrf_modem_gnss_agnss_e
 			 */
 
 			/* QZSS ephemerides are valid for a maximum of two hours, so no expiry
-			 * is used here.
+			 * threshold is used here.
 			 */
 			if (agnss_expiry->sv[i].ephe_expiry == 0) {
 				expired_qzss_ephe_mask |=


### PR DESCRIPTION
GNSS asks for some A-GNSS data, like UTC and iono parameters, once every 24 hours. This may have caused a separate A-GNSS data request for this data alone. The implementation has now been modified to skip such a request. All data is downloaded with the next ephemeris request, which happens approximately every two hours.