### PR TITLE
suit: Allow to postpone DFU initialization

### DIFF
--- a/subsys/suit/cache/include/suit_dfu_cache_rw.h
+++ b/subsys/suit/cache/include/suit_dfu_cache_rw.h
@@ -74,6 +74,21 @@ suit_plat_err_t suit_dfu_cache_rw_slot_drop(struct suit_cache_slot *slot);
 suit_plat_err_t suit_dfu_cache_0_resize(void);
 
 /**
+ * @brief Update characteristics of NVM device unavailable at compile time
+ *
+ * For some NVM devices, especially external Flash, some characteristics
+ * like write or erase block size can be at runtime only.
+ * The same applies to memory mapping.
+ *
+ * For sake of simplicity, for devices with varying erase block size
+ * the largest erase block size is taken as reference.
+ *
+ * Functionality leaves NVM content intact.
+ *
+ */
+suit_plat_err_t suit_dfu_cache_rw_init(void);
+
+/**
  * @brief Validates content of cache partitions
  *
  * Validates content of cache partitions and erases nvm partition in case of content incoherency

--- a/subsys/suit/cache/src/suit_dfu_cache_rw.c
+++ b/subsys/suit/cache/src/suit_dfu_cache_rw.c
@@ -719,20 +719,7 @@ suit_plat_err_t suit_dfu_cache_rw_slot_drop(struct suit_cache_slot *slot)
 	return SUIT_PLAT_ERR_INVAL;
 }
 
-/**
- * @brief Update characteristics of NVM device unavailable at compile time
- *
- * For some NVM devices, especially external Flash, some characteristics
- * like write or erase block size can be at runtime only.
- * The same applies to memory mapping.
- *
- * For sake of simplicity, for devices with varying erase block size
- * the largest erase block size is taken as reference.
- *
- * Functionality leaves NVM content intact.
- *
- */
-static int preinitialize(void)
+int suit_dfu_cache_rw_init(void)
 {
 	for (size_t i = 1; i < ARRAY_SIZE(dfu_partitions_ext); i++) {
 
@@ -806,5 +793,3 @@ static int preinitialize(void)
 	}
 	return 0;
 }
-
-SYS_INIT(preinitialize, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/subsys/suit/orchestrator_app/src/suit_orchestrator_app.c
+++ b/subsys/suit/orchestrator_app/src/suit_orchestrator_app.c
@@ -78,6 +78,10 @@ int suit_dfu_initialize(void)
 	LOG_INF("DFU partition detected, addr: %p, size %d bytes",
 		(void *)device_info.mapped_address, device_info.partition_size);
 
+#if CONFIG_SUIT_CACHE_RW
+	suit_dfu_cache_rw_init();
+#endif /* CONFIG_SUIT_CACHE_RW */
+
 #if CONFIG_SUIT_CLEANUP_ON_INIT
 	suit_dfu_cleanup();
 

--- a/tests/subsys/suit/cache_pool_digest/src/main.c
+++ b/tests/subsys/suit/cache_pool_digest/src/main.c
@@ -53,6 +53,14 @@ FAKE_VALUE_FUNC(int, suit_plat_authorize_unsigned_manifest, struct zcbor_string 
 FAKE_VALUE_FUNC(int, suit_plat_authenticate_manifest, struct zcbor_string *, enum suit_cose_alg,
 		struct zcbor_string *, struct zcbor_string *, struct zcbor_string *);
 
+static void test_before(void *data)
+{
+	suit_plat_err_t plat_ret = suit_dfu_cache_rw_init();
+
+	zassert_equal(plat_ret, SUIT_PLAT_SUCCESS,
+		      "Unable to initialize DFU cache module before test execution: %d", plat_ret);
+}
+
 void clear_dfu_test_partitions(void *f)
 {
 	/* Erase the area, to meet the preconditions in the next test. */
@@ -71,7 +79,7 @@ void clear_dfu_test_partitions(void *f)
 	zassert_equal(rc, 0, "Unable to erase dfu_cache_partition_3 before test execution: %i", rc);
 }
 
-ZTEST_SUITE(cache_pool_digest_tests, NULL, NULL, NULL, clear_dfu_test_partitions, NULL);
+ZTEST_SUITE(cache_pool_digest_tests, NULL, NULL, test_before, clear_dfu_test_partitions, NULL);
 
 ZTEST(cache_pool_digest_tests, test_cache_get_slot_ok)
 {

--- a/tests/subsys/suit/cache_sink/src/main.c
+++ b/tests/subsys/suit/cache_sink/src/main.c
@@ -120,6 +120,14 @@ void setup_dfu_test_corrupted_cache(const uint8_t *corrupted_cache, size_t corru
 	zassert_equal(res, 0, "Mem compare after write failed");
 }
 
+static void test_before(void *data)
+{
+	suit_plat_err_t plat_ret = suit_dfu_cache_rw_init();
+
+	zassert_equal(plat_ret, SUIT_PLAT_SUCCESS,
+		      "Unable to initialize DFU cache module before test execution: %d", plat_ret);
+}
+
 void clear_dfu_test_partitions(void *f)
 {
 	/* Erase the area, to meet the preconditions in the next test. */
@@ -153,9 +161,10 @@ bool is_cache_partition_1_empty(void)
 	return true;
 }
 
-ZTEST_SUITE(cache_rw_initialization_tests, NULL, NULL, NULL, clear_dfu_test_partitions, NULL);
+ZTEST_SUITE(cache_rw_initialization_tests, NULL, NULL, test_before, clear_dfu_test_partitions,
+	    NULL);
 
-ZTEST_SUITE(cache_sink_recovery_tests, NULL, NULL, NULL, clear_dfu_test_partitions, NULL);
+ZTEST_SUITE(cache_sink_recovery_tests, NULL, NULL, test_before, clear_dfu_test_partitions, NULL);
 
 ZTEST(cache_sink_recovery_tests, test_cache_recovery_header_ok_size_nok)
 {
@@ -192,7 +201,7 @@ ZTEST(cache_sink_recovery_tests, test_cache_recovery_malformed_zcbor)
 	zassert_true(is_cache_partition_1_empty(), "Corrupted cache partition was not recovered");
 }
 
-ZTEST_SUITE(cache_sink_tests, NULL, NULL, NULL, clear_dfu_test_partitions, NULL);
+ZTEST_SUITE(cache_sink_tests, NULL, NULL, test_before, clear_dfu_test_partitions, NULL);
 
 ZTEST(cache_sink_tests, test_cache_drop_slot_ok)
 {


### PR DESCRIPTION
Add a possibility to initialize DFU partition later than at the system initialization phase.

Ref: NCSDK-NONE