### PR TITLE
manifest: update sdk-zephyr, cherry-pick ADC changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -70,7 +70,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 47893258ef36e758020524ba236fcc88aa2e042d
+      revision: 314f3ddd7fd670ce6038e846c8e69dd11c396edd
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Include ADC related changes from the upstream zephyr:
- add support for adc gain 2/7;
- enable ADC tests on nrf54l20pdk.

https://github.com/nrfconnect/sdk-zephyr/pull/2497