### PR TITLE
applications: nrf5340_audio: Button handler for different kits

### DIFF
--- a/applications/nrf5340_audio/boards/nrf5340_audio_dk_nrf5340_cpuapp.overlay
+++ b/applications/nrf5340_audio/boards/nrf5340_audio_dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		sw-vol-down = &button_1_vol_dn;
+		sw-vol-up = &button_2_vol_up;
+		sw-play-pause = &button3;
+		sw-tone = &button4;
+		sw-mute = &button5;
+		led-device-type = &rgb1_red;
+		led-net-status = &rgb2_red;
+		led-app-status = &led3_green;
+		led-conn-status = &led1_blue;
+		led-sync-status = &led2_green;
+	};
+};

--- a/applications/nrf5340_audio/boards/nrf5340_audio_dk_nrf5340_cpuapp_fota.overlay
+++ b/applications/nrf5340_audio/boards/nrf5340_audio_dk_nrf5340_cpuapp_fota.overlay
@@ -37,3 +37,18 @@
 		gpios = < &gpio1 0x9 0x0 >, < &gpio1 0x8 0x0 >, < &gpio1 0xb 0x0 >;
 	};
 };
+
+/ {
+	aliases {
+		sw-vol-down = &button_1_vol_dn;
+		sw-vol-up = &button_2_vol_up;
+		sw-play-pause = &button3;
+		sw-tone = &button4;
+		sw-mute = &button5;
+		led-device-type = &rgb1_red;
+		led-net-status = &rgb2_red;
+		led-app-status = &led3_green;
+		led-conn-status = &led1_blue;
+		led-sync-status = &led2_green;
+	};
+};

--- a/applications/nrf5340_audio/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/applications/nrf5340_audio/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NRF5340_AUDIO_CS47L63_DRIVER=n
+CONFIG_NRF5340_AUDIO_POWER_MEASUREMENT=n
+CONFIG_NRF5340_AUDIO_SD_CARD_MODULE=n

--- a/applications/nrf5340_audio/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/applications/nrf5340_audio/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -16,3 +16,15 @@
 		hp-channel-r;
 	};
 };
+
+/ {
+	aliases {
+		sw-vol-down = &button0;
+		sw-vol-up = &button1;
+		sw-play-pause = &button2;
+		sw-mute = &button3;
+		led-app-status = &led1;
+		led-conn-status = &led0;
+		led-sync-status = &led2;
+	};
+};

--- a/applications/nrf5340_audio/broadcast_sink/main.c
+++ b/applications/nrf5340_audio/broadcast_sink/main.c
@@ -11,7 +11,7 @@
 
 #include "broadcast_sink.h"
 #include "zbus_common.h"
-#include "nrf5340_audio_dk.h"
+#include "nrf5340_board.h"
 #include "led.h"
 #include "button_assignments.h"
 #include "macros_common.h"
@@ -127,7 +127,7 @@ static void button_msg_sub_thread(void)
 
 			break;
 
-		case BUTTON_4:
+		case BUTTON_TONE:
 			ret = broadcast_sink_change_active_audio_stream();
 			if (ret) {
 				LOG_WRN("Failed to change active audio stream: %d", ret);
@@ -135,7 +135,7 @@ static void button_msg_sub_thread(void)
 
 			break;
 
-		case BUTTON_5:
+		case BUTTON_MUTE:
 			if (IS_ENABLED(CONFIG_AUDIO_MUTE)) {
 				ret = bt_r_and_c_volume_mute(false);
 				if (ret) {
@@ -208,7 +208,7 @@ static void le_audio_msg_sub_thread(void)
 
 			audio_system_start();
 			stream_state_set(STATE_STREAMING);
-			ret = led_blink(LED_APP_1_BLUE);
+			ret = led_blink(LED_AUDIO_CONN_STATUS);
 			ERR_CHK(ret);
 
 			break;
@@ -223,7 +223,7 @@ static void le_audio_msg_sub_thread(void)
 
 			stream_state_set(STATE_PAUSED);
 			audio_system_stop();
-			ret = led_on(LED_APP_1_BLUE);
+			ret = led_on(LED_AUDIO_CONN_STATUS);
 			ERR_CHK(ret);
 
 			break;
@@ -265,7 +265,7 @@ static void le_audio_msg_sub_thread(void)
 			if (strm_state == STATE_STREAMING) {
 				stream_state_set(STATE_PAUSED);
 				audio_system_stop();
-				ret = led_on(LED_APP_1_BLUE);
+				ret = led_on(LED_AUDIO_CONN_STATUS);
 				ERR_CHK(ret);
 			}
 
@@ -566,7 +566,7 @@ int main(void)
 
 	LOG_DBG("Main started");
 
-	ret = nrf5340_audio_dk_init();
+	ret = nrf5340_board_init();
 	ERR_CHK(ret);
 
 	ret = fw_info_app_print();

--- a/applications/nrf5340_audio/broadcast_source/main.c
+++ b/applications/nrf5340_audio/broadcast_source/main.c
@@ -13,7 +13,7 @@
 
 #include "broadcast_source.h"
 #include "zbus_common.h"
-#include "nrf5340_audio_dk.h"
+#include "nrf5340_board.h"
 #include "led.h"
 #include "button_assignments.h"
 #include "macros_common.h"
@@ -152,7 +152,7 @@ static void button_msg_sub_thread(void)
 
 			break;
 
-		case BUTTON_4:
+		case BUTTON_TONE:
 			if (IS_ENABLED(CONFIG_AUDIO_TEST_TONE)) {
 				if (strm_state != STATE_STREAMING) {
 					LOG_WRN("Not in streaming state");
@@ -206,7 +206,7 @@ static void le_audio_msg_sub_thread(void)
 
 			audio_system_start();
 			stream_state_set(STATE_STREAMING);
-			ret = led_blink(LED_APP_1_BLUE);
+			ret = led_blink(LED_AUDIO_CONN_STATUS);
 			ERR_CHK(ret);
 
 			break;
@@ -223,7 +223,7 @@ static void le_audio_msg_sub_thread(void)
 
 			stream_state_set(STATE_PAUSED);
 			audio_system_stop();
-			ret = led_on(LED_APP_1_BLUE);
+			ret = led_on(LED_AUDIO_CONN_STATUS);
 			ERR_CHK(ret);
 
 			break;
@@ -558,7 +558,7 @@ int main(void)
 	size_t ext_adv_buf_cnt = 0;
 	size_t per_adv_buf_cnt = 0;
 
-	ret = nrf5340_audio_dk_init();
+	ret = nrf5340_board_init();
 	ERR_CHK(ret);
 
 	ret = fw_info_app_print();

--- a/applications/nrf5340_audio/sample.yaml
+++ b/applications/nrf5340_audio/sample.yaml
@@ -4,7 +4,10 @@ sample:
 common:
   integration_platforms:
     - nrf5340_audio_dk/nrf5340/cpuapp
-  platform_allow: nrf5340_audio_dk/nrf5340/cpuapp
+    - nrf5340dk/nrf5340/cpuapp
+  platform_allow:
+    - nrf5340_audio_dk/nrf5340/cpuapp
+    - nrf5340dk/nrf5340/cpuapp
   sysbuild: true
   build_only: true
   tags:

--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -354,9 +354,9 @@ static void pres_comp_state_set(enum pres_comp_state new_state)
 	/* NOTE: The string below is used by the Nordic CI system */
 	LOG_INF("Pres comp state: %s", pres_comp_state_names[new_state]);
 	if (new_state == PRES_STATE_LOCKED) {
-		ret = led_on(LED_APP_2_GREEN);
+		ret = led_on(LED_AUDIO_SYNC_STATUS);
 	} else {
-		ret = led_off(LED_APP_2_GREEN);
+		ret = led_off(LED_AUDIO_SYNC_STATUS);
 	}
 	ERR_CHK(ret);
 }

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.c
@@ -20,9 +20,7 @@
 #include "bt_mgmt_ctlr_cfg_internal.h"
 #include "bt_mgmt_adv_internal.h"
 #include "bt_mgmt_dfu_internal.h"
-#if CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP
 #include "button_assignments.h"
-#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mgmt, CONFIG_BT_MGMT_LOG_LEVEL);
@@ -213,11 +211,10 @@ static void bt_enabled_cb(int err)
 
 static int bonding_clear_check(void)
 {
-#if CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP
 	int ret;
 	bool pressed;
 
-	ret = button_pressed(BUTTON_5, &pressed);
+	ret = button_pressed(BUTTON_MUTE, &pressed);
 	if (ret) {
 		return ret;
 	}
@@ -227,7 +224,6 @@ static int bonding_clear_check(void)
 		return ret;
 	}
 
-#endif
 	return 0;
 }
 
@@ -420,7 +416,7 @@ int bt_mgmt_init(void)
 #if defined(CONFIG_AUDIO_BT_MGMT_DFU)
 	bool pressed;
 
-	ret = button_pressed(BUTTON_4, &pressed);
+	ret = button_pressed(BUTTON_TONE, &pressed);
 	if (ret) {
 		return ret;
 	}

--- a/applications/nrf5340_audio/src/modules/button_assignments.h
+++ b/applications/nrf5340_audio/src/modules/button_assignments.h
@@ -16,14 +16,50 @@
 
 #include <zephyr/drivers/gpio.h>
 
+/** @brief Constant to indicate an unused button assignment
+ */
+#define BUTTON_NOT_ASSIGNED 0xFF
+
 /** @brief List of buttons and associated metadata
  */
-enum button_pin_names {
-	BUTTON_VOLUME_DOWN = DT_GPIO_PIN(DT_ALIAS(sw0), gpios),
-	BUTTON_VOLUME_UP = DT_GPIO_PIN(DT_ALIAS(sw1), gpios),
-	BUTTON_PLAY_PAUSE = DT_GPIO_PIN(DT_ALIAS(sw2), gpios),
-	BUTTON_4 = DT_GPIO_PIN(DT_ALIAS(sw3), gpios),
-	BUTTON_5 = DT_GPIO_PIN(DT_ALIAS(sw4), gpios),
-};
+#if DT_NODE_EXISTS(DT_ALIAS(sw_vol_down))
+#define BUTTON_VOLUME_DOWN	 DT_GPIO_PIN(DT_ALIAS(sw_vol_down), gpios)
+#define BUTTON_VOLUME_DOWN_FLAGS DT_GPIO_FLAGS(DT_ALIAS(sw_vol_down), gpios)
+#else
+#define BUTTON_VOLUME_DOWN	 BUTTON_NOT_ASSIGNED
+#define BUTTON_VOLUME_DOWN_FLAGS 0
+#endif
+
+#if DT_NODE_EXISTS(DT_ALIAS(sw_vol_up))
+#define BUTTON_VOLUME_UP       DT_GPIO_PIN(DT_ALIAS(sw_vol_up), gpios)
+#define BUTTON_VOLUME_UP_FLAGS DT_GPIO_FLAGS(DT_ALIAS(sw_vol_up), gpios)
+#else
+#define BUTTON_VOLUME_UP       BUTTON_NOT_ASSIGNED
+#define BUTTON_VOLUME_UP_FLAGS 0
+#endif
+
+#if DT_NODE_EXISTS(DT_ALIAS(sw_play_pause))
+#define BUTTON_PLAY_PAUSE	DT_GPIO_PIN(DT_ALIAS(sw_play_pause), gpios)
+#define BUTTON_PLAY_PAUSE_FLAGS DT_GPIO_FLAGS(DT_ALIAS(sw_play_pause), gpios)
+#else
+#define BUTTON_PLAY_PAUSE	BUTTON_NOT_ASSIGNED
+#define BUTTON_PLAY_PAUSE_FLAGS 0
+#endif
+
+#if DT_NODE_EXISTS(DT_ALIAS(sw_tone))
+#define BUTTON_TONE	  DT_GPIO_PIN(DT_ALIAS(sw_tone), gpios)
+#define BUTTON_TONE_FLAGS DT_GPIO_FLAGS(DT_ALIAS(sw_tone), gpios)
+#else
+#define BUTTON_TONE	  BUTTON_NOT_ASSIGNED
+#define BUTTON_TONE_FLAGS 0
+#endif
+
+#if DT_NODE_EXISTS(DT_ALIAS(sw_mute))
+#define BUTTON_MUTE	  DT_GPIO_PIN(DT_ALIAS(sw_mute), gpios)
+#define BUTTON_MUTE_FLAGS DT_GPIO_FLAGS(DT_ALIAS(sw_mute), gpios)
+#else
+#define BUTTON_MUTE	  BUTTON_NOT_ASSIGNED
+#define BUTTON_MUTE_FLAGS 0
+#endif
 
 #endif /* _BUTTON_ASSIGNMENTS_H_ */

--- a/applications/nrf5340_audio/src/modules/led.h
+++ b/applications/nrf5340_audio/src/modules/led.h
@@ -9,11 +9,14 @@
 
 #include <stdint.h>
 
-#define LED_APP_RGB	0
-#define LED_NET_RGB	1
-#define LED_APP_1_BLUE	2
-#define LED_APP_2_GREEN 3
-#define LED_APP_3_GREEN 4
+enum led_unit_assignment {
+	LED_AUDIO_DEVICE_TYPE,
+	LED_AUDIO_NET_STATUS,
+	LED_AUDIO_CONN_STATUS,
+	LED_AUDIO_SYNC_STATUS,
+	LED_AUDIO_APP_STATUS,
+	LED_AUDIO_ASSIGN_NUM
+};
 
 #define RED   0
 #define GREEN 1
@@ -54,7 +57,7 @@ enum led_color {
  *			-EINVAL if the color argument is illegal.
  *			Other errors from underlying drivers.
  */
-int led_blink(uint8_t led_unit, ...);
+int led_blink(enum led_unit_assignment led_unit, ...);
 
 /**
  * @brief Turn the given LED unit on.
@@ -71,7 +74,7 @@ int led_blink(uint8_t led_unit, ...);
  *			-EINVAL if the color argument is illegal.
  *			Other errors from underlying drivers.
  */
-int led_on(uint8_t led_unit, ...);
+int led_on(enum led_unit_assignment led_unit, ...);
 
 /**
  * @brief Set the state of a given LED unit to off.
@@ -85,7 +88,7 @@ int led_on(uint8_t led_unit, ...);
  *			-EINVAL if the color argument is illegal.
  *			Other errors from underlying drivers.
  */
-int led_off(uint8_t led_unit);
+int led_off(enum led_unit_assignment led_unit);
 
 /**
  * @brief Initialise the LED module.

--- a/applications/nrf5340_audio/src/modules/led_assignments.h
+++ b/applications/nrf5340_audio/src/modules/led_assignments.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _LED_ASSIGNMENTS_H_
+#define _LED_ASSIGNMENTS_H_
+
+#include <zephyr/devicetree.h>
+#include <stdint.h>
+
+#define LED_AUDIO_NOT_ASSIGNED 0xFF
+
+/**
+ * @brief Mapping of LEDs on board to indication.
+ */
+#if DT_NODE_EXISTS(DT_ALIAS(led_device_type))
+#define LED_AUDIO_DEVICE_TYPE_INDEX DT_NODE_CHILD_IDX(DT_ALIAS(led_device_type))
+#else
+#define LED_AUDIO_DEVICE_TYPE_INDEX LED_AUDIO_NOT_ASSIGNED
+#endif
+
+#if DT_NODE_EXISTS(DT_ALIAS(led_net_status))
+#define LED_AUDIO_NET_STATUS_INDEX DT_NODE_CHILD_IDX(DT_ALIAS(led_net_status))
+#else
+#define LED_AUDIO_NET_STATUS_INDEX LED_AUDIO_NOT_ASSIGNED
+#endif
+
+#if DT_NODE_EXISTS(DT_ALIAS(led_conn_status))
+#define LED_AUDIO_CONN_STATUS_INDEX DT_NODE_CHILD_IDX(DT_ALIAS(led_conn_status))
+#else
+#define LED_AUDIO_CONN_STATUS_INDEX LED_AUDIO_NOT_ASSIGNED
+#endif
+
+#if DT_NODE_EXISTS(DT_ALIAS(led_app_status))
+#define LED_AUDIO_APP_STATUS_INDEX DT_NODE_CHILD_IDX(DT_ALIAS(led_app_status))
+#else
+#define LED_AUDIO_APP_STATUS_INDEX LED_AUDIO_NOT_ASSIGNED
+#endif
+
+#if DT_NODE_EXISTS(DT_ALIAS(led_sync_status))
+#define LED_AUDIO_SYNC_STATUS_INDEX DT_NODE_CHILD_IDX(DT_ALIAS(led_sync_status))
+#else
+#define LED_AUDIO_SYNC_STATUS_INDEX LED_AUDIO_NOT_ASSIGNED
+#endif
+
+#endif /* _LED_ASSIGNMENTS_H_ */

--- a/applications/nrf5340_audio/src/utils/CMakeLists.txt
+++ b/applications/nrf5340_audio/src/utils/CMakeLists.txt
@@ -8,8 +8,8 @@ target_sources(app PRIVATE
 	       ${CMAKE_CURRENT_SOURCE_DIR}/channel_assignment.c
 	       ${CMAKE_CURRENT_SOURCE_DIR}/error_handler.c
 	       ${CMAKE_CURRENT_SOURCE_DIR}/uicr.c
+		   ${CMAKE_CURRENT_SOURCE_DIR}/nrf5340_board.c
 )
 
 target_sources_ifdef(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP app PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/nrf5340_audio_dk.c
 		${CMAKE_CURRENT_SOURCE_DIR}/board_version.c)

--- a/applications/nrf5340_audio/src/utils/Kconfig
+++ b/applications/nrf5340_audio/src/utils/Kconfig
@@ -40,6 +40,10 @@ endmenu # FIFO
 #----------------------------------------------------------------------------#
 menu "Log levels"
 
+module = NRF5340_BOARD
+module-str = nrf5340-board
+source "subsys/logging/Kconfig.template.log_config"
+
 module = BOARD_VERSION
 module-str = board-version
 source "subsys/logging/Kconfig.template.log_config"

--- a/applications/nrf5340_audio/src/utils/error_handler.c
+++ b/applications/nrf5340_audio/src/utils/error_handler.c
@@ -16,9 +16,14 @@ LOG_MODULE_REGISTER(error_handler, CONFIG_ERROR_HANDLER_LOG_LEVEL);
 
 #if (defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP) && (CONFIG_DEBUG))
 /* nRF5340 Audio DK center RGB LED */
-static const struct gpio_dt_spec center_led_r = GPIO_DT_SPEC_GET(DT_NODELABEL(rgb1_red), gpios);
-static const struct gpio_dt_spec center_led_g = GPIO_DT_SPEC_GET(DT_NODELABEL(rgb1_green), gpios);
-static const struct gpio_dt_spec center_led_b = GPIO_DT_SPEC_GET(DT_NODELABEL(rgb1_blue), gpios);
+static const struct gpio_dt_spec error_led_0 = GPIO_DT_SPEC_GET(DT_NODELABEL(rgb1_red), gpios);
+static const struct gpio_dt_spec error_led_1 = GPIO_DT_SPEC_GET(DT_NODELABEL(rgb1_green), gpios);
+static const struct gpio_dt_spec error_led_2 = GPIO_DT_SPEC_GET(DT_NODELABEL(rgb1_blue), gpios);
+#elif defined(CONFIG_DEBUG)
+static const struct gpio_dt_spec error_led_0 = GPIO_DT_SPEC_GET(DT_NODELABEL(led0), gpios);
+static const struct gpio_dt_spec error_led_1 = GPIO_DT_SPEC_GET(DT_NODELABEL(led1), gpios);
+static const struct gpio_dt_spec error_led_2 = GPIO_DT_SPEC_GET(DT_NODELABEL(led2), gpios);
+static const struct gpio_dt_spec error_led_3 = GPIO_DT_SPEC_GET(DT_NODELABEL(led3), gpios);
 #endif /* (defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP) && (CONFIG_DEBUG)) */
 
 void error_handler(unsigned int reason, const struct arch_esf *esf)
@@ -27,9 +32,14 @@ void error_handler(unsigned int reason, const struct arch_esf *esf)
 	LOG_ERR("Caught system error -- reason %d. Entering infinite loop", reason);
 	LOG_PANIC();
 #if defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP)
-	(void)gpio_pin_configure_dt(&center_led_r, GPIO_OUTPUT_ACTIVE);
-	(void)gpio_pin_configure_dt(&center_led_g, GPIO_OUTPUT_INACTIVE);
-	(void)gpio_pin_configure_dt(&center_led_b, GPIO_OUTPUT_INACTIVE);
+	(void)gpio_pin_configure_dt(&error_led_0, GPIO_OUTPUT_ACTIVE);
+	(void)gpio_pin_configure_dt(&error_led_1, GPIO_OUTPUT_INACTIVE);
+	(void)gpio_pin_configure_dt(&error_led_2, GPIO_OUTPUT_INACTIVE);
+#else
+	(void)gpio_pin_configure_dt(&error_led_0, GPIO_OUTPUT_ACTIVE);
+	(void)gpio_pin_configure_dt(&error_led_1, GPIO_OUTPUT_INACTIVE);
+	(void)gpio_pin_configure_dt(&error_led_2, GPIO_OUTPUT_INACTIVE);
+	(void)gpio_pin_configure_dt(&error_led_3, GPIO_OUTPUT_INACTIVE);
 #endif /* defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP) */
 	irq_lock();
 	while (1) {

--- a/applications/nrf5340_audio/src/utils/nrf5340_board.c
+++ b/applications/nrf5340_audio/src/utils/nrf5340_board.c
@@ -16,16 +16,18 @@
 #include "sd_card_playback.h"
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(nrf5340_audio_dk, CONFIG_MODULE_NRF5340_AUDIO_DK_LOG_LEVEL);
+LOG_MODULE_REGISTER(nrf5340_board, CONFIG_NRF5340_BOARD_LOG_LEVEL);
 
+#if defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP)
 static struct board_version board_rev;
+#endif /* CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP */
 
 static int leds_set(void)
 {
 	int ret;
 
 	/* Blink LED 3 to indicate that APP core is running */
-	ret = led_blink(LED_APP_3_GREEN);
+	ret = led_blink(LED_AUDIO_APP_STATUS);
 	if (ret) {
 		return ret;
 	}
@@ -36,12 +38,12 @@ static int leds_set(void)
 	channel_assignment_get(&channel);
 
 	if (channel == AUDIO_CH_L) {
-		ret = led_on(LED_APP_RGB, LED_COLOR_BLUE);
+		ret = led_on(LED_AUDIO_DEVICE_TYPE, LED_COLOR_BLUE);
 	} else {
-		ret = led_on(LED_APP_RGB, LED_COLOR_MAGENTA);
+		ret = led_on(LED_AUDIO_DEVICE_TYPE, LED_COLOR_MAGENTA);
 	}
 #elif (CONFIG_AUDIO_DEV == GATEWAY)
-	ret = led_on(LED_APP_RGB, LED_COLOR_GREEN);
+	ret = led_on(LED_AUDIO_DEVICE_TYPE, LED_COLOR_GREEN);
 #endif /* (CONFIG_AUDIO_DEV == HEADSET) */
 
 	if (ret) {
@@ -81,7 +83,7 @@ static int channel_assign_check(void)
 	return 0;
 }
 
-int nrf5340_audio_dk_init(void)
+int nrf5340_board_init(void)
 {
 	int ret;
 
@@ -103,6 +105,7 @@ int nrf5340_audio_dk_init(void)
 		return ret;
 	}
 
+#if defined(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP)
 	ret = board_version_valid_check();
 	if (ret) {
 		return ret;
@@ -121,18 +124,19 @@ int nrf5340_audio_dk_init(void)
 		}
 	}
 
-	ret = leds_set();
-	if (ret) {
-		LOG_ERR("Failed to set LEDs");
-		return ret;
-	}
-
 	if (IS_ENABLED(CONFIG_SD_CARD_PLAYBACK)) {
 		ret = sd_card_playback_init();
 		if (ret) {
 			LOG_ERR("Failed to initialize SD card playback");
 			return ret;
 		}
+	}
+#endif /* CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP */
+
+	ret = leds_set();
+	if (ret) {
+		LOG_ERR("Failed to set LEDs");
+		return ret;
 	}
 
 	/* Use this to turn on 128 MHz clock for cpu_app */

--- a/applications/nrf5340_audio/src/utils/nrf5340_board.h
+++ b/applications/nrf5340_audio/src/utils/nrf5340_board.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#ifndef _NRF5340_AUDIO_DK_H_
-#define _NRF5340_AUDIO_DK_H_
+#ifndef _NRF5340_BOARD_H_
+#define _NRF5340_BOARD_H_
 
 #include "led.h"
 
@@ -14,6 +14,6 @@
  *
  * @return	0 if successful, error otherwise.
  */
-int nrf5340_audio_dk_init(void);
+int nrf5340_board_init(void);
 
-#endif /* _NRF5340_AUDIO_DK_H_ */
+#endif /* _NRF5340_BOARD_H_ */

--- a/applications/nrf5340_audio/unicast_client/main.c
+++ b/applications/nrf5340_audio/unicast_client/main.c
@@ -10,7 +10,7 @@
 
 #include "unicast_client.h"
 #include "zbus_common.h"
-#include "nrf5340_audio_dk.h"
+#include "nrf5340_board.h"
 #include "led.h"
 #include "button_assignments.h"
 #include "macros_common.h"
@@ -158,7 +158,7 @@ static void button_msg_sub_thread(void)
 
 			break;
 
-		case BUTTON_4:
+		case BUTTON_TONE:
 			if (IS_ENABLED(CONFIG_AUDIO_TEST_TONE)) {
 				if (IS_ENABLED(CONFIG_WALKIE_TALKIE_DEMO)) {
 					LOG_DBG("Test tone is disabled in walkie-talkie mode");
@@ -180,7 +180,7 @@ static void button_msg_sub_thread(void)
 
 			break;
 
-		case BUTTON_5:
+		case BUTTON_MUTE:
 			if (IS_ENABLED(CONFIG_AUDIO_MUTE)) {
 				ret = bt_r_and_c_volume_mute(false);
 				if (ret) {
@@ -234,7 +234,7 @@ static void le_audio_msg_sub_thread(void)
 			audio_system_start();
 			stream_state_set(STATE_STREAMING);
 
-			ret = led_blink(LED_APP_1_BLUE);
+			ret = led_blink(LED_AUDIO_CONN_STATUS);
 			ERR_CHK(ret);
 			break;
 
@@ -253,7 +253,7 @@ static void le_audio_msg_sub_thread(void)
 			stream_state_set(STATE_PAUSED);
 			audio_system_stop();
 
-			ret = led_on(LED_APP_1_BLUE);
+			ret = led_on(LED_AUDIO_CONN_STATUS);
 			ERR_CHK(ret);
 			break;
 
@@ -542,7 +542,7 @@ int main(void)
 
 	LOG_DBG("Main started");
 
-	ret = nrf5340_audio_dk_init();
+	ret = nrf5340_board_init();
 	ERR_CHK(ret);
 
 	ret = fw_info_app_print();

--- a/applications/nrf5340_audio/unicast_server/main.c
+++ b/applications/nrf5340_audio/unicast_server/main.c
@@ -10,7 +10,7 @@
 
 #include "unicast_server.h"
 #include "zbus_common.h"
-#include "nrf5340_audio_dk.h"
+#include "nrf5340_board.h"
 #include "led.h"
 #include "button_assignments.h"
 #include "macros_common.h"
@@ -122,7 +122,7 @@ static void button_msg_sub_thread(void)
 
 			break;
 
-		case BUTTON_4:
+		case BUTTON_TONE:
 			if (IS_ENABLED(CONFIG_AUDIO_TEST_TONE)) {
 				if (IS_ENABLED(CONFIG_WALKIE_TALKIE_DEMO)) {
 					LOG_DBG("Test tone is disabled in walkie-talkie mode");
@@ -144,7 +144,7 @@ static void button_msg_sub_thread(void)
 
 			break;
 
-		case BUTTON_5:
+		case BUTTON_MUTE:
 			if (IS_ENABLED(CONFIG_AUDIO_MUTE)) {
 				ret = bt_r_and_c_volume_mute(false);
 				if (ret) {
@@ -198,7 +198,7 @@ static void le_audio_msg_sub_thread(void)
 
 			audio_system_start();
 			stream_state_set(STATE_STREAMING);
-			ret = led_blink(LED_APP_1_BLUE);
+			ret = led_blink(LED_AUDIO_CONN_STATUS);
 			ERR_CHK(ret);
 
 			break;
@@ -217,7 +217,7 @@ static void le_audio_msg_sub_thread(void)
 
 			stream_state_set(STATE_PAUSED);
 			audio_system_stop();
-			ret = led_on(LED_APP_1_BLUE);
+			ret = led_on(LED_AUDIO_CONN_STATUS);
 			ERR_CHK(ret);
 
 			break;
@@ -522,7 +522,7 @@ int main(void)
 
 	size_t ext_adv_buf_cnt = 0;
 
-	ret = nrf5340_audio_dk_init();
+	ret = nrf5340_board_init();
 	ERR_CHK(ret);
 
 	ret = fw_info_app_print();


### PR DESCRIPTION
OCT-3005

Currently the button handler expects kits to have five buttons - which is true for the Audio DK, but not for the nRF5340 DK. To have the audio application running on the nRF5340 DK (and other kits in the future), the handler must be refactored to not fail compilation when fewer buttons are present, and reduce the application's overall dependency on button availability.

To configure which button performs which action set the aliases in the relevant overlay file:
		sw-vol-down
		sw-vol-up
		sw-play-pause
		sw-tone
		sw-mute

Example for the DK is:
		sw-vol-down = &button0;
		sw-vol-up = &button1;
		sw-play-pause = &button2;
		sw-mute = &button3;

Any unassigned button alias will be marked as such, no operation will be executed and a debug log message will be issued.
