### PR TITLE
sysbuild: Specify BOARD if the main image sets it

### DIFF
--- a/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
+++ b/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
@@ -22,11 +22,21 @@ function(ExternalNcsVariantProject_Add)
   ExternalProject_Get_Property(${VBUILD_APPLICATION} SOURCE_DIR BINARY_DIR)
   set(${VBUILD_APPLICATION}_BINARY_DIR ${BINARY_DIR})
 
-  ExternalZephyrProject_Add(
-    APPLICATION ${VBUILD_VARIANT}
-    SOURCE_DIR ${SOURCE_DIR}
-    BUILD_ONLY true
+  get_property(VARIANT_BOARD TARGET ${VBUILD_APPLICATION} PROPERTY BOARD)
+  if(DEFINED VARIANT_BOARD)
+    ExternalZephyrProject_Add(
+      APPLICATION ${VBUILD_VARIANT}
+      SOURCE_DIR ${SOURCE_DIR}
+      BOARD ${VARIANT_BOARD}
+      BUILD_ONLY true
   )
+  else()
+    ExternalZephyrProject_Add(
+      APPLICATION ${VBUILD_VARIANT}
+      SOURCE_DIR ${SOURCE_DIR}
+      BUILD_ONLY true
+    )
+  endif()
 
   set_property(TARGET ${VBUILD_VARIANT} PROPERTY NCS_VARIANT_APPLICATION ${VBUILD_APPLICATION})
   set_property(TARGET ${VBUILD_VARIANT} APPEND PROPERTY _EP_CMAKE_ARGS


### PR DESCRIPTION
It is necessary to configure the BOARD variable as fast as possible, since there are scritps (i.e. UICR generation) that uses this value and fail otherwise.

Ref: NCSDK-3012