### PR TITLE
manifest: pull DWC2 control transfer fixes from sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3b622698c61436558e8f7d8e3a0b02e5804ad22e
+      revision: 706ab3d781e4c280ca9982557e8d8a77ef6e2b4b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr to add [nrf fromtree] fixes:
  drivers: udc_dwc2: Fix large control write transfers
  drivers: udc_dwc2: Recover after STALLed OUT Data Stage
  drivers: udc_dwc2: Fix multipart DMA OUT transfers
  drivers: udc_dwc2: Add helpers to check operating mode
  drivers: udc_dwc2: Allocate multiple of bMaxPacketSize0
  drivers: udc_dwc2: Stop OUT transfers on ZLP
  drivers: udc_dwc2: Rework control endpoint feeding