### PR TITLE
doc: create_application: fix freestanding app desc

### DIFF
--- a/doc/nrf/app_dev/create_application.rst
+++ b/doc/nrf/app_dev/create_application.rst
@@ -111,8 +111,7 @@ Freestanding application
 
 This kind of application is handled separately from the |NCS|.
 It is located out-of-tree, that is outside of a west workspace, and is not using the `west manifest file`_ to specify the SDK version.
-Instead, the |NCS| version is taken from the :makevar:`ZEPHYR_BASE` environment variable.
-This means that all freestanding applications will use the same |NCS| version and the same copy of the SDK.
+The build system will find the location of the SDK through the :makevar:`ZEPHYR_BASE` environment variable, which is set either through a script or manually in an IDE.
 
 With this kind of application, the workspace has the following structure:
 


### PR DESCRIPTION
Updated one line in the freestanding application description. The line became incorrect with the recent changes in the IDE. The new line is reused from the adding_code.rst and more accurate. Reported by @kylebonnici.