### PR TITLE
ci: docs: add preview links

### DIFF
--- a/.github/workflows/docpreview.yml
+++ b/.github/workflows/docpreview.yml
@@ -1,0 +1,71 @@
+name: Documentation Preview
+
+on:
+  pull_request_target:
+    paths:
+      - '.github/workflows/docbuild.yml'
+      - '**.rst'
+      - '**/Kconfig'
+      - '**/sample.yaml'
+      - 'doc/**'
+      - 'applications/**'
+      - 'include/**'
+      - 'lib/**'
+      - 'doc/requirements.txt'
+      - 'scripts/tools-versions-*.yml'
+      - 'west.yml'
+
+jobs:
+  doc-preview:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Find nRF Connect SDK Edited Documents
+        id: nrf-edited-documents
+        run: |
+          PREFIX="${{ vars.NCS_DOC_HOSTING_URL }}PR-${{ github.event.pull_request.number }}/"
+          CHANGED=$(git diff --name-only --diff-filter=d "${{ github.event.pull_request.base.sha }}..HEAD")
+
+          NRF=$(echo "$CHANGED" | \
+                grep -e "doc/nrf/" | \
+                grep -e ".rst" | \
+                sed -e "s#^doc/nrf\(.*\)\.rst#${PREFIX}nrf\1.html#g")
+
+          NRF_EXT=$(echo "$CHANGED" | \
+                    grep -e "applications/" -e "samples/" -e "scripts/" -e "tests/" | \
+                    grep -e ".rst" | \
+                    sed -e "s#^\(applications\|samples\|scripts\|tests\)\(.*\)\.rst#${PREFIX}nrf\/\1\2.html#g")
+
+          NRF_ALL=$(printf "$NRF\n$NRF_EXT")
+
+          if [ ! -z "$NRF_ALL" ]; then
+            COMMENT=$(printf "\nPreview links for modified nRF Connect SDK documents:\n\n$NRF_ALL")
+
+            echo "COMMENT<<EOF" >> $GITHUB_OUTPUT
+            echo "$COMMENT" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: documentation preview
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            After documentation is built, you will find the preview for this PR [here](${{ vars.NCS_DOC_HOSTING_URL }}PR-${{ github.event.pull_request.number }}).
+            ${{ steps.nrf-edited-documents.outputs.COMMENT }}
+          edit-mode: replace

--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -68,11 +68,3 @@ jobs:
             quit
           EOF
           done
-
-      - name: Add preview URL comment for PRs
-        uses: nrfconnect/action-doc-url@main
-        with:
-          github-token: ${{ secrets.NCS_GITHUB_TOKEN }}
-          urlroot: ${{ vars.NCS_DOC_HOSTING_URL }}
-          pr-prefix: "PR-"
-          pr-file: docs/pr.txt


### PR DESCRIPTION
Add a new job that takes care of posting documentation preview
information, including:

- Link to preview site
- List of links to edited files, easing the review process