### PR TITLE
suit: Add delays before resets

### DIFF
--- a/subsys/suit/orchestrator/src/suit_orchestrator_sdfw.c
+++ b/subsys/suit/orchestrator/src/suit_orchestrator_sdfw.c
@@ -588,7 +588,7 @@ static int suit_orchestrator_run(void)
 			if (IS_ENABLED(CONFIG_SUIT_UPDATE_REBOOT_ENABLED)) {
 				LOG_INF("Reboot the system after update: %d", ret);
 				LOG_PANIC();
-
+				k_sleep(K_USEC(10));
 				sys_reboot(SYS_REBOOT_COLD);
 			}
 			return ret;
@@ -614,7 +614,7 @@ static int suit_orchestrator_run(void)
 			if (IS_ENABLED(CONFIG_SUIT_UPDATE_REBOOT_ENABLED)) {
 				LOG_INF("Reboot the system after update: %d", ret);
 				LOG_PANIC();
-
+				k_sleep(K_USEC(10));
 				sys_reboot(SYS_REBOOT_COLD);
 			}
 			return ret;
@@ -653,6 +653,7 @@ static int suit_orchestrator_run(void)
 			if (IS_ENABLED(CONFIG_SUIT_BOOT_RECOVERY_REBOOT_ENABLED)) {
 				LOG_INF("Reboot the system after unsuccessful boot: %d", ret);
 				LOG_PANIC();
+				k_sleep(K_USEC(10));
 				sys_reboot(SYS_REBOOT_COLD);
 			}
 			return -ENOTSUP;

--- a/subsys/suit/stream/stream_sinks/src/suit_sdfw_recovery_sink.c
+++ b/subsys/suit/stream/stream_sinks/src/suit_sdfw_recovery_sink.c
@@ -96,6 +96,7 @@ static void reboot_to_continue(void)
 
 		LOG_PANIC();
 
+		k_sleep(K_USEC(10));
 		sys_reboot(SYS_REBOOT_COLD);
 	} else {
 		LOG_DBG("Reboot disabled - perform manually");

--- a/subsys/suit/stream/stream_sinks/src/suit_sdfw_sink.c
+++ b/subsys/suit/stream/stream_sinks/src/suit_sdfw_sink.c
@@ -97,6 +97,7 @@ static void reboot_to_continue(void)
 
 		LOG_PANIC();
 
+		k_sleep(K_USEC(10));
 		sys_reboot(SYS_REBOOT_COLD);
 	} else {
 		LOG_DBG("Reboot disabled - perform manually");


### PR DESCRIPTION
Add a small delay before reset, so there is a better chance that MRAMC will be fast enough to update memory.

Ref: NCSDK-31415