### PR TITLE
samples: wifi: Fix proto type used for RAW sockets

### DIFF
--- a/samples/wifi/raw_tx_packet/src/main.c
+++ b/samples/wifi/raw_tx_packet/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(raw_tx_packet, CONFIG_LOG_DEFAULT_LEVEL);
 #include <zephyr/posix/sys/socket.h>
 #endif
 
+#include <zephyr/net/ethernet.h>
 #include <zephyr/net/socket.h>
 
 #include "net_private.h"
@@ -171,7 +172,7 @@ static int setup_raw_pkt_socket(int *sockfd, struct sockaddr_ll *sa)
 	struct net_if *iface = NULL;
 	int ret;
 
-	*sockfd = socket(AF_PACKET, SOCK_RAW, htons(IPPROTO_RAW));
+	*sockfd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
 	if (*sockfd < 0) {
 		LOG_ERR("Unable to create a socket %d", errno);
 		return -1;

--- a/samples/wifi/shell/src/wifi_raw_tx_pkt_shell.c
+++ b/samples/wifi/shell/src/wifi_raw_tx_pkt_shell.c
@@ -9,6 +9,7 @@
  */
 
 #include <stdlib.h>
+#include <zephyr/net/ethernet.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/posix/unistd.h>
 #include <zephyr/posix/sys/socket.h>
@@ -151,7 +152,7 @@ static int setup_raw_pkt_socket(int *sockfd, struct sockaddr_ll *sa)
 	struct net_if *iface;
 	int ret;
 
-	*sockfd = socket(AF_PACKET, SOCK_RAW, htons(IPPROTO_RAW));
+	*sockfd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
 	if (*sockfd < 0) {
 		LOG_ERR("Unable to create a socket %d", errno);
 		return -1;


### PR DESCRIPTION
It turned out that IPPROTO_RAW is not a valid proto type for AF_PACKET sockets, so it likely won't be supported anymore in the future.

As the samples doing raw TX aren't actually using IP protocols, but just sending raw L2 frames, we could just use ETH_P_ALL as protocol when creating socket instead.