### PR TITLE
scripts: quarantine_windows_mac: quarantine sample.benchmark.coremark

### DIFF
--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -45,3 +45,10 @@
     - thingy53/nrf5340/cpuapp/ns
     - thingy53/nrf5340/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/SHEL-3161"
+
+- scenarios:
+    - sample.benchmark.coremark.heap_memory
+    - sample.benchmark.coremark.multiple_threads
+  platforms:
+    - nrf54h20dk/nrf54h20/cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-31409"


### PR DESCRIPTION
region `RAM' overflowed