### PR TITLE
snippets: Added snippet for Matter power consumption measurements

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -691,6 +691,7 @@
 /snippets/hw-flow-control/                @nrfconnect/ncs-low-level-test @miha-nordic
 /snippets/matter-diagnostic-logs/         @nrfconnect/ncs-matter
 /snippets/matter-debug/                   @nrfconnect/ncs-matter
+/snippets/matter-power-consumption-tests/ @nrfconnect/ncs-matter
 /snippets/nordic-bt-rpc/                  @ppryga-nordic
 /snippets/nrf70-driver-debug/             @krish2718 @sachinthegreen
 /snippets/nrf70-driver-verbose-debug/     @krish2718 @sachinthegreen

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -132,17 +132,20 @@ tests:
     tags:
       - sysbuild
       - ci_samples_matter
-  sample.matter.lock.release.nrf54l15.power_consumption:
+  sample.matter.lock.release.power_consumption:
     sysbuild: true
     build_only: true
     extra_args:
       - FILE_SUFFIX=release
-      - CONFIG_NCS_SAMPLE_MATTER_LEDS=n
-      - CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
-      - CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
+      - lock_SNIPPET=power-consumption-tests
     integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     tags:
       - sysbuild
       - ci_samples_matter

--- a/samples/matter/smoke_co_alarm/sample.yaml
+++ b/samples/matter/smoke_co_alarm/sample.yaml
@@ -57,19 +57,20 @@ tests:
     tags:
       - sysbuild
       - ci_samples_matter
-  sample.matter.smoke_co_alarm.release.nrf54l15.power_consumption:
+  sample.matter.smoke_co_alarm.release.power_consumption:
     sysbuild: true
     build_only: true
     extra_args:
       - FILE_SUFFIX=release
-      - CONFIG_NCS_SAMPLE_MATTER_LEDS=n
-      - CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
+      - smoke_co_alarm_SNIPPET=power-consumption-tests
     integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
     platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
     tags:
       - sysbuild
       - ci_samples_matter

--- a/samples/matter/window_covering/sample.yaml
+++ b/samples/matter/window_covering/sample.yaml
@@ -53,16 +53,20 @@ tests:
     tags:
       - sysbuild
       - ci_samples_matter
-  sample.matter.window_cover.release.nrf54l15.power_consumption:
+  sample.matter.window_cover.release.power_consumption:
     sysbuild: true
     build_only: true
     extra_args:
       - FILE_SUFFIX=release
-      - CONFIG_NCS_SAMPLE_MATTER_LEDS=n
-      - CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
+      - window_covering_SNIPPET=power-consumption-tests
     integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow: nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     tags:
       - sysbuild
       - ci_samples_matter

--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -5,6 +5,7 @@
     - sample.matter.lock.release
     - sample.matter.lock.debug
     - sample.matter.lock.lto
+    - sample.matter.lock.release.power_consumption
     - sample.matter.light_switch.debug
     - sample.matter.thermostat.debug
     - sample.matter.light_switch.persistent_subscriptions
@@ -17,8 +18,10 @@
     - sample.matter.thermostat.lto
     - sample.matter.window_cover.release
     - sample.matter.window_cover.lto
+    - sample.matter.window_cover.release.power_consumption
     - sample.matter.thermostat.ext_temp
     - sample.matter.light_bulb.memory_profiling
+    - sample.matter.smoke_co_alarm.release.power_consumption
   platforms:
     - nrf52840dk/nrf52840
   comment: "Configurations excluded to limit resources usage in integration builds"
@@ -27,6 +30,7 @@
     - sample.matter.lock.nus
     - sample.matter.lock.debug
     - sample.matter.lock.lto
+    - sample.matter.lock.release.power_consumption
     - sample.matter.window_cover.debug
     - sample.matter.light_bulb.ffs
     - sample.matter.light_switch.persistent_subscriptions
@@ -39,6 +43,8 @@
     - sample.matter.thermostat.lto
     - sample.matter.window_cover.release
     - sample.matter.window_cover.lto
+    - sample.matter.window_cover.release.power_consumption
+    - sample.matter.smoke_co_alarm.release.power_consumption
     - sample.matter.thermostat.ext_temp
     - sample.matter.light_bulb.memory_profiling
     - applications.matter_bridge.lto.br_ble.memory_profiling
@@ -88,6 +94,7 @@
     - sample.matter.lock.lto
     - sample.matter.lock.smp_dfu
     - sample.matter.lock.nus
+    - sample.matter.lock.release.power_consumption
     - sample.matter.light_bulb.memory_profiling.persistent_subscriptions
     - sample.matter.light_switch.persistent_subscriptions
     - sample.matter.light_bulb.debug
@@ -102,6 +109,8 @@
     - sample.matter.window_cover.release
     - sample.matter.window_cover.debug
     - sample.matter.window_cover.lto
+    - sample.matter.window_cover.release.power_consumption
+    - sample.matter.smoke_co_alarm.release.power_consumption
   platforms:
     - nrf54l15dk/nrf54l15/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"

--- a/snippets/matter-power-consumption-tests/boards/nrf54l15dk.conf
+++ b/snippets/matter-power-consumption-tests/boards/nrf54l15dk.conf
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable LEDs that lead to the current leakages
+CONFIG_NCS_SAMPLE_MATTER_LEDS=n
+
+# Disable watchdog that increases the sleep current
+CONFIG_NCS_SAMPLE_MATTER_WATCHDOG=n
+
+# Increase MPSL calibration period to prevent too often CPU wake-ups.
+CONFIG_MPSL_CALIBRATION_PERIOD=60000

--- a/snippets/matter-power-consumption-tests/power_consumption_tests.conf
+++ b/snippets/matter-power-consumption-tests/power_consumption_tests.conf
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This is the configuration file used only for the purpose of Matter power consumption tests.
+
+# Enable pairing autostart to avoid issues with IO adapter
+CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
+
+# Enable persistent subscriptions to automatically recover connection after reboot.
+CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y

--- a/snippets/matter-power-consumption-tests/snippet.yml
+++ b/snippets/matter-power-consumption-tests/snippet.yml
@@ -1,0 +1,8 @@
+name: power-consumption-tests
+append:
+  EXTRA_CONF_FILE: power_consumption_tests.conf
+
+boards:
+  /nrf54l15dk.*/:
+    append:
+      EXTRA_CONF_FILE: boards/nrf54l15dk.conf


### PR DESCRIPTION
Matter requires some extra configuration for the power consumption measurements that are automatized. This change introduces snippet that simplifies it and adds dedicated variant in the sample.ymls.