### PR TITLE
applications: sdp: mspi: RX

### DIFF
--- a/applications/sdp/mspi/Kconfig
+++ b/applications/sdp/mspi/Kconfig
@@ -1,0 +1,5 @@
+config SDP_MSPI_MAX_RESPONSE_SIZE
+	int "Max size of response that can be sent to APP core. In bytes."
+	default 128
+
+source "Kconfig.zephyr"

--- a/applications/sdp/mspi/src/hrt/hrt-nrf54l15.s
+++ b/applications/sdp/mspi/src/hrt/hrt-nrf54l15.s
@@ -103,6 +103,67 @@ hrt_tx:
 	jalr	a2
 	j	.L13
 	.size	hrt_tx, .-hrt_tx
+	.section	.text.hrt_tx_rx.constprop.0,"ax",@progbits
+	.align	1
+	.type	hrt_tx_rx.constprop.0, @function
+hrt_tx_rx.constprop.0:
+	lw	a5,0(a0)
+	lw	a4,4(a0)
+	beq	a4,zero,.L26
+	li	a4,126976
+	slli	a1,a1,12
+	addi	sp,sp,-24
+	and	a1,a1,a4
+	li	a4,2097152
+	sw	s0,16(sp)
+	sw	ra,20(sp)
+	sw	s1,12(sp)
+	addi	a4,a4,1031
+	mv	s0,a0
+	lw	a5,0(a5)
+	or	a1,a1,a4
+ #APP
+	csrw 3019, a1
+ #NO_APP
+	li	s1,0
+.L17:
+	lw	a4,4(s0)
+	bltu	s1,a4,.L20
+	lw	ra,20(sp)
+	lw	s0,16(sp)
+	lw	s1,12(sp)
+	addi	sp,sp,24
+	jr	ra
+.L20:
+	lw	a4,16(s0)
+	li	a0,-16777216
+	and	a0,a5,a0
+	sw	a3,8(sp)
+	sw	a2,4(sp)
+	sw	a5,0(sp)
+	jalr	a4
+	lw	a5,0(sp)
+	lw	a2,4(sp)
+	lw	a3,8(sp)
+	slli	a5,a5,8
+	bne	s1,zero,.L18
+	beq	a2,zero,.L18
+	li	a4,65536
+	add	a4,a3,a4
+ #APP
+	csrw 2002, a4
+ #NO_APP
+.L19:
+	addi	s1,s1,1
+	j	.L17
+.L18:
+ #APP
+	csrr a4, 3018
+ #NO_APP
+	j	.L19
+.L26:
+	ret
+	.size	hrt_tx_rx.constprop.0, .-hrt_tx_rx.constprop.0
 	.section	.text.hrt_write,"ax",@progbits
 	.align	1
 	.globl	hrt_write
@@ -120,23 +181,23 @@ hrt_write:
 	li	a5,0
 	addi	a4,a0,4
 	li	a3,4
-.L17:
+.L31:
 	lw	a2,0(a4)
-	bne	a2,zero,.L16
+	bne	a2,zero,.L30
 	addi	a5,a5,1
 	andi	a5,a5,0xff
 	addi	a4,a4,20
-	bne	a5,a3,.L17
+	bne	a5,a3,.L31
 	li	a5,3
-.L16:
+.L30:
 	li	a4,1
-	beq	a5,a4,.L18
+	beq	a5,a4,.L32
 	li	a4,3
-	beq	a5,a4,.L19
+	beq	a5,a4,.L33
 	li	a4,0
-	bne	a5,zero,.L20
+	bne	a5,zero,.L34
 	lbu	a4,80(s0)
-.L20:
+.L34:
  #APP
 	csrw 2000, 2
  #NO_APP
@@ -163,21 +224,21 @@ hrt_write:
 	li	a2,1
 	add	a5,s0,a5
 	lw	a3,4(a5)
-	beq	a3,a2,.L21
+	beq	a3,a2,.L35
 	li	a2,2
-	beq	a3,a2,.L22
+	beq	a3,a2,.L36
 	li	a5,32
 	div	a5,a5,a4
-	j	.L39
-.L18:
+	j	.L53
+.L32:
 	lbu	a4,81(s0)
-	j	.L20
-.L19:
+	j	.L34
+.L33:
 	lbu	a4,83(s0)
-	j	.L20
-.L21:
+	j	.L34
+.L35:
 	lbu	a5,8(a5)
-.L39:
+.L53:
  #APP
 	csrw 3022, a5
  #NO_APP
@@ -187,11 +248,11 @@ hrt_write:
 	lbu	a4,88(s0)
 	slli	a5,a5,16
 	srli	a5,a5,16
-	bne	a4,zero,.L25
+	bne	a4,zero,.L39
  #APP
 	csrc 3008, a5
  #NO_APP
-.L26:
+.L40:
 	lhu	a3,84(s0)
 	lbu	a1,80(s0)
 	addi	a2,sp,3
@@ -213,17 +274,17 @@ hrt_write:
 	addi	a0,s0,60
 	call	hrt_tx
 	lbu	a5,89(s0)
-	beq	a5,zero,.L27
-.L28:
+	beq	a5,zero,.L41
+.L42:
  #APP
 	csrr a5, 3022
  #NO_APP
 	andi	a5,a5,0xff
-	bne	a5,zero,.L28
+	bne	a5,zero,.L42
  #APP
 	csrw 2010, 0
  #NO_APP
-.L27:
+.L41:
 	li	a5,16384
 	addi	a5,a5,1
  #APP
@@ -232,33 +293,173 @@ hrt_write:
 	csrw 2000, 0
  #NO_APP
 	lbu	a5,87(s0)
-	bne	a5,zero,.L15
+	bne	a5,zero,.L29
 	lbu	a4,86(s0)
 	li	a5,1
 	sll	a5,a5,a4
 	lbu	a4,88(s0)
 	slli	a5,a5,16
 	srli	a5,a5,16
-	bne	a4,zero,.L30
+	bne	a4,zero,.L44
  #APP
 	csrs 3008, a5
  #NO_APP
-.L15:
+.L29:
 	lw	ra,12(sp)
 	lw	s0,8(sp)
 	addi	sp,sp,16
 	jr	ra
-.L22:
+.L36:
 	lbu	a5,9(a5)
-	j	.L39
-.L25:
+	j	.L53
+.L39:
  #APP
 	csrs 3008, a5
  #NO_APP
-	j	.L26
-.L30:
+	j	.L40
+.L44:
  #APP
 	csrc 3008, a5
  #NO_APP
-	j	.L15
+	j	.L29
 	.size	hrt_write, .-hrt_write
+	.section	.text.hrt_read,"ax",@progbits
+	.align	1
+	.globl	hrt_read
+	.type	hrt_read, @function
+hrt_read:
+	addi	sp,sp,-12
+	sw	s0,4(sp)
+	sw	ra,8(sp)
+	lbu	a5,88(a0)
+	lbu	a4,86(a0)
+	mv	s0,a0
+	bne	a5,zero,.L55
+	li	a5,1
+	sll	a5,a5,a4
+	slli	a5,a5,16
+	srli	a5,a5,16
+ #APP
+	csrc 3008, a5
+ #NO_APP
+.L56:
+	lhu	a5,90(s0)
+	slli	a5,a5,16
+	srli	a5,a5,16
+	andi	a5,a5,-5
+	slli	a5,a5,16
+	srli	a5,a5,16
+	sh	a5,90(s0)
+	lhu	a5,90(s0)
+ #APP
+	csrw 3009, a5
+	csrw 3011, 2
+ #NO_APP
+	li	a5,65536
+	addi	a5,a5,4
+ #APP
+	csrw 3043, a5
+	csrw 3022, 8
+	csrw 2000, 2
+	csrw 2001, 2
+ #NO_APP
+	lhu	a5,84(s0)
+	slli	a5,a5,16
+	srli	a5,a5,16
+ #APP
+	csrr a4, 2003
+ #NO_APP
+	li	a3,-65536
+	and	a4,a4,a3
+	or	a5,a5,a4
+ #APP
+	csrw 2003, a5
+ #NO_APP
+	lhu	a5,84(s0)
+	slli	a5,a5,16
+	srli	a5,a5,16
+ #APP
+	csrr a4, 2003
+ #NO_APP
+	slli	a5,a5,1
+	slli	a4,a4,16
+	addi	a5,a5,1
+	srli	a4,a4,16
+	slli	a5,a5,16
+	or	a5,a5,a4
+ #APP
+	csrw 2003, a5
+ #NO_APP
+	lbu	a1,80(s0)
+	lhu	a3,84(s0)
+	li	a2,1
+	mv	a0,s0
+	call	hrt_tx_rx.constprop.0
+	lbu	a1,81(s0)
+	lhu	a3,84(s0)
+	li	a2,0
+	addi	a0,s0,20
+	call	hrt_tx_rx.constprop.0
+	li	a5,0
+.L57:
+	lw	a4,64(s0)
+	bltu	a5,a4,.L58
+ #APP
+	csrw 2000, 0
+	csrw 2001, 0
+	csrw 3019, 0
+ #NO_APP
+	lbu	a5,87(s0)
+	bne	a5,zero,.L59
+	lbu	a5,88(s0)
+	lbu	a4,86(s0)
+	bne	a5,zero,.L60
+	li	a5,1
+	sll	a5,a5,a4
+	slli	a5,a5,16
+	srli	a5,a5,16
+ #APP
+	csrs 3008, a5
+ #NO_APP
+.L59:
+	lhu	a5,90(s0)
+	ori	a5,a5,4
+	sh	a5,90(s0)
+	lhu	a5,90(s0)
+ #APP
+	csrw 3009, a5
+ #NO_APP
+	lw	ra,8(sp)
+	lw	s0,4(sp)
+	addi	sp,sp,12
+	jr	ra
+.L55:
+	li	a5,1
+	sll	a5,a5,a4
+	slli	a5,a5,16
+	srli	a5,a5,16
+ #APP
+	csrs 3008, a5
+ #NO_APP
+	j	.L56
+.L58:
+ #APP
+	csrr a3, 3018
+ #NO_APP
+	lw	a4,60(s0)
+	srli	a3,a3,24
+	add	a4,a4,a5
+	addi	a5,a5,1
+	sb	a3,0(a4)
+	andi	a5,a5,0xff
+	j	.L57
+.L60:
+	li	a5,1
+	sll	a5,a5,a4
+	slli	a5,a5,16
+	srli	a5,a5,16
+ #APP
+	csrc 3008, a5
+ #NO_APP
+	j	.L59
+	.size	hrt_read, .-hrt_read

--- a/applications/sdp/mspi/src/hrt/hrt.h
+++ b/applications/sdp/mspi/src/hrt/hrt.h
@@ -119,4 +119,12 @@ typedef struct {
  */
 void hrt_write(hrt_xfer_t *hrt_xfer_params);
 
+/** @brief Read.
+ *
+ *  Function to be used to read data from MSPI.
+ *
+ *  @param[in] hrt_xfer_params Hrt transfer parameters and data.
+ */
+void hrt_read(volatile hrt_xfer_t *hrt_xfer_params);
+
 #endif /* _HRT_H__ */


### PR DESCRIPTION
Added path for receiving data on SPI (SINGLE mode only, there will be another PR for QUAD).
For now, data is transceived byte by byte, and receiving starts right after transmission. This has its disadvantages, for example:
- INB register needs to be read when the transmission is still ongoing, otherwise, the clock will not be generated when a peripheral device is sending data (not sure why)
- Because data is transceived in bytes, there is less time between writing to OUTB and reading from INB. Although I checked that the current solution works for higher frequencies, it can still be a problem when processing a lot of requests from the APP.

There will be another ticket for fixing the above issues. Right now I am adding this so that we would have at least some working solution, even if it's not ideal.

Requires changes from https://github.com/nrfconnect/sdk-nrf/pull/20114 to be able to receive data from nRF54L15 DK external flash.