### PR TITLE
scripts: west ncs-provision: allow using without dev-id

### DIFF
--- a/scripts/west_commands/ncs_provision.py
+++ b/scripts/west_commands/ncs_provision.py
@@ -92,6 +92,8 @@ class NrfutilWrapper:
         ]
         if self.device_id:
             command += ["--serial-number", self.device_id]
+        else:
+            command += ["--traits", "jlink"]
 
         return command
 


### PR DESCRIPTION
When running west ncs-provision upload command locally, it is not required to add the device id if only one device is connected. Pass to nrfutil command: --traits jlink, to run command on connected device.

Before fix, when running:
`west ncs-provision upload -s nrf54l15 -k <path to key>`
received:
```
Keys file saved as /tmp/nrfutil_f2e2i8tc/keyfile.json
nrfutil device x-provision-nrf54l-keys --key-file /tmp/nrfutil_f2e2i8tc/keyfile.json --verify
Error: Missing --traits or --serial-number options. Add at least one of the options or make sure you have exactly one supported device connected
```
Also running twister with --device-serial was blocked (device id not passed), only hardware map were supported
