### PR TITLE
applications: nrf_desktop: Drop MPSL flash sync timeout workaround

### DIFF
--- a/applications/nrf_desktop/Kconfig.ble
+++ b/applications/nrf_desktop/Kconfig.ble
@@ -15,17 +15,12 @@ config DESKTOP_BT
 	select BT_SETTINGS
 	select BT_SIGNING
 	select BT_SMP
-	imply BT_CONN_TX_NOTIFY_WQ if SOC_FLASH_NRF_RADIO_SYNC_MPSL
 	help
 	  Enable support for Bluetooth connectivity in the nRF Desktop
 	  application. Specific Bluetooth configurations and application
 	  modules are selected according to the HID device role. Apart from
 	  that, the defaults of Bluetooth-related Kconfigs are aligned with
 	  the nRF Desktop use case.
-
-	  nRF Desktop conditionally implies using a separate workqueue for
-	  connection TX notify processing. This is done to work around the MPSL
-	  flash synchronization timeout known issue (NCSDK-29354).
 
 if DESKTOP_BT
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -271,6 +271,11 @@ nRF Desktop
   * The ``dongle_small`` configuration for the nRF52833 DK.
     The configuration enables logs and mimics the dongle configuration used for small SoCs.
 
+* Removed an imply from the nRF Desktop Bluetooth connectivity Kconfig option (:ref:`CONFIG_DESKTOP_BT <config_desktop_app_options>`).
+  The imply enabled a separate workqueue for connection TX notify processing (:kconfig:option:`CONFIG_BT_CONN_TX_NOTIFY_WQ`) if MPSL was used for synchronization between the flash memory driver and radio (:kconfig:option:`CONFIG_SOC_FLASH_NRF_RADIO_SYNC_MPSL`).
+  The MPSL flash synchronization issue (``NCSDK-29354`` in the :ref:`known_issues`) is fixed.
+  The workaround is no longer needed.
+
 nRF Machine Learning (Edge Impulse)
 -----------------------------------
 


### PR DESCRIPTION
The issue is already fixed. The workaround is no longer needed.

Jira: NCSDK-30717