### PR TITLE
net: openthread: rpc: Replace IPPROTO_RAW with ETH_P_ALL

### DIFF
--- a/subsys/net/openthread/rpc/server/ot_rpc_if.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_if.c
@@ -12,6 +12,7 @@
 
 #include <openthread/cli.h>
 
+#include <zephyr/net/ethernet.h> /* For ETH_P_ALL */
 #include <zephyr/net/net_l2.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
@@ -97,14 +98,13 @@ static void ot_rpc_cmd_if_enable(const struct nrf_rpc_group *group, struct nrf_r
 	if (enable) {
 		struct sockaddr_ll addr;
 
-		ret = net_context_get(AF_PACKET, SOCK_RAW, IPPROTO_RAW, &recv_net_context);
+		ret = net_context_get(AF_PACKET, SOCK_DGRAM, ETH_P_ALL, &recv_net_context);
 		if (ret) {
 			NET_ERR("Failed to allocate recv net context");
 			goto out;
 		}
 
 		addr.sll_family = AF_PACKET;
-		addr.sll_protocol = htons(IPPROTO_RAW);
 		addr.sll_ifindex = net_if_get_by_iface(iface);
 
 		ret = net_context_bind(recv_net_context, (const struct sockaddr *)&addr,


### PR DESCRIPTION
The combination of AF_PACKET and IPPROTO_RAW is not correct as packet sockets should only be used with IEEE 802.3 protocol numbers. As the support for this combination will likely be soon removed from Zephyr, switch to use DGRAM packet socket instead.

Using ETH_P_ALL is fine in this case, as OpenThread interface only provides IPv6 packets anyway.