### PR TITLE
boards: shields: Add EB II Wi-Fi  shield board files

### DIFF
--- a/boards/shields/nrf7002eb2_interposer_p1/Kconfig.shield
+++ b/boards/shields/nrf7002eb2_interposer_p1/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_NRF7002EB2_INTERPOSER_P1
+	def_bool $(shields_list_contains,nrf7002eb2_interposer_p1)

--- a/boards/shields/nrf7002eb2_interposer_p1/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/boards/shields/nrf7002eb2_interposer_p1/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+&pinctrl {
+	spi130_default: spi130_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK,  1, 1)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+		};
+	};
+
+	spi130_sleep: spi130_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK,  1, 1)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+			low-power-enable;
+		};
+	};
+};
+
+edge_connector_spi: &spi130 {
+	status = "okay";
+	cs-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&spi130_default>;
+	pinctrl-1 = <&spi130_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+};
+
+#include "../nrf7002eb2_interposer_p1_gpio_map_2.dtsi"

--- a/boards/shields/nrf7002eb2_interposer_p1/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/boards/shields/nrf7002eb2_interposer_p1/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi22_default: spi22_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK,  1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+		};
+	};
+
+	spi22_sleep: spi22_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK,  1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+			low-power-enable;
+		};
+	};
+};
+
+edge_connector_spi: &spi22 {
+	status = "okay";
+	cs-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&spi22_default>;
+	pinctrl-1 = <&spi22_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+#include "../nrf7002eb2_interposer_p1_gpio_map_1.dtsi"

--- a/boards/shields/nrf7002eb2_interposer_p1/nrf7002eb2_interposer_p1.overlay
+++ b/boards/shields/nrf7002eb2_interposer_p1/nrf7002eb2_interposer_p1.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gpio1 {
+	status = "okay";
+};

--- a/boards/shields/nrf7002eb2_interposer_p1/nrf7002eb2_interposer_p1_gpio_map_1.dtsi
+++ b/boards/shields/nrf7002eb2_interposer_p1/nrf7002eb2_interposer_p1_gpio_map_1.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+        chosen {
+                zephyr,wifi = &wlan0;
+		zephyr,console = &uart30;
+		zephyr,shell-uart = &uart30;
+        	zephyr,uart-mcumgr = &uart30;
+        	zephyr,bt-mon-uart = &uart30;
+        	zephyr,bt-c2h-uart = &uart30;
+        };
+
+        nrf_radio_coex: coex {
+                compatible = "nordic,nrf7002-coex";
+                status = "okay";
+
+                status0-gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+                req-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+                grant-gpios = <&gpio1 13 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
+        };
+
+
+};
+
+&edge_connector_spi {
+        nrf70: nrf7002@0 {
+                compatible = "nordic,nrf7002-spi";
+                status = "okay";
+                reg = <0>;
+                spi-max-frequency = <DT_FREQ_M(8)>;
+
+                iovdd-ctrl-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+                bucken-gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+                host-irq-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+
+                wlan0: wlan0 {
+                        compatible = "nordic,wlan";
+                };
+
+                wifi-max-tx-pwr-2g-dsss = <21>;
+                wifi-max-tx-pwr-2g-mcs0 = <16>;
+                wifi-max-tx-pwr-2g-mcs7 = <16>;
+                wifi-max-tx-pwr-5g-low-mcs0 = <13>;
+                wifi-max-tx-pwr-5g-low-mcs7 = <13>;
+                wifi-max-tx-pwr-5g-mid-mcs0 = <13>;
+                wifi-max-tx-pwr-5g-mid-mcs7 = <13>;
+                wifi-max-tx-pwr-5g-high-mcs0 = <12>;
+                wifi-max-tx-pwr-5g-high-mcs7 = <12>;
+        };
+};
+
+&mx25r64 {
+        status = "disabled";
+};
+
+&uart20 {
+        status = "disabled";
+};
+
+&uart30 {
+        status = "okay";
+};
+

--- a/boards/shields/nrf7002eb2_interposer_p1/nrf7002eb2_interposer_p1_gpio_map_2.dtsi
+++ b/boards/shields/nrf7002eb2_interposer_p1/nrf7002eb2_interposer_p1_gpio_map_2.dtsi
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/ {
+        chosen {
+                zephyr,wifi = &wlan0;
+        };
+
+        nrf_radio_coex: coex {
+                compatible = "nordic,nrf7002-coex";
+                status = "okay";
+
+                status0-gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+                req-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+                grant-gpios = <&gpio1 3 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
+        };
+
+
+};
+
+&edge_connector_spi {
+        nrf70: nrf7002@0 {
+                compatible = "nordic,nrf7002-spi";
+                status = "okay";
+                reg = <0>;
+                spi-max-frequency = <DT_FREQ_M(8)>;
+
+                iovdd-ctrl-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+                bucken-gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+                host-irq-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+
+                wlan0: wlan0 {
+                        compatible = "nordic,wlan";
+                };
+
+                wifi-max-tx-pwr-2g-dsss = <21>;
+                wifi-max-tx-pwr-2g-mcs0 = <16>;
+                wifi-max-tx-pwr-2g-mcs7 = <16>;
+                wifi-max-tx-pwr-5g-low-mcs0 = <13>;
+                wifi-max-tx-pwr-5g-low-mcs7 = <13>;
+                wifi-max-tx-pwr-5g-mid-mcs0 = <13>;
+                wifi-max-tx-pwr-5g-mid-mcs7 = <13>;
+                wifi-max-tx-pwr-5g-high-mcs0 = <12>;
+                wifi-max-tx-pwr-5g-high-mcs7 = <12>;
+        };
+};
+
+&uart135 {
+        status = "disabled";
+};
+
+&uart136 {
+        status = "okay";
+};


### PR DESCRIPTION
Initial eb2 board files for 54l15 and 54h20 boards