### PR TITLE
lib: at_host: Write AT response to correct UART device

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -621,6 +621,10 @@ Modem libraries
 
   * Removed references to HERE location services.
 
+* :ref:`lib_at_host` library:
+
+  * Fixed a bug where AT responses would erroneously be written to the logging UART instead of being written to the chosen ``ncs,at-host-uart`` UART device when the :kconfig:option:`CONFIG_LOG_BACKEND_UART` Kconfig option was set.
+
 Multiprotocol Service Layer libraries
 -------------------------------------
 

--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -37,6 +37,12 @@ enum term_modes {
 	DEVICE_DT_GET(COND_CODE_1(DT_HAS_CHOSEN(ncs_at_host_uart),                                 \
 		(DT_CHOSEN(ncs_at_host_uart)), (DT_NODELABEL(uart0))))
 
+#define IS_LOG_BACKEND_UART(_uart_dev)                                                             \
+	(IS_ENABLED(CONFIG_LOG_BACKEND_UART) && COND_CODE_1(DT_HAS_CHOSEN(zephyr_log_uart),        \
+		(_uart_dev == DEVICE_DT_GET(DT_CHOSEN(zephyr_log_uart))),                          \
+		(COND_CODE_1(DT_HAS_CHOSEN(zephyr_console),                                        \
+			(_uart_dev == DEVICE_DT_GET(DT_CHOSEN(zephyr_console))), (false)))))
+
 static enum term_modes term_mode;
 static const struct device *const uart_dev = AT_HOST_UART_DEV_GET();
 static bool at_buf_busy; /* Guards at_buf while processing a command */
@@ -46,7 +52,10 @@ static struct k_work cmd_send_work;
 
 static inline void write_uart_string(const char *str)
 {
-	if (IS_ENABLED(CONFIG_LOG_BACKEND_UART)) {
+	if (IS_LOG_BACKEND_UART(uart_dev)) {
+		/* The chosen AT host UART device is also the UART log backend device.
+		 * Therefore, log the AT response instead of writing directly to the UART device.
+		 */
 		LOG_RAW("%s", str);
 		return;
 	}

--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -33,12 +33,12 @@ enum term_modes {
 	MODE_COUNT      /* Counter of term_modes */
 };
 
+#define AT_HOST_UART_DEV_GET()                                                                     \
+	DEVICE_DT_GET(COND_CODE_1(DT_HAS_CHOSEN(ncs_at_host_uart),                                 \
+		(DT_CHOSEN(ncs_at_host_uart)), (DT_NODELABEL(uart0))))
+
 static enum term_modes term_mode;
-#if DT_HAS_CHOSEN(ncs_at_host_uart)
-static const struct device *const uart_dev = DEVICE_DT_GET(DT_CHOSEN(ncs_at_host_uart));
-#else
-static const struct device *const uart_dev = DEVICE_DT_GET(DT_NODELABEL(uart0));
-#endif
+static const struct device *const uart_dev = AT_HOST_UART_DEV_GET();
 static bool at_buf_busy; /* Guards at_buf while processing a command */
 static char at_buf[AT_BUF_SIZE]; /* AT command and modem response buffer */
 static struct k_work_q at_host_work_q;


### PR DESCRIPTION
If for instance trying to use `uart3` for the AT host while `CONFIG_LOG_BACKEND_UART` is enabled, AT responses all ended up in the log, not on the chosen AT host UART device.

This builds on PR https://github.com/nrfconnect/sdk-nrf/pull/20242 by @fellerts, where a fix for this issue was first posted.

