### PR TITLE
doc: jlink: update to 8.18

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -35,7 +35,7 @@ IDE, OS, and tool support
 
 * Updated:
 
-  * The required `SEGGER J-Link`_ version to v8.10f.
+  * The required `SEGGER J-Link`_ version to v8.18.
   * The :ref:`installing_vsc` section on the :ref:`installation` page with the Windows-only requirement to install SEGGER USB Driver for J-Link.
 
 Board support

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -6,7 +6,7 @@
 .. |release_tt| replace:: ``v2.9.0-nRF54H20-1-rc3``
 .. |release_number_tt| replace:: ``2.9.0-nRF54H20-1-rc3``
 
-.. |jlink_ver| replace:: v8.10f
+.. |jlink_ver| replace:: v8.18
 .. |jlink_ver_vsc| replace:: v7.94i
 
 .. ### Config shortcuts


### PR DESCRIPTION
Updated shortcuts.txt to list J-Link 8.18.
VSC version stays unchanged.
NRFU-1459.