### PR TITLE
action: manifest: Upgrade to v1.8.0 to allow unreachables

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -31,7 +31,7 @@ jobs:
           west update zephyr
 
       - name: Manifest
-        uses: zephyrproject-rtos/action-manifest@v1.7.0
+        uses: zephyrproject-rtos/action-manifest@v1.8.0
         with:
           github-token: ${{ secrets.NCS_GITHUB_TOKEN }}
           manifest-path: 'west.yml'
@@ -43,3 +43,4 @@ jobs:
           verbosity-level: '1'
           labels: 'manifest'
           dnm-labels: 'DNM'
+          allowed-unreachables: 'dragoon'


### PR DESCRIPTION
The new version allows specifying a list of unreachable repos which will not add a 'DNM' label.

See also
https://github.com/zephyrproject-rtos/action-manifest/pull/17