### PR TITLE
samples: cellular: modem_shell: sock: 'option' set/get commands

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -539,6 +539,7 @@ Cellular samples
 
 * :ref:`modem_shell_application` sample:
 
+  * Added support for setting and getting socket options using the ``sock option set`` and ``sock option get`` commands.
   * Removed the ``CONFIG_MOSH_LINK`` Kconfig option.
     The link control functionality is now always enabled and cannot be disabled.
 

--- a/samples/cellular/modem_shell/src/sock/sock.h
+++ b/samples/cellular/modem_shell/src/sock/sock.h
@@ -8,6 +8,7 @@
 #define MOSH_SOCK_H
 
 #define SOCK_ID_NONE -1
+#define SOCK_OPT_SOL_NONE -1
 #define SOCK_RAI_NONE -1
 #define SOCK_BUFFER_SIZE_NONE -1
 #define SOCK_SEND_DATA_INTERVAL_NONE -1
@@ -40,6 +41,8 @@ int sock_close(int socket_id);
 int sock_rai(
 	int socket_id, bool rai_last, bool rai_no_data, bool rai_one_resp,
 	bool rai_ongoing, bool rai_wait_more);
+int sock_setopt(int socket_id, int sock_level, int sock_opt_id, char *sock_opt_value);
+int sock_getopt(int socket_id, int sock_level, int sock_opt_id);
 int sock_list(void);
 
 #endif /* MOSH_SOCK_H */


### PR DESCRIPTION
Added support for setting/getting socket options in a generic manner.

Jira: MOSH-636