### PR TITLE
drivers: nrf700x: Add Kconfig for ps poll and stbc

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig
+++ b/drivers/wifi/nrf700x/Kconfig
@@ -768,3 +768,16 @@ config NRF_WIFI_PS_INT_PS
 	  whether to stay in PS (for lower amount of buffered data) or exit PS (for higher
 	  amount of buffered data).
 endchoice
+
+config NRF_WIFI_MAX_PS_POLL_FAIL_CNT
+	int "Maximum number of PS-Poll Failures"
+	default 10
+	range 10 4294967295
+	help
+	  Maximum number of PS-Poll failures before entering QoS Null based power save.
+
+config NRF_WIFI_RX_STBC_HT
+	bool "Enable STBC for HT"
+	default y
+	help
+	  Enable STBC (Space-Time Block Coding) for HT mode.

--- a/west.yml
+++ b/west.yml
@@ -61,7 +61,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.5.99-ncs1-3
+      revision: c0864fcca88c9aca53e9c1ec2d737a6cfcfdbdaf
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -142,7 +142,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 8167cf2dc807b0d8341c547918ca17fa7e466c4f
+      revision: 2a80626d96a9f40c35fc024607b4592f3a5349e2
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Add Kconfig in init command for maximum ps poll failures count
and stbc enable in HT.