### PR TITLE
samples: bluetooth: fast_pair: locator_tag: remove LTO experimental note

### DIFF
--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -533,9 +533,6 @@ The release build reduces the code size and RAM usage of the sample by disabling
 Additionally, it enables the Link Time Optimization (LTO) configuration through the :kconfig:option:`CONFIG_LTO` Kconfig option, which further reduces the code size.
 LTO is an advanced compilation technique that optimizes across all compiled units of an application at the link stage, rather than optimizing each unit separately.
 
-.. note::
-   Support for the LTO is experimental.
-
 See :ref:`cmake_options` for detailed instructions on how to add the ``FILE_SUFFIX=release`` option to your build.
 For example, when building from the command line, you can add it as follows:
 


### PR DESCRIPTION
Removed the documentation note regarding the experimental status of the LTO functionality in the Fast Pair Locator Tag sample.