### PR TITLE
applications/samples/tests: Fix sysbuild Kconfig source line

### DIFF
--- a/applications/asset_tracker_v2/Kconfig.sysbuild
+++ b/applications/asset_tracker_v2/Kconfig.sysbuild
@@ -32,4 +32,4 @@ config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
 		&& "${BOARD_REVISION}" != "0.8.5" \
 		&& "${BOARD_REVISION}" != "0.9.0"
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/applications/connectivity_bridge/Kconfig.sysbuild
+++ b/applications/connectivity_bridge/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/applications/machine_learning/Kconfig.sysbuild
+++ b/applications/machine_learning/Kconfig.sysbuild
@@ -33,4 +33,4 @@ config ML_APP_REMOTE_BOARD
 	depends on ML_APP_INCLUDE_REMOTE_IMAGE
 	default "nrf54h20dk/nrf54h20/cpuppr" if BOARD_NRF54H20DK_NRF54H20_CPUAPP
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/applications/matter_bridge/Kconfig.sysbuild
+++ b/applications/matter_bridge/Kconfig.sysbuild
@@ -68,4 +68,4 @@ endif # BOOTLOADER_MCUBOOT
 config MATTER_FACTORY_DATA_GENERATE
 	default y
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/applications/matter_weather_station/Kconfig.sysbuild
+++ b/applications/matter_weather_station/Kconfig.sysbuild
@@ -50,4 +50,4 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
 	default y
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/applications/nrf5340_audio/Kconfig.sysbuild
+++ b/applications/nrf5340_audio/Kconfig.sysbuild
@@ -7,4 +7,4 @@
 config NRF_DEFAULT_IPC_RADIO
 	default y
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/applications/zigbee_weather_station/Kconfig.sysbuild
+++ b/applications/zigbee_weather_station/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/central_and_peripheral_hr/Kconfig.sysbuild
+++ b/samples/bluetooth/central_and_peripheral_hr/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/central_bas/Kconfig.sysbuild
+++ b/samples/bluetooth/central_bas/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/central_hids/Kconfig.sysbuild
+++ b/samples/bluetooth/central_hids/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/central_hr_coded/Kconfig.sysbuild
+++ b/samples/bluetooth/central_hr_coded/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/central_nfc_pairing/Kconfig.sysbuild
+++ b/samples/bluetooth/central_nfc_pairing/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/central_smp_client/Kconfig.sysbuild
+++ b/samples/bluetooth/central_smp_client/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/central_uart/Kconfig.sysbuild
+++ b/samples/bluetooth/central_uart/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/conn_time_sync/Kconfig.sysbuild
+++ b/samples/bluetooth/conn_time_sync/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_BLUETOOTH
 	default y

--- a/samples/bluetooth/direct_test_mode/Kconfig.sysbuild
+++ b/samples/bluetooth/direct_test_mode/Kconfig.sysbuild
@@ -47,4 +47,4 @@ config DTM_NO_DFE
 	help
 	  Disable direction finding feature.
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/bluetooth/direction_finding_central/Kconfig.sysbuild
+++ b/samples/bluetooth/direction_finding_central/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/direction_finding_connectionless_rx/Kconfig.sysbuild
+++ b/samples/bluetooth/direction_finding_connectionless_rx/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/direction_finding_connectionless_tx/Kconfig.sysbuild
+++ b/samples/bluetooth/direction_finding_connectionless_tx/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/direction_finding_peripheral/Kconfig.sysbuild
+++ b/samples/bluetooth/direction_finding_peripheral/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/fast_pair/input_device/Kconfig.sysbuild
+++ b/samples/bluetooth/fast_pair/input_device/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/fast_pair/locator_tag/Kconfig.sysbuild
+++ b/samples/bluetooth/fast_pair/locator_tag/Kconfig.sysbuild
@@ -17,4 +17,4 @@ config APP_DFU
 	  (BOOTLOADER_MCUBOOT Kconfig) and for the SUIT-based targets
 	  (SOC_SERIES_NRF54HX Kconfig).
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/bluetooth/hci_lpuart/Kconfig.sysbuild
+++ b/samples/bluetooth/hci_lpuart/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/iso_combined_bis_and_cis/Kconfig.sysbuild
+++ b/samples/bluetooth/iso_combined_bis_and_cis/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_BLUETOOTH
 	default y

--- a/samples/bluetooth/iso_time_sync/Kconfig.sysbuild
+++ b/samples/bluetooth/iso_time_sync/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_BLUETOOTH
 	default y

--- a/samples/bluetooth/llpm/Kconfig.sysbuild
+++ b/samples/bluetooth/llpm/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/mesh/chat/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/chat/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/mesh/dfu/distributor/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/dfu/distributor/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/mesh/dfu/target/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/dfu/target/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/mesh/light/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/light/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/mesh/light_ctrl/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/light_ctrl/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/mesh/light_dimmer/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/light_dimmer/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/mesh/light_switch/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/light_switch/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/mesh/sensor_client/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/sensor_client/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/mesh/sensor_server/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/sensor_server/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/mesh/silvair_enocean/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/silvair_enocean/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/multiple_adv_sets/Kconfig.sysbuild
+++ b/samples/bluetooth/multiple_adv_sets/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/nrf_auraconfig/Kconfig.sysbuild
+++ b/samples/bluetooth/nrf_auraconfig/Kconfig.sysbuild
@@ -7,4 +7,4 @@
 config NRF_DEFAULT_IPC_RADIO
 	default y
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/bluetooth/nrf_dm/Kconfig.sysbuild
+++ b/samples/bluetooth/nrf_dm/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_ams_client/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_ams_client/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_ancs_client/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_ancs_client/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_bms/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_bms/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_cgms/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_cgms/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_cts_client/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_cts_client/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_gatt_dm/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_gatt_dm/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_hids_keyboard/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_hids_keyboard/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_hids_mouse/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_hids_mouse/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_hr_coded/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_hr_coded/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_lbs/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_lbs/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_mds/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_mds/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_nfc_pairing/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_nfc_pairing/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_power_profiling/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_power_profiling/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_rscs/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_rscs/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_status/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_status/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_uart/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_uart/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_with_multiple_identities/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_with_multiple_identities/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/scanning_while_connecting/Kconfig.sysbuild
+++ b/samples/bluetooth/scanning_while_connecting/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_BLUETOOTH
 	default y

--- a/samples/bluetooth/shell_bt_nus/Kconfig.sysbuild
+++ b/samples/bluetooth/shell_bt_nus/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/subrating/Kconfig.sysbuild
+++ b/samples/bluetooth/subrating/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/throughput/Kconfig.sysbuild
+++ b/samples/bluetooth/throughput/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/caf_sensor_manager/Kconfig.sysbuild
+++ b/samples/caf_sensor_manager/Kconfig.sysbuild
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config INCLUDE_REMOTE_IMAGE
-	bool "Include CAF Sensor Manager romete image"
+	bool "Include CAF Sensor Manager remote image"
 	default y
 
 config REMOTE_BOARD

--- a/samples/cellular/location/Kconfig.sysbuild
+++ b/samples/cellular/location/Kconfig.sysbuild
@@ -11,4 +11,4 @@ choice WIFI_NRF70_OPER_MODES
 	default WIFI_NRF70_SCAN_ONLY if BOARD_THINGY91X_NRF9151_NS
 endchoice
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/cellular/nrf_cloud_multi_service/Kconfig.sysbuild
+++ b/samples/cellular/nrf_cloud_multi_service/Kconfig.sysbuild
@@ -11,4 +11,4 @@ choice WIFI_NRF70_OPER_MODES
 	default WIFI_NRF70_SCAN_ONLY if BOARD_THINGY91X_NRF9151_NS
 endchoice
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/cellular/nrf_cloud_rest_fota/Kconfig.sysbuild
+++ b/samples/cellular/nrf_cloud_rest_fota/Kconfig.sysbuild
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2023 Nordic Semiconductor
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"

--- a/samples/debug/memfault/Kconfig.sysbuild
+++ b/samples/debug/memfault/Kconfig.sysbuild
@@ -7,4 +7,4 @@
 config WIFI_NRF70
 	default y if BOARD_NRF7002DK_NRF5340_CPUAPP
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/event_manager_proxy/Kconfig.sysbuild
+++ b/samples/event_manager_proxy/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/samples/ipc/ipc_service/Kconfig.sysbuild
+++ b/samples/ipc/ipc_service/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/samples/matter/light_bulb/Kconfig.sysbuild
+++ b/samples/matter/light_bulb/Kconfig.sysbuild
@@ -81,4 +81,4 @@ endif # BOOTLOADER_MCUBOOT
 config MATTER_FACTORY_DATA_GENERATE
 	default y if !BOARD_NRF21540DK
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/matter/light_switch/Kconfig.sysbuild
+++ b/samples/matter/light_switch/Kconfig.sysbuild
@@ -81,4 +81,4 @@ endif # BOOTLOADER_MCUBOOT
 config MATTER_FACTORY_DATA_GENERATE
 	default y if !BOARD_NRF21540DK
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/matter/lock/Kconfig.sysbuild
+++ b/samples/matter/lock/Kconfig.sysbuild
@@ -81,4 +81,4 @@ endif # BOOTLOADER_MCUBOOT
 config MATTER_FACTORY_DATA_GENERATE
 	default y if !BOARD_NRF21540DK
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/matter/smoke_co_alarm/Kconfig.sysbuild
+++ b/samples/matter/smoke_co_alarm/Kconfig.sysbuild
@@ -73,4 +73,4 @@ endif # BOOTLOADER_MCUBOOT
 config MATTER_FACTORY_DATA_GENERATE
 	default y
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/matter/template/Kconfig.sysbuild
+++ b/samples/matter/template/Kconfig.sysbuild
@@ -81,4 +81,4 @@ endif # BOOTLOADER_MCUBOOT
 config MATTER_FACTORY_DATA_GENERATE
 	default y if !BOARD_NRF21540DK
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/matter/thermostat/Kconfig.sysbuild
+++ b/samples/matter/thermostat/Kconfig.sysbuild
@@ -81,4 +81,4 @@ endif # BOOTLOADER_MCUBOOT
 config MATTER_FACTORY_DATA_GENERATE
 	default y
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/matter/window_covering/Kconfig.sysbuild
+++ b/samples/matter/window_covering/Kconfig.sysbuild
@@ -81,4 +81,4 @@ endif # BOOTLOADER_MCUBOOT
 config MATTER_FACTORY_DATA_GENERATE
 	default y if !BOARD_NRF21540DK
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/net/aws_iot/Kconfig.sysbuild
+++ b/samples/net/aws_iot/Kconfig.sysbuild
@@ -14,4 +14,4 @@ config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
 config WIFI_NRF70
 	default y if BOARD_NRF7002DK_NRF5340_CPUAPP_NS || BOARD_NRF54L15DK_NRF54L15_CPUAPP
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/net/azure_iot_hub/Kconfig.sysbuild
+++ b/samples/net/azure_iot_hub/Kconfig.sysbuild
@@ -14,4 +14,4 @@ config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
 config WIFI_NRF70
 	default y if BOARD_NRF7002DK_NRF5340_CPUAPP_NS
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/net/coap_client/Kconfig.sysbuild
+++ b/samples/net/coap_client/Kconfig.sysbuild
@@ -7,4 +7,4 @@
 config WIFI_NRF70
 	default y if BOARD_NRF7002DK_NRF5340_CPUAPP_NS || BOARD_NRF54L15DK_NRF54L15_CPUAPP
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/net/download/Kconfig.sysbuild
+++ b/samples/net/download/Kconfig.sysbuild
@@ -7,4 +7,4 @@
 config WIFI_NRF70
 	default y if BOARD_NRF7002DK_NRF5340_CPUAPP_NS || BOARD_NRF54L15DK_NRF54L15_CPUAPP
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/net/http_server/Kconfig.sysbuild
+++ b/samples/net/http_server/Kconfig.sysbuild
@@ -7,4 +7,4 @@
 config WIFI_NRF70
 	default y if BOARD_NRF7002DK_NRF5340_CPUAPP_NS
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/net/https_client/Kconfig.sysbuild
+++ b/samples/net/https_client/Kconfig.sysbuild
@@ -7,4 +7,4 @@
 config WIFI_NRF70
 	default y if BOARD_NRF7002DK_NRF5340_CPUAPP_NS || BOARD_NRF54L15DK_NRF54L15_CPUAPP
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/net/mqtt/Kconfig.sysbuild
+++ b/samples/net/mqtt/Kconfig.sysbuild
@@ -7,4 +7,4 @@
 config WIFI_NRF70
 	default y if BOARD_NRF7002DK_NRF5340_CPUAPP_NS || BOARD_NRF54L15DK_NRF54L15_CPUAPP
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/net/udp/Kconfig.sysbuild
+++ b/samples/net/udp/Kconfig.sysbuild
@@ -7,4 +7,4 @@
 config WIFI_NRF70
 	default y if BOARD_NRF7002DK_NRF5340_CPUAPP_NS || BOARD_NRF54L15DK_NRF54L15_CPUAPP
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/openthread/cli/Kconfig.sysbuild
+++ b/samples/openthread/cli/Kconfig.sysbuild
@@ -11,4 +11,4 @@ config PARTITION_MANAGER
 config NRF_DEFAULT_IPC_RADIO
 	default y
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/openthread/coap_client/Kconfig.sysbuild
+++ b/samples/openthread/coap_client/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/openthread/coap_server/Kconfig.sysbuild
+++ b/samples/openthread/coap_server/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/peripheral/802154_phy_test/Kconfig.sysbuild
+++ b/samples/peripheral/802154_phy_test/Kconfig.sysbuild
@@ -9,4 +9,4 @@ choice APPCORE
 
 endchoice
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/peripheral/802154_sniffer/Kconfig.sysbuild
+++ b/samples/peripheral/802154_sniffer/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/tfm/tfm_psa_template/Kconfig.sysbuild
+++ b/samples/tfm/tfm_psa_template/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 

--- a/samples/wifi/ble_coex/Kconfig.sysbuild
+++ b/samples/wifi/ble_coex/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/wifi/provisioning/ble/Kconfig.sysbuild
+++ b/samples/wifi/provisioning/ble/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/wifi/radio_test/multi_domain/Kconfig.sysbuild
+++ b/samples/wifi/radio_test/multi_domain/Kconfig.sysbuild
@@ -35,4 +35,4 @@ endif # !NETCORE_NONE
 
 endmenu
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/wifi/thread_coex/Kconfig.sysbuild
+++ b/samples/wifi/thread_coex/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/zigbee/light_bulb/Kconfig.sysbuild
+++ b/samples/zigbee/light_bulb/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/zigbee/light_switch/Kconfig.sysbuild
+++ b/samples/zigbee/light_switch/Kconfig.sysbuild
@@ -43,4 +43,4 @@ endif # SOC_SERIES_NRF53X
 
 endif # BOOTLOADER_MCUBOOT
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/samples/zigbee/ncp/Kconfig.sysbuild
+++ b/samples/zigbee/ncp/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/zigbee/network_coordinator/Kconfig.sysbuild
+++ b/samples/zigbee/network_coordinator/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/zigbee/shell/Kconfig.sysbuild
+++ b/samples/zigbee/shell/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/zigbee/template/Kconfig.sysbuild
+++ b/samples/zigbee/template/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/tests/benchmarks/current_consumption/multicore_system_off/Kconfig.sysbuild
+++ b/tests/benchmarks/current_consumption/multicore_system_off/Kconfig.sysbuild
@@ -1,9 +1,10 @@
+#
 # Copyright (c) 2024 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/current_consumption/nfc_idle/Kconfig.sysbuild
+++ b/tests/benchmarks/current_consumption/nfc_idle/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string

--- a/tests/benchmarks/current_consumption/twim_suspend/Kconfig.sysbuild
+++ b/tests/benchmarks/current_consumption/twim_suspend/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string

--- a/tests/benchmarks/current_consumption/uarte_suspend/Kconfig.sysbuild
+++ b/tests/benchmarks/current_consumption/uarte_suspend/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string

--- a/tests/benchmarks/multicore/idle/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/multicore/idle_adc/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_adc/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string

--- a/tests/benchmarks/multicore/idle_clock_control/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_clock_control/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string

--- a/tests/benchmarks/multicore/idle_comp/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_comp/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string

--- a/tests/benchmarks/multicore/idle_exmif/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_exmif/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string

--- a/tests/benchmarks/multicore/idle_gpio/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_gpio/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/multicore/idle_hpu_temp_meas/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_hpu_temp_meas/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/multicore/idle_ipc/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_ipc/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string

--- a/tests/benchmarks/multicore/idle_outside_of_main/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_outside_of_main/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/multicore/idle_pwm_led/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_pwm_led/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string

--- a/tests/benchmarks/multicore/idle_pwm_loopback/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_pwm_loopback/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_GLOBAL_DOMAIN_CLOCK_FREQUENCY_SWITCHING
 	bool "Enable global domain frequency changing from remote"

--- a/tests/benchmarks/multicore/idle_spim_loopback/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_spim_loopback/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_GLOBAL_DOMAIN_CLOCK_FREQUENCY_SWITCHING
 	bool "Enable global domain frequency changing from remote"

--- a/tests/benchmarks/multicore/idle_twim/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_twim/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string

--- a/tests/benchmarks/multicore/idle_uarte/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_uarte/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_GLOBAL_DOMAIN_CLOCK_FREQUENCY_SWITCHING
 	bool "Enable global domain frequency changing from remote"

--- a/tests/benchmarks/multicore/idle_usb/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_usb/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/multicore/idle_wdt/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_wdt/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string

--- a/tests/benchmarks/power_consumption/adc/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/adc/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/adc_async/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/adc_async/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/flash/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/flash/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/gpio/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/gpio/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/i2c/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/i2c/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/lpcomp/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/lpcomp/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/qdec/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/qdec/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/spi/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/spi/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/temperature_sensor/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/temperature_sensor/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/timer_waiting/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/timer_waiting/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/uart_async/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/uart_async/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/uart_interrupt/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/uart_interrupt/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/benchmarks/power_consumption/uart_polling/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/uart_polling/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/bluetooth/bsim/nrf_auraconfig/Kconfig.sysbuild
+++ b/tests/bluetooth/bsim/nrf_auraconfig/Kconfig.sysbuild
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+source "share/sysbuild/Kconfig"
 
 config NET_CORE_BOARD
 	string

--- a/tests/bluetooth/bsim/nrf_auraconfig/tester/Kconfig.sysbuild
+++ b/tests/bluetooth/bsim/nrf_auraconfig/tester/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NET_CORE_BOARD
 	string

--- a/tests/bluetooth/iso/Kconfig.sysbuild
+++ b/tests/bluetooth/iso/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/tests/drivers/sensor/multicore_temp/Kconfig.sysbuild
+++ b/tests/drivers/sensor/multicore_temp/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/modules/mcuboot/external_flash/Kconfig.sysbuild
+++ b/tests/modules/mcuboot/external_flash/Kconfig.sysbuild
@@ -21,4 +21,4 @@ config SECURE_BOOT_NETCORE
 config NETCORE_APP_UPDATE
 	default y if SOC_NRF5340_CPUAPP
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/tests/subsys/bluetooth/mesh/metadata_extraction/Kconfig.sysbuild
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/Kconfig.sysbuild
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
 choice COMP_DATA_LAYOUT
 	prompt "Composition data layout"
 	default COMP_DATA_LAYOUT_SINGLE
@@ -13,4 +19,4 @@ config COMP_DATA_LAYOUT_ARRAY
 
 endchoice
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/tests/subsys/bootloader/bl_validation_ff_key/Kconfig.sysbuild
+++ b/tests/subsys/bootloader/bl_validation_ff_key/Kconfig.sysbuild
@@ -11,4 +11,4 @@ config SECURE_BOOT_DEBUG_NO_VERIFY_HASHES
 config SECURE_BOOT_PUBLIC_KEY_FILES
 	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/subsys/bootloader/bl_validation_ff_key/ff_pub.pem"
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/tests/subsys/bootloader/bl_validation_neg/Kconfig.sysbuild
+++ b/tests/subsys/bootloader/bl_validation_neg/Kconfig.sysbuild
@@ -8,4 +8,4 @@ config SECURE_BOOT_BUILD_S1_VARIANT_IMAGE
 	bool
 	default n
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/tests/subsys/event_manager_proxy/Kconfig.sysbuild
+++ b/tests/subsys/event_manager_proxy/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/subsys/partition_manager/region/Kconfig.sysbuild
+++ b/tests/subsys/partition_manager/region/Kconfig.sysbuild
@@ -7,4 +7,4 @@
 config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
 	default y if BOARD_NRF5340DK_NRF5340_CPUAPP
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"

--- a/tests/subsys/pcd/Kconfig.sysbuild
+++ b/tests/subsys/pcd/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"

--- a/tests/subsys/zigbee/osif/nvram/Kconfig.sysbuild
+++ b/tests/subsys/zigbee/osif/nvram/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/tests/subsys/zigbee/zboss_api/alarm_api/Kconfig.sysbuild
+++ b/tests/subsys/zigbee/zboss_api/alarm_api/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/tests/subsys/zigbee/zboss_api/callback_api/Kconfig.sysbuild
+++ b/tests/subsys/zigbee/zboss_api/callback_api/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+source "share/sysbuild/Kconfig"
 
 config NRF_DEFAULT_IPC_RADIO
 	default y


### PR DESCRIPTION
Fixes ZEPHYR_BASE being in the source part of a Kconfig source line, which is not needed. Also fixes some minor issues like a pointless file being removed and typo