### PR TITLE
TESTING: manifest: sdk-zephyr: Bluetooth: Host: Fix deadlock when failing to alloc on BT RX thread

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -66,7 +66,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 7fe2732d7bee0b6825fc30871e95c2a72e641475
+      revision: pull/2563/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
**NOTE: This is for testing a change from upstream with our downstream applications and tests. DNM. Added label.**

Automatically created by action-manifest-pr GH action from PR: https://github.com/nrfconnect/sdk-zephyr/pull/2563