### PR TITLE
driver: creating a cs multiantenna callback

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -21,6 +21,11 @@ zephyr_library_sources_ifdef(
   ecdh.c
 )
 
+zephyr_library_sources_ifdef(
+  CONFIG_BT_CHANNEL_SOUNDING
+  cs_antenna_switch.c
+)
+
 zephyr_library_link_libraries_ifdef(
   CONFIG_BT_CTLR_ECDH_LIB_OBERON
   nrfxlib_crypto

--- a/subsys/bluetooth/controller/cs_antenna_switch.c
+++ b/subsys/bluetooth/controller/cs_antenna_switch.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdint.h>
+#include "cs_antenna_switch.h"
+
+#include <hal/nrf_gpio.h>
+
+#define DEFAULT_CS_ANTENNA_GPIO_PORT NRF_P1
+#define DEFAULT_CS_ANTENNA_BASE_PIN (11)
+#define DEFAULT_CS_ANTENNA_PIN_MASK (0xF << DEFAULT_CS_ANTENNA_BASE_PIN)
+
+/* Antenna control below is implemented as described in the CS documentation.
+ * https://docs.nordicsemi.com/bundle/ncs-latest/page/nrfxlib/softdevice_controller/doc/channel_sounding.html#multiple_antennas_support
+ * The board has four antenna ports (ANT1-ANT4) that can be individually
+ * enabled by setting the connected gpio pin high, while setting the gpio
+ * pins for the other antenna ports low.
+ *
+ * Map of antenna ports to gpio pins for nrf54xDK:
+ * ANT1 <----> P1.11
+ * ANT2 <----> P1.12
+ * ANT3 <----> P1.13
+ * ANT4 <----> P1.14
+ */
+void cs_antenna_switch_func(uint8_t antenna_number)
+{
+	uint32_t out = nrf_gpio_port_out_read(DEFAULT_CS_ANTENNA_GPIO_PORT);
+
+	out &= ~DEFAULT_CS_ANTENNA_PIN_MASK;
+	out |= 1 << (DEFAULT_CS_ANTENNA_BASE_PIN + antenna_number);
+	nrf_gpio_port_out_write(DEFAULT_CS_ANTENNA_GPIO_PORT, out);
+}
+
+void cs_antenna_switch_enable(void)
+{
+	nrf_gpio_port_dir_output_set(DEFAULT_CS_ANTENNA_GPIO_PORT, DEFAULT_CS_ANTENNA_BASE_PIN);
+}

--- a/subsys/bluetooth/controller/cs_antenna_switch.h
+++ b/subsys/bluetooth/controller/cs_antenna_switch.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdint.h>
+
+/** @brief Antenna switching Callback for use in Channel Sounding.
+ *
+ *  See also @ref sdc_support_channel_sounding
+ *
+ *  @param[in] antenna_index the index of the antenna being switched to.
+ *                           Valid range [0, @ref sdc_cfg_cs_cfg_t::num_antennas_supported - 1]
+ */
+void cs_antenna_switch_func(uint8_t antenna_number);
+
+/** @brief Function to enable the pins used by antenna switching in Channel Sounding. */
+void cs_antenna_switch_enable(void);

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -31,6 +31,7 @@
 #include "hci_internal.h"
 #include "ecdh.h"
 #include "radio_nrf5_txp.h"
+#include "cs_antenna_switch.h"
 
 #define DT_DRV_COMPAT nordic_bt_hci_sdc
 
@@ -983,7 +984,16 @@ static int configure_supported_features(void)
 		if (err) {
 			return -ENOTSUP;
 		}
+#ifdef CS_ANTENNA_SWITCH_CALLBACK_TYPE_DEFINED
+#if CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS > 1
+		err = sdc_support_channel_sounding(cs_antenna_switch_func);
+		cs_antenna_switch_enable();
+#else
+		err = sdc_support_channel_sounding(NULL);
+#endif
+#else
 		err = sdc_support_channel_sounding();
+#endif
 		if (err) {
 			return -ENOTSUP;
 		}


### PR DESCRIPTION
in order to allow customers to use their own antenna switches for cs they need a way to link their antenna switching functions to the SDC.

adding the callback for the antenna switch currently supported as well as linking the new callback to the SDC.