### PR TITLE
cmake: sysbuild: partition_manager: Fix cpunet static PM file support

### DIFF
--- a/cmake/sysbuild/partition_manager.cmake
+++ b/cmake/sysbuild/partition_manager.cmake
@@ -138,7 +138,6 @@ function(partition_manager)
       dynamic_partition_argument
       "--flash_primary-dynamic-partition;${dynamic_partition}"
       )
-    set(static_configuration)
   endif()
 
   if (DEFINED PM_DOMAIN)


### PR DESCRIPTION
Fixes an issue which prevented static PM files working for cpunet on nrf5340 devices