### PR TITLE
bluetooth: controller: Use GPIO driver for CS antenna switching

### DIFF
--- a/dts/bindings/bluetooth/nordic,bt-cs-antenna-switch.yaml
+++ b/dts/bindings/bluetooth/nordic,bt-cs-antenna-switch.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+description: |
+  This is an abstract representation of a generic antenna switching circuit
+  which is controlled by GPIO pins. Up to four antenna ports (ANT1-4) are defined.
+
+compatible: "nordic,bt-cs-antenna-switch"
+
+include: base.yaml
+
+properties:
+  multiplexing-mode:
+    type: int
+    description: |
+      Multiplexing mode. This setting determines whether or not the switching circuit
+      is controlled using a one-to-one mapping between pins and antennas.
+      The possible values are:
+      0: (default) One-to-one mapping. Each pin selects one antenna.
+        Only one pin is active at a time.
+      1: Multiplexed mapping. Antenna selection is derived from the state of all
+        pins. Example: two pins select between four antennas.
+
+  ant-gpios:
+    type: phandle-array
+    required: true
+    description: |
+      Array of pins corresponding to <ANT1, ANT2, ANT3, ANT4>.
+      At least one pin is needed.

--- a/samples/bluetooth/channel_sounding_ras_initiator/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/channel_sounding_ras_initiator/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	cs_antenna_switch: cs-antenna-config {
+		status = "okay";
+		compatible = "nordic,bt-cs-antenna-switch";
+		ant-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH)>,
+			    <&gpio1 12 (GPIO_ACTIVE_HIGH)>,
+			    <&gpio1 13 (GPIO_ACTIVE_HIGH)>,
+			    <&gpio1 14 (GPIO_ACTIVE_HIGH)>;
+		multiplexing-mode = <0>;
+	};
+};

--- a/samples/bluetooth/channel_sounding_ras_reflector/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/channel_sounding_ras_reflector/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	cs_antenna_switch: cs-antenna-config {
+		status = "okay";
+		compatible = "nordic,bt-cs-antenna-switch";
+		ant-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH)>,
+			    <&gpio1 12 (GPIO_ACTIVE_HIGH)>,
+			    <&gpio1 13 (GPIO_ACTIVE_HIGH)>,
+			    <&gpio1 14 (GPIO_ACTIVE_HIGH)>;
+		multiplexing-mode = <0>;
+	};
+};

--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -23,7 +23,7 @@ zephyr_library_sources_ifdef(
 )
 
 zephyr_library_sources_ifdef(
-  CONFIG_BT_CTLR_CHANNEL_SOUNDING
+  CONFIG_BT_CTLR_SDC_CS_MULTIPLE_ANTENNA_SUPPORT
   cs_antenna_switch.c
 )
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -603,6 +603,14 @@ config BT_CTLR_SDC_CS_NUM_ANTENNAS
 	range 1 BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS
 	depends on BT_CTLR_CHANNEL_SOUNDING
 
+config BT_CTLR_SDC_CS_MULTIPLE_ANTENNA_SUPPORT
+	bool
+	default y if BT_CTLR_SDC_CS_NUM_ANTENNAS > 1
+	select GPIO
+	depends on BT_CTLR_CHANNEL_SOUNDING
+	help
+	  Internal helper config. Not intended for use.
+
 config BT_CTLR_SDC_CS_STEP_MODE3
 	bool "Enable optional step mode-3 capability [EXPERIMENTAL]"
 	depends on BT_CTLR_CHANNEL_SOUNDING

--- a/subsys/bluetooth/controller/cs_antenna_switch.c
+++ b/subsys/bluetooth/controller/cs_antenna_switch.c
@@ -7,34 +7,110 @@
 #include <stdint.h>
 #include "cs_antenna_switch.h"
 
-#include <hal/nrf_gpio.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
 
-#define DEFAULT_CS_ANTENNA_GPIO_PORT NRF_P1
-#define DEFAULT_CS_ANTENNA_BASE_PIN (11)
-#define DEFAULT_CS_ANTENNA_PIN_MASK (0xF << DEFAULT_CS_ANTENNA_BASE_PIN)
+#if DT_NODE_EXISTS(DT_NODELABEL(cs_antenna_switch))
+#define ANTENNA_SWITCH_NODE DT_NODELABEL(cs_antenna_switch)
+#else
+#define ANTENNA_SWITCH_NODE DT_INVALID_NODE
+#error No channel sounding antenna switch nodes registered in DTS.
+#endif
+
+#if !DT_NODE_HAS_COMPAT(ANTENNA_SWITCH_NODE, nordic_bt_cs_antenna_switch)
+#error Configured antenna switch node is not compatible.
+#endif
+
+#if DT_NODE_HAS_PROP(ANTENNA_SWITCH_NODE, multiplexing_mode)
+#define MULTIPLEXED DT_PROP(ANTENNA_SWITCH_NODE, multiplexing_mode)
+#else
+#define MULTIPLEXED false
+#endif
+
+#define ANTENNA_NOT_SET 0xFF
+
+BUILD_ASSERT(DT_NODE_HAS_PROP(ANTENNA_SWITCH_NODE, ant_gpios));
+
+#if MULTIPLEXED
+#if CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS == 2
+BUILD_ASSERT(DT_PROP_LEN(ANTENNA_SWITCH_NODE, ant_gpios) >= 1);
+#else
+BUILD_ASSERT(DT_PROP_LEN(ANTENNA_SWITCH_NODE, ant_gpios) >= 2);
+#endif
+#else
+BUILD_ASSERT(DT_PROP_LEN(ANTENNA_SWITCH_NODE, ant_gpios) >= CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS);
+#endif /* MULTIPLEXED */
+
+static uint8_t currently_active_antenna = ANTENNA_NOT_SET;
+static const struct gpio_dt_spec gpio_dt_spec_table[] = {
+	GPIO_DT_SPEC_GET_BY_IDX_OR(ANTENNA_SWITCH_NODE, ant_gpios, 0, {0}),
+	GPIO_DT_SPEC_GET_BY_IDX_OR(ANTENNA_SWITCH_NODE, ant_gpios, 1, {0}),
+#if !MULTIPLEXED
+	GPIO_DT_SPEC_GET_BY_IDX_OR(ANTENNA_SWITCH_NODE, ant_gpios, 2, {0}),
+	GPIO_DT_SPEC_GET_BY_IDX_OR(ANTENNA_SWITCH_NODE, ant_gpios, 3, {0}),
+#endif
+};
 
 /* Antenna control below is implemented as described in the CS documentation.
- * https://docs.nordicsemi.com/bundle/ncs-latest/page/nrfxlib/softdevice_controller/doc/channel_sounding.html#multiple_antennas_support
- * The board has four antenna ports (ANT1-ANT4) that can be individually
- * enabled by setting the connected gpio pin high, while setting the gpio
- * pins for the other antenna ports low.
  *
- * Map of antenna ports to gpio pins for nrf54xDK:
- * ANT1 <----> P1.11
- * ANT2 <----> P1.12
- * ANT3 <----> P1.13
- * ANT4 <----> P1.14
+ * Example valid device tree configuration for the nRF54L15:
+ *
+ * / {
+ *   cs_antenna_switch: cs-antenna-config {
+ *     status = "okay";
+ *     compatible = "nordic,bt-cs-antenna-switch";
+ *     ant-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH)>,
+ *                 <&gpio1 12 (GPIO_ACTIVE_HIGH)>,
+ *                 <&gpio1 13 (GPIO_ACTIVE_HIGH)>,
+ *                 <&gpio1 14 (GPIO_ACTIVE_HIGH)>;
+ *     multiplexing-mode = <0>;
+ *   };
+ * };
+ *
  */
 void cs_antenna_switch_func(uint8_t antenna_number)
 {
-	uint32_t out = nrf_gpio_port_out_read(DEFAULT_CS_ANTENNA_GPIO_PORT);
+	int err;
+#if MULTIPLEXED
+	err = gpio_pin_set_dt(&gpio_dt_spec_table[0], antenna_number & (1 << 0));
+	__ASSERT_NO_MSG(err == 0);
 
-	out &= ~DEFAULT_CS_ANTENNA_PIN_MASK;
-	out |= 1 << (DEFAULT_CS_ANTENNA_BASE_PIN + antenna_number);
-	nrf_gpio_port_out_write(DEFAULT_CS_ANTENNA_GPIO_PORT, out);
+	err = gpio_pin_set_dt(&gpio_dt_spec_table[1], antenna_number & (1 << 1));
+	__ASSERT_NO_MSG(err == 0);
+#else
+	if (currently_active_antenna != antenna_number) {
+		if (currently_active_antenna != ANTENNA_NOT_SET) {
+			err = gpio_pin_set_dt(&gpio_dt_spec_table[currently_active_antenna], false);
+			__ASSERT_NO_MSG(err == 0);
+		}
+
+		err = gpio_pin_set_dt(&gpio_dt_spec_table[antenna_number], true);
+		__ASSERT_NO_MSG(err == 0);
+	}
+
+	currently_active_antenna = antenna_number;
+#endif
 }
 
-void cs_antenna_switch_enable(void)
+void cs_antenna_switch_init(void)
 {
-	nrf_gpio_port_dir_output_set(DEFAULT_CS_ANTENNA_GPIO_PORT, DEFAULT_CS_ANTENNA_PIN_MASK);
+	int err;
+
+	for (uint8_t i = 0; i < DT_PROP_LEN(ANTENNA_SWITCH_NODE, ant_gpios); i++) {
+		err = gpio_pin_configure_dt(&gpio_dt_spec_table[i], GPIO_OUTPUT_INACTIVE);
+		__ASSERT(err == 0, "Failed to initialize GPIOs for CS (%d)", ret);
+	}
+}
+
+void cs_antenna_switch_clear(void)
+{
+	int err;
+
+	for (uint8_t i = 0; i < DT_PROP_LEN(ANTENNA_SWITCH_NODE, ant_gpios); i++) {
+		err = gpio_pin_set_dt(&gpio_dt_spec_table[i], false);
+		__ASSERT_NO_MSG(err == 0);
+	}
+
+	currently_active_antenna = ANTENNA_NOT_SET;
 }

--- a/subsys/bluetooth/controller/cs_antenna_switch.h
+++ b/subsys/bluetooth/controller/cs_antenna_switch.h
@@ -15,5 +15,8 @@
  */
 void cs_antenna_switch_func(uint8_t antenna_number);
 
-/** @brief Function to enable the pins used by antenna switching in Channel Sounding. */
-void cs_antenna_switch_enable(void);
+/** @brief Function to initialize the pins used by antenna switching in Channel Sounding. */
+void cs_antenna_switch_init(void);
+
+/** @brief Function to clear the pins used by antenna switching in Channel Sounding. */
+void cs_antenna_switch_clear(void);

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -984,9 +984,9 @@ static int configure_supported_features(void)
 		if (err) {
 			return -ENOTSUP;
 		}
-#if CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS > 1
+#if defined(CONFIG_BT_CTLR_SDC_CS_MULTIPLE_ANTENNA_SUPPORT)
 		err = sdc_support_channel_sounding(cs_antenna_switch_func);
-		cs_antenna_switch_enable();
+		cs_antenna_switch_init();
 #else
 		err = sdc_support_channel_sounding(NULL);
 #endif
@@ -1469,6 +1469,10 @@ static int hci_driver_close(const struct device *dev)
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_ECDH)) {
 		hci_ecdh_uninit();
+	}
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_SDC_CS_MULTIPLE_ANTENNA_SUPPORT)) {
+		cs_antenna_switch_clear();
 	}
 
 	err = MULTITHREADING_LOCK_ACQUIRE();


### PR DESCRIPTION
Adds relevant DTS bindings and uses zephyr/gpio.h to provide a generic API for multiantenna channel sounding.