### PR TITLE
bluetooth: fast_pair: fmdn: add restriction for fmdn tx power

### DIFF
--- a/doc/nrf/external_comp/bt_fast_pair.rst
+++ b/doc/nrf/external_comp/bt_fast_pair.rst
@@ -580,6 +580,7 @@ For example, the "It's here" status message is displayed in the "Hot & Cold" exp
 
 You can set the TX power for the FMDN advertising and connections using the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_TX_POWER` Kconfig option.
 The configured value is directly used to set the TX power in the Bluetooth LE controller using an HCI command.
+This Kconfig option must be set to 0 at minimum as the Fast Pair specification requires that the conducted Bluetooth transmit power for FMDN advertisements must not be lower than 0 dBm.
 By default, 0 dBm is used for the FMDN TX power configuration.
 
 You can use the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_TX_POWER_CORRECTION_VAL` Kconfig option to define a correction value that is added to TX power readout from the Bluetooth LE controller (usually equal to the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_TX_POWER` Kconfig option), when calculating the calibrated TX power reported in the Read Beacon Parameters response.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -588,6 +588,9 @@ Bluetooth libraries and services
 
 * :ref:`bt_fast_pair_readme` library:
 
+  * Added a restriction on the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_TX_POWER` Kconfig option in the Find My Device Network (FMDN) extension configuration.
+    This Kconfig option must now be set to 0 at minimum as the Fast Pair specification now requires that the conducted Bluetooth transmit power for FMDN advertisements must not be lower than 0 dBm.
+
   * Updated the automatically generated ``bt_fast_pair`` partition definition (located in the :file:`subsys/partition_manager/pm.yml.bt_fast_pair`) to work correctly when building with TF-M.
 
 * :ref:`bt_mesh` library:

--- a/subsys/bluetooth/services/fast_pair/fmdn/Kconfig
+++ b/subsys/bluetooth/services/fast_pair/fmdn/Kconfig
@@ -16,6 +16,7 @@ if BT_FAST_PAIR_FMDN
 config BT_FAST_PAIR_FMDN_TX_POWER
 	int "TX power set in Bluetooth LE controller [dBm]"
 	default 0
+	range 0 127
 	help
 	  Define the TX power configuration used for the extension advertising and
 	  connections in dBm. The value is passed to the Bluetooth LE controller
@@ -25,6 +26,10 @@ config BT_FAST_PAIR_FMDN_TX_POWER
 	  a warning notifying the user about the real TX power during the enabling
 	  procedure of this library. The actual TX power value will be as close to
 	  the desired configuration as possible.
+
+	  This Kconfig option must be set to zero at minimum. The Fast Pair specification
+	  requires that the conducted Bluetooth transmit power for FMDN advertisements
+	  must be set to at least 0 dBm.
 
 config BT_FAST_PAIR_FMDN_TX_POWER_CORRECTION_VAL
 	int "TX power correction value [dBm]"


### PR DESCRIPTION
Added a restriction on the CONFIG_BT_FAST_PAIR_FMDN_TX_POWER Kconfig option in the Find My Device Network (FMDN) extension configuration. This Kconfig option should now be set to 0 at minimum as the Fast Pair specification now requires that the conducted Bluetooth transmit power for FMDN advertisements must not be lower than 0 dBm.

Ref: NCSDK-30857