### PR TITLE
manifest: Update Memfault SDK to 1.18.0

### DIFF
--- a/samples/bluetooth/peripheral_mds/memfault_config/memfault_platform_config.h
+++ b/samples/bluetooth/peripheral_mds/memfault_config/memfault_platform_config.h
@@ -8,5 +8,3 @@
  * memfault-firmware-sdk. Default configuration settings can be found in
  * "<NCS folder>/modules/lib/memfault-firmware-sdk/components/include/memfault/default_config.h"
  */
-
- /* #define MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS 1800 */

--- a/samples/debug/memfault/config/memfault_platform_config.h
+++ b/samples/debug/memfault/config/memfault_platform_config.h
@@ -11,11 +11,3 @@
  * memfault-firmware-sdk. Default configuration settings can be found in
  * "<NCS folder>/modules/lib/memfault-firmware-sdk/components/include/memfault/default_config.h"
  */
-
-/* Uncomment the definition below to override the default setting for
- * heartbeat interval. This will prepare the captured metric data for upload
- * to Memfault cloud at the specified interval.
- */
-/*
- * #define MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS 1800
- */

--- a/west.yml
+++ b/west.yml
@@ -251,7 +251,7 @@ manifest:
       remote: throwtheswitch
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 1.12.0
+      revision: 1.18.0
       remote: memfault
     - name: bsim
       repo-path: bsim_west


### PR DESCRIPTION
In Memfault SDK 1.18.0, the config
`MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS` set via `memfault_platform_config.h` was replaced with the Kconfig option `CONFIG_MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS`.

This commit updates the SDK version and:
 - Removes references to the old config
 - Adds example usage of `CONFIG_MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS`

 Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>