### PR TITLE
doc: add SoC revision compatibility page

### DIFF
--- a/doc/nrf/releases_and_maturity.rst
+++ b/doc/nrf/releases_and_maturity.rst
@@ -28,4 +28,5 @@ If an issue is found in a release after it has taken place, those issues are lis
    releases_and_maturity/repository_revisions
    releases_and_maturity/software_maturity
    releases_and_maturity/abi_compatibility
+   releases_and_maturity/soc_rev_compatibility
    releases_and_maturity/known_issues

--- a/doc/nrf/releases_and_maturity/soc_rev_compatibility.rst
+++ b/doc/nrf/releases_and_maturity/soc_rev_compatibility.rst
@@ -1,0 +1,31 @@
+.. _soc_compatibility:
+
+SoC Revision Compatibility
+##########################
+
+.. contents::
+   :local:
+   :depth: 2
+
+Some Nordic Semiconductor SoCs undergo multiple revisions throughout their lifecycle, each characterized by specific enhancements, features, and capabilities.
+As these revisions can impact software compatibility and performance, it is essential to assure compatibility between specific SoC revisions and |NCS| versions.
+
+This page provides detailed information about the compatibility of SoC revisions with different versions of the |NCS|.
+
+nRF54L15 Compatibility
+**********************
+
++----------------------+-------------------------+-------------+
+| nRF54L15 SoC revision| nRF Connect SDK version | Support     |
++======================+=========================+=============+
+| B                    | 2.7.0                   |             |
+|                      | 2.8.0                   | Experimental|
++----------------------+-------------------------+-------------+
+| 1                    | 2.8.0                   |             |
+|                      | 2.9.0                   | Supported   |
++----------------------+-------------------------+-------------+
+| 1,2                  | 2.9.1                   |             |
+|                      | 3.0.0                   |             |
+|                      | 3.1.0                   |             |
+|                      | 3.2.0                   | Supported   |
++----------------------+-------------------------+-------------+


### PR DESCRIPTION
Adding new page under Releases and Maturity to
document SDK support for different revisions of nRF54L. In the future, this will be used for other SoCs as well.