### PR TITLE
DNM: manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 76a46cb2baf310a06bbdb0b1d7d99394ec04a671
+      revision: pull/2440/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updates sdk-zephyr manifest to test net_buf reversal in CI.