### PR TITLE
doc: nrf: releases: Clarify supplicant switch to kernel heap

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
@@ -76,6 +76,8 @@ nRF70 Series
        For example, ``CONFIG_WPA_SUPP=y`` to ``CONFIG_WIFI_NM_WPA_SUPPLICANT=y``.
        Update your application configurations to use the new namespace.
 
+     * You need to reconcile the application heap and kernel heap usage appropriately to accommodate this switch from application to kernel heap.
+
    * The SR co-existence feature should now be explicitly enabled using the :kconfig:option:`CONFIG_NRF70_SR_COEX` Kconfig option.
      The RF switch feature should be enabled using the :kconfig:option:`CONFIG_NRF70_SR_COEX_RF_SWITCH` Kconfig option.
 


### PR DESCRIPTION
We have recieved a few queries about the increase in kernel heap usage when migrated to 2.9.0 from 2.7.0, so, add a couple of notes to clarify the same.