### PR TITLE
subsys: net: fix CoAP downloads for PGPS downloads

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
@@ -239,11 +239,13 @@ static bool validate_pgps_header(const struct nrf_cloud_pgps_header *header)
 	    (header->prediction_period_min != PREDICTION_PERIOD) ||
 	    (header->prediction_count <= 0) ||
 	    (header->prediction_count > NUM_PREDICTIONS)) {
-		if ((((uint8_t)header->schema_version) == 0xff) &&
-		    (((uint8_t)header->array_type) == 0xff)) {
-			LOG_WRN("Flash is erased.");
+		if ((((uint8_t)header->schema_version) == 0x00) &&
+		    (((uint8_t)header->array_type) == 0x00)) {
+			LOG_WRN("No P-GPS data downloaded yet.");
 		} else {
-			LOG_WRN("One or more fields are wrong");
+			LOG_HEXDUMP_WRN(
+				header,	sizeof(struct nrf_cloud_pgps_header),
+				"P-GPS data corrupted; header:");
 		}
 		return false;
 	}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
@@ -562,6 +562,7 @@ static int downloader_callback(const struct downloader_evt *event)
 		 */
 		if ((socket_retries_left) && ((event->error == -ENOTCONN) ||
 					      (event->error == -ECONNREFUSED) ||
+					      (event->error == -EAGAIN) ||
 					      (event->error == -ECONNRESET))) {
 			LOG_WRN("Download socket error. %d retries left...",
 				socket_retries_left);


### PR DESCRIPTION
Fixes issue introduced in #19908:
PGPS downloads were previously wrongly redirected
through the FOTA pipeline,
but should be handed over to downloader directly.