### PR TITLE
net: openthread: enable NEWLIB_LIBC_NANO only if NEWLIB_LIBC

### DIFF
--- a/subsys/net/openthread/Kconfig.defconfig
+++ b/subsys/net/openthread/Kconfig.defconfig
@@ -35,7 +35,7 @@ choice LIBC_IMPLEMENTATION
 endchoice
 
 config NEWLIB_LIBC_NANO
-	default y
+	default y if NEWLIB_LIBC
 
 config NUM_METAIRQ_PRIORITIES
 	default 1


### PR DESCRIPTION
Without this change, NEWLIB_LIBC_NANO gets selected even when building OpenThread application with PICOLIBC.