### PR TITLE
SDP: fix max frequency and device frequency in MSPI API test

### DIFF
--- a/snippets/sdp/mspi/board/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/snippets/sdp/mspi/board/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+
+/delete-node/ &mx25r64;
+
+&sdp_mspi {
+	mx25r64: mx25r6435f@0 {
+		compatible = "jedec,mspi-nor";
+		status = "okay";
+		reg = <0>;
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 48 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+		reset-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+
+		mspi-max-frequency = <DT_FREQ_M(1)>;
+		mspi-io-mode = "MSPI_IO_MODE_SINGLE";
+		mspi-data-rate = "MSPI_DATA_RATE_SINGLE";
+		mspi-hardware-ce-num = <0>;
+		mspi-cpp-mode = "MSPI_CPP_MODE_0";
+		mspi-endian = "MSPI_BIG_ENDIAN";
+		mspi-ce-polarity = "MSPI_CE_ACTIVE_LOW";
+	};
+};

--- a/snippets/sdp/mspi/snippet.yml
+++ b/snippets/sdp/mspi/snippet.yml
@@ -14,3 +14,6 @@ boards:
   /.*/nrf54l15/cpuapp/:
     append:
       EXTRA_DTC_OVERLAY_FILE: soc/nrf54l15_cpuapp.overlay
+  /nrf54l15dk/nrf54l15/cpuapp/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: board/nrf54l15dk_nrf54l15_cpuapp.overlay

--- a/snippets/sdp/mspi/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/sdp/mspi/soc/nrf54l15_cpuapp.overlay
@@ -96,37 +96,10 @@
 	};
 };
 
-/delete-node/ &mx25r64;
-
 &sdp_mspi {
 	clock-frequency = <DT_FREQ_M(64)>;
 	pinctrl-0 = <&sdp_mspi_default>;
 	pinctrl-1 = <&sdp_mspi_sleep>;
 	pinctrl-names = "default", "sleep";
 	status = "okay";
-	mx25r64: mx25r6435f@0 {
-		compatible = "jedec,mspi-nor", "zephyr,mspi-emul-device";
-		status = "okay";
-		reg = <0>;
-		jedec-id = [c2 28 17];
-		sfdp-bfp = [
-			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
-			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
-			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 48 44
-			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
-		];
-		size = <67108864>;
-		has-dpd;
-		t-enter-dpd = <10000>;
-		t-exit-dpd = <35000>;
-		reset-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
-
-		mspi-max-frequency = <DT_FREQ_M(1)>;
-		mspi-io-mode = "MSPI_IO_MODE_SINGLE";
-		mspi-data-rate = "MSPI_DATA_RATE_SINGLE";
-		mspi-hardware-ce-num = <0>;
-		mspi-cpp-mode = "MSPI_CPP_MODE_0";
-		mspi-endian = "MSPI_BIG_ENDIAN";
-		mspi-ce-polarity = "MSPI_CE_ACTIVE_LOW";
-	};
 };

--- a/snippets/sdp/mspi/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/sdp/mspi/soc/nrf54l15_cpuapp.overlay
@@ -99,7 +99,7 @@
 /delete-node/ &mx25r64;
 
 &sdp_mspi {
-	clock-frequency = <DT_FREQ_M(48)>;
+	clock-frequency = <DT_FREQ_M(64)>;
 	pinctrl-0 = <&sdp_mspi_default>;
 	pinctrl-1 = <&sdp_mspi_sleep>;
 	pinctrl-names = "default", "sleep";


### PR DESCRIPTION
~Remove dummy device from MSPI API test overlay for nRF54L15, since external flash is already defined in snippets.~
~Fix device frequency in MSPI API test.~ (updated in other PR).
Fix max frequency available on SDP MSPI.
Move definition of external flash to board overlay.