### PR TITLE
boards: use nrfutil runner by default

### DIFF
--- a/boards/nordic/nrf52810dmouse/board.cmake
+++ b/boards/nordic/nrf52810dmouse/board.cmake
@@ -5,6 +5,8 @@
 #
 
 board_runner_args(nrfjprog "--softreset")
+board_runner_args(nrfutil "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nRF52810_xxAA" "--speed=4000")
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/nordic/nrf52820dongle/board.cmake
+++ b/boards/nordic/nrf52820dongle/board.cmake
@@ -5,7 +5,9 @@
 #
 
 board_runner_args(jlink "--device=nRF52820_xxAA" "--speed=4000")
+board_runner_args(nrfutil "--nrf-family=NRF52")
 board_runner_args(pyocd "--target=nrf52820" "--frequency=4000000")
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/nordic/nrf52833dongle/board.cmake
+++ b/boards/nordic/nrf52833dongle/board.cmake
@@ -5,7 +5,9 @@
 #
 
 board_runner_args(jlink "--device=nRF52833_xxAA" "--speed=4000")
+board_runner_args(nrfutil "--nrf-family=NRF52")
 board_runner_args(pyocd "--target=nrf52833" "--frequency=4000000")
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/nordic/nrf52840gmouse/board.cmake
+++ b/boards/nordic/nrf52840gmouse/board.cmake
@@ -5,6 +5,8 @@
 #
 
 board_runner_args(nrfjprog "--softreset")
+board_runner_args(nrfutil "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/nordic/nrf52dmouse/board.cmake
+++ b/boards/nordic/nrf52dmouse/board.cmake
@@ -5,6 +5,8 @@
 #
 
 board_runner_args(nrfjprog "--softreset")
+board_runner_args(nrfutil "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/nordic/nrf52kbd/board.cmake
+++ b/boards/nordic/nrf52kbd/board.cmake
@@ -5,6 +5,8 @@
 #
 
 board_runner_args(nrfjprog "--softreset")
+board_runner_args(nrfutil "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/nordic/thingy91/board.cmake
+++ b/boards/nordic/thingy91/board.cmake
@@ -3,10 +3,13 @@
 
 if(CONFIG_BOARD_THINGY91_NRF9160 OR CONFIG_BOARD_THINGY91_NRF9160_NS)
   board_runner_args(nrfjprog "--softreset")
-  board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+  board_runner_args(nrfutil "--nrf-family=NRF91")
+  board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
 elseif(CONFIG_BOARD_THINGY91_NRF52840)
+  board_runner_args(nrfutil "--nrf-family=NRF52")
   board_runner_args(jlink "--device=nrf52" "--speed=4000")
 endif()
 
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/nordic/thingy91x/board.cmake
+++ b/boards/nordic/thingy91x/board.cmake
@@ -4,7 +4,7 @@
 if(CONFIG_BOARD_THINGY91X_NRF9151 OR CONFIG_BOARD_THINGY91X_NRF9151_NS)
   board_runner_args(nrfjprog)
   board_runner_args(nrfutil "--nrf-family=NRF91")
-  board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
+  board_runner_args(jlink "--device=nRF9151_xxAA" "--speed=4000")
 elseif(CONFIG_BOARD_THINGY91X_NRF5340_CPUAPP OR CONFIG_BOARD_THINGY91X_NRF5340_CPUAPP_NS)
   board_runner_args(nrfjprog)
   board_runner_args(nrfutil "--nrf-family=NRF53")


### PR DESCRIPTION
We should use nrfutil as the default now.
nrfjprog is being phased out soon.