### PR TITLE
boards: thingy91x: Fixing wrong led definition in device tree

### DIFF
--- a/boards/nordic/thingy91x/thingy91x_nrf9151_common.dts
+++ b/boards/nordic/thingy91x/thingy91x_nrf9151_common.dts
@@ -33,11 +33,11 @@
 			label = "RGB red channel";
 		};
 		green_led: led_2 {
-			gpios = <&gpio0 30 0>;
+			gpios = <&gpio0 31 0>;
 			label = "RGB green channel";
 		};
 		blue_led: led_3 {
-			gpios = <&gpio0 31 0>;
+			gpios = <&gpio0 30 0>;
 			label = "RGB blue channel";
 		};
 	};


### PR DESCRIPTION
The pin-out declared in the device tree does not respect the schematics of the thingy:91X.

The pwm are also wrongly defined, but as their names are ambiguous, like pwm_0 instead of pwm_green, this commit does not change the pin control of the pwm. A note should be made that the pwm channels are RBG instead of RGB if their definition in the device tree remains the same