### PR TITLE
samples: coremark: Remove compiler flag -funroll-loops

### DIFF
--- a/samples/benchmarks/coremark/prj_heap_memory.conf
+++ b/samples/benchmarks/coremark/prj_heap_memory.conf
@@ -8,7 +8,8 @@
 CONFIG_COREMARK=y
 
 # Compiler options
-CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
+# Do not use -funroll-loops as then the coremark benchmark will not fit to local RAM.
+CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -ffunction-sections -fdata-sections"
 
 # Config results output
 # The default logging level is set to the ERROR level.

--- a/samples/benchmarks/coremark/prj_multiple_threads.conf
+++ b/samples/benchmarks/coremark/prj_multiple_threads.conf
@@ -8,7 +8,8 @@
 CONFIG_COREMARK=y
 
 # Compiler options
-CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
+# Do not use -funroll-loops as then the coremark benchmark will not fit to local RAM.
+CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -ffunction-sections -fdata-sections"
 
 # Config results output
 # The default logging level is set to the ERROR level.


### PR DESCRIPTION
Remove compiler flag -funroll-loops for
heap and multithread configurations as with them
the coremark benchmark will not fit to local RAM.

JIRA: NCSDK-30665