### PR TITLE
doc/device_guide: nrfutil for qspi

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf53/qspi_xip_guide_nrf5340.rst
+++ b/doc/nrf/app_dev/device_guides/nrf53/qspi_xip_guide_nrf5340.rst
@@ -203,25 +203,22 @@ Programming the project
 ***********************
 
 For the nRF5340 DK and other boards equipped with flash working in the QSPI mode, use the :ref:`standard programming command <programming>` (``west flash``).
-For other cases, set up a configuration file for nrfjprog, as described in the following section.
-
-.. note::
-      |nrfjprog_deprecation_note|
+For other cases, set up a configuration file for nrfutil, as described in the following section.
 
 Programming to external flash in SPI/DSPI mode
 ==============================================
 
-Programming an application with west triggers the nrfjprog runner.
+Programming an application with west triggers the nrfutil runner.
 The runner uses the default system settings that configure the application in the QSPI mode when programming the external flash.
-You can change this behavior by using a custom :file:`Qspi.ini` configuration file.
+You can change this behavior by using a custom :file:`Qspi.json` configuration file.
 
 .. note::
-    The :file:`Qspi.ini` file is required to work on the Nordic Thingy:53.
+    The :file:`Qspi.json` file is required to work on the Nordic Thingy:53.
 
 This file can specify the mode to use when programming the QSPI flash.
 For example, the following code is from the file for the Thingy:53 and uses ``PP`` for programming and ``READ2IO`` for reading:
 
-.. literalinclude:: ../../../../../samples/nrf5340/extxip_smp_svr/Qspi_thingy53.ini
+.. literalinclude:: ../../../../../samples/nrf5340/extxip_smp_svr/qspi_thingy53.json
     :language: yaml
 
 To use this file automatically in a project, update the ``CMakeLists.txt`` file by :ref:`adding the mention of the new file <modifying_files_compiler>`.
@@ -238,7 +235,7 @@ The following code shows how to set the configuration file used when flashing th
     macro(app_set_runner_args)
       if(CONFIG_BOARD_THINGY53_NRF5340_CPUAPP)
         # Use alternative QSPI configuration file when flashing Thingy53
-        board_runner_args(nrfjprog "--qspiini=${CMAKE_CURRENT_SOURCE_DIR}/Qspi_thingy53.ini")
+        board_runner_args(nrfutil "--ext-mem-config-file=${CMAKE_CURRENT_SOURCE_DIR}/qspi_thingy53.json")
       endif()
     endmacro()
 
@@ -248,7 +245,7 @@ The following code shows how to set the configuration file used when flashing th
 
 .. note::
     The external flash chip must be connected to the dedicated QSPI peripheral port pins of the nRF5340 SoC.
-    It is not possible to program an external flash chip that is connected to different pins using nrfjprog.
+    It is not possible to program an external flash chip that is connected to different pins using nrfutil.
 
 Troubleshooting
 ***************

--- a/doc/nrf/app_dev/device_guides/nrf70/fw_patches_ext_flash.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/fw_patches_ext_flash.rst
@@ -168,14 +168,11 @@ With other tools
 
 You must use the :file:`merged.hex` file instead of the :file:`zephyr.hex` file to choose the program image explicitly.
 
-For example, for nrfjprog:
+For example, for nrfutil:
 
 .. code-block:: console
 
-   nrfjprog -f nrf53 -s 0 --program build/merged.hex ---sectorerase --qspisectorerase --verify --reset
-
-.. note::
-      |nrfjprog_deprecation_note|
+   nrfutil device program --x-family nrf53 --options chip_erase_mode=ERASE_RANGES_TOUCHED_BY_FIRMWARE,qspi_erase_mode=ERASE_ALL,verify=VERIFY_HASH,reset=RESET_SOFT --firmware build/merged.hex
 
 Updating firmware patches
 =========================


### PR DESCRIPTION
Commandlines for qspi programing with nrfutil.

can be merged after #20275