### PR TITLE
quarantine_zephyr: Enabled zephyr mesh sample again

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -281,15 +281,6 @@
     - nrf54l15dk/nrf54l15/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-31783"
 
-- scenarios:
-    - sample.bluetooth.mesh.onoff_level_lighting_vnd
-    - sample.bluetooth.mesh_provisioner
-    - bluetooth.mesh.mesh_shell
-    - sample.bluetooth.mesh.onoff
-    - sample.bluetooth.mesh_demo
-    - sample.bluetooth.mesh
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-31884"
-
 # ---------------------------------   Won't fix section -----------------------------------
 
 - scenarios:
@@ -572,3 +563,15 @@
   platforms:
     - native_sim/native
   comment: "clang is not available in our toolchain"
+
+- scenarios:
+    - sample.bluetooth.mesh.onoff_level_lighting_vnd
+    - sample.bluetooth.mesh_provisioner
+    - bluetooth.mesh.mesh_shell
+    - sample.bluetooth.mesh.onoff
+    - sample.bluetooth.mesh_demo
+    - sample.bluetooth.mesh
+  comment:
+    - "Mesh by default enables HW_UNIQUE_KEY_WRITE_ON_CRYPTO_INIT which has dependency on
+      Partition Manager. Upstream has no PM support and sysbuild is not by default supported
+      which can implicitly enable PM, consequently building those samples in NCS fails."

--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -563,15 +563,3 @@
   platforms:
     - native_sim/native
   comment: "clang is not available in our toolchain"
-
-- scenarios:
-    - sample.bluetooth.mesh.onoff_level_lighting_vnd
-    - sample.bluetooth.mesh_provisioner
-    - bluetooth.mesh.mesh_shell
-    - sample.bluetooth.mesh.onoff
-    - sample.bluetooth.mesh_demo
-    - sample.bluetooth.mesh
-  comment:
-    - "Mesh by default enables HW_UNIQUE_KEY_WRITE_ON_CRYPTO_INIT which has dependency on
-      Partition Manager. Upstream has no PM support and sysbuild is not by default supported
-      which can implicitly enable PM, consequently building those samples in NCS fails."


### PR DESCRIPTION
Fixed here: https://github.com/nrfconnect/sdk-nrf/commit/1883f06ef4c288b7265552421a71afd22462566f