### PR TITLE
samples: matter: Added nullptr checks after memory allocation

### DIFF
--- a/samples/matter/common/src/binding/binding_handler.cpp
+++ b/samples/matter/common/src/binding/binding_handler.cpp
@@ -31,6 +31,7 @@ namespace Nrf::Matter
 
 	void BindingHandler::OnInvokeCommandSucces(BindingData *bindingData)
 	{
+		VerifyOrReturn(bindingData != nullptr, LOG_ERR("Invalid binding data"));
 		LOG_DBG("Binding command applied successfully!");
 
 		/* If session was recovered and communication works, reset flag to the initial state. */

--- a/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -7,9 +7,6 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 

--- a/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -13,9 +13,6 @@ CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 # TODO: KRKNWK-19382: Disable NFC commissioning due to an issue with definitions for ns build.
 CONFIG_CHIP_NFC_COMMISSIONING=n
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.

--- a/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -7,9 +7,6 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.

--- a/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -13,9 +13,6 @@ CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 # TODO: KRKNWK-19382: Disable NFC commissioning due to an issue with definitions for ns build.
 CONFIG_CHIP_NFC_COMMISSIONING=n
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.

--- a/samples/matter/light_switch/src/shell_commands.cpp
+++ b/samples/matter/light_switch/src/shell_commands.cpp
@@ -67,42 +67,51 @@ namespace Unicast
 	{
 		Nrf::Matter::BindingHandler::BindingData *data =
 			Platform::New<Nrf::Matter::BindingHandler::BindingData>();
-		data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
-		data->CommandId = Clusters::OnOff::Commands::On::Id;
-		data->ClusterId = Clusters::OnOff::Id;
-		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
-		data->IsGroup.SetValue(false);
+		if (data) {
+			data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
+			data->CommandId = Clusters::OnOff::Commands::On::Id;
+			data->ClusterId = Clusters::OnOff::Id;
+			data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
+			data->IsGroup.SetValue(false);
 
-		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
-		return CHIP_NO_ERROR;
+			Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
+			return CHIP_NO_ERROR;
+		}
+		return CHIP_ERROR_NO_MEMORY;
 	}
 
 	static CHIP_ERROR OffCommandHandler(int argc, char **argv)
 	{
 		Nrf::Matter::BindingHandler::BindingData *data =
 			Platform::New<Nrf::Matter::BindingHandler::BindingData>();
-		data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
-		data->CommandId = Clusters::OnOff::Commands::Off::Id;
-		data->ClusterId = Clusters::OnOff::Id;
-		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
-		data->IsGroup.SetValue(false);
+		if (data) {
+			data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
+			data->CommandId = Clusters::OnOff::Commands::Off::Id;
+			data->ClusterId = Clusters::OnOff::Id;
+			data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
+			data->IsGroup.SetValue(false);
 
-		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
-		return CHIP_NO_ERROR;
+			Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
+			return CHIP_NO_ERROR;
+		}
+		return CHIP_ERROR_NO_MEMORY;
 	}
 
 	static CHIP_ERROR ToggleCommandHandler(int argc, char **argv)
 	{
 		Nrf::Matter::BindingHandler::BindingData *data =
 			Platform::New<Nrf::Matter::BindingHandler::BindingData>();
-		data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
-		data->CommandId = Clusters::OnOff::Commands::Toggle::Id;
-		data->ClusterId = Clusters::OnOff::Id;
-		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
-		data->IsGroup.SetValue(false);
+		if (data) {
+			data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
+			data->CommandId = Clusters::OnOff::Commands::Toggle::Id;
+			data->ClusterId = Clusters::OnOff::Id;
+			data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
+			data->IsGroup.SetValue(false);
 
-		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
-		return CHIP_NO_ERROR;
+			Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
+			return CHIP_NO_ERROR;
+		}
+		return CHIP_ERROR_NO_MEMORY;
 	}
 } /* namespace Unicast */
 
@@ -142,42 +151,51 @@ namespace Group
 	{
 		Nrf::Matter::BindingHandler::BindingData *data =
 			Platform::New<Nrf::Matter::BindingHandler::BindingData>();
-		data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
-		data->CommandId = Clusters::OnOff::Commands::On::Id;
-		data->ClusterId = Clusters::OnOff::Id;
-		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
-		data->IsGroup.SetValue(true);
+		if (data) {
+			data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
+			data->CommandId = Clusters::OnOff::Commands::On::Id;
+			data->ClusterId = Clusters::OnOff::Id;
+			data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
+			data->IsGroup.SetValue(true);
 
-		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
-		return CHIP_NO_ERROR;
+			Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
+			return CHIP_NO_ERROR;
+		}
+		return CHIP_ERROR_NO_MEMORY;
 	}
 
 	CHIP_ERROR OffCommandHandler(int argc, char **argv)
 	{
 		Nrf::Matter::BindingHandler::BindingData *data =
 			Platform::New<Nrf::Matter::BindingHandler::BindingData>();
-		data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
-		data->CommandId = Clusters::OnOff::Commands::Off::Id;
-		data->ClusterId = Clusters::OnOff::Id;
-		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
-		data->IsGroup.SetValue(true);
+		if (data) {
+			data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
+			data->CommandId = Clusters::OnOff::Commands::Off::Id;
+			data->ClusterId = Clusters::OnOff::Id;
+			data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
+			data->IsGroup.SetValue(true);
 
-		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
-		return CHIP_NO_ERROR;
+			Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
+			return CHIP_NO_ERROR;
+		}
+		return CHIP_ERROR_NO_MEMORY;
 	}
 
 	CHIP_ERROR ToggleCommandHandler(int argc, char **argv)
 	{
 		Nrf::Matter::BindingHandler::BindingData *data =
 			Platform::New<Nrf::Matter::BindingHandler::BindingData>();
-		data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
-		data->CommandId = Clusters::OnOff::Commands::Toggle::Id;
-		data->ClusterId = Clusters::OnOff::Id;
-		data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
-		data->IsGroup.SetValue(true);
+		if (data) {
+			data->EndpointId = LightSwitch::GetInstance().GetLightSwitchEndpointId();
+			data->CommandId = Clusters::OnOff::Commands::Toggle::Id;
+			data->ClusterId = Clusters::OnOff::Id;
+			data->InvokeCommandFunc = LightSwitch::SwitchChangedHandler;
+			data->IsGroup.SetValue(true);
 
-		Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
-		return CHIP_NO_ERROR;
+			Nrf::Matter::BindingHandler::RunBoundClusterAction(data);
+			return CHIP_NO_ERROR;
+		}
+		return CHIP_ERROR_NO_MEMORY;
 	}
 
 } /* namespace Group */

--- a/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -7,9 +7,6 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.

--- a/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -13,9 +13,6 @@ CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 # TODO: KRKNWK-19382: Disable NFC commissioning due to an issue with definitions for ns build.
 CONFIG_CHIP_NFC_COMMISSIONING=n
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.

--- a/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -7,10 +7,6 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.

--- a/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -7,9 +7,6 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -7,10 +7,6 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_CHIP_MALLOC_SYS_HEAP_SIZE=10240
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -7,9 +7,6 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
@@ -7,9 +7,6 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -10,9 +10,6 @@ CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 # TODO: Workaround to be removed once Zephyr's CONFIG_FPROTECT is supported on nRF54L_ns
 CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.

--- a/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -7,9 +7,6 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 

--- a/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -13,9 +13,6 @@ CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 # TODO: KRKNWK-19382: Disable NFC commissioning due to an issue with definitions for ns build.
 CONFIG_CHIP_NFC_COMMISSIONING=n
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.

--- a/samples/matter/thermostat/src/temperature_measurement/sensor.cpp
+++ b/samples/matter/thermostat/src/temperature_measurement/sensor.cpp
@@ -85,10 +85,12 @@ void TemperatureSensor::InternalMeasurement()
 void TemperatureSensor::ExternalMeasurement()
 {
 	Nrf::Matter::BindingHandler::BindingData *data = Platform::New<Nrf::Matter::BindingHandler::BindingData>();
-	data->ClusterId = Clusters::TemperatureMeasurement::Id;
-	data->EndpointId = mTemperatureMeasurementEndpointId;
-	data->InvokeCommandFunc = ExternalTemperatureMeasurementReadHandler;
-	BindingHandler::RunBoundClusterAction(data);
+	if (data) {
+		data->ClusterId = Clusters::TemperatureMeasurement::Id;
+		data->EndpointId = mTemperatureMeasurementEndpointId;
+		data->InvokeCommandFunc = ExternalTemperatureMeasurementReadHandler;
+		BindingHandler::RunBoundClusterAction(data);
+	}
 }
 
 void TemperatureSensor::ExternalTemperatureMeasurementReadHandler(const EmberBindingTableEntry &binding,

--- a/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -7,9 +7,6 @@
 # Multirole is the only currently supported role by SoftDevice.
 CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.

--- a/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -13,9 +13,6 @@ CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT=n
 # TODO: KRKNWK-19382: Disable NFC commissioning due to an issue with definitions for ns build.
 CONFIG_CHIP_NFC_COMMISSIONING=n
 
-# nRF54L15 requires bigger stack sizes than nRF52/nRF53 families
-CONFIG_MPSL_WORK_STACK_SIZE=2048
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 # Workaround required as Zephyr L2 implies usage of NVS backend for settings.

--- a/west.yml
+++ b/west.yml
@@ -159,7 +159,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 36d3ddf55de6cb700e859af8a519253fa7dd7712
+      revision: 7e94f1c336ed437c32d0dec80c72fa9f4f2ce3ee
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
In few places there are missing nullptr checks, what can lead to using not allocated memory.