### PR TITLE
manifest: Update sdk-zephyr to bring in smp_svr sample fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -66,7 +66,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a17094ebfe168eb162ff4521748ce0222690ab96
+      revision: ff01b5fcc22333ff6f7bafebe79464d4d85c01fd
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix for smp_svr on external memory, using PM.