### PR TITLE
samples: openthread: cli: Enable 802.15.4 carrier functions

### DIFF
--- a/samples/openthread/cli/sysbuild/ipc_radio/prj.conf
+++ b/samples/openthread/cli/sysbuild/ipc_radio/prj.conf
@@ -10,6 +10,7 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_NRF_802154_SER_RADIO=y
+CONFIG_NRF_802154_CARRIER_FUNCTIONS=y
 CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT=2
 
 # Enable the frame encryption feature in the radio driver, it's required for proper working


### PR DESCRIPTION
Enable carrier functions required by OPENTHREAD_DIAG.