### PR TITLE
B0 self lock before jump

### DIFF
--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -104,6 +104,13 @@ config SB_CLEANUP_RAM
 	help
 	  Sets contents of memory to 0 before jumping to application.
 
+config SB_DISABLE_SELF_RWX
+	bool "Disable read and execution on self NVM"
+	depends on SOC_NRF54L15_CPUAPP && !FPROTECT_ALLOW_COMBINED_REGIONS
+	help
+	  Sets RRAMC's BOOTCONF region protection before jumping to application.
+	  It disables reads writes and execution memory area which holds NSIB.
+
 endif # IS_SECURE_BOOTLOADER
 
 config IS_BOOTLOADER_IMG

--- a/subsys/bootloader/bl_boot/bl_boot.c
+++ b/subsys/bootloader/bl_boot/bl_boot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -18,6 +18,25 @@
 #include <hal/nrf_uarte.h>
 #include <hal/nrf_gpio.h>
 #endif
+
+#if defined(CONFIG_SB_DISABLE_SELF_RWX)
+/* Disabling R_X has to be done while running from RAM for obvious reasons.
+ * Moreover as a last step before jumping to application it must work even after
+ * RAM has been cleared, therefore we are using custom RAM function relocator.
+ * This relocator runs after RAM cleanup.
+ * Size of the relocated 'locking' function isn't known but it doesn't matter
+ * as long as at least entire aforementioned function is copied to RAM.
+ */
+#include <hal/nrf_rramc.h>
+
+#define FUNCTION_BUFFER_LEN 64
+#define RRAMC_REGION_RWX_LSB 0
+#define RRAMC_REGION_RWX_WIDTH 3
+#define RRAMC_REGION_TO_LOCK_ADDR NRF_RRAMC->REGION[3].CONFIG
+#define RRAMC_REGION_TO_LOCK_ADDR_H (((uint32_t)(&(RRAMC_REGION_TO_LOCK_ADDR))) >> 16)
+#define RRAMC_REGION_TO_LOCK_ADDR_L (((uint32_t)(&(RRAMC_REGION_TO_LOCK_ADDR))) & 0x0000fffful)
+static uint8_t ram_exec_buf[FUNCTION_BUFFER_LEN];
+#endif /* CONFIG_SB_DISABLE_SELF_RWX */
 
 #ifdef CONFIG_UART_NRFX_UARTE
 static void uninit_used_uarte(NRF_UARTE_Type *p_reg)
@@ -151,39 +170,100 @@ void bl_boot(const struct fw_info *fw_info)
 	__set_PSPLIM(0);
 	__set_MSPLIM(0);
 #endif
-
 	/* Set MSP to the new address and clear any information from PSP */
 	__set_MSP(vector_table[0]);
 	__set_PSP(0);
 
-#if CONFIG_SB_CLEANUP_RAM
 	__asm__ volatile (
 		/* vector_table[1] -> r0 */
-		"   mov r0, %0\n"
+		"   mov  r0, %0\n"
+#ifdef CONFIG_SB_CLEANUP_RAM
 		/* Base to write -> r1 */
-		"   mov r1, %1\n"
+		"   mov  r1, %1\n"
 		/* Size to write -> r2 */
-		"   mov r2, %2\n"
+		"   mov  r2, %2\n"
 		/* Value to write -> r3 */
-		"   mov r3, %3\n"
+		"   movw r3, %3\n"
 		"clear:\n"
-		"   str r3, [r1]\n"
-		"   add r1, r1, #4\n"
-		"   sub r2, r2, #4\n"
-		"   cbz r2, out\n"
-		"   b   clear\n"
+		"   str  r3, [r1]\n"
+		"   add  r1, r1, #4\n"
+		"   sub  r2, r2, #4\n"
+		"   cbz  r2, out\n"
+		"   b    clear\n"
 		"out:\n"
 		"   dsb\n"
+#endif /* CONFIG_SB_CLEANUP_RAM */
+
+#ifdef CONFIG_SB_DISABLE_SELF_RWX
+		/* FUNCTION_BUFFER_LEN */
+		"   movw r4, %4\n"
+		/* Address of ram_exec_buf goes to r2 */
+		"   mov  r2, %5\n"
+		"   movw r3, :lower16:bootconf_disable_rwx\n"
+		"   movt r3, :upper16:bootconf_disable_rwx\n"
+		/* Adjust address for thumb */
+		"   and  r3, #0xfffffffe\n"
+		/* Address of ram_exec_buf also goes to r5 */
+		"   mov  r5, %5\n"
+		/* Adjust buffer address for thumb */
+		"   orr  r5, #0x1\n"
+		/* End of the copy address in r4 */
+		"   add  r4, r2\n"
+		"ram_cpy:\n"
+		/* Read and increment */
+		"   ldrb r1, [r3], #1\n"
+		/* Write and increment */
+		"   strb r1, [r2], #1\n"
+		/* Check if end address is reached */
+		"   cmp  r2, r4\n"
+		"   bne  ram_cpy\n"
+		"   dsb\n"
+		/* Jump to ram */
+		"   bx   r5\n"
+		/* CODE_UNREACHABLE */
+
+		".thumb_func\n"
+		"bootconf_disable_rwx:\n"
+		"   movw r1, %6\n"
+		"   movt r1, %7\n"
+		"   ldr  r2, [r1]\n"
+		/* Size of the region should be set at this point
+		 * by provisioning through BOOTCONF.
+		 * If not, set it according partition size.
+		 */
+		"   ands r4, r2, %12\n"
+		"   cbnz r4, clear_rwx\n"
+		"   movt r2, %8\n"
+		"clear_rwx:\n"
+		"   bfc  r2, %9, %10\n"
+		/* Disallow further modifications */
+		"   orr  r2, %11\n"
+		"   str  r2, [r1]\n"
+		"   dsb\n"
+		/* Next assembly line is important for current function */
+
+#endif /* CONFIG_SB_DISABLE_SELF_RWX */
+
 		/* Jump to reset vector of an app */
-		"   bx r0\n"
+		"   bx   r0\n"
 		:
-		: "r" (vector_table[1]), "i" (CONFIG_SRAM_BASE_ADDRESS),
-		  "i" (CONFIG_SRAM_SIZE * 1024), "i" (0)
-		: "r0", "r1", "r2", "r3", "memory"
+		: "r" (vector_table[1]),
+		  "i" (CONFIG_SRAM_BASE_ADDRESS),
+		  "i" (CONFIG_SRAM_SIZE * 1024),
+		  "i" (0)
+#ifdef CONFIG_SB_DISABLE_SELF_RWX
+		  , "i" (FUNCTION_BUFFER_LEN),
+		  "r" (ram_exec_buf),
+		  "i" (RRAMC_REGION_TO_LOCK_ADDR_L),
+		  "i" (RRAMC_REGION_TO_LOCK_ADDR_H),
+		  "i" (CONFIG_PM_PARTITION_SIZE_B0_IMAGE / 1024),
+		  "i" (RRAMC_REGION_RWX_LSB),
+		  "i" (RRAMC_REGION_RWX_WIDTH),
+		  "i" (RRAMC_REGION_CONFIG_LOCK_Msk),
+		  "i" (RRAMC_REGION_CONFIG_SIZE_Msk)
+#endif /* CONFIG_SB_DISABLE_SELF_RWX */
+		: "r0", "r1", "r2", "r3", "r4", "r5", "memory"
 	);
-#else
-	/* Call reset handler. */
-	((void (*)(void))vector_table[1])();
-#endif
+
 	CODE_UNREACHABLE;
 }

--- a/tests/subsys/bootloader/b0_lock/CMakeLists.txt
+++ b/tests/subsys/bootloader/b0_lock/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(NONE)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+target_include_directories(app PRIVATE .)

--- a/tests/subsys/bootloader/b0_lock/prj.conf
+++ b/tests/subsys/bootloader/b0_lock/prj.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_ZTEST=y

--- a/tests/subsys/bootloader/b0_lock/src/main.c
+++ b/tests/subsys/bootloader/b0_lock/src/main.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/ztest.h>
+#include <hal/nrf_rramc.h>
+
+#define RRAMC_REGION_FOR_BOOTCONF 3
+static uint32_t expected_fatal;
+static uint32_t actual_fatal;
+static nrf_rramc_region_config_t config;
+
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+{
+	printk("Caught system error -- reason %d\n", reason);
+	actual_fatal++;
+}
+
+void check_fatal(void *unused)
+{
+	zassert_equal(expected_fatal, actual_fatal,
+		"Wrong number of fatal errors has occurred (e:%d != a:%d).",
+		expected_fatal, actual_fatal);
+}
+
+void *get_config(void)
+{
+	nrf_rramc_region_config_get(NRF_RRAMC,
+			RRAMC_REGION_FOR_BOOTCONF,
+			&config);
+	zassert_equal(0, config.permissions &
+			(NRF_RRAMC_REGION_PERM_READ_MASK |
+			 NRF_RRAMC_REGION_PERM_WRITE_MASK |
+			 NRF_RRAMC_REGION_PERM_EXECUTE_MASK),
+			"Read Write and eXecute permissions aren't cleared");
+	zassert_true(config.size_kb > 0, "Protected region has zero size.");
+	return NULL;
+}
+
+ZTEST(b0_self_lock_test, test_reading_b0_image)
+{
+	uint32_t protected_end_address = 1024 * config.size_kb;
+	int val;
+
+	printk("Legal read\n");
+	val = *((volatile int*)protected_end_address);
+	config.permissions = NRF_RRAMC_REGION_PERM_READ_MASK |
+			     NRF_RRAMC_REGION_PERM_WRITE_MASK |
+			     NRF_RRAMC_REGION_PERM_EXECUTE_MASK;
+	/* Try unlocking. This should take no effect at this point */
+	nrf_rramc_region_config_set(NRF_RRAMC, RRAMC_REGION_FOR_BOOTCONF, &config);
+	printk("Illegal read\n");
+	expected_fatal++;
+	val = *((volatile int*)protected_end_address-1);
+}
+
+ZTEST_SUITE(b0_self_lock_test, NULL, get_config, NULL, check_fatal, NULL);

--- a/tests/subsys/bootloader/b0_lock/sysbuild.conf
+++ b/tests/subsys/bootloader/b0_lock/sysbuild.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+SB_CONFIG_SECURE_BOOT_APPCORE=y

--- a/tests/subsys/bootloader/b0_lock/testcase.yaml
+++ b/tests/subsys/bootloader/b0_lock/testcase.yaml
@@ -1,0 +1,10 @@
+tests:
+  b0.self_lock:
+    sysbuild: true
+    extra_args:
+      - b0_CONFIG_SB_DISABLE_SELF_RWX=y
+    platform_allow: nrf54l15dk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - b0


### PR DESCRIPTION
Disables read and execute on memory containing NSIB
right before jumping to application.