### PR TITLE
mpsl: Correct CMakeLists.txt formatting

### DIFF
--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -81,6 +81,6 @@ zephyr_linker_sources(SECTIONS scene_types.ld)
 
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_RPL_STORAGE_MODE_EMDS rpl.c)
 
-if (CONFIG_BT_MESH_USES_MBEDTLS_PSA AND (NOT CONFIG_SOC_FAMILY_NORDIC_NRF))
-    zephyr_library_link_libraries(mbedTLS)
+if(CONFIG_BT_MESH_USES_MBEDTLS_PSA AND (NOT CONFIG_SOC_FAMILY_NORDIC_NRF))
+  zephyr_library_link_libraries(mbedTLS)
 endif()

--- a/subsys/mpsl/CMakeLists.txt
+++ b/subsys/mpsl/CMakeLists.txt
@@ -4,21 +4,21 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if (CONFIG_MPSL AND NOT CONFIG_MPSL_FEM_ONLY)
+if(CONFIG_MPSL AND NOT CONFIG_MPSL_FEM_ONLY)
   add_subdirectory(init)
 endif()
 
-if (CONFIG_MPSL_FEM OR CONFIG_MPSL_FEM_PIN_FORWARDER OR CONFIG_MPSL_FEM_API_AVAILABLE)
+if(CONFIG_MPSL_FEM OR CONFIG_MPSL_FEM_PIN_FORWARDER OR CONFIG_MPSL_FEM_API_AVAILABLE)
   add_subdirectory(fem)
 endif()
 
 add_subdirectory(cx)
 
-if (CONFIG_MPSL_USE_ZEPHYR_PM)
+if(CONFIG_MPSL_USE_ZEPHYR_PM)
   add_subdirectory(pm)
 endif()
 
-if (CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL)
+if(CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL)
   add_subdirectory(clock_ctrl)
 endif()
 

--- a/subsys/mpsl/cx/CMakeLists.txt
+++ b/subsys/mpsl/cx/CMakeLists.txt
@@ -4,24 +4,24 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if (CONFIG_MPSL_CX_3WIRE OR
-    CONFIG_MPSL_CX_1WIRE OR
-    CONFIG_MPSL_CX_BT_1WIRE OR
-    CONFIG_MPSL_CX_NRF700X OR
-    CONFIG_MPSL_CX_SOFTWARE)
-    zephyr_library()
+if(CONFIG_MPSL_CX_3WIRE OR
+   CONFIG_MPSL_CX_1WIRE OR
+   CONFIG_MPSL_CX_BT_1WIRE OR
+   CONFIG_MPSL_CX_NRF700X OR
+   CONFIG_MPSL_CX_SOFTWARE)
+   zephyr_library()
 
-    zephyr_library_sources_ifdef(CONFIG_MPSL_CX_3WIRE 3wire/mpsl_cx_3wire.c)
-    zephyr_library_sources_ifdef(CONFIG_MPSL_CX_BT_1WIRE 1wire/mpsl_cx_1wire.c)
-    zephyr_library_sources_ifdef(CONFIG_MPSL_CX_1WIRE 1wire/mpsl_cx_1wire.c)
-    zephyr_library_sources_ifdef(CONFIG_MPSL_CX_NRF700X nrf700x/mpsl_cx_nrf700x.c)
-    zephyr_library_sources_ifdef(CONFIG_MPSL_CX_SOFTWARE_RPC software/mpsl_cx_software_rpc.c)
+   zephyr_library_sources_ifdef(CONFIG_MPSL_CX_3WIRE 3wire/mpsl_cx_3wire.c)
+   zephyr_library_sources_ifdef(CONFIG_MPSL_CX_BT_1WIRE 1wire/mpsl_cx_1wire.c)
+   zephyr_library_sources_ifdef(CONFIG_MPSL_CX_1WIRE 1wire/mpsl_cx_1wire.c)
+   zephyr_library_sources_ifdef(CONFIG_MPSL_CX_NRF700X nrf700x/mpsl_cx_nrf700x.c)
+   zephyr_library_sources_ifdef(CONFIG_MPSL_CX_SOFTWARE_RPC software/mpsl_cx_software_rpc.c)
 endif()
 
-if (CONFIG_MPSL_CX_NRF700X AND CONFIG_SOC_SERIES_NRF53X AND CONFIG_NRF_RPC)
-    zephyr_library_sources(nrf700x/mpsl_cx_nrf700x_rpc.c)
+if(CONFIG_MPSL_CX_NRF700X AND CONFIG_SOC_SERIES_NRF53X AND CONFIG_NRF_RPC)
+  zephyr_library_sources(nrf700x/mpsl_cx_nrf700x_rpc.c)
 endif()
 
-if (CONFIG_MPSL_CX_SOFTWARE AND CONFIG_MPSL)
-    zephyr_library_sources(software/mpsl_cx_software.c)
+if(CONFIG_MPSL_CX_SOFTWARE AND CONFIG_MPSL)
+  zephyr_library_sources(software/mpsl_cx_software.c)
 endif()

--- a/subsys/mpsl/fem/CMakeLists.txt
+++ b/subsys/mpsl/fem/CMakeLists.txt
@@ -4,25 +4,24 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if (CONFIG_MPSL_FEM_API_AVAILABLE OR CONFIG_MPSL_FEM_NCS_SUPPORTED_FEM_USED)
-    zephyr_library()
+if(CONFIG_MPSL_FEM_API_AVAILABLE OR CONFIG_MPSL_FEM_NCS_SUPPORTED_FEM_USED)
+  zephyr_library()
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_MPSL_FEM_API_AVAILABLE api_init/mpsl_fem_api_init.c)
 
-if (CONFIG_MPSL_FEM_NCS_SUPPORTED_FEM_USED)
+if(CONFIG_MPSL_FEM_NCS_SUPPORTED_FEM_USED)
+  zephyr_library_include_directories_ifdef(CONFIG_MPSL_FEM common/include)
+  zephyr_library_sources_ifdef(CONFIG_MPSL_FEM common/mpsl_fem_utils.c)
+  zephyr_library_sources_ifdef(CONFIG_MPSL_FEM_USE_TWI_DRV common/mpsl_fem_twi_drv.c)
 
-    zephyr_library_include_directories_ifdef(CONFIG_MPSL_FEM common/include)
-    zephyr_library_sources_ifdef(CONFIG_MPSL_FEM common/mpsl_fem_utils.c)
-    zephyr_library_sources_ifdef(CONFIG_MPSL_FEM_USE_TWI_DRV common/mpsl_fem_twi_drv.c)
+  zephyr_library_sources_ifdef(CONFIG_MPSL_FEM_NRF21540_GPIO nrf21540_gpio/mpsl_fem_nrf21540_gpio.c)
 
-    zephyr_library_sources_ifdef(CONFIG_MPSL_FEM_NRF21540_GPIO nrf21540_gpio/mpsl_fem_nrf21540_gpio.c)
+  add_subdirectory_ifdef(CONFIG_MPSL_FEM_NRF21540_GPIO_SPI nrf21540_gpio_spi)
 
-    add_subdirectory_ifdef(CONFIG_MPSL_FEM_NRF21540_GPIO_SPI nrf21540_gpio_spi)
+  zephyr_library_sources_ifdef(CONFIG_MPSL_FEM_SIMPLE_GPIO simple_gpio/mpsl_fem_simple_gpio.c)
 
-    zephyr_library_sources_ifdef(CONFIG_MPSL_FEM_SIMPLE_GPIO simple_gpio/mpsl_fem_simple_gpio.c)
+  add_subdirectory_ifdef(CONFIG_MPSL_FEM_NRF2220 nrf2220)
 
-    add_subdirectory_ifdef(CONFIG_MPSL_FEM_NRF2220 nrf2220)
-
-    add_subdirectory_ifdef(CONFIG_MPSL_FEM_NRF2240 nrf2240)
+  add_subdirectory_ifdef(CONFIG_MPSL_FEM_NRF2240 nrf2240)
 endif()


### PR DESCRIPTION
Correct formatting in CMakeList.txt files in MPSL and Bluetooth Mesh subsystems to align it to common sdk-nrf format.