### PR TITLE
treewide: replace kconfig docs macro

### DIFF
--- a/applications/nrf_desktop/src/util/hid_reportq.h
+++ b/applications/nrf_desktop/src/util/hid_reportq.h
@@ -61,7 +61,7 @@ const void *hid_reportq_get_sub_id(struct hid_reportq *q);
  * The function returns an error if HID report subscription is disabled for the added HID report.
  *
  * If number of enqueued reports with a given report ID exceeds limit defined by the configuration
- * (@kconfig{CONFIG_DESKTOP_HID_REPORTQ_MAX_ENQUEUED_REPORTS}), the oldest enqueued HID report with
+ * (`CONFIG_DESKTOP_HID_REPORTQ_MAX_ENQUEUED_REPORTS`), the oldest enqueued HID report with
  * the ID is dropped.
  *
  * @param[in] q		Pointer to the queue instance.

--- a/include/app_event_manager.h
+++ b/include/app_event_manager.h
@@ -217,7 +217,7 @@ static inline bool app_event_get_type_flag(const struct event_type *et,
  * Function that calculates the event size using its header.
  * @note
  * For this function to be available the
- * @kconfig{CONFIG_APP_EVENT_MANAGER_PROVIDE_EVENT_SIZE} option needs to be enabled.
+ * `CONFIG_APP_EVENT_MANAGER_PROVIDE_EVENT_SIZE` option needs to be enabled.
  *
  * @param aeh Pointer to the application event header.
  *

--- a/include/bl_storage.h
+++ b/include/bl_storage.h
@@ -225,7 +225,7 @@ int get_monotonic_counter(uint16_t counter_desc, counter_t *counter_value);
  * @retval -EINVAL  @p new_counter is invalid (must be larger than current
  *                  counter, and cannot be 0xFFFF).
  * @retval -ENOMEM  There are no more free counter slots (see
- *                  @kconfig{CONFIG_SB_NUM_VER_COUNTER_SLOTS}).
+ *                  `CONFIG_SB_NUM_VER_COUNTER_SLOTS`).
  */
 int set_monotonic_counter(uint16_t counter_desc, counter_t new_counter);
 

--- a/include/bl_validation.h
+++ b/include/bl_validation.h
@@ -41,7 +41,7 @@ bool (*bl_validate_firmware_t)(uint32_t fw_dst_address, uint32_t fw_src_address)
 /** Whether bl_validate_firmware() is available.
  *
  * @details This is only relevant when
- *          @kconfig{CONFIG_BL_VALIDATE_FW_EXT_API_OPTIONAL} is set.
+ *          `CONFIG_BL_VALIDATE_FW_EXT_API_OPTIONAL` is set.
  *
  * @retval true  bl_validate_firmware() can be called and should work correctly.
  * @retval false bl_validate_firmware() is unavailable and will always return

--- a/include/bluetooth/adv_prov.h
+++ b/include/bluetooth/adv_prov.h
@@ -48,7 +48,7 @@ struct bt_le_adv_prov_adv_state {
 	bool new_adv_session;
 
 	/** Information about the advertising set for which the advertising data is prepared.
-	 *  If @kconfig{CONFIG_BT_EXT_ADV} is used, the advertising handle can be acquired using
+	 *  If `CONFIG_BT_EXT_ADV` is used, the advertising handle can be acquired using
 	 *  the bt_hci_get_adv_handle function.
 	 *  Otherwise, the advertising handle must be set to 0.
 	 */

--- a/include/bluetooth/adv_prov/fast_pair.h
+++ b/include/bluetooth/adv_prov/fast_pair.h
@@ -31,7 +31,7 @@ void bt_le_adv_prov_fast_pair_enable(bool enable);
 
 /** Show/hide UI indication in Fast Pair not discoverable advertising.
  *
- * This API is only available when the @kconfig{CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING}
+ * This API is only available when the `CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING`
  * Kconfig option is enabled. With this Kconfig option disabled, UI indications are always
  * hidden.
  *
@@ -46,7 +46,7 @@ void bt_le_adv_prov_fast_pair_show_ui_pairing(bool enable);
 
 /** Set advertising battery mode in Fast Pair not dicoverable advertising.
  *
- * This API can only be used when the @kconfig{CONFIG_BT_FAST_PAIR_BN} Kconfig option is enabled.
+ * This API can only be used when the `CONFIG_BT_FAST_PAIR_BN` Kconfig option is enabled.
  * With this Kconfig option disabled, battery data is not included in the advertising packet.
  *
  * To prevent tracking, the Fast Pair Provider should not include battery data in the advertising

--- a/include/bluetooth/mesh/gen_prop_srv.h
+++ b/include/bluetooth/mesh/gen_prop_srv.h
@@ -30,7 +30,7 @@ struct bt_mesh_prop_srv;
  * @param[in] _properties Array of properties supported by the server.
  * @param[in] _property_count Number of properties supported by the server.
  *                            Cannot be larger than
- *                            @kconfig{CONFIG_BT_MESH_PROP_MAXCOUNT}.
+ *                            `CONFIG_BT_MESH_PROP_MAXCOUNT`.
  * @param[in] _get Getter handler for property values. @sa
  * bt_mesh_prop_srv::get.
  * @param[in] _set Setter handler for property values. @sa

--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -34,7 +34,7 @@ struct bt_mesh_light_ctrl_srv;
  *
  *  @brief Initialization parameters for @ref bt_mesh_light_ctrl_srv with custom regulator.
  *
- *  Only available if @kconfig{CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG} is selected.
+ *  Only available if `CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG` is selected.
  *
  *  @param[in] _lightness_srv Pointer to the @ref bt_mesh_lightness_srv this
  *                            server controls.
@@ -55,8 +55,8 @@ struct bt_mesh_light_ctrl_srv;
  *  @brief Initialization parameters for @ref bt_mesh_light_ctrl_srv.
  *
  *  This will enable the specification-defined regulator if
- *  @kconfig{CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG} and
- *  @kconfig{CONFIG_BT_MESH_LIGHT_CTRL_REG_SPEC} are selected.
+ *  `CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG` and
+ *  `CONFIG_BT_MESH_LIGHT_CTRL_REG_SPEC` are selected.
  *
  *  @param[in] _lightness_srv Pointer to the @ref bt_mesh_lightness_srv this
  *                            server controls.
@@ -226,7 +226,7 @@ int bt_mesh_light_ctrl_srv_on(struct bt_mesh_light_ctrl_srv *srv);
  *  state). Calling this function temporarily disables occupancy sensor
  *  triggering (referred to as "manual mode" in the documentation). The server
  *  will remain in manual mode until the manual mode timer expires, see
- *  @kconfig{CONFIG_BT_MESH_LIGHT_CTRL_SRV_TIME_MANUAL}.
+ *  `CONFIG_BT_MESH_LIGHT_CTRL_SRV_TIME_MANUAL`.
  *
  *  @param[in] srv        Light Lightness Control Server instance.
  *

--- a/include/bluetooth/mesh/sensor.h
+++ b/include/bluetooth/mesh/sensor.h
@@ -829,7 +829,7 @@ bool bt_mesh_sensor_value_in_column(const struct bt_mesh_sensor_value *value,
 /** @brief Get a human readable representation of a single sensor channel.
  *
  *  @note This prints float values internally for most formats, which requires
- *  @kconfig{CONFIG_CBPRINTF_FP_SUPPORT} to be enabled.
+ *  `CONFIG_CBPRINTF_FP_SUPPORT` to be enabled.
  *
  *  @param[in]  ch  Sensor channel to represent.
  *  @param[out] str String buffer to fill. Should be @ref
@@ -845,7 +845,7 @@ int bt_mesh_sensor_ch_to_str(const struct bt_mesh_sensor_value *ch, char *str,
 /** @brief Get a human readable representation of a single sensor channel.
  *
  *  @note This prints float values internally for most formats, which requires
- *  @kconfig{CONFIG_CBPRINTF_FP_SUPPORT} to be enabled.
+ *  `CONFIG_CBPRINTF_FP_SUPPORT` to be enabled.
  *
  *  @note This function is not thread safe.
  *
@@ -859,7 +859,7 @@ const char *bt_mesh_sensor_ch_str(const struct bt_mesh_sensor_value *ch);
  *
  *  Only known sensor types from @ref bt_mesh_sensor_types will be available.
  *  Sensor types can be made known to the sensor module by enabling
- *  @kconfig{CONFIG_BT_MESH_SENSOR_ALL_TYPES} or by referencing them in the
+ *  `CONFIG_BT_MESH_SENSOR_ALL_TYPES` or by referencing them in the
  *  application.
  *
  *  @param[in] id A Device Property ID.

--- a/include/bluetooth/mesh/sensor_srv.h
+++ b/include/bluetooth/mesh/sensor_srv.h
@@ -30,7 +30,7 @@ struct bt_mesh_sensor_srv;
  *
  *  @param[in] _sensors Array of pointers to sensors owned by this server.
  *  @param[in] _count Number of sensors in the array. Can at most be
- *                    @kconfig{CONFIG_BT_MESH_SENSOR_SRV_SENSORS_MAX}.
+ *                    `CONFIG_BT_MESH_SENSOR_SRV_SENSORS_MAX`.
  */
 #define BT_MESH_SENSOR_SRV_INIT(_sensors, _count)                              \
 	{                                                                      \

--- a/include/bluetooth/services/fast_pair/fast_pair.h
+++ b/include/bluetooth/services/fast_pair/fast_pair.h
@@ -14,7 +14,7 @@
  * @brief Fast Pair API
  *
  * The Fast Pair subsystem needs the Bluetooth GATT operations to be run from the cooperative
- * thread context. It requires proper configuration of the @kconfig{CONFIG_BT_RECV_CONTEXT}
+ * thread context. It requires proper configuration of the `CONFIG_BT_RECV_CONTEXT`
  * Kconfig option.
  *
  * @{
@@ -26,7 +26,7 @@ extern "C" {
 
 /** Value that denotes unknown battery level (see @ref bt_fast_pair_battery).
  *
- * Used only when the @kconfig{CONFIG_BT_FAST_PAIR_BN} Kconfig option is enabled.
+ * Used only when the `CONFIG_BT_FAST_PAIR_BN` Kconfig option is enabled.
  */
 #define BT_FAST_PAIR_BATTERY_LEVEL_UNKNOWN	0x7f
 
@@ -45,7 +45,7 @@ enum bt_fast_pair_adv_mode {
 /** @brief Fast Pair not discoverable advertising type. Used to generate advertising packet. */
 enum bt_fast_pair_not_disc_adv_type {
 	/** Show UI indication.
-	 *  Used only when the @kconfig{CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING} is enabled.
+	 *  Used only when the `CONFIG_BT_FAST_PAIR_SUBSEQUENT_PAIRING` is enabled.
 	 */
 	BT_FAST_PAIR_NOT_DISC_ADV_TYPE_SHOW_UI_IND,
 
@@ -58,7 +58,7 @@ enum bt_fast_pair_not_disc_adv_type {
 
 /** @brief Fast Pair advertising battery mode. Used to generate advertising packet.
  *
- * Used only when the @kconfig{CONFIG_BT_FAST_PAIR_BN} Kconfig option is enabled.
+ * Used only when the `CONFIG_BT_FAST_PAIR_BN` Kconfig option is enabled.
  *
  * Battery data can be included in advertising packet only if the Fast Pair Provider is in Fast Pair
  * not discoverable advertising mode and is in possession of at least one Account Key. To prevent
@@ -81,7 +81,7 @@ enum bt_fast_pair_adv_battery_mode {
 
 /** @brief Index of Fast Pair battery component.
  *
- * Used only when the @kconfig{CONFIG_BT_FAST_PAIR_BN} Kconfig option is enabled.
+ * Used only when the `CONFIG_BT_FAST_PAIR_BN` Kconfig option is enabled.
  */
 enum bt_fast_pair_battery_comp {
 	/** Left bud. */
@@ -110,7 +110,7 @@ struct bt_fast_pair_not_disc_adv_info {
 	/** Fast Pair advertising battery mode. Battery values can be set using
 	 *  @ref bt_fast_pair_battery_set.
 	 *
-	 *  This field is used only when the @kconfig{CONFIG_BT_FAST_PAIR_BN} Kconfig option is
+	 *  This field is used only when the `CONFIG_BT_FAST_PAIR_BN` Kconfig option is
 	 *  enabled. Otherwise, it should be set to @ref BT_FAST_PAIR_ADV_BATTERY_MODE_NONE or
 	 *  zero.
 	 */
@@ -140,7 +140,7 @@ struct bt_fast_pair_adv_config {
 
 /** @brief Fast Pair battery component descriptor.
  *
- * Used only when the @kconfig{CONFIG_BT_FAST_PAIR_BN} Kconfig option is enabled.
+ * Used only when the `CONFIG_BT_FAST_PAIR_BN` Kconfig option is enabled.
  */
 struct bt_fast_pair_battery {
 	/** Battery status. True means that battery is charging and False means that battery is not
@@ -281,7 +281,7 @@ bool bt_fast_pair_has_account_key(void);
  * responsibility to update battery value and regenerate advertising packet when battery value
  * change.
  *
- * This function can only be used only when the @kconfig{CONFIG_BT_FAST_PAIR_BN} Kconfig option is
+ * This function can only be used only when the `CONFIG_BT_FAST_PAIR_BN` Kconfig option is
  * enabled.
  *
  * @param[in] battery_comp	Battery component.

--- a/include/bluetooth/services/fast_pair/fmdn.h
+++ b/include/bluetooth/services/fast_pair/fmdn.h
@@ -36,13 +36,13 @@ enum bt_fast_pair_fmdn_ring_src {
 
 	/** Ringing source type originating from the Bluetooth accessory non-owner
 	 *  service that is defined in the DULT specification.
-	 *  Used only when the @kconfig{CONFIG_BT_FAST_PAIR_FMDN_DULT} is enabled.
+	 *  Used only when the `CONFIG_BT_FAST_PAIR_FMDN_DULT` is enabled.
 	 */
 	BT_FAST_PAIR_FMDN_RING_SRC_DULT_BT_GATT,
 
 	/** Ringing source type originating from the Motion detector defined in the
 	 *  DULT specification.
-	 *  Used only when the @kconfig{CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR}
+	 *  Used only when the `CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR`
 	 *  is enabled.
 	 */
 	BT_FAST_PAIR_FMDN_RING_SRC_DULT_MOTION_DETECTOR,
@@ -157,9 +157,9 @@ struct bt_fast_pair_fmdn_ring_cb {
 	 *
 	 *  This callback is executed in the cooperative thread context. You
 	 *  can learn about the exact thread context by analyzing the
-	 *  @kconfig{CONFIG_BT_RECV_CONTEXT} configuration choice. By default, this
+	 *  `CONFIG_BT_RECV_CONTEXT` configuration choice. By default, this
 	 *  callback is executed in the Bluetooth-specific workqueue thread
-	 *  (@kconfig{CONFIG_BT_RECV_WORKQ_BT}).
+	 *  (`CONFIG_BT_RECV_WORKQ_BT`).
 	 *
 	 *  @param src   Source of the ringing activity.
 	 *  @param param Requested ringing parameters.
@@ -217,9 +217,9 @@ struct bt_fast_pair_fmdn_ring_cb {
 	 *
 	 *  This callback is executed in the cooperative thread context. You
 	 *  can learn about the exact thread context by analyzing the
-	 *  @kconfig{CONFIG_BT_RECV_CONTEXT} configuration choice. By default, this
+	 *  `CONFIG_BT_RECV_CONTEXT` configuration choice. By default, this
 	 *  callback is executed in the Bluetooth-specific workqueue thread
-	 *  (@kconfig{CONFIG_BT_RECV_WORKQ_BT}).
+	 *  (`CONFIG_BT_RECV_WORKQ_BT`).
 	 *
 	 *  @param src Source of the ringing activity.
 	 */
@@ -229,7 +229,7 @@ struct bt_fast_pair_fmdn_ring_cb {
 /** @brief Register the ringing callbacks in the FMDN module.
  *
  *  This function registers the ringing callbacks. If you declare at least one
- *  ringing component using the @kconfig{CONFIG_BT_FAST_PAIR_FMDN_RING_COMP} Kconfig
+ *  ringing component using the `CONFIG_BT_FAST_PAIR_FMDN_RING_COMP` Kconfig
  *  choice option, you shall call this API before you enable Fast Pair with the
  *  @ref bt_fast_pair_enable function. Otherwise, the enable operation fails.
  *
@@ -309,7 +309,7 @@ int bt_fast_pair_fmdn_ring_state_update(
 
 /** @brief Motion detector callback structure.
  *
- *  Used only if the @kconfig{CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR} Kconfig option
+ *  Used only if the `CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR` Kconfig option
  *  is enabled.
  */
 struct bt_fast_pair_fmdn_motion_detector_cb {
@@ -352,7 +352,7 @@ struct bt_fast_pair_fmdn_motion_detector_cb {
  *
  *  This function registers callbacks to handle motion detector activities defined
  *  in the Motion detector feature from the DULT specification. This API can
- *  only be used when the @kconfig{CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR}
+ *  only be used when the `CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR`
  *  Kconfig option is enabled. If this configuration is active, this function must
  *  be called before you enable Fast Pair with the @ref bt_fast_pair_enable function.
  *  Otherwise, the enable operation fails.
@@ -384,7 +384,7 @@ int bt_fast_pair_fmdn_motion_detector_cb_register(
  *  If you do not want to support the battery level indication, you should
  *  ignore this API and never call it in their application.
  *
- *  However, if the @kconfig{CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT} Kconfig is enabled,
+ *  However, if the `CONFIG_BT_FAST_PAIR_FMDN_BATTERY_DULT` Kconfig is enabled,
  *  you must initialize battery level with this API before you enable Fast Pair
  *  with the @ref bt_fast_pair_enable API. This requirement is necessary as the
  *  DULT battery mechanism does not support unknown battery levels. As a result,
@@ -398,8 +398,8 @@ int bt_fast_pair_fmdn_motion_detector_cb_register(
  *  The exact mapping of the battery percentage to the battery level as defined by the
  *  FMDN Accessory specification in the advertising payload is implementation-specific.
  *  The mapping configuration is controlled by the following Kconfig options:
- *  @kconfig{CONFIG_BT_FAST_PAIR_FMDN_BATTERY_LEVEL_LOW_THR} and
- *  @kconfig{CONFIG_BT_FAST_PAIR_FMDN_BATTERY_LEVEL_CRITICAL_THR}.
+ *  `CONFIG_BT_FAST_PAIR_FMDN_BATTERY_LEVEL_LOW_THR` and
+ *  `CONFIG_BT_FAST_PAIR_FMDN_BATTERY_LEVEL_CRITICAL_THR`.
  *
  *  @param percentage_level Battery level as a percentage [0-100%] or
  *                          @ref BT_FAST_PAIR_FMDN_BATTERY_LEVEL_NONE value if the
@@ -500,9 +500,9 @@ struct bt_fast_pair_fmdn_info_cb {
 	 *
 	 *  This callback is executed in the cooperative thread context. You
 	 *  can learn about the exact thread context by analyzing the
-	 *  @kconfig{CONFIG_BT_RECV_CONTEXT} configuration choice. By default, this
+	 *  `CONFIG_BT_RECV_CONTEXT` configuration choice. By default, this
 	 *  callback is executed in the Bluetooth-specific workqueue thread
-	 *  (@kconfig{CONFIG_BT_RECV_WORKQ_BT}).
+	 *  (`CONFIG_BT_RECV_WORKQ_BT`).
 	 */
 	void (*clock_synced)(void);
 
@@ -517,9 +517,9 @@ struct bt_fast_pair_fmdn_info_cb {
 	 *  The first callback is executed in the workqueue context after the
 	 *  @ref bt_fast_pair_enable function call. Subsequent callbacks are
 	 *  also executed in the cooperative thread context. You can learn about
-	 *  the exact thread context by analyzing the @kconfig{CONFIG_BT_RECV_CONTEXT}
+	 *  the exact thread context by analyzing the `CONFIG_BT_RECV_CONTEXT`
 	 *  configuration choice. By default, this callback is executed in the
-	 *  Bluetooth-specific workqueue thread (@kconfig{CONFIG_BT_RECV_WORKQ_BT}).
+	 *  Bluetooth-specific workqueue thread (`CONFIG_BT_RECV_WORKQ_BT`).
 	 *
 	 *  @param provisioned true if the accessory has been successfully provisioned.
 	 *                     false if the accessory has been successfully unprovisioned.
@@ -552,7 +552,7 @@ enum bt_fast_pair_fmdn_read_mode {
 	BT_FAST_PAIR_FMDN_READ_MODE_FMDN_RECOVERY,
 
 	/** Identification read mode.
-	 *  Used only when the @kconfig{CONFIG_BT_FAST_PAIR_FMDN_DULT} is enabled.
+	 *  Used only when the `CONFIG_BT_FAST_PAIR_FMDN_DULT` is enabled.
 	 */
 	BT_FAST_PAIR_FMDN_READ_MODE_DULT_ID,
 };

--- a/include/dult.h
+++ b/include/dult.h
@@ -109,9 +109,9 @@ int dult_user_register(const struct dult_user *user);
  *
  *  This function sets the current battery level. The battery level is an optional
  *  feature in the DULT specification and this API must not be used when the
- *  @kconfig{CONFIG_DULT_BATTERY} Kconfig is disabled.
+ *  `CONFIG_DULT_BATTERY` Kconfig is disabled.
  *
- *  If the @kconfig{CONFIG_DULT_BATTERY} Kconfig is enabled, this function must be called to
+ *  If the `CONFIG_DULT_BATTERY` Kconfig is enabled, this function must be called to
  *  initialize the battery level after registering the DULT user with @ref dult_user_register
  *  and before enabling DULT with @ref dult_enable function. Subsequent calls to update
  *  the battery level are allowed in the enabled mode.
@@ -122,8 +122,8 @@ int dult_user_register(const struct dult_user *user);
  *  The exact mapping of the battery percentage to the battery level as defined by the
  *  DULT specification in the ANOS is implementation-specific. The mapping configuration
  *  is controlled by the following Kconfig options:
- *  @kconfig{CONFIG_DULT_BATTERY_LEVEL_CRITICAL_THR}, @kconfig{CONFIG_DULT_BATTERY_LEVEL_LOW_THR}
- *  and @kconfig{CONFIG_DULT_BATTERY_LEVEL_MEDIUM_THR}.
+ *  `CONFIG_DULT_BATTERY_LEVEL_CRITICAL_THR}, `CONFIG_DULT_BATTERY_LEVEL_LOW_THR`
+ *  and `CONFIG_DULT_BATTERY_LEVEL_MEDIUM_THR`.
  *
  *  @param user	            User structure used to authenticate the user.
  *  @param percentage_level Battery level as a percentage [0-100%]
@@ -193,7 +193,7 @@ enum dult_sound_src {
 	DULT_SOUND_SRC_BT_GATT,
 
 	/** Sound source type originating from the Motion detector.
-	 *  Used only when the @kconfig{CONFIG_DULT_MOTION_DETECTOR} is enabled.
+	 *  Used only when the `CONFIG_DULT_MOTION_DETECTOR` is enabled.
 	 */
 	DULT_SOUND_SRC_MOTION_DETECTOR,
 
@@ -290,7 +290,7 @@ int dult_sound_state_update(const struct dult_user *user,
 
 /** @brief Motion detector callback structure.
  *
- *  Used only when the @kconfig{CONFIG_DULT_MOTION_DETECTOR} Kconfig option is enabled.
+ *  Used only when the `CONFIG_DULT_MOTION_DETECTOR` Kconfig option is enabled.
  */
 struct dult_motion_detector_cb {
 	/** @brief Request the user to start the motion detector.
@@ -332,7 +332,7 @@ struct dult_motion_detector_cb {
  *
  *  This function registers callbacks to handle motion detector activities defined
  *  in the Motion detector feature from the DULT specification. This API can only
- *  be used when the @kconfig{CONFIG_DULT_MOTION_DETECTOR} Kconfig option is
+ *  be used when the `CONFIG_DULT_MOTION_DETECTOR` Kconfig option is
  *  enabled. If this configuration is active, this function must be called after
  *  registering the DULT user with @ref dult_user_register and before enabling
  *  DULT with @ref dult_enable function.

--- a/include/esb.h
+++ b/include/esb.h
@@ -501,7 +501,7 @@ int esb_set_base_address_1(const uint8_t *addr);
  *
  *  @param[in] prefixes		Prefixes for each pipe.
  *  @param[in] num_pipes	Number of pipes. Must be less than or equal to
- *				@kconfig{CONFIG_ESB_PIPE_COUNT}.
+ *				`CONFIG_ESB_PIPE_COUNT`.
  *
  * @retval 0 If successful.
  *           Otherwise, a (negative) error code is returned.
@@ -512,7 +512,7 @@ int esb_set_prefixes(const uint8_t *prefixes, uint8_t num_pipes);
  *
  *  The @p enable_mask parameter must contain the same number of pipes as has
  *  been configured with @ref esb_set_prefixes. This number may not be
- *  greater than the number defined by @kconfig{CONFIG_ESB_PIPE_COUNT}
+ *  greater than the number defined by `CONFIG_ESB_PIPE_COUNT`
  *
  *  @param enable_mask	Bitfield mask to enable or disable pipes.
  *			Setting a bit to 0 disables the pipe.

--- a/include/event_manager_proxy.h
+++ b/include/event_manager_proxy.h
@@ -41,7 +41,7 @@
  *
  * @param instance The instance used for IPC service to transfer data between cores.
  * @retval -EALREADY Given remote instance was added already.
- * @retval -ENOMEM No place for the new endpoint. See @kconfig{CONFIG_EVENT_MANAGER_PROXY_CH_COUNT}.
+ * @retval -ENOMEM No place for the new endpoint. See `CONFIG_EVENT_MANAGER_PROXY_CH_COUNT`.
  * @retval -EIO    Comes from IPC service,
  *                 see ipc_service_open_instance or ipc_service_register_endpoint.
  * @retval -EINVAL Comes from IPC service,

--- a/include/fw_info.h
+++ b/include/fw_info.h
@@ -188,7 +188,7 @@ bool fw_info_ext_api_provide(const struct fw_info *fwinfo, bool provide);
  *
  * @details Invalidation happens by setting the @c valid value to INVALID_VAL.
  *
- * @note This function needs to have @kconfig{CONFIG_NRFX_NVMC} enabled.
+ * @note This function needs to have `CONFIG_NRFX_NVMC` enabled.
  *
  * @param[in]  fw_info  The info structure to invalidate.
  *                      This memory will be modified directly in flash.

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -78,7 +78,7 @@ enum location_event_id {
 	 * Application has indicated that getting location has been completed,
 	 * the result is not known, and the Location library does not need to care about it.
 	 *
-	 * This event can occur only if @kconfig{CONFIG_LOCATION_SERVICE_EXTERNAL} is set.
+	 * This event can occur only if `CONFIG_LOCATION_SERVICE_EXTERNAL` is set.
 	 */
 	LOCATION_EVT_RESULT_UNKNOWN,
 	/**
@@ -104,14 +104,14 @@ enum location_event_id {
 	/**
 	 * Location request has been started.
 	 *
-	 * This event is only sent if @kconfig{CONFIG_LOCATION_DATA_DETAILS} is set.
+	 * This event is only sent if `CONFIG_LOCATION_DATA_DETAILS` is set.
 	 */
 	LOCATION_EVT_STARTED,
 	/**
 	 * A fallback from one method to another has occurred,
 	 * and the positioning procedure continues.
 	 *
-	 * This event is only sent if @kconfig{CONFIG_LOCATION_DATA_DETAILS} is set and
+	 * This event is only sent if `CONFIG_LOCATION_DATA_DETAILS` is set and
 	 * @ref location_config.mode is @ref LOCATION_REQ_MODE_FALLBACK.
 	 */
 	LOCATION_EVT_FALLBACK,
@@ -377,7 +377,7 @@ struct location_gnss_config {
 	 *
 	 * Default value is 120000 (2 minutes). It is applied when
 	 * location_config_defaults_set() function is called and can be changed at build time
-	 * with @kconfig{CONFIG_LOCATION_REQUEST_DEFAULT_GNSS_TIMEOUT} configuration.
+	 * with `CONFIG_LOCATION_REQUEST_DEFAULT_GNSS_TIMEOUT` configuration.
 	 */
 	int32_t timeout;
 
@@ -391,7 +391,7 @@ struct location_gnss_config {
 	 *
 	 * Default value is @ref LOCATION_ACCURACY_NORMAL. It is applied when
 	 * location_config_defaults_set() function is called and can be changed at build time
-	 * with @kconfig{CONFIG_LOCATION_REQUEST_DEFAULT_GNSS_ACCURACY} choice configuration.
+	 * with `CONFIG_LOCATION_REQUEST_DEFAULT_GNSS_ACCURACY` choice configuration.
 	 */
 	enum location_accuracy accuracy;
 
@@ -404,7 +404,7 @@ struct location_gnss_config {
 	 *
 	 * Default value is 3. It is applied when location_config_defaults_set()
 	 * function is called and can be changed at build time with
-	 * @kconfig{CONFIG_LOCATION_REQUEST_DEFAULT_GNSS_NUM_CONSECUTIVE_FIXES} configuration.
+	 * `CONFIG_LOCATION_REQUEST_DEFAULT_GNSS_NUM_CONSECUTIVE_FIXES` configuration.
 	 */
 	uint8_t num_consecutive_fixes;
 
@@ -418,7 +418,7 @@ struct location_gnss_config {
 	 *
 	 * Default value is false. It is applied when location_config_defaults_set()
 	 * function is called and can be changed at build time with
-	 * @kconfig{CONFIG_LOCATION_REQUEST_DEFAULT_GNSS_VISIBILITY_DETECTION} configuration.
+	 * `CONFIG_LOCATION_REQUEST_DEFAULT_GNSS_VISIBILITY_DETECTION` configuration.
 	 *
 	 * @note Only supported with modem firmware v1.3.2 or later.
 	 */
@@ -442,7 +442,7 @@ struct location_gnss_config {
 	 *
 	 * Default value is false. It is applied when location_config_defaults_set()
 	 * function is called and can be changed at build time with
-	 * @kconfig{CONFIG_LOCATION_REQUEST_DEFAULT_GNSS_PRIORITY_MODE} configuration.
+	 * `CONFIG_LOCATION_REQUEST_DEFAULT_GNSS_PRIORITY_MODE` configuration.
 	 */
 	bool priority_mode;
 };
@@ -455,12 +455,12 @@ struct location_cellular_config {
 	 *
 	 * @details Default value is 30000 (30 seconds). It is applied when
 	 * location_config_defaults_set() function is called and can be changed at build time
-	 * with @kconfig{CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_TIMEOUT} configuration.
+	 * with `CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_TIMEOUT` configuration.
 	 *
 	 * Timeout only applies to neighbor cell search, not the cloud communication.
 	 * Timeout for the entire location request specified in @ref location_config structure
 	 * is still valid.
-	 * When @kconfig{CONFIG_LOCATION_SERVICE_EXTERNAL} is enabled, this timeout stops when
+	 * When `CONFIG_LOCATION_SERVICE_EXTERNAL` is enabled, this timeout stops when
 	 * event @ref LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST is sent. However, timeout specified in
 	 * @ref location_config structure is still valid.
 	 */
@@ -472,7 +472,7 @@ struct location_cellular_config {
 	 * @details Default value is @ref LOCATION_SERVICE_ANY. It is applied when
 	 * location_config_defaults_set() function is called.
 	 *
-	 * This parameter is ignored when @kconfig{CONFIG_LOCATION_SERVICE_EXTERNAL} is enabled.
+	 * This parameter is ignored when `CONFIG_LOCATION_SERVICE_EXTERNAL` is enabled.
 	 */
 	enum location_service service;
 
@@ -481,7 +481,7 @@ struct location_cellular_config {
 	 *
 	 * @details Default value is 4. It is applied when
 	 * location_config_defaults_set() function is called and can be changed at build time
-	 * with @kconfig{CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_CELL_COUNT} configuration.
+	 * with `CONFIG_LOCATION_REQUEST_DEFAULT_CELLULAR_CELL_COUNT` configuration.
 	 *
 	 * Maximum value is 15.
 	 *
@@ -508,13 +508,13 @@ struct location_wifi_config {
 	 *
 	 * @details Default value is 30000 (30 seconds). It is applied when
 	 * location_config_defaults_set() function is called and can be changed at build time
-	 * with @kconfig{CONFIG_LOCATION_REQUEST_DEFAULT_WIFI_TIMEOUT} configuration.
+	 * with `CONFIG_LOCATION_REQUEST_DEFAULT_WIFI_TIMEOUT` configuration.
 	 *
 	 * Timeout only applies to Wi-Fi scan, not the cloud communication.
 	 * Timeout for the entire location request specified in @ref location_config structure
 	 * is still valid.
 	 *
-	 * When @kconfig{CONFIG_LOCATION_SERVICE_EXTERNAL} is enabled, this timeout stops when
+	 * When `CONFIG_LOCATION_SERVICE_EXTERNAL` is enabled, this timeout stops when
 	 * event @ref LOCATION_EVT_CLOUD_LOCATION_EXT_REQUEST is sent. However, timeout specified in
 	 * @ref location_config structure is still valid.
 	 */
@@ -526,7 +526,7 @@ struct location_wifi_config {
 	 * @details Default value is @ref LOCATION_SERVICE_ANY. It is applied when
 	 * location_config_defaults_set() function is called.
 	 *
-	 * This parameter is ignored when @kconfig{CONFIG_LOCATION_SERVICE_EXTERNAL} is enabled.
+	 * This parameter is ignored when `CONFIG_LOCATION_SERVICE_EXTERNAL` is enabled.
 	 */
 	enum location_service service;
 };
@@ -572,7 +572,7 @@ struct location_config {
 	 *
 	 * Default value is 0. It is applied when
 	 * location_config_defaults_set() function is called and can be changed at build time
-	 * with @kconfig{CONFIG_LOCATION_REQUEST_DEFAULT_INTERVAL} configuration.
+	 * with `CONFIG_LOCATION_REQUEST_DEFAULT_INTERVAL` configuration.
 	 */
 	uint16_t interval;
 
@@ -583,7 +583,7 @@ struct location_config {
 	 *
 	 * Default value is 300000 (5 minutes). It is applied when
 	 * location_config_defaults_set() function is called and can be changed
-	 * at build time with @kconfig{CONFIG_LOCATION_REQUEST_DEFAULT_TIMEOUT} configuration.
+	 * at build time with `CONFIG_LOCATION_REQUEST_DEFAULT_TIMEOUT` configuration.
 	 *
 	 * This is intended to be a safety timer preventing location request from getting stuck
 	 * in any of its phases, because parts of the method-specific functionality are not
@@ -686,7 +686,7 @@ int location_request_cancel(void);
  *
  * @param[in,out] config Configuration to be supplied with default values.
  * @param[in] methods_count Number of location methods. This must not exceed
- *                          @kconfig{CONFIG_LOCATION_METHODS_LIST_SIZE}.
+ *                          `CONFIG_LOCATION_METHODS_LIST_SIZE`.
  * @param[in] method_types List of location method types in priority order.
  *                         Location methods with these types are initialized with default values
  *                         into given configuration. List size must be as given in 'methods_count'.
@@ -736,7 +736,7 @@ const struct location_data_details *location_details_get(
  *
  * @return 0 on success, or negative error code on failure.
  * @retval -EINVAL Given buffer is NULL or buffer length zero.
- * @retval -ENOTSUP @kconfig{CONFIG_LOCATION_SERVICE_EXTERNAL} is not set.
+ * @retval -ENOTSUP `CONFIG_LOCATION_SERVICE_EXTERNAL` is not set.
  */
 int location_agnss_data_process(const char *buf, size_t buf_len);
 
@@ -756,7 +756,7 @@ int location_agnss_data_process(const char *buf, size_t buf_len);
  *
  * @return 0 on success, or negative error code on failure.
  * @retval -EINVAL Given buffer is NULL or buffer length zero.
- * @retval -ENOTSUP @kconfig{CONFIG_LOCATION_SERVICE_EXTERNAL} is not set.
+ * @retval -ENOTSUP `CONFIG_LOCATION_SERVICE_EXTERNAL` is not set.
  */
 int location_pgps_data_process(const char *buf, size_t buf_len);
 

--- a/include/modem/nrf_modem_lib_trace.h
+++ b/include/modem/nrf_modem_lib_trace.h
@@ -107,7 +107,7 @@ int nrf_modem_lib_trace_clear(void);
 /** @brief Get the last measured rolling average bitrate of the trace backend.
  *
  * This function returns the last measured rolling average bitrate of the trace backend
- * calculated over the last @kconfig{CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_PERIOD_MS} period.
+ * calculated over the last `CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_PERIOD_MS` period.
  *
  * @return Rolling average bitrate of the trace backend
  */

--- a/include/net/azure_iot_hub.h
+++ b/include/net/azure_iot_hub.h
@@ -299,7 +299,7 @@ typedef void (*azure_iot_hub_evt_handler_t)(struct azure_iot_hub_evt *evt);
 struct azure_iot_hub_config {
 	/** Hostname to IoT Hub to connect to.
 	 *  If the buffer size is zero, the device ID provided by
-	 *  @kconfig{CONFIG_AZURE_IOT_HUB_HOSTNAME} is used. If DPS is enabled and `use_dps` is
+	 *  `CONFIG_AZURE_IOT_HUB_HOSTNAME` is used. If DPS is enabled and `use_dps` is
 	 *  set to true, the provided hostname is ignored.
 	 */
 	struct azure_iot_hub_buf hostname;
@@ -309,12 +309,12 @@ struct azure_iot_hub_config {
 	struct azure_iot_hub_buf device_id;
 
 	/** Use DPS to obtain hostname and device ID if true.
-	 *  Using DPS requires that @kconfig{CONFIG_AZURE_IOT_HUB_DPS} is enabled and DPS
+	 *  Using DPS requires that `CONFIG_AZURE_IOT_HUB_DPS` is enabled and DPS
 	 *  configured accordingly.
 	 *  If a hostname and device ID have already been obtained previously, the stored values
 	 *  will be used. To re-run DPS, the DPS information must be reset first.
 	 *  Note that using this option will use the device ID as DPS registration ID and the
-	 *  ID cope from @kconfig{CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE}.
+	 *  ID cope from `CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE`.
 	 *  For more fine-grained control over DPS, use the azure_iot_hub_dps APIs directly instead.
 	 */
 	bool use_dps;

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -261,8 +261,8 @@ int download_client_set_host(struct download_client *client, const char *host,
  * @brief Download a file.
  *
  * The download is carried out in fragments of up to
- * @kconfig{CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE} bytes for HTTP, or
- * @kconfig{CONFIG_DOWNLOAD_CLIENT_COAP_BLOCK_SIZE} bytes for CoAP,
+ * `CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE` bytes for HTTP, or
+ * `CONFIG_DOWNLOAD_CLIENT_COAP_BLOCK_SIZE` bytes for CoAP,
  * which are delivered to the application
  * via @ref DOWNLOAD_CLIENT_EVT_FRAGMENT events.
  *
@@ -326,8 +326,8 @@ int download_client_disconnect(struct download_client *client);
  * this returns -EALREADY.
  *
  * The download is carried out in fragments of up to
- * @kconfig{CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE} bytes for HTTP, or
- * @kconfig{CONFIG_DOWNLOAD_CLIENT_COAP_BLOCK_SIZE} bytes for CoAP,
+ * `CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE` bytes for HTTP, or
+ * `CONFIG_DOWNLOAD_CLIENT_COAP_BLOCK_SIZE` bytes for CoAP,
  * which are delivered to the application
  * through @ref DOWNLOAD_CLIENT_EVT_FRAGMENT events.
  *

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -138,7 +138,7 @@ int fota_download_init(fota_download_callback_t client_callback);
  * @retval 0	     If download has started successfully.
  * @retval -EALREADY If download is already ongoing.
  * @retval -E2BIG    If sec_tag_count is larger than
- *		     @kconfig{CONFIG_FOTA_DOWNLOAD_SEC_TAG_LIST_SIZE_MAX}
+ *		     `CONFIG_FOTA_DOWNLOAD_SEC_TAG_LIST_SIZE_MAX`
  *                   Otherwise, a negative value is returned.
  */
 int fota_download(const char *host, const char *file, const int *sec_tag_list,
@@ -163,7 +163,7 @@ int fota_download(const char *host, const char *file, const int *sec_tag_list,
  * @retval 0	     If download has started successfully.
  * @retval -EALREADY If download is already ongoing.
  * @retval -E2BIG    If sec_tag_count is larger than
- *		     @kconfig{CONFIG_FOTA_DOWNLOAD_SEC_TAG_LIST_SIZE_MAX}
+ *		     `CONFIG_FOTA_DOWNLOAD_SEC_TAG_LIST_SIZE_MAX`
  *                   Otherwise, a negative value is returned.
  */
 int fota_download_with_host_cfg(const char *host, const char *file,
@@ -202,7 +202,7 @@ int fota_download_with_host_cfg(const char *host, const char *file,
  * @retval 0	     If download has started successfully.
  * @retval -EALREADY If download is already ongoing.
  * @retval -E2BIG    If sec_tag_count is larger than
- *		     @kconfig{CONFIG_FOTA_DOWNLOAD_SEC_TAG_LIST_SIZE_MAX}
+ *		     `CONFIG_FOTA_DOWNLOAD_SEC_TAG_LIST_SIZE_MAX`
  *                   Otherwise, a negative value is returned.
  */
 int fota_download_any(const char *host, const char *file, const int *sec_tag_list,

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -112,7 +112,7 @@ enum nrf_cloud_evt_type {
 	 */
 	NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED,
 	/** A FOTA update has started.
-	 *  This event is only sent if @kconfig{CONFIG_NRF_CLOUD_FOTA_AUTO_START_JOB} is enabled.
+	 *  This event is only sent if `CONFIG_NRF_CLOUD_FOTA_AUTO_START_JOB` is enabled.
 	 */
 	NRF_CLOUD_EVT_FOTA_START,
 	/** The device should be restarted to apply a firmware upgrade */
@@ -126,7 +126,7 @@ enum nrf_cloud_evt_type {
 	/** FOTA update job information has been received.
 	 *  When ready, the application should start the job by
 	 *  calling @ref nrf_cloud_fota_job_start.
-	 *  This event is only sent if @kconfig{CONFIG_NRF_CLOUD_FOTA_AUTO_START_JOB} is disabled.
+	 *  This event is only sent if `CONFIG_NRF_CLOUD_FOTA_AUTO_START_JOB` is disabled.
 	 */
 	NRF_CLOUD_EVT_FOTA_JOB_AVAILABLE,
 	/** An error occurred. The status field in the event struct will
@@ -271,8 +271,8 @@ enum nrf_cloud_topic_type {
 	NRF_CLOUD_TOPIC_BULK,
 	/** Endpoint used to publish binary data to nRF Cloud for certain services.
 	 *  One example is dictionary formatted logs enabled by
-	 *  @kconfig{CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_DICTIONARY}, which enables the
-	 *  Zephyr option @kconfig{CONFIG_LOG_DICTIONARY_SUPPORT}. Binary data published to
+	 *  `CONFIG_LOG_BACKEND_NRF_CLOUD_OUTPUT_DICTIONARY`, which enables the
+	 *  Zephyr option `CONFIG_LOG_DICTIONARY_SUPPORT`. Binary data published to
 	 *  this topic should be prefixed by the binary header structure defined in
 	 *  nrf_cloud_codec.h - struct nrf_cloud_bin_hdr.  A unique format value
 	 *  should be included to distinguish this data from binary logging.
@@ -670,8 +670,8 @@ struct nrf_cloud_init_param {
 	 */
 	char *client_id;
 	/** Flash device information required for full modem FOTA updates.
-	 * Only used if @kconfig{CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE} is enabled.
-	 * Ignored if @kconfig{CONFIG_DFU_TARGET_FULL_MODEM_USE_EXT_PARTITION} is
+	 * Only used if `CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE` is enabled.
+	 * Ignored if `CONFIG_DFU_TARGET_FULL_MODEM_USE_EXT_PARTITION` is
 	 * enabled.
 	 */
 	struct dfu_target_fmfu_fdev *fmfu_dev_inf;
@@ -680,13 +680,13 @@ struct nrf_cloud_init_param {
 	 */
 	struct nrf_cloud_os_mem_hooks *hooks;
 	/** Optional application version that is reported to nRF Cloud if
-	 * @kconfig{CONFIG_NRF_CLOUD_SEND_DEVICE_STATUS} is enabled.
+	 * `CONFIG_NRF_CLOUD_SEND_DEVICE_STATUS` is enabled.
 	 */
 	const char *application_version;
 
 	/** Callback of type @ref dfu_target_reset_cb_t for resetting the SMP device to enter
 	 * MCUboot recovery mode.
-	 * Used if @kconfig{CONFIG_NRF_CLOUD_FOTA_SMP} is enabled.
+	 * Used if `CONFIG_NRF_CLOUD_FOTA_SMP` is enabled.
 	 */
 	void *smp_reset_cb;
 };
@@ -720,7 +720,7 @@ int nrf_cloud_init(const struct nrf_cloud_init_param *param);
  * @retval 0        If successful.
  * @retval -EBUSY   If a FOTA job is in progress.
  * @retval -EISCONN If the expected disconnect event did not occur.
- * @retval -ETIME   If @kconfig{CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD} is enabled and
+ * @retval -ETIME   If `CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` is enabled and
  *                  the connection poll thread did not become inactive.
  * @return A negative value indicates an error.
  */
@@ -729,7 +729,7 @@ int nrf_cloud_uninit(void);
 /**
  * @brief Print details about cloud connection.
  *
- * If @kconfig{CONFIG_NRF_CLOUD_VERBOSE_DETAILS} is not enabled,
+ * If `CONFIG_NRF_CLOUD_VERBOSE_DETAILS` is not enabled,
  * only print the device id. If enabled, also print the protocol,
  * sec tag, and host name.
  *
@@ -752,7 +752,7 @@ int nrf_cloud_print_cloud_details(void);
 /**
  * @brief Retrieve the IMEI.
  *
- * If @kconfig{CONFIG_NRF_MODEM_LIB} is not enabled, returns an error.
+ * If `CONFIG_NRF_MODEM_LIB` is not enabled, returns an error.
  *
  * @param[in,out] buf A pointer in which to store the IMEI string.
  * @param[in]  buf_sz The size of the buffer. It should be at least 22
@@ -768,7 +768,7 @@ int nrf_cloud_get_imei(char *buf, size_t buf_sz);
 /**
  * @brief Retrieve the device's UUID.
  *
- * If @kconfig{CONFIG_NRF_MODEM_LIB} is not enabled, returns an error.
+ * If `CONFIG_NRF_MODEM_LIB` is not enabled, returns an error.
  *
  * @param[in,out] buf A pointer in which to store the UUID string.
  * @param[in]  buf_sz The size of the buffer. It should be at least
@@ -785,7 +785,7 @@ int nrf_cloud_get_uuid(char *buf, size_t buf_sz);
 /**
  * @brief Retrieve the Modem firmware version.
  *
- * If @kconfig{CONFIG_NRF_MODEM_LIB} is not enabled, returns an error.
+ * If `CONFIG_NRF_MODEM_LIB` is not enabled, returns an error.
  *
  * @param[in,out] buf A pointer in which to store the mfw string.
  * @param[in]  buf_sz The size of the buffer. The required size could
@@ -896,7 +896,7 @@ int nrf_cloud_obj_shadow_update(struct nrf_cloud_obj *const shadow_obj);
  *                         @ref NRF_CLOUD_TRANSFORM_MAX_RESPONSE_LEN.
  *
  * @retval 0        Request was sent successfully.
- * @retval -ENOTSUP Error; @kconfig{CONFIG_NRF_CLOUD_MQTT_SHADOW_TRANSFORMS} is not enabled.
+ * @retval -ENOTSUP Error; `CONFIG_NRF_CLOUD_MQTT_SHADOW_TRANSFORMS` is not enabled.
  * @retval -EINVAL  Error; invalid parameter.
  * @return A negative value indicates an error.
  */
@@ -930,7 +930,7 @@ int nrf_cloud_process(void);
  * @brief The application has handled reinit after a modem FOTA update and the
  *        LTE link has been reestablished.
  *        This function must be called in order to complete the modem update.
- *        Depends on @kconfig{CONFIG_NRF_CLOUD_FOTA}.
+ *        Depends on `CONFIG_NRF_CLOUD_FOTA`.
  *
  * @param[in] fota_success true if modem update was successful, false otherwise.
  *
@@ -949,7 +949,7 @@ int nrf_cloud_modem_fota_completed(const bool fota_success);
  * @retval -EINVAL   The id_buf parameter is NULL and/or the id_buf_sz parameter is 0.
  * @retval -EMSGSIZE The provided buffer is too small.
  * @retval -EIO      The client ID could not be initialized.
- * @retval -ENXIO    The Kconfig option @kconfig{CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME} is enabled
+ * @retval -ENXIO    The Kconfig option `CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME` is enabled
  *                   but the runtime client ID has not been set.
  *                   See @ref nrf_cloud_client_id_runtime_set.
  * @return A negative value indicates an error.
@@ -958,7 +958,7 @@ int nrf_cloud_client_id_get(char *id_buf, size_t id_buf_sz);
 
 /**
  * @brief Set the device ID at runtime.
- *        Requires @kconfig{CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME} to be enabled.
+ *        Requires `CONFIG_NRF_CLOUD_CLIENT_ID_SRC_RUNTIME` to be enabled.
  *
  * @note This function does not perform any management of the device's connection to nRF Cloud.
  *
@@ -1004,7 +1004,7 @@ int nrf_cloud_jwt_generate(uint32_t time_valid_s, char * const jwt_buf, size_t j
  * @brief Process/validate a pending FOTA update job. Typically the job
  *        information is read from non-volatile storage on startup. This function
  *        is intended to be used by custom REST-based FOTA implementations.
- *        It is called internally if @kconfig{CONFIG_NRF_CLOUD_FOTA} is enabled.
+ *        It is called internally if `CONFIG_NRF_CLOUD_FOTA` is enabled.
  *        For pending NRF_CLOUD_FOTA_MODEM_DELTA jobs the modem library must
  *        be initialized before calling this function, otherwise the job will
  *        be marked as completed without validation.
@@ -1023,7 +1023,7 @@ int nrf_cloud_pending_fota_job_process(struct nrf_cloud_settings_fota_job * cons
 /**
  * @brief Set the active bootloader (B1) slot flag which is needed
  *        to validate a bootloader FOTA update. For proper functionality,
- *        @kconfig{CONFIG_FOTA_DOWNLOAD} must be enabled.
+ *        `CONFIG_FOTA_DOWNLOAD` must be enabled.
  *
  * @param[in,out] job FOTA job state information.
  *
@@ -1035,7 +1035,7 @@ int nrf_cloud_bootloader_fota_slot_set(struct nrf_cloud_settings_fota_job * cons
 /**
  * @brief Retrieve the FOTA type of a pending FOTA job. A value of
  *        NRF_CLOUD_FOTA_TYPE__INVALID indicates that there are no pending FOTA jobs.
- *        Depends on @kconfig{CONFIG_NRF_CLOUD_FOTA}.
+ *        Depends on `CONFIG_NRF_CLOUD_FOTA`.
  *
  * @param[out] pending_fota_type FOTA type of pending job.
  *
@@ -1053,7 +1053,7 @@ int nrf_cloud_fota_pending_job_type_get(enum nrf_cloud_fota_type * const pending
  *        For pending NRF_CLOUD_FOTA_MODEM_DELTA jobs the modem library must
  *        be initialized before calling this function, otherwise the job will
  *        be marked as completed without validation.
- *        Depends on @kconfig{CONFIG_NRF_CLOUD_FOTA}.
+ *        Depends on `CONFIG_NRF_CLOUD_FOTA`.
  *
  * @param[out] fota_type_out FOTA type of pending job.
  *                           NRF_CLOUD_FOTA_TYPE__INVALID if no pending job.
@@ -1072,7 +1072,7 @@ int nrf_cloud_fota_pending_job_validate(enum nrf_cloud_fota_type * const fota_ty
  * @brief Set the flash device used for full modem FOTA updates.
  *        This function is intended to be used by custom REST-based FOTA implementations.
  *        It is called internally when @ref nrf_cloud_init is executed if
- *        @kconfig{CONFIG_NRF_CLOUD_FOTA} is enabled. It can be called before @ref nrf_cloud_init
+ *        `CONFIG_NRF_CLOUD_FOTA` is enabled. It can be called before @ref nrf_cloud_init
  *        if required by the application.
  *
  * @param[in] fmfu_dev_inf Flash device information.
@@ -1087,11 +1087,11 @@ int nrf_cloud_fota_fmfu_dev_set(const struct dfu_target_fmfu_fdev *const fmfu_de
  * @brief Install a full modem update from flash. If successful,
  *        reboot the device or reinit the modem to complete the update.
  *        This function is intended to be used by custom REST-based FOTA implementations.
- *        If @kconfig{CONFIG_NRF_CLOUD_FOTA} is enabled,
+ *        If `CONFIG_NRF_CLOUD_FOTA` is enabled,
  *        call @ref nrf_cloud_fota_pending_job_validate
  *        to install a downloaded NRF_CLOUD_FOTA_MODEM_FULL update after the
  *        @ref NRF_CLOUD_EVT_FOTA_DONE event is received.
- *        Depends on @kconfig{CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE}.
+ *        Depends on `CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE`.
  *
  * @retval 0 Modem update installed successfully.
  * @retval -EACCES Flash device not set; see @ref nrf_cloud_fota_fmfu_dev_set or
@@ -1109,8 +1109,8 @@ bool nrf_cloud_fota_is_type_modem(const enum nrf_cloud_fota_type type);
 
 /**
  * @brief Determine if the specified FOTA type is enabled by the
- *        configuration. This function returns false if both @kconfig{CONFIG_NRF_CLOUD_FOTA}
- *        and @kconfig{CONFIG_NRF_CLOUD_REST} are disabled.
+ *        configuration. This function returns false if both `CONFIG_NRF_CLOUD_FOTA`
+ *        and `CONFIG_NRF_CLOUD_REST` are disabled.
  *        REST-based applications are responsible for implementing FOTA updates
  *        for all configured types.
  *
@@ -1125,12 +1125,12 @@ bool nrf_cloud_fota_is_type_enabled(const enum nrf_cloud_fota_type type);
  * @brief Start the FOTA update job.
  *        This function should be called after the NRF_CLOUD_EVT_FOTA_JOB_AVAILABLE event
  *        is received.
- *        This function should only be called if @kconfig{CONFIG_NRF_CLOUD_FOTA_AUTO_START_JOB}
+ *        This function should only be called if `CONFIG_NRF_CLOUD_FOTA_AUTO_START_JOB`
  *        is disabled.
- *        Depends on @kconfig{CONFIG_NRF_CLOUD_FOTA}.
+ *        Depends on `CONFIG_NRF_CLOUD_FOTA`.
  *
  * @retval 0            FOTA update job started successfully.
- * @retval -ENOTSUP     Error; @kconfig{CONFIG_NRF_CLOUD_FOTA_AUTO_START_JOB} is enabled.
+ * @retval -ENOTSUP     Error; `CONFIG_NRF_CLOUD_FOTA_AUTO_START_JOB` is enabled.
  * @retval -ENOENT      Error; FOTA update job information has not been received.
  * @retval -EINPROGRESS Error; a FOTA update job is in progress.
  * @retval -EPIPE       Error; failed to start FOTA download.
@@ -1140,24 +1140,24 @@ int nrf_cloud_fota_job_start(void);
 
 /**
  * @brief Initialize the SMP client.
- *        Called automatically if @kconfig{CONFIG_NRF_CLOUD_FOTA} or
- *        @kconfig{CONFIG_NRF_CLOUD_FOTA_POLL} is enabled.
+ *        Called automatically if `CONFIG_NRF_CLOUD_FOTA` or
+ *        `CONFIG_NRF_CLOUD_FOTA_POLL` is enabled.
  *
  * @param smp_reset_cb Callback of type @ref dfu_target_reset_cb_t for resetting the SMP device to
  *                     enter MCUboot recovery mode.
  *
  * @retval 0        SMP client successfully initialized.
- * @retval -ENOTSUP Error; @kconfig{CONFIG_NRF_CLOUD_FOTA_SMP} is not enabled.
+ * @retval -ENOTSUP Error; `CONFIG_NRF_CLOUD_FOTA_SMP` is not enabled.
  * @return A negative value indicates an error.
  */
 int nrf_cloud_fota_smp_client_init(const void *smp_reset_cb);
 
 /**
  * @brief Install a downloaded SMP FOTA job.
- *        Called automatically if @kconfig{CONFIG_NRF_CLOUD_FOTA} is enabled (MQTT FOTA).
+ *        Called automatically if `CONFIG_NRF_CLOUD_FOTA` is enabled (MQTT FOTA).
  *
  * @retval 0        SMP update installed successfully.
- * @retval -ENOTSUP Error; @kconfig{CONFIG_NRF_CLOUD_FOTA_SMP} is not enabled.
+ * @retval -ENOTSUP Error; `CONFIG_NRF_CLOUD_FOTA_SMP` is not enabled.
  * @retval -EIO     Error; failed to schedule image installation.
  * @retval -EPROTO  Error; failed to reset SMP device.
  * @return A negative value indicates an error.
@@ -1213,8 +1213,8 @@ int nrf_cloud_credentials_configured_check(void);
 
 /**
  * @brief Set the sec tag used for nRF Cloud credentials.
- *        The default sec tag value is @kconfig{CONFIG_NRF_CLOUD_COAP_SEC_TAG} or
- *        @kconfig{CONFIG_NRF_CLOUD_COAP_SEC_TAG} for CoAP.
+ *        The default sec tag value is `CONFIG_NRF_CLOUD_COAP_SEC_TAG` or
+ *        `CONFIG_NRF_CLOUD_COAP_SEC_TAG` for CoAP.
  *
  * @note This API only needs to be called if the default configured sec tag value is no
  *       longer applicable. This function does not perform any management of the
@@ -1239,9 +1239,9 @@ sec_tag_t nrf_cloud_sec_tag_get(void);
 /**
  * @brief Set the sec tag containing the private key used to sign CoAP JWTs for nRF Cloud
  *        authentication.
- *        The default sec tag value is @kconfig{CONFIG_NRF_CLOUD_COAP_JWT_SEC_TAG}.
+ *        The default sec tag value is `CONFIG_NRF_CLOUD_COAP_JWT_SEC_TAG`.
  *
- * @note This API requires @kconfig{CONFIG_NRF_CLOUD_COAP} to be enabled.
+ * @note This API requires `CONFIG_NRF_CLOUD_COAP` to be enabled.
  *       This API only needs to be called if the default configured sec tag value is no
  *       longer applicable. This function does not perform any management of the
  *       device's authentication status with nRF Cloud.
@@ -1255,7 +1255,7 @@ void nrf_cloud_sec_tag_coap_jwt_set(const sec_tag_t sec_tag);
  * @brief Get the sec tag containing the private key used to sign CoAP JWTs for nRF Cloud
  *        authentication.
  *
- * @note This API requires @kconfig{CONFIG_NRF_CLOUD_COAP} to be enabled.
+ * @note This API requires `CONFIG_NRF_CLOUD_COAP` to be enabled.
  *
  * @return The sec tag.
  */

--- a/include/net/nrf_cloud_fota_poll.h
+++ b/include/net/nrf_cloud_fota_poll.h
@@ -82,7 +82,7 @@ struct nrf_cloud_fota_poll_ctx {
 
 	/** Callback of type @ref dfu_target_reset_cb_t for resetting the SMP device to enter
 	 * MCUboot recovery mode.
-	 * Used if @kconfig{CONFIG_NRF_CLOUD_FOTA_SMP} is enabled.
+	 * Used if `CONFIG_NRF_CLOUD_FOTA_SMP` is enabled.
 	 */
 	void *smp_reset_cb;
 };

--- a/include/net/nrf_cloud_location.h
+++ b/include/net/nrf_cloud_location.h
@@ -82,7 +82,7 @@ struct nrf_cloud_location_result {
 	sys_slist_t anchor_list;
 
 	/** User provided buffer to contain the @ref anchor_list.
-	 *  @kconfig{CONFIG_NRF_CLOUD_LOCATION_PARSE_ANCHORS} must be enabled for anchor data
+	 *  `CONFIG_NRF_CLOUD_LOCATION_PARSE_ANCHORS` must be enabled for anchor data
 	 *  to be parsed.
 	 *  This buffer must point to valid memory or be set to NULL.
 	 *  A valid buffer should have a size of at least @ref NRF_CLOUD_ANCHOR_LIST_BUF_MIN_SZ.
@@ -147,7 +147,7 @@ typedef void (*nrf_cloud_location_response_t)(const struct nrf_cloud_location_re
  *                 which is do_reply = true, hi_conf = false, and fallback = true.
  * @param cb Callback function to receive parsed location result. Only used when
  *           config->do_reply is true or config is NULL.
- *           If @kconfig{CONFIG_NRF_CLOUD_LOCATION_ANCHOR_LIST} is enabled, the application
+ *           If `CONFIG_NRF_CLOUD_LOCATION_ANCHOR_LIST` is enabled, the application
  *           should not access the anchor list data after exiting the callback as it may
  *           become invalid.
  *           If cb is NULL, JSON result will be sent to the cloud event handler as

--- a/include/net/rest_client.h
+++ b/include/net/rest_client.h
@@ -98,7 +98,7 @@ struct rest_client_req_context {
 	 *  for socket connection creation and data transfer meaning REST request can take
 	 *  longer than this given timeout. To disable, set the timeout duration to SYS_FOREVER_MS.
 	 *  A value of zero will result in an immediate timeout.
-	 *  Default: @kconfig{CONFIG_REST_CLIENT_REST_REQUEST_TIMEOUT}.
+	 *  Default: `CONFIG_REST_CLIENT_REST_REQUEST_TIMEOUT`.
 	 */
 	int32_t timeout_ms;
 

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
@@ -179,7 +179,7 @@ int nrf_cloud_coap_shadow_default_process(struct nrf_cloud_obj_shadow_data *cons
 
 /** @brief Encode the info sections that are enabled to be sent to the device's shadow on
  * initial connection. The sections are enabled based on the configuration options that
- * set the Kconfig @kconfig{CONFIG_NRF_CLOUD_SEND_SHADOW_INFO} symbol.
+ * set the Kconfig `CONFIG_NRF_CLOUD_SEND_SHADOW_INFO` symbol.
  *
  * @retval 0		Success.
  * @retval -ENODEV	No info sections are enabled, no data encoded.


### PR DESCRIPTION
This patch makes the now broken KConfig mentions in docs look slightly better.