### PR TITLE
driver: switch to new sdc_support_channel_sounding function

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -23,7 +23,7 @@ zephyr_library_sources_ifdef(
 )
 
 zephyr_library_sources_ifdef(
-  CONFIG_BT_CHANNEL_SOUNDING
+  CONFIG_BT_CTLR_CHANNEL_SOUNDING
   cs_antenna_switch.c
 )
 

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -984,15 +984,11 @@ static int configure_supported_features(void)
 		if (err) {
 			return -ENOTSUP;
 		}
-#ifdef CS_ANTENNA_SWITCH_CALLBACK_TYPE_DEFINED
 #if CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS > 1
 		err = sdc_support_channel_sounding(cs_antenna_switch_func);
 		cs_antenna_switch_enable();
 #else
 		err = sdc_support_channel_sounding(NULL);
-#endif
-#else
-		err = sdc_support_channel_sounding();
 #endif
 		if (err) {
 			return -ENOTSUP;


### PR DESCRIPTION
In order to allow users to configure their own antenna switch logic, we needed to update the sdc_support_channel_sounding function. This should change the default logic to use the new function.

Also fixed a bug in the kconfig dependency to compile with the cs antenna switch logic.