### PR TITLE
Bluetooth: Mesh: Fix idx in dtt_srv_get

### DIFF
--- a/subsys/bluetooth/mesh/gen_dtt_srv.c
+++ b/subsys/bluetooth/mesh/gen_dtt_srv.c
@@ -195,7 +195,7 @@ struct bt_mesh_dtt_srv *bt_mesh_dtt_srv_get(const struct bt_mesh_elem *elem)
 	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
 	uint16_t index;
 
-	index = elem->rt->addr - comp->elem[0].rt->addr;
+	index = elem - comp->elem;
 	for (int i = index; i >= 0; --i) {
 		const struct bt_mesh_elem *element = &comp->elem[i];
 


### PR DESCRIPTION
Finds the element index used in `bt_mesh_dtt_srv_get` based on the composition data instead of the runtime address.

Previously, the index used to locate the DTT Server was computed based on the runtime address set during provisioning. As the Scene Setup Server extends this model (which isn't necessarily present in the same element), model initialization would fail as the address wasn't yet set.