### PR TITLE
tests: benchmarks: Correct tags used for coverage analysis

### DIFF
--- a/tests/benchmarks/multicore/idle_adc/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_adc/testcase.yaml
@@ -1,14 +1,14 @@
 common:
   sysbuild: true
   depends_on: adc
-  tags:
-    - ci_build
-    - ci_tests_benchmarks_multicore
-    - adc
-    - ppk_power_measure
 
 tests:
   benchmarks.multicore.idle_adc.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - adc
+      - ppk_power_measure
     filter: not CONFIG_COVERAGE
     harness: pytest
     platform_allow:
@@ -23,6 +23,10 @@ tests:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_adc"
 
   benchmarks.multicore.idle_adc.nrf54h20dk_cpuapp_cpurad.coverage:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - adc
     filter: CONFIG_COVERAGE
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/benchmarks/multicore/idle_clock_control/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_clock_control/testcase.yaml
@@ -1,12 +1,12 @@
 common:
   sysbuild: true
-  tags:
-    - ci_build
-    - ci_tests_benchmarks_multicore
-    - ppk_power_measure
 
 tests:
   benchmarks.multicore.idle_clock_control.app:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - ppk_power_measure
     filter: not CONFIG_COVERAGE
     harness: pytest
     platform_allow:
@@ -21,6 +21,10 @@ tests:
 
   # note: in this scenario cpuapp is the 'remote'
   benchmarks.multicore.idle_clock_control.rad:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - ppk_power_measure
     filter: not CONFIG_COVERAGE
     harness: pytest
     platform_allow:
@@ -44,6 +48,9 @@ tests:
     timeout: 90
 
   benchmarks.multicore.idle_clock_control.coverage:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
     filter: CONFIG_COVERAGE
     harness: console
     harness_config:

--- a/tests/benchmarks/multicore/idle_comp/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_comp/testcase.yaml
@@ -1,11 +1,12 @@
 common:
   sysbuild: true
-  tags:
-    - ci_build
-    - ci_tests_benchmarks_multicore
-    - ppk_power_measure
+
 tests:
   benchmarks.multicore.idle_comp.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - ppk_power_measure
     filter: not CONFIG_COVERAGE
     harness: pytest
     platform_allow:
@@ -21,6 +22,10 @@ tests:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_comp"
 
   benchmarks.multicore.idle_lpcomp.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - ppk_power_measure
     filter: not CONFIG_COVERAGE
     harness: pytest
     platform_allow:
@@ -36,6 +41,9 @@ tests:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_lpcomp"
 
   benchmarks.multicore.idle_lpcomp.nrf54h20dk_cpuapp_cpurad.coverage:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
     filter: CONFIG_COVERAGE
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/benchmarks/multicore/idle_exmif/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_exmif/testcase.yaml
@@ -1,14 +1,14 @@
 common:
   sysbuild: true
-  depends_on: gpio
-  tags:
-    - ci_build
-    - ci_tests_benchmarks_multicore
-    - exmif
-    - ppk_power_measure
+  depends_on: spi
 
 tests:
   benchmarks.multicore.idle_exmif.nrf54h20dk_cpuapp_cpurad:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - exmif
+      - ppk_power_measure
     filter: not CONFIG_COVERAGE
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
@@ -21,6 +21,10 @@ tests:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_exmif_and_s2ram"
 
   benchmarks.multicore.idle_exmif.nrf54h20dk_cpuapp_cpurad.coverage:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - exmif
     filter: CONFIG_COVERAGE
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/benchmarks/multicore/idle_ipc/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_ipc/testcase.yaml
@@ -1,12 +1,13 @@
 common:
   sysbuild: true
-  tags:
-    - ci_build
-    - ci_tests_benchmarks_multicore
-    - ipc
-    - ppk_power_measure
+
 tests:
   benchmarks.multicore.idle_ipc.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - ipc
+      - ppk_power_measure
     filter: not CONFIG_COVERAGE
     harness: pytest
     platform_allow:
@@ -19,6 +20,11 @@ tests:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_ipc"
 
   benchmarks.multicore.idle_ipc.shifted.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - ipc
+      - ppk_power_measure
     filter: not CONFIG_COVERAGE
     harness: pytest
     platform_allow:
@@ -33,6 +39,10 @@ tests:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_ipc"
 
   benchmarks.multicore.idle_ipc.shifted.nrf54h20dk_cpuapp_cpurad.coverage:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - ipc
     filter: CONFIG_COVERAGE
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/benchmarks/multicore/idle_pwm_led/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_pwm_led/testcase.yaml
@@ -46,20 +46,6 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_pwm_and_s2ram"
 
-  benchmarks.multicore.idle_pwm_led.nrf54h20dk_cpuapp_cpurad.coverage:
-    filter: CONFIG_COVERAGE
-    extra_args:
-      - idle_pwm_led_CONF_FILE=coverage.conf
-      - SHIELD=coverage_support
-    harness: console
-    harness_config:
-      type: multi_line
-      ordered: true
-      regex:
-        - ".*Coverage analysis enabled.*"
-        - ".*Coverage analysis start.*"
-    timeout: 90
-
   benchmarks.multicore.idle_pwm_led.nrf54h20dk_cpuapp_cpurad.idle_fast:
     filter: not CONFIG_COVERAGE
     tags: ppk_power_measure
@@ -87,3 +73,17 @@ tests:
       fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_pwm_and_s2ram"
+
+  benchmarks.multicore.idle_pwm_led.nrf54h20dk_cpuapp_cpurad.coverage:
+    filter: CONFIG_COVERAGE
+    extra_args:
+      - idle_pwm_led_CONF_FILE=coverage.conf
+      - SHIELD=coverage_support
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - ".*Coverage analysis enabled.*"
+        - ".*Coverage analysis start.*"
+    timeout: 90

--- a/tests/benchmarks/multicore/idle_pwm_loopback/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_pwm_loopback/testcase.yaml
@@ -47,20 +47,6 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_pwm_and_s2ram"
 
-  benchmarks.multicore.idle_pwm_loopback.nrf54h20dk_cpuapp_cpurad.coverage:
-    filter: CONFIG_COVERAGE
-    extra_args:
-      - idle_pwm_loopback_CONF_FILE=coverage.conf
-      - SHIELD=coverage_support
-    harness: console
-    harness_config:
-      fixture: spi_loopback
-      type: multi_line
-      ordered: true
-      regex:
-        - ".*Coverage analysis enabled.*"
-        - ".*Coverage analysis start.*"
-
   benchmarks.multicore.idle_pwm_loopback.nrf54h20dk_cpuapp_cpurad.no_sleep_fast:
     filter: not CONFIG_COVERAGE
     extra_args:
@@ -161,3 +147,17 @@ tests:
       fixture: spi_loopback
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_pwm_and_s2ram_with_clock_control"
+
+  benchmarks.multicore.idle_pwm_loopback.nrf54h20dk_cpuapp_cpurad.coverage:
+    filter: CONFIG_COVERAGE
+    extra_args:
+      - idle_pwm_loopback_CONF_FILE=coverage.conf
+      - SHIELD=coverage_support
+    harness: console
+    harness_config:
+      fixture: spi_loopback
+      type: multi_line
+      ordered: true
+      regex:
+        - ".*Coverage analysis enabled.*"
+        - ".*Coverage analysis start.*"

--- a/tests/benchmarks/multicore/idle_spim/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_spim/testcase.yaml
@@ -1,13 +1,14 @@
 common:
   sysbuild: true
   depends_on: spi
-  tags:
-    - ci_build
-    - ci_tests_benchmarks_multicore
-    - spim
-    - ppk_power_measure
+
 tests:
   benchmarks.multicore.idle_spim.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - spim
+      - ppk_power_measure
     filter: not CONFIG_COVERAGE
     harness: pytest
     platform_allow:
@@ -21,7 +22,11 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_spim"
 
-  benchmarks.multicore.idle_spim.nrf54h20dk_cpuapp_cpurad.coverge:
+  benchmarks.multicore.idle_spim.nrf54h20dk_cpuapp_cpurad.coverage:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - spim
     filter: CONFIG_COVERAGE
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/benchmarks/multicore/idle_spim_loopback/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_spim_loopback/testcase.yaml
@@ -50,20 +50,6 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_spim_and_s2ram"
 
-  benchmarks.multicore.idle_spim_loopback.coverage:
-    filter: CONFIG_COVERAGE
-    extra_args:
-      - SHIELD=coverage_support
-      - CONF_FILE=coverage.conf
-    harness: console
-    harness_config:
-      fixture: spi_loopback
-      type: multi_line
-      ordered: true
-      regex:
-        - ".*Coverage analysis enabled.*"
-        - ".*Coverage analysis start.*"
-
   benchmarks.multicore.idle_spim_loopback.4_bytes.no_sleep_fast:
     filter: not CONFIG_COVERAGE
     extra_args:
@@ -513,3 +499,17 @@ tests:
       fixture: spi_loopback
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_spim_and_s2ram"
+
+  benchmarks.multicore.idle_spim_loopback.coverage:
+    filter: CONFIG_COVERAGE
+    extra_args:
+      - SHIELD=coverage_support
+      - CONF_FILE=coverage.conf
+    harness: console
+    harness_config:
+      fixture: spi_loopback
+      type: multi_line
+      ordered: true
+      regex:
+        - ".*Coverage analysis enabled.*"
+        - ".*Coverage analysis start.*"

--- a/tests/benchmarks/multicore/idle_twim/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_twim/testcase.yaml
@@ -1,13 +1,14 @@
 common:
   sysbuild: true
   depends_on: i2c
-  tags:
-    - ci_build
-    - ci_tests_benchmarks_multicore
-    - twim
-    - ppk_power_measure
+
 tests:
   benchmarks.multicore.idle_twim.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - twim
+      - ppk_power_measure
     filter: not CONFIG_COVERAGE
     harness: pytest
     platform_allow:
@@ -21,7 +22,11 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_twim"
 
-  benchmarks.multicore.idle_twim.nrf54h20dk_cpuapp_cpurad.coverge:
+  benchmarks.multicore.idle_twim.nrf54h20dk_cpuapp_cpurad.coverage:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - twim
     filter: CONFIG_COVERAGE
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/benchmarks/multicore/idle_uarte/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_uarte/testcase.yaml
@@ -1,13 +1,14 @@
 common:
   sysbuild: true
   depends_on: gpio
-  tags:
-    - ci_build
-    - ci_tests_benchmarks_multicore
-    - uarte
-    - ppk_power_measure
+
 tests:
   benchmarks.multicore.idle_uarte.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - uarte
+      - ppk_power_measure
     filter: not CONFIG_COVERAGE
     harness: pytest
     platform_allow:
@@ -21,7 +22,116 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_uarte"
 
+  benchmarks.multicore.idle_uarte.fast.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - uarte
+      - ppk_power_measure
+    filter: not CONFIG_COVERAGE
+    harness: pytest
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+    harness_config:
+      fixture: gpio_loopback
+      pytest_root:
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_uarte"
+
+  benchmarks.multicore.idle_uarte.fast.gd_freq_256MHz.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - uarte
+      - ppk_power_measure
+    filter: not CONFIG_COVERAGE
+    harness: pytest
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - CONFIG_CLOCK_CONTROL=y
+      - CONFIG_GLOBAL_DOMAIN_CLOCK_FREQUENCY_OPTION_256MHZ=y
+    harness_config:
+      fixture: gpio_loopback
+      pytest_root:
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_uarte"
+
+  benchmarks.multicore.idle_uarte.fast.gd_freq_128MHz.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - uarte
+      - ppk_power_measure
+    filter: not CONFIG_COVERAGE
+    harness: pytest
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - CONFIG_CLOCK_CONTROL=y
+      - CONFIG_GLOBAL_DOMAIN_CLOCK_FREQUENCY_OPTION_128MHZ=y
+    harness_config:
+      fixture: gpio_loopback
+      pytest_root:
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_uarte"
+
+  benchmarks.multicore.idle_uarte.fast.gd_freq_64MHz.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - uarte
+      - ppk_power_measure
+    filter: not CONFIG_COVERAGE
+    harness: pytest
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - CONFIG_CLOCK_CONTROL=y
+      - CONFIG_GLOBAL_DOMAIN_CLOCK_FREQUENCY_OPTION_64MHZ=y
+    harness_config:
+      fixture: gpio_loopback
+      pytest_root:
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_uarte"
+
+  benchmarks.multicore.idle_uarte.automatic_pm.nrf54h20dk_cpuapp_cpurad.s2ram:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - uarte
+      - ppk_power_measure
+    filter: not CONFIG_COVERAGE
+    harness: pytest
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_normal.overlay"
+      - CONFIG_PRINTK=y
+      - CONFIG_LOG=y
+      - CONFIG_CONSOLE=y
+      - CONFIG_UART_CONSOLE=y
+    harness_config:
+      fixture: gpio_loopback
+      pytest_root:
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_uarte"
+
   benchmarks.multicore.idle_uarte.nrf54h20dk_cpuapp_cpurad.coverage:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - uarte
     filter: CONFIG_COVERAGE
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
@@ -39,83 +149,3 @@ tests:
       regex:
         - ".*Coverage analysis enabled.*"
         - ".*Coverage analysis start.*"
-
-  benchmarks.multicore.idle_uarte.fast.nrf54h20dk_cpuapp_cpurad.s2ram:
-    filter: not CONFIG_COVERAGE
-    harness: pytest
-    platform_allow:
-      - nrf54h20dk/nrf54h20/cpuapp
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
-    harness_config:
-      fixture: gpio_loopback
-      pytest_root:
-        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_uarte"
-
-  benchmarks.multicore.idle_uarte.fast.gd_freq_256MHz.nrf54h20dk_cpuapp_cpurad.s2ram:
-    filter: not CONFIG_COVERAGE
-    harness: pytest
-    platform_allow:
-      - nrf54h20dk/nrf54h20/cpuapp
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
-      - CONFIG_CLOCK_CONTROL=y
-      - CONFIG_GLOBAL_DOMAIN_CLOCK_FREQUENCY_OPTION_256MHZ=y
-    harness_config:
-      fixture: gpio_loopback
-      pytest_root:
-        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_uarte"
-
-  benchmarks.multicore.idle_uarte.fast.gd_freq_128MHz.nrf54h20dk_cpuapp_cpurad.s2ram:
-    filter: not CONFIG_COVERAGE
-    harness: pytest
-    platform_allow:
-      - nrf54h20dk/nrf54h20/cpuapp
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
-      - CONFIG_CLOCK_CONTROL=y
-      - CONFIG_GLOBAL_DOMAIN_CLOCK_FREQUENCY_OPTION_128MHZ=y
-    harness_config:
-      fixture: gpio_loopback
-      pytest_root:
-        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_uarte"
-
-  benchmarks.multicore.idle_uarte.fast.gd_freq_64MHz.nrf54h20dk_cpuapp_cpurad.s2ram:
-    filter: not CONFIG_COVERAGE
-    harness: pytest
-    platform_allow:
-      - nrf54h20dk/nrf54h20/cpuapp
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
-      - CONFIG_CLOCK_CONTROL=y
-      - CONFIG_GLOBAL_DOMAIN_CLOCK_FREQUENCY_OPTION_64MHZ=y
-    harness_config:
-      fixture: gpio_loopback
-      pytest_root:
-        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_uarte"
-
-  benchmarks.multicore.idle_uarte.automatic_pm.nrf54h20dk_cpuapp_cpurad.s2ram:
-    filter: not CONFIG_COVERAGE
-    harness: pytest
-    platform_allow:
-      - nrf54h20dk/nrf54h20/cpuapp
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_normal.overlay"
-      - CONFIG_PRINTK=y
-      - CONFIG_LOG=y
-      - CONFIG_CONSOLE=y
-      - CONFIG_UART_CONSOLE=y
-    harness_config:
-      fixture: gpio_loopback
-      pytest_root:
-        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_uarte"


### PR DESCRIPTION
Part of the idle* tests have been skipped due to incorrect tags. This commit fixes this issue.