### PR TITLE
coremark: Explain sysbuild partition manager option

### DIFF
--- a/samples/benchmarks/coremark/sysbuild.conf
+++ b/samples/benchmarks/coremark/sysbuild.conf
@@ -3,4 +3,10 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
+# We need to disable partition manager to avoid build errors for multicore SoCs
+# that enable it by default, such as the nRF5340 and nRF54L15.
+# For these SoCs, we don't add the second sample-specific sysbuild image
+# to the partition manager domains.
+# Since the CoreMark sample works correctly without partition manager
+# (relying on partition map from DTS), we can disable it for all build configurations.
 SB_CONFIG_PARTITION_MANAGER=n


### PR DESCRIPTION
Add comment to explain the purpose of the sysbuild partition manager.

JIRA: NCSDK-26736

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>