### PR TITLE
Bluetooth: Mesh: Store comp data hash as Number in JSON file

### DIFF
--- a/doc/nrf/protocols/bt/bt_mesh/dfu_over_bt_mesh.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/dfu_over_bt_mesh.rst
@@ -268,7 +268,7 @@ For this particular example, the following output is generated:
             }
           ]
         },
-        "composition_hash": "0x71f3267c",
+        "composition_hash": 1911760508,
         "encoded_metadata": "020000000000000094cf24017c26f3710100",
         "firmware_id": "59000200000000000000"
       }

--- a/scripts/bluetooth/mesh/mesh_dfu_metadata.py
+++ b/scripts/bluetooth/mesh/mesh_dfu_metadata.py
@@ -464,7 +464,7 @@ if __name__ == "__main__":
                 "binary_size": binary_size,
                 "core_type": core_type,
                 "composition_data": comp.dict_generate(),
-                "composition_hash": str(hex(comp.hash_generate())),
+                "composition_hash": comp.hash_generate(),
                 "encoded_metadata": str(encoded_metadata.hex())
             }
             if fwid is not None:

--- a/tests/subsys/bluetooth/mesh/metadata_extraction/verify_metadata.py
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/verify_metadata.py
@@ -62,7 +62,7 @@ def expected_metadata(size):
                     {'location': 1, 'sig_models': [0, 2], 'vendor_models': []}
                 ]
             },
-            'composition_hash': '0x587a2fb',
+            'composition_hash': 92775163,
             'encoded_metadata': f'0102030004000000{encoded_size}01fba287050100'
         },
         {
@@ -80,7 +80,7 @@ def expected_metadata(size):
                     {'location': 2, 'sig_models': [4097, 4099], 'vendor_models': []}
                 ]
             },
-            'composition_hash': '0x13f1a143',
+            'composition_hash': 334602563,
             'encoded_metadata': f'0102030004000000{encoded_size}0143a1f1130200'
         }
     ]


### PR DESCRIPTION
The comp data hash is an integer (32-bit unsigned integer), and, like other integers in the JSON file (CID, PID, etc. for instance), should be stored as a number in the JSON file, not a hex-encoded string.