### PR TITLE
CODEOWNERS: move /subsys/esb to ncs-si-muffin

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -737,7 +737,7 @@
 /subsys/dm/                               @nrfconnect/ncs-si-muffin
 /subsys/dult/                             @nrfconnect/ncs-si-bluebagel
 /subsys/emds/                             @balaklaka @nrfconnect/ncs-paladin
-/subsys/esb/                              @lemrey
+/subsys/esb/                              @nrfconnect/ncs-si-muffin
 /subsys/event_manager_proxy/              @nrfconnect/ncs-si-muffin
 /subsys/fw_info/                          @nrfconnect/ncs-pluto
 /subsys/gazell/                           @leewkb4567


### PR DESCRIPTION
Change ownership.
I was never really intended to be the owner of ESB :)