### PR TITLE
snippets: matter: Added snippet for matter debug purposes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -693,6 +693,7 @@
 /snippets/sdp/                            @nrfconnect/ncs-ll-ursus
 /snippets/hw-flow-control/                @nrfconnect/ncs-low-level-test @miha-nordic
 /snippets/matter-diagnostic-logs/         @nrfconnect/ncs-matter
+/snippets/matter-debug/                   @nrfconnect/ncs-matter
 /snippets/nordic-bt-rpc/                  @ppryga-nordic
 /snippets/nrf70-driver-debug/             @krish2718 @sachinthegreen
 /snippets/nrf70-driver-verbose-debug/     @krish2718 @sachinthegreen

--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -326,3 +326,31 @@ Example for the ``nrf52840dk/nrf52840`` board target and the :ref:`matter_lock_s
    :class: highlight
 
    west build -b nrf52840dk/nrf52840 -- -Dlock_SNIPPET=matter-diagnostic-logs
+
+.. _ug_matter_debug_snippet:
+
+Debug snippet
+=============
+
+The Matter debug snippet allows you to enable additional debug features while using Matter samples.
+
+The following features are enabled when using this snippet:
+
+  * UART speed is increased to 1 Mbit/s.
+  * Log buffer size is set to high value to allow showing all logs.
+  * Deferred mode of logging.
+  * Increased verbosity of Matter logs.
+  * Openthread is built from sources.
+  * Openthread shell is enabled.
+  * Openthread logging level is set to INFO.
+  * Full shell functionalities.
+  * Logging source code location on VerifyOrDie failure that occurs in the Matter stack.
+
+To use the snippet when building a sample, add ``-D<project_name>_SNIPPET=matter-debug`` to the west arguments list.
+
+For example, for the ``nrf52840dk/nrf52840`` board target and the :ref:`matter_lock_sample` sample, use the following command:
+
+.. parsed-literal::
+   :class: highlight
+
+   west build -b nrf52840dk/nrf52840 -- -Dlock_SNIPPET=matter-debug

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -139,6 +139,7 @@ Matter
 ------
 
 * Disabled the :ref:`mpsl` before performing factory reset to speed up the process.
+* Added :ref:`ug_matter_debug_snippet`.
 
 Matter fork
 +++++++++++

--- a/snippets/matter-debug/boards/nrf52840dk_nrf52840.overlay
+++ b/snippets/matter-debug/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,8 @@
+/* Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&uart0 {
+	current-speed = <1000000>;
+};

--- a/snippets/matter-debug/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/snippets/matter-debug/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,8 @@
+/* Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&uart0 {
+	current-speed = <1000000>;
+};

--- a/snippets/matter-debug/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/snippets/matter-debug/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,8 @@
+/* Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&uart136 {
+	current-speed = <1000000>;
+};

--- a/snippets/matter-debug/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/snippets/matter-debug/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,8 @@
+/* Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&uart20 {
+	current-speed = <1000000>;
+};

--- a/snippets/matter-debug/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/snippets/matter-debug/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,8 @@
+/* Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&uart0 {
+	current-speed = <1000000>;
+};

--- a/snippets/matter-debug/matter_debug.conf
+++ b/snippets/matter-debug/matter_debug.conf
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable OpenThread debug logs
+CONFIG_OPENTHREAD_SOURCES=y
+CONFIG_OPENTHREAD_DEBUG=y
+CONFIG_OPENTHREAD_LOG_LEVEL_INFO=y
+CONFIG_OPENTHREAD_SHELL=y
+
+# Deferred mode of logging
+CONFIG_LOG=y
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_LOG_BUFFER_SIZE=40960
+CONFIG_LOG_SPEED=y
+CONFIG_LOG_BLOCK_IN_THREAD=y
+CONFIG_LOG_BLOCK_IN_THREAD_TIMEOUT_MS=50
+
+# Enable shell features
+CONFIG_SHELL_MINIMAL=n
+
+# Increase verbosity of Matter logs
+CONFIG_CHIP_LOG_SIZE_OPTIMIZATION=n
+
+# Enable logging source code location on VerifyOrDie failure
+CONFIG_CHIP_LOG_VERIFY_OR_DIE=y

--- a/snippets/matter-debug/snippet.yml
+++ b/snippets/matter-debug/snippet.yml
@@ -1,0 +1,23 @@
+name: matter-debug
+append:
+  EXTRA_CONF_FILE: matter_debug.conf
+
+boards:
+  /.*nrf52840.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf52840dk_nrf52840.overlay
+  /.*nrf5340.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf5340dk_nrf5340_cpuapp.overlay
+  nrf7002dk/nrf5340/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf7002dk_nrf5340_cpuapp.overlay
+  thingy53/nrf5340/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf5340dk_nrf5340_cpuapp.overlay
+  /.*nrf54l.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+  /.*nrf54h20.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf54h20dk_nrf54h20_cpuapp.overlay


### PR DESCRIPTION
Utilizing this snippet:
- Extended log buffer size
- Increased UART speed to 1M
- Eabled OpenThread debug
- Disabled log size optimization
- Switched to log mode deferred.