### PR TITLE
applications: ipc_radio: Fix release_rx_buffer spurious error

### DIFF
--- a/applications/ipc_radio/src/bt_hci_ipc.c
+++ b/applications/ipc_radio/src/bt_hci_ipc.c
@@ -283,8 +283,10 @@ static void queue_thread(void)
 		}
 
 		err = ipc_service_release_rx_buffer(&hci_ept, (void *)block.ptr);
-		if (err) {
+		if (err < 0) {
 			LOG_ERR("Failed to release rx buffer: %d.", err);
+		} else {
+			LOG_DBG("Released rx buffer with ret %d.", err);
 		}
 
 		if (buf) {


### PR DESCRIPTION
Fix spurious error of positive return value of the function ipc_service_release_rx_buffer for icbmsg.

The function should return only negative error codes, but returns positive values passed from send_release<-send_control_message<-icmsg_send . This triggers error message on successful exit.