### PR TITLE
[Backport v2.9-nRF54H20-branch] Increase A-GNSS data buffer size

### DIFF
--- a/include/net/nrf_cloud_agnss.h
+++ b/include/net/nrf_cloud_agnss.h
@@ -8,7 +8,7 @@
 #define NRF_CLOUD_AGNSS_H_
 
 /** @file nrf_cloud_agnss.h
- * @brief Module to provide nRF Cloud A-GNSS support to nRF9160 SiP.
+ * @brief Module to provide nRF Cloud A-GNSS support to nRF91 SiP.
  */
 
 #include <zephyr/kernel.h>
@@ -18,6 +18,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * Maximum size of assistance data in bytes when all assistance data types are received.
+ * Can be used to set the buffer size for REST and CoAP.
+ */
+#define NRF_CLOUD_AGNSS_MAX_DATA_SIZE 3600
 
 /** Exclude the mask angle from the A-GNSS request */
 #define NRF_CLOUD_AGNSS_MASK_ANGLE_NONE	0xFF

--- a/lib/location/method_gnss.c
+++ b/lib/location/method_gnss.c
@@ -57,7 +57,6 @@ BUILD_ASSERT(
 #define AT_MDM_SLEEP_NOTIF_START "AT%%XMODEMSLEEP=1,%d,%d"
 #endif
 #if (defined(CONFIG_NRF_CLOUD_AGNSS) || defined(CONFIG_NRF_CLOUD_PGPS))
-#define AGNSS_REQUEST_RECV_BUF_SIZE 3500
 #define AGNSS_REQUEST_HTTPS_RESP_HEADER_SIZE 400
 /* Minimum time between two A-GNSS data requests in seconds. */
 #define AGNSS_REQUEST_MIN_INTERVAL (60 * 60)
@@ -97,7 +96,7 @@ static int64_t agnss_req_timestamp;
 #if !defined(CONFIG_LOCATION_SERVICE_EXTERNAL) && \
 	(defined(CONFIG_NRF_CLOUD_REST) || defined(CONFIG_NRF_CLOUD_COAP)) && \
 	!defined(CONFIG_NRF_CLOUD_MQTT)
-static char agnss_rest_data_buf[AGNSS_REQUEST_RECV_BUF_SIZE];
+static char agnss_rest_data_buf[NRF_CLOUD_AGNSS_MAX_DATA_SIZE];
 #endif
 #endif
 

--- a/samples/cellular/gnss/src/assistance.c
+++ b/samples/cellular/gnss/src/assistance.c
@@ -25,7 +25,7 @@ static char jwt_buf[600];
 static char rx_buf[2048];
 
 #if defined(CONFIG_NRF_CLOUD_AGNSS)
-static char agnss_data_buf[3500];
+static char agnss_data_buf[NRF_CLOUD_AGNSS_MAX_DATA_SIZE];
 #endif /* CONFIG_NRF_CLOUD_AGNSS */
 
 #if defined(CONFIG_NRF_CLOUD_PGPS)

--- a/samples/cellular/modem_shell/src/gnss/gnss.c
+++ b/samples/cellular/modem_shell/src/gnss/gnss.c
@@ -102,7 +102,7 @@ static bool agnss_inject_int = true;
 
 #if defined(CONFIG_NRF_CLOUD_AGNSS) && !defined(CONFIG_NRF_CLOUD_MQTT) && \
 	!defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_AGNSS)
-static char agnss_data_buf[3500];
+static char agnss_data_buf[NRF_CLOUD_AGNSS_MAX_DATA_SIZE];
 #endif
 
 #if defined(CONFIG_NRF_CLOUD_PGPS)

--- a/samples/cellular/modem_shell/src/gnss/gnss_shell.c
+++ b/samples/cellular/modem_shell/src/gnss/gnss_shell.c
@@ -12,7 +12,8 @@
 #include "mosh_print.h"
 #include "gnss.h"
 
-#define AGNSS_CMD_LINE_INJECT_MAX_LENGTH MIN(3500, CONFIG_SHELL_CMD_BUFF_SIZE)
+#define AGNSS_CMD_LINE_INJECT_MAX_LENGTH MIN(NRF_CLOUD_AGNSS_MAX_DATA_SIZE, \
+					     CONFIG_SHELL_CMD_BUFF_SIZE)
 
 static int cmd_gnss_start(const struct shell *shell, size_t argc, char **argv)
 {


### PR DESCRIPTION
Backport 38e71566d9d0efcf42c40067dbb77b43c3cfe813 from #20046.