### PR TITLE
samples: benchmarks: coremark: align nRF54H20 DTS with STM snippet

### DIFF
--- a/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -48,4 +48,5 @@
 	status = "okay";
 	etrsources = <(NRF_TDDCONF_SOURCE_STMMAINCORE | NRF_TDDCONF_SOURCE_STMPPR)>;
 	portconfig = <0>;
+	etrbuffer = <&etr_buffer>;
 };

--- a/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -53,5 +53,4 @@
 &tddconf {
 	status = "okay";
 	etrsources = <(NRF_TDDCONF_SOURCE_STMMAINCORE)>;
-	portconfig = <0>;
 };


### PR DESCRIPTION
Aligned the DTS configuration of the nRF54H20 DK Application Core build target with the current state of the Zephyr STM snippet.

Ref: NCSDK-31536