### PR TITLE
manifest: update sdk-zephyr, enable sensor tests on nRF54L20pdk

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 6dd077969d74ec33b4a401d5c5f9579cfab15be7
+      revision: pull/2493/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Include:
Nrfx 6832 enable sensor tests on nrf54l20pdk
https://github.com/nrfconnect/sdk-zephyr/pull/2493
https://github.com/zephyrproject-rtos/zephyr/pull/85734