### PR TITLE
Revert "scripts: quarantine: nRF52832 is added for mesh light ctrl sample

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -327,6 +327,13 @@ Bluetooth samples
 
   * Added reconnection to bonded devices based on their address.
 
+Bluetooth Mesh samples
+----------------------
+
+* :ref:`bluetooth_mesh_light_lc` sample:
+
+  * Disabled the Friend feature when the sample is compiled for the :ref:`zephyr:nrf52dk_nrf52832` board target to increase the amount of RAM available for the application.
+
 Bluetooth Fast Pair samples
 ---------------------------
 

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -167,7 +167,15 @@ Configuration
 
 |config|
 
-|nrf5340_mesh_sample_note|
+.. tabs::
+
+   .. group-tab:: nRF52 DK (nRF52832)
+
+      Due to limited RAM on the nRF52832 device, the Friend feature is disabled for this DK.
+
+   .. group-tab:: nRF53 DKs
+
+      |nrf5340_mesh_sample_note|
 
 The Kconfig option :kconfig:option:`CONFIG_BT_MESH_LIGHT_CTRL_REG_SPEC` is set by default as it is necessary for the :ref:`bt_mesh_light_ctrl_srv_readme` model according to the `Bluetooth Mesh model specification`_.
 The option enables a separate module called illuminance regulator.

--- a/samples/bluetooth/mesh/light_ctrl/boards/nrf52dk_nrf52832.conf
+++ b/samples/bluetooth/mesh/light_ctrl/boards/nrf52dk_nrf52832.conf
@@ -7,3 +7,4 @@
 # Application overlay - nrf52dk_nrf52832
 
 CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n
+CONFIG_BT_MESH_FRIEND=n

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -42,13 +42,6 @@
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-31493"
 
 - scenarios:
-    - sample.bluetooth.mesh.light_ctrl
-    - sample.bluetooth.mesh.light_ctrl.emds
-  platforms:
-    - nrf52dk/nrf52832
-  comment: "To be fixed after upmerge. Footprint should be reduced. NCSDK-31428"
-
-- scenarios:
     - applications.connectivity_bridge
   platforms:
     - thingy91x/nrf5340/cpuapp


### PR DESCRIPTION
Revert "scripts: quarantine: nRF52832 is added for mesh light ctrl sample

This reverts commit cf70bbd1ccc62e2982e9ddfa566d1d6ee43fdad8.

As we now know that the sample fits for nRF52832.

Also, to improve ram availability for the application, friendship feature is disabled by default when sample is compiled for nRF52DK.

No EMDS:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      367028 B       480 KB     74.67%
             RAM:       60922 B        64 KB     92.96%
        IDT_LIST:          0 GB        32 KB      0.00%
```

With EMDS:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      369776 B       476 KB     75.86%
             RAM:       61306 B        64 KB     93.55%
        IDT_LIST:          0 GB        32 KB      0.00%
```
