### PR TITLE
treewide: add check for NRF_MODEM_LIB_ON_INIT return

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -84,6 +84,11 @@ NRF_MODEM_LIB_ON_INIT(asset_tracker_init_hook, on_modem_lib_init, NULL);
 
 static void on_modem_lib_init(int ret, void *ctx)
 {
+	if (ret != 0) {
+		LOG_ERR("Modem library did not initialize: %d", ret);
+		return;
+	}
+
 	k_sem_give(&nrf_modem_initialized);
 }
 

--- a/lib/modem_antenna/modem_antenna.c
+++ b/lib/modem_antenna/modem_antenna.c
@@ -29,6 +29,7 @@ void set_antenna_configuration(const char *config_value)
 static void on_modem_lib_init(int ret, void *ctx)
 {
 	if (ret != 0) {
+		LOG_ERR("Modem library did not initialize: %d", ret);
 		return;
 	}
 

--- a/lib/modem_battery/modem_battery.c
+++ b/lib/modem_battery/modem_battery.c
@@ -184,6 +184,11 @@ static void on_modem_init(int ret, void *ctx)
 {
 	int err;
 
+	if (ret != 0) {
+		LOG_ERR("Modem library did not initialize: %d", ret);
+		return;
+	}
+
 	err = modem_battery_low_level_set(CONFIG_MODEM_BATTERY_LOW_LEVEL);
 	if (err) {
 		LOG_ERR("Failed to set battery low level, error: %d", err);

--- a/lib/nrf_modem_lib/cfun_hooks.c
+++ b/lib/nrf_modem_lib/cfun_hooks.c
@@ -22,7 +22,12 @@ static void cfun_callback(int mode)
 	}
 }
 
-static void on_modem_init(int err, void *ctx)
+static void on_modem_init(int ret, void *ctx)
 {
+	if (ret != 0) {
+		LOG_ERR("Modem library did not initialize: %d", ret);
+		return;
+	}
+
 	nrf_modem_at_cfun_handler_set(cfun_callback);
 }

--- a/lib/pdn/pdn.c
+++ b/lib/pdn/pdn.c
@@ -289,10 +289,9 @@ static void on_modem_init(int ret, void *ctx)
 #endif
 {
 	int err;
-	(void) err;
 
 	if (ret != 0) {
-		/* Return if modem initialization failed */
+		LOG_ERR("Modem library did not initialize: %d", ret);
 		return;
 	}
 

--- a/modules/memfault-firmware-sdk/memfault_integration.c
+++ b/modules/memfault-firmware-sdk/memfault_integration.c
@@ -179,7 +179,7 @@ NRF_MODEM_LIB_ON_INIT(memfault_ncs_init_hook, on_modem_lib_init, NULL);
 static void on_modem_lib_init(int ret, void *ctx)
 {
 	if (ret != 0) {
-		/* Return if modem initialization failed */
+		LOG_ERR("Modem library did not initialize: %d", ret);
 		return;
 	}
 

--- a/modules/memfault-firmware-sdk/memfault_lte_coredump.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_coredump.c
@@ -161,6 +161,11 @@ static struct fsm_state_object state_object = { 0 };
 
 static void on_modem_lib_init(int ret, void *ctx)
 {
+	if (ret != 0) {
+		LOG_ERR("Modem library did not initialize: %d", ret);
+		return;
+	}
+
 	event_send(EVENT_NRF_MODEM_LIB_INITED);
 }
 

--- a/samples/cellular/lwm2m_carrier/src/main.c
+++ b/samples/cellular/lwm2m_carrier/src/main.c
@@ -28,6 +28,7 @@ static void on_modem_lib_init(int ret, void *ctx)
 	ARG_UNUSED(ctx);
 
 	if (ret != 0) {
+		printk("Modem library did not initialize: %d\n", ret);
 		return;
 	}
 

--- a/samples/cellular/modem_shell/src/cloud/cloud_lwm2m.c
+++ b/samples/cellular/modem_shell/src/cloud/cloud_lwm2m.c
@@ -73,8 +73,12 @@ NRF_MODEM_LIB_ON_INIT(cloud_lwm2m_init_hook, on_modem_lib_init, NULL);
 
 static void on_modem_lib_init(int ret, void *ctx)
 {
-	ARG_UNUSED(ret);
 	ARG_UNUSED(ctx);
+
+	if (ret != 0) {
+		printk("Modem library did not initialize: %d\n", ret);
+		return;
+	}
 
 	static bool initialized;
 

--- a/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_ctrl.c
+++ b/samples/dect/dect_phy/dect_shell/src/dect/dect_phy_ctrl.c
@@ -1806,8 +1806,12 @@ int dect_phy_ctrl_radio_mode_cmd(enum nrf_modem_dect_phy_radio_mode radio_mode)
 
 static void dect_phy_ctrl_on_modem_lib_init(int ret, void *ctx)
 {
-	ARG_UNUSED(ret);
 	ARG_UNUSED(ctx);
+
+	if (ret != 0) {
+		printk("Modem library did not initialize: %d\n", ret);
+		return;
+	}
 
 	if (!ctrl_data.phy_api_initialized) {
 		k_sem_reset(&dect_phy_ctrl_mdm_api_init_sema);

--- a/samples/net/mqtt/src/modules/transport/credentials_provision/credentials_provision.c
+++ b/samples/net/mqtt/src/modules/transport/credentials_provision/credentials_provision.c
@@ -136,5 +136,10 @@ NRF_MODEM_LIB_ON_INIT(mqtt_sample_init_hook, on_modem_lib_init, NULL);
 
 static void on_modem_lib_init(int ret, void *ctx)
 {
+	if (ret != 0) {
+		printk("Modem library did not initialize: %d\n", ret);
+		return;
+	}
+
 	credentials_provision();
 }

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_rai.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_rai.c
@@ -47,8 +47,12 @@ int lwm2m_rai_req(enum lwm2m_rai_mode mode)
 NRF_MODEM_LIB_ON_INIT(lwm2m_init_rai, lwm2m_init_rai, NULL);
 static void lwm2m_init_rai(int ret, void *ctx)
 {
-	ARG_UNUSED(ret);
 	ARG_UNUSED(ctx);
+
+	if (ret != 0) {
+		LOG_ERR("Modem library did not initialize: %d", ret);
+		return;
+	}
 
 	int r;
 

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
@@ -76,6 +76,11 @@ static void nrf_provisioning_on_modem_init(int ret, void *ctx)
 {
 	int err;
 
+	if (ret != 0) {
+		LOG_ERR("Modem library did not initialize: %d", ret);
+		return;
+	}
+
 	if (IS_ENABLED(CONFIG_NRF_PROVISIONING_AUTO_INIT)) {
 		err = nrf_provisioning_init(NULL, NULL);
 		if (err) {

--- a/subsys/net/lib/tls_credentials/tls_credentials_nrf_modem.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_nrf_modem.c
@@ -369,7 +369,7 @@ static void credentials_on_modem_init(int ret, void *ctx)
 	ARG_UNUSED(ctx);
 
 	if (ret != 0) {
-		/* Return if modem initialization failed */
+		LOG_ERR("Modem library did not initialize: %d", ret);
 		return;
 	}
 


### PR DESCRIPTION
Adds missing checks for the return value passed by `NRF_MODEM_LIB_ON_INIT`.