### PR TITLE
Bluetooth: Enable C2H ACL data flow control by default

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -130,8 +130,10 @@ Amazon Sidewalk
 Bluetooth® LE
 -------------
 
-* Fixed an issue where a flash operation executed on the system workqueue might result in ``-ETIMEDOUT``, if there is an active Bluetooth LE connection.
-* Fixed an issue where Bluetooth applications built with the ``nordic-bt-rpc`` snippet (in the :ref:`ble_rpc` configuration) did not work on the nRF54H20 devices due to incorrect memory mapping.
+  * Fixed:
+
+    * An issue where a flash operation executed on the system workqueue might result in ``-ETIMEDOUT``, if there is an active Bluetooth LE connection.
+    * An issue where Bluetooth applications built with the ``nordic-bt-rpc`` snippet (in the :ref:`ble_rpc` configuration) did not work on the nRF54H20 devices due to incorrect memory mapping.
 
 Bluetooth Mesh
 --------------

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -135,6 +135,8 @@ Bluetooth® LE
     * An issue where a flash operation executed on the system workqueue might result in ``-ETIMEDOUT``, if there is an active Bluetooth LE connection.
     * An issue where Bluetooth applications built with the ``nordic-bt-rpc`` snippet (in the :ref:`ble_rpc` configuration) did not work on the nRF54H20 devices due to incorrect memory mapping.
 
+  * Updated the :kconfig:option:`CONFIG_BT_HCI_ACL_FLOW_CONTROL` Kconfig option to be enabled by default to mitigate the risk of potential deadlocks in the Bluetooth Host.
+
 Bluetooth Mesh
 --------------
 

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -45,6 +45,14 @@ config BT_LONG_WQ_STACK_SIZE
 	default 1800 if (BT_ECC || BT_GATT_CACHING)
 	default 1024
 
+if BT_CONN
+
+config BT_HCI_ACL_FLOW_CONTROL
+	# Enabling this option by default for now to avoid potential deadlocks. See NCSDK-30959.
+	default y
+
+endif # BT_CONN
+
 rsource "controller/Kconfig"
 rsource "host_extensions/Kconfig"
 


### PR DESCRIPTION
This commit enables C2H ACL data flow control by default to avoid potential deadlocks. See NCSDK-30959 for details.

Known issues are updated in https://github.com/nrfconnect/sdk-nrf/pull/20200.