### PR TITLE
samples: matter: Fix build error when CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE is enabled

### DIFF
--- a/samples/matter/common/src/app/fabric_table_delegate.h
+++ b/samples/matter/common/src/app/fabric_table_delegate.h
@@ -41,7 +41,9 @@ public:
 private:
 	void OnFabricRemoved(const chip::FabricTable &fabricTable, chip::FabricIndex fabricIndex)
 	{
+#ifndef CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
 		k_timer_start(&sFabricRemovedTimer, K_MSEC(CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY), K_NO_WAIT);
+#endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
 	}
 
 	static void OnFabricRemovedTimerCallback(k_timer *timer)


### PR DESCRIPTION
When `CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE` is enabled `CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY` is not defined as there is no expected action.