### PR TITLE
tests: lib: nrf_modem_lib: lte_net_if: Fix compiler warning

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -965,6 +965,7 @@ ci_tests_subsys_nfc:
 ci_tests_lib_nrf_modem_lib:
   files:
     - nrf/lib/nrf_modem_lib/
+    - nrf/lib/pdn
     - nrf/tests/lib/nrf_modem_lib/
     - nrf/tests/mocks/nrf_modem_at/
     - zephyr/subsys/net/

--- a/tests/lib/nrf_modem_lib/lte_net_if/src/main.c
+++ b/tests/lib/nrf_modem_lib/lte_net_if/src/main.c
@@ -45,8 +45,8 @@ static void lte_lc_register_handler_stub(lte_lc_evt_handler_t cb, int num_of_cal
 }
 
 /* Stub used to report a non-default link MTU */
-static int pdn_dynamic_info_get_1000_stub(uint32_t cid,  struct pdn_dynamic_info *pdn_info,
-										  int num_of_calls)
+static int pdn_dynamic_info_get_1000_stub(
+	uint8_t cid,  struct pdn_dynamic_info *pdn_info, int num_of_calls)
 {
 	pdn_info->ipv4_mtu = 1000;
 	return 0;


### PR DESCRIPTION
Signature of pdn_dynamic_info_get() was updated in #20135, though the test was not running on thePR. This commit updates the stub's function signature. It also enables the nrf_modem_lib tests on changes to the PDN library.