### PR TITLE
tests: benchmarks: multicore: idle: Enable logs on app

### DIFF
--- a/tests/benchmarks/multicore/idle/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/benchmarks/multicore/idle/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,3 @@
+&uart136 {
+	disable-rx;
+};

--- a/tests/benchmarks/multicore/idle/remote/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/benchmarks/multicore/idle/remote/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,3 @@
+&uart135 {
+	status = "disabled";
+};

--- a/tests/benchmarks/multicore/idle/testcase.yaml
+++ b/tests/benchmarks/multicore/idle/testcase.yaml
@@ -86,9 +86,6 @@ tests:
       - CONFIG_PM_S2RAM=y
       - CONFIG_POWEROFF=y
       - CONFIG_PM_S2RAM_CUSTOM_MARKING=y
-      - CONFIG_CONSOLE=n
-      - CONFIG_UART_CONSOLE=n
-      - CONFIG_SERIAL=n
       - CONFIG_GPIO=n
       - CONFIG_BOOT_BANNER=n
       - remote_CONFIG_PM=y


### PR DESCRIPTION
Disable uart135 on cpurad so it can be used by scfw for debugging.

FOR TESTING PURPOSES ONLY.