### PR TITLE
doc improvement: Add common Matter Kconfig options

### DIFF
--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -169,25 +169,25 @@ When the device leaves the last fabric, one of several reactions can be set to h
 
 To enable one of the reactions to the last fabric removal, set the corresponding Kconfig option to ``y``:
 
-* :kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE` - Do not react to the last fabric removal.
+* :ref:`CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE<CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE>` - Do not react to the last fabric removal.
   The device will keep all saved data and network credentials, and will not reboot.
-* :kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY` - Remove all saved network credentials.
+* :ref:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY<CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY>` - Remove all saved network credentials.
   The device will remove all saved network credentials, keep application-specific non-volatile data, and will not reboot.
-* :kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START` - Remove all saved network credentials and start Bluetooth LE advertising.
+* :ref:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START<CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START>` - Remove all saved network credentials and start Bluetooth LE advertising.
   The device will remove all saved network credentials, keep application-specific non-volatile data, and start advertising Bluetooth LE Matter service.
   After that, it will be ready for commissioning to Matter over Bluetooth LE.
-* :kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT` - Remove all saved network credentials and reboot the device.
+* :ref:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT<CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT>` - Remove all saved network credentials and reboot the device.
   This option is selected by default.
 
   When the :kconfig:option:`CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS` Kconfig option is also set to ``y``, the device will also remove all non-volatile data stored on the device, including application-specific entries.
   This means the device is restored to the factory settings.
 
-To create a delay between  the chosen reaction and the last fabric being removed, set the :kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY` Kconfig option to a specific time in milliseconds.
+To create a delay between  the chosen reaction and the last fabric being removed, set the :ref:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY<CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY>` Kconfig option to a specific time in milliseconds.
 By default this Kconfig option is set to 1 second.
 
 .. note::
-  The :kconfig:option:`CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS` Kconfig option is set to ``y`` by default.
-  To disable removing application-specific non-volatile data when the :kconfig:option:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT` Kconfig option is selected, set the :kconfig:option:`CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS` Kconfig option to ``n``.
+   The :kconfig:option:`CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS` Kconfig option is set to ``y`` by default.
+   To disable removing application-specific non-volatile data when the :ref:`CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT<CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT>` Kconfig option is selected, set the :kconfig:option:`CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS` Kconfig option to ``n``.
 
 .. _ug_matter_configuring_read_client:
 

--- a/samples/matter/common/config.rst
+++ b/samples/matter/common/config.rst
@@ -104,6 +104,44 @@ CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_REDIRECT
 
   This option enables only redirection of logs from the ``chip`` module (as diagnostic network logs) and from the ``app`` module (as diagnostic end-user logs).
 
+Last fabric removal
+===================
+
+You can configure the reaction to the last Matter fabric removal using the following options:
+
+.. _CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE:
+
+CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
+  ``bool`` - After removing the last fabric, do not perform any action.
+  The current state will be left as is and the BLE advertising will not start automatically.
+
+.. _CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY:
+
+CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY
+  ``bool`` After removing the last fabric, erase NVS only.
+  The current RAM state will be saved and the new commissioning to the next fabric will use the next possible fabric index.
+
+.. _CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START:
+
+CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START
+  ``bool`` After removing the last fabric, erase NVS and start Bluetooth LE advertising.
+  The current RAM state will be saved and the new commissioning to the next fabric will use the next possible fabric index.
+  This option should not be used for devices that normally do not advertise Bluetooth LE on boot to keep their original behavior.
+
+.. _CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT:
+
+CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
+  ``bool`` After removing the last fabric, erase NVS and reboot.
+  The current RAM state will be removed and the new commissioning to the new fabric will use the initial fabric index.
+  This is the safest option.
+
+.. _CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY:
+
+CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY
+  ``int`` After removing the last fabric, wait for the defined time (in milliseconds) to perform an action.
+  This schedule will allow for avoiding race conditions before the device removes non-volatile data.
+
+
 Migration of operational keys
 =============================
 


### PR DESCRIPTION
Added common Matter Kconfig options to the Shared configurations in Matter samples page and made them links in the Matter protocol documentation.

Ref: https://nordicsemi.atlassian.net/browse/NCSDK-32260