### PR TITLE
doc: matter: fix clusterExtension tab name

### DIFF
--- a/doc/nrf/protocols/matter/getting_started/custom_clusters.rst
+++ b/doc/nrf/protocols/matter/getting_started/custom_clusters.rst
@@ -120,7 +120,7 @@ See the description of each element in the following tabs:
             </event>
          </cluster>
 
-   .. tab:: ``<cluster>``
+   .. tab:: ``<clusterExtension>``
 
       ``<clusterExtension>`` defines the extension of an existing cluster and consist of the following attributes and child elements:
 


### PR DESCRIPTION
rename `<cluster>` to `<clusterExtension>`