### PR TITLE
doc: KMU provisioning: update nRF Util command

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_keys.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_keys.rst
@@ -16,6 +16,8 @@ The keys provisioning workflow for the nRF54H20 SoC consists of two main steps:
    The nRF54H20 SoC must be in RoT lifecycle state for key provisioning to work.
    For more details on lifecycle states, see :ref:`ug_nrf54h20_architecture_lifecycle`.
 
+.. _ug_nrf54h20_keys_generating:
+
 Generating the keys
 ===================
 
@@ -82,6 +84,6 @@ Provisioning a key calls the function to import the key:
 
 To provision the keys from ``all_keys.json`` onto the KMU of the nRF54H20 SoC, use nRF Util as follows::
 
-      nrfutil device x-provision-nrf54h-keys --serial-number <snr> --key-file all_keys.json
+      nrfutil device x-provision-keys --serial-number <snr> --key-file all_keys.json
 
 For more information on how to provision keys, see the `Provisioning keys for hardware KMU`_ page in the nRF Util documentation.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -48,6 +48,7 @@
 .. _`Zephyr pull request #50305`: https://github.com/zephyrproject-rtos/zephyr/pull/50305
 .. _`Zephyr issue #69546`: https://github.com/zephyrproject-rtos/zephyr/issues/69546
 
+.. _`generate_psa_key_attributes.py`: https://github.com/nrfconnect/sdk-nrf/blob/main/scripts/generate_psa_key_attributes.py
 .. _`print_toolchain_checksum.sh`: https://github.com/nrfconnect/sdk-nrf/blob/main/scripts/print_toolchain_checksum.sh
 .. _`JLink License Agreement`: https://github.com/nrfconnect/sdk-nrf/blob/main/scripts/docker/jlink/license.txt
 


### PR DESCRIPTION
Updated the name of the nRF Util command used to provision keys on nRF54H/L devices. NRFU-1450.