### PR TITLE
Konfig.nrf: default CONFIG_MCUMGR_GRP_IMG_ALLOW_ERASE_PENDING=y

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -134,6 +134,12 @@ config MBEDTLS_HEAP_SIZE
 	default 2048
 endif
 
+# Override configuration from zephyr which disables it by default
+config MCUMGR_GRP_IMG_ALLOW_ERASE_PENDING
+	bool
+	depends on !MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
+	default y
+
 rsource "samples/Kconfig"
 rsource "subsys/Kconfig"
 rsource "modules/Kconfig"


### PR DESCRIPTION
Override default configuration from zephyr of
MCUMGR_GRP_IMG_ALLOW_ERASE_PENDING Kconfig so it is default enabled. This allow our user to not stuck with pending irremovable image.

fixes NCSIDB-1475