### PR TITLE
sdp: vio pins dependent on overlay

### DIFF
--- a/applications/sdp/mspi/src/main.c
+++ b/applications/sdp/mspi/src/main.c
@@ -22,7 +22,6 @@
 
 #define DEVICES_MAX   5
 #define DATA_PINS_MAX 8
-#define VIO_COUNT     11
 
 /* Bellow this CNT0 period pin steering force has to be increased to produce correct waveform.
  * CNT0 value 1 generates 32MHz clock.
@@ -53,7 +52,7 @@
 
 BUILD_ASSERT(CONFIG_SDP_MSPI_MAX_RESPONSE_SIZE > 0, "Response max size should be greater that 0");
 
-static const uint8_t pin_to_vio_map[VIO_COUNT] = {
+static const uint8_t pin_to_vio_map[NRFE_MSPI_PINS_MAX] = {
 	4,  /* Physical pin 0 */
 	0,  /* Physical pin 1 */
 	1,  /* Physical pin 2 */
@@ -342,7 +341,7 @@ static void config_pins(nrfe_mspi_pinctrl_soc_pin_msg_t *pins_cfg)
 	xfer_params.tx_direction_mask = 0;
 	xfer_params.rx_direction_mask = 0;
 
-	for (uint8_t i = 0; i < NRFE_MSPI_PINS_MAX; i++) {
+	for (uint8_t i = 0; i < pins_cfg->pins_count; i++) {
 		uint32_t psel = NRF_GET_PIN(pins_cfg->pin[i]);
 		uint32_t fun = NRF_GET_FUN(pins_cfg->pin[i]);
 
@@ -352,7 +351,7 @@ static void config_pins(nrfe_mspi_pinctrl_soc_pin_msg_t *pins_cfg)
 
 		uint8_t pin_number = NRF_PIN_NUMBER_TO_PIN(psel);
 
-		NRFX_ASSERT(pin_number < VIO_COUNT);
+		NRFX_ASSERT(pin_number < NRFE_MSPI_PINS_MAX);
 
 		if ((fun >= NRF_FUN_SDP_MSPI_CS0) && (fun <= NRF_FUN_SDP_MSPI_CS4)) {
 

--- a/drivers/mspi/mspi_nrfe.c
+++ b/drivers/mspi/mspi_nrfe.c
@@ -451,6 +451,7 @@ static int api_config(const struct mspi_dt_spec *spec)
 		mspi_pin_config.pin[i] = drv_cfg->pcfg->states[state_id].pins[i];
 	}
 	mspi_pin_config.opcode = NRFE_MSPI_CONFIG_PINS;
+	mspi_pin_config.pins_count = drv_cfg->pcfg->states[state_id].pin_cnt;
 
 	/* Send pinout configuration to FLPR */
 	return send_data(NRFE_MSPI_CONFIG_PINS, (const void *)&mspi_pin_config,

--- a/include/drivers/mspi/nrfe_mspi.h
+++ b/include/drivers/mspi/nrfe_mspi.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif
 
 #ifdef CONFIG_SOC_NRF54L15
-#define NRFE_MSPI_PINS_MAX	 6
+#define NRFE_MSPI_PINS_MAX	 11
 #else
 #error "Unsupported SoC for SDP MSPI"
 #endif
@@ -61,6 +61,7 @@ typedef struct {
 
 typedef struct {
 	nrfe_mspi_opcode_t opcode; /* NRFE_MSPI_CONFIG_PINS */
+	uint8_t pins_count;
 	pinctrl_soc_pin_t pin[NRFE_MSPI_PINS_MAX];
 } nrfe_mspi_pinctrl_soc_pin_msg_t;
 

--- a/include/drivers/mspi/nrfe_mspi.h
+++ b/include/drivers/mspi/nrfe_mspi.h
@@ -16,16 +16,7 @@ extern "C" {
 #endif
 
 #ifdef CONFIG_SOC_NRF54L15
-
-#define NRFE_MSPI_PORT_NUMBER	 2 /* Physical port number */
-#define NRFE_MSPI_SCK_PIN_NUMBER 1 /* Physical pins number on port 2 */
-#define NRFE_MSPI_DQ0_PIN_NUMBER 2
-#define NRFE_MSPI_DQ1_PIN_NUMBER 4
-#define NRFE_MSPI_DQ2_PIN_NUMBER 3
-#define NRFE_MSPI_DQ3_PIN_NUMBER 0
-#define NRFE_MSPI_CS0_PIN_NUMBER 5
 #define NRFE_MSPI_PINS_MAX	 6
-
 #else
 #error "Unsupported SoC for SDP MSPI"
 #endif


### PR DESCRIPTION
~It still needs some testing but can be reviewed already.~

~Needs the revert commit from https://github.com/nrfconnect/sdk-nrf/pull/20807 to be able to switch to QUAD mode (not enough pins declared in DTS).~