### PR TITLE
applications: nrf5340_audio: Buildprog transport mandatory

### DIFF
--- a/applications/nrf5340_audio/tools/buildprog/buildprog.py
+++ b/applications/nrf5340_audio/tools/buildprog/buildprog.py
@@ -312,9 +312,8 @@ def __main():
     parser.add_argument(
         "-t",
         "--transport",
-        type=str,
+        required=True,
         choices=[i.name for i in Transport],
-        default=Transport.unicast.name,
         help="Select the transport type",
     )
 


### PR DESCRIPTION
- OCT-3328
- Now forces the -t/--transport option in buildprog as mandatory