### PR TITLE
doc: nrf: libraries: nrf_compression minor fix

### DIFF
--- a/doc/nrf/libraries/others/nrf_compression.rst
+++ b/doc/nrf/libraries/others/nrf_compression.rst
@@ -47,7 +47,7 @@ You can use the available compression types by enabling their respective Kconfig
        | Fixed probability size of 14272 bytes.
        | Fixed dictionary size of 128 KiB.
    * - ARM thumb filter
-     - :kconfig:option:`NRF_COMPRESS_ARM_THUMB`
+     - :kconfig:option:`CONFIG_NRF_COMPRESS_ARM_THUMB`
      - ---
 
 Memory allocation configuration options


### PR DESCRIPTION
added missing CONFIG_ to NRF_COMPRESS_ARM_THUMB