### PR TITLE
samples: nrf5340: extxip_smp_svr: Add nrfutil flash runner config

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -525,6 +525,7 @@
 /samples/net/                             @nrfconnect/ncs-cia @nrfconnect/ncs-modem
 /samples/nfc/                             @nrfconnect/ncs-si-muffin
 /samples/nrf5340/netboot/                 @nrfconnect/ncs-pluto
+/samples/nrf5340/extxip_smp_svr/          @nrfconnect/ncs-pluto
 /samples/nrf_rpc/                         @nrfconnect/ncs-si-muffin
 /samples/sensor/bh1749/                   @nrfconnect/ncs-cia
 /samples/sensor/bme68x_iaq/               @nrfconnect/ncs-cia

--- a/doc/nrf/app_dev/bootloaders_dfu/qspi_xip_split_image.rst
+++ b/doc/nrf/app_dev/bootloaders_dfu/qspi_xip_split_image.rst
@@ -215,10 +215,7 @@ Programming with the QSPI XIP split image
 *****************************************
 
 Programming of the application is supported using the :ref:`standard procedure <programming>`.
-The standard procedure will program the firmware using the default nrfjprog configuration which, for QSPI, is PP4IO mode.
-
-.. note::
-      |nrfjprog_deprecation_note|
+The standard procedure programs the firmware using the default nRF Util configuration, which, for QSPI, is the PP4IO mode.
 
 Programming using a different SPI mode
 ======================================
@@ -233,8 +230,8 @@ To use this file when programming, add the following lines to the application's 
 .. code-block:: cmake
 
     macro(app_set_runner_args)
-      # Replace with the filename of your ini file
-      board_runner_args(nrfjprog "--qspiini=${CMAKE_CURRENT_SOURCE_DIR}/Qspi_thingy53.ini")
+      # Replace with the filename of your json file
+      board_runner_args(nrfutil "--ext-mem-config-file=${CMAKE_CURRENT_SOURCE_DIR}/qspi_thingy53.json")
     endmacro()
 
 This will enable programming the target board successfully when using ``west flash``.


### PR DESCRIPTION
    Adds a configuration file so that this sample can be flashed on a
    thingy53 using nrfutil

Ref: NCSDK-30142


Requires that the new nrfutil flash runner parts are brought in via cherry-pick or upmerge