### PR TITLE
manifest: pull DWC2 hibernation exit fixes from sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 942ee1baa8e1389e150a5e34244a347de0c67cd3
+      revision: 3b622698c61436558e8f7d8e3a0b02e5804ad22e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr to add USB hibernation exit fixes:
[nrf fromlist] drivers: udc_dwc2: Set bit 17 if needed on Hibernation Exit
[nrf fromlist] drivers: udc_dwc2: Workaround hibernation exit glitch