### PR TITLE
samples: npm2100_fuel_gauge: Set build only

### DIFF
--- a/samples/pmic/native/npm2100_fuel_gauge/sample.yaml
+++ b/samples/pmic/native/npm2100_fuel_gauge/sample.yaml
@@ -18,6 +18,7 @@ common:
 tests:
   samples.npm2100_fuel_gauge_compile:
     sysbuild: true
+    build_only: true
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp


### PR DESCRIPTION
Update sample.yaml to build_only.