### PR TITLE
bluetooth: samples: Reduce RAS sample memory usage

### DIFF
--- a/samples/bluetooth/channel_sounding_ras_initiator/prj.conf
+++ b/samples/bluetooth/channel_sounding_ras_initiator/prj.conf
@@ -31,6 +31,20 @@ CONFIG_BT_BUF_ACL_RX_SIZE=502
 CONFIG_BT_ATT_PREPARE_COUNT=3
 CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
 
+# This reduces RAM usage. Additional RAM is needed to support optional
+# features such as mode 3 or multiantenna. Change or remove these if
+# using those features
+CONFIG_BT_RAS_MODE_3_SUPPORTED=n
+CONFIG_BT_RAS_MAX_ANTENNA_PATHS=1
+CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS=1
+CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS=1
+CONFIG_BT_CTLR_SDC_CS_STEP_MODE3=n
+
+# This size assumes the largest step size is mode 2 with one antenna path:
+# 12 bytes * 160 steps in a subevent. Change or remove this if using mode 3
+# or multiantenna.
+CONFIG_BT_CHANNEL_SOUNDING_REASSEMBLY_BUFFER_SIZE=1920
+
 # This allows CS and ACL to use different PHYs
 CONFIG_BT_TRANSMIT_POWER_CONTROL=y
 

--- a/samples/bluetooth/channel_sounding_ras_reflector/prj.conf
+++ b/samples/bluetooth/channel_sounding_ras_reflector/prj.conf
@@ -22,6 +22,20 @@ CONFIG_BT_BUF_ACL_RX_SIZE=502
 CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
 CONFIG_BT_CTLR_PHY_2M=y
 
+# This reduces RAM usage. Additional RAM is needed to support optional
+# features such as mode 3 or multiantenna. Change or remove these if
+# using those features
+CONFIG_BT_RAS_MODE_3_SUPPORTED=n
+CONFIG_BT_RAS_MAX_ANTENNA_PATHS=1
+CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS=1
+CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS=1
+CONFIG_BT_CTLR_SDC_CS_STEP_MODE3=n
+
+# This size assumes the largest step size is mode 2 with one antenna path:
+# 12 bytes * 160 steps in a subevent. Change or remove this if using mode 3
+# or multiantenna.
+CONFIG_BT_CHANNEL_SOUNDING_REASSEMBLY_BUFFER_SIZE=1920
+
 # This allows CS and ACL to use different PHYs
 CONFIG_BT_TRANSMIT_POWER_CONTROL=y
 


### PR DESCRIPTION
Reduce ranging profile samples' RAM based what CS
capabilities are used in the sample parameters.

Please read the RREQ and RRSP docs for more information about how
to configure these.
