### PR TITLE
nrf_security: cracen: kmu: Fix ecdsa public key import

### DIFF
--- a/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -330,6 +330,9 @@ psa_status_t psa_driver_wrapper_sign_hash(const psa_key_attributes_t *attributes
 
 #if defined(PSA_NEED_CRACEN_ASYMMETRIC_SIGNATURE_DRIVER)
 	case PSA_KEY_LOCATION_CRACEN:
+#if defined(PSA_NEED_CRACEN_KMU_DRIVER)
+	case PSA_KEY_LOCATION_CRACEN_KMU:
+#endif /* PSA_NEED_CRACEN_KMU_DRIVER */
 		status = cracen_sign_hash(attributes, key_buffer, key_buffer_size, alg, hash,
 					  hash_length, signature, signature_size, signature_length);
 		/* Declared with fallback == true */
@@ -391,6 +394,9 @@ psa_status_t psa_driver_wrapper_verify_hash(const psa_key_attributes_t *attribut
 		 */
 #if defined(PSA_NEED_CRACEN_ASYMMETRIC_SIGNATURE_DRIVER)
 	case PSA_KEY_LOCATION_CRACEN:
+#if defined(PSA_NEED_CRACEN_KMU_DRIVER)
+	case PSA_KEY_LOCATION_CRACEN_KMU:
+#endif /* PSA_NEED_CRACEN_KMU_DRIVER */
 		status = cracen_verify_hash(attributes, key_buffer, key_buffer_size, alg, hash,
 					    hash_length, signature, signature_length);
 


### PR DESCRIPTION
The ECDSA public key is 65 bytes long, but the kmu only supported keys up to 32 bytes.
The first byte is Compact Binary Representation
where only one option is supported so this is removed before storing and added back in when retrieved.
This means we only use 4 slots instead of 5 to store the key

Fix bug in psa_crypto_driver_wrappers which meant kmu keys could not be used for sign and verify hash.

Add support for storting  ecdsa keys using sha256 to the kmu