### PR TITLE
CODEOWNERS: Add @nrfconnect/ncs-merge as owner for west.yml

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,7 +18,7 @@
 /LICENSE                                  @carlescufi
 /README.rst                               @carlescufi @nrfconnect/ncs-doc-leads
 /VERSION                                  @nrfconnect/ncs-code-owners
-/west.yml                                 @nrfconnect/ncs-code-owners
+/west.yml                                 @nrfconnect/ncs-code-owners @nrfconnect/ncs-merge
 /west-test.yml                            @nrfconnect/ncs-ci
 
 # Dot folders


### PR DESCRIPTION
The following scenarion happens quite often:
1. A PR is created to a subrepo referenced in the west.yml
2. The PR is reviewed. It is merged by someone in @nrfconnect/ncs-merge.
3. The PR to sdk-nrf cannot be merged until someone in @nrfconnect/ncs-code-owners approves it.

This adds additional dependencies and increases the time to integrate the change done in the subrepo. Because the sub-PR was anyways merged by someone in @nrfconnect/ncs-merge, it seems unreasonable that these people cannot also merge the manifest-PR.

Another alternatives:
1. Always require an approval from @nrfconnect/ncs-code-owners for any PR to any subrepo. This seems unreasonable.
2. Always wait for someone in @nrfconnect/ncs-code-owners to approve the (unfinished, pointing to PR) west.yml before merging the sub-PR. This seems unreasonable because the west.yml-PR is not done, and it may also increase delays.
3. Always wait from someone in @nrfconnect/ncs-code-owners to get the PR to sdk-nrf merged. This may increase delays and leaving NCS in a half-merged state where the subPR is merged, but the manifest-PR is not. This may increase the risk of ending up in a state where incompatible changes are merged.