### PR TITLE
bootloader: bl_validation: Use correct S0/S1 symbols

### DIFF
--- a/subsys/bootloader/bl_validation/bl_validation.c
+++ b/subsys/bootloader/bl_validation/bl_validation.c
@@ -370,10 +370,10 @@ static bool validate_firmware(uint32_t fw_dst_address, uint32_t fw_src_address,
 		return false;
 	}
 
-#if defined(PM_S0_SIZE) && defined(PM_S1_SIZE)
-	BUILD_ASSERT(PM_S0_SIZE == PM_S1_SIZE,
+#if defined(PM_S0_IMAGE_SIZE) && defined(PM_S1_IMAGE_SIZE)
+	BUILD_ASSERT(PM_S0_IMAGE_SIZE == PM_S1_IMAGE_SIZE,
 		"B0's slots aren't the same size. Check pm.yml.");
-	if ((fwinfo->size > (PM_S0_SIZE))
+	if ((fwinfo->size > (PM_S0_IMAGE_SIZE))
 		|| (fwinfo->total_size > fwinfo->size)) {
 		LOG_ERR("Invalid size or total_size in firmware info.");
 		return false;


### PR DESCRIPTION
The current implementation fails when building with CONFIG_SECURE_BOOT=y and SB_CONFIG_SECURE_BOOT_APPCORE=y on the 9160DK because the s0 region includes EMPTY_0 but the s1 region has no equivalent.

This doesn't matter anyway, because the important thing is the size of the s0_image and s1_image areas, not the outer s0 and s1 areas.