### PR TITLE
ci: docbuild: fix Doxygen links patching for Zoomin

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -168,7 +168,7 @@ jobs:
 
             # Patch links from Sphinx to Doxygen APIs
             find doc/_build/html/$docset -type f -name "*.html" -exec \
-              sed -ri "/href=\"(.*)\/doxygen\/html\/(.*)\"/{s//href=\"\1\/..\/..\/..\/$docset-apis-$VERSION\/page\/\2\"/; :a s/__/_/;ta; }" {} \;
+              sed -ri "/href=\"([^\"]+)\/doxygen\/html\/([^\"]+)\"/{s//href=\"\1\/..\/..\/..\/$docset-apis-$VERSION\/page\/\2\"/; :a s/__/_/;ta; }" {} \;
 
             pushd "$OUTDIR"
             ARCHIVE="$docset-apis-$VERSION.zip"


### PR DESCRIPTION
Because .* is greedy, the regular expression was not valid for cases where e.g. we have >1 entry in the same line.