### PR TITLE
sysbuild: sdp: Use Kconfig to specify FLPR image path

### DIFF
--- a/sysbuild/Kconfig.sdp
+++ b/sysbuild/Kconfig.sdp
@@ -39,6 +39,13 @@ endchoice
 
 endif # SDP_GPIO
 
+config SDP_IMAGE_PATH
+	string
+	default "${ZEPHYR_NRF_MODULE_DIR}/applications/sdp/gpio" if SDP_GPIO
+	default "${ZEPHYR_NRF_MODULE_DIR}/applications/sdp/mspi" if SDP_MSPI
+	help
+	  Source directory of SDP image.
+
 endif # SDP
 
 endmenu

--- a/sysbuild/sdp.cmake
+++ b/sysbuild/sdp.cmake
@@ -9,22 +9,12 @@ if(SB_CONFIG_SDP)
   set(board_target_flpr "${BOARD}/${target_soc}/cpuflpr")
   set(target_soc)
 
-  # Select the SDP application
-  if(SB_CONFIG_SDP_GPIO)
-    set(sdp_app_dir "${ZEPHYR_NRF_MODULE_DIR}/applications/sdp/gpio")
-  elseif(SB_CONFIG_SDP_MSPI)
-    set(sdp_app_dir "${ZEPHYR_NRF_MODULE_DIR}/applications/sdp/mspi")
-  else()
-    message(FATAL_ERROR "Unknown SDP application type")
-  endif()
-
   # Include the SDP application in the build
   ExternalZephyrProject_Add(
     APPLICATION sdp
-    SOURCE_DIR ${sdp_app_dir}
+    SOURCE_DIR ${SB_CONFIG_SDP_IMAGE_PATH}
     BOARD ${board_target_flpr}
     BOARD_REVISION ${BOARD_REVISION}
   )
-  set(sdp_app_dir)
   set(board_target_flpr)
 endif()


### PR DESCRIPTION
Specifying the FLPR image path in Kconfig makes it easier to select the SDP image and allows the use of external SDP images.