### PR TITLE
tests: Make ZTEST_MULTICORE_DEFAULT_SETTINGS depend on ZTEST

### DIFF
--- a/tests/Kconfig
+++ b/tests/Kconfig
@@ -8,6 +8,7 @@ menu "Test"
 
 config ZTEST_MULTICORE_DEFAULT_SETTINGS
 	bool "Implement default image for multicore boards"
+	depends on ZTEST
 	default y
 
 rsource "unity/Kconfig"


### PR DESCRIPTION
The generated .config for a sample application should not contain CONFIG_ZTEST_MULTICORE_DEFAULT_SETTINGS=y unless ZTEST is enabled.