### PR TITLE
samples: psa_tls: Fix folder naming for tls tests

### DIFF
--- a/samples/crypto/psa_tls/sample.yaml
+++ b/samples/crypto/psa_tls/sample.yaml
@@ -302,7 +302,7 @@ tests:
   ################################################################################
   ## PSA APIs with Cracen and Oberon
   ################################################################################
-  sample.psa_tls.1_3_server.ecdsa.cracen_oberon:
+  sample.psa_tls.tls_1_3_server.ecdsa.cracen_oberon:
     sysbuild: true
     build_only: true
     extra_args:
@@ -318,7 +318,7 @@ tests:
       - cracen_oberon
       - sysbuild
       - ci_samples_crypto
-  sample.psa_tls.1_3_client.ecdsa.cracen_oberon:
+  sample.psa_tls.tls_1_3_client.ecdsa.cracen_oberon:
     sysbuild: true
     build_only: true
     extra_args:


### PR DESCRIPTION
Folder naming scheme was wrong for tls 1.3 tests with cracen + oberon backend. Fixed it.