### PR TITLE
suit: Remove ECDSA support

### DIFF
--- a/sysbuild/Kconfig.suit
+++ b/sysbuild/Kconfig.suit
@@ -113,15 +113,6 @@ choice SUIT_ENVELOPE_ROOT_SIGN_ALG
 config SUIT_ENVELOPE_ROOT_SIGN_ALG_EDDSA
 	bool "Use the EdDSA algorithm"
 
-config SUIT_ENVELOPE_ROOT_SIGN_ALG_ECDSA_256
-	bool "Use the ECDSA algorithm with key length of 256 bits"
-
-config SUIT_ENVELOPE_ROOT_SIGN_ALG_ECDSA_384
-	bool "Use the ECDSA algorithm with key length of 384 bits"
-
-config SUIT_ENVELOPE_ROOT_SIGN_ALG_ECDSA_521
-	bool "Use the ECDSA algorithm with key length of 521 bits"
-
 config SUIT_ENVELOPE_ROOT_SIGN_ALG_HASH_EDDSA
 	bool "Use the HashEdDSA algorithm (specifically: ed25519ph)"
 	select EXPERIMENTAL
@@ -131,9 +122,6 @@ endchoice
 config SUIT_ENVELOPE_ROOT_SIGN_ALG_NAME
 	string "String name of the algorithm used to sign the root envelope"
 	default "eddsa" if SUIT_ENVELOPE_ROOT_SIGN_ALG_EDDSA
-	default "es-256" if SUIT_ENVELOPE_ROOT_SIGN_ALG_ECDSA_256
-	default "es-384" if SUIT_ENVELOPE_ROOT_SIGN_ALG_ECDSA_384
-	default "es-521" if SUIT_ENVELOPE_ROOT_SIGN_ALG_ECDSA_521
 	default "hash-eddsa" if SUIT_ENVELOPE_ROOT_SIGN_ALG_HASH_EDDSA
 
 endif # SUIT_ENVELOPE_ROOT_SIGN
@@ -253,15 +241,6 @@ choice SUIT_ENVELOPE_APP_RECOVERY_SIGN_ALG
 config SUIT_ENVELOPE_APP_RECOVERY_SIGN_ALG_EDDSA
 	bool "Use the EdDSA algorithm"
 
-config SUIT_ENVELOPE_APP_RECOVERY_SIGN_ALG_ECDSA_256
-	bool "Use the ECDSA algorithm with key length of 256 bits"
-
-config SUIT_ENVELOPE_APP_RECOVERY_SIGN_ALG_ECDSA_384
-	bool "Use the ECDSA algorithm with key length of 384 bits"
-
-config SUIT_ENVELOPE_APP_RECOVERY_SIGN_ALG_ECDSA_521
-	bool "Use the ECDSA algorithm with key length of 521 bits"
-
 config SUIT_ENVELOPE_APP_RECOVERY_SIGN_ALG_HASH_EDDSA
 	bool "Use the HashEdDSA algorithm (specifically: ed25519ph)"
 	select EXPERIMENTAL
@@ -271,9 +250,6 @@ endchoice
 config SUIT_ENVELOPE_APP_RECOVERY_SIGN_ALG_NAME
 	string "String name of the algorithm used to sign the app recovery envelope"
 	default "eddsa" if SUIT_ENVELOPE_APP_RECOVERY_SIGN_ALG_EDDSA
-	default "es-256" if SUIT_ENVELOPE_APP_RECOVERY_SIGN_ALG_ECDSA_256
-	default "es-384" if SUIT_ENVELOPE_APP_RECOVERY_SIGN_ALG_ECDSA_384
-	default "es-521" if SUIT_ENVELOPE_APP_RECOVERY_SIGN_ALG_ECDSA_521
 	default "hash-eddsa" if SUIT_ENVELOPE_APP_RECOVERY_SIGN_ALG_HASH_EDDSA
 
 endif # SUIT_ENVELOPE_APP_RECOVERY_SIGN

--- a/west.yml
+++ b/west.yml
@@ -238,7 +238,7 @@ manifest:
           upstream-sha: c6eaeda5a1c1c5dbb24dce7e027340cb8893a77b
           compare-by-default: false
     - name: suit-generator
-      revision: 2e22c176ba50930604519c3f70ee8ae5ba2a09ac
+      revision: 0a8712aa142490deb02ca39c4bb150c70c66f835
       path: modules/lib/suit-generator
     - name: suit-processor
       revision: 726c585a064e957d5e2074aed2d680b1d2a8b5c4


### PR DESCRIPTION
The algorithm is not supported by SUIT due to key storage limitations.