### PR TITLE
Coremark issues for NCS 3.0.0

### DIFF
--- a/samples/benchmarks/coremark/prj.conf
+++ b/samples/benchmarks/coremark/prj.conf
@@ -11,11 +11,10 @@ CONFIG_COREMARK=y
 CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
 
 # Config results output
-# The default logging level is set to the OFF level.
+# The default logging level is set to the ERROR level.
 # Kernel error logging is enabled to notify the developer about system faults.
 CONFIG_LOG=y
-CONFIG_LOG_DEFAULT_LEVEL=0
-CONFIG_KERNEL_LOG_LEVEL_ERR=y
+CONFIG_LOG_DEFAULT_LEVEL=1
 CONFIG_CBPRINTF_FP_SUPPORT=y
 
 CONFIG_GPIO=y

--- a/samples/benchmarks/coremark/prj.conf
+++ b/samples/benchmarks/coremark/prj.conf
@@ -8,7 +8,7 @@
 CONFIG_COREMARK=y
 
 # Compiler options
-CONFIG_COMPILER_OPT="-O3"
+CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
 
 # Config results output
 # The default logging level is set to the OFF level.

--- a/samples/benchmarks/coremark/prj.conf
+++ b/samples/benchmarks/coremark/prj.conf
@@ -20,8 +20,6 @@ CONFIG_CBPRINTF_FP_SUPPORT=y
 
 CONFIG_GPIO=y
 
-CONFIG_MAIN_THREAD_PRIORITY=-1
-
 # Configuration variant:
 # Memory allocation using the stack memory
 # Single-threaded benchmark execution

--- a/samples/benchmarks/coremark/prj_flash_and_run.conf
+++ b/samples/benchmarks/coremark/prj_flash_and_run.conf
@@ -11,11 +11,10 @@ CONFIG_COREMARK=y
 CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
 
 # Config results output
-# The default logging level is set to the OFF level.
+# The default logging level is set to the ERROR level.
 # Kernel error logging is enabled to notify the developer about system faults.
 CONFIG_LOG=y
-CONFIG_LOG_DEFAULT_LEVEL=0
-CONFIG_KERNEL_LOG_LEVEL_ERR=y
+CONFIG_LOG_DEFAULT_LEVEL=1
 CONFIG_CBPRINTF_FP_SUPPORT=y
 
 CONFIG_GPIO=y

--- a/samples/benchmarks/coremark/prj_flash_and_run.conf
+++ b/samples/benchmarks/coremark/prj_flash_and_run.conf
@@ -8,7 +8,7 @@
 CONFIG_COREMARK=y
 
 # Compiler options
-CONFIG_COMPILER_OPT="-O3"
+CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
 
 # Config results output
 # The default logging level is set to the OFF level.

--- a/samples/benchmarks/coremark/prj_flash_and_run.conf
+++ b/samples/benchmarks/coremark/prj_flash_and_run.conf
@@ -20,8 +20,6 @@ CONFIG_CBPRINTF_FP_SUPPORT=y
 
 CONFIG_GPIO=y
 
-CONFIG_MAIN_THREAD_PRIORITY=-1
-
 # Configuration variant:
 # Memory allocation using the stack memory
 # Single-threaded benchmark execution

--- a/samples/benchmarks/coremark/prj_heap_memory.conf
+++ b/samples/benchmarks/coremark/prj_heap_memory.conf
@@ -11,11 +11,10 @@ CONFIG_COREMARK=y
 CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
 
 # Config results output
-# The default logging level is set to the OFF level.
+# The default logging level is set to the ERROR level.
 # Kernel error logging is enabled to notify the developer about system faults.
 CONFIG_LOG=y
-CONFIG_LOG_DEFAULT_LEVEL=0
-CONFIG_KERNEL_LOG_LEVEL_ERR=y
+CONFIG_LOG_DEFAULT_LEVEL=1
 CONFIG_CBPRINTF_FP_SUPPORT=y
 
 CONFIG_GPIO=y

--- a/samples/benchmarks/coremark/prj_heap_memory.conf
+++ b/samples/benchmarks/coremark/prj_heap_memory.conf
@@ -20,8 +20,6 @@ CONFIG_CBPRINTF_FP_SUPPORT=y
 
 CONFIG_GPIO=y
 
-CONFIG_MAIN_THREAD_PRIORITY=-1
-
 # Configuration variant:
 # Memory allocation using the heap memory
 # Single-threaded benchmark execution

--- a/samples/benchmarks/coremark/prj_heap_memory.conf
+++ b/samples/benchmarks/coremark/prj_heap_memory.conf
@@ -8,7 +8,7 @@
 CONFIG_COREMARK=y
 
 # Compiler options
-CONFIG_COMPILER_OPT="-O3"
+CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
 
 # Config results output
 # The default logging level is set to the OFF level.

--- a/samples/benchmarks/coremark/prj_multiple_threads.conf
+++ b/samples/benchmarks/coremark/prj_multiple_threads.conf
@@ -20,8 +20,6 @@ CONFIG_CBPRINTF_FP_SUPPORT=y
 
 CONFIG_GPIO=y
 
-CONFIG_MAIN_THREAD_PRIORITY=-1
-
 # Configuration variant:
 # Memory allocation using the stack memory
 # Multi-threaded benchmark execution

--- a/samples/benchmarks/coremark/prj_multiple_threads.conf
+++ b/samples/benchmarks/coremark/prj_multiple_threads.conf
@@ -11,11 +11,10 @@ CONFIG_COREMARK=y
 CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
 
 # Config results output
-# The default logging level is set to the OFF level.
+# The default logging level is set to the ERROR level.
 # Kernel error logging is enabled to notify the developer about system faults.
 CONFIG_LOG=y
-CONFIG_LOG_DEFAULT_LEVEL=0
-CONFIG_KERNEL_LOG_LEVEL_ERR=y
+CONFIG_LOG_DEFAULT_LEVEL=1
 CONFIG_CBPRINTF_FP_SUPPORT=y
 
 CONFIG_GPIO=y

--- a/samples/benchmarks/coremark/prj_multiple_threads.conf
+++ b/samples/benchmarks/coremark/prj_multiple_threads.conf
@@ -8,7 +8,7 @@
 CONFIG_COREMARK=y
 
 # Compiler options
-CONFIG_COMPILER_OPT="-O3"
+CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
 
 # Config results output
 # The default logging level is set to the OFF level.

--- a/samples/benchmarks/coremark/prj_static_memory.conf
+++ b/samples/benchmarks/coremark/prj_static_memory.conf
@@ -11,11 +11,10 @@ CONFIG_COREMARK=y
 CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
 
 # Config results output
-# The default logging level is set to the OFF level.
+# The default logging level is set to the ERROR level.
 # Kernel error logging is enabled to notify the developer about system faults.
 CONFIG_LOG=y
-CONFIG_LOG_DEFAULT_LEVEL=0
-CONFIG_KERNEL_LOG_LEVEL_ERR=y
+CONFIG_LOG_DEFAULT_LEVEL=1
 CONFIG_CBPRINTF_FP_SUPPORT=y
 
 CONFIG_GPIO=y

--- a/samples/benchmarks/coremark/prj_static_memory.conf
+++ b/samples/benchmarks/coremark/prj_static_memory.conf
@@ -8,7 +8,7 @@
 CONFIG_COREMARK=y
 
 # Compiler options
-CONFIG_COMPILER_OPT="-O3"
+CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
 
 # Config results output
 # The default logging level is set to the OFF level.

--- a/samples/benchmarks/coremark/prj_static_memory.conf
+++ b/samples/benchmarks/coremark/prj_static_memory.conf
@@ -20,8 +20,6 @@ CONFIG_CBPRINTF_FP_SUPPORT=y
 
 CONFIG_GPIO=y
 
-CONFIG_MAIN_THREAD_PRIORITY=-1
-
 # Configuration variant:
 # Memory allocation using the static memory
 # Single-threaded benchmark execution

--- a/samples/benchmarks/coremark/src/main.c
+++ b/samples/benchmarks/coremark/src/main.c
@@ -15,6 +15,8 @@
 
 LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
 
+#define COOP_PRIO -1
+
 #ifndef CONFIG_APP_MODE_FLASH_AND_RUN
 /*
  * Get button configuration from the devicetree. This is mandatory.
@@ -170,8 +172,20 @@ static int button_init(void)
 	return ret;
 }
 
+static void main_thread_priority_cooperative_set(void)
+{
+	BUILD_ASSERT(CONFIG_MAIN_THREAD_PRIORITY >= 0);
+	k_thread_priority_set(k_current_get(), COOP_PRIO);
+}
+
 int main(void)
 {
+	/* Drivers need to be run from a non-blocking thread.
+	 * We need preemptive priority during init.
+	 * Later we prefer cooperative priority to ensure no interference with the benchmark.
+	 */
+	main_thread_priority_cooperative_set();
+
 	LOG_INF("CoreMark sample for %s", CONFIG_BOARD_TARGET);
 
 	if (IS_ENABLED(CONFIG_APP_MODE_FLASH_AND_RUN)) {


### PR DESCRIPTION
Set coremark main thread to cooperative priority at start of main - requirement to allow starting drivers form non-blocking context.

Add extra compiler flags to improve performance.

Change log level to enable seeing errors.