### PR TITLE
manifest: Update zephyr with clock control XOSTART workaround

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.7.99-ncs2
+      revision: ca954a6216c986c1a1d978e9e42ff773a2c7155a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr with workaround for XOSTART in clock control.