### PR TITLE
samples: benchmarks: coremark: add FLPR support for nRF54H20 DK

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -583,7 +583,7 @@ Other samples
   * Added:
 
     * Support for the nRF54L05 and nRF54L10 SoCs (emulated on nRF54L15 DK).
-    * FLPR core support for the :ref:`zephyr:nrf54l15dk_nrf54l15` board target.
+    * FLPR core support for the :ref:`zephyr:nrf54l15dk_nrf54l15` and :ref:`zephyr:nrf54h20dk_nrf54h20` board targets.
 
   * Removed the following compiler options that were set in the :kconfig:option:`CONFIG_COMPILER_OPT` Kconfig option:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -585,6 +585,15 @@ Other samples
     * Support for the nRF54L05 and nRF54L10 SoCs (emulated on nRF54L15 DK).
     * FLPR core support for the :ref:`zephyr:nrf54l15dk_nrf54l15` board target.
 
+  * Removed the following compiler options that were set in the :kconfig:option:`CONFIG_COMPILER_OPT` Kconfig option:
+
+    * ``-fno-pie``
+    * ``-fno-pic``
+    * ``-ffunction-sections``
+    * ``-fdata-sections``
+
+    These options are enabled by default in Zephyr and do not need to be set with the dedicated Kconfig option.
+
 Drivers
 =======
 

--- a/samples/benchmarks/coremark/Kconfig.sysbuild
+++ b/samples/benchmarks/coremark/Kconfig.sysbuild
@@ -8,7 +8,7 @@ source "share/sysbuild/Kconfig"
 
 config APP_CPUFLPR_RUN
 	bool "Run the CoreMark benchmark on the FLPR core"
-	depends on SUPPORT_FLPRCORE && !SOC_NRF54H20_CPUAPP
+	depends on SUPPORT_FLPRCORE
 	default y
 
 config APP_CPUNET_RUN

--- a/samples/benchmarks/coremark/README.rst
+++ b/samples/benchmarks/coremark/README.rst
@@ -167,8 +167,8 @@ CONFIG_APP_MODE_FLASH_AND_RUN - Start CoreMark sample automatically after flashi
    Otherwise, it will wait for the button press.
 
 .. note::
-   The :kconfig:option:`CONFIG_APP_MODE_FLASH_AND_RUN` Kconfig option is always enabled for the PPR core on the ``nrf54h20dk/nrf54h20/cpuapp`` board target.
-   This core on the ``nrf54h20dk/nrf54h20/cpuapp`` board target does not use the on-board buttons and LEDs.
+   The :kconfig:option:`CONFIG_APP_MODE_FLASH_AND_RUN` Kconfig option is always enabled for the PPR and FLPR cores on the ``nrf54h20dk/nrf54h20/cpuapp`` board target.
+   These cores on the ``nrf54h20dk/nrf54h20/cpuapp`` board target do not use the on-board buttons and LEDs.
 
 .. _SB_CONFIG_APP_CPUFLPR_RUN:
 
@@ -180,7 +180,6 @@ SB_CONFIG_APP_CPUFLPR_RUN - Enable the benchmark execution also for the FLPR cor
 
    This option is not supported for the following board targets that include an SoC with the FLPR core:
 
-     * ``nrf54h20dk/nrf54h20/cpuapp``
      * ``nrf54l15dk/nrf54l05/cpuapp``
      * ``nrf54l15dk/nrf54l10/cpuapp``
 

--- a/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -30,6 +30,11 @@
 	status = "okay";
 };
 
+/* DTS nodes required to run the cpuflpr target. */
+&cpuflpr_vpr {
+	status = "okay";
+};
+
 /* DTS nodes required to run the cpuppr target. */
 &cpuppr_vpr {
 	status = "okay";
@@ -46,7 +51,8 @@
 
 &tddconf {
 	status = "okay";
-	etrsources = <(NRF_TDDCONF_SOURCE_STMMAINCORE | NRF_TDDCONF_SOURCE_STMPPR)>;
+	etrsources = <(NRF_TDDCONF_SOURCE_STMMAINCORE | NRF_TDDCONF_SOURCE_STMPPR |
+		       NRF_TDDCONF_SOURCE_STMFLPR)>;
 	portconfig = <0>;
 	etrbuffer = <&etr_buffer>;
 };

--- a/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpuflpr.conf
+++ b/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpuflpr.conf
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_COREMARK_ITERATIONS=10000
+
+# Disable the UART console Kconfig to be consistent with the DTS configuration.
+CONFIG_UART_CONSOLE=n
+
+# Kconfigs required for the STM standalone logging, imported from the nordic-log-stm snippet.
+CONFIG_TEST_LOGGING_DEFAULTS=n
+CONFIG_LOG_FRONTEND=y
+CONFIG_LOG_FRONTEND_ONLY=y
+CONFIG_LOG_FRONTEND_STMESP=y
+CONFIG_LOG_FRONTEND_STMESP_FSC=y
+
+# Disable the NCS boot banner - the application core is responsible for printing the boot banner.
+CONFIG_NCS_BOOT_BANNER=n
+CONFIG_BOOT_BANNER=n
+
+# Reduce speed optimizations to fit the sample into the TCM of the FLPR core.
+# Removed the following options from the default configuration (prj.conf):
+# -funroll-loops
+CONFIG_COMPILER_OPT="-O3 -fno-lto"

--- a/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
+++ b/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Disable the default UART node for the FLPR core, as logs are forwarded
+ * with STM and the application core UART. This setting also prevents access
+ * issues to the same UART instance from two or more different cores.
+ */
+&uart120 {
+	status = "disabled";
+};

--- a/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpuppr.conf
+++ b/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpuppr.conf
@@ -5,7 +5,7 @@
 
 CONFIG_COREMARK_ITERATIONS=500
 
-# Disable the UART console Kconfig to make Kconfig configuration with the DTS configuration.
+# Disable the UART console Kconfig to be consistent with the DTS configuration.
 CONFIG_UART_CONSOLE=n
 
 # Kconfigs required for the STM standalone logging, imported from the nordic-log-stm snippet.

--- a/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/samples/benchmarks/coremark/boards/nrf54h20dk_nrf54h20_cpurad.conf
@@ -5,7 +5,7 @@
 
 CONFIG_COREMARK_ITERATIONS=10000
 
-# Disable the UART console Kconfig to make Kconfig configuration with the DTS configuration.
+# Disable the UART console Kconfig to be consistent with the DTS configuration.
 CONFIG_UART_CONSOLE=n
 
 # Kconfigs required for the STM standalone logging, imported from the nordic-log-stm snippet.

--- a/samples/benchmarks/coremark/prj.conf
+++ b/samples/benchmarks/coremark/prj.conf
@@ -7,8 +7,8 @@
 ############################################################################
 CONFIG_COREMARK=y
 
-# Compiler options
-CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
+# Add compiler options that are not included by default in Zephyr.
+CONFIG_COMPILER_OPT="-O3 -fno-lto -funroll-loops"
 
 # Config results output
 # The default logging level is set to the ERROR level.

--- a/samples/benchmarks/coremark/prj_flash_and_run.conf
+++ b/samples/benchmarks/coremark/prj_flash_and_run.conf
@@ -7,8 +7,8 @@
 ############################################################################
 CONFIG_COREMARK=y
 
-# Compiler options
-CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
+# Add compiler options that are not included by default in Zephyr.
+CONFIG_COMPILER_OPT="-O3 -fno-lto -funroll-loops"
 
 # Config results output
 # The default logging level is set to the ERROR level.

--- a/samples/benchmarks/coremark/prj_heap_memory.conf
+++ b/samples/benchmarks/coremark/prj_heap_memory.conf
@@ -7,8 +7,8 @@
 ############################################################################
 CONFIG_COREMARK=y
 
-# Compiler options
-CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
+# Add compiler options that are not included by default in Zephyr.
+CONFIG_COMPILER_OPT="-O3 -fno-lto -funroll-loops"
 
 # Config results output
 # The default logging level is set to the ERROR level.

--- a/samples/benchmarks/coremark/prj_multiple_threads.conf
+++ b/samples/benchmarks/coremark/prj_multiple_threads.conf
@@ -7,8 +7,8 @@
 ############################################################################
 CONFIG_COREMARK=y
 
-# Compiler options
-CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
+# Add compiler options that are not included by default in Zephyr.
+CONFIG_COMPILER_OPT="-O3 -fno-lto -funroll-loops"
 
 # Config results output
 # The default logging level is set to the ERROR level.

--- a/samples/benchmarks/coremark/prj_static_memory.conf
+++ b/samples/benchmarks/coremark/prj_static_memory.conf
@@ -7,8 +7,8 @@
 ############################################################################
 CONFIG_COREMARK=y
 
-# Compiler options
-CONFIG_COMPILER_OPT="-O3 -fno-lto -fno-pie -fno-pic -funroll-loops -ffunction-sections -fdata-sections"
+# Add compiler options that are not included by default in Zephyr.
+CONFIG_COMPILER_OPT="-O3 -fno-lto -funroll-loops"
 
 # Config results output
 # The default logging level is set to the ERROR level.


### PR DESCRIPTION
Added the FLPR core support for the nRF54H20 DK board target in the CoreMark sample.

Ref: NCSDK-30327