### PR TITLE
bluetooth: controller: Reset ECDH command on deinitialization

### DIFF
--- a/subsys/bluetooth/controller/ecdh.c
+++ b/subsys/bluetooth/controller/ecdh.c
@@ -313,6 +313,7 @@ void hci_ecdh_uninit(void)
 {
 #if !defined(CONFIG_BT_CTLR_ECDH_IN_MPSL_WORK)
 	k_thread_abort(&ecdh_thread_data);
+	atomic_set(&cmd, 0);
 #endif /* !defined(CONFIG_BT_CTLR_ECDH_IN_MPSL_WORK) */
 }
 


### PR DESCRIPTION
If the ECDH thread is aborted without processing the currently requested command, any further command after a new initialization will be answered as command disallowed.