### PR TITLE
nfc: lib: Add clock handling for nRF54H20

### DIFF
--- a/subsys/nfc/lib/Kconfig
+++ b/subsys/nfc/lib/Kconfig
@@ -7,6 +7,7 @@ config NFC_PLATFORM
 	bool "Common NFC configuration"
 	default y if NFC_T2T_NRFXLIB || NFC_T4T_NRFXLIB
 	select NRFX_NFCT
+	select CLOCK_CONTROL
 	help
 	  Enable common configuration for the NFC
 


### PR DESCRIPTION
For the nRF54H20, added clock handling when a field is detected or lost.