### PR TITLE
nrf_security: cracen: kmu: Support KMU reserved area through DTS

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -66,7 +66,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 16dc0c6c01401abcb069ec35139f490c2b13d907
+      revision: b91aa4fec5484f6cd076c9333bb474a7f5c002c1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
    When execution in place (CONFIG_XIP) is not enabled, which in practice
    means that when Zephyr is built for a RAM loaded image, the Zephyr
    linker script always places the RAM loaded image in the top address
    of the RAM and then loads the linker scripts defined with the Zephyr
    SECTION_PROLOGUE macros.
    
    SECTION_PROLOGUE Zephyr macros was used to set the address of the
    kmu_push_area making it incompatible with RAM loaded images.
    
    The Zephyr reserved-memory devicetree methodology works for both use
    cases but it requires heavy updates of multiple device tree files and
    overlays. In order to support the RAM loaded images use cases faster
    initial support for reserving the memory of nrf_kmu_reserved_push_area
    though devicetree is limited to RAM loaded images.
    
    Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>
