### PR TITLE
applications: nrf_desktop: Use Picolibc

### DIFF
--- a/applications/nrf_desktop/Kconfig.defaults
+++ b/applications/nrf_desktop/Kconfig.defaults
@@ -16,12 +16,6 @@ config DESKTOP_COMMON_MODULES
 	imply DESKTOP_SETTINGS_LOADER
 	imply DESKTOP_POWER_MANAGER
 
-choice LIBC_IMPLEMENTATION
-	default MINIMAL_LIBC
-	help
-	  Use minimal libc implementation to reduce memory footprint.
-endchoice
-
 config DESKTOP_LTO_DEFAULTS
 	bool
 	default y

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -264,6 +264,8 @@ nRF Desktop
   * The IPC radio image configurations of the nRF5340 DK to use Picolibc (:kconfig:option:`CONFIG_PICOLIBC`).
     This aligns the configurations to the IPC radio image configurations of the nRF54H20 DK.
     Picolibc is used by default in Zephyr.
+  * The nRF Desktop application image configurations to use Picolibc (:kconfig:option:`CONFIG_PICOLIBC`) by default.
+    Using the minimal libc implementation (:kconfig:option:`CONFIG_MINIMAL_LIBC`) no longer decreases the memory footprint of the application image for most of the configurations.
 
 * Added:
 


### PR DESCRIPTION
Using minimal libc no longer reduces application's memory footprint. Currently it actually increases the memory footprint for most of the configurations. The Picolibc is used by default in Zephyr.

Jira: NCSDK-32238