### PR TITLE
samples: cellular: modem_shell: increased sleep time for 1st info read

### DIFF
--- a/samples/cellular/modem_shell/src/link/link.c
+++ b/samples/cellular/modem_shell/src/link/link.c
@@ -180,8 +180,10 @@ static void link_registered_work(struct k_work *unused)
 	/* Activate the deactive ones that have been connected by us */
 	link_api_activate_mosh_contexts(pdn_act_status_arr, PDN_CONTEXTS_MAX);
 
-	/* Seems that 1st info read fails without this. Thus, let modem have some time */
-	k_sleep(K_MSEC(1500));
+	/* PDN activation may take some time. Thus, let modem have some time
+	 * before reading the PDN information.
+	 */
+	k_sleep(K_MSEC(2000));
 
 	link_api_modem_info_get_for_shell(true);
 }


### PR DESCRIPTION
increased sleep time before first info read to prevent modem failures for some nrf91 dks.