### PR TITLE
esb: Fix radio mode switching in fast_switching mode

### DIFF
--- a/subsys/esb/esb_dppi.c
+++ b/subsys/esb/esb_dppi.c
@@ -27,7 +27,7 @@ static uint8_t radio_end_timer_start;
 
 static nrf_dppi_channel_group_t ramp_up_dppi_group;
 
-void esb_ppi_for_txrx_set(bool rx, bool timer_start, bool fast_switching)
+void esb_ppi_for_txrx_set(bool rx, bool timer_start)
 {
 	uint32_t channels_mask;
 
@@ -48,11 +48,6 @@ void esb_ppi_for_txrx_set(bool rx, bool timer_start, bool fast_switching)
 
 	nrf_egu_subscribe_set(ESB_EGU, ESB_EGU_TASK, disabled_phy_end_egu);
 
-	if (fast_switching) {
-		nrf_radio_subscribe_set(NRF_RADIO, rx ? NRF_RADIO_TASK_TXEN : NRF_RADIO_TASK_RXEN,
-					disabled_phy_end_egu);
-	}
-
 	if (timer_start) {
 		nrf_timer_subscribe_set(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_TASK_START,
 					egu_timer_start);
@@ -64,7 +59,7 @@ void esb_ppi_for_txrx_set(bool rx, bool timer_start, bool fast_switching)
 	nrf_dppi_channels_enable(ESB_DPPIC, channels_mask);
 }
 
-void esb_ppi_for_txrx_clear(bool rx, bool timer_start, bool fast_switching)
+void esb_ppi_for_txrx_clear(bool rx, bool timer_start)
 {
 	uint32_t channels_mask;
 
@@ -83,11 +78,6 @@ void esb_ppi_for_txrx_clear(bool rx, bool timer_start, bool fast_switching)
 	nrf_egu_subscribe_clear(ESB_EGU, ESB_EGU_TASK);
 
 	nrf_dppi_channels_remove_from_group(ESB_DPPIC, BIT(egu_ramp_up), ramp_up_dppi_group);
-
-	if (fast_switching) {
-		nrf_radio_subscribe_clear(NRF_RADIO, rx ? NRF_RADIO_TASK_TXEN :
-							  NRF_RADIO_TASK_RXEN);
-	}
 
 	if (timer_start) {
 		nrf_timer_subscribe_clear(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_TASK_START);

--- a/subsys/esb/esb_ppi.c
+++ b/subsys/esb/esb_ppi.c
@@ -43,10 +43,8 @@ void esb_ppi_for_fem_clear(void)
 	nrf_ppi_channel_endpoint_setup(NRF_PPI, egu_timer_start, 0, 0);
 }
 
-void esb_ppi_for_txrx_set(bool rx, bool timer_start, bool fast_switching)
+void esb_ppi_for_txrx_set(bool rx, bool timer_start)
 {
-	ARG_UNUSED(fast_switching);
-
 	uint32_t channels_mask;
 	uint32_t egu_event = nrf_egu_event_address_get(ESB_EGU, ESB_EGU_EVENT);
 	uint32_t egu_task = nrf_egu_task_address_get(ESB_EGU, ESB_EGU_TASK);
@@ -75,9 +73,8 @@ void esb_ppi_for_txrx_set(bool rx, bool timer_start, bool fast_switching)
 	nrf_ppi_channels_enable(NRF_PPI, channels_mask);
 }
 
-void esb_ppi_for_txrx_clear(bool rx, bool timer_start, bool fast_switching)
+void esb_ppi_for_txrx_clear(bool rx, bool timer_start)
 {
-	ARG_UNUSED(fast_switching);
 	ARG_UNUSED(rx);
 
 	uint32_t channels_mask = (BIT(egu_ramp_up) | BIT(disabled_egu));

--- a/subsys/esb/esb_ppi_api.h
+++ b/subsys/esb/esb_ppi_api.h
@@ -35,25 +35,18 @@ extern "C" {
  *           |
  *           \----> self disable
  *
- *      if (fast_switching)
- *                    1
- *      RADIO_PHYEND ---> RADIO_TASK_TXEN/RXEN
- *
  * @param[in] rx Radio Rx mode, otherwise Tx mode.
  * @param[in] timer_start Indicates whether the timer is to be started on the EGU event.
- * @param[in] fast_switch Indicates whether to configure fast switching.
  */
-void esb_ppi_for_txrx_set(bool rx, bool timer_start, bool fast_switching);
+void esb_ppi_for_txrx_set(bool rx, bool timer_start);
 
 /** @brief Clear PPI/DPPI connection for Tx or Rx radio operations
  *
  * @param[in] rx Radio Rx mode, otherwise Tx mode.
  * @param[in] timer_start Clear timer connections if the timer was set using
  *                        the @ref esb_ppi_for_txrx_set function.
- * @param[in] fast_switching Clear fast switching configuration if the fast switching was set using
- *                        the @ref esb_ppi_for_txrx_set function.
  */
-void esb_ppi_for_txrx_clear(bool rx, bool timer_start, bool fast_switching);
+void esb_ppi_for_txrx_clear(bool rx, bool timer_start);
 
 /** @brief Configure PPIs/DPPIs for the external front-end module. The EGU event will be connected
  *         to the TIMER_START event. As a result, the front-end module ramp-up will be scheduled\


### PR DESCRIPTION
Manual switching between radio TX/RX and RX/TX modes in fast_switching mode instead of using DPPI. In some cases, linking the RADIO_PHYEND event to the RADIO_TASK_TXEN/RXEN task caused the radio to start transmitting or receiving before the radio was configured and the appropriate buffers were set.
