### PR TITLE
nrf_modem_lib: don't require POSIX sockets names

### DIFF
--- a/lib/nrf_modem_lib/Kconfig
+++ b/lib/nrf_modem_lib/Kconfig
@@ -9,7 +9,6 @@ menuconfig NRF_MODEM_LIB
 	select EXPERIMENTAL if SOC_NRF9280_CPUAPP
 	select NRF_MODEM
 	imply NET_SOCKETS_OFFLOAD
-	imply NET_SOCKETS_POSIX_NAMES if !POSIX_API
 	# The modem must be turned on to achieve low power consumption.
 	# But disable it for ZTEST's as some tests have HW
 	# resource-conflicts with NRF_MODEM_LIB.

--- a/lib/nrf_modem_lib/sanity.c
+++ b/lib/nrf_modem_lib/sanity.c
@@ -161,19 +161,19 @@ BUILD_ASSERT(NRF_SPROTO_DTLS1v2 == IPPROTO_DTLS_1_2, "Socket value not aligned w
 BUILD_ASSERT(SOL_TLS == NRF_SOL_SECURE, "Socket value not aligned with modemlib.");
 BUILD_ASSERT(SOL_SOCKET == NRF_SOL_SOCKET, "Socket value not aligned with modemlib.");
 
-BUILD_ASSERT(MSG_DONTWAIT == NRF_MSG_DONTWAIT, "Socket value not aligned with modemlib.");
-BUILD_ASSERT(MSG_PEEK == NRF_MSG_PEEK, "Socket value not aligned with modemlib.");
-BUILD_ASSERT(MSG_WAITALL == NRF_MSG_WAITALL, "Socket value not aligned with modemlib.");
+BUILD_ASSERT(ZSOCK_MSG_DONTWAIT == NRF_MSG_DONTWAIT, "Socket value not aligned with modemlib.");
+BUILD_ASSERT(ZSOCK_MSG_PEEK == NRF_MSG_PEEK, "Socket value not aligned with modemlib.");
+BUILD_ASSERT(ZSOCK_MSG_WAITALL == NRF_MSG_WAITALL, "Socket value not aligned with modemlib.");
 
 BUILD_ASSERT(AI_CANONNAME == NRF_AI_CANONNAME, "Socket value not aligned with modemlib.");
 BUILD_ASSERT(AI_NUMERICSERV == NRF_AI_NUMERICSERV, "Socket value not aligned with modemlib.");
 BUILD_ASSERT(AI_PDNSERV == NRF_AI_PDNSERV, "Socket value not aligned with modemlib.");
 
-BUILD_ASSERT(POLLIN == NRF_POLLIN, "Socket value not aligned with modemlib.");
-BUILD_ASSERT(POLLOUT == NRF_POLLOUT, "Socket value not aligned with modemlib.");
-BUILD_ASSERT(POLLERR == NRF_POLLERR, "Socket value not aligned with modemlib.");
-BUILD_ASSERT(POLLHUP == NRF_POLLHUP, "Socket value not aligned with modemlib.");
-BUILD_ASSERT(POLLNVAL == NRF_POLLNVAL, "Socket value not aligned with modemlib.");
+BUILD_ASSERT(ZSOCK_POLLIN == NRF_POLLIN, "Socket value not aligned with modemlib.");
+BUILD_ASSERT(ZSOCK_POLLOUT == NRF_POLLOUT, "Socket value not aligned with modemlib.");
+BUILD_ASSERT(ZSOCK_POLLERR == NRF_POLLERR, "Socket value not aligned with modemlib.");
+BUILD_ASSERT(ZSOCK_POLLHUP == NRF_POLLHUP, "Socket value not aligned with modemlib.");
+BUILD_ASSERT(ZSOCK_POLLNVAL == NRF_POLLNVAL, "Socket value not aligned with modemlib.");
 
 BUILD_ASSERT(DNS_EAI_ADDRFAMILY == NRF_EAI_ADDRFAMILY, "Socket value not aligned with modemlib.");
 BUILD_ASSERT(DNS_EAI_AGAIN == NRF_EAI_AGAIN, "Socket value not aligned with modemlib.");


### PR DESCRIPTION
- Replace POSIX API macros with Zephyr socket API (ZSOCK) macros in sanity.c
- Don't imply NET_SOCKETS_POSIX_NAMES if !POSIX_API

CONFIG_POSIX_API enables experimental symbols and the NET_SOCKETS_POSIX_NAMES symbol is deprecated. POSIX names don't seems to be required for the library with the exception of 8 BUILD_ASSERTs. All of those BUILD_ASSERTs use POSIX macros that are aliases for ZSOCK macros.