### PR TITLE
samples: bluetooth: hids: Enable TF-M profile small for /ns target

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -294,6 +294,15 @@ Bluetooth samples
   * :ref:`bluetooth_central_hids`
   * :ref:`peripheral_hids_keyboard`
 
+* Updated the configurations of the non-secure ``nrf5340dk/nrf5340/cpuapp/ns`` board target in the following samples to properly use the TF-M profile instead of the predefined minimal TF-M profile:
+
+  * :ref:`bluetooth_central_hids`
+  * :ref:`peripheral_hids_keyboard`
+  * :ref:`peripheral_hids_mouse`
+
+  This change results from the Bluetooth subsystem transition to the PSA cryptographic standard.
+  The Bluetooth stack can now use the PSA crypto API in the non-secure domain as all necessary TF-M partitions are configured properly.
+
 * :ref:`direct_test_mode` sample:
 
   * Added loading of radio trims and a fix of a hardware errata for the nRF54H20 SoC to improve the RF performance.

--- a/samples/bluetooth/central_hids/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/central_hids/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TF-M profile has to be properly configured to be able to run
+# the Bluetooth stack which uses PSA crypto API as minimal TF-M
+# profile cannot be used.
+CONFIG_TFM_PROFILE_TYPE_SMALL=y

--- a/samples/bluetooth/peripheral_hids_keyboard/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/peripheral_hids_keyboard/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TF-M profile has to be properly configured to be able to run
+# the Bluetooth stack which uses PSA crypto API as minimal TF-M
+# profile cannot be used.
+CONFIG_TFM_PROFILE_TYPE_SMALL=y

--- a/samples/bluetooth/peripheral_hids_mouse/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/peripheral_hids_mouse/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TF-M profile has to be properly configured to be able to run
+# the Bluetooth stack which uses PSA crypto API as minimal TF-M
+# profile cannot be used.
+CONFIG_TFM_PROFILE_TYPE_SMALL=y


### PR DESCRIPTION
Enabled the CONFIG_TFM_PROFILE_TYPE_SMALL for the
nrf5340dk/nrf5340/cpuapp/ns as it is required for the Bluetooth stack to work properly as it now uses the PSA crypto API.

Jira: NCSDK-31777