### PR TITLE
applications: sdp: mspi: use enum instead of pointer to function in HRT

### DIFF
--- a/applications/sdp/mspi/src/hrt/hrt-nrf54l15.s
+++ b/applications/sdp/mspi/src/hrt/hrt-nrf54l15.s
@@ -9,157 +9,157 @@
 	.type	hrt_tx, @function
 hrt_tx:
 	lw	a5,4(a0)
-	beq	a5,zero,.L16
-	addi	sp,sp,-32
-	sw	s1,20(sp)
+	addi	sp,sp,-20
+	sw	s0,16(sp)
+	sw	s1,12(sp)
+	sw	a2,0(sp)
+	sw	a3,8(sp)
+	beq	a5,zero,.L1
 	li	a4,32
-	mv	s1,a1
-	div	a4,a4,s1
-	lui	t1,%hi(xfer_shift_ctrl)
-	sw	s0,24(sp)
-	sw	ra,28(sp)
-	addi	a1,t1,%lo(xfer_shift_ctrl)
-	lbu	t0,2(a1)
-	lbu	a5,1(a1)
-	sb	s1,2(a1)
-	lbu	a1,3(a1)
-	mv	s0,a0
+	div	a4,a4,a1
+	lui	t0,%hi(xfer_shift_ctrl)
+	addi	a3,t0,%lo(xfer_shift_ctrl)
+	lbu	s0,2(a3)
+	lbu	a5,1(a3)
+	sb	a1,2(a3)
+	lbu	a3,3(a3)
+	li	a2,3145728
 	slli	a5,a5,8
-	li	a0,3145728
-	slli	a1,a1,20
-	and	a1,a1,a0
+	slli	a3,a3,20
+	and	a3,a3,a2
 	andi	a5,a5,1792
-	or	a5,a5,a1
-	li	a0,126976
-	slli	a1,s1,12
-	and	a1,a1,a0
-	or	a5,a5,a1
+	or	a5,a5,a3
+	li	a2,126976
+	slli	a3,a1,12
+	and	a3,a3,a2
+	or	a5,a5,a3
 	addi	a4,a4,-1
 	andi	a4,a4,0xff
-	sb	a4,%lo(xfer_shift_ctrl)(t1)
+	sb	a4,%lo(xfer_shift_ctrl)(t0)
 	andi	a4,a4,63
 	or	a5,a5,a4
  #APP
 	csrw 3019, a5
  #NO_APP
 	li	a4,2031616
-	slli	a5,s1,16
+	slli	a5,a1,16
 	and	a5,a5,a4
 	ori	a5,a5,4
-	sw	a5,0(sp)
-	li	a1,0
+	sw	a5,4(sp)
+	li	a2,0
+	li	t2,1
+	addi	t1,t0,%lo(xfer_shift_ctrl)
 .L3:
-	lw	a5,4(s0)
-	bltu	a1,a5,.L11
-	lw	ra,28(sp)
-	lw	s0,24(sp)
-	lw	s1,20(sp)
-	addi	sp,sp,32
+	lw	a5,4(a0)
+	bltu	a2,a5,.L13
+.L1:
+	lw	s0,16(sp)
+	lw	s1,12(sp)
+	addi	sp,sp,20
 	jr	ra
-.L11:
-	lw	a5,4(s0)
-	li	a4,1
-	sub	a5,a5,a1
-	beq	a5,a4,.L4
+.L13:
+	lw	a5,4(a0)
+	sub	a5,a5,a2
+	beq	a5,t2,.L4
 	li	a4,2
 	beq	a5,a4,.L5
 .L6:
-	lw	a5,0(s0)
-	li	a0,0
-	beq	a5,zero,.L7
-	lw	a5,0(s0)
-	slli	a4,a1,2
+	lw	a4,0(a0)
+	li	a5,0
+	beq	a4,zero,.L7
+	lw	a5,0(a0)
+	slli	a4,a2,2
 	add	a5,a5,a4
-	lw	a0,0(a5)
+	lw	a5,0(a5)
 	j	.L7
 .L4:
-	addi	t2,t1,%lo(xfer_shift_ctrl)
-	lbu	a0,1(t2)
-	lbu	a5,2(t2)
-	li	ra,126976
-	slli	a0,a0,8
+	lbu	a3,1(t1)
+	lbu	a5,2(t1)
+	li	s1,126976
+	slli	a3,a3,8
 	slli	a5,a5,12
-	andi	a0,a0,1792
-	and	a5,a5,ra
-	lbu	a4,8(s0)
-	or	a5,a0,a5
-	lbu	a0,3(t2)
+	and	a5,a5,s1
+	andi	a3,a3,1792
+	or	a3,a3,a5
+	lbu	a4,8(a0)
+	lbu	a5,3(t1)
+	li	s1,3145728
 	addi	a4,a4,-1
-	li	t2,3145728
-	slli	a0,a0,20
+	slli	a5,a5,20
 	andi	a4,a4,0xff
-	and	a0,a0,t2
-	sb	a4,%lo(xfer_shift_ctrl)(t1)
-	or	a5,a5,a0
+	and	a5,a5,s1
+	sb	a4,%lo(xfer_shift_ctrl)(t0)
+	or	a5,a3,a5
 	andi	a4,a4,63
 	or	a5,a5,a4
  #APP
 	csrw 3019, a5
  #NO_APP
-	lw	a0,12(s0)
+	lw	a5,12(a0)
 .L7:
-	beq	s1,t0,.L8
+	beq	a1,s0,.L8
 .L9:
  #APP
-	csrr a5, 3022
+	csrr a4, 3022
  #NO_APP
-	andi	a5,a5,0xff
-	bne	a5,zero,.L9
-	lw	a5,0(sp)
+	andi	a4,a4,0xff
+	bne	a4,zero,.L9
+	lw	a4,4(sp)
  #APP
-	csrw 3043, a5
+	csrw 3043, a4
  #NO_APP
-	mv	t0,s1
+	mv	s0,a1
 .L8:
-	lw	a5,16(s0)
-	sw	a3,16(sp)
-	sw	a2,12(sp)
-	sw	t0,8(sp)
-	sw	a1,4(sp)
-	jalr	a5
-	lw	a1,4(sp)
-	lw	t0,8(sp)
-	lw	a2,12(sp)
-	lw	a3,16(sp)
-	lui	t1,%hi(xfer_shift_ctrl)
-	bne	a1,zero,.L10
-	lbu	a5,0(a2)
-	bne	a5,zero,.L10
+	lbu	a4,16(a0)
+	andi	a3,a4,0xff
+	beq	a4,zero,.L10
+	bne	a3,t2,.L11
  #APP
-	csrw 2005, a3
+	csrw 3017, a5
  #NO_APP
-	li	a5,1
-	sb	a5,0(a2)
-.L10:
-	addi	a1,a1,1
+.L11:
+	bne	a2,zero,.L12
+	lw	a5,0(sp)
+	lbu	a5,0(a5)
+	bne	a5,zero,.L12
+	lw	a5,8(sp)
+ #APP
+	csrw 2005, a5
+ #NO_APP
+	lw	a5,0(sp)
+	sb	t2,0(a5)
+.L12:
+	addi	a2,a2,1
 	j	.L3
 .L5:
-	addi	t2,t1,%lo(xfer_shift_ctrl)
-	lbu	a0,1(t2)
-	lbu	a5,2(t2)
-	li	ra,126976
-	slli	a0,a0,8
+	lbu	a3,1(t1)
+	lbu	a5,2(t1)
+	li	s1,126976
+	slli	a3,a3,8
 	slli	a5,a5,12
-	andi	a0,a0,1792
-	and	a5,a5,ra
-	lbu	a4,9(s0)
-	or	a5,a0,a5
-	lbu	a0,3(t2)
+	and	a5,a5,s1
+	andi	a3,a3,1792
+	or	a3,a3,a5
+	lbu	a4,9(a0)
+	lbu	a5,3(t1)
+	li	s1,3145728
 	addi	a4,a4,-1
-	li	t2,3145728
-	slli	a0,a0,20
+	slli	a5,a5,20
 	andi	a4,a4,0xff
-	and	a0,a0,t2
-	sb	a4,%lo(xfer_shift_ctrl)(t1)
-	or	a5,a5,a0
+	and	a5,a5,s1
+	sb	a4,%lo(xfer_shift_ctrl)(t0)
+	or	a5,a3,a5
 	andi	a4,a4,63
 	or	a5,a5,a4
  #APP
 	csrw 3019, a5
  #NO_APP
 	j	.L6
-.L16:
-	ret
+.L10:
+ #APP
+	csrw 3016, a5
+ #NO_APP
+	j	.L11
 	.size	hrt_tx, .-hrt_tx
 	.section	.text.hrt_tx_rx.constprop.0,"ax",@progbits
 	.align	1
@@ -167,60 +167,57 @@ hrt_tx:
 hrt_tx_rx.constprop.0:
 	lw	a5,0(a0)
 	lw	a4,4(a0)
-	beq	a4,zero,.L30
-	li	a4,126976
+	beq	a4,zero,.L18
+	lw	a4,0(a5)
 	slli	a1,a1,12
-	addi	sp,sp,-24
-	and	a1,a1,a4
-	li	a4,2097152
-	sw	s0,16(sp)
-	sw	ra,20(sp)
-	sw	s1,12(sp)
-	addi	a4,a4,1031
-	mv	s0,a0
-	lw	a5,0(a5)
-	or	a1,a1,a4
+	li	a5,126976
+	and	a1,a1,a5
+	li	a5,2097152
+	addi	a5,a5,1031
+	or	a1,a1,a5
  #APP
 	csrw 3019, a1
  #NO_APP
-	li	s1,0
-.L21:
-	lw	a4,4(s0)
-	bltu	s1,a4,.L24
-	lw	ra,20(sp)
-	lw	s0,16(sp)
-	lw	s1,12(sp)
-	addi	sp,sp,24
-	jr	ra
-.L24:
-	lw	a4,16(s0)
-	li	a0,-16777216
-	and	a0,a5,a0
-	sw	a3,8(sp)
-	sw	a2,4(sp)
-	sw	a5,0(sp)
-	jalr	a4
-	lw	a5,0(sp)
-	lw	a2,4(sp)
-	lw	a3,8(sp)
-	slli	a5,a5,8
-	bne	s1,zero,.L22
-	beq	a2,zero,.L22
-	li	a4,65536
-	add	a4,a3,a4
- #APP
-	csrw 2002, a4
- #NO_APP
-.L23:
-	addi	s1,s1,1
-	j	.L21
-.L22:
- #APP
-	csrr a4, 3018
- #NO_APP
-	j	.L23
-.L30:
+	li	t1,65536
+	li	a5,0
+	li	a1,-16777216
+	li	t0,1
+	add	a3,a3,t1
+.L20:
+	lw	t1,4(a0)
+	bltu	a5,t1,.L25
+.L18:
 	ret
+.L25:
+	lbu	t1,16(a0)
+	andi	t2,t1,0xff
+	beq	t1,zero,.L21
+	bne	t2,t0,.L22
+	and	t1,a4,a1
+ #APP
+	csrw 3017, t1
+ #NO_APP
+.L22:
+	slli	a4,a4,8
+	bne	a5,zero,.L23
+	beq	a2,zero,.L23
+ #APP
+	csrw 2002, a3
+ #NO_APP
+.L24:
+	addi	a5,a5,1
+	j	.L20
+.L21:
+	and	t1,a4,a1
+ #APP
+	csrw 3016, t1
+ #NO_APP
+	j	.L22
+.L23:
+ #APP
+	csrr t1, 3018
+ #NO_APP
+	j	.L24
 	.size	hrt_tx_rx.constprop.0, .-hrt_tx_rx.constprop.0
 	.section	.text.hrt_write,"ax",@progbits
 	.align	1
@@ -239,23 +236,23 @@ hrt_write:
 	li	a5,0
 	addi	a4,a0,4
 	li	a3,4
-.L35:
+.L32:
 	lw	a2,0(a4)
-	bne	a2,zero,.L34
+	bne	a2,zero,.L31
 	addi	a5,a5,1
 	andi	a5,a5,0xff
 	addi	a4,a4,20
-	bne	a5,a3,.L35
+	bne	a5,a3,.L32
 	li	a5,3
-.L34:
+.L31:
 	li	a4,1
-	beq	a5,a4,.L36
+	beq	a5,a4,.L33
 	li	a4,3
-	beq	a5,a4,.L37
+	beq	a5,a4,.L34
 	li	a4,0
-	bne	a5,zero,.L38
+	bne	a5,zero,.L35
 	lbu	a4,80(s0)
-.L38:
+.L35:
 	lui	a3,%hi(xfer_shift_ctrl+2)
 	sb	a4,%lo(xfer_shift_ctrl+2)(a3)
  #APP
@@ -284,21 +281,21 @@ hrt_write:
 	li	a2,1
 	add	a5,s0,a5
 	lw	a3,4(a5)
-	beq	a3,a2,.L39
+	beq	a3,a2,.L36
 	li	a2,2
-	beq	a3,a2,.L40
+	beq	a3,a2,.L37
 	li	a5,32
 	div	a5,a5,a4
-	j	.L56
-.L36:
+	j	.L53
+.L33:
 	lbu	a4,81(s0)
-	j	.L38
-.L37:
+	j	.L35
+.L34:
 	lbu	a4,83(s0)
-	j	.L38
-.L39:
+	j	.L35
+.L36:
 	lbu	a5,8(a5)
-.L56:
+.L53:
  #APP
 	csrw 3022, a5
  #NO_APP
@@ -308,11 +305,11 @@ hrt_write:
 	lbu	a4,89(s0)
 	slli	a5,a5,16
 	srli	a5,a5,16
-	bne	a4,zero,.L43
+	bne	a4,zero,.L40
  #APP
 	csrc 3008, a5
  #NO_APP
-.L44:
+.L41:
 	lhu	a3,84(s0)
 	lbu	a1,80(s0)
 	addi	a2,sp,3
@@ -334,7 +331,7 @@ hrt_write:
 	addi	a0,s0,60
 	call	hrt_tx
 	lbu	a5,94(s0)
-	bne	a5,zero,.L45
+	bne	a5,zero,.L42
 	li	a5,16384
 	addi	a5,a5,1
  #APP
@@ -342,41 +339,41 @@ hrt_write:
 	csrw 3017, 0
 	csrw 2000, 0
  #NO_APP
-.L46:
+.L43:
  #APP
 	csrw 2005, 0
  #NO_APP
 	lbu	a5,88(s0)
-	bne	a5,zero,.L33
+	bne	a5,zero,.L30
 	lbu	a4,87(s0)
 	li	a5,1
 	sll	a5,a5,a4
 	lbu	a4,89(s0)
 	slli	a5,a5,16
 	srli	a5,a5,16
-	bne	a4,zero,.L49
+	bne	a4,zero,.L46
  #APP
 	csrs 3008, a5
  #NO_APP
-.L33:
+.L30:
 	lw	ra,12(sp)
 	lw	s0,8(sp)
 	addi	sp,sp,16
 	jr	ra
-.L40:
+.L37:
 	lbu	a5,9(a5)
-	j	.L56
-.L43:
+	j	.L53
+.L40:
  #APP
 	csrs 3008, a5
  #NO_APP
-	j	.L44
-.L45:
+	j	.L41
+.L42:
  #APP
 	csrr a5, 3022
  #NO_APP
 	andi	a5,a5,0xff
-	bne	a5,zero,.L45
+	bne	a5,zero,.L42
  #APP
 	csrw 2000, 0
  #NO_APP
@@ -387,7 +384,7 @@ hrt_write:
  #NO_APP
 	lbu	a5,94(s0)
 	li	a4,1
-	bne	a5,a4,.L47
+	bne	a5,a4,.L44
 	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
@@ -395,10 +392,10 @@ hrt_write:
  #APP
 	csrc 3008, a5
  #NO_APP
-	j	.L46
-.L47:
+	j	.L43
+.L44:
 	li	a3,3
-	bne	a5,a3,.L46
+	bne	a5,a3,.L43
 	lbu	a5,86(s0)
 	sll	a4,a4,a5
 	slli	a4,a4,16
@@ -406,12 +403,12 @@ hrt_write:
  #APP
 	csrs 3008, a4
  #NO_APP
-	j	.L46
-.L49:
+	j	.L43
+.L46:
  #APP
 	csrc 3008, a5
  #NO_APP
-	j	.L33
+	j	.L30
 	.size	hrt_write, .-hrt_write
 	.section	.text.hrt_read,"ax",@progbits
 	.align	1
@@ -424,7 +421,7 @@ hrt_read:
 	lbu	a5,89(a0)
 	lbu	a4,87(a0)
 	mv	s0,a0
-	bne	a5,zero,.L58
+	bne	a5,zero,.L55
 	li	a5,1
 	sll	a5,a5,a4
 	slli	a5,a5,16
@@ -432,7 +429,7 @@ hrt_read:
  #APP
 	csrc 3008, a5
  #NO_APP
-.L59:
+.L56:
 	lhu	a5,90(s0)
 	slli	a5,a5,16
 	srli	a5,a5,16
@@ -491,19 +488,19 @@ hrt_read:
 	addi	a0,s0,20
 	call	hrt_tx_rx.constprop.0
 	li	a5,0
-.L60:
+.L57:
 	lw	a4,64(s0)
-	bltu	a5,a4,.L61
+	bltu	a5,a4,.L58
  #APP
 	csrw 2000, 0
 	csrw 2001, 0
 	csrw 3019, 0
  #NO_APP
 	lbu	a5,88(s0)
-	bne	a5,zero,.L62
+	bne	a5,zero,.L59
 	lbu	a5,89(s0)
 	lbu	a4,87(s0)
-	bne	a5,zero,.L63
+	bne	a5,zero,.L60
 	li	a5,1
 	sll	a5,a5,a4
 	slli	a5,a5,16
@@ -511,7 +508,7 @@ hrt_read:
  #APP
 	csrs 3008, a5
  #NO_APP
-.L62:
+.L59:
 	lhu	a5,90(s0)
 	ori	a5,a5,4
 	sh	a5,90(s0)
@@ -523,7 +520,7 @@ hrt_read:
 	lw	s0,4(sp)
 	addi	sp,sp,12
 	jr	ra
-.L58:
+.L55:
 	li	a5,1
 	sll	a5,a5,a4
 	slli	a5,a5,16
@@ -531,8 +528,8 @@ hrt_read:
  #APP
 	csrs 3008, a5
  #NO_APP
-	j	.L59
-.L61:
+	j	.L56
+.L58:
  #APP
 	csrr a3, 3018
  #NO_APP
@@ -542,8 +539,8 @@ hrt_read:
 	addi	a5,a5,1
 	sb	a3,0(a4)
 	andi	a5,a5,0xff
-	j	.L60
-.L63:
+	j	.L57
+.L60:
 	li	a5,1
 	sll	a5,a5,a4
 	slli	a5,a5,16
@@ -551,7 +548,7 @@ hrt_read:
  #APP
 	csrc 3008, a5
  #NO_APP
-	j	.L62
+	j	.L59
 	.size	hrt_read, .-hrt_read
 	.section	.sdata.xfer_shift_ctrl,"aw"
 	.align	2

--- a/applications/sdp/mspi/src/hrt/hrt.c
+++ b/applications/sdp/mspi/src/hrt/hrt.c
@@ -130,7 +130,16 @@ static void hrt_tx(volatile hrt_xfer_data_t *xfer_data, uint8_t frame_width, boo
 			nrf_vpr_csr_vio_mode_out_set(&out_mode);
 		}
 
-		xfer_data->vio_out_set(data);
+		switch (xfer_data->fun_out) {
+		case HRT_FUN_OUT_WORD:
+			nrf_vpr_csr_vio_out_buffered_reversed_word_set(data);
+			break;
+		case HRT_FUN_OUT_BYTE:
+			nrf_vpr_csr_vio_out_buffered_reversed_byte_set(data);
+			break;
+		default:
+			break;
+		}
 
 		if ((i == 0) && (!*counter_running)) {
 			/* Start counter */
@@ -270,7 +279,16 @@ static void hrt_tx_rx(volatile hrt_xfer_data_t *xfer_data, uint8_t frame_width, 
 	nrf_vpr_csr_vio_shift_ctrl_buffered_set(&shift_ctrl);
 
 	for (uint32_t i = 0; i < xfer_data->word_count; i++) {
-		xfer_data->vio_out_set(to_send & MSB_MASK);
+		switch (xfer_data->fun_out) {
+		case HRT_FUN_OUT_WORD:
+			nrf_vpr_csr_vio_out_buffered_reversed_word_set(to_send & MSB_MASK);
+			break;
+		case HRT_FUN_OUT_BYTE:
+			nrf_vpr_csr_vio_out_buffered_reversed_byte_set(to_send & MSB_MASK);
+			break;
+		default:
+			break;
+		}
 
 		to_send = to_send << BITS_IN_BYTE;
 

--- a/applications/sdp/mspi/src/hrt/hrt.h
+++ b/applications/sdp/mspi/src/hrt/hrt.h
@@ -29,6 +29,11 @@ typedef enum {
 	HRT_FE_MAX
 } hrt_frame_element_t;
 
+typedef enum {
+	HRT_FUN_OUT_BYTE,
+	HRT_FUN_OUT_WORD,
+} hrt_fun_out_t;
+
 /** @brief Structure for holding bus width of different xfer parts */
 typedef struct {
 	uint8_t command;
@@ -71,7 +76,7 @@ typedef struct {
 	uint32_t last_word;
 
 	/** @brief Function for writing to buffered out register. */
-	void (*vio_out_set)(uint32_t value);
+	hrt_fun_out_t fun_out;
 } hrt_xfer_data_t;
 
 /** @brief Hrt transfer parameters. */

--- a/applications/sdp/mspi/src/main.c
+++ b/applications/sdp/mspi/src/main.c
@@ -201,24 +201,21 @@ static void xfer_execute(nrfe_mspi_xfer_packet_msg_t *xfer_packet)
 		xfer_packet->address
 		<< (BITS_IN_WORD - nrfe_mspi_xfer_config.address_length * BITS_IN_BYTE);
 
-	xfer_params.xfer_data[HRT_FE_COMMAND].vio_out_set =
-		&nrf_vpr_csr_vio_out_buffered_reversed_word_set;
+	xfer_params.xfer_data[HRT_FE_COMMAND].fun_out = HRT_FUN_OUT_WORD;
 	xfer_params.xfer_data[HRT_FE_COMMAND].data = (uint8_t *)&xfer_packet->command;
 	xfer_params.xfer_data[HRT_FE_COMMAND].word_count = 0;
 
 	adjust_tail(&xfer_params.xfer_data[HRT_FE_COMMAND], xfer_params.bus_widths.command,
 		    nrfe_mspi_xfer_config.command_length * BITS_IN_BYTE);
 
-	xfer_params.xfer_data[HRT_FE_ADDRESS].vio_out_set =
-		&nrf_vpr_csr_vio_out_buffered_reversed_word_set;
+	xfer_params.xfer_data[HRT_FE_ADDRESS].fun_out = HRT_FUN_OUT_WORD;
 	xfer_params.xfer_data[HRT_FE_ADDRESS].data = (uint8_t *)&xfer_packet->address;
 	xfer_params.xfer_data[HRT_FE_ADDRESS].word_count = 0;
 
 	adjust_tail(&xfer_params.xfer_data[HRT_FE_ADDRESS], xfer_params.bus_widths.address,
 		    nrfe_mspi_xfer_config.address_length * BITS_IN_BYTE);
 
-	xfer_params.xfer_data[HRT_FE_DUMMY_CYCLES].vio_out_set =
-		&nrf_vpr_csr_vio_out_buffered_reversed_word_set;
+	xfer_params.xfer_data[HRT_FE_DUMMY_CYCLES].fun_out = HRT_FUN_OUT_WORD;
 	xfer_params.xfer_data[HRT_FE_DUMMY_CYCLES].data = NULL;
 	xfer_params.xfer_data[HRT_FE_DUMMY_CYCLES].word_count = 0;
 
@@ -238,8 +235,7 @@ static void xfer_execute(nrfe_mspi_xfer_packet_msg_t *xfer_packet)
 			    nrfe_mspi_xfer_config.tx_dummy * xfer_params.bus_widths.dummy_cycles);
 	}
 
-	xfer_params.xfer_data[HRT_FE_DATA].vio_out_set =
-		&nrf_vpr_csr_vio_out_buffered_reversed_byte_set;
+	xfer_params.xfer_data[HRT_FE_DATA].fun_out = HRT_FUN_OUT_BYTE;
 	xfer_params.xfer_data[HRT_FE_DATA].data = xfer_packet->data;
 	xfer_params.xfer_data[HRT_FE_DATA].word_count = 0;
 
@@ -293,14 +289,12 @@ void prepare_and_read_data(nrfe_mspi_xfer_packet_msg_t *xfer_packet, volatile ui
 		<< (BITS_IN_WORD - nrfe_mspi_xfer_config.address_length * BITS_IN_BYTE);
 
 	/* Configure command phase. */
-	xfer_params.xfer_data[HRT_FE_COMMAND].vio_out_set =
-		nrf_vpr_csr_vio_out_buffered_reversed_word_set;
+	xfer_params.xfer_data[HRT_FE_COMMAND].fun_out = HRT_FUN_OUT_WORD;
 	xfer_params.xfer_data[HRT_FE_COMMAND].data = (uint8_t *)&xfer_packet->command;
 	xfer_params.xfer_data[HRT_FE_COMMAND].word_count = nrfe_mspi_xfer_config.command_length;
 
 	/* Configure address phase. */
-	xfer_params.xfer_data[HRT_FE_ADDRESS].vio_out_set =
-		nrf_vpr_csr_vio_out_buffered_reversed_word_set;
+	xfer_params.xfer_data[HRT_FE_ADDRESS].fun_out = HRT_FUN_OUT_WORD;
 	xfer_params.xfer_data[HRT_FE_ADDRESS].data = (uint8_t *)&xfer_packet->address;
 	xfer_params.xfer_data[HRT_FE_ADDRESS].word_count = nrfe_mspi_xfer_config.address_length;
 


### PR DESCRIPTION
To make all code changes explicitly visible, do not use pointers to functions.