### PR TITLE
lib: nrf_modem_lib: jump to init callbacks when err 

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -538,6 +538,10 @@ Modem libraries
 
 * Updated the :ref:`nrf_modem_lib_lte_net_if` to automatically set the actual link :term:`Maximum Transmission Unit (MTU)` on the network interface when PDN connectivity is gained.
 
+* :ref:`nrf_modem_lib_readme`:
+
+  * Fixed a bug where various subsystems would be erroneously initialized during a failed initialization of the library.
+
 Multiprotocol Service Layer libraries
 -------------------------------------
 

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -169,6 +169,9 @@ int nrf_modem_lib_init(void)
 	err = nrf_modem_init(&init_params);
 	if (err) {
 		LOG_ERR("Modem library initialization failed, err %d", err);
+
+		/* Jump to the init callbacks and pass them the returned error. */
+		goto init_callbacks;
 	}
 
 #if CONFIG_NRF_MODEM_LIB_TRACE
@@ -182,6 +185,7 @@ int nrf_modem_lib_init(void)
 		log_fw_version_uuid();
 	}
 
+init_callbacks:
 	STRUCT_SECTION_FOREACH(nrf_modem_lib_init_cb, e) {
 		LOG_DBG("Modem init callback: %p", e->callback);
 		e->callback(err, e->context);


### PR DESCRIPTION
`nrf_modem_lib_init` should not initialize traces or log
the firmware version UUID when `nrf_modem_init` fails,
because they require the modem library to be initialized.
However it should iterate through the init callbacks and
report the returned error.