### PR TITLE
ci: update zephyr to 0.18.0 clang enabled on ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("CI_LIB") _
+@Library("CI_LIB@clang") _
 
 def pipeline = new ncs.sdk_nrf.Main()
 

--- a/boards/nordic/nrf52810dmouse/nrf52810dmouse_nrf52810.yaml
+++ b/boards/nordic/nrf52810dmouse/nrf52810dmouse_nrf52810.yaml
@@ -4,6 +4,8 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
   - gnuarmemb
   - xtools
 supported:

--- a/boards/nordic/nrf52820dongle/nrf52820dongle_nrf52820.yaml
+++ b/boards/nordic/nrf52820dongle/nrf52820dongle_nrf52820.yaml
@@ -6,6 +6,8 @@ ram: 32
 flash: 256
 toolchain:
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
   - gnuarmemb
   - xtools
   - netif:openthread

--- a/boards/nordic/nrf52833dongle/nrf52833dongle_nrf52833.yaml
+++ b/boards/nordic/nrf52833dongle/nrf52833dongle_nrf52833.yaml
@@ -6,6 +6,8 @@ ram: 128
 flash: 512
 toolchain:
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
   - gnuarmemb
   - xtools
 supported:

--- a/boards/nordic/nrf52840gmouse/nrf52840gmouse_nrf52840.yaml
+++ b/boards/nordic/nrf52840gmouse/nrf52840gmouse_nrf52840.yaml
@@ -4,6 +4,8 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
   - gnuarmemb
 ram: 256
 flash: 1024

--- a/boards/nordic/nrf52dmouse/nrf52dmouse_nrf52832.yaml
+++ b/boards/nordic/nrf52dmouse/nrf52dmouse_nrf52832.yaml
@@ -4,6 +4,8 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
   - gnuarmemb
   - xtools
 supported:

--- a/boards/nordic/nrf52kbd/nrf52kbd_nrf52832.yaml
+++ b/boards/nordic/nrf52kbd/nrf52kbd_nrf52832.yaml
@@ -4,6 +4,8 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
   - gnuarmemb
 ram: 64
 flash: 512

--- a/boards/nordic/thingy91/thingy91_nrf52840.yaml
+++ b/boards/nordic/thingy91/thingy91_nrf52840.yaml
@@ -4,6 +4,8 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
   - gnuarmemb
 ram: 256
 flash: 1024

--- a/boards/nordic/thingy91/thingy91_nrf9160.yaml
+++ b/boards/nordic/thingy91/thingy91_nrf9160.yaml
@@ -5,6 +5,8 @@ arch: arm
 toolchain:
   - gnuarmemb
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
 ram: 64
 flash: 256
 supported:

--- a/boards/nordic/thingy91/thingy91_nrf9160_ns.yaml
+++ b/boards/nordic/thingy91/thingy91_nrf9160_ns.yaml
@@ -5,6 +5,8 @@ arch: arm
 toolchain:
   - gnuarmemb
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
 ram: 128
 flash: 256
 supported:

--- a/boards/nordic/thingy91x/thingy91x_nrf5340_cpuapp.yaml
+++ b/boards/nordic/thingy91x/thingy91x_nrf5340_cpuapp.yaml
@@ -6,6 +6,8 @@ toolchain:
   - gnuarmemb
   - xtools
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
 ram: 448
 flash: 1024
 supported:

--- a/boards/nordic/thingy91x/thingy91x_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/thingy91x/thingy91x_nrf5340_cpuapp_ns.yaml
@@ -6,6 +6,8 @@ toolchain:
   - gnuarmemb
   - xtools
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
 ram: 192
 flash: 192
 supported:

--- a/boards/nordic/thingy91x/thingy91x_nrf5340_cpunet.yaml
+++ b/boards/nordic/thingy91x/thingy91x_nrf5340_cpunet.yaml
@@ -6,6 +6,8 @@ toolchain:
   - gnuarmemb
   - xtools
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
 ram: 64
 flash: 256
 supported:

--- a/boards/nordic/thingy91x/thingy91x_nrf9151.yaml
+++ b/boards/nordic/thingy91x/thingy91x_nrf9151.yaml
@@ -5,6 +5,8 @@ arch: arm
 toolchain:
   - gnuarmemb
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
 ram: 64
 flash: 256
 supported:

--- a/boards/nordic/thingy91x/thingy91x_nrf9151_ns.yaml
+++ b/boards/nordic/thingy91x/thingy91x_nrf9151_ns.yaml
@@ -5,6 +5,8 @@ arch: arm
 toolchain:
   - gnuarmemb
   - zephyr
+  - zephyr-gnu
+  - zephyr-llvm
 ram: 128
 flash: 256
 supported:

--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -16,7 +16,7 @@ west:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.17.0
+  version: 0.18.0-alpha2
   architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.17.0
     - arm-zephyr-eabi
     - riscv64-zephyr-elf

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -17,7 +17,7 @@ gn:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.17.0
+  version: 0.18.0-alpha2
   architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.17.0
     - arm-zephyr-eabi
     - riscv64-zephyr-elf

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -15,7 +15,7 @@ west:
 nanopb:
   version: 0.4.6
 zephyr-sdk:
-  version: 0.17.0
+  version: 0.18.0-alpha2
   architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.17.0
     - arm-zephyr-eabi
     - riscv64-zephyr-elf

--- a/west.yml
+++ b/west.yml
@@ -66,7 +66,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 80cc5318ea91317d25fdeffb70e59507d68a1966
+      revision: pull/2509/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Still WIP

- **ci: update zephyr to 0.18.0**
- **pointing to zephyr with clang addition**
- **ci: crypto python package update**
- **enable zephyr-gnu and zephyr-llvm support for boards**
- **Switch to clang branch on CI for clang testing**
