### PR TITLE
samples: bluetooth: fast_pair: Drop MPSL flash sync timeout workaround

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -350,6 +350,10 @@ Bluetooth Fast Pair samples
 
     This change results from the Bluetooth subsystem transition to the PSA cryptographic API.
 
+* Removed using a separate workqueue for connection TX notify processing (:kconfig:option:`CONFIG_BT_CONN_TX_NOTIFY_WQ`) from configurations.
+  The MPSL flash synchronization issue (``NCSDK-29354`` in the :ref:`known_issues`) is fixed.
+  The workaround is no longer needed.
+
 * :ref:`fast_pair_locator_tag` sample:
 
   * Added:

--- a/samples/bluetooth/fast_pair/input_device/prj.conf
+++ b/samples/bluetooth/fast_pair/input_device/prj.conf
@@ -45,10 +45,6 @@ CONFIG_BT_ADV_PROV_GAP_APPEARANCE_SD=y
 #   * nrf54h20dk/nrf54h20/cpuapp
 CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
 
-# Use a separate workqueue for connection TX notify processing. This is done to work
-# around the MPSL flash synchronization timeout known issue (NCSDK-29354).
-CONFIG_BT_CONN_TX_NOTIFY_WQ=y
-
 # Disable automatic initiation of PHY updates.
 # Workaround to prevent disconnection with reason 42 (BT_HCI_ERR_DIFF_TRANS_COLLISION).
 # Some Android phones reply to the LL_PHY_REQ and at the same time initiate a connection

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/prj.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/prj.conf
@@ -37,10 +37,6 @@ CONFIG_BT_ADV_PROV_FAST_PAIR=y
 CONFIG_BT_ADV_PROV_DEVICE_NAME=y
 CONFIG_BT_ADV_PROV_DEVICE_NAME_SD=y
 
-# Use a separate workqueue for connection TX notify processing. This is done to work
-# around the MPSL flash synchronization timeout known issue (NCSDK-29354).
-CONFIG_BT_CONN_TX_NOTIFY_WQ=y
-
 # Disable automatic initiation of PHY updates.
 # Workaround to prevent disconnection with reason 42 (BT_HCI_ERR_DIFF_TRANS_COLLISION).
 # Some Android phones reply to the LL_PHY_REQ and at the same time initiate a connection

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/prj_release.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/prj_release.conf
@@ -49,10 +49,6 @@ CONFIG_BT_ADV_PROV_FAST_PAIR=y
 CONFIG_BT_ADV_PROV_DEVICE_NAME=y
 CONFIG_BT_ADV_PROV_DEVICE_NAME_SD=y
 
-# Use a separate workqueue for connection TX notify processing. This is done to work
-# around the MPSL flash synchronization timeout known issue (NCSDK-29354).
-CONFIG_BT_CONN_TX_NOTIFY_WQ=y
-
 # Disable automatic initiation of PHY updates.
 # Workaround to prevent disconnection with reason 42 (BT_HCI_ERR_DIFF_TRANS_COLLISION).
 # Some Android phones reply to the LL_PHY_REQ and at the same time initiate a connection


### PR DESCRIPTION
The issue is already fixed. The workaround is no longer needed.

Jira: NCSDK-30717