### PR TITLE
lib: edge_impulse: Suppress build warnings for Edge Impulse SDK

### DIFF
--- a/lib/edge_impulse/CMakeLists.ei.template
+++ b/lib/edge_impulse/CMakeLists.ei.template
@@ -73,3 +73,9 @@ list(APPEND SOURCE_FILES ${MODEL_FILES})
 
 # Add all sources to the project
 target_sources(app PRIVATE ${SOURCE_FILES})
+
+# Suppress known build warnings for Edge Impulse source/header files.
+target_compile_options(app
+		       PRIVATE -Wno-double-promotion
+		       PRIVATE -Wno-unused
+		       PRIVATE -Wno-stringop-overread)

--- a/lib/edge_impulse/CMakeLists.txt
+++ b/lib/edge_impulse/CMakeLists.txt
@@ -12,9 +12,6 @@ set(EDGE_IMPULSE_BINARY_DIR ${EDGE_IMPULSE_DIR}/src/edge_impulse_project-build)
 set(EDGE_IMPULSE_STAMP_DIR  ${EDGE_IMPULSE_DIR}/src/edge_impulse_project-stamp)
 set(EDGE_IMPULSE_LIBRARY    ${EDGE_IMPULSE_BINARY_DIR}/libedge_impulse.a)
 
-# Override Zephyr's Wdouble-promotion and unused variable warnings, as Edge Impulse gives warnings.
-zephyr_compile_options(-Wno-double-promotion -Wno-unused)
-
 file(GENERATE OUTPUT ${EDGE_IMPULSE_DIR}/compile_options.$<COMPILE_LANGUAGE>.cmake CONTENT
 "set(EI_$<COMPILE_LANGUAGE>_COMPILE_OPTIONS \"$<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>\")"
 )
@@ -130,6 +127,11 @@ add_dependencies(edge_impulse
                  edge_impulse_project
                  edge_impulse_project_download
 )
+
+# Suppress known build warnings for Edge Impulse library header files.
+target_compile_options(edge_impulse
+		       INTERFACE -Wno-double-promotion
+		       INTERFACE -Wno-unused)
 
 if(CONFIG_EI_WRAPPER)
   zephyr_library_named(ei_wrapper)

--- a/samples/edge_impulse/wrapper/src/main.c
+++ b/samples/edge_impulse/wrapper/src/main.c
@@ -38,7 +38,7 @@ static void result_ready_cb(int err)
 			break;
 		}
 
-		printk("Value: %.2f\tLabel: %s\n", value, label);
+		printk("Value: %.2f\tLabel: %s\n", (double)value, label);
 	}
 
 	if (err) {
@@ -49,7 +49,7 @@ static void result_ready_cb(int err)
 			if (err) {
 				printk("Cannot get anomaly (err: %d)\n", err);
 			} else {
-				printk("Anomaly: %.2f\n", anomaly);
+				printk("Anomaly: %.2f\n", (double)anomaly);
 			}
 		}
 	}


### PR DESCRIPTION
Change suppresses build warnings related to known issues. PR also fixes build warning for EI wrapper sample.

Jira: NCSDK-31594
