### PR TITLE
NCSDK-32040: Do not include IPUC cache if it is not used

### DIFF
--- a/subsys/suit/cache/include/suit_dfu_cache_rw.h
+++ b/subsys/suit/cache/include/suit_dfu_cache_rw.h
@@ -111,6 +111,15 @@ suit_plat_err_t suit_dfu_cache_drop_content(void);
  *
  * @return suit_plat_success on success, error code otherwise.
  */
+suit_plat_err_t
+suit_dfu_cache_rw_declared_device_info_get(uint8_t cache_partition_id,
+					   struct suit_nvm_device_info *device_info);
+
+/**
+ * @brief Gets information about characteristics of active cache partition
+ *
+ * @return suit_plat_success on success, error code otherwise.
+ */
 suit_plat_err_t suit_dfu_cache_rw_device_info_get(uint8_t cache_partition_id,
 						  struct suit_nvm_device_info *device_info);
 

--- a/subsys/suit/cache/src/suit_dfu_cache_rw.c
+++ b/subsys/suit/cache/src/suit_dfu_cache_rw.c
@@ -545,8 +545,8 @@ suit_plat_err_t suit_dfu_cache_drop_content(void)
 	return SUIT_PLAT_SUCCESS;
 }
 
-suit_plat_err_t suit_dfu_cache_rw_device_info_get(uint8_t cache_partition_id,
-						  struct suit_nvm_device_info *device_info)
+suit_plat_err_t suit_dfu_cache_rw_declared_device_info_get(uint8_t cache_partition_id,
+							   struct suit_nvm_device_info *device_info)
 {
 
 	if (device_info != NULL) {
@@ -569,6 +569,18 @@ suit_plat_err_t suit_dfu_cache_rw_device_info_get(uint8_t cache_partition_id,
 
 	LOG_ERR("Invalid argument. NULL pointer.");
 	return SUIT_PLAT_ERR_INVAL;
+}
+
+suit_plat_err_t suit_dfu_cache_rw_device_info_get(uint8_t cache_partition_id,
+						  struct suit_nvm_device_info *device_info)
+{
+	suit_plat_err_t ret =
+		suit_dfu_cache_rw_declared_device_info_get(cache_partition_id, device_info);
+	if ((ret == SUIT_PLAT_SUCCESS) && (device_info->fdev == NULL)) {
+		return SUIT_PLAT_ERR_NOT_FOUND;
+	}
+
+	return ret;
 }
 
 suit_plat_err_t suit_dfu_cache_rw_slot_create(uint8_t cache_partition_id,

--- a/subsys/suit/orchestrator_app/src/suit_orchestrator_app.c
+++ b/subsys/suit/orchestrator_app/src/suit_orchestrator_app.c
@@ -241,14 +241,14 @@ int suit_dfu_update_start(void)
 
 	for (size_t i = 0; i < CONFIG_SUIT_CACHE_MAX_CACHES; i++) {
 		if (suit_dfu_cache_rw_device_info_get(i, &device_info) == SUIT_PLAT_SUCCESS) {
-
 			update_candidate[update_regions_count].mem = device_info.mapped_address;
 			update_candidate[update_regions_count].size = device_info.partition_size;
 			update_regions_count++;
 		}
 	}
 
-#ifdef CONFIG_SUIT_CACHE_SDFW_IPUC_ID
+#if defined(CONFIG_SUIT_CACHE_SDFW_IPUC_ID) &&                                                     \
+	(CONFIG_SUIT_CACHE_SDFW_IPUC_ID >= CONFIG_SUIT_CACHE_MAX_CACHES)
 	if (suit_dfu_cache_rw_device_info_get(CONFIG_SUIT_CACHE_SDFW_IPUC_ID, &device_info) ==
 	    SUIT_PLAT_SUCCESS) {
 		update_candidate[update_regions_count].mem = device_info.mapped_address;
@@ -256,7 +256,8 @@ int suit_dfu_update_start(void)
 		update_regions_count++;
 	}
 #endif /* CONFIG_SUIT_CACHE_SDFW_IPUC_ID */
-#ifdef CONFIG_SUIT_CACHE_APP_IPUC_ID
+#if defined(CONFIG_SUIT_CACHE_APP_IPUC_ID) &&                                                      \
+	(CONFIG_SUIT_CACHE_APP_IPUC_ID >= CONFIG_SUIT_CACHE_MAX_CACHES)
 	if (suit_dfu_cache_rw_device_info_get(CONFIG_SUIT_CACHE_APP_IPUC_ID, &device_info) ==
 	    SUIT_PLAT_SUCCESS) {
 		update_candidate[update_regions_count].mem = device_info.mapped_address;

--- a/subsys/suit/stream/stream_sinks/src/suit_dfu_cache_sink.c
+++ b/subsys/suit/stream/stream_sinks/src/suit_dfu_cache_sink.c
@@ -42,7 +42,7 @@ suit_plat_err_t suit_dfu_cache_sink_get(struct stream_sink *sink, uint8_t cache_
 
 		struct suit_nvm_device_info device_info;
 
-		if (suit_dfu_cache_rw_device_info_get(cache_partition_id, &device_info) !=
+		if (suit_dfu_cache_rw_declared_device_info_get(cache_partition_id, &device_info) !=
 		    SUIT_PLAT_SUCCESS) {
 			return SUIT_PLAT_ERR_NOT_FOUND;
 		}


### PR DESCRIPTION
UCI should not include all possible SUIT cache IPUCs, but only those, that were initialized.

Ref: NCSDK-32040