### PR TITLE
nrf_security: cracen: Fix psa_export_key when exporting from kmu

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
@@ -1348,10 +1348,11 @@ psa_status_t cracen_export_key(const psa_key_attributes_t *attributes, const uin
 		/* The keys will already be in the key buffer as they got loaded their by a previous
 		 * call to cracen_get_builtin_key or cached in the memory.
 		 */
-		psa_ecc_family_t ecc_fam =
-			PSA_KEY_TYPE_ECC_GET_FAMILY(psa_get_key_type(attributes));
+		psa_key_type_t key_type = psa_get_key_type(attributes);
+
+		psa_ecc_family_t ecc_fam = PSA_KEY_TYPE_ECC_GET_FAMILY(key_type);
 		if (ecc_fam == PSA_ECC_FAMILY_TWISTED_EDWARDS ||
-		    ecc_fam == PSA_ECC_FAMILY_SECP_R1) {
+		    ecc_fam == PSA_ECC_FAMILY_SECP_R1 || key_type == PSA_KEY_TYPE_HMAC) {
 			memcpy(data, key_buffer, key_buffer_size);
 			*data_length = key_buffer_size;
 			return PSA_SUCCESS;


### PR DESCRIPTION
`psa_export_key` would fail due to key not being populated. Add functions to populate key with attributes
Remove special case for ecc which is not needed and did not work. `psa_export_key` should now function for all supported key types.
