### PR TITLE
sysbuild: nrf70: Use PM for external flash store

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf70/fw_patches_ext_flash.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/fw_patches_ext_flash.rst
@@ -80,7 +80,11 @@ In this case the upload of the firmware patch from the external memory to the nR
 1. The firmware patch is loaded from the external memory onto internal RAM.
 #. The firmware patch is uploaded to the nRF70 device.
 
-This feature can be enabled using DTS or the :ref:`app_build_snippets` feature, or by using :ref:`partition_manager`.
+You can enable this feature using the :ref:`app_build_snippets` feature.
+
+.. note::
+
+   Storing the nRF70 firmware patches in external RAM memory requires the partition manager to be enabled.
 
 Configuration
 -------------
@@ -91,24 +95,7 @@ The following configuration options are available:
 * :kconfig:option:`CONFIG_NRF_WIFI_FW_FLASH_CHUNK_SIZE` - Defines the size of the chunks used to read the firmware patches from the external non-XIP memory.
   The default value is 8192 bytes.
 
-The external memory partition name must be defined in the devicetree or in the partition manager configuration file.
-
-* ``nrf70_fw_partition`` - Defines the name of the external memory partition that stores the firmware patches.
-  This must be defined in the devicetree, for example:
-
-.. code-block:: dts
-
-    &flash0 {
-        partitions {
-            compatible = "fixed-partitions";
-            #address-cells = <1>;
-            #size-cells = <1>;
-            nrf70_fw_partition: partition@0 {
-                label = "nrf70_fw_partition";
-                reg = <0x00000000 DT_SIZE_K(128)>;
-            };
-        };
-    };
+You must define the external memory partition name in the Partition Manager configuration file as follows:
 
 * ``nrf70_wifi_fw`` - Defines the name of the external memory partition that stores the firmware patches.
   This must be defined in the partition manager configuration file, for example:
@@ -126,8 +113,7 @@ Building
 
 See :ref:`nrf7002dk_nrf5340` for general instructions on building.
 
-Additionally, you can build the sample either with the ``nrf70-fw-patch-ext-flash`` snippet or with Partition Manager (``SB_CONFIG_PARTITION_MANAGER``).
-When using the ``nrf70-fw-patch-ext-flash`` snippet, set ``SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE``, and disable ``SB_CONFIG_PARTITION_MANAGER``.
+Additionally, you can build the sample using the ``nrf70-fw-patch-ext-flash`` snippet and set the ``SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y`` Kconfig option.
 
 For example, to build the :ref:`wifi_shell_sample` sample for the nRF5340 DK with the ``nrf70-fw-patch-ext-flash`` snippet enabled, run the following commands.
 
@@ -136,14 +122,14 @@ With west
 
 .. code-block:: console
 
-    west build -p -b nrf5340dk/nrf5340/cpuapp samples/wifi/shell -- -Dnrf_wifi_shell_SHIELD=nrf7002ek -Dnrf_wifi_shell_SNIPPET="nrf70-fw-patch-ext-flash" -DSB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y -DSB_CONFIG_PARTITION_MANAGER=n
+    west build -p -b nrf5340dk/nrf5340/cpuapp samples/wifi/shell -- -Dnrf_wifi_shell_SHIELD=nrf7002ek -Dnrf_wifi_shell_SNIPPET="nrf70-fw-patch-ext-flash" -DSB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y
 
 With CMake
 ^^^^^^^^^^
 
 .. code-block:: console
 
-    cmake -GNinja -Bbuild -DBOARD=nrf5340dk/nrf5340/cpuapp -Dnrf_wifi_shell_SHIELD=nrf7002ek -Dnrf_wifi_shell_SNIPPET="nrf70-fw-patch-ext-flash" -DSB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y -DSB_CONFIG_PARTITION_MANAGER=n samples/wifi/shell
+    cmake -GNinja -Bbuild -DBOARD=nrf5340dk/nrf5340/cpuapp -Dnrf_wifi_shell_SHIELD=nrf7002ek -Dnrf_wifi_shell_SNIPPET="nrf70-fw-patch-ext-flash" -DSB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y samples/wifi/shell
     ninja -C build
 
 For example, to build the :ref:`wifi_shell_sample` sample for the nRF5340 DK with partition manager enabled, run the following commands:

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -61,7 +61,10 @@ Developing with nRF91 Series
 Developing with nRF70 Series
 ============================
 
-|no_changes_yet_note|
+* :ref:`ug_nrf70_developing_fw_patch_ext_flash`
+
+   * Removed support for storing the nRF70 firmware patches in external flash without the :ref:`partition_manager`.
+
 
 Working with nRF54H Series
 ==========================
@@ -451,6 +454,10 @@ Wi-Fi samples
   * Updated:
 
     * The :ref:`wifi_radio_test` sample is now moved to :zephyr_file:`samples/wifi/radio_test/multi_domain`.
+
+* :ref:`wifi_shell_sample` sample:
+
+  * Modified support for storing the nRF70 firmware patches in external flash using the :ref:`partition_manager`.
 
 Other samples
 -------------

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -280,7 +280,6 @@ tests:
     extra_args:
       - shell_SHIELD=nrf7002ek
       - shell_SNIPPET=nrf70-fw-patch-ext-flash
-      - SB_CONFIG_PARTITION_MANAGER=n
       - SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp

--- a/snippets/nrf70-fw-patch-ext-flash/fw-patch-ext-flash.overlay
+++ b/snippets/nrf70-fw-patch-ext-flash/fw-patch-ext-flash.overlay
@@ -3,16 +3,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-&qspi {
-	mx25r64: mx25r6435f@0 {
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-			nrf70_fw_partition: partition@0 {
-				label = "nrf70_fw_partition";
-				reg = <0x0 DT_SIZE_K(128)>;
-			};
-		};
+/{
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
 	};
 };

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -131,6 +131,10 @@ if (CONFIG_SOC_NRF54L15_CPUFLPR)
   ncs_add_partition_manager_config(pm.yml.vpr_launcher)
 endif()
 
+if(CONFIG_WIFI_NRF70 AND CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE)
+  ncs_add_partition_manager_config(pm.yml.wifi)
+endif()
+
 # We are using partition manager if we are a child image or if we are
 # the root image and the 'partition_manager' target exists.
 zephyr_compile_definitions(

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -156,6 +156,15 @@ config PM_PARTITION_SIZE_VPR_LAUNCHER
 	  This to place the flpr app's code at the address found in the devicetree.
 endif
 
+if WIFI_NRF70 && NRF_WIFI_PATCHES_EXT_FLASH_STORE
+
+partition=NRF70_WIFI_FW
+partition-size=0x20000
+rsource "Kconfig.template.partition_config"
+rsource "Kconfig.template.partition_region"
+
+endif
+
 endmenu # Zephyr subsystem configurations
 menu "NCS subsystem configurations"
 

--- a/subsys/partition_manager/pm.yml.wifi
+++ b/subsys/partition_manager/pm.yml.wifi
@@ -1,0 +1,7 @@
+#include <zephyr/autoconf.h>
+
+nrf70_wifi_fw:
+  placement:
+    after: [settings_storage]
+  region: external_flash
+  size: 131072

--- a/sysbuild/Kconfig.wifi
+++ b/sysbuild/Kconfig.wifi
@@ -60,6 +60,7 @@ config WIFI_PATCHES_EXT_FLASH_STORE
 	# nRF7002 supports SPI based external memory access but missing tools support
 	# TODO: Enable when tools support is available (NRFJPROG-157)
 	depends on !BOARD_NRF7002DK_NRF5340_CPUAPP && !BOARD_NRF7002DK_NRF5340_CPUAPP_NS
+	depends on PARTITION_MANAGER
 
 endchoice
 


### PR DESCRIPTION
Drop support for non-PM based build for external flash support, now PM is mandatory for cross-platform support.

Fix SHEL-3355.