### PR TITLE
drivers: mspi: mspi_nrfe: cleanup

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -616,8 +616,11 @@
 "CI-test-low-level":
   - "applications/sdp/**/*"
   - "drivers/gpio/**/*"
+  - "drivers/mspi/**/*"
   - "dts/bindings/gpio/**/*"
+  - "dts/bindings/mspi/**/*"
   - "include/drivers/gpio/**/*"
+  - "include/drivers/mspi/**/*"
   - "include/event_manager_proxy.h"
   - "subsys/event_manager_proxy/**/*"
   - "samples/ipc/**/*"
@@ -629,6 +632,7 @@
   - "tests/drivers/gpio/**/*"
   - "tests/drivers/lpuart/**/*"
   - "tests/drivers/pwm/**/*"
+  - "tests/drivers/sdp_asm/**/*"
   - "tests/drivers/sensor/**/*"
   - "tests/drivers/audio/**/*"
 

--- a/drivers/mspi/mspi_nrfe.c
+++ b/drivers/mspi/mspi_nrfe.c
@@ -11,9 +11,6 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/ipc/ipc_service.h>
 #include <zephyr/pm/device.h>
-#if !defined(CONFIG_MULTITHREADING)
-#include <zephyr/sys/atomic.h>
-#endif
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mspi_nrfe, CONFIG_MSPI_LOG_LEVEL);
 
@@ -45,13 +42,9 @@ static struct ipc_ept ep;
 static size_t ipc_received;
 static uint8_t *ipc_receive_buffer;
 
-#if defined(CONFIG_MULTITHREADING)
 static K_SEM_DEFINE(ipc_sem, 0, 1);
 static K_SEM_DEFINE(ipc_sem_cfg, 0, 1);
 static K_SEM_DEFINE(ipc_sem_xfer, 0, 1);
-#else
-static atomic_t ipc_atomic_sem = ATOMIC_INIT(0);
-#endif
 
 #define MSPI_CONFIG                                                                                \
 	{                                                                                          \
@@ -81,153 +74,86 @@ static const struct mspi_nrfe_config dev_config = {
 
 static struct mspi_nrfe_data dev_data;
 
+static const char * const opcode_strs[] = {
+	[NRFE_MSPI_EP_BOUNDED]   = "EP bound",
+	[NRFE_MSPI_CONFIG_PINS]  = "config pins",
+	[NRFE_MSPI_CONFIG_DEV]   = "config dev",
+	[NRFE_MSPI_CONFIG_XFER]  = "config xfer",
+	[NRFE_MSPI_TX]           = "TX",
+	[NRFE_MSPI_TXRX]         = "TXRX",
+	[NRFE_MSPI_WRONG_OPCODE] = "wrong opcode",
+};
+
 static void ep_recv(const void *data, size_t len, void *priv);
 
 static void ep_bound(void *priv)
 {
 	ipc_received = 0;
-#if defined(CONFIG_MULTITHREADING)
 	k_sem_give(&ipc_sem);
-#else
-	atomic_set_bit(&ipc_atomic_sem, NRFE_MSPI_EP_BOUNDED);
-#endif
-	LOG_DBG("Ep bounded");
+	LOG_DBG("Endpoint bound.");
 }
 
 static struct ipc_ept_cfg ep_cfg = {
-	.cb = {.bound = ep_bound, .received = ep_recv},
+	.cb = {
+		.bound = ep_bound,
+		.received = ep_recv
+	},
 };
 
-/**
- * @brief IPC receive callback function.
- *
- * This function is called by the IPC stack when a message is received from the
- * other core. The function checks the opcode of the received message and takes
- * appropriate action.
- *
- * @param data Pointer to the received message.
- * @param len Length of the received message.
- */
 static void ep_recv(const void *data, size_t len, void *priv)
 {
 	nrfe_mspi_flpr_response_msg_t *response = (nrfe_mspi_flpr_response_msg_t *)data;
 
 	switch (response->opcode) {
-	case NRFE_MSPI_CONFIG_PINS: {
-#if defined(CONFIG_MULTITHREADING)
+	case NRFE_MSPI_CONFIG_PINS:
+	case NRFE_MSPI_CONFIG_DEV:
+	case NRFE_MSPI_CONFIG_XFER:
 		k_sem_give(&ipc_sem_cfg);
-#else
-		atomic_set_bit(&ipc_atomic_sem, NRFE_MSPI_CONFIG_PINS);
-#endif
 		break;
-	}
-	case NRFE_MSPI_CONFIG_DEV: {
-#if defined(CONFIG_MULTITHREADING)
-		k_sem_give(&ipc_sem_cfg);
-#else
-		atomic_set_bit(&ipc_atomic_sem, NRFE_MSPI_CONFIG_DEV);
-#endif
-		break;
-	}
-	case NRFE_MSPI_CONFIG_XFER: {
-#if defined(CONFIG_MULTITHREADING)
-		k_sem_give(&ipc_sem_cfg);
-#else
-		atomic_set_bit(&ipc_atomic_sem, NRFE_MSPI_CONFIG_XFER);
-#endif
-		break;
-	}
-	case NRFE_MSPI_TX: {
-#if defined(CONFIG_MULTITHREADING)
-		k_sem_give(&ipc_sem_xfer);
-#else
-		atomic_set_bit(&ipc_atomic_sem, NRFE_MSPI_TX);
-#endif
-		break;
-	}
-	case NRFE_MSPI_TXRX: {
+	case NRFE_MSPI_TXRX:
 		if (len > 0) {
 			ipc_received = len - sizeof(nrfe_mspi_opcode_t);
 			ipc_receive_buffer = (uint8_t *)&response->data;
 		}
-#if defined(CONFIG_MULTITHREADING)
+	case NRFE_MSPI_TX:
 		k_sem_give(&ipc_sem_xfer);
-#else
-		atomic_set_bit(&ipc_atomic_sem, NRFE_MSPI_TXRX);
-#endif
 		break;
-	}
-	default: {
+	default:
 		LOG_ERR("Invalid response opcode: %d", response->opcode);
 		break;
 	}
-	}
-
-	LOG_HEXDUMP_DBG((uint8_t *)data, len, "Received msg:");
 }
 
-/**
- * @brief Send data to the flpr with the given opcode.
- *
- * @param opcode The opcode of the message to send.
- * @param data The data to send.
- * @param len The length of the data to send.
- *
- * @return 0 on success, -ENOMEM if there is no space in the buffer,
- *         -ETIMEDOUT if the transfer timed out.
- */
-static int mspi_ipc_data_send(nrfe_mspi_opcode_t opcode, const void *data, size_t len)
+static int ipc_data_send(nrfe_mspi_opcode_t opcode, const void *data, size_t len)
 {
 	int rc;
 
-	LOG_DBG("Sending msg with opcode: %d", (uint8_t)opcode);
-#if defined(CONFIG_SYS_CLOCK_EXISTS)
+	LOG_DBG("Sending msg with opcode: %s, size: %d", opcode_strs[opcode], len);
 	uint32_t start = k_uptime_get_32();
-#else
-	uint32_t repeat = EP_SEND_TIMEOUT_MS;
-#endif
-#if !defined(CONFIG_MULTITHREADING)
-	atomic_clear_bit(&ipc_atomic_sem, opcode);
-#endif
 
 	do {
 		rc = ipc_service_send(&ep, data, len);
-#if defined(CONFIG_SYS_CLOCK_EXISTS)
 		if ((k_uptime_get_32() - start) > EP_SEND_TIMEOUT_MS) {
-#else
-		repeat--;
-		if ((rc < 0) && (repeat == 0)) {
-#endif
 			break;
-		};
+		}
 	} while (rc == -ENOMEM); /* No space in the buffer. Retry. */
 
 	return rc;
 }
 
-/**
- * @brief Waits for a response from the peer with the given opcode.
- *
- * @param opcode The opcode of the response to wait for.
- * @param timeout The timeout in milliseconds.
- *
- * @return 0 on success, -ETIMEDOUT if the operation timed out.
- */
-static int nrfe_mspi_wait_for_response(nrfe_mspi_opcode_t opcode, uint32_t timeout)
+static int wait_for_response(nrfe_mspi_opcode_t opcode)
 {
-#if defined(CONFIG_MULTITHREADING)
 	int ret = 0;
 
 	switch (opcode) {
 	case NRFE_MSPI_CONFIG_PINS:
 	case NRFE_MSPI_CONFIG_DEV:
-	case NRFE_MSPI_CONFIG_XFER: {
-		ret = k_sem_take(&ipc_sem_cfg, K_MSEC(timeout));
+	case NRFE_MSPI_CONFIG_XFER:
+		ret = k_sem_take(&ipc_sem_cfg, K_MSEC(IPC_TIMEOUT_MS));
 		break;
-	}
 	case NRFE_MSPI_TX:
 	case NRFE_MSPI_TXRX:
-		ret = k_sem_take(&ipc_sem_xfer, K_MSEC(timeout));
+		ret = k_sem_take(&ipc_sem_xfer, K_MSEC(IPC_TIMEOUT_MS));
 		break;
 	default:
 		break;
@@ -236,39 +162,10 @@ static int nrfe_mspi_wait_for_response(nrfe_mspi_opcode_t opcode, uint32_t timeo
 	if (ret < 0) {
 		return -ETIMEDOUT;
 	}
-#else
-#if defined(CONFIG_SYS_CLOCK_EXISTS)
-	uint32_t start = k_uptime_get_32();
-#else
-	uint32_t repeat = timeout * 1000; /* Convert ms to us */
-#endif
-	while (!atomic_test_and_clear_bit(&ipc_atomic_sem, opcode)) {
-#if defined(CONFIG_SYS_CLOCK_EXISTS)
-		if ((k_uptime_get_32() - start) > timeout) {
-			return -ETIMEDOUT;
-		};
-#else
-		repeat--;
-		if (!repeat) {
-			return -ETIMEDOUT;
-		};
-#endif
-		k_sleep(K_USEC(1));
-	}
-#endif /* CONFIG_MULTITHREADING */
 	return 0;
 }
 
-/**
- * @brief Send data to the FLPR core using the IPC service, and wait for FLPR response.
- *
- * @param opcode The configuration packet opcode to send.
- * @param data The data to send.
- * @param len The length of the data to send.
- *
- * @return 0 on success, negative errno code on failure.
- */
-static int send_data(nrfe_mspi_opcode_t opcode, const void *data, size_t len)
+static int send_and_wait(nrfe_mspi_opcode_t opcode, const void *data, size_t len)
 {
 	int rc;
 
@@ -276,9 +173,9 @@ static int send_data(nrfe_mspi_opcode_t opcode, const void *data, size_t len)
 	(void)len;
 	void *data_ptr = (void *)data;
 
-	rc = mspi_ipc_data_send(opcode, &data_ptr, sizeof(void *));
+	rc = ipc_data_send(opcode, &data_ptr, sizeof(void *));
 #else
-	rc = mspi_ipc_data_send(opcode, data, len);
+	rc = ipc_data_send(opcode, data, len);
 #endif
 
 	if (rc < 0) {
@@ -286,25 +183,125 @@ static int send_data(nrfe_mspi_opcode_t opcode, const void *data, size_t len)
 		return rc;
 	}
 
-	rc = nrfe_mspi_wait_for_response(opcode, IPC_TIMEOUT_MS);
+	rc = wait_for_response(opcode);
 	if (rc < 0) {
-		LOG_ERR("Data transfer: %d response timeout: %d!", opcode, rc);
+		LOG_ERR("Data transfer: %s response timeout: %d!", opcode_strs[opcode], rc);
 	}
 
 	return rc;
 }
 
-/**
- * @brief Configures the MSPI controller based on the provided spec.
- *
- * This function configures the MSPI controller according to the provided
- * spec. It checks if the spec is valid and sends the configuration to
- * the FLPR.
- *
- * @param spec The MSPI spec to use for configuration.
- *
- * @return 0 on success, negative errno code on failure.
- */
+
+static int xfer_packet(struct mspi_xfer *xfer, uint32_t packets_done)
+{
+	int rc;
+	struct mspi_xfer_packet *packet = (struct mspi_xfer_packet *)&xfer->packets[packets_done];
+	nrfe_mspi_opcode_t opcode = (packet->dir == MSPI_RX) ? NRFE_MSPI_TXRX : NRFE_MSPI_TX;
+
+	if (packet->num_bytes >= MAX_TX_MSG_SIZE) {
+		LOG_ERR("Packet size to large: %u. Increase SRAM data region.", packet->num_bytes);
+		return -EINVAL;
+	}
+
+#ifdef CONFIG_MSPI_NRFE_IPC_NO_COPY
+	/* Check for alignment problems. */
+	uint32_t len = ((uint32_t)packet->data_buf) % sizeof(uint32_t) != 0
+			       ? sizeof(nrfe_mspi_xfer_packet_msg_t) + packet->num_bytes
+			       : sizeof(nrfe_mspi_xfer_packet_msg_t);
+#else
+	uint32_t len = sizeof(nrfe_mspi_xfer_packet_msg_t) + packet->num_bytes;
+#endif
+	uint8_t buffer[len];
+	nrfe_mspi_xfer_packet_msg_t *xfer_packet = (nrfe_mspi_xfer_packet_msg_t *)buffer;
+
+	xfer_packet->opcode = opcode;
+	xfer_packet->command = packet->cmd;
+	xfer_packet->address = packet->address;
+	xfer_packet->num_bytes = packet->num_bytes;
+
+#ifdef CONFIG_MSPI_NRFE_IPC_NO_COPY
+	/*
+	 * Check for alignment problems. With no-copy mode, FLPR expects data buffer to be aligned
+	 * to word size.
+	 */
+	if (((uint32_t)packet->data_buf) % sizeof(uint32_t) != 0) {
+		memcpy((void *)(buffer + sizeof(nrfe_mspi_xfer_packet_msg_t)),
+		       (void *)packet->data_buf, packet->num_bytes);
+		xfer_packet->data = buffer + sizeof(nrfe_mspi_xfer_packet_msg_t);
+	} else {
+		xfer_packet->data = packet->data_buf;
+	}
+#else
+	memcpy((void *)xfer_packet->data, (void *)packet->data_buf, packet->num_bytes);
+#endif
+
+	/* Wait for the transfer to complete and receive data. */
+	rc = send_and_wait(xfer_packet->opcode, xfer_packet, len);
+
+	if ((packet->dir == MSPI_RX) && (ipc_receive_buffer != NULL) && (ipc_received > 0)) {
+		/*
+		 * It is not possible to check whether received data is valid, so packet->num_bytes
+		 * should always be equal to ipc_received. If it is not, then something went wrong.
+		 */
+		if (packet->num_bytes != ipc_received) {
+			rc = -EIO;
+		} else {
+			memcpy((void *)packet->data_buf, (void *)ipc_receive_buffer, ipc_received);
+		}
+
+		/* Clear the receive buffer pointer and size */
+		ipc_receive_buffer = NULL;
+		ipc_received = 0;
+	}
+
+	return rc;
+}
+
+static int api_transceive(const struct device *dev, const struct mspi_dev_id *dev_id,
+			  const struct mspi_xfer *req)
+{
+	struct mspi_nrfe_data *drv_data = dev->data;
+	uint32_t packet_idx = 0;
+	int rc;
+
+	/* TODO: add support for asynchronous transfers */
+	if (req->async) {
+		return -ENOTSUP;
+	}
+
+	if (req->num_packet == 0 || !req->packets ||
+	    req->timeout > CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE) {
+		return -EFAULT;
+	}
+
+	drv_data->xfer_config_msg.opcode = NRFE_MSPI_CONFIG_XFER;
+	drv_data->xfer_config_msg.xfer_config.device_index = dev_id->dev_idx;
+	drv_data->xfer_config_msg.xfer_config.command_length = req->cmd_length;
+	drv_data->xfer_config_msg.xfer_config.address_length = req->addr_length;
+	drv_data->xfer_config_msg.xfer_config.hold_ce = req->hold_ce;
+	drv_data->xfer_config_msg.xfer_config.tx_dummy = req->tx_dummy;
+	drv_data->xfer_config_msg.xfer_config.rx_dummy = req->rx_dummy;
+
+	rc = send_and_wait(NRFE_MSPI_CONFIG_XFER, (void *)&drv_data->xfer_config_msg,
+		       sizeof(nrfe_mspi_xfer_config_msg_t));
+
+	if (rc < 0) {
+		LOG_ERR("Send xfer config error: %d", rc);
+		return rc;
+	}
+
+	while (packet_idx < req->num_packet) {
+		rc = xfer_packet((struct mspi_xfer *)req, packet_idx);
+		if (rc < 0) {
+			LOG_ERR("xfer_packet error: %d packet_idx: %d", rc, packet_idx);
+			return rc;
+		}
+		packet_idx++;
+	}
+
+	return 0;
+}
+
 static int api_config(const struct mspi_dt_spec *spec)
 {
 	const struct mspi_cfg *config = &spec->config;
@@ -351,7 +348,7 @@ static int api_config(const struct mspi_dt_spec *spec)
 	mspi_pin_config.opcode = NRFE_MSPI_CONFIG_PINS;
 
 	/* Send pinout configuration to FLPR */
-	return send_data(NRFE_MSPI_CONFIG_PINS, (const void *)&mspi_pin_config,
+	return send_and_wait(NRFE_MSPI_CONFIG_PINS, (const void *)&mspi_pin_config,
 			 sizeof(nrfe_mspi_pinctrl_soc_pin_msg_t));
 }
 
@@ -371,16 +368,6 @@ static int check_io_mode(enum mspi_io_mode io_mode)
 	return 0;
 }
 
-/**
- * @brief Configure a device on the MSPI bus.
- *
- * @param dev MSPI controller device.
- * @param dev_id Device ID to configure.
- * @param param_mask Bitmask of parameters to configure.
- * @param cfg Device configuration.
- *
- * @return 0 on success, negative errno code on failure.
- */
 static int api_dev_config(const struct device *dev, const struct mspi_dev_id *dev_id,
 			  const enum mspi_dev_cfg_mask param_mask, const struct mspi_dev_cfg *cfg)
 {
@@ -439,7 +426,7 @@ static int api_dev_config(const struct device *dev, const struct mspi_dev_id *de
 	mspi_dev_config_msg.dev_config.freq = cfg->freq;
 	mspi_dev_config_msg.dev_config.ce_index = cfg->ce_num;
 
-	return send_data(NRFE_MSPI_CONFIG_DEV, (void *)&mspi_dev_config_msg,
+	return send_and_wait(NRFE_MSPI_CONFIG_DEV, (void *)&mspi_dev_config_msg,
 			 sizeof(nrfe_mspi_dev_config_msg_t));
 }
 
@@ -448,203 +435,6 @@ static int api_get_channel_status(const struct device *dev, uint8_t ch)
 	return 0;
 }
 
-/**
- * @brief Send a transfer packet to the eMSPI controller.
- *
- * @param dev eMSPI controller device
- * @param packet Transfer packet containing the data to be transferred
- * @param timeout Timeout in milliseconds
- *
- * @retval 0 on success
- * @retval -ENOTSUP if the packet is not supported
- * @retval -ENOMEM if there is no space in the buffer
- * @retval -ETIMEDOUT if the transfer timed out
- */
-static int xfer_packet(struct mspi_xfer_packet *packet, uint32_t timeout)
-{
-	int rc;
-	nrfe_mspi_opcode_t opcode = (packet->dir == MSPI_RX) ? NRFE_MSPI_TXRX : NRFE_MSPI_TX;
-
-#ifdef CONFIG_MSPI_NRFE_IPC_NO_COPY
-	/* Check for alignment problems. */
-	uint32_t len = ((uint32_t)packet->data_buf) % sizeof(uint32_t) != 0
-			       ? sizeof(nrfe_mspi_xfer_packet_msg_t) + packet->num_bytes
-			       : sizeof(nrfe_mspi_xfer_packet_msg_t);
-#else
-	uint32_t len = sizeof(nrfe_mspi_xfer_packet_msg_t) + packet->num_bytes;
-#endif
-	uint8_t buffer[len];
-	nrfe_mspi_xfer_packet_msg_t *xfer_packet = (nrfe_mspi_xfer_packet_msg_t *)buffer;
-
-	xfer_packet->opcode = opcode;
-	xfer_packet->command = packet->cmd;
-	xfer_packet->address = packet->address;
-	xfer_packet->num_bytes = packet->num_bytes;
-
-#ifdef CONFIG_MSPI_NRFE_IPC_NO_COPY
-	/* Check for alignlemt problems. */
-	if (((uint32_t)packet->data_buf) % sizeof(uint32_t) != 0) {
-		memcpy((void *)(buffer + sizeof(nrfe_mspi_xfer_packet_msg_t)),
-		       (void *)packet->data_buf, packet->num_bytes);
-		xfer_packet->data = buffer + sizeof(nrfe_mspi_xfer_packet_msg_t);
-	} else {
-		xfer_packet->data = packet->data_buf;
-	}
-#else
-	memcpy((void *)xfer_packet->data, (void *)packet->data_buf, packet->num_bytes);
-#endif
-
-	rc = send_data(xfer_packet->opcode, xfer_packet, len);
-
-	/* Wait for the transfer to complete and receive data. */
-	if ((packet->dir == MSPI_RX) && (ipc_receive_buffer != NULL) && (ipc_received > 0)) {
-		/*
-		 * It is not possible to check whether received data is valid, so packet->num_bytes
-		 * should always be equal to ipc_received. If it is not, then something went wrong.
-		 */
-		if (packet->num_bytes != ipc_received) {
-			rc = -EIO;
-		} else {
-			memcpy((void *)packet->data_buf, (void *)ipc_receive_buffer, ipc_received);
-		}
-
-		/* Clear the receive buffer pointer and size */
-		ipc_receive_buffer = NULL;
-		ipc_received = 0;
-	}
-
-	return rc;
-}
-
-/**
- * @brief Initiates the transfer of the next packet in an MSPI transaction.
- *
- * This function prepares and starts the transmission of the next packet
- * specified in the MSPI transfer configuration. It checks if the packet
- * size is within the allowable limits before initiating the transfer.
- *
- * @param xfer Pointer to the mspi_xfer structure.
- * @param packets_done Number of packets that have already been processed.
- *
- * @retval 0 If the packet transfer is successfully started.
- * @retval -EINVAL If the packet size exceeds the maximum transmission size.
- */
-static int start_next_packet(struct mspi_xfer *xfer, uint32_t packets_done)
-{
-	struct mspi_xfer_packet *packet = (struct mspi_xfer_packet *)&xfer->packets[packets_done];
-
-	if (packet->num_bytes >= MAX_TX_MSG_SIZE) {
-		LOG_ERR("Packet size to large: %u. Increase SRAM data region.", packet->num_bytes);
-		return -EINVAL;
-	}
-
-	return xfer_packet(packet, xfer->timeout);
-}
-
-/**
- * @brief Send a multi-packet transfer request to the host.
- *
- * This function sends a multi-packet transfer request to the host and waits
- * for the host to complete the transfer. This function does not support
- * asynchronous transfers.
- *
- * @param dev Pointer to the device structure.
- * @param dev_id Pointer to the device identification structure.
- * @param req Pointer to the xfer structure.
- *
- * @retval 0 If successful.
- * @retval -ENOTSUP If asynchronous transfers are requested.
- * @retval -EIO If an I/O error occurs.
- */
-static int api_transceive(const struct device *dev, const struct mspi_dev_id *dev_id,
-			  const struct mspi_xfer *req)
-{
-	struct mspi_nrfe_data *drv_data = dev->data;
-	uint32_t packets_done = 0;
-	int rc;
-
-	/* TODO: add support for asynchronous transfers */
-	if (req->async) {
-		return -ENOTSUP;
-	}
-
-	if (req->num_packet == 0 || !req->packets ||
-	    req->timeout > CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE) {
-		return -EFAULT;
-	}
-
-	drv_data->xfer_config_msg.opcode = NRFE_MSPI_CONFIG_XFER;
-	drv_data->xfer_config_msg.xfer_config.device_index = dev_id->dev_idx;
-	drv_data->xfer_config_msg.xfer_config.command_length = req->cmd_length;
-	drv_data->xfer_config_msg.xfer_config.address_length = req->addr_length;
-	drv_data->xfer_config_msg.xfer_config.hold_ce = req->hold_ce;
-	drv_data->xfer_config_msg.xfer_config.tx_dummy = req->tx_dummy;
-	drv_data->xfer_config_msg.xfer_config.rx_dummy = req->rx_dummy;
-
-	rc = send_data(NRFE_MSPI_CONFIG_XFER, (void *)&drv_data->xfer_config_msg,
-		       sizeof(nrfe_mspi_xfer_config_msg_t));
-
-	if (rc < 0) {
-		LOG_ERR("Send xfer config error: %d", rc);
-		return rc;
-	}
-
-	while (packets_done < req->num_packet) {
-		rc = start_next_packet((struct mspi_xfer *)req, packets_done);
-		if (rc < 0) {
-			LOG_ERR("Start next packet error: %d", rc);
-			return rc;
-		}
-		++packets_done;
-	}
-
-	return 0;
-}
-
-#if CONFIG_PM_DEVICE
-/**
- * @brief Callback function to handle power management actions.
- *
- * This function is responsible for handling power management actions
- * such as suspend and resume for the given device. It performs the
- * necessary operations when the device is requested to transition
- * between different power states.
- *
- * @param dev Pointer to the device structure.
- * @param action The power management action to be performed.
- *
- * @retval 0 If successful.
- * @retval -ENOTSUP If the action is not supported.
- */
-static int dev_pm_action_cb(const struct device *dev, enum pm_device_action action)
-{
-	switch (action) {
-	case PM_DEVICE_ACTION_SUSPEND:
-		/* TODO: Handle PM suspend state */
-		break;
-	case PM_DEVICE_ACTION_RESUME:
-		/* TODO: Handle PM resume state */
-		break;
-	default:
-		return -ENOTSUP;
-	}
-
-	return 0;
-}
-#endif
-
-/**
- * @brief Initialize the MSPI NRFE driver.
- *
- * This function initializes the MSPI NRFE driver. It is responsible for
- * setting up the hardware and registering the IPC endpoint for the
- * driver.
- *
- * @param dev Pointer to the device structure for the MSPI NRFE driver.
- *
- * @retval 0 If successful.
- * @retval -errno If an error occurs.
- */
 static int nrfe_mspi_init(const struct device *dev)
 {
 	int ret;
@@ -673,24 +463,13 @@ static int nrfe_mspi_init(const struct device *dev)
 	}
 
 	/* Wait for ep to be bounded */
-#if defined(CONFIG_MULTITHREADING)
 	k_sem_take(&ipc_sem, K_FOREVER);
-#else
-	while (!atomic_test_and_clear_bit(&ipc_atomic_sem, NRFE_MSPI_EP_BOUNDED)) {
-	}
-#endif
 
 	ret = api_config(&spec);
 	if (ret < 0) {
 		return ret;
 	}
 
-#if CONFIG_PM_DEVICE
-	ret = pm_device_driver_init(dev, dev_pm_action_cb);
-	if (ret < 0) {
-		return ret;
-	}
-#endif
 	return ret;
 }
 
@@ -700,8 +479,6 @@ static const struct mspi_driver_api drv_api = {
 	.get_channel_status = api_get_channel_status,
 	.transceive = api_transceive,
 };
-
-PM_DEVICE_DT_INST_DEFINE(0, dev_pm_action_cb);
 
 DEVICE_DT_INST_DEFINE(0, nrfe_mspi_init, PM_DEVICE_DT_INST_GET(0), &dev_data, &dev_config,
 		      POST_KERNEL, CONFIG_MSPI_NRFE_INIT_PRIORITY, &drv_api);


### PR DESCRIPTION
This commit:
- removes support for `CONFIG_MULTITHREADING=n`
- removes support for `CONFIG_SYS_CLOCK_EXISTS=n`
- removes unnecessary decriptions for functions
- renames functions to make them more descriptive and remove namespacing where unnecessary
- removes arguments that where unnecessary
- moves functions around to make it more readable
- removes code for `CONFIG_PM_DEVICE`
- other minor changes