### PR TITLE
mgmt: fmfu: Hide MGMT_FMFU logging options when not enabled

### DIFF
--- a/subsys/mgmt/fmfu/Kconfig
+++ b/subsys/mgmt/fmfu/Kconfig
@@ -12,8 +12,12 @@ config MGMT_FMFU
 	depends on MCUMGR
 	depends on NRF_MODEM_LIB
 
+if MGMT_FMFU
+
 module=MGMT_FMFU
 module-dep=LOG
 module-str=FMFU
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endif
 endmenu


### PR DESCRIPTION
When building an application we don't want
CONFIG_MGMT_FMFU_LOG_LEVEL_DEFAULT to turn up in the generated .config file unless CONFIG_MGMT_FMFU is enabled.