### PR TITLE
samples: Unify the name of samples

### DIFF
--- a/samples/cellular/nidd/sample.yaml
+++ b/samples/cellular/nidd/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: NIDD sample
 tests:
-  samples.cellular.nidd:
+  sample.cellular.nidd:
     sysbuild: true
     build_only: true
     platform_allow:

--- a/samples/nrf_rpc/protocols_serialization/client/sample.yaml
+++ b/samples/nrf_rpc/protocols_serialization/client/sample.yaml
@@ -3,7 +3,7 @@ sample:
   description: Demonstrates serialization of Bluetooth LE and OpenThread API using
     nRF RPC
 tests:
-  samples.nrf_rpc.protocols_serialization.client.rpc_ble:
+  sample.nrf_rpc.protocols_serialization.client.rpc_ble:
     build_only: true
     platform_allow:
       - nrf52840dk/nrf52840
@@ -16,7 +16,7 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-  samples.nrf_rpc.protocols_serialization.client.rpc_ot:
+  sample.nrf_rpc.protocols_serialization.client.rpc_ot:
     build_only: true
     platform_allow:
       - nrf52840dk/nrf52840
@@ -29,7 +29,7 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-  samples.nrf_rpc.protocols_serialization.client.rpc:
+  sample.nrf_rpc.protocols_serialization.client.rpc:
     build_only: true
     platform_allow:
       - nrf52840dk/nrf52840

--- a/samples/nrf_rpc/protocols_serialization/server/sample.yaml
+++ b/samples/nrf_rpc/protocols_serialization/server/sample.yaml
@@ -3,7 +3,7 @@ sample:
   description: Demonstrates serialization of Bluetooth LE and OpenThread API using
     nRF RPC
 tests:
-  samples.nrf_rpc.protocols_serialization.server.rpc_ble:
+  sample.nrf_rpc.protocols_serialization.server.rpc_ble:
     build_only: true
     platform_allow:
       - nrf52840dk/nrf52840
@@ -16,7 +16,7 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-  samples.nrf_rpc.protocols_serialization.server.rpc_ot:
+  sample.nrf_rpc.protocols_serialization.server.rpc_ot:
     build_only: true
     platform_allow:
       - nrf52840dk/nrf52840
@@ -29,7 +29,7 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
-  samples.nrf_rpc.protocols_serialization.server.rpc:
+  sample.nrf_rpc.protocols_serialization.server.rpc:
     build_only: true
     platform_allow:
       - nrf52840dk/nrf52840

--- a/samples/pmic/native/npm1300_fuel_gauge/sample.yaml
+++ b/samples/pmic/native/npm1300_fuel_gauge/sample.yaml
@@ -23,7 +23,7 @@ common:
     - pmic
     - ci_samples_pmic
 tests:
-  samples.npm1300_fuel_gauge:
+  sample.npm1300_fuel_gauge:
     sysbuild: true
     platform_allow:
       - nrf52dk/nrf52832
@@ -39,7 +39,7 @@ tests:
         - "PMIC device ok"
         - "V: [0-9.]+, I: [0-9.-]+, T: [0-9.-]+"
         - "SoC: [0-9.]+, TTE: ([0-9.]+|nan), TTF: ([0-9.]+|nan)"
-  samples.compile:
+  sample.compile:
     sysbuild: true
     platform_allow:
       - nrf9160dk/nrf9160

--- a/samples/pmic/native/npm1300_one_button/sample.yaml
+++ b/samples/pmic/native/npm1300_one_button/sample.yaml
@@ -23,7 +23,7 @@ common:
     - pmic
     - ci_samples_pmic
 tests:
-  samples.npm1300_one_button:
+  sample.npm1300_one_button:
     sysbuild: true
     platform_allow:
       - nrf52dk/nrf52832
@@ -39,7 +39,7 @@ tests:
     tags:
       - sysbuild
       - ci_samples_pmic
-  samples.npm1300_one_button_compile:
+  sample.npm1300_one_button_compile:
     sysbuild: true
     platform_allow:
       - nrf9160dk/nrf9160

--- a/samples/pmic/native/npm2100_fuel_gauge/sample.yaml
+++ b/samples/pmic/native/npm2100_fuel_gauge/sample.yaml
@@ -16,7 +16,7 @@ common:
     - pmic
     - ci_samples_pmic
 tests:
-  samples.npm2100_fuel_gauge_compile:
+  sample.npm2100_fuel_gauge_compile:
     sysbuild: true
     build_only: true
     platform_allow:

--- a/samples/pmic/native/npm2100_one_button/sample.yaml
+++ b/samples/pmic/native/npm2100_one_button/sample.yaml
@@ -17,7 +17,7 @@ common:
     - ci_samples_pmic
 
 tests:
-  samples.npm2100_one_button_compile:
+  sample.npm2100_one_button_compile:
     sysbuild: true
     build_only: true
     platform_allow:

--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -338,8 +338,8 @@
   comment: "Configurations excluded to limit resources usage in integration builds"
 
 - scenarios:
-    - samples.npm1300_fuel_gauge
-    - samples.npm1300_one_button
+    - sample.npm1300_fuel_gauge
+    - sample.npm1300_one_button
   platforms:
     - nrf52840dk/nrf52840
     - nrf52dk/nrf52832


### PR DESCRIPTION
Samples should start with word `sample`.
This commit unify name of samples.