### PR TITLE
suit: Template - do not fail on synchronous invoke timeout

### DIFF
--- a/config/suit/templates/nrf54h20/default/v1/app_recovery_local_envelope.yaml.jinja2
+++ b/config/suit/templates/nrf54h20/default/v1/app_recovery_local_envelope.yaml.jinja2
@@ -65,14 +65,16 @@ SUIT_Envelope_Tagged:
           - suit-send-sysinfo-failure
     suit-invoke:
     - suit-directive-set-component-index: 0
+    - suit-directive-run-sequence:
 {%- if 'CONFIG_SUIT_INVOKE_APP_LOCAL_3_BEFORE_MAIN_APP' in app_recovery_img['config'] and app_recovery_img['config'][CONFIG_SUIT_INVOKE_APP_LOCAL_3_BEFORE_MAIN_APP] != ''  %}
-    - suit-directive-override-parameters:
-        suit-parameter-invoke-args:
-          suit-synchronous-invoke: True
-          suit-timeout: 5000
+      - suit-directive-override-parameters:
+          suit-parameter-invoke-args:
+            suit-synchronous-invoke: True
+            suit-timeout: 5000
+          suit-parameter-soft-failure: True
 {%- endif %}
-    - suit-directive-invoke:
-      - suit-send-record-failure
+      - suit-directive-invoke:
+        - suit-send-record-failure
 
 {%- if APP_LOCAL_3_VERSION is defined %}
     suit-current-version: {{ APP_LOCAL_3_VERSION }}


### PR DESCRIPTION
A timeout in the default APP_LOCAL_3 (recovery image) manifest synchronous invoke directive resulted in manifest processing failure.

This should not be the default behavior - if the recovery application fails to boot, an attempt to run the main applciation should be made.