### PR TITLE
samples: bluetooth: fast_pair: locator_tag: enable PM for nRF54H20 DK

### DIFF
--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -24,6 +24,10 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. note::
+   In case of the :ref:`zephyr:nrf54h20dk_nrf54h20` board target, the application still has high power consumption as the Bluetooth LE controller running on the radio core requires disabling MRAM latency (:kconfig:option:`CONFIG_MRAM_LATENCY_AUTO_REQ`).
+   Enabling MRAM latency makes the Bluetooth LE controller unstable.
+
 Overview
 ********
 

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/ipc_radio/boards/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/ipc_radio/boards/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,12 +1,8 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2025 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-CONFIG_SUIT=y
-
 # nRF54H-specific power management configuration
 CONFIG_PM=y
-CONFIG_PM_S2RAM=y
-CONFIG_PM_S2RAM_CUSTOM_MARKING=y


### PR DESCRIPTION
Updated the nRF54H20 DK configuration in the Fast Pair Locator Tag sample to enable the Zephyr Power Management system for the application and radio core.