### PR TITLE
quarantine_zephyr: Add quarantine for libraries.encoding.jwt.rsa.*

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -272,6 +272,15 @@
     - nrf54l15dk/nrf54l15/cpuapp
   comment: "needs porting, owner not clear"
 
+- scenarios:
+    - libraries.encoding.jwt.rsa.psa
+    - libraries.encoding.jwt.rsa.legacy
+  platforms:
+    - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf9160dk@0.14.0/nrf9160/ns
+    - nrf54l15dk/nrf54l15/cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-31783"
+
 # ---------------------------------   Won't fix section -----------------------------------
 
 - scenarios:


### PR DESCRIPTION
Test configurations for scenarios
libraries.encoding.jwt.rsa.{psa | legacy} are added to quarantine due to building issues.