### PR TITLE
samples: bluetooth: fast_pair: Increase BT RX stack size for nRF54L

### DIFF
--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -5,7 +5,7 @@
 #
 
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=3584
-CONFIG_BT_RX_STACK_SIZE=2560
+CONFIG_BT_RX_STACK_SIZE=3072
 
 # Align the advertised TX power with Fast Pair expectations.
 # The value has been tailored for following targets:

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -5,7 +5,7 @@
 #
 
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=3584
-CONFIG_BT_RX_STACK_SIZE=2560
+CONFIG_BT_RX_STACK_SIZE=3072
 
 # Align the TX power encoded in the Fast Pair advertising set and
 # the Read Beacon Parameters response with Fast Pair expectations.


### PR DESCRIPTION
Increased BT RX stack size for nrf54l15dk/nrf54l15/cpuapp target to fix stack overflows encountered during FP validator tests.

Jira: NCSDK-31777
Jira: NCSDK-31786