### PR TITLE
wifi: Add support for nRF7120 DTS

### DIFF
--- a/boards/nordic/nrf7120pdk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120pdk/nrf7120_cpuapp_common.dtsi
@@ -16,6 +16,7 @@
 		zephyr,uart-mcumgr = &uart20;
 		zephyr,flash = &cpuapp_mram;
 		zephyr,ieee802154 = &ieee802154;
+		zephyr,wifi = &wlan0;
 	};
 };
 
@@ -126,5 +127,9 @@
 };
 
 &adc {
+	status = "okay";
+};
+
+&wifi {
 	status = "okay";
 };

--- a/dts/bindings/wifi/nordic,nrf71.yaml
+++ b/dts/bindings/wifi/nordic,nrf71.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+description: >
+  This is a representation of the Wi-Fi parts of the nRF71 Series Wi-Fi and
+  Bluetooth chip SoC.
+
+compatible: nordic,wifi71
+
+include:
+  - "wifi-tx-power-2g.yaml"
+  - "wifi-tx-power-5g.yaml"

--- a/dts/common/nordic/nrf7120_enga.dtsi
+++ b/dts/common/nordic/nrf7120_enga.dtsi
@@ -844,4 +844,23 @@
 			#mbox-cells = <1>;
 		};
 	};
+
+	wifi: wifi {
+		compatible = "nordic,wifi71";
+		status = "disabled";
+
+		wifi-max-tx-pwr-2g-dsss = <21>;
+		wifi-max-tx-pwr-2g-mcs0 = <16>;
+		wifi-max-tx-pwr-2g-mcs7 = <16>;
+		wifi-max-tx-pwr-5g-low-mcs0 = <13>;
+		wifi-max-tx-pwr-5g-low-mcs7 = <13>;
+		wifi-max-tx-pwr-5g-mid-mcs0 = <13>;
+		wifi-max-tx-pwr-5g-mid-mcs7 = <13>;
+		wifi-max-tx-pwr-5g-high-mcs0 = <12>;
+		wifi-max-tx-pwr-5g-high-mcs7 = <12>;
+
+		wlan0: wlan0 {
+			compatible = "nordic,wlan";
+		};
+	};
 };


### PR DESCRIPTION
Extend DTS files for nRF7120 PDF to include Wi-Fi support.