### PR TITLE
applications: matter_bridge: fix sample name config

### DIFF
--- a/applications/matter_bridge/sample.yaml
+++ b/applications/matter_bridge/sample.yaml
@@ -20,7 +20,7 @@ tests:
     tags:
       - sysbuild
       - ci_applications_matter
-  applications.matter_bridge:
+  applications.matter_bridge.debug:
     sysbuild: true
     build_only: true
     extra_args:

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -30,7 +30,7 @@
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-31409"
 
 - scenarios:
-    - applications.matter_bridge
+    - applications.matter_bridge.debug
     - applications.matter_bridge.br_ble
     - applications.matter_bridge.br_ble.memory_profiling
     - applications.matter_bridge.release


### PR DESCRIPTION
Fix the name of matter_bridge debug configuration to follow the internal rules.