### PR TITLE
doc: fix known issues javascript

### DIFF
--- a/doc/_extensions/static/page_filter.mjs
+++ b/doc/_extensions/static/page_filter.mjs
@@ -11,7 +11,7 @@ function displayOption(option, dropdown) {
 
   document.querySelectorAll(".hideable").forEach(e => e.hidden = false);
   var filters = all_dropdowns
-    .map(dp => dp.options[dp.selectedIndex].value)
+    .map(dp => dp.options[dp.selectedIndex].value.toLowerCase())
     .filter(val => val !== "all");
 
   if (filters.length == 0) return;


### PR DESCRIPTION
The issue related to handling more complex release names seems to be caused by HTML class names being turned to all lowercase in rst->html conversion process.
This update in mjs will convert the filter values
to lowercase before matching with class names.