### PR TITLE
doc: Correct changelog entry for nrfDesktop

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-3.0.0-preview1.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-3.0.0-preview1.rst
@@ -254,8 +254,6 @@ nRF Desktop
 * Added:
 
   * System Power Management for the :ref:`zephyr:nrf54h20dk_nrf54h20` board target on the application and radio cores.
-    The application still has high power consumption as the Bluetooth LE controller running on the radio core requires disabling MRAM latency (:kconfig:option:`CONFIG_MRAM_LATENCY_AUTO_REQ`).
-    Enabling MRAM latency makes the Bluetooth LE controller unstable.
   * Application configurations for the nRF54L05 and nRF54L10 SoCs (emulated on the nRF54L15 DK).
     The configurations are supported through ``nrf54l15dk/nrf54l10/cpuapp`` and ``nrf54l15dk/nrf54l05/cpuapp`` board targets.
     For details, see the :ref:`nrf_desktop_board_configuration`.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -276,8 +276,6 @@ nRF Desktop
 * Added:
 
   * System Power Management for the :ref:`zephyr:nrf54h20dk_nrf54h20` board target on the application and radio cores.
-    The application still has high power consumption as the Bluetooth LE controller running on the radio core requires disabling MRAM latency (:kconfig:option:`CONFIG_MRAM_LATENCY_AUTO_REQ`).
-    Enabling MRAM latency makes the Bluetooth LE controller unstable.
   * Application configurations for the nRF54L05 and nRF54L10 SoCs (emulated on the nRF54L15 DK).
     The configurations are supported through ``nrf54l15dk/nrf54l10/cpuapp`` and ``nrf54l15dk/nrf54l05/cpuapp`` board targets.
     For details, see the :ref:`nrf_desktop_board_configuration`.


### PR DESCRIPTION
Correct changelog entry for Power Management
in nrfDesktop.
Change was introduced in commit:
ed4de929c5183312629087e7fe6d5a2767927269

JIRA: None