### PR TITLE
mcuboot: Fix monotomic counter issues

### DIFF
--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -16,9 +16,14 @@ menuconfig MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
 	bool "Downgrade prevention using hardware security counters"
 	depends on (SOC_NRF5340_CPUAPP || SOC_SERIES_NRF91X)
 	depends on !SECURE_BOOT_APPCORE
+	depends on !QSPI_XIP_SPLIT_IMAGE
 	help
 	  This option can be enabled by the application and will ensure that the
 	  MCUBOOT_HW_DOWNGRADE_PREVENTION Kconfig option is enabled in the MCUboot image.
+
+	  Note that this can only be used on first image, it will not be applied to the second
+	  image (network core updates) on nRF5340 which will use software downgrade protection
+	  on the network core CPU instead.
 
 if MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
 

--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 72bcf3861f526d4091e3c2bf44a52823da8e7a11
+      revision: 3bd17963688423aa7a1e139ce54572fa2c7c700f
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
    manifest: Update sdk-mcuboot
    
    Updates MCUboot to pull in a fix for monotonic counter usage


    sysbuild: mcuboot: Clarify monotonic counter usage
    
    Clarifies that monotonic hardware counter will only be used on
    the first image and disallow usage of this feature with QSPI XIP
    split image updates as it is not compatible
