### PR TITLE
applications: nrf_desktop: nRF52810 and nRF52820 optimizations

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/prj.conf
@@ -54,7 +54,7 @@ CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE=n
 ################################################################################
 # Zephyr Configuration
 
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=1460
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=1792
 CONFIG_ISR_STACK_SIZE=1536
 CONFIG_MAIN_STACK_SIZE=840
 

--- a/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/prj.conf
@@ -60,6 +60,10 @@ CONFIG_MAIN_STACK_SIZE=840
 
 # Reuse system workqueue as Bluetooth RX context to reduce memory consumption
 CONFIG_BT_RECV_WORKQ_SYS=y
+# Disable Bluetooth long workqueue to reduce memory consumption
+CONFIG_BT_LONG_WQ=n
+# Limit number of key slots in the PSA Crypto core to reduce memory consumption
+CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT=10
 
 CONFIG_BOOT_BANNER=n
 CONFIG_NCS_BOOT_BANNER=n

--- a/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/prj_release.conf
@@ -56,6 +56,10 @@ CONFIG_MAIN_STACK_SIZE=840
 
 # Reuse system workqueue as Bluetooth RX context to reduce memory consumption
 CONFIG_BT_RECV_WORKQ_SYS=y
+# Disable Bluetooth long workqueue to reduce memory consumption
+CONFIG_BT_LONG_WQ=n
+# Limit number of key slots in the PSA Crypto core to reduce memory consumption
+CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT=10
 
 CONFIG_BOOT_BANNER=n
 CONFIG_NCS_BOOT_BANNER=n

--- a/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/prj_release.conf
@@ -50,7 +50,7 @@ CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE=n
 ################################################################################
 # Zephyr Configuration
 
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=1460
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=1792
 CONFIG_ISR_STACK_SIZE=1536
 CONFIG_MAIN_STACK_SIZE=840
 

--- a/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/prj.conf
@@ -41,6 +41,10 @@ CONFIG_BT_HCI_TX_STACK_SIZE=1536
 
 # Reuse system workqueue as Bluetooth RX context to reduce memory consumption
 CONFIG_BT_RECV_WORKQ_SYS=y
+# Disable Bluetooth long workqueue to reduce memory consumption
+CONFIG_BT_LONG_WQ=n
+# Limit number of key slots in the PSA Crypto core to reduce memory consumption
+CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT=10
 
 CONFIG_BOOT_BANNER=n
 CONFIG_NCS_BOOT_BANNER=n

--- a/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/prj_release.conf
@@ -39,6 +39,10 @@ CONFIG_BT_HCI_TX_STACK_SIZE=1536
 
 # Reuse system workqueue as Bluetooth RX context to reduce memory consumption
 CONFIG_BT_RECV_WORKQ_SYS=y
+# Disable Bluetooth long workqueue to reduce memory consumption
+CONFIG_BT_LONG_WQ=n
+# Limit number of key slots in the PSA Crypto core to reduce memory consumption
+CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT=10
 
 CONFIG_BOOT_BANNER=n
 CONFIG_NCS_BOOT_BANNER=n

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/prj.conf
@@ -42,6 +42,10 @@ CONFIG_BT_HCI_TX_STACK_SIZE=1536
 
 # Reuse system workqueue as Bluetooth RX context to reduce memory consumption
 CONFIG_BT_RECV_WORKQ_SYS=y
+# Disable Bluetooth long workqueue to reduce memory consumption
+CONFIG_BT_LONG_WQ=n
+# Limit number of key slots in the PSA Crypto core to reduce memory consumption
+CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT=10
 
 CONFIG_BOOT_BANNER=n
 CONFIG_NCS_BOOT_BANNER=n

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/prj_release.conf
@@ -40,6 +40,10 @@ CONFIG_BT_HCI_TX_STACK_SIZE=1536
 
 # Reuse system workqueue as Bluetooth RX context to reduce memory consumption
 CONFIG_BT_RECV_WORKQ_SYS=y
+# Disable Bluetooth long workqueue to reduce memory consumption
+CONFIG_BT_LONG_WQ=n
+# Limit number of key slots in the PSA Crypto core to reduce memory consumption
+CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT=10
 
 CONFIG_BOOT_BANNER=n
 CONFIG_NCS_BOOT_BANNER=n

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/prj_dongle_small.conf
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/prj_dongle_small.conf
@@ -47,6 +47,10 @@ CONFIG_BT_HCI_TX_STACK_SIZE=1536
 
 # Reuse system workqueue as Bluetooth RX context to reduce memory consumption
 CONFIG_BT_RECV_WORKQ_SYS=y
+# Disable Bluetooth long workqueue to reduce memory consumption
+CONFIG_BT_LONG_WQ=n
+# Limit number of key slots in the PSA Crypto core to reduce memory consumption
+CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT=10
 
 CONFIG_BOOT_BANNER=n
 CONFIG_NCS_BOOT_BANNER=n

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -238,6 +238,10 @@ nRF Desktop
   * Application configurations for nRF54L05, nRF54L10, and nRF54L15 SoCs to use Fast Pair PSA cryptography (:kconfig:option:`CONFIG_BT_FAST_PAIR_CRYPTO_PSA`).
     Using PSA cryptography improves security and reduces memory footprint.
     Also increased the size of the Bluetooth receiving thread stack (:kconfig:option:`CONFIG_BT_RX_STACK_SIZE`) to prevent stack overflows.
+  * Application configurations for nRF52810 and nRF52820 SoCs to reduce memory footprint:
+
+    * Disabled Bluetooth long workqueue (:kconfig:option:`CONFIG_BT_LONG_WQ`).
+    * Limited the number of key slots in the PSA Crypto core to 10 (:kconfig:option:`CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT`).
 
 * Added:
 

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -49,22 +49,6 @@
   comment: "To be fixed after upmerge. Footprint should be reduced. NCSDK-31428"
 
 - scenarios:
-    - applications.nrf_desktop.zrelease
-  platforms:
-    - nrf52833dk/nrf52820
-    - nrf52820dongle/nrf52820
-    - nrf52810dmouse/nrf52810
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-31675"
-
-- scenarios:
-    - applications.nrf_desktop.zdebug
-  platforms:
-    - nrf52833dk/nrf52820
-    - nrf52820dongle/nrf52820
-    - nrf52810dmouse/nrf52810
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-31675"
-
-- scenarios:
     - applications.connectivity_bridge
   platforms:
     - thingy91x/nrf5340/cpuapp


### PR DESCRIPTION
Change introduces memory footprint optimizations for boards based on nRF52810 and nRF52820 SoCs. The optimizations are needed to make nRF Desktop again fit in these memory-limited SoCs.

The PR also removes the fixed configurations from CI quarantine and aligns system workq stack size on nrf52810dmouse to prevent faults right after boot.

Jira: NCSDK-31675