### PR TITLE
applications: sdp: mspi: add timer and trap handler for SDP app fault handling

### DIFF
--- a/applications/sdp/mspi/Kconfig
+++ b/applications/sdp/mspi/Kconfig
@@ -11,4 +11,11 @@ config SDP_MSPI_IPC_NO_COPY
 	  this requires both cores to be able to access each others memory spaces.
 	  If n Data is passed through IPC by copy.
 
+config SDP_MSPI_FAULT_TIMER
+	bool "SDP application fault timer"
+	help
+	  Enable SDP application fault timer.
+	  Timer is used to detect application faults. If the timer expires,
+	  the application is considered to be in a fault state.
+
 source "Kconfig.zephyr"

--- a/applications/sdp/mspi/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/applications/sdp/mspi/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -11,11 +11,15 @@
 			#size-cells = <1>;
 
 			sram_tx: memory@2003c000 {
-				reg = <0x2003c000 0x0800>;
+				reg = <0x2003c000 0x07f0>;
 			};
 
-			sram_rx: memory@2003c800 {
-				reg = <0x2003c800 0x0800>;
+			sram_rx: memory@2003c7f0 {
+				reg = <0x2003c7f0 0x07f0>;
+			};
+
+			cpuflpr_error_code: memory@2003cfe0 {
+				reg = <0x2003cfe0 0x0020>; /* 32bytes */
 			};
 		};
 	};

--- a/drivers/mspi/Kconfig.nrfe
+++ b/drivers/mspi/Kconfig.nrfe
@@ -34,4 +34,22 @@ config MSPI_NRFE_IPC_NO_COPY
 	  this requires both cores to be able to access each others memory spaces.
 	  If n Data is passed through IPC by copy.
 
+config MSPI_NRFE_FAULT_TIMER
+	bool "SDP application fault timer"
+	select COUNTER
+	help
+	  Enable SDP application fault timer.
+	  Timer is used to detect application faults. If the timer expires,
+	  the application is considered to be in a fault state.
+
+if MSPI_NRFE_FAULT_TIMER
+
+config MSPI_NRFE_FAULT_TIMEOUT
+	int "SDP application fault timeout"
+	default 1000000
+	help
+	  Fault timeout in microseconds.
+
+endif # MSPI_NRFE_FAULT_TIMER
+
 endif # MSPI_NRFE

--- a/include/drivers/mspi/nrfe_mspi.h
+++ b/include/drivers/mspi/nrfe_mspi.h
@@ -9,6 +9,7 @@
 
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/mspi.h>
+#include <hal/nrf_timer.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,10 +33,11 @@ extern "C" {
 /** @brief eMSPI opcodes. */
 typedef enum {
 	NRFE_MSPI_EP_BOUNDED = 0,
-	NRFE_MSPI_CONFIG_PINS, /* nrfe_mspi_pinctrl_soc_pin_msg_t */
-	NRFE_MSPI_CONFIG_DEV,  /* nrfe_mspi_dev_config_msg_t */
-	NRFE_MSPI_CONFIG_XFER, /* nrfe_mspi_xfer_config_msg_t */
-	NRFE_MSPI_TX,	       /* nrfe_mspi_xfer_packet_msg_t + data buffer at the end */
+	NRFE_MSPI_CONFIG_TIMER_PTR, /* nrfe_mspi_flpr_timer_msg_t */
+	NRFE_MSPI_CONFIG_PINS,      /* nrfe_mspi_pinctrl_soc_pin_msg_t */
+	NRFE_MSPI_CONFIG_DEV,       /* nrfe_mspi_dev_config_msg_t */
+	NRFE_MSPI_CONFIG_XFER,      /* nrfe_mspi_xfer_config_msg_t */
+	NRFE_MSPI_TX,	            /* nrfe_mspi_xfer_packet_msg_t + data buffer at the end */
 	NRFE_MSPI_TXRX,
 	NRFE_MSPI_WRONG_OPCODE,
 	NRFE_MSPI_ALL_OPCODES = NRFE_MSPI_WRONG_OPCODE,
@@ -57,6 +59,11 @@ typedef struct {
 	uint16_t tx_dummy;
 	uint16_t rx_dummy;
 } nrfe_mspi_xfer_config_t;
+
+typedef struct {
+	nrfe_mspi_opcode_t opcode; /* NRFE_MSPI_CONFIG_TIMER_PTR */
+	NRF_TIMER_Type *timer_ptr;
+} nrfe_mspi_flpr_timer_msg_t;
 
 typedef struct {
 	nrfe_mspi_opcode_t opcode; /* NRFE_MSPI_CONFIG_PINS */

--- a/include/drivers/mspi/nrfe_mspi.h
+++ b/include/drivers/mspi/nrfe_mspi.h
@@ -39,6 +39,7 @@ typedef enum {
 	NRFE_MSPI_CONFIG_XFER,      /* nrfe_mspi_xfer_config_msg_t */
 	NRFE_MSPI_TX,	            /* nrfe_mspi_xfer_packet_msg_t + data buffer at the end */
 	NRFE_MSPI_TXRX,
+	NRFE_MSPI_SDP_APP_HARD_FAULT,
 	NRFE_MSPI_WRONG_OPCODE,
 	NRFE_MSPI_ALL_OPCODES = NRFE_MSPI_WRONG_OPCODE,
 } nrfe_mspi_opcode_t;

--- a/snippets/sdp/mspi/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/sdp/mspi/soc/nrf54l15_cpuapp.overlay
@@ -15,14 +15,17 @@
 			};
 
 			sram_rx: memory@2003c000 {
-				reg = <0x2003c000 0x0800>;
+				reg = <0x2003c000 0x07f0>;
 			};
 
-			sram_tx: memory@2003c800 {
-				reg = <0x2003c800 0x0800>;
+			sram_tx: memory@2003c7f0 {
+				reg = <0x2003c7f0 0x07f0>;
+			};
+
+			cpuflpr_error_code: memory@2003cfe0 {
+				reg = <0x2003cfe0 0x0020>; /* 32bytes */
 			};
 		};
-
 
 		cpuflpr_sram_code_data: memory@2003d000 {
 			compatible = "mmio-sram";


### PR DESCRIPTION
- TIMER is set up by the Host and cleared periodically by SDP FW. If SDP FW fails to clear the TIMER, the Host receives an IRQ signalling an SDP FW error.

- Implementation of trap handler. Signals status to host and sends dump of most important registers at the time of error.