### PR TITLE
[Backport v2.9-branch] matter: Add factory reset event handlers

### DIFF
--- a/applications/matter_bridge/src/app_task.cpp
+++ b/applications/matter_bridge/src/app_task.cpp
@@ -92,6 +92,19 @@ void BLEStateChangeCallback(Nrf::BLEConnectivityManager::State state)
 
 #endif /* CONFIG_BRIDGED_DEVICE_BT */
 
+#ifndef CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
+void AppFactoryResetHandler(const ChipDeviceEvent *event, intptr_t /* unused */)
+{
+	switch (event->Type) {
+	case DeviceEventType::kFactoryReset:
+		Nrf::BridgeStorageManager::Instance().FactoryReset();
+		break;
+	default:
+		break;
+	}
+}
+#endif
+
 } /* namespace */
 
 CHIP_ERROR AppTask::RestoreBridgedDevices()
@@ -198,6 +211,14 @@ CHIP_ERROR AppTask::Init()
 	/* Register Matter event handler that controls the connectivity status LED based on the captured Matter
 	 * network state. */
 	ReturnErrorOnFailure(Nrf::Matter::RegisterEventHandler(Nrf::Board::DefaultMatterEventHandler, 0));
+
+#ifndef CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
+	/* Register factory reset event handler.
+	 * With this configuration we have to manually clean up the storage,
+	 * as whole settings partition won't be erased.
+	 * */
+	ReturnErrorOnFailure(Nrf::Matter::RegisterEventHandler(AppFactoryResetHandler, 0));
+#endif
 
 	return Nrf::Matter::StartServer();
 }

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -140,7 +140,10 @@ Matter
 Matter fork
 +++++++++++
 
-|no_changes_yet_note|
+* Added:
+
+  * A new ``kFactoryReset`` event that is posted during factory reset.
+    The application can register a handler and perform additional cleanup.
 
 nRF IEEE 802.15.4 radio driver
 ------------------------------

--- a/samples/matter/common/src/app/fabric_table_delegate.h
+++ b/samples/matter/common/src/app/fabric_table_delegate.h
@@ -50,7 +50,6 @@ private:
 		if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0) {
 			chip::DeviceLayer::PlatformMgr().ScheduleWork([](intptr_t) {
 #ifdef CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
-				GroupDataProviderImpl::Instance().WillBeFactoryReset();
 				chip::Server::GetInstance().ScheduleFactoryReset();
 #elif defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY) ||                                                           \
 	defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START)

--- a/samples/matter/common/src/app/matter_event_handler.cpp
+++ b/samples/matter/common/src/app/matter_event_handler.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "matter_event_handler.h"
+#include "group_data_provider.h"
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 #include "dfu/ota/ota_util.h"
@@ -59,6 +60,9 @@ void DefaultEventHandler(const ChipDeviceEvent *event, intptr_t /* unused */)
 		InitBasicOTARequestor();
 		break;
 #endif /* CONFIG_CHIP_OTA_REQUESTOR */
+	case DeviceEventType::kFactoryReset:
+		GroupDataProviderImpl::Instance().WillBeFactoryReset();
+		break;
 	default:
 		break;
 	}

--- a/samples/matter/common/src/board/board.cpp
+++ b/samples/matter/common/src/board/board.cpp
@@ -213,7 +213,6 @@ void Board::FunctionTimerEventHandler()
 	} else if (sInstance.mFunction == BoardFunctions::FactoryReset) {
 		/* Actually trigger Factory Reset */
 		sInstance.mFunction = BoardFunctions::None;
-		Matter::GroupDataProviderImpl::Instance().WillBeFactoryReset();
 		chip::Server::GetInstance().ScheduleFactoryReset();
 	}
 }

--- a/samples/matter/common/src/bridge/bridge_storage_manager.cpp
+++ b/samples/matter/common/src/bridge/bridge_storage_manager.cpp
@@ -189,14 +189,19 @@ template <> bool BridgeStorageManager::LoadBridgedDevice(BridgedDeviceV2 &device
 
 bool BridgeStorageManager::Init()
 {
-	bool result = Nrf::GetPersistentStorage().NonSecureInit();
+	const PSErrorCode status = Nrf::GetPersistentStorage().NonSecureInit(&mBridge);
 
-	if (!result) {
-		return result;
+	if (status != PSErrorCode::Success) {
+		return false;
 	}
 
 	/* Perform data migration from previous data structure versions if needed. */
 	return MigrateData();
+}
+
+void BridgeStorageManager::FactoryReset()
+{
+	Nrf::GetPersistentStorage().NonSecureFactoryReset();
 }
 
 #ifdef CONFIG_BRIDGE_MIGRATE_PRE_2_7_0

--- a/samples/matter/common/src/bridge/bridge_storage_manager.h
+++ b/samples/matter/common/src/bridge/bridge_storage_manager.h
@@ -34,6 +34,22 @@ class BridgeStorageManager {
 public:
 	static inline constexpr auto kMaxUserDataSize = 128u;
 
+	constexpr static auto kBridgePrefix = "br";
+	constexpr static auto kBridgedDevicesCountPrefix = "brd_cnt";
+	constexpr static auto kBridgedDevicesIndexesPrefix = "brd_ids";
+	constexpr static auto kBridgedDevicePrefix = "brd";
+	constexpr static auto kVersionPrefix = "ver";
+
+#ifdef CONFIG_BRIDGE_MIGRATE_PRE_2_7_0
+	constexpr static auto kBridgedDeviceEndpointIdPrefix = "eid";
+	constexpr static auto kBridgedDeviceLabelPrefix = "label";
+	constexpr static auto kBridgedDeviceTypePrefix = "type";
+#ifdef CONFIG_BRIDGED_DEVICE_BT
+	constexpr static auto kBtPrefix = "bt";
+	constexpr static auto kBtAddrPrefix = "addr";
+#endif
+#endif
+
 #ifdef CONFIG_BRIDGE_MIGRATE_VERSION_1
 	struct BridgedDeviceV1 {
 		uint16_t mEndpointId;
@@ -62,17 +78,22 @@ public:
 	static constexpr auto kMaxIndexLength = 3;
 
 	BridgeStorageManager()
-		: mBridge("br", strlen("br")), mBridgedDevicesCount("brd_cnt", strlen("brd_cnt"), &mBridge),
-		  mBridgedDevicesIndexes("brd_ids", strlen("brd_ids"), &mBridge),
-		  mBridgedDevice("brd", strlen("brd"), &mBridge), mVersion("ver", strlen("ver"), &mBridge)
+		: mBridge(kBridgePrefix, strlen(kBridgePrefix)),
+		  mBridgedDevicesCount(kBridgedDevicesCountPrefix, strlen(kBridgedDevicesCountPrefix), &mBridge),
+		  mBridgedDevicesIndexes(kBridgedDevicesIndexesPrefix, strlen(kBridgedDevicesIndexesPrefix), &mBridge),
+		  mBridgedDevice(kBridgedDevicePrefix, strlen(kBridgedDevicePrefix), &mBridge),
+		  mVersion(kVersionPrefix, strlen(kVersionPrefix), &mBridge)
 #ifdef CONFIG_BRIDGE_MIGRATE_PRE_2_7_0
 		  ,
-		  mBridgedDeviceEndpointId("eid", strlen("eid"), &mBridgedDevice),
-		  mBridgedDeviceNodeLabel("label", strlen("label"), &mBridgedDevice),
-		  mBridgedDeviceType("type", strlen("type"), &mBridgedDevice)
+		  mBridgedDeviceEndpointId(kBridgedDeviceEndpointIdPrefix, strlen(kBridgedDeviceEndpointIdPrefix),
+					   &mBridgedDevice),
+		  mBridgedDeviceNodeLabel(kBridgedDeviceLabelPrefix, strlen(kBridgedDeviceLabelPrefix),
+					  &mBridgedDevice),
+		  mBridgedDeviceType(kBridgedDeviceTypePrefix, strlen(kBridgedDeviceTypePrefix), &mBridgedDevice)
 #ifdef CONFIG_BRIDGED_DEVICE_BT
 		  ,
-		  mBt("bt", strlen("bt"), &mBridgedDevice), mBtAddress("addr", strlen("addr"), &mBt)
+		  mBt(kBtPrefix, strlen(kBtPrefix), &mBridgedDevice),
+		  mBtAddress(kBtAddrPrefix, strlen(kBtAddrPrefix), &mBt)
 #endif
 #endif
 	{

--- a/samples/matter/common/src/bridge/bridge_storage_manager.h
+++ b/samples/matter/common/src/bridge/bridge_storage_manager.h
@@ -114,6 +114,11 @@ public:
 	bool Init();
 
 	/**
+	 * @brief Factory reset the storage.
+	 */
+	void FactoryReset();
+
+	/**
 	 * @brief Store bridged devices count into settings
 	 *
 	 * @param count count value to be stored

--- a/samples/matter/common/src/event_triggers/default_event_triggers.cpp
+++ b/samples/matter/common/src/event_triggers/default_event_triggers.cpp
@@ -61,7 +61,6 @@ void DelayTimerCallback(k_timer *timer)
 
 		switch (ctx->action) {
 		case DelayedAction::FactoryReset:
-			GroupDataProviderImpl::Instance().WillBeFactoryReset();
 			Server::GetInstance().ScheduleFactoryReset();
 			break;
 #ifdef CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_EVENT_TRIGGERS

--- a/samples/matter/common/src/migration/migration_manager.cpp
+++ b/samples/matter/common/src/migration/migration_manager.cpp
@@ -43,7 +43,6 @@ namespace Migration
 #ifdef CONFIG_NCS_SAMPLE_MATTER_FACTORY_RESET_ON_KEY_MIGRATION_FAILURE
 		if (CHIP_NO_ERROR != err) {
 			LOG_ERR("Keystore migration failure due to %s. Performing Factory reset...", err.AsString());
-			GroupDataProviderImpl::Instance().WillBeFactoryReset();
 			chip::Server::GetInstance().ScheduleFactoryReset();
 			/* Return a success to not block the Matter event Loop and allow to call scheduled factory
 			 * reset. */

--- a/samples/matter/common/src/persistent_storage/backends/persistent_storage_secure.cpp
+++ b/samples/matter/common/src/persistent_storage/backends/persistent_storage_secure.cpp
@@ -12,8 +12,11 @@ namespace Nrf
 PersistentStorageSecure::UidMap PersistentStorageSecure::sUidMap{};
 PersistentStorageSecure::Byte PersistentStorageSecure::sSerializedMapBuff[kMaxMapSerializationBufferSize]{};
 
-PSErrorCode PersistentStorageSecure::_SecureInit()
+PSErrorCode PersistentStorageSecure::_SecureInit(PersistentStorageNode *rootNode)
 {
+	// Ignored in this backend
+	(void)rootNode;
+
 	return LoadUIDMap();
 }
 
@@ -83,6 +86,30 @@ PSErrorCode PersistentStorageSecure::_SecureRemove(PersistentStorageNode *node)
 	}
 
 	return PSErrorCode::Failure;
+}
+
+PSErrorCode PersistentStorageSecure::_SecureFactoryReset()
+{
+	PSErrorCode error = PSErrorCode::Success;
+
+	// Remove all keys
+	for (auto it = std::begin(sUidMap.mMap); it != std::end(sUidMap.mMap) - sUidMap.FreeSlots(); ++it) {
+		psa_status_t status = psa_ps_remove(it->key);
+		if (status != PSA_SUCCESS) {
+			// Set error but try to remove all keys
+			error = PSErrorCode::Failure;
+		}
+	}
+
+	// Remove UidMap
+	psa_status_t status = psa_ps_remove(kKeyOffset);
+	if (status != PSA_SUCCESS) {
+		error = PSErrorCode::Failure;
+	}
+
+	sUidMap = {};
+
+	return error;
 }
 
 psa_storage_uid_t PersistentStorageSecure::UIDFromString(char *str, bool *alreadyInTheMap)

--- a/samples/matter/common/src/persistent_storage/backends/persistent_storage_secure.h
+++ b/samples/matter/common/src/persistent_storage/backends/persistent_storage_secure.h
@@ -15,17 +15,19 @@ namespace Nrf
 {
 class PersistentStorageSecure {
 protected:
-	PSErrorCode _NonSecureInit();
+	PSErrorCode _NonSecureInit(PersistentStorageNode *rootNode);
 	PSErrorCode _NonSecureStore(PersistentStorageNode *node, const void *data, size_t dataSize);
 	PSErrorCode _NonSecureLoad(PersistentStorageNode *node, void *data, size_t dataMaxSize, size_t &outSize);
 	PSErrorCode _NonSecureHasEntry(PersistentStorageNode *node);
 	PSErrorCode _NonSecureRemove(PersistentStorageNode *node);
+	PSErrorCode _NonSecureFactoryReset();
 
-	PSErrorCode _SecureInit();
+	PSErrorCode _SecureInit(PersistentStorageNode *rootNode);
 	PSErrorCode _SecureStore(PersistentStorageNode *node, const void *data, size_t dataSize);
 	PSErrorCode _SecureLoad(PersistentStorageNode *node, void *data, size_t dataMaxSize, size_t &outSize);
 	PSErrorCode _SecureHasEntry(PersistentStorageNode *node);
 	PSErrorCode _SecureRemove(PersistentStorageNode *node);
+	PSErrorCode _SecureFactoryReset();
 
 private:
 	static constexpr size_t kMaxEntriesNumber = CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_MAX_ENTRY_NUMBER;
@@ -90,7 +92,7 @@ private:
 	static Byte sSerializedMapBuff[kMaxMapSerializationBufferSize];
 };
 
-inline PSErrorCode PersistentStorageSecure::_NonSecureInit()
+inline PSErrorCode PersistentStorageSecure::_NonSecureInit(PersistentStorageNode *rootNode)
 {
 	return PSErrorCode::NotSupported;
 };
@@ -113,6 +115,11 @@ inline PSErrorCode PersistentStorageSecure::_NonSecureHasEntry(PersistentStorage
 }
 
 inline PSErrorCode PersistentStorageSecure::_NonSecureRemove(PersistentStorageNode *node)
+{
+	return PSErrorCode::NotSupported;
+}
+
+inline PSErrorCode PersistentStorageSecure::_NonSecureFactoryReset()
 {
 	return PSErrorCode::NotSupported;
 }

--- a/samples/matter/common/src/persistent_storage/backends/persistent_storage_settings.h
+++ b/samples/matter/common/src/persistent_storage/backends/persistent_storage_settings.h
@@ -12,23 +12,27 @@ namespace Nrf
 {
 class PersistentStorageSettings {
 protected:
-	PSErrorCode _NonSecureInit();
+	PSErrorCode _NonSecureInit(PersistentStorageNode *rootNode);
 	PSErrorCode _NonSecureStore(PersistentStorageNode *node, const void *data, size_t dataSize);
 	PSErrorCode _NonSecureLoad(PersistentStorageNode *node, void *data, size_t dataMaxSize, size_t &outSize);
 	PSErrorCode _NonSecureHasEntry(PersistentStorageNode *node);
 	PSErrorCode _NonSecureRemove(PersistentStorageNode *node);
+	PSErrorCode _NonSecureFactoryReset();
 
-	PSErrorCode _SecureInit();
+	PSErrorCode _SecureInit(PersistentStorageNode *rootNode);
 	PSErrorCode _SecureStore(PersistentStorageNode *node, const void *data, size_t dataSize);
 	PSErrorCode _SecureLoad(PersistentStorageNode *node, void *data, size_t dataMaxSize, size_t &outSize);
 	PSErrorCode _SecureHasEntry(PersistentStorageNode *node);
 	PSErrorCode _SecureRemove(PersistentStorageNode *node);
+	PSErrorCode _SecureFactoryReset();
 
 private:
 	bool LoadEntry(const char *key, void *data = nullptr, size_t dataMaxSize = 0, size_t *outSize = nullptr);
+
+	PersistentStorageNode *mRootNode{ nullptr };
 };
 
-inline PSErrorCode PersistentStorageSettings::_SecureInit()
+inline PSErrorCode PersistentStorageSettings::_SecureInit(PersistentStorageNode *rootNode)
 {
 	return PSErrorCode::NotSupported;
 };
@@ -51,6 +55,11 @@ inline PSErrorCode PersistentStorageSettings::_SecureHasEntry(PersistentStorageN
 }
 
 inline PSErrorCode PersistentStorageSettings::_SecureRemove(PersistentStorageNode *node)
+{
+	return PSErrorCode::NotSupported;
+}
+
+inline PSErrorCode PersistentStorageSettings::_SecureFactoryReset()
 {
 	return PSErrorCode::NotSupported;
 }

--- a/samples/matter/common/src/persistent_storage/persistent_storage.h
+++ b/samples/matter/common/src/persistent_storage/persistent_storage.h
@@ -26,10 +26,12 @@ public:
 	/**
 	 * @brief Perform the initialization required before using the storage.
 	 *
+	 * @param rootNode address of the tree root node containing information about the key, it must outlive
+	 * PersistentStorage object.
 	 * @return true if success.
 	 * @return false otherwise.
 	 */
-	PSErrorCode NonSecureInit();
+	PSErrorCode NonSecureInit(PersistentStorageNode *rootNode);
 
 	/**
 	 * @brief Store data into the persistent storage.
@@ -72,12 +74,24 @@ public:
 	 */
 	PSErrorCode NonSecureRemove(PersistentStorageNode *node);
 
+	/**
+	 * @brief Perform factory reset and remove all keys.
+	 *
+	 * In case of error, the caller must take responsibility for additional clearing
+	 * of storage as it may be corrupted.
+	 *
+	 * @return true if subtree has been removed successfully.
+	 * @return false an error occurred.
+	 */
+	PSErrorCode NonSecureFactoryReset();
+
 	/* Secure storage API counterparts.*/
-	PSErrorCode SecureInit();
+	PSErrorCode SecureInit(PersistentStorageNode *rootNode);
 	PSErrorCode SecureStore(PersistentStorageNode *node, const void *data, size_t dataSize);
 	PSErrorCode SecureLoad(PersistentStorageNode *node, void *data, size_t dataMaxSize, size_t &outSize);
 	PSErrorCode SecureHasEntry(PersistentStorageNode *node);
 	PSErrorCode SecureRemove(PersistentStorageNode *node);
+	PSErrorCode SecureFactoryReset();
 
 protected:
 	PersistentStorage() = default;
@@ -107,9 +121,9 @@ inline PersistentStorageImpl *PersistentStorage::Impl()
 }
 
 /* Non secure storage API. */
-inline PSErrorCode PersistentStorage::NonSecureInit()
+inline PSErrorCode PersistentStorage::NonSecureInit(PersistentStorageNode *rootNode)
 {
-	return Impl()->_NonSecureInit();
+	return Impl()->_NonSecureInit(rootNode);
 };
 
 inline PSErrorCode PersistentStorage::NonSecureStore(PersistentStorageNode *node, const void *data, size_t dataSize)
@@ -133,10 +147,15 @@ inline PSErrorCode PersistentStorage::NonSecureRemove(PersistentStorageNode *nod
 	return Impl()->_NonSecureRemove(node);
 }
 
-/* Secure storage API. */
-inline PSErrorCode PersistentStorage::SecureInit()
+inline PSErrorCode PersistentStorage::NonSecureFactoryReset()
 {
-	return Impl()->_SecureInit();
+	return Impl()->_NonSecureFactoryReset();
+}
+
+/* Secure storage API. */
+inline PSErrorCode PersistentStorage::SecureInit(PersistentStorageNode *rootNode)
+{
+	return Impl()->_SecureInit(rootNode);
 };
 
 inline PSErrorCode PersistentStorage::SecureStore(PersistentStorageNode *node, const void *data, size_t dataSize)
@@ -158,6 +177,11 @@ inline PSErrorCode PersistentStorage::SecureHasEntry(PersistentStorageNode *node
 inline PSErrorCode PersistentStorage::SecureRemove(PersistentStorageNode *node)
 {
 	return Impl()->_SecureRemove(node);
+}
+
+inline PSErrorCode PersistentStorage::SecureFactoryReset()
+{
+	return Impl()->_SecureFactoryReset();
 }
 
 } /* namespace Nrf */

--- a/samples/matter/common/src/persistent_storage/persistent_storage_impl.h
+++ b/samples/matter/common/src/persistent_storage/persistent_storage_impl.h
@@ -31,15 +31,16 @@ class PersistentStorageImpl : public PersistentStorage
 	friend class PersistentStorage;
 
 #ifdef CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND
-
 	using PersistentStorageSettings::_NonSecureHasEntry;
 	using PersistentStorageSettings::_NonSecureInit;
 	using PersistentStorageSettings::_NonSecureLoad;
 	using PersistentStorageSettings::_NonSecureRemove;
+	using PersistentStorageSettings::_NonSecureFactoryReset;
 	using PersistentStorageSettings::_NonSecureStore;
 #endif
 
 #ifdef CONFIG_NCS_SAMPLE_MATTER_SECURE_STORAGE_BACKEND
+	using PersistentStorageSecure::_SecureFactoryReset;
 	using PersistentStorageSecure::_SecureHasEntry;
 	using PersistentStorageSecure::_SecureInit;
 	using PersistentStorageSecure::_SecureLoad;

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -71,13 +71,6 @@ config SHELL_CMD_BUFF_SIZE
 
 endif
 
-config LOCK_LEAVE_FABRIC_CLEAR_CREDENTIAL
-	bool "Clear all credentials assigned to given fabric index"
-	default y
-	help
-	  This feature allows to remove all credentials which were created or modified
-	  within the fabric which is being removed from the door lock.
-
 config STATE_LEDS
 	bool "Use LEDs to indicate the device state"
 	default y

--- a/samples/matter/lock/src/access/access_manager.cpp
+++ b/samples/matter/lock/src/access/access_manager.cpp
@@ -33,6 +33,15 @@ void AccessManager<CRED_BIT_MASK>::Init(SetCredentialCallback setCredentialClbk,
 #endif /* CONFIG_LOCK_SCHEDULES */
 }
 
+template <CredentialsBits CRED_BIT_MASK> void AccessManager<CRED_BIT_MASK>::FactoryReset()
+{
+	/* Factory reset the storage */
+	AccessStorage::Instance().FactoryReset();
+
+	/* Reinitialize to clear removed users/credentials/schedules */
+	InitializeAllCredentials();
+}
+
 template <CredentialsBits CRED_BIT_MASK>
 bool AccessManager<CRED_BIT_MASK>::ValidateCustom(CredentialTypeEnum type, chip::MutableByteSpan &secret)
 {

--- a/samples/matter/lock/src/access/access_manager.h
+++ b/samples/matter/lock/src/access/access_manager.h
@@ -264,15 +264,6 @@ public:
 	 */
 	bool GetRequirePIN() { return mRequirePINForRemoteOperation; };
 
-#ifdef CONFIG_LOCK_LEAVE_FABRIC_CLEAR_CREDENTIAL
-	/**
-	 * @brief Clear all credentials from the fabric which is currently being removed
-	 *
-	 * @return true on success, false otherwise
-	 */
-	bool ClearAllCredentialsFromFabric();
-#endif
-
 #ifdef CONFIG_LOCK_ENABLE_DEBUG
 	/* DEBUG API allowing to retrieve internally stored credentials and user data */
 	void PrintCredential(CredentialTypeEnum type, uint16_t index);
@@ -335,10 +326,6 @@ private:
 				    chip::FabricIndex creator, chip::FabricIndex modifier,
 				    DlCredentialStatus credentialStatus, CredentialTypeEnum credentialType,
 				    const chip::ByteSpan &secret);
-
-#ifdef CONFIG_LOCK_LEAVE_FABRIC_CLEAR_CREDENTIAL
-	static bool ClearCredential(DoorLockData::Credential &credential, uint8_t credIdx);
-#endif
 
 	SetCredentialCallback mSetCredentialCallback{ nullptr };
 	ClearCredentialCallback mClearCredentialCallback{ nullptr };

--- a/samples/matter/lock/src/access/access_manager.h
+++ b/samples/matter/lock/src/access/access_manager.h
@@ -276,6 +276,11 @@ public:
 #endif /* CONFIG_LOCK_SCHEDULES */
 #endif /* CONFIG_LOCK_ENABLE_DEBUG */
 
+	/**
+	 * @brief Factory reset the manager.
+	 */
+	void FactoryReset();
+
 private:
 	struct CredentialsIndexes {
 		using CredentialList = DoorLockData::IndexList<CONFIG_LOCK_MAX_NUM_CREDENTIALS_PER_TYPE>;

--- a/samples/matter/lock/src/access/access_storage.cpp
+++ b/samples/matter/lock/src/access/access_storage.cpp
@@ -53,16 +53,23 @@ bool GetStorageFreeSpace(size_t &freeBytes)
 #define PSStore SecureStore
 #define PSRemove SecureRemove
 #define PSLoad SecureLoad
+#define PSFactoryReset SecureFactoryReset
 #elif defined(CONFIG_NCS_SAMPLE_MATTER_SETTINGS_STORAGE_BACKEND)
 #define PSInit NonSecureInit
 #define PSStore NonSecureStore
 #define PSLoad NonSecureLoad
 #define PSRemove NonSecureRemove
+#define PSFactoryReset NonSecureFactoryReset
 #endif
 
 bool AccessStorage::Init()
 {
-	return (Nrf::Success == Nrf::GetPersistentStorage().PSInit());
+	return Nrf::PSErrorCode::Success == Nrf::GetPersistentStorage().PSInit(&mRootNode);
+}
+
+void AccessStorage::FactoryReset()
+{
+	Nrf::GetPersistentStorage().PSFactoryReset();
 }
 
 bool AccessStorage::PrepareKeyName(Type storageType, uint16_t index, uint16_t subindex)

--- a/samples/matter/lock/src/access/access_storage.h
+++ b/samples/matter/lock/src/access/access_storage.h
@@ -64,6 +64,11 @@ public:
 	bool Init();
 
 	/**
+	 * @brief Factory reset the storage.
+	 */
+	void FactoryReset();
+
+	/**
 	 * @brief Store the entry into the persistent storage.
 	 *
 	 * @param storageType depending on that there will be a different key set.
@@ -122,6 +127,7 @@ private:
 #endif /* CONFIG_LOCK_SCHEDULES */
 	constexpr static auto kMaxAccessName = Nrf::PersistentStorageNode::kMaxKeyNameLength;
 
+	Nrf::PersistentStorageNode mRootNode{ kAccessPrefix, strlen(kAccessPrefix) };
 	char mKeyName[AccessStorage::kMaxAccessName];
 
 	bool PrepareKeyName(Type storageType, uint16_t index, uint16_t subindex);

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -54,6 +54,20 @@ constexpr uint32_t kSwitchTransportTimeout = 10000;
 
 #define APPLICATION_BUTTON_MASK DK_BTN2_MSK
 #define SWITCHING_BUTTON_MASK DK_BTN3_MSK
+
+#ifndef CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
+void AppFactoryResetHandler(const ChipDeviceEvent *event, intptr_t /* unused */)
+{
+	switch (event->Type) {
+	case DeviceEventType::kFactoryReset:
+		BoltLockMgr().FactoryReset();
+		break;
+	default:
+		break;
+	}
+}
+#endif
+
 } /* namespace */
 
 Identify sIdentify = { kLockEndpointId, AppTask::IdentifyStartHandler, AppTask::IdentifyStopHandler,
@@ -245,6 +259,14 @@ CHIP_ERROR AppTask::Init()
 	/* Register Matter event handler that controls the connectivity status LED based on the captured Matter network
 	 * state. */
 	ReturnErrorOnFailure(Nrf::Matter::RegisterEventHandler(Nrf::Board::DefaultMatterEventHandler, 0));
+
+#ifndef CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
+	/* Register factory reset event handler.
+	 * With this configuration we have to manually clean up the storage,
+	 * as whole settings partition won't be erased.
+	 * */
+	ReturnErrorOnFailure(Nrf::Matter::RegisterEventHandler(AppFactoryResetHandler, 0));
+#endif
 
 #ifdef CONFIG_THREAD_WIFI_SWITCHING
 	CHIP_ERROR err = ThreadWifiSwitch::StartCurrentTransport();

--- a/samples/matter/lock/src/bolt_lock_manager.cpp
+++ b/samples/matter/lock/src/bolt_lock_manager.cpp
@@ -166,3 +166,8 @@ void BoltLockManager::SetState(State state, OperationSource source)
 		mStateChangeCallback(state, source);
 	}
 }
+
+void BoltLockManager::FactoryReset()
+{
+	AccessMgr::Instance().FactoryReset();
+}

--- a/samples/matter/lock/src/bolt_lock_manager.h
+++ b/samples/matter/lock/src/bolt_lock_manager.h
@@ -82,6 +82,8 @@ public:
 	void SetRequirePIN(bool require);
 	bool GetRequirePIN();
 
+	void FactoryReset();
+
 private:
 	using AccessMgr = AccessManager<DoorLockData::PIN>;
 	friend class AppTask;

--- a/west.yml
+++ b/west.yml
@@ -159,7 +159,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 1f5605c7ee6b406161e0d57b8d5851f62c9f26f0
+      revision: ba1d7cf5fd0394614a11b6c6483beb942601cc24
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
- Remove old code handling clearing users/credentials from fabric as it's unused and not spec compilant.
- Implement factory reset for persistent storage.
- Handle factory reset event in lock and matter_bridge.
- Add common factory reset handler in matter_event_handler.

Fixes [KRKNWK-20041](https://nordicsemi.atlassian.net/browse/KRKNWK-20041)

[KRKNWK-20041]: https://nordicsemi.atlassian.net/browse/KRKNWK-20041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ