### PR TITLE
scripts: quarantine: fix sample.nrf7002.ble-wifi-provision

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -82,7 +82,7 @@
 - scenarios:
     - sample.nrf7002.ble-wifi-provision
   platforms:
-    - nnrf7002dk/nrf5340/cpuapp
+    - nrf7002dk/nrf5340/cpuapp
   comment: "https://github.com/nrfconnect/sdk-nrf/pull/20439"
 
 - scenarios:


### PR DESCRIPTION
Typo.