### PR TITLE
applications: nrf5340_audio: Hide audio configs when not enabled

### DIFF
--- a/subsys/audio_module/Kconfig
+++ b/subsys/audio_module/Kconfig
@@ -17,14 +17,19 @@ config AUDIO_MODULE_TEST
 
 config AUDIO_MODULE_NAME_SIZE
 	int "Maximum size for module naming in characters"
+	depends on AUDIO_MODULE
 	default 20
 
 #----------------------------------------------------------------------------#
 menu "Log levels"
 
+if AUDIO_MODULE || AUDIO_MODULE_TEST
+
 module = AUDIO_MODULE
 module-str = audio_module
 source "subsys/logging/Kconfig.template.log_config"
+
+endif
 
 endmenu # Log levels
 endmenu # Audio Modules

--- a/subsys/audio_module/Kconfig
+++ b/subsys/audio_module/Kconfig
@@ -11,7 +11,6 @@ config AUDIO_MODULE
 
 config AUDIO_MODULE_TEST
 	bool "Enable test mode"
-	default n
 	help
 	  Enable the test mode for the audio module.
 


### PR DESCRIPTION
When building non-audio applications the generated .config file previously contained the entries
CONFIG_AUDIO_MODULE_NAME_SIZE
CONFIG_AUDIO_MODULE_LOG_LEVEL
which we do not want to have there.