### PR TITLE
tests: benchmarks: multicore: Adjust power testing at idle state

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -815,6 +815,7 @@
 # Tests
 /tests/benchmarks/                        @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/              @carlescufi @nrfconnect/ncs-low-level-test
+/tests/benchmarks/multicore/common/       @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/idle*         @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/idle/         @adamkondraciuk @nrfconnect/ncs-low-level-test
 /tests/benchmarks/multicore/idle_gpio/    @adamkondraciuk @nrfconnect/ncs-low-level-test

--- a/tests/benchmarks/multicore/common/workaround_idle.overlay
+++ b/tests/benchmarks/multicore/common/workaround_idle.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Modify S2RAM low power state - increase it's min-residency
+ * so the cpu stays at IDLE state.
+ */
+
+/ {
+	cpus {
+		power-states {
+			s2ram: s2ram {
+				min-residency-us = <800000>;
+			};
+		};
+	};
+};

--- a/tests/benchmarks/multicore/idle_flpr/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_flpr/testcase.yaml
@@ -29,6 +29,7 @@ tests:
       - remote_flpr_CONF_FILE=prj_s2ram.conf
       - idle_flpr_CONFIG_TEST_SLEEP_DURATION_MS=500
       - remote_flpr_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_flpr_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/multicore/idle_ppr/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_ppr/testcase.yaml
@@ -28,6 +28,7 @@ tests:
       - idle_ppr_CONFIG_TEST_SLEEP_DURATION_MS=500
       - remote_rad_CONFIG_TEST_SLEEP_DURATION_MS=500
       - remote_ppr_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_ppr_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/multicore/idle_pwm_led/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_pwm_led/testcase.yaml
@@ -28,6 +28,7 @@ tests:
       - remote_CONF_FILE=prj_s2ram.conf
       - idle_pwm_led_CONFIG_TEST_SLEEP_DURATION_MS=500
       - remote_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_pwm_led_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: ppk_power_measure
@@ -55,6 +56,7 @@ tests:
       - idle_pwm_led_CONFIG_TEST_SLEEP_DURATION_MS=500
       - remote_CONFIG_TEST_SLEEP_DURATION_MS=500
       - idle_pwm_led_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay"
+      - idle_pwm_led_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: ppk_power_measure

--- a/tests/benchmarks/multicore/idle_pwm_loopback/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_pwm_loopback/testcase.yaml
@@ -29,6 +29,7 @@ tests:
       - remote_CONF_FILE=prj_s2ram.conf
       - idle_pwm_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
       - remote_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_pwm_loopback_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -69,6 +70,7 @@ tests:
       - idle_pwm_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
       - remote_CONFIG_TEST_SLEEP_DURATION_MS=500
       - idle_pwm_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_1.overlay"
+      - idle_pwm_loopback_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback

--- a/tests/benchmarks/multicore/idle_spim_loopback/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_spim_loopback/testcase.yaml
@@ -34,6 +34,7 @@ tests:
     extra_args:
       - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
       - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_spim_loopback_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -72,6 +73,7 @@ tests:
       - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
       - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
       - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -157,6 +159,7 @@ tests:
       - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
       - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
       - idle_spim_loopback_CONFIG_DATA_FIELD=16
+      - idle_spim_loopback_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -199,6 +202,7 @@ tests:
       - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
       - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
       - idle_spim_loopback_CONFIG_DATA_FIELD=16
+      - idle_spim_loopback_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -327,6 +331,7 @@ tests:
       - idle_spim_loopback_CONFIG_TEST_SPI_LOCK_ON=y
       - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
       - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_spim_loopback_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -374,6 +379,7 @@ tests:
       - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
       - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
       - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -428,6 +434,7 @@ tests:
       - idle_spim_loopback_CONFIG_TEST_SPI_RELEASE_BEFORE_SLEEP=n
       - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
       - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_spim_loopback_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback
@@ -479,6 +486,7 @@ tests:
       - idle_spim_loopback_CONF_FILE=prj_s2ram.conf
       - idle_spim_loopback_CONFIG_TEST_SLEEP_DURATION_MS=500
       - idle_spim_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - idle_spim_loopback_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: spi_loopback

--- a/tests/benchmarks/multicore/idle_wdt/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_wdt/testcase.yaml
@@ -26,6 +26,7 @@ tests:
       - remote_CONF_FILE=prj_s2ram.conf
       - idle_wdt_CONFIG_TEST_SLEEP_DURATION_MS=500
       - remote_CONFIG_TEST_SLEEP_DURATION_MS=500
+      - idle_wdt_EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/workaround_idle.overlay"
     harness: pytest
     harness_config:
       fixture: ppk_power_measure


### PR DESCRIPTION
In tests where Application core shall enter IDLE low power state add EXTRA_DTC_OVERLAY_FILE that prevents mooving forward to S2RAM low power state.