### PR TITLE
boards: shields: coverage_support: fix flash start address

### DIFF
--- a/boards/shields/coverage_support/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/boards/shields/coverage_support/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -9,8 +9,8 @@
 
 /* Extend by 160 KB, taken from rad */
 &cpuapp_rx_partitions {
-	cpuapp_slot0_partition: partition@74000 {
-		reg = <0x74000 DT_SIZE_K(480)>;
+	cpuapp_slot0_partition: partition@6C000 {
+		reg = <0x6C000 DT_SIZE_K(480)>;
 	};
 };
 


### PR DESCRIPTION
Flash was extended but start address was not aligned.

Regression after https://github.com/nrfconnect/sdk-nrf/commit/990d717096c137e008153b058a62820ff65d53aa