### PR TITLE
tests: drivers: gpio: gpio_more_loops: check pulls only at H20

### DIFF
--- a/tests/drivers/gpio/gpio_more_loops/Kconfig
+++ b/tests/drivers/gpio/gpio_more_loops/Kconfig
@@ -8,4 +8,8 @@ config TEST_DURATION
 	  Test will run for (at least) defined time.
 	  This value affects how many times GPIOs will be toggled.
 
+config CHECK_PULLS
+	bool "When enabled, additional check of GPIO pull-up and pull-down is executed."
+	default y if BOARD_NRF54H20DK_NRF54H20_CPUAPP
+
 source "Kconfig.zephyr"

--- a/tests/drivers/gpio/gpio_more_loops/src/main.c
+++ b/tests/drivers/gpio/gpio_more_loops/src/main.c
@@ -102,8 +102,7 @@ static void *suite_setup(void)
 
 	}
 
-/* ToDo: Remove this #ifdef when nRF54L20 supports pull-up/pull-down. */
-#if !defined(CONFIG_BOARD_NRF54L20PDK)
+#if defined CONFIG_CHECK_PULLS
 	for (i = 0; i < npairs; i++) {
 		rc = gpio_pin_configure_dt(&in_pins[i], GPIO_INPUT | GPIO_PULL_UP);
 		zassert_equal(rc, 0, "IN[%d] config failed", i);


### PR DESCRIPTION
It was designed for H20, other platforms are not needed. It is checked with gpio tests already.