### PR TITLE
applications: sdp: mspi: fix for ipc bound problem

### DIFF
--- a/applications/sdp/mspi/src/main.c
+++ b/applications/sdp/mspi/src/main.c
@@ -456,7 +456,7 @@ static int backend_init(void)
 
 #if !defined(CONFIG_SYS_CLOCK_EXISTS)
 	/* Wait a little bit for IPC service to be ready on APP side. */
-	while (delay < 1000) {
+	while (delay < 5000) {
 		delay++;
 	}
 #endif


### PR DESCRIPTION
Increase delay to wait a little bit more for IPC service to be ready on APP side.