### PR TITLE
Add eb2 shields

### DIFF
--- a/boards/shields/nrf7002eb2/Kconfig.shield
+++ b/boards/shields/nrf7002eb2/Kconfig.shield
@@ -1,0 +1,14 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+config SHIELD_NRF7002EB2
+	def_bool $(shields_list_contains,nrf7002eb2)
+
+config SHIELD_NRF7002EB2_NRF7001
+	def_bool $(shields_list_contains,nrf7002eb2_nrf7001)
+
+config SHIELD_NRF7002EB2_NRF7000
+	def_bool $(shields_list_contains,nrf7002eb2_nrf7000)
+
+config SHIELD_NRF7002EB2_COEX
+	def_bool $(shields_list_contains,nrf7002eb2_coex)

--- a/boards/shields/nrf7002eb2/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/boards/shields/nrf7002eb2/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../nrf7002eb2_gpio_pins_2.dtsi"
+
+&pinctrl {
+	spi130_default: spi130_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK,  1, 1)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+		};
+	};
+
+	spi130_sleep: spi130_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK,  1, 1)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi130 {
+	status = "okay";
+	cs-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&spi130_default>;
+	pinctrl-1 = <&spi130_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+};
+
+&uart135 {
+	status = "disabled";
+};
+
+&uart136 {
+	status = "okay";
+};

--- a/boards/shields/nrf7002eb2/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/boards/shields/nrf7002eb2/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../nrf7002eb2_gpio_pins_1.dtsi"
+
+/ {
+	chosen {
+		zephyr,wifi = &wlan0;
+		zephyr,console = &uart30;
+		zephyr,shell-uart = &uart30;
+		zephyr,uart-mcumgr = &uart30;
+		zephyr,bt-mon-uart = &uart30;
+		zephyr,bt-c2h-uart = &uart30;
+	};
+};
+
+&pinctrl {
+	spi22_default: spi22_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK,  1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+		};
+	};
+
+	spi22_sleep: spi22_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK,  1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+			low-power-enable;
+		};
+	};
+};
+
+
+&spi22 {
+	cs-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&spi22_default>;
+	pinctrl-1 = <&spi22_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&uart20 {
+	status = "disabled";
+};
+
+&uart30 {
+	status = "okay";
+};

--- a/boards/shields/nrf7002eb2/nrf7002eb2.overlay
+++ b/boards/shields/nrf7002eb2/nrf7002eb2.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,wifi = &wlan0;
+	};
+};
+
+&wifi_spi {
+	status = "okay";
+
+	nrf70: nrf7002-spi@0 {
+		compatible = "nordic,nrf7002-spi";
+		status = "okay";
+
+		/* Include common nRF70 overlays */
+		#include "nrf7002eb2_common.dtsi"
+		#include "nrf7002eb2_common_5g.dtsi"
+	};
+};

--- a/boards/shields/nrf7002eb2/nrf7002eb2_coex.overlay
+++ b/boards/shields/nrf7002eb2/nrf7002eb2_coex.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&nrf_radio_coex{
+	status = "okay";
+};

--- a/boards/shields/nrf7002eb2/nrf7002eb2_common.dtsi
+++ b/boards/shields/nrf7002eb2/nrf7002eb2_common.dtsi
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <freq.h>
+
+/* Common assignments for nRF70 EB-II shield */
+reg = <0>;
+spi-max-frequency = <DT_FREQ_M(8)>;
+
+/* Maximum TX power limits for 2.4 GHz */
+wifi-max-tx-pwr-2g-dsss = <21>;
+wifi-max-tx-pwr-2g-mcs0 = <16>;
+wifi-max-tx-pwr-2g-mcs7 = <16>;
+
+/* List of interfaces */
+wlan0: wlan0 {
+	compatible = "nordic,wlan";
+};

--- a/boards/shields/nrf7002eb2/nrf7002eb2_common_5g.dtsi
+++ b/boards/shields/nrf7002eb2/nrf7002eb2_common_5g.dtsi
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+wifi-max-tx-pwr-5g-low-mcs0 = <13>;
+wifi-max-tx-pwr-5g-low-mcs7 = <13>;
+wifi-max-tx-pwr-5g-mid-mcs0 = <13>;
+wifi-max-tx-pwr-5g-mid-mcs7 = <13>;
+wifi-max-tx-pwr-5g-high-mcs0 = <12>;
+wifi-max-tx-pwr-5g-high-mcs7 = <12>;

--- a/boards/shields/nrf7002eb2/nrf7002eb2_gpio_pins_1.dtsi
+++ b/boards/shields/nrf7002eb2/nrf7002eb2_gpio_pins_1.dtsi
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	nrf_radio_coex: coex {
+		compatible = "nordic,nrf7002-coex";
+		status = "disabled";
+		status0-gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+		req-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		grant-gpios = <&gpio1 13 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
+	};
+};
+
+&nrf70 {
+	iovdd-ctrl-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	bucken-gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+	host-irq-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+};
+
+&gpio1 {
+	status = "okay";
+};

--- a/boards/shields/nrf7002eb2/nrf7002eb2_gpio_pins_2.dtsi
+++ b/boards/shields/nrf7002eb2/nrf7002eb2_gpio_pins_2.dtsi
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	nrf_radio_coex: coex {
+		compatible = "nordic,nrf7002-coex";
+		status = "disabled";
+		status0-gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+		req-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		grant-gpios = <&gpio1 3 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
+	};
+};
+
+&nrf70 {
+	iovdd-ctrl-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+	bucken-gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+	host-irq-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+};
+
+&gpio1 {
+	status = "okay";
+};

--- a/boards/shields/nrf7002eb2/nrf7002eb2_nrf7000.overlay
+++ b/boards/shields/nrf7002eb2/nrf7002eb2_nrf7000.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,wifi = &wlan0;
+	};
+};
+
+&wifi_spi {
+	status = "okay";
+
+	nrf70: nrf7000-spi@0 {
+		compatible = "nordic,nrf7000-spi";
+		status = "okay";
+
+		/* Include common nRF70 overlays */
+		#include "nrf7002eb2_common.dtsi"
+		#include "nrf7002eb2_common_5g.dtsi"
+	};
+};

--- a/boards/shields/nrf7002eb2/nrf7002eb2_nrf7001.overlay
+++ b/boards/shields/nrf7002eb2/nrf7002eb2_nrf7001.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,wifi = &wlan0;
+	};
+};
+
+&wifi_spi {
+	status = "okay";
+
+	nrf70: nrf7001-spi@0 {
+		compatible = "nordic,nrf7001-spi";
+		status = "okay";
+
+		/* Include common nRF70 overlays */
+		#include "nrf7002eb2_common.dtsi"
+	};
+};

--- a/west.yml
+++ b/west.yml
@@ -70,7 +70,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 10ab9b6c55c196abec008f3cd0c0d2560a70be1f
+      revision: pull/2475/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add nRF70 shield files for EB-II shields to add wi-fi support to nRF54H and nRF54L DKs.