### PR TITLE
samples: cellular: nrf_cloud_multi_service: Wi-Fi improvements

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -352,6 +352,8 @@ Cellular samples
     * An issue with an uninitialized variable in the :c:func:`handle_at_cmd_requests` function.
     * An issue with the too small :kconfig:option:`CONFIG_COAP_EXTENDED_OPTIONS_LEN_VALUE` Kconfig value
       in the :file:`overlay-coap_nrf_provisioning.conf` file.
+    * Slow Wi-Fi connectivity startup by selecting ``TFM_SFN`` instead of ``TFM_IPC``.
+    * The size of TLS credentials buffer for Wi-Fi connectivity to allow installing both AWS and CoAP CA certificates.
 
 * :ref:`lte_sensor_gateway` sample:
 

--- a/samples/cellular/nrf_cloud_multi_service/overlay_nrf700x_wifi_coap_no_lte.conf
+++ b/samples/cellular/nrf_cloud_multi_service/overlay_nrf700x_wifi_coap_no_lte.conf
@@ -44,6 +44,9 @@ CONFIG_TFM_PARTITION_PROTECTED_STORAGE=y
 ## Configure TFM Profile. The NOT_SET profile will enable all features.
 ## We then reduce some settings to save flash and RAM.
 CONFIG_TFM_PROFILE_TYPE_NOT_SET=y
+## Select SFN for faster crypto
+CONFIG_TFM_IPC=n
+CONFIG_TFM_SFN=y
 CONFIG_TFM_CRYPTO_CONC_OPER_NUM=4
 CONFIG_TFM_CRYPTO_ASYM_SIGN_MODULE_ENABLED=n
 

--- a/samples/cellular/nrf_cloud_multi_service/overlay_nrf700x_wifi_mqtt_no_lte.conf
+++ b/samples/cellular/nrf_cloud_multi_service/overlay_nrf700x_wifi_mqtt_no_lte.conf
@@ -43,6 +43,9 @@ CONFIG_TFM_PARTITION_PROTECTED_STORAGE=y
 ## Configure TFM Profile. The NOT_SET profile will enable all features.
 ## We then reduce some settings to save flash and RAM.
 CONFIG_TFM_PROFILE_TYPE_NOT_SET=y
+## Select SFN for faster crypto
+CONFIG_TFM_IPC=n
+CONFIG_TFM_SFN=y
 CONFIG_TFM_CRYPTO_CONC_OPER_NUM=4
 CONFIG_TFM_CRYPTO_ASYM_SIGN_MODULE_ENABLED=n
 
@@ -63,7 +66,7 @@ CONFIG_TLS_CREDENTIALS_BACKEND_PROTECTED_STORAGE=y
 # Increased stack size needed for wifi_cred auto_connect command
 CONFIG_SHELL_STACK_SIZE=4850
 # nRFCloud credentials can exceed 1024 bytes
-CONFIG_TLS_CREDENTIALS_SHELL_CRED_BUF_SIZE=2048
+CONFIG_TLS_CREDENTIALS_SHELL_CRED_BUF_SIZE=3072
 # Needed by the TLS credentials shell
 CONFIG_BASE64=y
 


### PR DESCRIPTION
Switch to using TFM_SFN for faster crypto.

Increase TLS credentials buffer size to 3072 to allow for both AWS and CoAP CA certs.

Jira: NCSDK-29650