### PR TITLE
doc: Replace error links with text in the AVSystem guide

### DIFF
--- a/doc/nrf/external_comp/avsystem.rst
+++ b/doc/nrf/external_comp/avsystem.rst
@@ -117,7 +117,8 @@ nRF Cloud integration with AVSystem
 
 You can optionally integrate nRF Cloud with AVSystem and make use of nRF Cloud Location services for device positioning.
 The advantage of this integration is that it removes the need to establish a separate DTLS session into nRF Cloud.
-See `nRF Cloud integration with Coiote Device Management`_ for more information on how the integration can be done.
+See the AVSystem Coiote user guide for information on how the integration can be done.
+Login to `Coiote Device Management server`_, click :guilabel:`Integrations`, and then :guilabel:`Other integrations` to access the user guide.
 
 The integration supports the following location services:
 
@@ -165,7 +166,7 @@ This data is used in combination with the data broadcast by the GNSS satellites 
 For cell-based location assistance, each supported sample might use a different overlay file.
 See the sample or application documentation for more information.
 
-After building the sample, complete the steps in `Setting observations for an object`_ to enable observations for the Location object.
+After building the sample, complete the steps in the Setting observations for an object user guide of the `Coiote Device Management server`_ to enable observations for the Location object.
 
 After you flash the sample, Location object under **Data model** in the Coiote Device Management UI will be updated with values after the fix is obtained.
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1539,9 +1539,7 @@
 
 .. _`Coiote Device Management`: https://www.avsystem.com/products/coiote-iot-device-management-platform/
 .. _`Coiote Device Management server`: https://eu.iot.avsystem.cloud/
-.. _`nRF Cloud integration with Coiote Device Management`: https://iotdevzone.avsystem.com/docs/Cloud_integrations/nRF_Cloud_Location_services/Configure_nRF_Cloud_integration/
 .. _`Viewing device location in Coiote Device Management`: https://iotdevzone.avsystem.com/docs/Cloud_integrations/nRF_Cloud_Location_services/Configure_nRF_Cloud_integration/#view-device-location-in-coiote-dm
-.. _`Setting observations for an object`: https://iotdevzone.avsystem.com/docs/Coiote_IoT_DM/Quick_Start/Visualize_device_data/#set-observation-and-add-widget
 .. _`nRF9160 Anjay integration`: https://iotdevzone.avsystem.com/docs/LwM2M_Client/Nordic/nRF9160DK/
 .. _`Thingy:91 integration`: https://iotdevzone.avsystem.com/docs/LwM2M_Client/Nordic/Thingy91/#thingy91
 


### PR DESCRIPTION
Replaced following error links with text in the
AVSystem guide.
* nRF Cloud integration with Coiote Device Management
* Setting observations for an object