### PR TITLE
mpsl: fem: add support for nrf21540_gpio for nrf54l

### DIFF
--- a/doc/nrf/app_dev/device_guides/fem/fem_nrf21540_gpio.rst
+++ b/doc/nrf/app_dev/device_guides/fem/fem_nrf21540_gpio.rst
@@ -3,7 +3,7 @@
 Enabling GPIO mode support for nRF21540
 #######################################
 
-The `nRF21540`_ device is a range extender that you can use with nRF52 and nRF53 Series devices.
+The `nRF21540`_ device is a range extender that you can use with nRF52, nRF53 and nRF54L Series devices.
 The nRF21540 GPIO mode implementation of FEM is compatible with the nRF21540 device and implements the 3-pin PA/LNA interface.
 
 .. ncs_implementation_desc_start
@@ -74,3 +74,45 @@ To use nRF21540 in GPIO mode, complete the following steps:
       };
 
    The pins defined in the GPIO forwarder node in the application core's devicetree file must match the pins defined in the FEM nodes in the network core's devicetree file.
+
+#. On nRF54L devices, the GPIO pins of the SoC selected to control ``tx-en-gpios``, ``rx-en-gpios`` and ``pdn-gpios`` must support GPIOTE.
+   For example, on the nRF54L15 device, you can only use pins belonging to GPIO P1 or GPIO P0.
+   You cannot use the GPIO P2 pins, because there is no related GPIOTE peripheral.
+   It is recommended to use the GPIO pins that belong to the PERI Power Domain of the nRF54L device.
+   For example, on the nRF54L15, these are pins belonging to GPIO P1.
+   Using pins belonging to Low Power Domain (GPIO P0 on nRF54L15) is supported but requires more DPPI and PPIB channels of the SoC.
+   The nRF54L devices contain only four PPIB channels between PERI Power Domain and Low Power Domain.
+   Due to this limitation, only two out of three pins from group ``tx-en-gpios``, ``rx-en-gpios`` and ``pdn-gpios`` (for example, ``tx-en-gpios`` and ``rx-en-gpios``) can be controlled by GPIO P0.
+   The one remaining pin of the pin group (for example ``pdn-gpios``) must be controlled by other GPIO port.
+   To ensure proper timing, set the ``tx-en-settle-time-us`` and ``rx-en-settle-time-us`` devicetree properties of the ``nrf_radio_fem`` node to the value ``12``.
+   You must also enable appropriate instances of the ``DPPIC`` and ``PPIB`` peripherals in the devicetree file:
+
+   .. code-block:: devicetree
+
+      &dppic10 {
+            status = "okay";
+      };
+
+      &ppib11 {
+            status = "okay";
+      };
+
+      &ppib21 {
+            status = "okay";
+      };
+
+      &dppic20 {
+            status = "okay";
+      };
+
+      &ppib22 {
+            status = "okay";
+      };
+
+      &ppib30 {
+            status = "okay";
+      };
+
+      &dppic30 {
+            status = "okay";
+      };

--- a/doc/nrf/app_dev/device_guides/fem/index.rst
+++ b/doc/nrf/app_dev/device_guides/fem/index.rst
@@ -20,7 +20,7 @@ Zephyr and the |NCS| provides support for developing applications with the follo
      - nRF52, nRF53, nRF54L
    * - nRF21540
      - nRF21540 GPIO
-     - nRF52, nRF53
+     - nRF52, nRF53, nRF54L
    * - nRF21540
      - nRF21540 GPIO+SPI
      - nRF52, nRF53

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -96,6 +96,7 @@ Developing with Front-End Modules
 
   * :ref:`nRF2220 Front-End Module <ug_radio_fem_nrf2220>`.
   * :ref:`nRF2220 EK shield <ug_radio_fem_nrf2220ek>`.
+  * :ref:`nRF21540 Front-End Module in GPIO mode <ug_radio_fem_nrf21540_gpio>` for the nRF54L Series devices.
 
 Developing with PMICs
 =====================

--- a/subsys/mpsl/fem/Kconfig
+++ b/subsys/mpsl/fem/Kconfig
@@ -83,6 +83,11 @@ config MPSL_FEM_NRF21540_GPIO
 		$(dt_nodelabel_has_prop,nrf_radio_fem,ant-sel-gpios))
 	select NRFX_PPI if HAS_HW_NRF_PPI
 	select NRFX_DPPI if HAS_HW_NRF_DPPIC
+	select NRFX_GPPI if SOC_SERIES_NRF54LX
+	select NRFX_DPPI10 if SOC_SERIES_NRF54LX
+	select NRFX_DPPI20 if SOC_SERIES_NRF54LX
+	select NRFX_PPIB11 if SOC_SERIES_NRF54LX
+	select NRFX_PPIB21 if SOC_SERIES_NRF54LX
 	select MPSL_FEM_NCS_SUPPORTED_FEM_USED
 	bool "nRF21540 front-end module in GPIO mode"
 	help

--- a/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
+++ b/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
@@ -91,7 +91,10 @@ static int fem_nrf21540_gpio_configure(void)
 			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(tx_en_gpios),
-			.gpiote_ch_id  = txen_gpiote_channel
+			.gpiote_ch_id  = txen_gpiote_channel,
+#if defined(NRF54L_SERIES)
+			.p_gpiote = txen_gpiote.p_reg,
+#endif
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif
@@ -105,7 +108,10 @@ static int fem_nrf21540_gpio_configure(void)
 			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(rx_en_gpios),
-			.gpiote_ch_id  = rxen_gpiote_channel
+			.gpiote_ch_id  = rxen_gpiote_channel,
+#if defined(NRF54L_SERIES)
+			.p_gpiote = rxen_gpiote.p_reg,
+#endif
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif
@@ -119,7 +125,10 @@ static int fem_nrf21540_gpio_configure(void)
 			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(pdn_gpios),
-			.gpiote_ch_id  = pdn_gpiote_channel
+			.gpiote_ch_id  = pdn_gpiote_channel,
+#if defined(NRF54L_SERIES)
+			.p_gpiote = pdn_gpiote.p_reg,
+#endif
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif
@@ -163,6 +172,27 @@ static int fem_nrf21540_gpio_configure(void)
 	if (err) {
 		return err;
 	}
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), tx_en_gpios)
+	err = mpsl_fem_utils_gpiote_pin_init(&cfg.pa_pin_config);
+	if (err) {
+		return err;
+	}
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), rx_en_gpios)
+	err = mpsl_fem_utils_gpiote_pin_init(&cfg.lna_pin_config);
+	if (err) {
+		return err;
+	}
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), pdn_gpios)
+	err = mpsl_fem_utils_gpiote_pin_init(&cfg.pdn_pin_config);
+	if (err) {
+		return err;
+	}
+#endif
 
 	BUILD_ASSERT(
 	  (CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB == CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTA) ||


### PR DESCRIPTION
This PR adds support for the nRF21540 Front-End Module in GPIO mode for the nRF54L Series devices.

Note: This PR contains only code related configuration and documentation. The core of the support is provided by MPSL. The MPSL is prvided by a separate PR.

- [x] Merge after MPSL contaning the support for nrf21540_gpio for nRF54L is deployed to sdk-nrfxlib:
      https://github.com/nrfconnect/sdk-nrfxlib/pull/1652
      https://github.com/nrfconnect/sdk-nrf/pull/20375