### PR TITLE
suit: Allow for selecting 16 active components

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -245,7 +245,7 @@ manifest:
       revision: 2e22c176ba50930604519c3f70ee8ae5ba2a09ac
       path: modules/lib/suit-generator
     - name: suit-processor
-      revision: 013963d0aa883732d915dc712e849df0e5996ce4
+      revision: 726c585a064e957d5e2074aed2d680b1d2a8b5c4
       path: modules/lib/suit-processor
     - name: doc-internal
       repo-path: doc-internal


### PR DESCRIPTION
Update CDDLs so all component indexes can be listed as an argument for set-component-index command.

Ref: NCSDK-NONE