### PR TITLE
applications: nrf_desktop: Enable LTO

### DIFF
--- a/applications/nrf_desktop/Kconfig.defaults
+++ b/applications/nrf_desktop/Kconfig.defaults
@@ -21,3 +21,13 @@ choice LIBC_IMPLEMENTATION
 	help
 	  Use minimal libc implementation to reduce memory footprint.
 endchoice
+
+config LTO
+	default y
+	help
+	  nRF Desktop enables LTO to limit memory usage and improve performance.
+
+config ISR_TABLES_LOCAL_DECLARATION
+	default y
+	help
+	  nRF Desktop enables LTO to limit memory usage and improve performance.

--- a/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/images/mcuboot/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/images/mcuboot/prj_release.conf
@@ -58,5 +58,9 @@ CONFIG_BOOT_SERIAL_IMG_GRP_HASH=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/images/mcuboot/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/images/mcuboot/prj_release.conf
@@ -62,5 +62,9 @@ CONFIG_BOOT_SERIAL_IMG_GRP_HASH=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/images/mcuboot/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/images/mcuboot/prj.conf
@@ -60,5 +60,9 @@ CONFIG_NCS_BOOT_BANNER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/images/mcuboot/prj_dongle_small.conf
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/images/mcuboot/prj_dongle_small.conf
@@ -57,5 +57,9 @@ CONFIG_NCS_BOOT_BANNER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/images/mcuboot/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/images/mcuboot/prj_release.conf
@@ -57,5 +57,9 @@ CONFIG_NCS_BOOT_BANNER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/images/mcuboot/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/images/mcuboot/prj.conf
@@ -60,5 +60,9 @@ CONFIG_NCS_BOOT_BANNER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/images/mcuboot/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/images/mcuboot/prj_release.conf
@@ -56,5 +56,9 @@ CONFIG_NCS_BOOT_BANNER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/b0/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/b0/prj.conf
@@ -39,5 +39,9 @@ CONFIG_LOG=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/b0/prj_dongle.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/b0/prj_dongle.conf
@@ -39,5 +39,9 @@ CONFIG_LOG=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/b0/prj_keyboard.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/b0/prj_keyboard.conf
@@ -39,5 +39,9 @@ CONFIG_LOG=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/b0/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/b0/prj_release.conf
@@ -39,5 +39,9 @@ CONFIG_LOG=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/b0/prj_wwcb.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/b0/prj_wwcb.conf
@@ -39,5 +39,9 @@ CONFIG_LOG=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_fast_pair.conf
@@ -34,5 +34,9 @@ CONFIG_NORDIC_QSPI_NOR=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_mcuboot_qspi.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_mcuboot_qspi.conf
@@ -46,5 +46,9 @@ CONFIG_NCS_BOOT_BANNER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Disable Link Time Optimization (LTO). LTO causes application boot failures.
+CONFIG_LTO=n
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=n
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_mcuboot_smp.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_mcuboot_smp.conf
@@ -33,5 +33,9 @@ CONFIG_NCS_BOOT_BANNER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/images/b0/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/images/b0/prj.conf
@@ -45,5 +45,9 @@ CONFIG_BOARD_HAS_NRF5_BOOTLOADER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/images/b0/prj_3bleconn.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/images/b0/prj_3bleconn.conf
@@ -45,5 +45,9 @@ CONFIG_BOARD_HAS_NRF5_BOOTLOADER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/images/b0/prj_4llpmconn.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/images/b0/prj_4llpmconn.conf
@@ -45,5 +45,9 @@ CONFIG_BOARD_HAS_NRF5_BOOTLOADER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/images/b0/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/images/b0/prj_release.conf
@@ -45,5 +45,9 @@ CONFIG_BOARD_HAS_NRF5_BOOTLOADER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/images/b0/prj_release_4llpmconn.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/images/b0/prj_release_4llpmconn.conf
@@ -45,5 +45,9 @@ CONFIG_BOARD_HAS_NRF5_BOOTLOADER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/images/b0/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/images/b0/prj.conf
@@ -46,5 +46,9 @@ CONFIG_USB_DEVICE_DRIVER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/images/b0/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/images/b0/prj_release.conf
@@ -45,5 +45,9 @@ CONFIG_USB_DEVICE_DRIVER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/images/mcuboot/prj_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/images/mcuboot/prj_fast_pair.conf
@@ -35,5 +35,9 @@ CONFIG_USB_DEVICE_DRIVER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/images/mcuboot/prj_mcuboot_smp.conf
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/images/mcuboot/prj_mcuboot_smp.conf
@@ -40,5 +40,9 @@ CONFIG_USB_DEVICE_DRIVER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/images/mcuboot/prj_release_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/images/mcuboot/prj_release_fast_pair.conf
@@ -35,5 +35,9 @@ CONFIG_NCS_BOOT_BANNER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/images/b0/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/images/b0/prj_release.conf
@@ -39,5 +39,9 @@ CONFIG_LOG=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/images/mcuboot/prj_release_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/images/mcuboot/prj_release_fast_pair.conf
@@ -28,5 +28,9 @@ CONFIG_NCS_BOOT_BANNER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpuapp/images/b0/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpuapp/images/b0/prj.conf
@@ -39,6 +39,10 @@ CONFIG_LOG=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # The anomaly 160 workaround is not needed for the bootloader.
 CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED=n
 

--- a/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpuapp/images/b0/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpuapp/images/b0/prj_release.conf
@@ -39,6 +39,10 @@ CONFIG_LOG=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # The anomaly 160 workaround is not needed for the bootloader.
 CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED=n
 

--- a/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpunet/images/ipc_radio/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpunet/images/ipc_radio/prj.conf
@@ -33,6 +33,10 @@ CONFIG_ASSERT=y
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n
 

--- a/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpunet/images/ipc_radio/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpunet/images/ipc_radio/prj_release.conf
@@ -31,6 +31,10 @@ CONFIG_BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT=3000
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 # Improve firmware reliability
 CONFIG_RESET_ON_FATAL_ERROR=y
 

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpurad/images/ipc_radio/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpurad/images/ipc_radio/prj.conf
@@ -40,6 +40,10 @@ CONFIG_RESET_ON_FATAL_ERROR=n
 
 CONFIG_SPEED_OPTIMIZATIONS=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 ################################################################################
 # Debug logs
 

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpurad/images/ipc_radio/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpurad/images/ipc_radio/prj_release.conf
@@ -37,6 +37,10 @@ CONFIG_RESET_ON_FATAL_ERROR=y
 
 CONFIG_SPEED_OPTIMIZATIONS=y
 
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
 ################################################################################
 # Disable unused features
 

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/images/mcuboot/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/images/mcuboot/prj_release.conf
@@ -37,6 +37,6 @@ CONFIG_USE_SEGGER_RTT=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Activate LTO
+# Activate Link Time Optimization (LTO)
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/images/mcuboot/prj_release_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/images/mcuboot/prj_release_fast_pair.conf
@@ -37,6 +37,6 @@ CONFIG_USE_SEGGER_RTT=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Activate LTO
+# Activate Link Time Optimization (LTO)
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/images/mcuboot/prj_release_keyboard.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/images/mcuboot/prj_release_keyboard.conf
@@ -37,6 +37,6 @@ CONFIG_USE_SEGGER_RTT=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Activate LTO
+# Activate Link Time Optimization (LTO)
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/images/mcuboot/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/images/mcuboot/prj.conf
@@ -34,9 +34,9 @@ CONFIG_USE_SEGGER_RTT=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Improve debugging experience by disabling reset on fatal error
-CONFIG_RESET_ON_FATAL_ERROR=n
-
-# Activate LTO
+# Activate Link Time Optimization (LTO)
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
+# Improve debugging experience by disabling reset on fatal error
+CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/images/mcuboot/prj_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/images/mcuboot/prj_fast_pair.conf
@@ -35,9 +35,9 @@ CONFIG_USE_SEGGER_RTT=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Improve debugging experience by disabling reset on fatal error
-CONFIG_RESET_ON_FATAL_ERROR=n
-
-# Activate LTO
+# Activate Link Time Optimization (LTO)
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
+# Improve debugging experience by disabling reset on fatal error
+CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/images/mcuboot/prj_keyboard.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/images/mcuboot/prj_keyboard.conf
@@ -35,9 +35,9 @@ CONFIG_USE_SEGGER_RTT=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Improve debugging experience by disabling reset on fatal error
-CONFIG_RESET_ON_FATAL_ERROR=n
-
-# Activate LTO
+# Activate Link Time Optimization (LTO)
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
+# Improve debugging experience by disabling reset on fatal error
+CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/images/mcuboot/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/images/mcuboot/prj_release.conf
@@ -37,6 +37,6 @@ CONFIG_USE_SEGGER_RTT=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Activate LTO
+# Activate Link Time Optimization (LTO)
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/images/mcuboot/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/images/mcuboot/prj.conf
@@ -34,9 +34,9 @@ CONFIG_USE_SEGGER_RTT=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Improve debugging experience by disabling reset on fatal error
-CONFIG_RESET_ON_FATAL_ERROR=n
-
-# Activate LTO
+# Activate Link Time Optimization (LTO)
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
+# Improve debugging experience by disabling reset on fatal error
+CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/images/mcuboot/prj_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/images/mcuboot/prj_fast_pair.conf
@@ -35,9 +35,9 @@ CONFIG_USE_SEGGER_RTT=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Improve debugging experience by disabling reset on fatal error
-CONFIG_RESET_ON_FATAL_ERROR=n
-
-# Activate LTO
+# Activate Link Time Optimization (LTO)
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
+# Improve debugging experience by disabling reset on fatal error
+CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/images/mcuboot/prj_keyboard.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/images/mcuboot/prj_keyboard.conf
@@ -35,9 +35,9 @@ CONFIG_USE_SEGGER_RTT=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Improve debugging experience by disabling reset on fatal error
-CONFIG_RESET_ON_FATAL_ERROR=n
-
-# Activate LTO
+# Activate Link Time Optimization (LTO)
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+
+# Improve debugging experience by disabling reset on fatal error
+CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/images/mcuboot/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/images/mcuboot/prj_release.conf
@@ -37,6 +37,6 @@ CONFIG_USE_SEGGER_RTT=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Activate LTO
+# Activate Link Time Optimization (LTO)
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -233,6 +233,8 @@ nRF Desktop
   * The :ref:`nrf_desktop_failsafe` to use the Zephyr :ref:`zephyr:hwinfo_api` driver for getting and clearing the reset reason information (see the :c:func:`hwinfo_get_reset_cause` and :c:func:`hwinfo_clear_reset_cause` functions).
     The Zephyr :ref:`zephyr:hwinfo_api` driver replaces the dependency on the nrfx reset reason helper (see the :c:func:`nrfx_reset_reason_get` and :c:func:`nrfx_reset_reason_clear` functions).
   * The release configuration for the :ref:`zephyr:nrf54h20dk_nrf54h20` board target to enable the :ref:`nrf_desktop_failsafe` (see the :ref:`CONFIG_DESKTOP_FAILSAFE_ENABLE <config_desktop_app_options>` Kconfig option).
+  * Enabled Link Time Optimization (:kconfig:option:`CONFIG_LTO` and :kconfig:option:`CONFIG_ISR_TABLES_LOCAL_DECLARATION`) by default for an nRF Desktop application image.
+    LTO was also explicitly enabled in configurations of other images built by sysbuild (bootloader, network core image).
 
 * Added:
 


### PR DESCRIPTION
Change enables the Link Time Optimization (LTO) by default for nRF Desktop application image and sysbuild images to limit memory usage and improve performance.

Jira: NCSDK-26866