### PR TITLE
tests: drivers: sdp_asm: Fix build error

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -28,9 +28,3 @@
 - platforms:
     - native_posix
   comment: "native_posix will be removed soon - native_sim platform is the default simulator now"
-
-- scenarios:
-    - drivers.sdp_asm.basic
-  platforms:
-    - nrf54l15dk/nrf54l15/cpuflpr
-  comment: https://nordicsemi.atlassian.net/browse/NCSDK-31409

--- a/tests/drivers/sdp_asm/pytest/test_sdp_asm.py
+++ b/tests/drivers/sdp_asm/pytest/test_sdp_asm.py
@@ -62,8 +62,7 @@ after add_100: 212, 323, 434"""
         execute_shell_cmd(cmd, f"{BUILD_DIR}")
 
     logger.info("# Reflash")
-    cmd = ['west', 'flash', '--erase']
-    execute_shell_cmd(cmd, f"{BUILD_DIR}")
+    dut._flash_and_run()
 
     logger.info("# Get output from serial port")
     output = "\n".join(dut.readlines_until(regex='Test completed', timeout=5.0))

--- a/tests/drivers/sdp_asm/src/add_1.c
+++ b/tests/drivers/sdp_asm/src/add_1.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/kernel.h>
+#include <stdint.h>
 
 extern volatile uint8_t arg_uint8_t;
 extern volatile uint16_t arg_uint16_t;

--- a/tests/drivers/sdp_asm/src/add_10.c
+++ b/tests/drivers/sdp_asm/src/add_10.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/kernel.h>
+#include <stdint.h>
 
 extern volatile uint8_t arg_uint8_t;
 extern volatile uint16_t arg_uint16_t;

--- a/tests/drivers/sdp_asm/src/add_100.c
+++ b/tests/drivers/sdp_asm/src/add_100.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/kernel.h>
+#include <stdint.h>
 
 extern volatile uint8_t arg_uint8_t;
 extern volatile uint16_t arg_uint16_t;

--- a/tests/drivers/sdp_asm/src/main.c
+++ b/tests/drivers/sdp_asm/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <zephyr/kernel.h>
 #include <stdio.h>
 #include "./add_1.h"
 #include "./add_10.h"


### PR DESCRIPTION
Twister is unable to build tests/drivers/sdp_asm.
However, issue is not observed when test is compiled with 'west build'.

test_low_level: PR-1796