### PR TITLE
treewide: do not select NRF_MODEM_LIB

### DIFF
--- a/lib/modem_info/Kconfig
+++ b/lib/modem_info/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig MODEM_INFO
 	bool "nRF91 modem information library"
-	select NRF_MODEM_LIB
+	depends on NRF_MODEM_LIB
 	select AT_PARSER
 	select AT_MONITOR
 

--- a/lib/modem_jwt/Kconfig
+++ b/lib/modem_jwt/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig MODEM_JWT
 	bool "Modem JWT Library"
-	select NRF_MODEM_LIB
+	depends on NRF_MODEM_LIB
 	select BASE64
 	help
 	  Functionality requires modem firmware version 1.3 or greater.

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
@@ -104,7 +104,7 @@ endif # NRF_CLOUD_REST
 
 menuconfig NRF_CLOUD_FOTA_FULL_MODEM_UPDATE
 	bool "Full modem FOTA updates"
-	select NRF_MODEM_LIB
+	depends on NRF_MODEM_LIB
 	select ZCBOR
 	select DFU_TARGET
 	select DFU_TARGET_FULL_MODEM

--- a/subsys/net/lib/nrf_provisioning/Kconfig
+++ b/subsys/net/lib/nrf_provisioning/Kconfig
@@ -7,7 +7,7 @@
 menuconfig NRF_PROVISIONING
 	bool "nRF Provisioning"
 	select EXPERIMENTAL
-	imply NRF_MODEM_LIB
+	depends on NRF_MODEM_LIB
 	depends on SETTINGS
 	imply FCB
 

--- a/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_codec
+++ b/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_codec
@@ -6,7 +6,7 @@
 menuconfig NRF_PROVISIONING_CODEC
 	bool "nRF Provisioning codec"
 	select EXPERIMENTAL
-	imply NRF_MODEM_LIB
+	depends on NRF_MODEM_LIB
 
 if NRF_PROVISIONING_CODEC
 

--- a/tests/subsys/net/lib/nrf_provisioning/Kconfig
+++ b/tests/subsys/net/lib/nrf_provisioning/Kconfig
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menuconfig NRF_PROVISIONING
+	bool "nRF Provisioning"
+	select EXPERIMENTAL
+	#depends on NRF_MODEM_LIB
+	depends on SETTINGS
+	imply FCB
+	help
+	  Redefinition to disable modemlib requirement from the tests as we want to mock it.
+
+menuconfig NRF_PROVISIONING_CODEC
+	bool "nRF Provisioning codec"
+	select EXPERIMENTAL
+	#depends on NRF_MODEM_LIB
+	help
+	  Redefinition to disable modemlib requirement from the tests as we want to mock it.
+
+menu "Zephyr Kernel"
+source "Kconfig.zephyr"
+endmenu


### PR DESCRIPTION
`libmodem` is enabled automatically for all nRF9 projects.
Using `select` to express a dependency is bad practice, and should be avoided in favor of `depends on`.

This is a re-opening of PR #17366, which was closed and we couldn't open (maybe due to a force push).