### PR TITLE
bluetooth: samples: Add nrf54l15dk/nrf54l05 to RAS requestor sample

### DIFF
--- a/samples/bluetooth/channel_sounding_ras_initiator/sample.yaml
+++ b/samples/bluetooth/channel_sounding_ras_initiator/sample.yaml
@@ -7,9 +7,11 @@ tests:
     sysbuild: true
     build_only: true
     integration_platforms:
+      - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
+      - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     tags:


### PR DESCRIPTION
Building this sample for this target does work, but the docs were not updated.