### PR TITLE
tests: Nrf7120 GPIO, PWM and UART twister test support

### DIFF
--- a/tests/drivers/gpio/gpio_more_loops/boards/nrf7120pdk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_more_loops/boards/nrf7120pdk_nrf7120_cpuapp.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/* Test requirements:
+	 * out-gpios[0] wire connected with in-gpios[0],
+	 * out-gpios[1] wire connected with in-gpios[1],
+	 * etc.
+	 * Output-input GPIO pair must have identical active level flag.
+	 */
+	test_gpios {
+		compatible = "gpio-leds";
+		out_gpios: out_gpios {
+			gpios = <&gpio2 8 GPIO_ACTIVE_HIGH>, <&gpio1 8 GPIO_ACTIVE_HIGH>,
+					<&gpio1 10 GPIO_ACTIVE_HIGH>, <&gpio1 12 GPIO_ACTIVE_HIGH>,
+					<&gpio2 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		in_gpios: in_gpios {
+			gpios = <&gpio2 9 GPIO_ACTIVE_HIGH>, <&gpio1 9 GPIO_ACTIVE_HIGH>,
+					<&gpio1 11 GPIO_ACTIVE_HIGH>, <&gpio1 13 GPIO_ACTIVE_HIGH>,
+					<&gpio1 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpiote20 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_more_loops/testcase.yaml
+++ b/tests/drivers/gpio/gpio_more_loops/testcase.yaml
@@ -19,8 +19,10 @@ tests:
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l20pdk/nrf54l20/cpuflpr
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp

--- a/tests/drivers/gpio/gpio_nfct/boards/nrf7120pdk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_nfct/boards/nrf7120pdk_nrf7120_cpuapp.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/* Test requirements:
+	 * P1.00 shorted with P1.01;
+	 * P1.02 shorted with P1.03.
+	 * (NFC pins are P1.01 and P1.02)
+	 */
+	test_gpios {
+		compatible = "gpio-leds";
+		out_gpios: out_gpios {
+			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>, <&gpio1 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		in_gpios: in_gpios {
+			gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>, <&gpio1 3 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&uicr {
+	nfct-pins-as-gpios;
+};
+
+&gpiote20 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_nfct/testcase.yaml
+++ b/tests/drivers/gpio/gpio_nfct/testcase.yaml
@@ -16,7 +16,9 @@ tests:
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
+      - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp

--- a/tests/drivers/lpuart/boards/nrf7120pdk_nrf7120_cpuapp.conf
+++ b/tests/drivers/lpuart/boards/nrf7120pdk_nrf7120_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_UART_21_ASYNC=y
+CONFIG_UART_21_INTERRUPT_DRIVEN=n
+# Do not use interrupt driven API for console UART to not enable RX.
+CONFIG_UART_20_INTERRUPT_DRIVEN=n

--- a/tests/drivers/lpuart/boards/nrf7120pdk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/lpuart/boards/nrf7120pdk_nrf7120_cpuapp.overlay
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: LicenseRef-Nordic-5-Clause */
+
+&pinctrl {
+	uart21_default_alt: uart21_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_RX, 1, 10)>,
+				<NRF_PSEL(UART_TX, 1, 11)>;
+		};
+	};
+
+	uart21_sleep_alt: uart21_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_RX, 1, 10)>,
+				<NRF_PSEL(UART_TX, 1, 11)>;
+			low-power-enable;
+		};
+	};
+};
+
+&uart21 {
+	status = "okay";
+	pinctrl-0 = <&uart21_default_alt>;
+	pinctrl-1 = <&uart21_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	current-speed = <115200>;
+	lpuart: nrf-sw-lpuart {
+		compatible = "nordic,nrf-sw-lpuart";
+		status = "okay";
+		req-pin = <40>;
+		rdy-pin = <41>;
+	};
+};
+
+&gpiote20 {
+	status = "okay";
+};
+
+&timer20 {
+	status = "okay";
+	interrupts = <202 0>;
+};
+
+/ {
+	busy-sim {
+		compatible = "vnd,busy-sim";
+		status = "okay";
+		counter = <&timer20>;
+	};
+};

--- a/tests/drivers/lpuart/testcase.yaml
+++ b/tests/drivers/lpuart/testcase.yaml
@@ -26,12 +26,14 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp
     extra_configs:
       - CONFIG_TEST_LPUART_LOOPBACK=y
     harness: ztest
@@ -45,12 +47,14 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp
     extra_configs:
       - CONFIG_TEST_LPUART_LOOPBACK=y
       - CONFIG_TEST_BUSY_SIM=y

--- a/tests/drivers/pwm/gpio_loopback/boards/nrf7120pdk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/pwm/gpio_loopback/boards/nrf7120pdk_nrf7120_cpuapp.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm20 0 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/tests/drivers/pwm/gpio_loopback/boards/nrf7120pdk_nrf7120_cpuflpr.overlay
+++ b/tests/drivers/pwm/gpio_loopback/boards/nrf7120pdk_nrf7120_cpuflpr.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm20 0 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&uart30 {
+	/delete-property/ hw-flow-control;
+};

--- a/tests/drivers/pwm/gpio_loopback/testcase.yaml
+++ b/tests/drivers/pwm/gpio_loopback/testcase.yaml
@@ -16,9 +16,11 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp
 
   drivers.pwm.gpio_loopback.fast_p7_0:
     platform_allow:

--- a/tests/drivers/uart/uart_baudrate_test/boards/nrf7120pdk_nrf7120_cpuapp_uart00.overlay
+++ b/tests/drivers/uart/uart_baudrate_test/boards/nrf7120pdk_nrf7120_cpuapp_uart00.overlay
@@ -1,0 +1,41 @@
+/*
+ * Test requires wire connection between:
+ *  - uart00 TX at P2.08 <-> GPIO input at P2.09
+ */
+
+/ {
+	zephyr,user {
+		gpios = <&gpio2 9 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&pinctrl {
+	uart00_default: uart00_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 2, 8)>,
+				<NRF_PSEL(UART_RX, 2, 7)>;
+				bias-pull-up;
+		};
+	};
+
+	uart00_sleep: uart00_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 2, 8)>,
+				<NRF_PSEL(UART_RX, 2, 7)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart00 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart00_default>;
+	pinctrl-1 = <&uart00_sleep>;
+	pinctrl-names = "default", "sleep";
+	disable-rx;
+};

--- a/tests/drivers/uart/uart_baudrate_test/boards/nrf7120pdk_nrf7120_cpuapp_uart21.overlay
+++ b/tests/drivers/uart/uart_baudrate_test/boards/nrf7120pdk_nrf7120_cpuapp_uart21.overlay
@@ -1,0 +1,41 @@
+/*
+ * Test requires wire connection between:
+ *  - uart21 TX at P1.10 <-> GPIO input at P1.11
+ */
+
+/ {
+	zephyr,user {
+		gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pinctrl {
+	uart21_default: uart21_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 8)>;
+				bias-pull-up;
+		};
+	};
+
+	uart21_sleep: uart21_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 8)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart21 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart21_default>;
+	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-names = "default", "sleep";
+	disable-rx;
+};

--- a/tests/drivers/uart/uart_baudrate_test/boards/nrf7120pdk_nrf7120_cpuapp_uart22.overlay
+++ b/tests/drivers/uart/uart_baudrate_test/boards/nrf7120pdk_nrf7120_cpuapp_uart22.overlay
@@ -1,0 +1,42 @@
+/*
+ * Test requires wire connection between:
+ *  - uart21 TX at P1.9 <-> GPIO input at P1.8
+ */
+
+
+/ {
+	zephyr,user {
+		gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pinctrl {
+	uart22_default: uart22_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 9)>,
+				<NRF_PSEL(UART_RX, 1, 11)>;
+				bias-pull-up;
+		};
+	};
+
+	uart22_sleep: uart22_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 9)>,
+				<NRF_PSEL(UART_RX, 1, 11)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart22 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart22_default>;
+	pinctrl-1 = <&uart22_sleep>;
+	pinctrl-names = "default", "sleep";
+	disable-rx;
+};

--- a/tests/drivers/uart/uart_baudrate_test/testcase.yaml
+++ b/tests/drivers/uart/uart_baudrate_test/testcase.yaml
@@ -72,3 +72,21 @@ tests:
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
     extra_args: DTC_OVERLAY_FILE="boards/nrf54l09pdk_nrf54l09_cpuapp_uart21.overlay"
+  drivers.uart.baudrate_test.7120_uart00:
+    platform_allow:
+      - nrf7120pdk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120pdk/nrf7120/cpuapp
+    extra_args: DTC_OVERLAY_FILE="boards/nrf7120pdk_nrf7120_cpuapp_uart00.overlay"
+  drivers.uart.baudrate_test.7120_uart21:
+    platform_allow:
+      - nrf7120pdk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120pdk/nrf7120/cpuapp
+    extra_args: DTC_OVERLAY_FILE="boards/nrf7120pdk_nrf7120_cpuapp_uart21.overlay"
+  drivers.uart.baudrate_test.7120_uart22:
+    platform_allow:
+      - nrf7120pdk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120pdk/nrf7120/cpuapp
+    extra_args: DTC_OVERLAY_FILE="boards/nrf7120pdk_nrf7120_cpuapp_uart22.overlay"


### PR DESCRIPTION
Adding support for PWM and UART NCS twister tests