### PR TITLE
Revert "samples: matter: remove `zephyr,priority` phandle"

### DIFF
--- a/applications/matter_bridge/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/applications/matter_bridge/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -12,6 +12,11 @@
 	};
 };
 
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+	zephyr,priority = <0 PRIO_COOP>;
+};
+
 /* Disable unused peripherals to reduce power consumption */
 &adc {
 	status = "disabled";

--- a/applications/matter_weather_station/app.overlay
+++ b/applications/matter_weather_station/app.overlay
@@ -67,7 +67,7 @@
 
 /* Set IPC thread priority to the highest value to not collide with other threads. */
 &ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
+	zephyr,priority = <0 PRIO_COOP>;
 };
 
 &i2c1 {

--- a/applications/matter_weather_station/app.overlay
+++ b/applications/matter_weather_station/app.overlay
@@ -65,6 +65,11 @@
 	};
 };
 
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
 &i2c1 {
 	bme688@76 {
 		compatible = "bosch,bme680";

--- a/samples/matter/light_bulb/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_bulb/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -30,7 +30,7 @@
 
 /* Set IPC thread priority to the highest value to not collide with other threads. */
 &ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
+	zephyr,priority = <0 PRIO_COOP>;
 };
 
 &pwm0 {

--- a/samples/matter/light_bulb/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_bulb/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -28,6 +28,11 @@
 	};
 };
 
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
 &pwm0 {
 	pinctrl-0 = <&pwm0_default_alt>;
 	pinctrl-1 = <&pwm0_sleep_alt>;

--- a/samples/matter/light_bulb/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_bulb/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -31,7 +31,7 @@
 
 /* Set IPC thread priority to the highest value to not collide with other threads. */
 &ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
+	zephyr,priority = <0 PRIO_COOP>;
 };
 
 &pwm0 {

--- a/samples/matter/light_bulb/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_bulb/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -29,6 +29,11 @@
 	};
 };
 
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
 &pwm0 {
 	pinctrl-0 = <&pwm0_default_alt>;
 	pinctrl-1 = <&pwm0_sleep_alt>;

--- a/samples/matter/light_switch/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_switch/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,7 +14,7 @@
 
 /* Set IPC thread priority to the highest value to not collide with other threads. */
 &ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
+	zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/samples/matter/light_switch/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_switch/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -12,6 +12,11 @@
 	};
 };
 
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
 /* Disable unused peripherals to reduce power consumption */
 &adc {
 	status = "disabled";

--- a/samples/matter/light_switch/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_switch/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -18,5 +18,5 @@
 
 /* Set IPC thread priority to the highest value to not collide with other threads. */
 &ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
+	zephyr,priority = <0 PRIO_COOP>;
 };

--- a/samples/matter/light_switch/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_switch/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -15,3 +15,8 @@
 		watchdog0 = &wdt0;
 	};
 };
+
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};

--- a/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,7 +14,7 @@
 
 /* Set IPC thread priority to the highest value to not collide with other threads. */
 &ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
+	zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -12,6 +12,11 @@
 	};
 };
 
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
 /* Disable unused peripherals to reduce power consumption */
 &adc {
 	status = "disabled";

--- a/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -18,5 +18,5 @@
 
 /* Set IPC thread priority to the highest value to not collide with other threads. */
 &ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
+	zephyr,priority = <0 PRIO_COOP>;
 };

--- a/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -15,3 +15,8 @@
 		watchdog0 = &wdt0;
 	};
 };
+
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};

--- a/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp_nrf7001.overlay
+++ b/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp_nrf7001.overlay
@@ -15,3 +15,8 @@
 		watchdog0 = &wdt0;
 	};
 };
+
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+	zephyr,priority = <0 PRIO_COOP>;
+};

--- a/samples/matter/smoke_co_alarm/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/smoke_co_alarm/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,7 +14,7 @@
 
 /* Set IPC thread priority to the highest value to not collide with other threads. */
 &ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
+	zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/samples/matter/smoke_co_alarm/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/smoke_co_alarm/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -12,6 +12,11 @@
 	};
 };
 
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
 /* Disable unused peripherals to reduce power consumption */
 &adc {
 	status = "disabled";

--- a/samples/matter/template/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/template/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,7 +14,7 @@
 
 /* Set IPC thread priority to the highest value to not collide with other threads. */
 &ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
+	zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/samples/matter/template/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/template/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -12,6 +12,11 @@
 	};
 };
 
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
 /* Disable unused peripherals to reduce power consumption */
 &adc {
 	status = "disabled";

--- a/samples/matter/template/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/template/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -19,5 +19,5 @@
 
 /* Set IPC thread priority to the highest value to not collide with other threads. */
 &ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
+	zephyr,priority = <0 PRIO_COOP>;
 };

--- a/samples/matter/template/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/template/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -16,3 +16,8 @@
 	};
 
 };
+
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};

--- a/samples/matter/window_covering/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/window_covering/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -33,7 +33,7 @@
 
 /* Set IPC thread priority to the highest value to not collide with other threads. */
 &ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
+	zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/samples/matter/window_covering/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/window_covering/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -31,6 +31,11 @@
 	};
 };
 
+/* Set IPC thread priority to the highest value to not collide with other threads. */
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
+};
+
 /* Disable unused peripherals to reduce power consumption */
 &adc {
 	status = "disabled";


### PR DESCRIPTION
IPC has been switched back to rpmsg. Revert alignment change.

This reverts commit e7055e7e2e614ee4a15bd01ae86fafaaffcbe0d4.