### PR TITLE
applications: asset_tracker_v2: Remove deprecated Kconfig option

### DIFF
--- a/applications/asset_tracker_v2/src/modules/Kconfig.cloud_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.cloud_module
@@ -55,9 +55,6 @@ config NRF_CLOUD_SEND_DEVICE_STATUS_SIM
 config NRF_CLOUD_SEND_SERVICE_INFO_FOTA
 	default y
 
-config NRF_CLOUD_SEND_SERVICE_INFO_UI
-	default y
-
 # Enable cards for sensor data display in the nRF Cloud UI.
 config NRF_CLOUD_ENABLE_SVC_INF_UI_TEMP
 	default y if EXTERNAL_SENSORS


### PR DESCRIPTION
Removed usage of deprecated Kconfig option `CONFIG_NRF_CLOUD_SEND_SERVICE_INFO_UI`. nRF Cloud no longer uses the UI section in the shadow. Cards are displayed based on the messages sent by the device.