### PR TITLE
dts: bindings: Update nordic,nrf-mpc

### DIFF
--- a/dts/bindings/mpc/nordic,nrf-mpc.yaml
+++ b/dts/bindings/mpc/nordic,nrf-mpc.yaml
@@ -1,10 +1,17 @@
-description: Nordic, Memory Protection Controller (MPC)
+description: Nordic Memory Privilege Controller (MPC)
 
 compatible: "nordic,nrf-mpc"
 
 include: base.yaml
 
 properties:
-  protection-region-size:
+  reg:
+    required: true
+
+  override-num:
     type: int
-    description: Region size for the Memory Protection Controller (MPC) in bytes.
+    description: Number of override regions supported by the MPC instance.
+
+  override-granularity:
+    type: int
+    description: Override region addresses must be aligned to this value.

--- a/dts/common/nordic/nrf7120_enga.dtsi
+++ b/dts/common/nordic/nrf7120_enga.dtsi
@@ -82,7 +82,8 @@
 			#size-cells = <1>;
 			compatible = "nordic,nrf-mpc";
 			reg = <0x50041000 0x1000>;
-			protection-region-size = <4096>;
+			override-num = <14>;
+			override-granularity = <4096>;
 		};
 	};
 

--- a/soc/nordic/nrf71/Kconfig
+++ b/soc/nordic/nrf71/Kconfig
@@ -28,7 +28,7 @@ DT_MPC_REGION_SIZE := $(dt_nodelabel_path,nrf_mpc_region)
 
 config NRF_TRUSTZONE_FLASH_REGION_SIZE
 	hex
-	default $(dt_node_int_prop_hex,$(DT_MPC_REGION_SIZE),protection-region-size)
+	default $(dt_node_int_prop_hex,$(DT_MPC_REGION_SIZE),override-granularity)
 	help
 	  This defines the flash region size from the TRUSTZONE perspective.
 	  It is used when configuring the TRUSTZONE and when setting alignments
@@ -38,7 +38,7 @@ config NRF_TRUSTZONE_FLASH_REGION_SIZE
 
 config NRF_TRUSTZONE_RAM_REGION_SIZE
 	hex
-	default $(dt_node_int_prop_hex,$(DT_MPC_REGION_SIZE),protection-region-size)
+	default $(dt_node_int_prop_hex,$(DT_MPC_REGION_SIZE),override-granularity)
 	help
 	  This defines the RAM region size from the TRUSTZONE perspective.
 	  It is used when configuring the TRUSTZONE and when setting alignments


### PR DESCRIPTION
Update the MPC binding to cover both nRF54H20 and nRF7120 use cases. Note that the MPC IP revisions used by the two devices are compatible.

Property `protection-region-size` is renamed to `override-granularity`, a more appropriate term which comes from the datasheet. The description is also corrected, as MPC stands for Memory Privilege Controller.