### PR TITLE
lib: gcf_sms: pass NULL to strtok_r to continue parsing same string

### DIFF
--- a/lib/gcf_sms/gcf_sms.c
+++ b/lib/gcf_sms/gcf_sms.c
@@ -202,7 +202,7 @@ int gcf_sms_filter_callback(char *buf, size_t len, char *at_cmd)
 		}
 
 		/* Get the next command. */
-		msg = strtok_r(msg_rest, ";", &msg_rest);
+		msg = strtok_r(NULL, ";", &msg_rest);
 		/* Add AT for concatenated AT-commands. */
 		if ((msg) && (msg - 2 * sizeof(char) >= at_cmd)) {
 			msg = msg - 2 * sizeof(char);


### PR DESCRIPTION
The strtok_r documentation says that each subsequent call that should parse the same string should set the str arguement to NULL.

Restarting the parsing based on the saveptr argument, as was previously done, only works because the context that the strtok_r function saves to saveptr happens to be the address where the function left off. (However, the save context will likely not change for this function.)