### PR TITLE
applications: asset_tracker_v2: Remove Thingy91 support

### DIFF
--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -298,10 +298,8 @@ tests:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
-      - thingy91/nrf9160/ns
     integration_platforms:
       - nrf9160dk/nrf9160/ns
-      - thingy91/nrf9160/ns
     extra_args: EXTRA_CONF_FILE="overlay-lwm2m.conf;overlay-debug.conf"
     tags:
       - ci_build


### PR DESCRIPTION
Remove Thingy91 support for LwM2M + debug builds due to memory constraints.