### PR TITLE
samples: modem_shell: bt: use 0.14.0 nrf9160dk pin mapping

### DIFF
--- a/samples/cellular/modem_shell/bt.overlay
+++ b/samples/cellular/modem_shell/bt.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <nrf9160/nrf9160dk_nrf52840_reset_on_if5.dtsi>
+#include <nrf9160/nrf9160dk_nrf52840_reset_on_if9.dtsi>
 
 / {
 	chosen {


### PR DESCRIPTION
Default nrf9160dk revision is 0.14.0 starting from mid 2023, instead of
0.7.0. Update bt.overlay (which is nrf9160dk specific) to use 0.14.0 pin
mapping.

This fixes using nrf9160dk when following "BT shell support" section in README.rst, which says to
build controller firmware with:

```
 west build -p -b nrf9160dk/nrf52840
```

However it was required to use `nrf9160dk@0.7.0/nrf52840` in order to make it compatible with
(Bluetooth) host firmware. After this change it is possible to use default revision of 0.14.0 of
both Bluetooth host (nrf9160) and controller (nrf52840).