### PR TITLE
net: lib: nrf_cloud: misc improvements

### DIFF
--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -625,14 +625,6 @@ struct nrf_cloud_gnss_data {
 	};
 };
 
-#ifdef CONFIG_NRF_CLOUD_GATEWAY
-/** @brief Structure to hold message received from nRF Cloud. */
-struct nrf_cloud_gw_data {
-	struct nrf_cloud_data data;
-	uint16_t id;
-};
-#endif
-
 /** @brief Data to control behavior of the nrf_cloud library from the
  *  cloud side. This data is stored in the device shadow.
  */

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec_internal.h
@@ -413,18 +413,6 @@ int nrf_cloud_json_to_url_params_convert(char *const buf, const size_t buf_size,
 int nrf_cloud_ground_fix_url_encode(char *buf, size_t size, const char *base,
 				    const struct nrf_cloud_location_config *config);
 
-#ifdef CONFIG_NRF_CLOUD_GATEWAY
-typedef int (*gateway_state_handler_t)(void *root_obj);
-
-/** @brief Register a callback, which is called whenever the shadow changes.
- *  The callback is passed a pointer to the shadow JSON document.  The callback
- *  should return 0 to allow further processing of shadow changes in
- *  nrf_cloud_codec.c.  It should return a negative error code only when the
- *  shadow is malformed.
- */
-void nrf_cloud_register_gateway_state_handler(gateway_state_handler_t handler);
-#endif
-
 /** @brief Encode a log output buffer for transport to the cloud */
 int nrf_cloud_log_json_encode(struct nrf_cloud_log_context *ctx, uint8_t *buf, size_t size,
 			 struct nrf_cloud_data *output);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -355,6 +355,13 @@ int nrf_cloud_send(const struct nrf_cloud_tx_data *msg)
 		if (current_state < STATE_CC_CONNECTED) {
 			return -EACCES;
 		}
+#if defined(CONFIG_NRF_CLOUD_MQTT_SHADOW_TRANSFORMS)
+	} else if (msg->topic_type == NRF_CLOUD_TOPIC_STATE_TF) {
+		/* State (shadow) updates need to have the control channel connected */
+		if (current_state < STATE_CC_CONNECTED) {
+			return -EACCES;
+		}
+#endif
 	} else {
 		/* All other topics require device channel connected */
 		if (current_state != STATE_DC_CONNECTED) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec_internal.c
@@ -55,9 +55,6 @@ static bool modem_inf_initd;
 static int init_modem_info(void);
 #endif
 
-#if defined(CONFIG_NRF_CLOUD_MQTT) && defined(CONFIG_NRF_CLOUD_GATEWAY)
-static gateway_state_handler_t gateway_state_handler;
-#endif
 static int shadow_connection_info_update(cJSON * device_obj);
 
 static const char *const sensor_type_str[] = {
@@ -458,13 +455,6 @@ int nrf_cloud_sensor_data_encode(const struct nrf_cloud_sensor_data *sensor,
 	return 0;
 }
 
-#ifdef CONFIG_NRF_CLOUD_GATEWAY
-void nrf_cloud_register_gateway_state_handler(gateway_state_handler_t handler)
-{
-	gateway_state_handler = handler;
-}
-#endif
-
 int nrf_cloud_state_encode(uint32_t reported_state, const bool update_desired_topic,
 			   const bool add_info_sections, struct nrf_cloud_data *output)
 {
@@ -749,19 +739,6 @@ int nrf_cloud_shadow_data_state_decode(const struct nrf_cloud_obj_shadow_data *c
 	cJSON *pairing_obj = NULL;
 	cJSON *pairing_state_obj = NULL;
 	cJSON *topic_prefix_obj = NULL;
-
-#ifdef CONFIG_NRF_CLOUD_GATEWAY
-	if (gateway_state_handler) {
-		ret = gateway_state_handler(input->json);
-		if (ret != 0) {
-			LOG_ERR("Error from gateway_state_handler: %d", ret);
-			return ret;
-		}
-	} else {
-		LOG_ERR("No gateway state handler registered");
-		return -EINVAL;
-	}
-#endif /* CONFIG_NRF_CLOUD_GATEWAY */
 
 	if (input->type == NRF_CLOUD_OBJ_SHADOW_TYPE_ACCEPTED) {
 		desired_obj = input->accepted->desired.json;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
@@ -121,7 +121,7 @@ static void update_last_job(char const *const job_id)
 
 static bool is_last_job(char const *const job_id)
 {
-	bool match;
+	bool match = false;
 
 	K_SPINLOCK(&last_job_slock) {
 		match = (strncmp(last_job, job_id, sizeof(last_job)) == 0);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -1118,6 +1118,18 @@ int nct_dc_connect(void)
 		.message_id = NCT_MSG_ID_DC_SUB
 	};
 
+#if defined(CONFIG_NRF_CLOUD_GATEWAY)
+	/** The topic for cloud to device we receive in the shadow for
+	 * BLE gateway devices is incorrect. The <device_id>/+/r suffix is invalid and
+	 * must be corrected here to be <device_id>/c2g. Using it without this
+	 * change results in immediate disconnection from nRF Cloud.
+	 */
+	char *p = (char *)subscribe_topic.topic.utf8;
+	int l = subscribe_topic.topic.size;
+
+	memcpy(&p[l - 3], NRF_CLOUD_JSON_KEY_CLOUD_TO_DEVICE, 3);
+#endif
+
 	LOG_DBG("Subscribing to:");
 	for (int i = 0; i < subscription_list.list_count; i++) {
 		LOG_DBG("%.*s", subscription_list.list[i].topic.size,


### PR DESCRIPTION
Add missing support for NRF_CLOUD_TOPIC_STATE_TF. This should have been done for the MQTT JSONata Transform feature added a while back (unrelated to the gateway).

Fix uninitialized variable issue in in_last_job() in nrf_cloud_fota.c.

Remove most of the conditionals for the gateway, but add one to fix up topic suffix.