### PR TITLE
nrf_security: cracen: Improve DCACHE handling

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/aead.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/aead.c
@@ -474,7 +474,8 @@ int sx_aead_status(struct sxaead *c)
 	}
 
 #if CONFIG_DCACHE
-	sys_cache_data_invd_range((void *)&c->extramem, sizeof(c->extramem));
+	sx_cmdma_outdescs_flush_and_invd_dcache(&c->dma);
+	sys_cache_data_flush_and_invd_range((void *)&c->extramem, sizeof(c->extramem));
 #endif
 
 	if (!(c->dma.dmamem.cfg & c->cfg->ctxsave) && c->expectedtag != NULL) {

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmdma.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmdma.h
@@ -28,7 +28,7 @@
 #define DMATAG_CONFIG(offset) ((1 << 4) | (offset << 8))
 
 /* can be 0, 1 or 2 */
-#define DMATAG_DATATYPE(x)   (x << 6)
+#define DMATAG_DATATYPE(x) (x << 6)
 
 #define DMATAG_DATATYPE_HEADER	    (1 << 6)
 #define DMATAG_DATATYPE_REFERENCE   (3 << 6)
@@ -106,17 +106,17 @@
 		(dmactl).d++;                                                                      \
 	} while (0)
 
-#define ADD_INDESC_BITS(dmactl, baddr, bsz, tag, msk, bitsz)\
-	do {\
-		size_t bitmask = (msk << 3) | 0x7;\
-		size_t validbitsz = bitsz & bitmask;\
-		if (validbitsz == 0)\
-			validbitsz = bitmask + 1;\
-		uint32_t asz = ALIGN_SZA(bsz, msk);\
-		(dmactl).d->addr = sx_map_usrdatain((char *)(baddr), bsz);\
-		(dmactl).d->sz = asz | DMA_REALIGN;\
-		(dmactl).d->dmatag = tag | DMATAG_IGN((validbitsz - 1)); \
-		(dmactl).d++;\
+#define ADD_INDESC_BITS(dmactl, baddr, bsz, tag, msk, bitsz)                                       \
+	do {                                                                                       \
+		size_t bitmask = (msk << 3) | 0x7;                                                 \
+		size_t validbitsz = bitsz & bitmask;                                               \
+		if (validbitsz == 0)                                                               \
+			validbitsz = bitmask + 1;                                                  \
+		uint32_t asz = ALIGN_SZA(bsz, msk);                                                \
+		(dmactl).d->addr = sx_map_usrdatain((char *)(baddr), bsz);                         \
+		(dmactl).d->sz = asz | DMA_REALIGN;                                                \
+		(dmactl).d->dmatag = tag | DMATAG_IGN((validbitsz - 1));                           \
+		(dmactl).d++;                                                                      \
 	} while (0)
 
 #define SET_LAST_DESC_IGN(dmactl, bsz, msk)                                                        \
@@ -162,6 +162,11 @@ void sx_cmdma_newcmd(struct sx_dmactl *dma, struct sxdesc *d, uint32_t cmd, uint
 
 /** Start input/fetcher DMA at indescs and output/pusher DMA at outdescs */
 void sx_cmdma_start(struct sx_dmactl *dma, size_t privsz, struct sxdesc *indescs);
+
+#ifdef CONFIG_DCACHE
+/** Flush and invalidate the buffers for the output descriptors */
+void sx_cmdma_outdescs_flush_and_invd_dcache(const struct sx_dmactl *dma);
+#endif
 
 /** Return how the DMA is doing.
  *

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hash.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hash.c
@@ -235,7 +235,7 @@ static int start_hash_hw(struct sxhash *c)
 {
 	sx_cmdma_start(&c->dma, sizeof(c->descs) + sizeof(c->extramem), c->descs);
 
-	return 0;
+	return SX_OK;
 }
 
 int sx_hash_save_state(struct sxhash *c)
@@ -289,7 +289,8 @@ int sx_hash_status(struct sxhash *c)
 	}
 
 #if CONFIG_DCACHE
-	sys_cache_data_invd_range((void *)&c->extramem, sizeof(c->extramem));
+	sx_cmdma_outdescs_flush_and_invd_dcache(&c->dma);
+	sys_cache_data_flush_and_invd_range((void *)&c->extramem, sizeof(c->extramem));
 #endif
 
 	sx_hash_free(c);

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/mac.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/mac.c
@@ -179,7 +179,8 @@ int sx_mac_status(struct sxmac *c)
 	}
 
 #if CONFIG_DCACHE
-	sys_cache_data_invd_range((void *)&c->extramem, sizeof(c->extramem));
+	sx_cmdma_outdescs_flush_and_invd_dcache(&c->dma);
+	sys_cache_data_flush_and_invd_range((void *)&c->extramem, sizeof(c->extramem));
 #endif
 
 	sx_mac_free(c);


### PR DESCRIPTION
Calling plain invalidate isn't always safe, as there might be pending writes in the cache line that just get thrown away. Just switch to full cache line evasion, so writeback + invalidate just to be safe. Also iterate over the out descriptors to make sure all the buffers are cache handled on completing of the cracen operations.