### PR TITLE
applications: asset_tracker_v2: Build unit tests for native_sim

### DIFF
--- a/applications/asset_tracker_v2/tests/debug_module/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/debug_module/testcase.yaml
@@ -3,12 +3,8 @@ tests:
     sysbuild: true
     platform_allow:
       - native_sim
-      - qemu_cortex_m3
-      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - native_sim
-      - qemu_cortex_m3
-      - nrf9160dk/nrf9160/ns
     tags:
       - debug_module
       - sysbuild

--- a/applications/asset_tracker_v2/tests/json_common/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/json_common/testcase.yaml
@@ -2,13 +2,9 @@ tests:
   applications.asset_tracker_v2.cloud.cloud_codec.json_common.aws:
     sysbuild: true
     platform_allow:
-      - nrf9160dk/nrf9160
       - native_sim
-      - qemu_cortex_m3
     integration_platforms:
-      - nrf9160dk/nrf9160
       - native_sim
-      - qemu_cortex_m3
     tags:
       - json_common_test-aws
       - sysbuild

--- a/applications/asset_tracker_v2/tests/location_module/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/location_module/testcase.yaml
@@ -3,12 +3,8 @@ tests:
     sysbuild: true
     platform_allow:
       - native_sim
-      - qemu_cortex_m3
-      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - native_sim
-      - qemu_cortex_m3
-      - nrf9160dk/nrf9160/ns
     tags:
       - location_module
       - sysbuild

--- a/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/testcase.yaml
@@ -3,12 +3,8 @@ tests:
     sysbuild: true
     platform_allow:
       - native_sim
-      - qemu_cortex_m3
-      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - native_sim
-      - qemu_cortex_m3
-      - nrf9160dk/nrf9160/ns
     tags:
       - lwm2m_codec
       - sysbuild

--- a/applications/asset_tracker_v2/tests/lwm2m_integration/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/lwm2m_integration/testcase.yaml
@@ -3,12 +3,8 @@ tests:
     sysbuild: true
     platform_allow:
       - native_sim
-      - qemu_cortex_m3
-      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - native_sim
-      - qemu_cortex_m3
-      - nrf9160dk/nrf9160/ns
     tags:
       - lwm2m_integration
       - sysbuild

--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec/testcase.yaml
@@ -3,12 +3,8 @@ tests:
     sysbuild: true
     platform_allow:
       - native_sim
-      - qemu_cortex_m3
-      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - native_sim
-      - qemu_cortex_m3
-      - nrf9160dk/nrf9160/ns
     tags:
       - nrf_cloud_codec
       - sysbuild

--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/testcase.yaml
@@ -3,10 +3,8 @@ tests:
     sysbuild: true
     platform_allow:
       - native_sim
-      - qemu_cortex_m3
     integration_platforms:
       - native_sim
-      - qemu_cortex_m3
     tags:
       - nrf_cloud_codec_mocked_cJSON
       - sysbuild

--- a/applications/asset_tracker_v2/tests/ui_module/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/ui_module/testcase.yaml
@@ -3,10 +3,8 @@ tests:
     sysbuild: true
     platform_allow:
       - native_sim
-      - nrf9160dk/nrf9160/ns
     integration_platforms:
       - native_sim
-      - nrf9160dk/nrf9160/ns
     tags:
       - ui_module
       - sysbuild


### PR DESCRIPTION
Build unit tests only for native_sim.
Having qemu_cortex_m3 and nRF9160 DK adds no extra value.