### PR TITLE
Samples: Bluetooth: Fix peripheral with multiple identities sample

### DIFF
--- a/samples/bluetooth/peripheral_with_multiple_identities/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_with_multiple_identities/Kconfig.sysbuild
@@ -6,8 +6,5 @@
 
 source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
 
-config NRF_DEFAULT_BLUETOOTH
-	default y
-
 config NRF_DEFAULT_IPC_RADIO
 	default y


### PR DESCRIPTION
Fix issue in the peripheral with multiple identities sample.
In the Kconfig.sysbuild file, both NRF_DEFAULT_BLUETOOTH (which enables hci_ipc)
and NRF_DEFAULT_IPC_RADIO (which enables ipc_radio) are enabled.
Only NRF_DEFAULT_IPC_RADIO is required.