### PR TITLE
net: nrf_provisioning: Improve error handling

### DIFF
--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
@@ -629,13 +629,9 @@ int nrf_provisioning_req(void)
 			__ASSERT(false, "Invalid exchange, abort");
 			LOG_ERR("Invalid exchange");
 		} else if (ret == -ECONNREFUSED) {
-			LOG_ERR("Connection refused, client exits");
+			LOG_ERR("Connection refused");
 			LOG_WRN("Please check the CA certificate stored in sectag "
 				STRINGIFY(CONFIG_NRF_PROVISIONING_ROOT_CA_SEC_TAG)"");
-			k_mutex_lock(&np_mtx, K_FOREVER);
-			initialized = false;
-			k_mutex_unlock(&np_mtx);
-			break;
 		} else if (ret < 0) {
 			LOG_ERR("Provisioning failed, error: %d", ret);
 		} else if (ret > 0) {


### PR DESCRIPTION
The provisioning thread should continue running even if the connection to the server is refused.

Return errno value if socket call fails.

Remove duplicate error prints.