### PR TITLE
mpsl: clock_ctrl: Fix wait for LFCLK if timeout returned earlier

### DIFF
--- a/subsys/mpsl/clock_ctrl/Kconfig
+++ b/subsys/mpsl/clock_ctrl/Kconfig
@@ -36,4 +36,16 @@ config MPSL_EXT_CLK_CTRL_NVM_CLOCK_REQUEST
 	  ensuring it operates at a frequency that prevents code execution being
 	  too slow. This is crucial to meet meet radio protocols requirements.
 
+config MPSL_EXT_CLK_CTRL_LFCLK_REQ_TIMEOUT_ALLOW
+	bool "Enables a workaround for LFCLK request timeout"
+	depends on SOC_SERIES_NRF54HX
+	default y
+	help
+	  This option enables a workaround in MPSL external clock control
+	  integration layer, to ignore the -NRF_ETIMEDOUT response for LFCLK
+	  request. This workaround is safe to use for cases where there is no
+	  other clock requests in the radio core FW or available requests are
+	  for a clock with better accuracy than the one requested by the MPSL.
+	  It is user responsibility to make sure these requirements are fulfilled.
+
 endif # MPSL_USE_EXTERNAL_CLOCK_CONTROL


### PR DESCRIPTION
There is a workaround implemented in the MPSL clock control integration layer for cases where nrf2 clock control desn't get response from sysctrl for the LFCLK request,

The workaround was incorreclty implemented, so that after a -NRF_ETIMEDOUT was returned by clock driver another call to m_lfclk_wait attempte to wait and timedout on a semaphore. The second call with semaphore timeout returned -NRF_EFAULT error code that caused an assert in later initialization stage.

The change makes sure if a clock driver returns -NRF_ETIMEDOUT error for LFCLK then next m_lfclk_wait immediately returns 0 (as if the clock was ready). That is based on an assumption:
- the sysctrl implicitly provided a LFCLK with accuracy that is the same or better than requested by MPSL.
- there are not other LFLCK requests from Radio core FW
- if there is another request put, it is for a LFCLK that accuracy is the same or better than required by radio protocols.

The change also affects lfclk request and response APIs, so that new requests or released for the clock will return immediately until the mpsl_clock_ctrl_uninit()_is executed, that resets the sated of the m_lflclk_req_timedout flag.

There is added a Kconfig option:CONFIG_MPSL_EXT_CLK_CTRL- _LFCLK_REQ_TIMEOUT_ALLOW that can be use to disable the workatround.