### PR TITLE
suit: Use cache pool 1 for SDFW updates

### DIFF
--- a/subsys/suit/cache/Kconfig
+++ b/subsys/suit/cache/Kconfig
@@ -39,16 +39,31 @@ config SUIT_CACHE_RW
 	depends on SUIT_UTILS
 	depends on !SUIT_PLATFORM_VARIANT_SDFW
 
-config SUIT_CACHE_SDFW_IPUC_ID
-	int "IPUC-based parition number, capable of performing SDFW updates"
+config SUIT_CACHE_SDFW_IPUC
+	bool "Enable IPUC-based partition, capable of performing SDFW updates"
 	depends on SUIT_CACHE_RW
 	depends on FLASH_IPUC
-	default 254
+	depends on !$(dt_nodelabel_enabled,dfu_cache_partition_1)
+	help
+	  Enables IPCU-based SUIT cache partition, capable of performing SDFW
+	  updates.
+	  Since this partition is always registered as DFU cache partition 1,
+	  it cannot be used if the application defines dfu_cache_partition_1
+	  prtition in the DTS.
+
+config SUIT_CACHE_SDFW_IPUC_ID
+	int
+	depends on SUIT_CACHE_SDFW_IPUC
+	default 1
+
+config SUIT_CACHE_APP_IPUC
+	bool "Enable IPUC-based partition, without address restrictions"
+	depends on SUIT_CACHE_RW
+	depends on FLASH_IPUC
 
 config SUIT_CACHE_APP_IPUC_ID
-	int "IPUC-based parition number, without address restrictions"
-	depends on SUIT_CACHE_RW
-	depends on FLASH_IPUC
+	int "IPUC-based partition number, without address restrictions"
+	depends on SUIT_CACHE_APP_IPUC
 	default 255
 
 endif # SUIT_CACHE

--- a/subsys/suit/cache/src/suit_dfu_cache_internal.h
+++ b/subsys/suit/cache/src/suit_dfu_cache_internal.h
@@ -62,7 +62,7 @@ suit_plat_err_t suit_dfu_cache_partition_slot_foreach(struct dfu_cache_pool *cac
  *
  * @param cache_pool  Pointer to the SUIT cache pool structure.
  *
- * @retval SUIT_PLAT_ERR_IO        if unable to read parition contents.
+ * @retval SUIT_PLAT_ERR_IO        if unable to read partition contents.
  * @retval SUIT_PLAT_ERR_NOT_FOUND if partition contains inconsistent data.
  * @retval SUIT_PLAT_SUCCESS       if partition initialized.
  */

--- a/subsys/suit/cache/src/suit_dfu_cache_rw.c
+++ b/subsys/suit/cache/src/suit_dfu_cache_rw.c
@@ -83,11 +83,13 @@ static struct dfu_cache_partition_ext dfu_partitions_ext[] = {
 		.id = 0,
 	},
 	LISTIFY(CONFIG_SUIT_CACHE_MAX_CACHES, PARTITION_DEFINE, (), dfu_cache_partition_)
+/* clang-format off */
 #ifdef CONFIG_SUIT_CACHE_SDFW_IPUC_ID
-		{
-			.id = CONFIG_SUIT_CACHE_SDFW_IPUC_ID,
-		},
+	{
+		.id = CONFIG_SUIT_CACHE_SDFW_IPUC_ID,
+	},
 #endif /* CONFIG_SUIT_CACHE_SDFW_IPUC_ID */
+/* clang-format on */
 #ifdef CONFIG_SUIT_CACHE_APP_IPUC_ID
 	{
 		.id = CONFIG_SUIT_CACHE_APP_IPUC_ID,
@@ -817,7 +819,7 @@ suit_plat_err_t suit_dfu_cache_rw_slot_drop(struct suit_cache_slot *slot)
 
 #ifdef CONFIG_FLASH_IPUC
 /**
- * @brief Check the availability of IPUCs that can be used as SUIT cache parition.
+ * @brief Check the availability of IPUCs that can be used as SUIT cache partition.
  */
 static void dfu_cache_ipuc_init(void)
 {

--- a/tests/subsys/suit/fetch/Kconfig
+++ b/tests/subsys/suit/fetch/Kconfig
@@ -35,8 +35,14 @@ endchoice # TEST_SUIT_PLATFORM_FETCH_VARIANT
 
 if TEST_SUIT_PLATFORM_FETCH_VARIANT_APP
 
+config SUIT_CACHE_SDFW_IPUC
+	default y
+
 config SUIT_CACHE_SDFW_IPUC_ID
-	default 254
+	default 1
+
+config SUIT_CACHE_APP_IPUC
+	default y
 
 config SUIT_CACHE_APP_IPUC_ID
 	default 255

--- a/tests/subsys/suit/fetch/boards/native_sim.overlay
+++ b/tests/subsys/suit/fetch/boards/native_sim.overlay
@@ -18,7 +18,7 @@
 			reg = <0xf5000 DT_SIZE_K(4)>;
 		};
 
-		dfu_cache_partition_1: partition@f6000 {
+		dfu_cache_partition_2: partition@f6000 {
 			reg = <0xf6000 DT_SIZE_K(4)>;
 		};
 

--- a/tests/subsys/suit/fetch/boards/native_sim_64.overlay
+++ b/tests/subsys/suit/fetch/boards/native_sim_64.overlay
@@ -18,7 +18,7 @@
 			reg = <0xf5000 DT_SIZE_K(4)>;
 		};
 
-		dfu_cache_partition_1: partition@f6000 {
+		dfu_cache_partition_2: partition@f6000 {
 			reg = <0xf6000 DT_SIZE_K(4)>;
 		};
 

--- a/tests/subsys/suit/fetch/src/test_app_ipuc.c
+++ b/tests/subsys/suit/fetch/src/test_app_ipuc.c
@@ -412,9 +412,8 @@ ZTEST(fetch_app_cache_tests, test_fetch_to_ipuc_cache_sdfw_scfw_OK)
 			0x4B, /* bytes(11) */
 				0x6A, /* text(10) */
 					'C', 'A', 'C', 'H', 'E', '_', 'P', 'O', 'O', 'L',
-			0x42, /* bytes(2) */
-				0x18, /* uint8_t */
-					CONFIG_SUIT_CACHE_SDFW_IPUC_ID,
+			0x41, /* bytes(1) */
+				CONFIG_SUIT_CACHE_SDFW_IPUC_ID, /* uint8_t == 0x01 */
 	};
 	/* clang-format on */
 	struct zcbor_string valid_dst_component_id = {


### PR DESCRIPTION
Change the default SUIT cache pool ID for SDFW updates to 1, so it matches other update scenarios that uses external memory for SDFW and SCFW FW transfers.

Ref: NCSDK-30810