### PR TITLE
samples: cellular: modem_shell: Fix errors when printing link status

### DIFF
--- a/samples/cellular/modem_shell/src/link/link.c
+++ b/samples/cellular/modem_shell/src/link/link.c
@@ -183,7 +183,7 @@ static void link_registered_work(struct k_work *unused)
 	/* PDN activation may take some time. Thus, let modem have some time
 	 * before reading the PDN information.
 	 */
-	k_sleep(K_MSEC(2000));
+	k_sleep(K_MSEC(1500));
 
 	link_api_modem_info_get_for_shell(true);
 }


### PR DESCRIPTION
When registration had already been dropped, a couple of errors were shown when trying to print registration and PDN status. AT response parsing has been improved to handle also this situation.

MOSH-640