### PR TITLE
[Backport v2.9-nRF54H20] snippets: Fix nordic-bt-rpc memory remapping for BT RPC on nRF54H20.

### DIFF
--- a/snippets/nordic-bt-rpc/boards/nrf54h20dk_nrf54h20-mem-map-move.dtsi
+++ b/snippets/nordic-bt-rpc/boards/nrf54h20dk_nrf54h20-mem-map-move.dtsi
@@ -18,6 +18,7 @@
 &mram1x {
 	cpurad_rw_partitions: cpurad-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
+		status = "disabled";
 		nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RWS>;
 		#address-cells = <1>;
 		#size-cells = <1>;


### PR DESCRIPTION
The Bluetooth RPC configuration for BLE samples didn't work due to an issue in the dts file that modifies the MRAM sections mapping for this build type. Application core was given an additional storage section that was intended for Radio core:
'cpurad_storage_partition'.

Ref. NCSDK-30458