### PR TITLE
[Backport v2.9-branch] cmake: sysbuild: partition_manager: Fix cpunet static PM file support

### DIFF
--- a/cmake/sysbuild/partition_manager.cmake
+++ b/cmake/sysbuild/partition_manager.cmake
@@ -123,7 +123,6 @@ function(partition_manager)
       dynamic_partition_argument
       "--flash_primary-dynamic-partition;${dynamic_partition}"
       )
-    set(static_configuration)
   endif()
 
   if (DEFINED PM_DOMAIN)


### PR DESCRIPTION
Backport 87405d6537d0cee9822ef11dec655fe0efee443b from #20561.