### PR TITLE
tests: benchmarks: multicore: idle_gpio: Fix uart wakeup

### DIFF
--- a/tests/benchmarks/multicore/idle_gpio/boards/wakeup_from_uart_pins.overlay
+++ b/tests/benchmarks/multicore/idle_gpio/boards/wakeup_from_uart_pins.overlay
@@ -19,36 +19,12 @@
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};
+
+	zephyr,user {
+		test-gpios = <&gpio2 7 GPIO_ACTIVE_LOW>;
+	};
 };
 
 &gpio2 {
 	status = "okay";
-};
-
-/*
- * Redefine RX -> P2.03 (not used)
- */
-&pinctrl {
-	/omit-if-no-ref/ uart136_default: uart136_default {
-		group1 {
-			psels = <NRF_PSEL(UART_TX, 2, 6)>,
-				<NRF_PSEL(UART_RTS, 2, 7)>;
-		};
-
-		group2 {
-			bias-pull-up;
-			psels = <NRF_PSEL(UART_RX, 2, 3)>,
-				<NRF_PSEL(UART_CTS, 2, 5)>;
-		};
-	};
-
-	/omit-if-no-ref/ uart136_sleep: uart136_sleep {
-		group1 {
-			low-power-enable;
-			psels = <NRF_PSEL(UART_TX, 2, 6)>,
-				<NRF_PSEL(UART_RX, 2, 3)>,
-				<NRF_PSEL(UART_RTS, 2, 7)>,
-				<NRF_PSEL(UART_CTS, 2, 5)>;
-		};
-	};
 };

--- a/tests/benchmarks/multicore/idle_gpio/remote/boards/wakeup_from_uart_pins.overlay
+++ b/tests/benchmarks/multicore/idle_gpio/remote/boards/wakeup_from_uart_pins.overlay
@@ -21,36 +21,11 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+	zephyr,user {
+		test-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+	};
 };
 
 &gpio1 {
 	status = "okay";
-};
-
-/*
- * Redefine RX -> P1.08 (not used)
- */
-&pinctrl {
-	/omit-if-no-ref/ uart135_default: uart135_default {
-	group1 {
-		psels = <NRF_PSEL(UART_TX, 1, 11)>,
-			<NRF_PSEL(UART_RTS, 1, 9)>;
-	};
-
-	group2 {
-		bias-pull-up;
-		psels = <NRF_PSEL(UART_RX, 1, 8)>,
-			<NRF_PSEL(UART_CTS, 1, 7)>;
-		};
-	};
-
-	/omit-if-no-ref/ uart135_sleep: uart135_sleep {
-	group1 {
-		low-power-enable;
-		psels = <NRF_PSEL(UART_TX, 1, 11)>,
-			<NRF_PSEL(UART_RX, 1, 8)>,
-			<NRF_PSEL(UART_RTS, 1, 9)>,
-			<NRF_PSEL(UART_CTS, 1, 7)>;
-		};
-	};
 };

--- a/tests/benchmarks/multicore/idle_gpio/src/main.c
+++ b/tests/benchmarks/multicore/idle_gpio/src/main.c
@@ -22,6 +22,10 @@ static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(DT_ALIAS(led1), gpios);
 #error "Invalid core selected. "
 #endif
 
+#if DT_NODE_EXISTS(DT_PATH(zephyr_user))
+static const struct gpio_dt_spec fake_rts = GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), test_gpios);
+#endif
+
 static K_SEM_DEFINE(my_gpio_sem, 0, 1);
 
 void my_gpio_callback(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
@@ -49,6 +53,20 @@ int main(void)
 		LOG_ERR("Could not configure led GPIO (%d)\n", rc);
 		return 0;
 	}
+
+#if DT_NODE_EXISTS(DT_PATH(zephyr_user))
+	rc = gpio_is_ready_dt(&fake_rts);
+	if (rc < 0) {
+		LOG_ERR("GPIO Device not ready (%d)\n", rc);
+		return 0;
+	}
+
+	rc = gpio_pin_configure_dt(&fake_rts, GPIO_OUTPUT_ACTIVE);
+	if (rc < 0) {
+		LOG_ERR("Could not configure fake_rst GPIO (%d)\n", rc);
+		return 0;
+	}
+#endif
 
 	rc = gpio_is_ready_dt(&sw);
 	if (rc < 0) {


### PR DESCRIPTION
There is need to emulate RTS to unblock transmission on board controller side when uart driver on SoC side is not used