### PR TITLE
suit: Fix IPUC cache issues

### DIFF
--- a/drivers/flash/flash_ipuc/flash_ipuc.c
+++ b/drivers/flash/flash_ipuc/flash_ipuc.c
@@ -121,19 +121,19 @@ static int nrf_ipuc_write(const struct device *dev, off_t offset, const void *da
 		return 0;
 	}
 
-	/* Optimize: Use a single write call if all bytes can be transferred using stack-based
-	 * aligned buffer.
-	 */
-	if (len <= ARRAY_SIZE(unaligned_data_buf)) {
-		unaligned_len = len;
-	}
-
 	/* If the data buffer is not aligned to the cache lines:
 	 *  - copy the unaligned part into stack-based aligned buffer
 	 *  - write the internal buffer
 	 *  - skip the unaligned bytes of the input buffer
 	 */
 	if (unaligned_len != CACHE_ALIGNMENT) {
+		/* Optimize: Use a single write call if all bytes can be transferred using
+		 * stack-based aligned buffer.
+		 */
+		if (len <= ARRAY_SIZE(unaligned_data_buf)) {
+			unaligned_len = len;
+		}
+
 		memcpy(unaligned_data_buf, data, unaligned_len);
 
 		LOG_DBG("align: %p:%zu", (void *)data, unaligned_len);

--- a/subsys/suit/stream/stream_sinks/src/suit_dfu_cache_sink.c
+++ b/subsys/suit/stream/stream_sinks/src/suit_dfu_cache_sink.c
@@ -44,7 +44,7 @@ suit_plat_err_t suit_dfu_cache_sink_get(struct stream_sink *sink, uint8_t cache_
 
 		if (suit_dfu_cache_rw_device_info_get(cache_partition_id, &device_info) !=
 		    SUIT_PLAT_SUCCESS) {
-			return SUIT_PLAT_ERR_NOT_FOUND;
+			return SUIT_PLAT_ERR_UNSUPPORTED;
 		}
 
 		suit_plat_err_t ret = SUIT_PLAT_SUCCESS;


### PR DESCRIPTION
In a specific case (len == CACHE_ALIGNMENT) and
unaligned address an aligned write was (incorrectly) performed, resulting in an error.