### PR TITLE
samples: openthread: enable 802.15.4 carrier functions for ble

### DIFF
--- a/samples/openthread/cli/sysbuild/ipc_radio/prj_ble.conf
+++ b/samples/openthread/cli/sysbuild/ipc_radio/prj_ble.conf
@@ -26,6 +26,7 @@ CONFIG_DEBUG_INFO=y
 CONFIG_EXCEPTION_STACK_TRACE=y
 
 CONFIG_NRF_802154_SER_RADIO=y
+CONFIG_NRF_802154_CARRIER_FUNCTIONS=y
 CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT=2
 
 # Enable the frame encryption feature in the radio driver, it's required for proper working


### PR DESCRIPTION
enable carrier functions when building multiprotocol image as well