### PR TITLE
applications: nrf_desktop: Remove reduntant LTO Kconfigs in app conf

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj.conf
@@ -73,10 +73,6 @@ CONFIG_REBOOT=y
 # Optimize for size to reduce memory footprint.
 CONFIG_SIZE_OPTIMIZATIONS=y
 
-# Activate LTO
-CONFIG_LTO=y
-CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
-
 CONFIG_PWM=y
 
 CONFIG_LED=y

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release.conf
@@ -75,10 +75,6 @@ CONFIG_REBOOT=y
 # Optimize for size to reduce memory footprint.
 CONFIG_SIZE_OPTIMIZATIONS=y
 
-# Activate LTO
-CONFIG_LTO=y
-CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
-
 CONFIG_PWM=y
 
 CONFIG_LED=y

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release_fast_pair.conf
@@ -94,10 +94,6 @@ CONFIG_REBOOT=y
 # Optimize for size to reduce memory footprint.
 CONFIG_SIZE_OPTIMIZATIONS=y
 
-# Activate LTO
-CONFIG_LTO=y
-CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
-
 CONFIG_PWM=y
 
 CONFIG_LED=y

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release_keyboard.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release_keyboard.conf
@@ -82,10 +82,6 @@ CONFIG_REBOOT=y
 # Optimize for size to reduce memory footprint.
 CONFIG_SIZE_OPTIMIZATIONS=y
 
-# Activate LTO
-CONFIG_LTO=y
-CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
-
 CONFIG_PWM=y
 
 CONFIG_LED=y


### PR DESCRIPTION
LTO is already enabled globally for the nRF Desktop app so enabling it in prj_*.conf is not needed.

Jira: NCSDK-31374