### PR TITLE
samples: bluetooth: Fix resume advertising

### DIFF
--- a/samples/bluetooth/central_and_peripheral_hr/src/main.c
+++ b/samples/bluetooth/central_and_peripheral_hr/src/main.c
@@ -50,6 +50,7 @@ K_MSGQ_DEFINE(hrs_queue, sizeof(struct bt_hrs_client_measurement), HRS_QUEUE_SIZ
 
 static struct bt_hrs_client hrs_c;
 static struct bt_conn *central_conn;
+static struct k_work adv_work;
 
 static const char * const sensor_location_str[] = {
 	"Other",
@@ -219,7 +220,7 @@ static int scan_start(void)
 	return err;
 }
 
-static void advertising_start(void)
+static void adv_work_handler(struct k_work *work)
 {
 	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 
@@ -229,6 +230,11 @@ static void advertising_start(void)
 	}
 
 	printk("Advertising successfully started\n");
+}
+
+static void advertising_start(void)
+{
+	k_work_submit(&adv_work);
 }
 
 static void connected(struct bt_conn *conn, uint8_t conn_err)
@@ -444,6 +450,7 @@ int main(void)
 
 	printk("Scanning started\n");
 
+	k_work_init(&adv_work, adv_work_handler);
 	advertising_start();
 
 	for (;;) {

--- a/samples/bluetooth/peripheral_bms/src/main.c
+++ b/samples/bluetooth/peripheral_bms/src/main.c
@@ -38,6 +38,7 @@
  * In hex: {0x41, 0x42, 0x43, 0x44}
  */
 static const uint8_t bms_auth_code[] = {'A', 'B', 'C', 'D'};
+static struct k_work adv_work;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -48,7 +49,7 @@ static const struct bt_data sd[] = {
 	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_BMS_VAL)),
 };
 
-static void advertising_start(void)
+static void adv_work_handler(struct k_work *work)
 {
 	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 
@@ -58,6 +59,11 @@ static void advertising_start(void)
 	}
 
 	printk("Advertising successfully started\n");
+}
+
+static void advertising_start(void)
+{
+	k_work_submit(&adv_work);
 }
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -236,6 +242,7 @@ int main(void)
 		return 0;
 	}
 
+	k_work_init(&adv_work, adv_work_handler);
 	advertising_start();
 
 	for (;;) {

--- a/samples/bluetooth/peripheral_cgms/src/main.c
+++ b/samples/bluetooth/peripheral_cgms/src/main.c
@@ -26,6 +26,7 @@
 #define APP_GLUCOSE_STEP   0.1f
 
 static bool session_state;
+static struct k_work adv_work;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -38,7 +39,7 @@ static const struct bt_data sd[] = {
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
-static void advertising_start(void)
+static void adv_work_handler(struct k_work *work)
 {
 	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 
@@ -48,6 +49,11 @@ static void advertising_start(void)
 	}
 
 	printk("Advertising successfully started\n");
+}
+
+static void advertising_start(void)
+{
+	k_work_submit(&adv_work);
 }
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -171,6 +177,7 @@ int main(void)
 		return 0;
 	}
 
+	k_work_init(&adv_work, adv_work_handler);
 	advertising_start();
 
 	/* Submit the measured glucose result in main loop. */

--- a/samples/bluetooth/peripheral_cts_client/src/main.c
+++ b/samples/bluetooth/peripheral_cts_client/src/main.c
@@ -30,7 +30,7 @@
 #define KEY_READ_TIME DK_BTN1_MSK
 
 static struct bt_cts_client cts_c;
-
+static struct k_work adv_work;
 static bool has_cts;
 
 static const struct bt_data ad[] = {
@@ -163,7 +163,7 @@ static const struct bt_gatt_dm_cb discover_cb = {
 };
 
 
-static void advertising_start(void)
+static void adv_work_handler(struct k_work *work)
 {
 	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), NULL, 0);
 
@@ -173,6 +173,11 @@ static void advertising_start(void)
 	}
 
 	printk("Advertising successfully started\n");
+}
+
+static void advertising_start(void)
+{
+	k_work_submit(&adv_work);
 }
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -366,6 +371,7 @@ int main(void)
 		return 0;
 	}
 
+	k_work_init(&adv_work, adv_work_handler);
 	advertising_start();
 
 	for (;;) {

--- a/samples/bluetooth/peripheral_gatt_dm/src/main.c
+++ b/samples/bluetooth/peripheral_gatt_dm/src/main.c
@@ -29,6 +29,8 @@
 #define KEY_PAIRING_ACCEPT DK_BTN1_MSK
 #define KEY_PAIRING_REJECT DK_BTN2_MSK
 
+static struct k_work adv_work;
+
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 	BT_DATA(BT_DATA_NAME_COMPLETE, DEVICE_NAME, DEVICE_NAME_LEN),
@@ -71,7 +73,7 @@ static struct bt_gatt_dm_cb discover_all_cb = {
 	.error_found = discover_all_error_found,
 };
 
-static void advertising_start(void)
+static void adv_work_handler(struct k_work *work)
 {
 	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), NULL, 0);
 
@@ -81,6 +83,11 @@ static void advertising_start(void)
 	}
 
 	printk("Advertising successfully started\n");
+}
+
+static void advertising_start(void)
+{
+	k_work_submit(&adv_work);
 }
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -197,6 +204,7 @@ int main(void)
 		return 0;
 	}
 
+	k_work_init(&adv_work, adv_work_handler);
 	advertising_start();
 
 	return 0;

--- a/samples/bluetooth/peripheral_lbs/src/main.c
+++ b/samples/bluetooth/peripheral_lbs/src/main.c
@@ -39,6 +39,7 @@
 #define USER_BUTTON             DK_BTN1_MSK
 
 static bool app_button_state;
+static struct k_work adv_work;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -49,7 +50,7 @@ static const struct bt_data sd[] = {
 	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_LBS_VAL),
 };
 
-static void advertising_start(void)
+static void adv_work_handler(struct k_work *work)
 {
 	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 
@@ -59,6 +60,11 @@ static void advertising_start(void)
 	}
 
 	printk("Advertising successfully started\n");
+}
+
+static void advertising_start(void)
+{
+	k_work_submit(&adv_work);
 }
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -252,6 +258,7 @@ int main(void)
 		return 0;
 	}
 
+	k_work_init(&adv_work, adv_work_handler);
 	advertising_start();
 
 	for (;;) {

--- a/samples/bluetooth/peripheral_mds/src/main.c
+++ b/samples/bluetooth/peripheral_mds/src/main.c
@@ -38,6 +38,7 @@ static const struct bt_data sd[] = {
 };
 
 static struct bt_conn *mds_conn;
+static struct k_work adv_work;
 
 static void bas_work_handler(struct k_work *work);
 
@@ -64,7 +65,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	}
 }
 
-static void advertising_start(void)
+static void adv_work_handler(struct k_work *work)
 {
 	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 
@@ -74,6 +75,11 @@ static void advertising_start(void)
 	}
 
 	printk("Advertising successfully started\n");
+}
+
+static void advertising_start(void)
+{
+	k_work_submit(&adv_work);
 }
 
 static void connected(struct bt_conn *conn, uint8_t conn_err)
@@ -302,6 +308,7 @@ int main(void)
 		}
 	}
 
+	k_work_init(&adv_work, adv_work_handler);
 	advertising_start();
 
 	k_work_schedule(&bas_work, K_SECONDS(1));

--- a/samples/bluetooth/peripheral_rscs/src/main.c
+++ b/samples/bluetooth/peripheral_rscs/src/main.c
@@ -30,6 +30,7 @@
 
 static struct bt_rscs_measurement measurement;
 static struct bt_conn *current_conn;
+static struct k_work adv_work;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -123,7 +124,7 @@ static const struct bt_rscs_cp_cb control_point_cb = {
 	.update_loc = update_loc,
 };
 
-static void advertising_start(void)
+static void adv_work_handler(struct k_work *work)
 {
 	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), NULL, 0);
 
@@ -133,6 +134,11 @@ static void advertising_start(void)
 	}
 
 	printk("Advertising successfully started\n");
+}
+
+static void advertising_start(void)
+{
+	k_work_submit(&adv_work);
 }
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -306,6 +312,7 @@ int main(void)
 		return 0;
 	}
 
+	k_work_init(&adv_work, adv_work_handler);
 	advertising_start();
 
 	for (;;) {

--- a/samples/bluetooth/peripheral_status/src/main.c
+++ b/samples/bluetooth/peripheral_status/src/main.c
@@ -37,6 +37,7 @@
 #define STATUS1_BUTTON             DK_BTN1_MSK
 #define STATUS2_BUTTON             DK_BTN2_MSK
 
+static struct k_work adv_work;
 
 /* Implementation of two status characteristics */
 BT_NSMS_DEF(nsms_btn1, "Button 1", false, "Unknown", 20);
@@ -52,7 +53,7 @@ static const struct bt_data sd[] = {
 	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_NSMS_VAL),
 };
 
-static void advertising_start(void)
+static void adv_work_handler(struct k_work *work)
 {
 	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 
@@ -62,6 +63,11 @@ static void advertising_start(void)
 	}
 
 	printk("Advertising successfully started\n");
+}
+
+static void advertising_start(void)
+{
+	k_work_submit(&adv_work);
 }
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -237,6 +243,7 @@ int main(void)
 		settings_load();
 	}
 
+	k_work_init(&adv_work, adv_work_handler);
 	advertising_start();
 
 	for (;;) {

--- a/samples/bluetooth/peripheral_uart/src/main.c
+++ b/samples/bluetooth/peripheral_uart/src/main.c
@@ -59,6 +59,7 @@ static K_SEM_DEFINE(ble_init_ok, 0, 1);
 
 static struct bt_conn *current_conn;
 static struct bt_conn *auth_conn;
+static struct k_work adv_work;
 
 static const struct device *uart = DEVICE_DT_GET(DT_CHOSEN(nordic_nus_uart));
 static struct k_work_delayable uart_work;
@@ -333,7 +334,7 @@ static int uart_init(void)
 	return err;
 }
 
-static void advertising_start(void)
+static void adv_work_handler(struct k_work *work)
 {
 	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 
@@ -343,6 +344,11 @@ static void advertising_start(void)
 	}
 
 	printk("Advertising successfully started\n");
+}
+
+static void advertising_start(void)
+{
+	k_work_submit(&adv_work);
 }
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -640,6 +646,7 @@ int main(void)
 		return 0;
 	}
 
+	k_work_init(&adv_work, adv_work_handler);
 	advertising_start();
 
 	for (;;) {

--- a/samples/bluetooth/shell_bt_nus/src/main.c
+++ b/samples/bluetooth/shell_bt_nus/src/main.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(app);
 
 
 static struct bt_conn *current_conn;
+static struct k_work adv_work;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -35,7 +36,7 @@ static const struct bt_data sd[] = {
 	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_NUS_VAL),
 };
 
-static void advertising_start(void)
+static void adv_work_handler(struct k_work *work)
 {
 	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 
@@ -45,6 +46,11 @@ static void advertising_start(void)
 	}
 
 	printk("Advertising successfully started\n");
+}
+
+static void advertising_start(void)
+{
+	k_work_submit(&adv_work);
 }
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -170,6 +176,7 @@ int main(void)
 		return 0;
 	}
 
+	k_work_init(&adv_work, adv_work_handler);
 	advertising_start();
 
 	return 0;


### PR DESCRIPTION
Making Bluetooth API calls in the `recycled`
callback context is error-prone.
The changes add the use of workqueue to resume advertising.