### PR TITLE
scripts: Don't force to use little-endian byte order

### DIFF
--- a/scripts/bootloader/validation_data.py
+++ b/scripts/bootloader/validation_data.py
@@ -117,7 +117,7 @@ class BaseValidator(abc.ABC):
     @staticmethod
     def _parse_magic_value(magic_value):
         parsed_magic_value = b''.join(
-            [struct.pack('<I', int(m, 0)) for m in magic_value.split(',')]
+            [struct.pack('I', int(m, 0)) for m in magic_value.split(',')]
         )
         return parsed_magic_value
 


### PR DESCRIPTION
In validation_data.py script we assume that
byte order is little-endian, but it may not
be true in some cases.
Changed the script to be os depended.