### PR TITLE
[Backport v2.9-branch] Reconnect to network after RPU recovery

### DIFF
--- a/applications/matter_bridge/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/applications/matter_bridge/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -10,3 +10,8 @@
 		zephyr,code-partition = &boot_partition;
 	};
 };
+
+// Disable GPIO forwarder for nRF7002 EK compatibility
+&gpio_fwd {
+	status = "disabled";
+};

--- a/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -10,3 +10,8 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
+
+// Disable GPIO forwarder for nRF7002 EK compatibility
+&gpio_fwd {
+	status = "disabled";
+};

--- a/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -10,3 +10,8 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
+
+// Disable GPIO forwarder for nRF7002 EK compatibility
+&gpio_fwd {
+	status = "disabled";
+};

--- a/samples/matter/lock/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/lock/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -10,3 +10,8 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
+
+// Disable GPIO forwarder for nRF7002 EK compatibility
+&gpio_fwd {
+	status = "disabled";
+};

--- a/samples/matter/smoke_co_alarm/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/smoke_co_alarm/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -10,3 +10,8 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
+
+// Disable GPIO forwarder for nRF7002 EK compatibility
+&gpio_fwd {
+	status = "disabled";
+};

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -10,3 +10,8 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
+
+// Disable GPIO forwarder for nRF7002 EK compatibility
+&gpio_fwd {
+	status = "disabled";
+};

--- a/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -10,3 +10,8 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
+
+// Disable GPIO forwarder for nRF7002 EK compatibility
+&gpio_fwd {
+	status = "disabled";
+};

--- a/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -10,3 +10,8 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
+
+// Disable GPIO forwarder for nRF7002 EK compatibility
+&gpio_fwd {
+	status = "disabled";
+};

--- a/west.yml
+++ b/west.yml
@@ -159,7 +159,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.9.1
+      revision: 1f5605c7ee6b406161e0d57b8d5851f62c9f26f0
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
*Reconnect to network after RPU recovery
*Disable GPIO forwarder in mcuboot