### PR TITLE
tests: drivers: audio: pdm_loopback: adjust nRF54L20 1000kHz

### DIFF
--- a/tests/drivers/audio/pdm_loopback/testcase.yaml
+++ b/tests/drivers/audio/pdm_loopback/testcase.yaml
@@ -13,6 +13,12 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
     extra_args: CONFIG_NRFX_TIMER00=y
+  drivers.audio.pdm_loopback.nrf54l20.1000khz:
+    platform_allow:
+      - nrf54l20pdk/nrf54l20/cpuapp
+    extra_args:
+      - CONFIG_NRFX_TIMER00=y
+      - CONFIG_TEST_PDM_SAMPLING_RATE=20000
   drivers.audio.pdm_loopback.nrf54l.1280khz:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
With MDK 8.69.1 introduced with nrfx 3.10, nRF54L20 no longer directly supports ratio of 100 for PDM. Thus, driver is unable to get the expected sample rate of 10kHz for 1000kHz clock. Since ratio of 50 is available, new configuration has been added and the old one will remain in quarantine.

Once support for nRF54L20-specific custom ratio in PDM is provided, the case can be brought back from quarantine.