### PR TITLE
chore: change from strtok to strtok_r

### DIFF
--- a/applications/nrf5340_audio/src/modules/sd_card.c
+++ b/applications/nrf5340_audio/src/modules/sd_card.c
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+
 #include "sd_card.h"
 
 #include <zephyr/kernel.h>

--- a/lib/date_time/date_time_core.c
+++ b/lib/date_time/date_time_core.c
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+#ifdef _POSIX_C_SOURCE
 #undef _POSIX_C_SOURCE
+#endif
 #define _POSIX_C_SOURCE 200809L /* Required for gmtime_r */
 
 #include <date_time.h>

--- a/lib/gcf_sms/gcf_sms.c
+++ b/lib/gcf_sms/gcf_sms.c
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
@@ -17,11 +24,6 @@
 #include <zephyr/logging/log.h>
 
 #include <modem/at_cmd_custom.h>
-
-/* Even though it's defined in minimal libc, the declaration of strtok_r appears to be missing in
- * some cases, so we forward declare it here.
- */
-extern char *strtok_r(char *, const char *, char **);
 
 LOG_MODULE_REGISTER(gcf_sms, CONFIG_GCF_SMS_LOG_LEVEL);
 

--- a/modules/wfa-qt/src/indigo_api_callback_dut.c
+++ b/modules/wfa-qt/src/indigo_api_callback_dut.c
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -367,6 +374,7 @@ static int generate_hostapd_config(char *output, int output_size,
 	size_t i;
 	int enable_wps = 0, use_mbss = 0;
 	char buffer[S_BUFFER_LEN], cfg_item[2*BUFFER_LEN];
+	char *save_buffer;
 	char band[64], value[16];
 	char country[16];
 	struct tlv_to_config_name *cfg = NULL;
@@ -440,13 +448,13 @@ static int generate_hostapd_config(char *output, int output_size,
 			char *token = NULL, *delimit = ";";
 
 			memcpy(buffer, tlv->value, sizeof(buffer));
-			token = strtok(buffer, delimit);
+			token = strtok_r(buffer, delimit, &save_buffer);
 
 			while (token != NULL) {
 				CHECK_SNPRINTF(cfg_item, sizeof(cfg_item), ret,
 					       "%s=%s\n", cfg->config_name, token);
 				strcat(output, cfg_item);
-				token = strtok(NULL, delimit);
+				token = strtok_r(NULL, delimit, &save_buffer);
 			}
 			continue;
 		}
@@ -2490,7 +2498,9 @@ static int send_sta_anqp_query_handler(struct packet_wrapper *req, struct packet
 			goto done;
 		}
 	} else {
-		token = strtok(anqp_info_id, delimit);
+		char *save_anqp_info_id;
+
+		token = strtok_r(anqp_info_id, delimit, &save_anqp_info_id);
 		memset(buffer, 0, sizeof(buffer));
 		CHECK_SNPRINTF(buffer, sizeof(buffer), ret, "ANQP_GET %s ", bssid);
 		while (token != NULL) {
@@ -2501,7 +2511,7 @@ static int send_sta_anqp_query_handler(struct packet_wrapper *req, struct packet
 				}
 			}
 
-			token = strtok(NULL, delimit);
+			token = strtok_r(NULL, delimit, &save_anqp_info_id);
 			if (token != NULL) {
 				strcat(buffer, ",");
 			}

--- a/modules/wfa-qt/src/utils.c
+++ b/modules/wfa-qt/src/utils.c
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
@@ -1320,8 +1327,9 @@ int parse_wireless_interface_info(char *info)
 {
 	char *token = NULL;
 	char *delimit = ",";
+	char *save_token;
 
-	token = strtok(info, delimit);
+	token = strtok_r(info, delimit, &save_token);
 
 	while (token != NULL) {
 		if (strncmp(token, "2:", 2) == 0) {
@@ -1333,7 +1341,7 @@ int parse_wireless_interface_info(char *info)
 		} else {
 			return -1;
 		}
-		token = strtok(NULL, delimit);
+		token = strtok_r(NULL, delimit, &save_token);
 	}
 
 	return 0;

--- a/samples/cellular/modem_shell/src/at/at_cmd_mode.c
+++ b/samples/cellular/modem_shell/src/at/at_cmd_mode.c
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+
 #include <string.h>
 #include <stdlib.h>
 
@@ -193,12 +200,12 @@ send:
 
 	if (strchr(at_buf, '|')) {
 		struct at_cmd_mode_pipelining_info *pipes = at_cmd_mode_work.pipe_infos;
-		char *next_char;
+		char *next_char, *save_next_char;
 		char *tmp;
 		int pipelined_at_cmd_len;
 
 		next_char = at_buf;
-		tmp = strtok(next_char, "|");
+		tmp = strtok_r(next_char, "|", &save_next_char);
 
 		while (tmp != NULL) {
 			if (at_cmd_mode_work.pipe_cnt >= AT_MAX_CMD_PIPELINED) {
@@ -218,7 +225,7 @@ send:
 					at_cmd_mode_work.pipe_cnt++;
 				}
 			}
-			tmp = strtok(NULL, "|");
+			tmp = strtok_r(NULL, "|", &save_next_char);
 		}
 	}
 

--- a/samples/cellular/modem_shell/src/link/link_api.c
+++ b/samples/cellular/modem_shell/src/link/link_api.c
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -368,7 +375,7 @@ int link_api_pdp_contexts_read(struct pdp_context_info_array *pdp_info)
 	struct pdp_context_info *populated_info;
 
 	char ip_addr_str[AT_CMD_PDP_CONTEXT_READ_IP_ADDR_STR_MAX_LEN];
-	char *ip_address1, *ip_address2;
+	char *ip_address1, *ip_address2, *save_ip_addr_str;
 	int family;
 	struct in_addr *addr4;
 	struct in6_addr *addr6;
@@ -470,10 +477,10 @@ parse:
 	/* Parse IP addresses from space delimited string. */
 
 	/* Get 1st 2 IP addresses from a CGDCONT string.
-	 * Notice that ip_addr_str is slightly modified by strtok()
+	 * Notice that ip_addr_str is modified by strtok_r()
 	 */
-	ip_address1 = strtok(ip_addr_str, " ");
-	ip_address2 = strtok(NULL, " ");
+	ip_address1 = strtok_r(ip_addr_str, " ", &save_ip_addr_str);
+	ip_address2 = strtok_r(NULL, " ", &save_ip_addr_str);
 
 	if (ip_address1 != NULL) {
 		family = net_utils_sa_family_from_ip_string(ip_address1);

--- a/samples/peripheral/802154_phy_test/src/ctrl/ptt_uart_proc.c
+++ b/samples/peripheral/802154_phy_test/src/ctrl/ptt_uart_proc.c
@@ -9,6 +9,13 @@
  * For example: "custom setchannel 0x00 0x00 0x08 0x00" to set 11 channel.
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+
 #include <assert.h>
 #include <stddef.h>
 #include <string.h>

--- a/samples/peripheral/802154_phy_test/src/ctrl/ptt_zb_perf_cmd_mode_uart.c
+++ b/samples/peripheral/802154_phy_test/src/ctrl/ptt_zb_perf_cmd_mode_uart.c
@@ -12,6 +12,13 @@
  * gets it back with result and then frees the event.
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+
 #include <assert.h>
 #include <stddef.h>
 #include <string.h>

--- a/subsys/net/lib/download_client/src/coap.c
+++ b/subsys/net/lib/download_client/src/coap.c
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+
 #include <zephyr/kernel.h>
 #include <zephyr/net/coap.h>
 #include <net/download_client.h>
@@ -16,11 +23,6 @@ LOG_MODULE_DECLARE(download_client, CONFIG_DOWNLOAD_CLIENT_LOG_LEVEL);
 #define COAP_VER 1
 #define FILENAME_SIZE CONFIG_DOWNLOAD_CLIENT_MAX_FILENAME_SIZE
 #define COAP_PATH_ELEM_DELIM "/"
-
-/* declaration of strtok_r appears to be missing in some cases,
- * even though it's defined in the minimal libc, so we forward declare it
- */
-extern char *strtok_r(char *str, const char *sep, char **state);
 
 int url_parse_file(const char *url, char *file, size_t len);
 int socket_send(const struct download_client *client, size_t len, int timeout);

--- a/subsys/net/lib/downloader/src/transports/coap.c
+++ b/subsys/net/lib/downloader/src/transports/coap.c
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+
 #include <zephyr/kernel.h>
 #include <zephyr/net/coap.h>
 #include <zephyr/net/socket.h>
@@ -64,11 +71,6 @@ struct transport_params_coap {
 };
 
 BUILD_ASSERT(CONFIG_DOWNLOADER_TRANSPORT_PARAMS_SIZE >= sizeof(struct transport_params_coap));
-
-/* declaration of strtok_r appears to be missing in some cases,
- * even though it's defined in the minimal libc, so we forward declare it
- */
-extern char *strtok_r(char *str, const char *sep, char **state);
 
 static int coap_get_current_from_response_pkt(const struct coap_packet *cpkt)
 {

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
@@ -4,6 +4,14 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+#include <string.h>
+
 #include <modem/modem_info.h>
 #include <modem/nrf_modem_lib.h>
 
@@ -384,7 +392,7 @@ static int generate_auth_path(char *buffer, size_t len)
 {
 	int ret;
 	char mver[CONFIG_MODEM_INFO_BUFFER_SIZE];
-	char *mvernmb;
+	char *mvernmb, *save_mvernmb;
 	int cnt;
 
 	if (!buffer) {
@@ -400,12 +408,12 @@ static int generate_auth_path(char *buffer, size_t len)
 		return ret ? ret : -ENODATA;
 	}
 
-	mvernmb = strtok(mver, "_-");
+	mvernmb = strtok_r(mver, "_-", &save_mvernmb);
 	cnt = 1;
 
 	/* mfw_nrf9160_1.3.2-FOTA-TEST - for example */
 	while (cnt++ < 3) {
-		mvernmb = strtok(NULL, "_-");
+		mvernmb = strtok_r(NULL, "_-", &save_mvernmb);
 	}
 
 	if (len < (sizeof(AUTH_API_TEMPLATE) + strlen(mvernmb) + strlen(CLIENT_VERSION))) {

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+
 #include <string.h>
 #include <zephyr/kernel.h>
 #include <stdlib.h>
@@ -255,7 +262,7 @@ static int gen_provisioning_url(struct rest_client_req_context *const req)
 	char mver[128];
 	char *cver = STRINGIFY(1);
 	int ret;
-	char *mvernmb;
+	char *mvernmb, *save_mvernmb;
 	int cnt;
 	char after[NRF_PROVISIONING_CORRELATION_ID_SIZE];
 
@@ -269,12 +276,12 @@ static int gen_provisioning_url(struct rest_client_req_context *const req)
 		return ret ? ret : -ENODATA;
 	}
 
-	mvernmb = strtok(mver, "_-");
+	mvernmb = strtok_r(mver, "_-", &save_mvernmb);
 	cnt = 1;
 
 	/* mfw_nrf9160_1.3.2-FOTA-TEST - for example */
 	while (cnt++ < 3) {
-		mvernmb = strtok(NULL, "_-");
+		mvernmb = strtok_r(NULL, "_-", &save_mvernmb);
 	}
 
 	buff_sz = sizeof(API_CMDS_TEMPLATE) +

--- a/tests/subsys/net/lib/nrf_provisioning/src/main.c
+++ b/tests/subsys/net/lib/nrf_provisioning/src/main.c
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+/* Define _POSIX_C_SOURCE before including <string.h> in order to use `strtok_r`. */
+#define _POSIX_C_SOURCE 200809L
+
 #include <zephyr/kernel.h>
 #include <zephyr/sys/reboot.h>
 #include <zephyr/sys/util.h>
@@ -339,7 +346,8 @@ static int rest_client_request_url_valid(struct rest_client_req_context *req_ctx
 
 	strcpy(tokens, req_ctx->url);
 
-	char *tok = strtok(tokens, "/");
+	char *save_tok;
+	char *tok = strtok_r(tokens, "/", &save_tok);
 
 	int sgmtc = 0; /* Path segment count */
 	int qcnt = 0; /* Query item count */
@@ -348,22 +356,22 @@ static int rest_client_request_url_valid(struct rest_client_req_context *req_ctx
 		switch (sgmtc) {
 		case 0:
 			info.apiver = tok;
-			tok = strtok(NULL, "/");
+			tok = strtok_r(NULL, "/", &save_tok);
 			sgmtc++;
 			break;
 		case 1:
 			info.endpoint = tok;
-			tok = strtok(NULL, "?");
+			tok = strtok_r(NULL, "?", &save_tok);
 			sgmtc++;
 			break;
 		case 2:
 			info.command = tok;
-			tok = strtok(NULL, "&");
+			tok = strtok_r(NULL, "&", &save_tok);
 			sgmtc++;
 			break;
 		default:
 			query_items[qcnt++] = tok;
-			tok = strtok(NULL, "&");
+			tok = strtok_r(NULL, "&", &save_tok);
 			break;
 		}
 	}


### PR DESCRIPTION
Use `strtok_r` instead of `strtok`, as `strtok` is not reentrant and uses a global state.