### PR TITLE
snippets: sdp: mspi: fix cpuapp_sram memory size and range

### DIFF
--- a/snippets/sdp/mspi/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/sdp/mspi/soc/nrf54l15_cpuapp.overlay
@@ -50,8 +50,8 @@
 };
 
 &cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(244)>;
-	ranges = <0x0 0x20000000 0x3d000>;
+	reg = <0x20000000 DT_SIZE_K(240)>;
+	ranges = <0x0 0x20000000 0x3c000>;
 };
 
 &cpuflpr_vpr {


### PR DESCRIPTION
Fix for CPUAPP sram memory size and address range.