### PR TITLE
samples: conn_time_sync: Fix out of bounds behavior of conn_state memset 

### DIFF
--- a/samples/bluetooth/conn_time_sync/src/central.c
+++ b/samples/bluetooth/conn_time_sync/src/central.c
@@ -234,7 +234,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	uint8_t conn_index = bt_conn_index(conn);
 
 	/* Reset state */
-	memset(&conn_state[conn_index], 0, sizeof(conn_state));
+	memset(&conn_state[conn_index], 0, sizeof(conn_state[0]));
 
 	const uint8_t peripheral_conn_count = 1;
 


### PR DESCRIPTION
In the disconnected callback, the array index of conn_state associated with the disconnected connection is cleared using memset. However, the size of the memset is set to the entire conn_state array size and not the size of a single element. This leads to faults due to clearing out of bounds memory if more than one device is connected to the central.