### PR TITLE
samples: caf_sensor_manager: Add power optimized config

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -628,6 +628,10 @@ Other samples
 
     These options are enabled by default in Zephyr and do not need to be set with the dedicated Kconfig option.
 
+* :ref:`caf_sensor_manager_sample` sample:
+
+  * Added low power configuration for the :ref:`zephyr:nrf54h20dk_nrf54h20` board target.
+
 Drivers
 =======
 

--- a/samples/caf_sensor_manager/sample.yaml
+++ b/samples/caf_sensor_manager/sample.yaml
@@ -114,3 +114,35 @@ tests:
     tags:
       - sysbuild
       - ci_samples_caf_sensor_manager
+  sample.caf_sensor_manager.nrf54h20.multicore.power_consumption_test:
+    build_only: true
+    sysbuild: true
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - caf_sensor_manager_SNIPPET=nordic-ppr
+      - SB_CONFIG_NETCORE_EMPTY=y
+      - CONFIG_PM=y
+      - CONFIG_PM_S2RAM=y
+      - CONFIG_PM_S2RAM_CUSTOM_MARKING=y
+    tags:
+      - sysbuild
+      - ci_samples_caf_sensor_manager
+  sample.caf_sensor_manager.nrf54h20.singlecore.power_consumption_test:
+    build_only: true
+    sysbuild: true
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - FILE_SUFFIX=singlecore
+      - SB_CONFIG_NETCORE_EMPTY=y
+      - CONFIG_PM=y
+      - CONFIG_PM_S2RAM=y
+      - CONFIG_PM_S2RAM_CUSTOM_MARKING=y
+    tags:
+      - sysbuild
+      - ci_samples_caf_sensor_manager

--- a/samples/caf_sensor_manager/sysbuild/empty_net_core/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/caf_sensor_manager/sysbuild/empty_net_core/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Disable uart135 for use in ppr core */
+
+&uart135 {
+	status = "disabled";
+};

--- a/samples/caf_sensor_manager/sysbuild/empty_net_core/prj.conf
+++ b/samples/caf_sensor_manager/sysbuild/empty_net_core/prj.conf
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_PM=y
+CONFIG_POWEROFF=y
+CONFIG_CONSOLE=n
+CONFIG_UART_CONSOLE=n
+CONFIG_SERIAL=n
+CONFIG_GPIO=n
+CONFIG_BOOT_BANNER=n


### PR DESCRIPTION
Add power optimized configuration for the sample.
Enable PM and disable unused devices.

Multicore:
Normal build: 1.62mA
Optimized build: 0.068mA

Singlecore:
Normal build: 1.85mA
Optimized build: 0.107mA

Jira: NCSDK-26415