### PR TITLE
manifest: sdk-zephyr: Test branch

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 1cdbd26200df91ae3500daf6f5e15fae686ffdf8
+      revision: pull/1529/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Test [pr 1529](https://github.com/nrfconnect/sdk-nrfxlib/pull/1529) in sdk-nrfxlib.