### PR TITLE
applications: sdp: mspi: remove toggling of pins after TX

### DIFF
--- a/applications/sdp/mspi/src/hrt/hrt-nrf54l15.s
+++ b/applications/sdp/mspi/src/hrt/hrt-nrf54l15.s
@@ -239,8 +239,12 @@ hrt_write:
 	addi	sp,sp,-16
 	sw	s0,8(sp)
 	sw	ra,12(sp)
+	sw	s1,4(sp)
 	mv	s0,a0
 	sb	zero,3(sp)
+ #APP
+	csrr s1, 3008
+ #NO_APP
 	lhu	a5,90(a0)
  #APP
 	csrw 3009, a5
@@ -344,11 +348,16 @@ hrt_write:
 	call	hrt_tx
 	lbu	a5,94(s0)
 	bne	a5,zero,.L43
-	li	a5,16384
+	li	a5,4096
 	addi	a5,a5,1
  #APP
 	csrw 3019, a5
-	csrw 3017, 0
+ #NO_APP
+	slli	s1,s1,1
+	slli	s1,s1,16
+	srli	s1,s1,16
+ #APP
+	csrw 3012, s1
 	csrw 2000, 0
  #NO_APP
 .L44:
@@ -370,6 +379,7 @@ hrt_write:
 .L31:
 	lw	ra,12(sp)
 	lw	s0,8(sp)
+	lw	s1,4(sp)
 	addi	sp,sp,16
 	jr	ra
 .L38:
@@ -389,7 +399,7 @@ hrt_write:
  #APP
 	csrw 2000, 0
  #NO_APP
-	li	a5,16384
+	li	a5,4096
 	addi	a5,a5,1
  #APP
 	csrw 3019, a5


### PR DESCRIPTION
Remove toggling of not used pins after sending data on SINGLE.

~This change temporary breaks sending data on QUAD, however, changes from https://github.com/nrfconnect/sdk-nrf/pull/20360 should fix it back (this change, to be more specific: https://github.com/nrfconnect/sdk-nrf/pull/20360/files#diff-1bfeb3937beffb96825c75549b69a42219ddedb103b28377bc8ef839e8f55574R393-R401)~