### PR TITLE
samples: peripheral: radio_test: enable fem before radio operation

### DIFF
--- a/lib/fem_al/fem_al.c
+++ b/lib/fem_al/fem_al.c
@@ -186,6 +186,7 @@ int fem_tx_configure(uint32_t ramp_up_time)
 
 	fem_activate_event.event.timer.counter_period.end = ramp_up_time;
 
+	mpsl_fem_enable();
 	err = mpsl_fem_pa_configuration_set(&fem_activate_event, &fem_deactivate_evt);
 	if (err) {
 		printk("PA configuration set failed (err %d)\n", err);
@@ -201,6 +202,7 @@ int fem_rx_configure(uint32_t ramp_up_time)
 
 	fem_activate_event.event.timer.counter_period.end = ramp_up_time;
 
+	mpsl_fem_enable();
 	err = mpsl_fem_lna_configuration_set(&fem_activate_event, &fem_deactivate_evt);
 	if (err) {
 		printk("LNA configuration set failed (err %d)\n", err);
@@ -248,6 +250,11 @@ int fem_txrx_configuration_clear(void)
 	err = mpsl_fem_lna_configuration_clear();
 	if (err) {
 		printk("Failed to clear LNA configuration\n");
+		return -EPERM;
+	}
+	err = mpsl_fem_disable();
+	if (err) {
+		printk("Failed to disable front-end module\n");
 		return -EPERM;
 	}
 


### PR DESCRIPTION
Adds 'fem_enable' call before using fem for radio operations.

## Verification with Logic analyzer
* Since right now, nrf2220 is the only FEM that implements `fem_enable` call, I had to verify the new timings with it.
I used it with nRF54l15 with the following configuration:
```
RADIO_TEST_CONFIG="-DSHIELD=nrf2220ek \
    -DCONFIG_PPI_TRACE=y \
    -DCONFIG_NRF_802154_ENCRYPTION=n \
    -DCONFIG_MPSL_BUILD_TYPE_SRC_DEBUG=y"
```

* I added custom commits to enable PPI Trace in `radio_test` and `dtm` apps.
Additionally, I disabled the `cs_gpote_pin` activation inside `pa_activation_on_timer_set` (CS is activated inside `fem_enable`).

For the verification changes see https://github.com/piotrkoziar/sdk-nrf/tree/piko/radio-test.

### dtm
I ran sequence:
```c
dtm_setup_reset();
dtm_test_transmit(0x11, 20, DTM_PACKET_55);
dtm_test_receive(11);
dtm_test_end(&cnt);
```
Below you can see the pin states just before the tx.
![image](https://github.com/user-attachments/assets/3022d921-88a5-4fb5-baf7-78fdbc6c9a69)
## radio_test
I ran:
`start_tx_modulated_carrier`
`cancel`
You can see pin states just before the tx.
![image](https://github.com/user-attachments/assets/bac196b2-7dd3-4367-bad0-bd4f1d4daf83)

### fem_disable() call

The added fem_disable() call will have an effect only when sweeping.
I ensured that the CS pin is being cleared:
![image](https://github.com/user-attachments/assets/b2871b90-8497-4703-95bb-15a683e8ed67)
Without the additional fem_disable() call, the clearing would not happen.