### PR TITLE
Fast Pair: FMDN: support firmware version read operation

### DIFF
--- a/include/bluetooth/services/fast_pair/fmdn.h
+++ b/include/bluetooth/services/fast_pair/fmdn.h
@@ -7,6 +7,7 @@
 #ifndef BT_FAST_PAIR_FMDN_H_
 #define BT_FAST_PAIR_FMDN_H_
 
+#include <zephyr/bluetooth/conn.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 
@@ -505,6 +506,34 @@ struct bt_fast_pair_fmdn_info_cb {
 	 *  (@kconfig{CONFIG_BT_RECV_WORKQ_BT}).
 	 */
 	void (*clock_synced)(void);
+
+	/** @brief Indicate that the peer was authenticated locally.
+	 *
+	 *  This callback is called to indicate that the connected peer was
+	 *  authenticated locally using the protocol defined in the FMDN
+	 *  Accessory specification. It is triggered on a successful Read
+	 *  Provisioning State operation on the Beacon Actions GATT
+	 *  characteristic.
+	 *
+	 *  This callback can be used to facilitate the FMDN firmware update
+	 *  flow by granting the authenticated connection read access to the
+	 *  GATT Firmware Revision characteristic that is part of the Device
+	 *  Information Service (DIS). By default, the read operations of the
+	 *  identifying information (for example, from the DIS characteristics)
+	 *  are blocked for unauthenticated peers. The firmware version,
+	 *  retrieved from the FMDN accessory, may be used by the authenticated
+	 *  peer (smartphone) to notify the user about the outdated firmware
+	 *  and the pending firmware update.
+	 *
+	 *  This callback is executed in the cooperative thread context. You
+	 *  can learn about the exact thread context by analyzing the
+	 *  @kconfig{CONFIG_BT_RECV_CONTEXT} configuration choice. By default, this
+	 *  callback is executed in the Bluetooth-specific workqueue thread
+	 *  (@kconfig{CONFIG_BT_RECV_WORKQ_BT}).
+	 *
+	 *  @param conn Authenticated connection object.
+	 */
+	void (*conn_authenticated)(struct bt_conn *conn);
 
 	/** @brief Indicate provisioning state changes.
 	 *

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/prj.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/prj.conf
@@ -80,6 +80,14 @@ CONFIG_BT_FAST_PAIR_FMDN_DULT_FIRMWARE_VERSION_MAJOR=2
 CONFIG_BT_FAST_PAIR_FMDN_DULT_FIRMWARE_VERSION_MINOR=8
 CONFIG_BT_FAST_PAIR_FMDN_DULT_FIRMWARE_VERSION_REVISION=99
 
+# Support firmware version read operation using the Device Information Service (DIS) for the
+# firmware update intent support in the Android OS and Google Find My Device app.
+CONFIG_BT_DIS=y
+CONFIG_BT_DIS_FW_REV=y
+CONFIG_BT_DIS_MODEL_NUMBER=n
+CONFIG_BT_DIS_MANUF_NAME=n
+CONFIG_BT_DIS_PNP=n
+
 # Align the TX power encoded in the Fast Pair advertising set and
 # the Read Beacon Parameters response with Fast Pair expectations.
 # The value has been tailored for following DKs:

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/prj_release.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/prj_release.conf
@@ -89,6 +89,14 @@ CONFIG_BT_FAST_PAIR_FMDN_DULT_FIRMWARE_VERSION_MAJOR=2
 CONFIG_BT_FAST_PAIR_FMDN_DULT_FIRMWARE_VERSION_MINOR=8
 CONFIG_BT_FAST_PAIR_FMDN_DULT_FIRMWARE_VERSION_REVISION=99
 
+# Support firmware version read operation using the Device Information Service (DIS) for the
+# firmware update intent support in the Android OS and Google Find My Device app.
+CONFIG_BT_DIS=y
+CONFIG_BT_DIS_FW_REV=y
+CONFIG_BT_DIS_MODEL_NUMBER=n
+CONFIG_BT_DIS_MANUF_NAME=n
+CONFIG_BT_DIS_PNP=n
+
 # Align the TX power encoded in the Fast Pair advertising set and
 # the Read Beacon Parameters response with Fast Pair expectations.
 # The value has been tailored for following DKs:

--- a/subsys/bluetooth/services/fast_pair/fmdn/beacon_actions.c
+++ b/subsys/bluetooth/services/fast_pair/fmdn/beacon_actions.c
@@ -332,6 +332,9 @@ static ssize_t provisioning_state_read_handle(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 	}
 
+	/* Fire the connection authenticated callback for the application if it is registered. */
+	fp_fmdn_callbacks_conn_authenticated_notify(conn);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/services/fast_pair/fmdn/callbacks.c
+++ b/subsys/bluetooth/services/fast_pair/fmdn/callbacks.c
@@ -37,6 +37,26 @@ void fp_fmdn_callbacks_clock_synced_notify(void)
 	}
 }
 
+void fp_fmdn_callbacks_conn_authenticated_notify(struct bt_conn *conn)
+{
+	sys_slist_t *slists[] = {
+		&fmdn_info_cb_internal_slist,
+		&fmdn_info_cb_slist
+	};
+
+	__ASSERT_NO_MSG(bt_fast_pair_is_ready());
+
+	for (size_t i = 0; i < ARRAY_SIZE(slists); i++) {
+		struct bt_fast_pair_fmdn_info_cb *listener;
+
+		SYS_SLIST_FOR_EACH_CONTAINER(slists[i], listener, node) {
+			if (listener->conn_authenticated) {
+				listener->conn_authenticated(conn);
+			}
+		}
+	}
+}
+
 void fp_fmdn_callbacks_provisioning_state_changed_notify(bool provisioned)
 {
 	sys_slist_t *slists[] = {

--- a/subsys/bluetooth/services/fast_pair/fmdn/include_priv/fp_fmdn_callbacks.h
+++ b/subsys/bluetooth/services/fast_pair/fmdn/include_priv/fp_fmdn_callbacks.h
@@ -10,6 +10,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include <zephyr/bluetooth/conn.h>
+
 #include <bluetooth/services/fast_pair/fmdn.h>
 
 /**
@@ -27,6 +29,12 @@ extern "C" {
  *  about the accessory clock value.
  */
 void fp_fmdn_callbacks_clock_synced_notify(void);
+
+/** Notify the callback layer that the connected peer was authenticated locally.
+ *
+ *  @param conn Authenticated connection object
+ */
+void fp_fmdn_callbacks_conn_authenticated_notify(struct bt_conn *conn);
 
 /** Notify the callback layer about the provisioning state changes.
  *


### PR DESCRIPTION
The following items will be covered in separate PRs:

- documentation update (Fast Pair UG + changelog)
- support for the same functionality in the sdk-find-my sample