### PR TITLE
ci: compliance: move link checks from docbuild to compliance

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -106,3 +106,28 @@ jobs:
         if [ "${exit}" == "1" ]; then
           exit 1;
         fi
+
+    - name: Check added or updated links
+      working-directory: ncs/nrf
+      run: |
+        RE=".. _\`(.*)\`: (.*)"
+        LINKS=$(git diff --unified=0 "${{ github.event.pull_request.base.sha }}..HEAD" -- "doc/nrf/links.txt" | \
+                grep "^+" || true | \
+                grep -Ev "^(---|\+\+\+)" || true)
+
+        while IFS= read -r link; do
+          if [[ $link =~ $RE ]]; then
+            NAME=${BASH_REMATCH[1]}
+            URL=${BASH_REMATCH[2]}
+
+            echo -n "Checking URL for '$NAME' ($URL)... "
+            status=$(curl --write-out "%{http_code}" --output /dev/null --silent --head "$URL" || true)
+
+            if [[ "$status" -ne 200 ]]; then
+              echo "FAIL (HTTP code: ${status})"
+                exit 1
+              else
+                echo "OK"
+              fi
+          fi
+        done <<< "$LINKS"

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -71,31 +71,6 @@ jobs:
         run: |
           west zephyr-export
 
-      - name: Check added or updated links
-        working-directory: ncs/nrf
-        run: |
-          RE=".. _\`(.*)\`: (.*)"
-          LINKS=$(git diff --unified=0 "${{ github.event.pull_request.base.sha }}..HEAD" -- "doc/nrf/links.txt" | \
-                  grep "^+" || true | \
-                  grep -Ev "^(---|\+\+\+)" || true)
-
-          while IFS= read -r link; do
-            if [[ $link =~ $RE ]]; then
-              NAME=${BASH_REMATCH[1]}
-              URL=${BASH_REMATCH[2]}
-
-              echo -n "Checking URL for '$NAME' ($URL)... "
-              status=$(curl --write-out "%{http_code}" --output /dev/null --silent --head "$URL" || true)
-
-              if [[ "$status" -ne 200 ]]; then
-                echo "FAIL (HTTP code: ${status})"
-                  exit 1
-                else
-                  echo "OK"
-                fi
-            fi
-          done <<< "$LINKS"
-
       - name: Build documentation
         working-directory: ncs/nrf
         run: |


### PR DESCRIPTION
Move documentation added/updated links check to the compliance workflow. This allows documentation to still build successfully and so get a preview.