### PR TITLE
caf: power_manager: Use `sys_poweroff` API on nRF54H20

### DIFF
--- a/subsys/caf/modules/Kconfig.power_manager
+++ b/subsys/caf/modules/Kconfig.power_manager
@@ -17,11 +17,14 @@ config CAF_POWER_MANAGER
 	  Enable power management, which will put the device to low-power mode
 	  if it is idle.
 
+	  The sys_poweroff API is not yet fully supported on nRF54H SoC Series.
+	  Because of that, it's not enabled by default for now.
+
 if CAF_POWER_MANAGER
 
 config CAF_POWER_MANAGER_STAY_ON
-	bool "Stay on while no connections"
-	depends on PM || POWEROFF
+	bool "Stay on while no connections" if POWEROFF
+	default y if !POWEROFF
 	help
 	  If disabled the device will switch SoC to OFF mode after power
 	  manager timeout is done. If enabled the device will stay on

--- a/subsys/caf/modules/power_manager.c
+++ b/subsys/caf/modules/power_manager.c
@@ -13,7 +13,6 @@
 #endif
 #include <zephyr/sys/reboot.h>
 #include <zephyr/sys/poweroff.h>
-#include <zephyr/pm/pm.h>
 
 #include <app_event_manager.h>
 #include <nrf_profiler.h>
@@ -149,18 +148,9 @@ static void system_off_post_action(void)
 	/* Ensure that logs are displayed. */
 	LOG_PANIC();
 
-	/* You shouldn't enable CONFIG_POWEROFF and CONFIG_PM simultaneously */
-	BUILD_ASSERT(!(IS_ENABLED(CONFIG_POWEROFF) && IS_ENABLED(CONFIG_PM)),
-		"CAF Power Manager uses either power off or power management, but never both");
-
-#if CONFIG_PM
-		(void)pm_state_force(0u, &(struct pm_state_info){.state = PM_STATE_SOFT_OFF,
-									.substate_id =  0,
-									.min_residency_us = 0,
-									.exit_latency_us = 0 });
-#elif CONFIG_POWEROFF
+	if (IS_ENABLED(CONFIG_POWEROFF)) {
 		sys_poweroff();
-#endif
+	}
 }
 
 static void submit_power_off_event(bool error)


### PR DESCRIPTION
The `pm_state_force` should not be used to enter `PM_STATE_SOFT_OFF`. We need to use `sys_poweroff` API instead.

Jira: NCSDK-31683