### PR TITLE
docs: app_dev: fixed verbose build command

### DIFF
--- a/doc/nrf/app_dev/config_and_build/building.rst
+++ b/doc/nrf/app_dev/config_and_build/building.rst
@@ -124,7 +124,7 @@ For more options, see Zephyr's :ref:`zephyr:west-building` or run the ``west --h
      - ``west build -b nrf52840dk/nrf52840 --no-sysbuild``
    * - ``-vvv``
      - Enable a detailed :ref:`zephyr:west-building-verbose` log, which includes the full commands used by the build system to generate the :ref:`app_build_output_files`.
-     - ``west build -b nrf52840dk/nrf52840 -vvv``
+     - ``west -vvv build -b nrf52840dk/nrf52840``
    * - *directory_name*
      - Build from a directory other than the current directory.
      - ``west build -b nrf5340dk/nrf5340/cpuapp/ns nrf/samples/tfm/tfm_psa_template``


### PR DESCRIPTION
Changed verbose build command order to reflect
proper order. Previous order caused the following error:

```
 > west build -b nrf54l15dk/nrf54l15/cpuapp -vvv
ERROR: source directory -vvv does not exist
FATAL ERROR: refusing to proceed without --force due to above error
```

Signed-off-by: Helmut Lord <kellyhlord@gmail.com>
