### PR TITLE
sysbuild: add support Kconfig for flpr core

### DIFF
--- a/sysbuild/Kconfig.flprcore
+++ b/sysbuild/Kconfig.flprcore
@@ -1,0 +1,16 @@
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+config SUPPORT_FLPRCORE
+	bool
+	default y if (SOC_NRF54L05_CPUAPP || SOC_NRF54L10_CPUAPP || SOC_NRF54L15_CPUAPP || \
+		      SOC_NRF54H20_CPUAPP)
+
+if SUPPORT_FLPRCORE
+
+config FLPRCORE_REMOTE_BOARD_TARGET_CPUCLUSTER
+	string
+	default "cpuflpr"
+
+endif # SUPPORT_FLPRCORE

--- a/sysbuild/Kconfig.sysbuild
+++ b/sysbuild/Kconfig.sysbuild
@@ -68,6 +68,7 @@ config BOARD_IS_NON_SECURE
 	default y if "$(BOARD_NS_QUALIFIER_CHECK)" = "/ns"
 
 rsource "Kconfig.appcore"
+rsource "Kconfig.flprcore"
 rsource "Kconfig.netcore"
 rsource "Kconfig.pprcore"
 rsource "Kconfig.secureboot"


### PR DESCRIPTION
Added a new general sysbuild Kconfig file with new Kconfig options that indicate support for the FLPR core.

Ref: NCSDK-30327