### PR TITLE
PSA core lite PR #1

### DIFF
--- a/subsys/nrf_security/src/core/CMakeLists.txt
+++ b/subsys/nrf_security/src/core/CMakeLists.txt
@@ -4,4 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-add_subdirectory(nrf_oberon)
+if(CONFIG_PSA_CORE_LITE)
+  add_subdirectory(lite)
+else()
+  add_subdirectory(nrf_oberon)
+endif()

--- a/subsys/nrf_security/src/core/Kconfig
+++ b/subsys/nrf_security/src/core/Kconfig
@@ -19,4 +19,14 @@ config PSA_CORE_OBERON
 	select PSA_WANT_AES_KEY_SIZE_192
 	select PSA_WANT_AES_KEY_SIZE_256
 
+config PSA_CORE_LITE
+	bool "PSA core created for tiny footprint"
+	depends on SOC_SERIES_NRF54LX
+	help
+	  The PSA core with tiny footprint is created to be used e.g. for bootloader
+	  or similar use-cases where there is severe size-restrictions. This PSA core
+	  will only provide limited algorithm support and only a limited amount of features
+	  from the PSA crypto key management APIs. Note that volatile key-store is not
+	  possible to use.
+
 endchoice

--- a/subsys/nrf_security/src/core/lite/CMakeLists.txt
+++ b/subsys/nrf_security/src/core/lite/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Note: Reusing the name oberon_psa_core as we don't have a normalized
+#       name for "any" PSA core in the current design
+
+add_library(oberon_psa_core STATIC
+    psa_core_lite.c
+    ${NRF_SECURITY_ROOT}/src/psa_crypto_driver_wrappers.c
+)
+
+target_link_libraries(oberon_psa_core
+  PRIVATE
+    psa_crypto_library_config
+)
+
+nrf_security_add_zephyr_options_library(oberon_psa_core)
+
+target_link_libraries(${mbedcrypto_target}
+  PRIVATE
+    oberon_psa_core
+)

--- a/subsys/nrf_security/src/core/lite/psa_core_lite.c
+++ b/subsys/nrf_security/src/core/lite/psa_core_lite.c
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "psa_core_lite.h"
+#include <psa/crypto.h>
+#include <psa_crypto_driver_wrappers.h>
+
+#if (defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)) && \
+	defined(PSA_WANT_ECC_SECP_R1_256)
+	const size_t pub_key_max_size = 65;
+#elif (defined(PSA_WANT_ALG_ED25519PH) || defined(PSA_WANT_ALG_PURE_EDDSA)) && \
+	defined(PSA_WANT_ECC_TWISTED_EDWARDS_255)
+	const size_t pub_key_max_size = 32;
+#else
+#error "No valid curve for signature validation"
+#endif
+
+extern void safe_memzero(void *dest, const size_t dest_size);
+
+
+
+/* Signature validation algorithms */
+
+#if defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA) || \
+	defined(PSA_WANT_ALG_ED25519PH)
+
+psa_status_t psa_verify_hash(
+	mbedtls_svc_key_id_t key_id, psa_algorithm_t alg, const uint8_t *hash, size_t hash_length,
+	const uint8_t *signature, size_t signature_length)
+{
+	psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
+	psa_key_attributes_t attr;
+	uint8_t pub_key[pub_key_max_size];
+	size_t pub_key_length;
+
+	if (hash == NULL || signature == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	if (!UTIL_CONCAT_OR(
+		VERIFY_ALG_ED25519PH(alg),
+		VERIFY_ALG_ECDSA_SECP_R1_256(alg),
+		VERIFY_ALG_DETERMINISTIC_ECDSA_SECP_R1_256(alg))) {
+		return PSA_ERROR_NOT_SUPPORTED;
+	}
+
+	status = get_key_buffer(key_id, &attr, pub_key, pub_key_max_size, &pub_key_length);
+	if (status != PSA_SUCCESS) {
+		return status;
+	}
+
+	return psa_driver_wrapper_verify_hash(&attr, pub_key, pub_key_length,
+					      alg, hash, hash_length,
+					      signature, signature_length);
+}
+
+#endif
+
+#if defined(PSA_WANT_ALG_ECDSA) || defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA) || \
+	defined(PSA_WANT_ALG_PURE_EDDSA)
+
+psa_status_t psa_verify_message(
+	mbedtls_svc_key_id_t key_id, psa_algorithm_t alg,
+	const uint8_t *input, size_t input_length,
+	const uint8_t *signature, size_t signature_length)
+{
+	psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
+	psa_key_attributes_t attr;
+	uint8_t pub_key[pub_key_max_size];
+	size_t pub_key_size = 0;
+
+	if (input == NULL || signature == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	if (!UTIL_CONCAT_OR(
+		VERIFY_ALG_ED25519(alg),
+		VERIFY_ALG_ECDSA_SECP_R1_256(alg),
+		VERIFY_ALG_DETERMINISTIC_ECDSA_SECP_R1_256(alg))) {
+		return PSA_ERROR_NOT_SUPPORTED;
+	}
+
+	status = get_key_buffer(key_id, &attr, pub_key, pub_key_max_size, &pub_key_size);
+	if (status != PSA_SUCCESS) {
+		return status;
+	}
+
+	return psa_driver_wrapper_verify_message(&attr, pub_key, pub_key_size,
+						 alg, input, input_length,
+						 signature, signature_length);
+}
+
+#endif
+
+/* Hash algorithms */
+
+#if defined(PSA_WANT_ALG_SHA_256) || defined(PSA_WANT_ALG_SHA_512)
+
+psa_status_t psa_hash_compute(
+	psa_algorithm_t alg, const uint8_t *input, size_t input_length,
+	uint8_t *hash, size_t hash_size, size_t *hash_length)
+{
+	if (input == NULL || hash_length == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	if (!UTIL_CONCAT_OR(VERIFY_ALG_SHA_256(alg),
+			    VERIFY_ALG_SHA_512(alg))) {
+		return PSA_ERROR_NOT_SUPPORTED;
+	}
+
+	return psa_driver_wrapper_hash_compute(alg, input, input_length,
+					       hash, hash_size, hash_length);
+}
+
+#endif /* PSA_WANT_ALG_SHA_256 || PSA_WANT_ALG_SHA_512 */
+
+/* Key establishment algorithms */
+
+/* Encryption algorithms */
+
+#if defined(PSA_WANT_ALG_CTR)
+
+/* Ensure that the largest key-size is supported */
+#if PSA_WANT_AES_KEY_SIZE_256
+#define ENC_KEY_MAX_SIZE	(32)
+#elif PSA_WANT_AES_KEY_SIZE_128
+#define ENC_KEY_MAX_SIZE	(16)
+#else
+#error "FW ecryption requires either AES-256 or AES-128 being enabled"
+#endif
+
+/** @brief Buffer containing the established/derived encryption key */
+uint8_t g_enc_key[ENC_KEY_MAX_SIZE];
+
+static psa_status_t get_enc_key(
+	mbedtls_svc_key_id_t key_id, psa_algorithm_t alg,
+	psa_key_attributes_t *attributes, size_t *key_length)
+{
+	if (attributes == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	if (IS_ENABLED(PSA_WANT_ALG_CTR) && alg == PSA_ALG_CTR) {
+		return PSA_ERROR_NOT_SUPPORTED;
+	}
+
+	return get_key_buffer(key_id, attributes, g_enc_key, ENC_KEY_MAX_SIZE, key_length);
+}
+
+static inline void clear_enc_key(void)
+{
+	safe_memzero(g_enc_key, ENC_KEY_MAX_SIZE);
+}
+
+
+psa_status_t psa_cipher_encrypt_setup(
+	psa_cipher_operation_t *operation, mbedtls_svc_key_id_t key, psa_algorithm_t alg)
+{
+	psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
+	psa_key_attributes_t attributes;
+	size_t key_length;
+
+	if (operation == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	status = get_enc_key(key, alg, &attributes, &key_length);
+	if (status != PSA_SUCCESS) {
+		clear_enc_key();
+	}
+
+	status = psa_driver_wrapper_cipher_encrypt_setup(operation, &attributes, g_enc_key,
+							 key_length, alg);
+	if (status != PSA_SUCCESS) {
+		clear_enc_key();
+	}
+
+	return status;
+}
+
+psa_status_t psa_cipher_decrypt_setup(
+	psa_cipher_operation_t *operation, mbedtls_svc_key_id_t key, psa_algorithm_t alg)
+{
+	psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
+	psa_key_attributes_t attributes;
+	size_t key_length;
+
+	if (operation == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	status = get_enc_key(key, alg, &attributes, &key_length);
+	if (status != PSA_SUCCESS) {
+		clear_enc_key();
+	}
+
+	status = psa_driver_wrapper_cipher_decrypt_setup(operation, &attributes, g_enc_key,
+							 key_length, alg);
+	if (status != PSA_SUCCESS) {
+		clear_enc_key();
+	}
+
+	return status;
+}
+
+psa_status_t psa_cipher_set_iv(
+	psa_cipher_operation_t *operation, const uint8_t *iv, size_t iv_length)
+{
+	psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
+
+	if (operation == NULL || iv == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	status = psa_driver_wrapper_cipher_set_iv(operation, iv, iv_length);
+	if (status != PSA_SUCCESS) {
+		clear_enc_key();
+	}
+
+	return PSA_SUCCESS;
+}
+
+psa_status_t psa_cipher_update(
+	psa_cipher_operation_t *operation, const uint8_t *input, size_t input_length,
+	uint8_t *output, size_t output_size, size_t *output_length)
+{
+	psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
+
+	if (operation == NULL || input == NULL || output == NULL || output_length == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	status = psa_driver_wrapper_cipher_update(operation, input, input_length,
+						  output, output_size, output_length);
+	if (status != PSA_SUCCESS) {
+		clear_enc_key();
+	}
+
+	return status;
+}
+
+psa_status_t psa_cipher_finish(
+	psa_cipher_operation_t *operation,
+	uint8_t *output, size_t output_size, size_t *output_length)
+{
+	psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
+
+	if (operation ==  NULL || output == NULL || output_length == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	status = psa_driver_wrapper_cipher_finish(operation, output, output_size, output_length);
+
+	/* Always clear key when finishing operation */
+	clear_enc_key();
+
+	return status;
+}
+
+psa_status_t psa_cipher_abort(psa_cipher_operation_t *operation)
+{
+	if (operation == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	return psa_driver_wrapper_cipher_abort(operation);
+}
+
+#endif /* PSA_WANT_ALG_CTR */
+
+/* Random function */
+
+#if defined(PSA_WANT_GENERATE_RANDOM)
+
+psa_status_t psa_generate_random(uint8_t *output, size_t output_size)
+{
+	psa_driver_random_context_t rng_ctx = {0};
+
+	if (output == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	return psa_driver_wrapper_get_random(&rng_ctx, output, output_size);
+}
+
+#endif /* PSA_WANT_GENERATE_RANDOM */
+
+/* Key management */
+#if defined(PSA_NEED_CRACEN_KMU_DRIVER)
+psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key_id)
+{
+	psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
+	psa_key_attributes_t attr;
+
+	status = get_key_attributes(&attr, key_id);
+	if (status != PSA_SUCCESS) {
+		return status;
+	}
+
+	/* Generalize to psa_driver_wrapper_destroy_key */
+	return psa_driver_wrapper_destroy_builtin_key(&attr);
+}
+
+psa_status_t psa_lock_key(mbedtls_svc_key_id_t key_id)
+{
+	psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
+	psa_key_attributes_t attr;
+
+	status = get_key_attributes(&attr, key_id);
+	if (status != PSA_SUCCESS) {
+		return status;
+	}
+
+	/* Generalize to psa_driver_wrapper_lock_key */
+	return cracen_kmu_block(&attr);
+}
+#endif /* PSA_NEED_CRACEN_KMU_DRIVER */
+
+/* Initialization function */
+
+psa_status_t psa_crypto_init(void)
+{
+	return psa_driver_wrapper_init();
+}

--- a/subsys/nrf_security/src/core/lite/psa_core_lite.h
+++ b/subsys/nrf_security/src/core/lite/psa_core_lite.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#ifndef PSA_CRYPTO_LITE__
+#define PSA_CRYPTO_LITE__
+
+#include "assert.h"
+#include "zephyr/sys/util_macro.h"
+#include <psa/crypto.h>
+
+/* Macros to verify different signature algorithms */
+
+#define VERIFY_ALG_ED25519(_alg)						\
+	UTIL_AND(IS_ENABLED_ALL(PSA_WANT_ALG_PURE_EDDSA,			\
+				PSA_WANT_ECC_TWISTED_EDWARDS_255),		\
+				_alg == PSA_ALG_PURE_EDDSA)
+
+#define VERIFY_ALG_ED25519PH(_alg)						\
+	UTIL_AND(IS_ENABLED_ALL(PSA_WANT_ALG_ED25519PH,				\
+				PSA_WANT_ECC_TWISTED_EDWARDS_255),		\
+				_alg == PSA_APSA_ALG_ED25519PH)
+
+#define VERIFY_ALG_ECDSA_SECP_R1_256(_alg)					\
+	UTIL_AND(IS_ENABLED_ALL(PSA_WANT_ALG_ECDSA, PSA_WANT_ECC_SECP_R1),	\
+				PSA_ALG_IS_ECDSA(_alg))
+
+#define VERIFY_ALG_DETERMINISTIC_ECDSA_SECP_R1_256(_alg)			\
+	UTIL_AND(IS_ENABLED_ALL(PSA_WANT_ALG_DETERMINISTIC_ECDSA,		\
+				PSA_WANT_ECC_SECP_R1_256),			\
+				PSA_ALG_ECDSA_IS_DETERMINISTIC(_alg))
+
+/* Macros to verify different hash algorithms */
+
+#define VERIFY_ALG_SHA_256(_alg) \
+	UTIL_AND(IS_ENABLED(PSA_WANT_ALG_SHA_256), _alg == PSA_ALG_SHA_256)
+
+#define VERIFY_ALG_SHA_512(_alg) \
+	UTIL_AND(IS_ENABLED(PSA_WANT_ALG_SHA_512), _alg == PSA_ALG_SHA_512)
+
+/* Macros to verify */
+
+#endif /* PSA_CRYPTO_LITE__ */

--- a/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -303,11 +303,15 @@ psa_status_t psa_driver_wrapper_verify_message(const psa_key_attributes_t *attri
 		break;
 	}
 
+#if defined(CONFIG_PSA_CORE_LITE)
+	return PSA_ERROR_NOT_SUPPORTED;
+#else
 	/* Call back to the core with psa_verify_message_builtin.
 	 * This will in turn forward this to use psa_crypto_driver_wrapper_verify_hash
 	 */
 	return psa_verify_message_builtin(attributes, key_buffer, key_buffer_size, alg, input,
 					  input_length, signature, signature_length);
+#endif
 }
 
 psa_status_t psa_driver_wrapper_sign_hash(const psa_key_attributes_t *attributes,

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a80a94e07ab07ff2597060c0d711b7344018333b
+      revision: pull/2637/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit adds a thin PSA core to use instead of the regular PSA core (oberon-psa-core). 
It is only supported for nRF54L15 devices, and it enabled CRACEN by default

This can be enabled by setting `CONFIG_PSA_CORE_LITE=y`

It decreases code-size for an NSIB-build with Ed25519 by ~2.7KB

**Closed PR, please see: https://github.com/nrfconnect/sdk-nrf/pull/20812 instead**