### PR TITLE
Rework of nrf54l/soc.c to get rid of noup commits

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -326,6 +326,8 @@ endchoice
 
 config TFM_CPU_FREQ_MHZ
 	int
+	default $(div, $(dt_node_int_prop_int,/clocks/hfpll,clock-frequency), 1000000) \
+		if SOC_SERIES_NRF54LX
 	default $(div, $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency), 1000000) \
 		if $(dt_node_has_prop,/cpus/cpu@0,clock-frequency)
 	default $(div, $(dt_node_int_prop_int,/cpus/cpu@1,clock-frequency), 1000000) \

--- a/modules/trusted-firmware-m/tfm_boards/include/zephyr/kernel.h
+++ b/modules/trusted-firmware-m/tfm_boards/include/zephyr/kernel.h
@@ -18,6 +18,7 @@
  */
 
 #include <stddef.h>
+#include <errno.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/irq.h>


### PR DESCRIPTION
Rework of zephyr nrf54l/soc.c file to get rid of TFM specific changes. Extended `kernel.h` used for TFM build to get rid of compilation errors.