### PR TITLE
manifest: Update bsim to version v2.5

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -267,7 +267,7 @@ manifest:
     - name: bsim
       repo-path: bsim_west
       remote: babblesim
-      revision: 1f242f4ed7fc141fdfcfeca8d21c6d9e801179d7
+      revision: a88d3353451387ca490a6a7f7c478a90c4ee05b7
       import:
         path-prefix: tools
     - name: bme68x


### PR DESCRIPTION
Main changes since v2.4:
* libRandv2: New API to fill buffers & Wextra warning fixes
* libCryptov1: Add new AES-ECB API

Note: Like before, bsim remains fully backwards compatible