### PR TITLE
Applications: Audio: Added delay to fix initial sync

### DIFF
--- a/applications/nrf5340_audio/src/modules/audio_i2s.c
+++ b/applications/nrf5340_audio/src/modules/audio_i2s.c
@@ -64,11 +64,9 @@ static i2s_blk_comp_callback_t i2s_blk_comp_callback;
 
 static void i2s_comp_handler(nrfx_i2s_buffers_t const *released_bufs, uint32_t status)
 {
-	uint32_t frame_start_ts = audio_sync_timer_capture_get();
-
 	if ((status == NRFX_I2S_STATUS_NEXT_BUFFERS_NEEDED) && released_bufs &&
 	    i2s_blk_comp_callback && (released_bufs->p_rx_buffer || released_bufs->p_tx_buffer)) {
-		i2s_blk_comp_callback(frame_start_ts, released_bufs->p_rx_buffer,
+		i2s_blk_comp_callback(audio_sync_timer_capture_get(), released_bufs->p_rx_buffer,
 				      released_bufs->p_tx_buffer);
 	}
 }

--- a/applications/nrf5340_audio/src/modules/audio_sync_timer.h
+++ b/applications/nrf5340_audio/src/modules/audio_sync_timer.h
@@ -21,6 +21,12 @@ uint32_t audio_sync_timer_capture(void);
  * @brief Returns the last captured value of the sync timer.
  *
  * The captured time is corresponding to the I2S frame start.
+ * NOTE: This function is not reentrant and must only be called
+ * once in the I2S ISR. There may be a delay in the capturing of
+ * the clock value. Hence, there is a retry-loop with a timeout.
+ * Should we not get the new capture value before the timeout,
+ * a warning will be printed and calculations based on the old
+ * timer capture values.
  *
  * See @ref audio_sync_timer_capture().
  *


### PR DESCRIPTION
- OCT-2585
- Added 0.39 us delay according to nRF5340 product specification.
- This resolves a race condition on sync