### PR TITLE
mpsl: clock_ctrl: Add MRAM high frequency request to MPSL

### DIFF
--- a/subsys/mpsl/clock_ctrl/Kconfig
+++ b/subsys/mpsl/clock_ctrl/Kconfig
@@ -13,3 +13,27 @@ config MPSL_USE_EXTERNAL_CLOCK_CONTROL
 	help
 	  This option configures MPSL to use an external clock driver, and
 	  not the clock driver provided as part of the MPSL library.
+
+if MPSL_USE_EXTERNAL_CLOCK_CONTROL
+
+config MPSL_EXT_CLK_CTRL_CLOCK_REQUEST_WAIT_TIMEOUT_MS
+	int "Timeout value that MPSL will wait for request to be completed by a clock driver, in milliseconds"
+	default CLOCK_CONTROL_NRF2_NRFS_CLOCK_TIMEOUT_MS if CLOCK_CONTROL_NRF2
+	default 1000
+	help
+	  The option specifies a timeout value that MPSL clock control integration layer
+	  will wait for completion of a request put to a clock driver. Note that the value
+	  depends on the clock driver used, for example if nrf2 clock driver is used,
+	  it must be greater or equalt than internal clock driver timeout value.
+
+config MPSL_EXT_CLK_CTRL_NVM_CLOCK_REQUEST
+	bool "Enables a request for a non-volatile memory clock"
+	depends on CLOCK_CONTROL_NRF2_GLOBAL_HSFLL
+	depends on SOC_SERIES_NRF54HX
+	default y
+	help
+	  This option enables MPSL to request a clock for non-volatile memory,
+	  ensuring it operates at a frequency that prevents code execution being
+	  too slow. This is crucial to meet meet radio protocols requirements.
+
+endif # MPSL_USE_EXTERNAL_CLOCK_CONTROL


### PR DESCRIPTION
In the nRF54h20 SoC the non-volatile memory is located in a global domain which by default configured by nrf2 clock control to run with 64MHz. That makes a code execution time longer so it doesn't fit into radio protocols time requirements. That causes e.g. Bluetooth stack to assert in radio events.

To make sure the clock needed for MRAM (non-volatile memory in nRF54h20 SoC) is always setup to highest avaialble frequency MPSL will put a request for the clock to clock control driver. In case there is any other user of the clock that runs from radio core and allows to lower the global domain clock frequency, the clock will still be stay as requested by MPSL.