### PR TITLE
Deprecate `at_params`, deprecate `modem_info_type_get`, add `enum modem_info_data_type` and `modem_info_data_type_get`

### DIFF
--- a/doc/nrf/libraries/modem/at_params.rst
+++ b/doc/nrf/libraries/modem/at_params.rst
@@ -7,6 +7,9 @@ AT parameters
    :local:
    :depth: 2
 
+.. important::
+   The AT parameters module is deprecated.
+
 The AT parameters module provides functionality to store lists of AT command or respond parameters.
 These lists can be used by other modules to write and read parameter values.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -678,6 +678,8 @@ Modem libraries
     * The :c:enum:`modem_info_data_type` type for representing LTE link information data types.
     * The :c:func:`modem_info_data_type_get` function for requesting the data type of the current modem information type.
 
+  * Deprecated the :c:func:`modem_info_type_get` function in favor of the :c:func:`modem_info_data_type_get` function.
+
 Multiprotocol Service Layer libraries
 -------------------------------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -671,6 +671,13 @@ Modem libraries
 
   * Fixed a bug where AT responses would erroneously be written to the logging UART instead of being written to the chosen ``ncs,at-host-uart`` UART device when the :kconfig:option:`CONFIG_LOG_BACKEND_UART` Kconfig option was set.
 
+* :ref:`modem_info_readme` library:
+
+  * Added:
+
+    * The :c:enum:`modem_info_data_type` type for representing LTE link information data types.
+    * The :c:func:`modem_info_data_type_get` function for requesting the data type of the current modem information type.
+
 Multiprotocol Service Layer libraries
 -------------------------------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -631,6 +631,8 @@ Security libraries
 Modem libraries
 ---------------
 
+* Deprecated the :ref:`at_params_readme` library.
+
 * :ref:`pdn_readme` library:
 
   * Deprecated the :c:func:`pdn_dynamic_params_get` function.

--- a/include/modem/at_params.h
+++ b/include/modem/at_params.h
@@ -8,6 +8,7 @@
 #define AT_PARAMS_H__
 
 #include <zephyr/types.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,6 +19,7 @@ extern "C" {
  *
  * @brief Store a list of AT command/response parameters.
  * @defgroup at_params AT command/response parameters
+ * @deprecated
  * @{
  *
  * A parameter list contains an array of parameters defined by a type,
@@ -33,7 +35,10 @@ extern "C" {
  * to read and write parameter values.
  */
 
-/** @brief Parameter types that can be stored. */
+/**
+ * @deprecated
+ * @brief Parameter types that can be stored.
+ */
 enum at_param_type {
 	/** Invalid parameter, typically a parameter that does not exist. */
 	AT_PARAM_TYPE_INVALID,
@@ -47,7 +52,10 @@ enum at_param_type {
 	AT_PARAM_TYPE_EMPTY,
 };
 
-/** @brief Parameter value. */
+/**
+ * @deprecated
+ * @brief Parameter value.
+ */
 union at_param_value {
 	/** Integer value. */
 	int64_t int_val;
@@ -57,7 +65,10 @@ union at_param_value {
 	uint32_t *array_val;
 };
 
-/** @brief A parameter is defined with a type, length and value. */
+/**
+ * @deprecated
+ * @brief A parameter is defined with a type, length and value.
+ */
 struct at_param {
 	enum at_param_type type;
 	size_t size;
@@ -65,6 +76,7 @@ struct at_param {
 };
 
 /**
+ * @deprecated
  * @brief List of AT parameters that compose an AT command or response.
  *
  * Contains an array of opaque data. Setter and getter methods should be used
@@ -76,6 +88,7 @@ struct at_param_list {
 };
 
 /**
+ * @deprecated
  * @brief Create a list of parameters.
  *
  * An array of @p max_params_count is allocated. Each parameter is
@@ -89,27 +102,30 @@ struct at_param_list {
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_list_init(struct at_param_list *list, size_t max_params_count);
+__deprecated int at_params_list_init(struct at_param_list *list, size_t max_params_count);
 
 /**
+ * @deprecated
  * @brief Clear/reset all parameter types and values.
  *
  * All parameter types and values are reset to default values.
  *
  * @param[in] list Parameter list to clear.
  */
-void at_params_list_clear(struct at_param_list *list);
+__deprecated void at_params_list_clear(struct at_param_list *list);
 
 /**
+ * @deprecated
  * @brief Free a list of parameters.
  *
  * First the list is cleared. Then the list and its elements are deleted.
  *
  * @param[in] list Parameter list to free.
  */
-void at_params_list_free(struct at_param_list *list);
+__deprecated void at_params_list_free(struct at_param_list *list);
 
 /**
+ * @deprecated
  * @brief Add a parameter in the list at the specified index and assign it an
  * integer value.
  *
@@ -122,9 +138,10 @@ void at_params_list_free(struct at_param_list *list);
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_int_put(const struct at_param_list *list, size_t index, int64_t value);
+__deprecated int at_params_int_put(const struct at_param_list *list, size_t index, int64_t value);
 
 /**
+ * @deprecated
  * @brief Add a parameter in the list at the specified index and assign it a
  * string value.
  *
@@ -139,10 +156,11 @@ int at_params_int_put(const struct at_param_list *list, size_t index, int64_t va
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_string_put(const struct at_param_list *list, size_t index,
-			 const char *str, size_t str_len);
+__deprecated int at_params_string_put(const struct at_param_list *list, size_t index,
+				      const char *str, size_t str_len);
 
 /**
+ * @deprecated
  * @brief Add a parameter in the list at the specified index and assign it an
  * array type value.
  *
@@ -161,10 +179,11 @@ int at_params_string_put(const struct at_param_list *list, size_t index,
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_array_put(const struct at_param_list *list, size_t index,
-			const uint32_t *array, size_t array_len);
+__deprecated int at_params_array_put(const struct at_param_list *list, size_t index,
+				     const uint32_t *array, size_t array_len);
 
 /**
+ * @deprecated
  * @brief Add a parameter in the list at the specified index and assign it an
  * empty status.
  *
@@ -177,9 +196,10 @@ int at_params_array_put(const struct at_param_list *list, size_t index,
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_empty_put(const struct at_param_list *list, size_t index);
+__deprecated int at_params_empty_put(const struct at_param_list *list, size_t index);
 
 /**
+ * @deprecated
  * @brief Get the size of a given parameter (in bytes).
  *
  * A size of '0' is returned for invalid and empty parameters.
@@ -191,10 +211,10 @@ int at_params_empty_put(const struct at_param_list *list, size_t index);
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_size_get(const struct at_param_list *list, size_t index,
-		       size_t *len);
+__deprecated int at_params_size_get(const struct at_param_list *list, size_t index, size_t *len);
 
 /**
+ * @deprecated
  * @brief Get a parameter value as a short number.
  *
  * @param[in] list    Parameter list.
@@ -204,10 +224,11 @@ int at_params_size_get(const struct at_param_list *list, size_t index,
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_short_get(const struct at_param_list *list, size_t index,
-			int16_t *value);
+__deprecated int at_params_short_get(const struct at_param_list *list, size_t index,
+				     int16_t *value);
 
 /**
+ * @deprecated
  * @brief Get a parameter value as an unsigned short number.
  *
  * @param[in] list    Parameter list.
@@ -217,10 +238,11 @@ int at_params_short_get(const struct at_param_list *list, size_t index,
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_unsigned_short_get(const struct at_param_list *list, size_t index,
-			uint16_t *value);
+__deprecated int at_params_unsigned_short_get(const struct at_param_list *list, size_t index,
+					      uint16_t *value);
 
 /**
+ * @deprecated
  * @brief Get a parameter value as an integer number.
  *
  * @param[in] list    Parameter list.
@@ -230,10 +252,11 @@ int at_params_unsigned_short_get(const struct at_param_list *list, size_t index,
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_int_get(const struct at_param_list *list, size_t index,
-		      int32_t *value);
+__deprecated int at_params_int_get(const struct at_param_list *list, size_t index,
+				   int32_t *value);
 
 /**
+ * @deprecated
  * @brief Get a parameter value as an unsigned integer number.
  *
  * @param[in] list    Parameter list.
@@ -243,9 +266,11 @@ int at_params_int_get(const struct at_param_list *list, size_t index,
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_unsigned_int_get(const struct at_param_list *list, size_t index, uint32_t *value);
+__deprecated int at_params_unsigned_int_get(const struct at_param_list *list, size_t index,
+					    uint32_t *value);
 
 /**
+ * @deprecated
  * @brief Get a parameter value as a signed 64-bit integer number.
  *
  * @param[in] list    Parameter list.
@@ -255,9 +280,11 @@ int at_params_unsigned_int_get(const struct at_param_list *list, size_t index, u
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_int64_get(const struct at_param_list *list, size_t index, int64_t *value);
+__deprecated int at_params_int64_get(const struct at_param_list *list, size_t index,
+				     int64_t *value);
 
 /**
+ * @deprecated
  * @brief Get a parameter value as a string.
  *
  * The parameter type must be a string, or an error is returned.
@@ -274,10 +301,11 @@ int at_params_int64_get(const struct at_param_list *list, size_t index, int64_t 
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_string_get(const struct at_param_list *list, size_t index,
-			 char *value, size_t *len);
+__deprecated int at_params_string_get(const struct at_param_list *list, size_t index,
+				      char *value, size_t *len);
 
 /**
+ * @deprecated
  * @brief Get a pointer to the string parameter value.
  *
  * The parameter type must be a string, or an error is returned.
@@ -292,10 +320,11 @@ int at_params_string_get(const struct at_param_list *list, size_t index,
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_string_ptr_get(const struct at_param_list *list, size_t index, const char **at_param,
-			     size_t *len);
+__deprecated int at_params_string_ptr_get(const struct at_param_list *list, size_t index,
+					  const char **at_param, size_t *len);
 
 /**
+ * @deprecated
  * @brief Get a parameter value as an array.
  *
  * The parameter type must be an array, or an error is returned.
@@ -312,19 +341,21 @@ int at_params_string_ptr_get(const struct at_param_list *list, size_t index, con
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_array_get(const struct at_param_list *list, size_t index,
-			uint32_t *array, size_t *len);
+__deprecated int at_params_array_get(const struct at_param_list *list, size_t index,
+				     uint32_t *array, size_t *len);
 
 /**
+ * @deprecated
  * @brief Get the number of valid parameters in the list.
  *
  * @param[in] list    Parameter list.
  *
  * @return The number of valid parameters until an empty parameter is found.
  */
-uint32_t at_params_valid_count_get(const struct at_param_list *list);
+__deprecated uint32_t at_params_valid_count_get(const struct at_param_list *list);
 
 /**
+ * @deprecated
  * @brief Get parameter type for parameter at index
  *
  * @param[in] list    Parameter list.
@@ -332,8 +363,7 @@ uint32_t at_params_valid_count_get(const struct at_param_list *list);
  *
  * @return Return parameter type of @ref at_param_type.
  */
-enum at_param_type at_params_type_get(const struct at_param_list *list,
-				      size_t index);
+__deprecated enum at_param_type at_params_type_get(const struct at_param_list *list, size_t index);
 
 /** @} */
 

--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -151,6 +151,16 @@ enum modem_info {
 	MODEM_INFO_COUNT,	/**< Number of legal elements in the enum. */
 };
 
+/** @brief LTE link information data types. */
+enum modem_info_data_type {
+	/** Data of type invalid. */
+	MODEM_INFO_DATA_TYPE_INVALID,
+	/** Data of type integer. */
+	MODEM_INFO_DATA_TYPE_NUM_INT,
+	/** Data of type string. */
+	MODEM_INFO_DATA_TYPE_STRING,
+};
+
 /**@brief LTE parameter data. **/
 struct lte_param {
 	uint16_t value; /**< The retrieved value. */
@@ -297,6 +307,15 @@ int modem_info_name_get(enum modem_info info, char *name);
  *         Otherwise, a (negative) error code is returned.
  */
 enum at_param_type modem_info_type_get(enum modem_info info);
+
+/** @brief Request the data type of the current modem information
+ *         type.
+ *
+ * @param info The requested information type.
+ *
+ * @return The data type of the requested modem information data.
+ */
+enum modem_info_data_type modem_info_data_type_get(enum modem_info info);
 
 /** @brief Obtain the modem parameters.
  *

--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -12,6 +12,8 @@
 #endif
 
 #include <modem/at_params.h>
+/* Include to use the __deprecated attribute */
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -298,15 +300,18 @@ int modem_info_short_get(enum modem_info info, uint16_t *buf);
  */
 int modem_info_name_get(enum modem_info info, char *name);
 
-/** @brief Request the data type of the current modem information
- *         type.
+/**
+ * @deprecated Use @ref modem_info_data_type_get instead.
+ *
+ * @brief Request the data type of the current modem information
+ *        type.
  *
  * @param info The requested information type.
  *
  * @return The data type of the requested modem information data.
  *         Otherwise, a (negative) error code is returned.
  */
-enum at_param_type modem_info_type_get(enum modem_info info);
+__deprecated enum at_param_type modem_info_type_get(enum modem_info info);
 
 /** @brief Request the data type of the current modem information
  *         type.

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -392,6 +392,7 @@ static int map_nrf_modem_at_scanf_error(int err)
 	}
 }
 
+/* Deprecated in favor of `modem_info_data_type_get`. */
 enum at_param_type modem_info_type_get(enum modem_info info_type)
 {
 	if (info_type >= MODEM_INFO_COUNT) {

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -154,7 +154,7 @@ struct modem_info_data {
 	const char *data_name;
 	uint8_t param_index;
 	uint8_t param_count;
-	enum at_param_type data_type;
+	enum modem_info_data_type data_type;
 };
 
 static const struct modem_info_data rsrp_data = {
@@ -162,7 +162,7 @@ static const struct modem_info_data rsrp_data = {
 	.data_name	= RSRP_DATA_NAME,
 	.param_index	= RSRP_PARAM_INDEX,
 	.param_count	= RSRP_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_NUM_INT,
+	.data_type	= MODEM_INFO_DATA_TYPE_NUM_INT,
 };
 
 static const struct modem_info_data band_data = {
@@ -170,7 +170,7 @@ static const struct modem_info_data band_data = {
 	.data_name	= CUR_BAND_DATA_NAME,
 	.param_index	= BAND_PARAM_INDEX,
 	.param_count	= BAND_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_NUM_INT,
+	.data_type	= MODEM_INFO_DATA_TYPE_NUM_INT,
 };
 
 static const struct modem_info_data band_sup_data = {
@@ -178,7 +178,7 @@ static const struct modem_info_data band_sup_data = {
 	.data_name	= SUP_BAND_DATA_NAME,
 	.param_index	= BAND_PARAM_INDEX,
 	.param_count	= BAND_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_STRING,
+	.data_type	= MODEM_INFO_DATA_TYPE_STRING,
 };
 
 static const struct modem_info_data mode_data = {
@@ -186,7 +186,7 @@ static const struct modem_info_data mode_data = {
 	.data_name	= UE_MODE_DATA_NAME,
 	.param_index	= MODE_PARAM_INDEX,
 	.param_count	= MODE_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_NUM_INT,
+	.data_type	= MODEM_INFO_DATA_TYPE_NUM_INT,
 };
 
 static const struct modem_info_data operator_data = {
@@ -194,7 +194,7 @@ static const struct modem_info_data operator_data = {
 	.data_name	= OPERATOR_DATA_NAME,
 	.param_index	= OPERATOR_PARAM_INDEX,
 	.param_count	= OPERATOR_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_STRING,
+	.data_type	= MODEM_INFO_DATA_TYPE_STRING,
 };
 
 static const struct modem_info_data mcc_data = {
@@ -202,7 +202,7 @@ static const struct modem_info_data mcc_data = {
 	.data_name	= MCC_DATA_NAME,
 	.param_index	= OPERATOR_PARAM_INDEX,
 	.param_count	= OPERATOR_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_NUM_INT,
+	.data_type	= MODEM_INFO_DATA_TYPE_NUM_INT,
 };
 
 static const struct modem_info_data mnc_data = {
@@ -210,7 +210,7 @@ static const struct modem_info_data mnc_data = {
 	.data_name	= MNC_DATA_NAME,
 	.param_index	= OPERATOR_PARAM_INDEX,
 	.param_count	= OPERATOR_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_NUM_INT,
+	.data_type	= MODEM_INFO_DATA_TYPE_NUM_INT,
 };
 
 static const struct modem_info_data cellid_data = {
@@ -218,7 +218,7 @@ static const struct modem_info_data cellid_data = {
 	.data_name	= CELLID_DATA_NAME,
 	.param_index	= CELLID_PARAM_INDEX,
 	.param_count	= CELLID_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_STRING,
+	.data_type	= MODEM_INFO_DATA_TYPE_STRING,
 };
 
 static const struct modem_info_data area_data = {
@@ -226,7 +226,7 @@ static const struct modem_info_data area_data = {
 	.data_name	= AREA_CODE_DATA_NAME,
 	.param_index	= AREA_CODE_PARAM_INDEX,
 	.param_count	= AREA_CODE_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_STRING,
+	.data_type	= MODEM_INFO_DATA_TYPE_STRING,
 };
 
 static const struct modem_info_data ip_data = {
@@ -234,7 +234,7 @@ static const struct modem_info_data ip_data = {
 	.data_name	= IP_ADDRESS_DATA_NAME,
 	.param_index	= IP_ADDRESS_PARAM_INDEX,
 	.param_count	= IP_ADDRESS_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_STRING,
+	.data_type	= MODEM_INFO_DATA_TYPE_STRING,
 };
 
 static const struct modem_info_data uicc_data = {
@@ -242,7 +242,7 @@ static const struct modem_info_data uicc_data = {
 	.data_name	= UICC_DATA_NAME,
 	.param_index	= UICC_PARAM_INDEX,
 	.param_count	= UICC_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_NUM_INT,
+	.data_type	= MODEM_INFO_DATA_TYPE_NUM_INT,
 };
 
 static const struct modem_info_data battery_data = {
@@ -250,7 +250,7 @@ static const struct modem_info_data battery_data = {
 	.data_name	= BATTERY_DATA_NAME,
 	.param_index	= VBAT_PARAM_INDEX,
 	.param_count	= VBAT_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_NUM_INT,
+	.data_type	= MODEM_INFO_DATA_TYPE_NUM_INT,
 };
 
 static const struct modem_info_data temp_data = {
@@ -258,7 +258,7 @@ static const struct modem_info_data temp_data = {
 	.data_name	= TEMPERATURE_DATA_NAME,
 	.param_index	= TEMP_PARAM_INDEX,
 	.param_count	= TEMP_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_NUM_INT,
+	.data_type	= MODEM_INFO_DATA_TYPE_NUM_INT,
 };
 
 static const struct modem_info_data fw_data = {
@@ -266,7 +266,7 @@ static const struct modem_info_data fw_data = {
 	.data_name	= MODEM_FW_DATA_NAME,
 	.param_index	= MODEM_FW_PARAM_INDEX,
 	.param_count	= MODEM_FW_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_STRING,
+	.data_type	= MODEM_INFO_DATA_TYPE_STRING,
 };
 
 static const struct modem_info_data iccid_data = {
@@ -274,7 +274,7 @@ static const struct modem_info_data iccid_data = {
 	.data_name	= ICCID_DATA_NAME,
 	.param_index	= ICCID_PARAM_INDEX,
 	.param_count	= ICCID_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_STRING,
+	.data_type	= MODEM_INFO_DATA_TYPE_STRING,
 };
 
 static const struct modem_info_data lte_mode_data = {
@@ -282,7 +282,7 @@ static const struct modem_info_data lte_mode_data = {
 	.data_name	= LTE_MODE_DATA_NAME,
 	.param_index	= LTE_MODE_PARAM_INDEX,
 	.param_count	= SYSTEMMODE_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_NUM_INT,
+	.data_type	= MODEM_INFO_DATA_TYPE_NUM_INT,
 };
 
 static const struct modem_info_data nbiot_mode_data = {
@@ -290,7 +290,7 @@ static const struct modem_info_data nbiot_mode_data = {
 	.data_name	= NBIOT_MODE_DATA_NAME,
 	.param_index	= NBIOT_MODE_PARAM_INDEX,
 	.param_count	= SYSTEMMODE_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_NUM_INT,
+	.data_type	= MODEM_INFO_DATA_TYPE_NUM_INT,
 };
 
 static const struct modem_info_data gps_mode_data = {
@@ -298,7 +298,7 @@ static const struct modem_info_data gps_mode_data = {
 	.data_name	= GPS_MODE_DATA_NAME,
 	.param_index	= GPS_MODE_PARAM_INDEX,
 	.param_count	= SYSTEMMODE_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_NUM_INT,
+	.data_type	= MODEM_INFO_DATA_TYPE_NUM_INT,
 };
 
 static const struct modem_info_data imsi_data = {
@@ -306,7 +306,7 @@ static const struct modem_info_data imsi_data = {
 	.data_name	= IMSI_DATA_NAME,
 	.param_index	= IMSI_PARAM_INDEX,
 	.param_count	= IMSI_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_STRING,
+	.data_type	= MODEM_INFO_DATA_TYPE_STRING,
 };
 
 static const struct modem_info_data imei_data = {
@@ -314,7 +314,7 @@ static const struct modem_info_data imei_data = {
 	.data_name	= MODEM_IMEI_DATA_NAME,
 	.param_index	= MODEM_IMEI_PARAM_INDEX,
 	.param_count	= MODEM_IMEI_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_STRING,
+	.data_type	= MODEM_INFO_DATA_TYPE_STRING,
 };
 
 static const struct modem_info_data date_time_data = {
@@ -322,7 +322,7 @@ static const struct modem_info_data date_time_data = {
 	.data_name	= DATE_TIME_DATA_NAME,
 	.param_index	= DATE_TIME_PARAM_INDEX,
 	.param_count	= DATE_TIME_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_STRING,
+	.data_type	= MODEM_INFO_DATA_TYPE_STRING,
 };
 
 static const struct modem_info_data apn_data = {
@@ -330,7 +330,7 @@ static const struct modem_info_data apn_data = {
 	.data_name	= APN_DATA_NAME,
 	.param_index	= APN_PARAM_INDEX,
 	.param_count	= APN_PARAM_COUNT,
-	.data_type	= AT_PARAM_TYPE_STRING,
+	.data_type	= MODEM_INFO_DATA_TYPE_STRING,
 };
 
 static const struct modem_info_data *const modem_data[] = {
@@ -398,6 +398,23 @@ enum at_param_type modem_info_type_get(enum modem_info info_type)
 		return -EINVAL;
 	}
 
+	switch (modem_data[info_type]->data_type) {
+	case MODEM_INFO_DATA_TYPE_NUM_INT:
+		return AT_PARAM_TYPE_NUM_INT;
+	case MODEM_INFO_DATA_TYPE_STRING:
+		return AT_PARAM_TYPE_STRING;
+	default:
+		/* Unreachable. */
+		return AT_PARAM_TYPE_INVALID;
+	}
+}
+
+enum modem_info_data_type modem_info_data_type_get(enum modem_info info_type)
+{
+	if (info_type >= MODEM_INFO_COUNT) {
+		return MODEM_INFO_DATA_TYPE_INVALID;
+	}
+
 	return modem_data[info_type]->data_type;
 }
 
@@ -433,7 +450,7 @@ int modem_info_short_get(enum modem_info info, uint16_t *buf)
 		return -EINVAL;
 	}
 
-	if (modem_data[info]->data_type == AT_PARAM_TYPE_STRING) {
+	if (modem_data[info]->data_type == MODEM_INFO_DATA_TYPE_STRING) {
 		return -EINVAL;
 	}
 
@@ -633,7 +650,7 @@ int modem_info_string_get(enum modem_info info, char *buf, const size_t buf_size
 	err = at_parser_init(&parser, recv_buf);
 	__ASSERT_NO_MSG(err == 0);
 
-	if (modem_data[info]->data_type == AT_PARAM_TYPE_NUM_INT) {
+	if (modem_data[info]->data_type == MODEM_INFO_DATA_TYPE_NUM_INT) {
 		err = at_parser_num_get(&parser,
 					modem_data[info]->param_index,
 					&param_value);
@@ -646,7 +663,7 @@ int modem_info_string_get(enum modem_info info, char *buf, const size_t buf_size
 		if ((len <= 0) || (len > buf_size)) {
 			return -EMSGSIZE;
 		}
-	} else if (modem_data[info]->data_type == AT_PARAM_TYPE_STRING) {
+	} else if (modem_data[info]->data_type == MODEM_INFO_DATA_TYPE_STRING) {
 		len = buf_size - out_buf_len;
 		err = at_parser_string_get(&parser,
 					   modem_data[info]->param_index,
@@ -685,7 +702,7 @@ static void modem_info_rsrp_subscribe_handler(const char *notif)
 		.data_name	= RSRP_DATA_NAME,
 		.param_index	= RSRP_NOTIFY_PARAM_INDEX,
 		.param_count	= RSRP_NOTIFY_PARAM_COUNT,
-		.data_type	= AT_PARAM_TYPE_NUM_INT,
+		.data_type	= MODEM_INFO_DATA_TYPE_NUM_INT,
 	};
 
 	err = at_parser_init(&parser, notif);

--- a/lib/modem_info/modem_info_params.c
+++ b/lib/modem_info/modem_info_params.c
@@ -107,16 +107,16 @@ static int cellid_to_dec(struct lte_param *cellID, double *cellID_dec)
 
 static int modem_data_get(struct lte_param *param)
 {
-	enum at_param_type data_type;
+	enum modem_info_data_type data_type;
 	int ret;
 
-	data_type = modem_info_type_get(param->type);
+	data_type = modem_info_data_type_get(param->type);
 
-	if (data_type < 0) {
+	if (data_type == MODEM_INFO_DATA_TYPE_INVALID) {
 		return -EINVAL;
 	}
 
-	if (data_type == AT_PARAM_TYPE_STRING) {
+	if (data_type == MODEM_INFO_DATA_TYPE_STRING) {
 		ret = modem_info_string_get(param->type,
 				param->value_string,
 				sizeof(param->value_string));
@@ -124,7 +124,7 @@ static int modem_data_get(struct lte_param *param)
 			LOG_ERR("Link data not obtained: %d %d", param->type, ret);
 			return ret;
 		}
-	} else if (data_type == AT_PARAM_TYPE_NUM_INT) {
+	} else if (data_type == MODEM_INFO_DATA_TYPE_NUM_INT) {
 		ret = modem_info_short_get(param->type, &param->value);
 		if (ret < 0) {
 			LOG_ERR("Link data not obtained: %d", ret);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
@@ -1233,7 +1233,7 @@ int nrf_cloud_get_single_cell_modem_info(struct lte_lc_cell *const cell_inf)
 static int add_modem_info_data(struct lte_param *param, cJSON *json_obj)
 {
 	char data_name[MODEM_INFO_MAX_RESPONSE_SIZE];
-	enum at_param_type data_type;
+	enum modem_info_data_type data_type;
 	int ret;
 
 	__ASSERT_NO_MSG(param != NULL);
@@ -1246,12 +1246,12 @@ static int add_modem_info_data(struct lte_param *param, cJSON *json_obj)
 		return -EINVAL;
 	}
 
-	data_type = modem_info_type_get(param->type);
+	data_type = modem_info_data_type_get(param->type);
 	if (data_type < 0) {
 		return -EINVAL;
 	}
 
-	if (data_type == AT_PARAM_TYPE_STRING &&
+	if (data_type == MODEM_INFO_DATA_TYPE_STRING &&
 	    param->type != MODEM_INFO_AREA_CODE) {
 		if (cJSON_AddStringToObject(json_obj, data_name, param->value_string) == NULL) {
 			return -ENOMEM;

--- a/tests/subsys/net/lib/nrf_provisioning/CMakeLists.txt
+++ b/tests/subsys/net/lib/nrf_provisioning/CMakeLists.txt
@@ -23,7 +23,8 @@ cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/lte_lc.h
 	WORD_EXCLUDE "__deprecated")
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/modem_key_mgmt.h)
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/modem_attest_token.h)
-cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/modem_info.h)
+cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/modem_info.h
+	WORD_EXCLUDE "__deprecated")
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/nrf_modem_lib.h)
 cmock_handle(${ZEPHYR_BASE}/include/zephyr/settings/settings.h)
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_at.h)


### PR DESCRIPTION
* Deprecates the `at_params` module.
   It will be removed in a future release.

* Adds the `enum modem_info_data_type` type
   for representing the LTE link information data
   types.
    
* Adds the `modem_info_data_type_get` function
   for requesting the data type of the current
   modem information type.

* Deprecates the `modem_info_type_get` function
   in favor of the  `modem_info_data_type_get` function.