### PR TITLE
nrf_security: drivers: cracen: Add workaround for ikg issues on 54l

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -92,9 +92,11 @@ int read_status(sx_pk_req *req)
 int sx_pk_wait(sx_pk_req *req)
 {
 	do {
+#ifdef CONFIG_CRACEN_HW_VERSION_BASE
 		if (!sx_pk_is_ik_cmd(req)) {
 			cracen_wait_for_pke_interrupt();
 		}
+#endif
 	} while (is_busy(req));
 
 	return read_status(req);
@@ -195,9 +197,10 @@ struct sx_pk_acq_req sx_pk_acquire_req(const struct sx_pk_cmd_def *cmd)
 	req.req->cmd = cmd;
 	req.req->cnx = &silex_pk_engine;
 
+#ifdef CONFIG_CRACEN_HW_VERSION_BASE
 	cracen_acquire();
 	nrf_cracen_int_enable(NRF_CRACEN, NRF_CRACEN_INT_PKE_IKG_MASK);
-
+#endif
 	/* Wait until initialized. */
 	while (ba414ep_is_busy(req.req) || ik_is_busy(req.req)) {
 		cracen_wait_for_pke_interrupt();

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ik/ikhardware.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ik/ikhardware.c
@@ -18,6 +18,9 @@
 #include "regs_addr.h"
 #include <silexpk/ec_curves.h>
 #include <silexpk/ik.h>
+#ifdef CONFIG_CRACEN_HW_VERSION_LITE
+#include "hal/nrf_cracen.h"
+#endif
 
 int cracen_prepare_ik_key(const uint8_t *user_data);
 
@@ -48,6 +51,16 @@ void sx_pk_run(sx_pk_req *req)
 	if (sx_pk_is_ik_cmd(req)) {
 		sx_pk_wrreg(&req->regs, IK_REG_PK_CONTROL,
 			    IK_PK_CONTROL_START_OP | IK_PK_CONTROL_CLEAR_IRQ);
+#ifdef CONFIG_CRACEN_HW_VERSION_LITE
+		/* Workaround to handle IKG freezing on CRACEN lite.
+		* THE PKE-IKG interrupt can not be cleared from software, but can
+		* be cleared by hardware when in pk mode.
+		* so the interrupt is disabled after leaving pk mode and enabled when entering.
+		*/
+		if (req->cmd != SX_PK_CMD_IK_EXIT) {
+			nrf_cracen_int_enable(NRF_CRACEN, CRACEN_INTENCLR_PKEIKG_Msk);
+		}
+#endif
 	} else {
 		sx_pk_wrreg(&req->regs, PK_REG_CONTROL,
 			    PK_RB_CONTROL_START_OP | PK_RB_CONTROL_CLEAR_IRQ);
@@ -75,11 +88,18 @@ int sx_pk_list_ik_inslots(sx_pk_req *req, unsigned int key, struct sx_pk_slot *i
 	const struct sx_pk_capabilities *caps;
 
 	if (req->cmd->cmdcode == PK_OP_IK_EXIT) {
+#ifdef CONFIG_CRACEN_HW_LITE
+		/* Workaround to handle IKG freezing on CRACEN lite.
+		 * THE PKE-IKG interrupt can not be cleared from software, but can
+		 * be cleared by hardware when in pk mode.
+		 * so the interrupt is disabled after leaving pk mode and enabled when entering.
+		 */
+		nrf_cracen_int_disable(NRF_CRACEN, CRACEN_INTENCLR_PKEIKG_Msk);
+#endif
 		req->ik_mode = 0;
 	} else {
 		if (!req->ik_mode) {
 			int status = cracen_prepare_ik_key((uint8_t *)&key);
-
 			if (status != SX_OK) {
 				sx_pk_release_req(req);
 				return SX_ERR_INVALID_PARAM;


### PR DESCRIPTION
Add workaround to handle freezing issue on cracen lite devices

Ref DLT-4048