### PR TITLE
samples: sensor: qdec: Use regular GPIOS for nRF54L20

### DIFF
--- a/samples/sensor/qdec/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/samples/sensor/qdec/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -8,10 +8,10 @@
 	encoder-emulate {
 		compatible = "gpio-leds";
 		phase_a: phase_a {
-			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
 		};
 		phase_b: phase_b {
-			gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };
@@ -19,8 +19,8 @@
 &pinctrl {
 	qdec_pinctrl: qdec_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 1, 1)>,
-				<NRF_PSEL(QDEC_B, 1, 3)>;
+			psels = <NRF_PSEL(QDEC_A, 1, 9)>,
+				<NRF_PSEL(QDEC_B, 1, 11)>;
 		};
 	};
 };


### PR DESCRIPTION
Test overlay used NFC pins. Changed them to regular pins.