### PR TITLE
manifest: update sdk-zephyr, enable WDT test on nRF5340dk

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -70,7 +70,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: bf64a318c900f2cf9b97e0df5bb813d47b398654
+      revision: 776b31e3ebc43993e2e7c2043a2bf1a5beb37815
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Include:
tests: drivers: watchodg: Enable wdt_error_cases on nRF5340dk
https://github.com/nrfconnect/sdk-zephyr/pull/2483
https://github.com/zephyrproject-rtos/zephyr/pull/85575