### PR TITLE
samples: cellular: mss: Fix for wrong header name

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -317,6 +317,7 @@ Cellular samples
 
   * Fixed:
 
+    * Wrong header naming in :file:`provisioning_support.h` that was causing build errors when :file:`sample_reboot.h` was included in other source files.
     * An issue with an uninitialized variable in the :c:func:`handle_at_cmd_requests` function.
     * An issue with the too small :kconfig:option:`CONFIG_COAP_EXTENDED_OPTIONS_LEN_VALUE` Kconfig value
       in the :file:`overlay-coap_nrf_provisioning.conf` file.

--- a/samples/cellular/nrf_cloud_multi_service/src/provisioning_support.h
+++ b/samples/cellular/nrf_cloud_multi_service/src/provisioning_support.h
@@ -1,10 +1,10 @@
-/* Copyright (c) 2023 Nordic Semiconductor ASA
+/* Copyright (c) 2023-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#ifndef _SAMPLE_REBOOT_H_
-#define _SAMPLE_REBOOT_H_
+#ifndef _PROVISIONING_SUPPORT_H_
+#define _PROVISIONING_SUPPORT_H_
 
 #include <zephyr/kernel.h>
 
@@ -28,4 +28,4 @@ static inline bool await_provisioning_idle(k_timeout_t timeout)
 
 #endif /*CONFIG_NRF_PROVISIONING*/
 
-#endif /* _SAMPLE_REBOOT_H_ */
+#endif /* _PROVISIONING_SUPPORT_H_ */


### PR DESCRIPTION
Replacing SAMPLE_REBOOT definition to PROVISIONING_SUPPORT. Based on #19302.
