### PR TITLE
net: nrf_provisioning: Change retry time for a CoAP request

### DIFF
--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
@@ -311,6 +311,7 @@ static int send_coap_request(struct coap_client *client, uint8_t method, const c
 			     struct nrf_provisioning_coap_context *const coap_ctx, bool confirmable)
 {
 	int retries = 0;
+	struct coap_transmission_parameters params = coap_get_transmission_parameters();
 
 	struct coap_client_request client_request = {
 		.method = method,
@@ -334,7 +335,7 @@ static int send_coap_request(struct coap_client *client, uint8_t method, const c
 			break;
 		}
 		LOG_DBG("CoAP client busy");
-		k_sleep(K_MSEC(500));
+		k_sleep(K_MSEC(params.ack_timeout));
 		retries++;
 	}
 	k_sem_take(&coap_response, K_FOREVER);

--- a/tests/subsys/net/lib/nrf_provisioning/src/coap.c
+++ b/tests/subsys/net/lib/nrf_provisioning/src/coap.c
@@ -124,6 +124,16 @@ char *z_impl_net_addr_ntop(sa_family_t family, const void *src, char *dst, size_
 	return "";
 }
 
+struct coap_transmission_parameters coap_transmission_params = {
+	.ack_timeout = 2000,
+	.coap_backoff_percent = 200,
+	.max_retransmission = 2};
+
+struct coap_transmission_parameters coap_get_transmission_parameters(void)
+{
+	return coap_transmission_params;
+}
+
 void setUp(void)
 {
 }


### PR DESCRIPTION
Use the CoAP ACK timeout to wait before retrying a CoAP request, rather than using a fixed delay of 500 milliseconds.