### PR TITLE
samples: 802154_sniffer: add `bootloader` command.

### DIFF
--- a/samples/peripheral/802154_sniffer/README.rst
+++ b/samples/peripheral/802154_sniffer/README.rst
@@ -90,6 +90,21 @@ The ``sleep`` command disables the radio and ends the receive process.
 
       sleep
 
+bootloader - reboot the device to the bootloader
+================================================
+
+The ``bootloader`` command reboots the device in bootloader mode.
+
+   .. parsed-literal::
+      :class: highlight
+
+      bootloader
+
+The device reboots into bootloader mode, and the red LED starts pulsing.
+
+.. note::
+   The ``bootloader`` command is available only for the ``nrf52840dongle/nrf52840`` board.
+
 Configuration
 *************
 


### PR DESCRIPTION
Add `bootloader` command that allows nRF52840 dongle to reboot into bootloader by pulling the P0.19 GPIO pim connected to reset to GND.

This allows easy reflashing of the dongle without physical access to the device.