### PR TITLE
sdp: switch to Quad mode by default

### DIFF
--- a/snippets/sdp/mspi/board/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/snippets/sdp/mspi/board/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -25,7 +25,7 @@
 		t-exit-dpd = <35000>;
 		reset-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
 
-		mspi-max-frequency = <DT_FREQ_M(1)>;
+		mspi-max-frequency = <DT_FREQ_M(13)>;
 		mspi-io-mode = "MSPI_IO_MODE_QUAD_1_4_4";
 		mspi-data-rate = "MSPI_DATA_RATE_SINGLE";
 		mspi-hardware-ce-num = <0>;

--- a/snippets/sdp/mspi/board/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/snippets/sdp/mspi/board/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -26,7 +26,7 @@
 		reset-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
 
 		mspi-max-frequency = <DT_FREQ_M(1)>;
-		mspi-io-mode = "MSPI_IO_MODE_SINGLE";
+		mspi-io-mode = "MSPI_IO_MODE_QUAD_1_4_4";
 		mspi-data-rate = "MSPI_DATA_RATE_SINGLE";
 		mspi-hardware-ce-num = <0>;
 		mspi-cpp-mode = "MSPI_CPP_MODE_0";

--- a/snippets/sdp/mspi/sdp-mspi-app.overlay
+++ b/snippets/sdp/mspi/sdp-mspi-app.overlay
@@ -9,6 +9,7 @@
 
 	sdp_mspi: sdp_mspi {
 		compatible = "nordic,nrfe-mspi-controller";
+		software-multiperipheral;
 		#address-cells = <1>;
 		#size-cells = <0>;
 	};

--- a/snippets/sdp/mspi/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/sdp/mspi/soc/nrf54l15_cpuapp.overlay
@@ -80,6 +80,8 @@
 			psels = <NRF_PSEL(SDP_MSPI_SCK, 2, 1)>,
 				<NRF_PSEL(SDP_MSPI_DQ0, 2, 2)>,
 				<NRF_PSEL(SDP_MSPI_DQ1, 2, 4)>,
+				<NRF_PSEL(SDP_MSPI_DQ2, 2, 3)>,
+				<NRF_PSEL(SDP_MSPI_DQ3, 2, 0)>,
 				<NRF_PSEL(SDP_MSPI_CS0, 2, 5)>;
 			nordic,drive-mode = <NRF_DRIVE_S0S1>;
 		};
@@ -89,6 +91,8 @@
 			psels = <NRF_PSEL(SDP_MSPI_SCK, 2, 1)>,
 				<NRF_PSEL(SDP_MSPI_DQ0, 2, 2)>,
 				<NRF_PSEL(SDP_MSPI_DQ1, 2, 4)>,
+				<NRF_PSEL(SDP_MSPI_DQ2, 2, 3)>,
+				<NRF_PSEL(SDP_MSPI_DQ3, 2, 0)>,
 				<NRF_PSEL(SDP_MSPI_CS0, 2, 5)>;
 			low-power-enable;
 		};

--- a/tests/zephyr/drivers/flash/common/single.overlay
+++ b/tests/zephyr/drivers/flash/common/single.overlay
@@ -1,0 +1,3 @@
+&mx25r64 {
+	mspi-io-mode = "MSPI_IO_MODE_SINGLE";
+};

--- a/tests/zephyr/drivers/flash/common/testcase.yaml
+++ b/tests/zephyr/drivers/flash/common/testcase.yaml
@@ -4,8 +4,14 @@ common:
     - flash
     - ci_tests_drivers_sdp
 tests:
-  nrf.extended.drivers.flash.common.sdp:
+  nrf.extended.drivers.flash.common.sdp.quad:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
+  nrf.extended.drivers.flash.common.sdp.single:
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    extra_args: EXTRA_DTC_OVERLAY_FILE="single.overlay"


### PR DESCRIPTION
Also, add testcase that keeps checking single mode in flash driver test.

Depends on https://github.com/nrfconnect/sdk-nrf/pull/20731 and https://github.com/nrfconnect/sdk-nrf/pull/21043