### PR TITLE
samples: cellular: mss: fix nrf9160 padding issue

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/sysbuild/mcuboot/boards/nrf9160dk_nrf9160.conf
+++ b/samples/cellular/nrf_cloud_multi_service/sysbuild/mcuboot/boards/nrf9160dk_nrf9160.conf
@@ -14,8 +14,8 @@ CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 CONFIG_FPROTECT=y
 
 # Enabling SPI increases the MCUBoot image size so that it does not fit in the default
-# partition size (0xC000). The minimum required size is 0xD000
-CONFIG_PM_PARTITION_SIZE_MCUBOOT=0xD000
+# partition size (0xC000). The minimum required size is 0xCE00
+CONFIG_PM_PARTITION_SIZE_MCUBOOT=0xCE00
 
 # MCUboot requires a large stack size, otherwise an MPU fault will occur
 CONFIG_MAIN_STACK_SIZE=16384


### PR DESCRIPTION
The MCUBoot partition size was incorrect for this one, resulting in a failing build.