### PR TITLE
net: fota_download: Add more error codes to callback

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -633,6 +633,7 @@ Libraries for networking
 
 * :ref:`lib_fota_download` library:
 
+  * Added error codes related to unsupported protocol, DFU failures, and invalid configuration.
   * Updated to use the :ref:`lib_downloader` library for CoAP downloads.
 
 * :ref:`lib_nrf_cloud` library:

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -83,6 +83,12 @@ enum fota_download_error_cause {
 	FOTA_DOWNLOAD_ERROR_CAUSE_TYPE_MISMATCH,
 	/** Generic error on device side. */
 	FOTA_DOWNLOAD_ERROR_CAUSE_INTERNAL,
+	/** Error on DFU library */
+	FOTA_DOWNLOAD_ERROR_CAUSE_DFU,
+	/** Protocol not supported */
+	FOTA_DOWNLOAD_ERROR_CAUSE_PROTO_NOT_SUPPORTED,
+	/** Invalid URI or invalid configuration */
+	FOTA_DOWNLOAD_ERROR_CAUSE_INVALID_CONFIGURATION,
 };
 
 /**

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -902,6 +902,9 @@ static void fota_download_callback(const struct fota_download_evt *evt)
 		LOG_INF("FOTA download failed, target %d", dfu_image_type);
 		target_image_type_store(ongoing_obj_id, dfu_image_type);
 		switch (evt->cause) {
+		case FOTA_DOWNLOAD_ERROR_CAUSE_PROTO_NOT_SUPPORTED:
+			set_result(ongoing_obj_id, RESULT_UNSUP_PROTO);
+			break;
 		/* Connecting to the FOTA server failed. */
 		case FOTA_DOWNLOAD_ERROR_CAUSE_CONNECT_FAILED:
 			/* FALLTHROUGH */


### PR DESCRIPTION
Add error codes for
* Unsupported protocol
* DFU failure
* Invalid configuration or invalid URI

This is because Downloader may give us -EPROTONOSUPPORT or -EINVAL and these have no equivalent on FOTA Download callbacks.

DFU failures might also be usefull to see as a separate error instead of generic INTERNAL error.