### PR TITLE
codeowners: Move the ncs-sbom command to Vestavind

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -691,7 +691,7 @@
 /scripts/requirements-*.txt               @nrfconnect/ncs-co-build-system @nrfconnect/ncs-ci
 /scripts/west_commands/utils/             @gmarull
 /scripts/west_commands/create_board/      @gmarull
-/scripts/west_commands/sbom/              @nrfconnect/ncs-si-muffin
+/scripts/west_commands/sbom/              @nrfconnect/ncs-co-scripts
 /scripts/west_commands/thingy91x_dfu.py   @nrfconnect/ncs-cia
 /scripts/west_commands/ncs_provision.py   @nrfconnect/ncs-pluto
 /scripts/bootloader/                      @nrfconnect/ncs-pluto
@@ -708,7 +708,7 @@
 /scripts/nrf_provision/fast_pair/*.rst    @nrfconnect/ncs-si-bluebagel-doc
 /scripts/partition_manager/*.rst          @nrfconnect/ncs-aurora-doc
 /scripts/shell/ble_console/**/*.rst       @nrfconnect/ncs-doc-leads
-/scripts/west_commands/sbom/*.rst         @nrfconnect/ncs-si-muffin-doc
+/scripts/west_commands/sbom/*.rst         @nrfconnect/ncs-co-doc @nrfconnect/ncs-doc-leads
 
 # Share
 /share/                                   @nrfconnect/ncs-co-build-system


### PR DESCRIPTION
The ncs-sbom command was originally developed and maintained by the SI team, but Vestavind is taking over its maintenance.