### PR TITLE
[Backport v2.9-nRF54H20-branch] samples: esb: Fix corrupted transmitted data in 4Mbit radio mode

### DIFF
--- a/samples/esb/esb_prx/src/main.c
+++ b/samples/esb/esb_prx/src/main.c
@@ -131,10 +131,8 @@ int clocks_start(void)
 		}
 	} while (err == -EAGAIN);
 
-#if defined(NRF54L15_XXAA)
-	/* MLTPAN-20 */
-	nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_PLLSTART);
-#endif /* defined(NRF54L15_XXAA) */
+	nrf_lrcconf_clock_always_run_force_set(NRF_LRCCONF000, 0, true);
+	nrf_lrcconf_task_trigger(NRF_LRCCONF000, NRF_LRCCONF_TASK_CLKSTART_0);
 
 	LOG_DBG("HF clock started");
 

--- a/samples/esb/esb_ptx/src/main.c
+++ b/samples/esb/esb_ptx/src/main.c
@@ -124,10 +124,8 @@ int clocks_start(void)
 		}
 	} while (err == -EAGAIN);
 
-#if defined(NRF54L15_XXAA)
-	/* MLTPAN-20 */
-	nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_PLLSTART);
-#endif /* defined(NRF54L15_XXAA) */
+	nrf_lrcconf_clock_always_run_force_set(NRF_LRCCONF000, 0, true);
+	nrf_lrcconf_task_trigger(NRF_LRCCONF000, NRF_LRCCONF_TASK_CLKSTART_0);
 
 	LOG_DBG("HF clock started");
 	return 0;


### PR DESCRIPTION
Backport 080349a885034679977d11e7f23c39093088c190 from #20416.