### PR TITLE
nrf_security: Remove redefined Kconfigs

### DIFF
--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -59,7 +59,7 @@ if NRF_SECURITY
 config MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS
 	bool
 	default y if SOC_SERIES_NRF54LX && PSA_CRYPTO_DRIVER_CRACEN
-	default y if SOC_SERIES_NRF54HX && SOC_NRF54H20_CPUSEC
+	default y if PSA_WANT_PLATFORM_KEYS
 	help
 	  Promptless option used to control if the PSA Crypto core should have support for builtin keys or not.
 
@@ -253,9 +253,5 @@ config MBEDTLS_LIBRARY_NRF_SECURITY
 	  Use Mbed TLS library from Nordic provided security backend
 
 endchoice
-
-# This is for internal use only.
-config SOC_NRF54H20_CPUSEC
-	bool
 
 endmenu

--- a/subsys/nrf_security/src/drivers/Kconfig
+++ b/subsys/nrf_security/src/drivers/Kconfig
@@ -36,6 +36,11 @@ config PSA_CRYPTO_DRIVER_CRACEN
 	help
 	  PSA crypto driver for the CRACEN HW peripheral.
 
+config PSA_WANT_PLATFORM_KEYS
+	bool
+	help
+	  Hidden option if platform keys are supported.
+
 menu "Choose DRBG algorithm"
 config PSA_WANT_ALG_CTR_DRBG
 	prompt "Enable CTR_DRBG"

--- a/subsys/nrf_security/src/drivers/cracen/psa_driver.Kconfig
+++ b/subsys/nrf_security/src/drivers/cracen/psa_driver.Kconfig
@@ -1857,7 +1857,6 @@ config PSA_NEED_CRACEN_PLATFORM_KEYS
 	default y
 	depends on PSA_WANT_ALG_GCM
 	depends on PSA_WANT_AES_KEY_SIZE_256
-	depends on SOC_NRF54H20_CPUSEC
-
+	depends on PSA_WANT_PLATFORM_KEYS
 
 endmenu


### PR DESCRIPTION
Removes Kconfigs that are redefined because they are defined in an out of tree repo to prevent hiding problems if these symbols are renamed or removed