### PR TITLE
tests: benchmarks: kernel_freq_change: extend timeout

### DIFF
--- a/tests/benchmarks/kernel_freq_change/testcase.yaml
+++ b/tests/benchmarks/kernel_freq_change/testcase.yaml
@@ -10,4 +10,4 @@ tests:
       - nrf54h20dk/nrf54h20/cpurad
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
-    timeout: 120
+    timeout: 180


### PR DESCRIPTION
More time needed for stress tests.