### PR TITLE
applications: sdp: mspi: fix for data longer than 256 bytes

### DIFF
--- a/applications/sdp/mspi/src/hrt/hrt-nrf54l15.s
+++ b/applications/sdp/mspi/src/hrt/hrt-nrf54l15.s
@@ -490,7 +490,7 @@ hrt_read:
 	li	a5,0
 .L57:
 	lw	a4,64(s0)
-	bltu	a5,a4,.L58
+	bgtu	a4,a5,.L58
  #APP
 	csrw 2000, 0
 	csrw 2001, 0
@@ -536,9 +536,8 @@ hrt_read:
 	lw	a4,60(s0)
 	srli	a3,a3,24
 	add	a4,a4,a5
-	addi	a5,a5,1
 	sb	a3,0(a4)
-	andi	a5,a5,0xff
+	addi	a5,a5,1
 	j	.L57
 .L60:
 	li	a5,1

--- a/applications/sdp/mspi/src/hrt/hrt.c
+++ b/applications/sdp/mspi/src/hrt/hrt.c
@@ -314,7 +314,7 @@ void hrt_read(volatile hrt_xfer_t *hrt_xfer_params)
 	hrt_tx_rx(&hrt_xfer_params->xfer_data[HRT_FE_ADDRESS], hrt_xfer_params->bus_widths.address,
 		  false, hrt_xfer_params->counter_value, CNT1_INIT_VALUE);
 
-	for (uint8_t i = 0; i < hrt_xfer_params->xfer_data[HRT_FE_DATA].word_count; i++) {
+	for (uint32_t i = 0; i < hrt_xfer_params->xfer_data[HRT_FE_DATA].word_count; i++) {
 		hrt_xfer_params->xfer_data[HRT_FE_DATA].data[i] =
 			nrf_vpr_csr_vio_in_buffered_reversed_byte_get() >> INPUT_SHIFT_COUNT;
 	}


### PR DESCRIPTION
Changed type uint8_t to uint32_t to be able to
send data longer than 256 bytes.