### PR TITLE
doc: TF-M: add TF-M docset wrapper

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -278,6 +278,7 @@
 /doc/nrf/templates/                       @nrfconnect/ncs-doc-leads
 /doc/nrf/test_and_optimize/               @nrfconnect/ncs-doc-leads
 /doc/nrf/test_and_optimize/optimizing/power_nrf91.rst @nrfconnect/ncs-cia-doc
+/doc/tfm/                                 @nrfconnect/ncs-aegir-doc
 /doc/wifi/                                @sachinthegreen @krish2718
 
 /doc/**/*.svg                             @nrfconnect/ncs-doc-leads

--- a/doc/tfm/conf.py
+++ b/doc/tfm/conf.py
@@ -41,9 +41,13 @@ extensions = [
     "zephyr.external_content",
 ]
 source_suffix = [".rst", ".md"]
+master_doc = "wrapper"
+
+linkcheck_ignore = [r"(\.\.(\\|/))+(kconfig|zephyr)"]
 
 exclude_patterns = [
   "platform/cypress/psoc64/security/keys/readme.rst"
+  "index.rst"
 ]
 
 numfig = True
@@ -87,6 +91,7 @@ warnings_filter_config = str(NRF_BASE / "doc" / "tfm" / "known-warnings.txt")
 # Options for external_content -------------------------------------------------
 
 external_content_contents = [
+    (NRF_BASE / "doc" / "tfm", "wrapper.rst"),
     (TFM_BASE / "docs", "**/*"),
 ]
 

--- a/doc/tfm/wrapper.rst
+++ b/doc/tfm/wrapper.rst
@@ -1,0 +1,30 @@
+.. _tfm_wrapper:
+
+Trusted Firmware-M documentation
+################################
+
+This section includes the official `Trusted Firmware-M (TF-M) <https://www.trustedfirmware.org/projects/tf-m/>`_ documentation.
+It is provided for reference only and is intended for the developers working on the integration of TF-M in the nRF Connect SDK.
+
+The section renders the content of the `official TF-M documentation <https://trustedfirmware-m.readthedocs.io/en/latest/index.html>`_ as-is using the sources from the downstream `TF-M repository <https://github.com/nrfconnect/sdk-trusted-firmware-m>`_.
+
+For information on how TF-M is integrated in the nRF Connect SDK, see the `Security section in the nRF Connect SDK documentation <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/security.html>`_.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents
+
+   introduction/index.rst
+   getting_started/index.rst
+   security/index.rst
+   releases/index.rst
+   roadmap.rst
+   glossary.rst
+   platform/index.rst
+   building/tfm_build_instruction.rst
+   configuration/index.rst
+   integration_guide/index.rst
+   design_docs/index.rst
+   contributing/index.rst
+   contributing/lic.rst
+   contributing/dco.rst


### PR DESCRIPTION
Added wrapper.rst and links.txt for the TF-M docset. NCSDK-32253.

----

Wrapper preview at https://ncsdoc.z6.web.core.windows.net/PR-20809/tfm/wrapper.html -- the current index won't be replaced until this PR is merged due to server cache.

----

Next PR will add more information to the wrapper and the links.txt file.