### PR TITLE
lib: date_time: Replace deprecated CONFIG_POSIX_CLOCK option

### DIFF
--- a/lib/date_time/Kconfig
+++ b/lib/date_time/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig DATE_TIME
 	bool "Date time library"
-	select POSIX_CLOCK
+	select POSIX_TIMERS
 
 if DATE_TIME
 


### PR DESCRIPTION
Replaced `CONFIG_POSIX_CLOCK` option with `CONFIG_POSIX_TIMERS`, which is now used to enable `clock_gettime()` and `clock_settime()` support.