### PR TITLE
doc: includes: add board target info to _ns txts

### DIFF
--- a/doc/nrf/includes/application_build_and_run_ns.txt
+++ b/doc/nrf/includes/application_build_and_run_ns.txt
@@ -1,6 +1,7 @@
 This application can be found under |application path| in the |NCS| folder structure.
 
-When built as a firmware image for a board target with the ``*/ns`` :ref:`variant <app_boards_names>`, the application has :term:`Cortex-M Security Extensions (CMSE)` enabled and separates the firmware between the :term:`Non-Secure Processing Environment (NSPE)` and the :term:`Secure Processing Environment (SPE)`.
+You can build this application as firmware image for a board target with the ``*/ns`` :ref:`variant <app_boards_names>` (see the Requirements section above).
+In such cases, the sample has Cortex-M Security Extensions (CMSE) enabled and separates the firmware between Non-Secure Processing Environment (NSPE) and Secure Processing Environment (SPE).
 Because of this, it automatically includes the :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`.
 To read more about CMSE, see :ref:`app_boards_spe_nspe`.
 

--- a/doc/nrf/includes/build_and_run_ns.txt
+++ b/doc/nrf/includes/build_and_run_ns.txt
@@ -1,6 +1,7 @@
 This sample can be found under |sample path| in the |NCS| folder structure.
 
-When built as firmware image for a board target with the ``*/ns`` :ref:`variant <app_boards_names>`, the sample has Cortex-M Security Extensions (CMSE) enabled and separates the firmware between Non-Secure Processing Environment (NSPE) and Secure Processing Environment (SPE).
+You can build this sample as firmware image for a board target with the ``*/ns`` :ref:`variant <app_boards_names>` (see the Requirements section above).
+In such cases, the sample has Cortex-M Security Extensions (CMSE) enabled and separates the firmware between Non-Secure Processing Environment (NSPE) and Secure Processing Environment (SPE).
 Because of this, it automatically includes the :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`.
 To read more about CMSE, see :ref:`app_boards_spe_nspe`.
 


### PR DESCRIPTION
Updated doc txt includes for build_and_run_ns with info where to look for */ns variant. NCSDK-29828.