### PR TITLE
suit: Fix incorrect node name in mem layout

### DIFF
--- a/subsys/suit/memory_layout/src/suit_memory_layout.c
+++ b/subsys/suit/memory_layout/src/suit_memory_layout.c
@@ -99,7 +99,7 @@ static struct ram_area ram_area_map[] = {
 #endif						/* ram0x */
 #if (DT_NODE_EXISTS(DT_NODELABEL(cpurad_ram0))) /* nrf54H20 */
 	{
-		.ra_start = DT_REG_ADDR(DT_NODELABEL(cpurad)),
+		.ra_start = DT_REG_ADDR(DT_NODELABEL(cpurad_ram0)),
 		.ra_size = DT_REG_SIZE(DT_NODELABEL(cpurad_ram0)),
 	},
 #endif							/* cpurad_ram0 */


### PR DESCRIPTION
Fix an incorrect node name of the radio core TCM memory inside the memory layout module.

Ref: NCSDK-NONE