### PR TITLE
lib: nrf_modem: imply NET_IPV4 and NET_IPV6

### DIFF
--- a/lib/nrf_modem_lib/Kconfig
+++ b/lib/nrf_modem_lib/Kconfig
@@ -6,9 +6,11 @@
 menuconfig NRF_MODEM_LIB
 	bool "Modem library"
 	depends on (SOC_SERIES_NRF91X && TRUSTED_EXECUTION_NONSECURE) || SOC_NRF9280_CPUAPP
-	select EXPERIMENTAL if SOC_NRF9280_CPUAPP
 	select NRF_MODEM
+	select EXPERIMENTAL if SOC_NRF9280_CPUAPP
 	imply NET_SOCKETS_OFFLOAD
+	imply NET_IPV4
+	imply NET_IPV6
 	# The modem must be turned on to achieve low power consumption.
 	# But disable it for ZTEST's as some tests have HW
 	# resource-conflicts with NRF_MODEM_LIB.


### PR DESCRIPTION
Those options indicate whether the device supports IPv4 and IPv6, which is always the case when the stack offloading is enabled on nRF9 series products.

Imply these settings.