### PR TITLE
samples: matter: Improved bridge storage manager error handling

### DIFF
--- a/samples/matter/common/src/persistent_storage/persistent_storage_common.h
+++ b/samples/matter/common/src/persistent_storage/persistent_storage_common.h
@@ -10,7 +10,7 @@
 
 namespace Nrf
 {
-enum PSErrorCode : uint8_t { Failure, Success, NotSupported };
+enum class PSErrorCode : uint8_t { Failure, Success, NotSupported };
 
 /**
  * @brief Class representing single tree node and containing information about its key.

--- a/samples/matter/lock/src/access/access_storage.cpp
+++ b/samples/matter/lock/src/access/access_storage.cpp
@@ -62,7 +62,7 @@ bool GetStorageFreeSpace(size_t &freeBytes)
 
 bool AccessStorage::Init()
 {
-	return (Nrf::Success == Nrf::GetPersistentStorage().PSInit());
+	return (Nrf::PSErrorCode::Success == Nrf::GetPersistentStorage().PSInit());
 }
 
 bool AccessStorage::PrepareKeyName(Type storageType, uint16_t index, uint16_t subindex)


### PR DESCRIPTION
Added checking the enum value returned by persistent storage. Changed PSErrorCode enum to enum class to prevent such unintuitive comparison in the future.