### PR TITLE
crypto: Disabling MBEDTLS_MAC_SHA256_ENABLED to optimize builds

### DIFF
--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -210,7 +210,6 @@ config MBEDTLS_MAC_ALL_ENABLED
 
 config MBEDTLS_MAC_SHA256_ENABLED
 	bool "Enable the SHA-224 and SHA-256 hash algorithms"
-	default y
 	select PSA_WANT_ALG_SHA_224
 	select PSA_WANT_ALG_SHA_256
 	select PSA_WANT_ALG_HMAC


### PR DESCRIPTION
-The configurations that are put-in-place in nrf_security for
 keeping compatible with Zephyr-named configurations used in context of
 PSA support (while being legacy configurations) was enabling
 PSA_WANT_ALG_SHA_224, PSA_WANT_SHA_256 and PsA_WANT_ALG_HMAC.
 This commit removes the default y for MBEDTLS_MAC_SHA256_ENABLED to
 avoid setting these always. This decreases some build-sizes