### PR TITLE
bootloader: bl_boot: Fix faulty boot logic

### DIFF
--- a/subsys/bootloader/bl_boot/bl_boot.c
+++ b/subsys/bootloader/bl_boot/bl_boot.c
@@ -121,6 +121,11 @@ void bl_boot(const struct fw_info *fw_info)
 
 	printk("Booting (0x%x).\r\n", fw_info->address);
 
+	if (!fw_info_ext_api_provide(fw_info, true)) {
+		printk("Failed to provide ext APIs to image, boot aborted.\r\n");
+		return;
+	}
+
 	uninit_used_peripherals();
 
 	/* Allow any pending interrupts to be recognized */
@@ -157,10 +162,6 @@ void bl_boot(const struct fw_info *fw_info)
 
 	VTOR = fw_info->address;
 	uint32_t *vector_table = (uint32_t *)fw_info->address;
-
-	if (!fw_info_ext_api_provide(fw_info, true)) {
-		return;
-	}
 
 #if defined(CONFIG_BUILTIN_STACK_GUARD) && \
     defined(CONFIG_CPU_CORTEX_M_HAS_SPLIM)


### PR DESCRIPTION
Fixes faulty boot logic that would do a return after changing vector addresses and a clear call stack which has undefined opeation. Also adds an error message when forwarding externally required APIs fails so it is visible to the user