### PR TITLE
manifest: Update sdk-zephyr to have GRTC and timer tests for nRF54L20

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a2eaddb4bcbb177a68f1feb6b43170ce31ea995f
+      revision: pull/1919/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Run GRTC tests for nRF54L20 target.