### PR TITLE
bluetooth: controller: use DIRSET mask for antenna switch gpios

### DIFF
--- a/subsys/bluetooth/controller/cs_antenna_switch.c
+++ b/subsys/bluetooth/controller/cs_antenna_switch.c
@@ -36,5 +36,5 @@ void cs_antenna_switch_func(uint8_t antenna_number)
 
 void cs_antenna_switch_enable(void)
 {
-	nrf_gpio_port_dir_output_set(DEFAULT_CS_ANTENNA_GPIO_PORT, DEFAULT_CS_ANTENNA_BASE_PIN);
+	nrf_gpio_port_dir_output_set(DEFAULT_CS_ANTENNA_GPIO_PORT, DEFAULT_CS_ANTENNA_PIN_MASK);
 }


### PR DESCRIPTION
We used the GPIO number inadvertently