### PR TITLE
manifest: Revert "CODEOWNERS: Add @nrfconnect/ncs-merge as owner for west.yml

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,7 +18,7 @@
 /LICENSE                                  @carlescufi
 /README.rst                               @carlescufi @nrfconnect/ncs-doc-leads
 /VERSION                                  @nrfconnect/ncs-code-owners
-/west.yml                                 @nrfconnect/ncs-code-owners @nrfconnect/ncs-merge
+/west.yml                                 @nrfconnect/ncs-code-owners
 /west-test.yml                            @nrfconnect/ncs-ci
 
 # Dot folders


### PR DESCRIPTION
This reverts commit 9edeaa4f345539f7c9e749238ac570493f98e73b.

Being a code owner for west.yml files creates too much noise for the ncs-merge group. We should find other ways of improving the manifest update processes. In the meantime we revert adding ncs-merge to as a codeowner to this file.