### PR TITLE
samples: matter: Set custom keystore manager during the init.

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -163,6 +163,7 @@ Matter
   * A description for the new :ref:`ug_matter_gs_tools_matter_west_commands_append` within the :ref:`ug_matter_gs_tools_matter_west_commands` page.
   * New arguments to the :ref:`ug_matter_gs_tools_matter_west_commands_zap_tool_gui` to provide a custom cache directory and add new clusters to Matter Data Model.
   * :ref:`ug_matter_debug_snippet`.
+  * Storing Matter key materials in the :ref:`matter_platforms_security_kmu`.
 
 * Disabled the :ref:`mpsl` before performing factory reset to speed up the process.
 

--- a/samples/matter/common/src/app/matter_init.cpp
+++ b/samples/matter/common/src/app/matter_init.cpp
@@ -46,6 +46,10 @@
 #include <ram_pwrdn.h>
 #endif
 
+#ifdef CONFIG_CHIP_STORE_KEYS_IN_KMU
+#include <platform/nrfconnect/KMUKeyAllocator.h>
+#endif
+
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
@@ -72,6 +76,10 @@ Clusters::NetworkCommissioning::Instance Nrf::Matter::InitData::sWiFiCommissioni
 chip::Crypto::PSAOperationalKeystore Nrf::Matter::InitData::sOperationalKeystoreDefault{};
 #endif
 
+#ifdef CONFIG_CHIP_STORE_KEYS_IN_KMU
+chip::DeviceLayer::KMUSessionKeystore Nrf::Matter::InitData::sKMUSessionKeystoreDefault{};
+#endif
+
 #ifdef CONFIG_CHIP_FACTORY_DATA
 FactoryDataProvider<InternalFlashFactoryData> Nrf::Matter::InitData::sFactoryDataProviderDefault{};
 #endif
@@ -87,6 +95,9 @@ Nrf::Matter::InitData sLocalInitData{ .mNetworkingInstance = nullptr,
 #endif
 #ifdef CONFIG_CHIP_CRYPTO_PSA
 				      .mOperationalKeyStore = nullptr,
+#endif
+#ifdef CONFIG_CHIP_STORE_KEYS_IN_KMU
+				      .mSessionKeystore = nullptr,
 #endif
 				      .mPreServerInitClbk = nullptr,
 				      .mPostServerInitClbk = nullptr };
@@ -275,6 +286,13 @@ void DoInitChipServer(intptr_t /* unused */)
 
 #ifdef CONFIG_CHIP_CRYPTO_PSA
 	sLocalInitData.mServerInitParams->operationalKeystore = sLocalInitData.mOperationalKeyStore;
+#endif
+
+/* Set KMUKeyAllocator for devices that supports KMU */
+#ifdef CONFIG_CHIP_STORE_KEYS_IN_KMU
+	static KMUKeyAllocator kmuAllocator;
+	Crypto::SetPSAKeyAllocator(&kmuAllocator);
+	sLocalInitData.mServerInitParams->sessionKeystore = sLocalInitData.mSessionKeystore;
 #endif
 
 	VerifyOrReturn(sLocalInitData.mServerInitParams, LOG_ERR("No valid server initialization parameters"));

--- a/samples/matter/common/src/app/matter_init.h
+++ b/samples/matter/common/src/app/matter_init.h
@@ -23,6 +23,10 @@
 #include <crypto/PSAOperationalKeystore.h>
 #endif
 
+#ifdef CONFIG_CHIP_STORE_KEYS_IN_KMU
+#include <platform/nrfconnect/KMUSessionKeystore.h>
+#endif
+
 #ifdef CONFIG_CHIP_FACTORY_DATA
 #include <platform/nrfconnect/FactoryDataProvider.h>
 #else
@@ -59,6 +63,10 @@ struct InitData {
 	/** @brief Pointer to the user provided OperationalKeystore implementation. */
 	chip::Crypto::OperationalKeystore *mOperationalKeyStore{ &sOperationalKeystoreDefault };
 #endif
+#ifdef CONFIG_CHIP_STORE_KEYS_IN_KMU
+	/** @brief Pointer to the user provided SessionKeystore implementation. */
+	chip::Crypto::SessionKeystore *mSessionKeystore{ &sKMUSessionKeystoreDefault };
+#endif
 	/** @brief Custom code to execute in the Matter main event loop before the server initialization. */
 	CustomInit mPreServerInitClbk{ nullptr };
 	/** @brief Custom code to execute in the Matter main event loop after the server initialization. */
@@ -76,6 +84,9 @@ struct InitData {
 #endif
 #ifdef CONFIG_CHIP_CRYPTO_PSA
 	static chip::Crypto::PSAOperationalKeystore sOperationalKeystoreDefault;
+#endif
+#ifdef CONFIG_CHIP_STORE_KEYS_IN_KMU
+	static chip::DeviceLayer::KMUSessionKeystore sKMUSessionKeystoreDefault;
 #endif
 };
 


### PR DESCRIPTION
We need to set a custom keystore manager in Matter server while using KMU.