### PR TITLE
snippets: matter: Use boards instead of wildcards for matter-debug

### DIFF
--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -354,3 +354,8 @@ For example, for the ``nrf52840dk/nrf52840`` board target and the :ref:`matter_l
    :class: highlight
 
    west build -b nrf52840dk/nrf52840 -- -Dlock_SNIPPET=matter-debug
+
+.. note::
+
+  You can increase the UART speed using this snippet only for Nordic Development Kits.
+  If you want to use the snippet for your custom board, you need to adjust the UART speed manually.

--- a/snippets/matter-debug/snippet.yml
+++ b/snippets/matter-debug/snippet.yml
@@ -3,21 +3,18 @@ append:
   EXTRA_CONF_FILE: matter_debug.conf
 
 boards:
-  /.*nrf52840.*/:
+  nrf52840dk/nrf52840:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/nrf52840dk_nrf52840.overlay
-  /.*nrf5340.*/:
+  nrf5340dk/nrf5340/cpuapp:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/nrf5340dk_nrf5340_cpuapp.overlay
   nrf7002dk/nrf5340/cpuapp:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/nrf7002dk_nrf5340_cpuapp.overlay
-  thingy53/nrf5340/cpuapp:
-    append:
-      EXTRA_DTC_OVERLAY_FILE: boards/nrf5340dk_nrf5340_cpuapp.overlay
-  /.*nrf54l.*/:
+  /nrf54l15dk.*/:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/nrf54l15dk_nrf54l15_cpuapp.overlay
-  /.*nrf54h20.*/:
+  nrf54h20dk/nrf54h20/cpuapp:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/nrf54h20dk_nrf54h20_cpuapp.overlay


### PR DESCRIPTION
We need to use exact boards for matter-debug snippet. If a user wants to add it to their board, they must increase UART speed manually. Added the update in the docs as well. 

The dts overlay with UART speed increase is not applicable to the Thingy board since it uses USB.