### PR TITLE
ci: docbuild: check added or updated links

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -63,6 +63,31 @@ jobs:
         run: |
           west zephyr-export
 
+      - name: Check added or updated links
+        working-directory: ncs/nrf
+        run: |
+          RE=".. _\`(.*)\`: (.*)"
+          LINKS=$(git diff --unified=0 "${{ github.event.pull_request.base.sha }}..HEAD" -- "doc/nrf/links.txt" | \
+                  grep "^+" || true | \
+                  grep -Ev "^(---|\+\+\+)" || true)
+
+          while IFS= read -r link; do
+            if [[ $link =~ $RE ]]; then
+              NAME=${BASH_REMATCH[1]}
+              URL=${BASH_REMATCH[2]}
+
+              echo -n "Checking URL for '$NAME' ($URL)... "
+              status=$(curl --write-out "%{http_code}" --output /dev/null --silent --head "$URL" || true)
+
+              if [[ "$status" -ne 200 ]]; then
+                echo "FAIL (HTTP code: ${status})"
+                  exit 1
+                else
+                  echo "OK"
+                fi
+            fi
+          done <<< "$LINKS"
+
       - name: Build documentation
         working-directory: ncs/nrf
         run: |

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -37,6 +37,14 @@ jobs:
         with:
           git-fetch-depth: 0
 
+      - name: Rebase
+        if: github.event_name == 'pull_request'
+        working-directory: ncs/nrf
+        run: |
+          git config --global user.email "bot@github.com"
+          git config --global user.name "Github Actions"
+          git rebase origin/${{ github.base_ref }}
+
       - name: cache-pip
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Add a new step that checks if added or updated links are reachable, ie, return HTTP 200 (note redirects, permanent moves, etc. will count as failures so updated URLs are put in place).