### PR TITLE
bluetooth: fast_pair: fmdn: add API for checking the provisioning state

### DIFF
--- a/include/bluetooth/services/fast_pair/fmdn.h
+++ b/include/bluetooth/services/fast_pair/fmdn.h
@@ -538,17 +538,18 @@ struct bt_fast_pair_fmdn_info_cb {
 	/** @brief Indicate provisioning state changes.
 	 *
 	 *  This callback is called to indicate that the FMDN accessory has been
-	 *  successfully provisioned or unprovisioned.
+	 *  successfully provisioned or unprovisioned by the connected Bluetooth
+	 *  peer.
 	 *
-	 *  This callback also reports the initial provisioning state when the
-	 *  user enables Fast Pair with the @ref bt_fast_pair_enable API.
+	 *  This callback does not report the initial provisioning state when the
+	 *  user enables Fast Pair with the @ref bt_fast_pair_enable API. To check
+	 *  the initial state, use the @ref bt_fast_pair_fmdn_is_provisioned API.
 	 *
-	 *  The first callback is executed in the workqueue context after the
-	 *  @ref bt_fast_pair_enable function call. Subsequent callbacks are
-	 *  also executed in the cooperative thread context. You can learn about
-	 *  the exact thread context by analyzing the @kconfig{CONFIG_BT_RECV_CONTEXT}
-	 *  configuration choice. By default, this callback is executed in the
-	 *  Bluetooth-specific workqueue thread (@kconfig{CONFIG_BT_RECV_WORKQ_BT}).
+	 *  This callback is executed in the cooperative thread context. You
+	 *  can learn about the exact thread context by analyzing the
+	 *  @kconfig{CONFIG_BT_RECV_CONTEXT} configuration choice. By default, this
+	 *  callback is executed in the Bluetooth-specific workqueue thread
+	 *  (@kconfig{CONFIG_BT_RECV_WORKQ_BT}).
 	 *
 	 *  @param provisioned true if the accessory has been successfully provisioned.
 	 *                     false if the accessory has been successfully unprovisioned.
@@ -558,6 +559,20 @@ struct bt_fast_pair_fmdn_info_cb {
 	/** Internally used field for list handling. */
 	sys_snode_t node;
 };
+
+/** @brief Check the FMDN provisioning state.
+ *
+ *  This function can be used to synchronously check the FMDN provisioning state.
+ *  To track the provisioning state asynchronously, use the
+ *  @ref bt_fast_pair_fmdn_info_cb.provisioning_state_changed callback.
+ *
+ *  The function shall only be used after the Fast Pair module is enabled with the
+ *  @ref bt_fast_pair_enable API. In the disabled state, this function always returns
+ *  false.
+ *
+ *  @return True if the device is provisioned, false otherwise.
+ */
+bool bt_fast_pair_fmdn_is_provisioned(void);
 
 /** @brief Register the information callbacks in the FMDN module.
  *

--- a/samples/bluetooth/fast_pair/locator_tag/src/main.c
+++ b/samples/bluetooth/fast_pair/locator_tag/src/main.c
@@ -79,13 +79,28 @@ APP_FP_ADV_TRIGGER_REGISTER(fp_adv_trigger_fmdn_provisioning, "fmdn_provisioning
  */
 APP_FP_ADV_TRIGGER_REGISTER(fp_adv_trigger_ui, "ui");
 
-static bool factory_reset_executed;
 static enum factory_reset_trigger factory_reset_trigger;
 
 static void init_work_handle(struct k_work *w);
 
 static K_SEM_DEFINE(init_work_sem, 0, 1);
 static K_WORK_DEFINE(init_work, init_work_handle);
+
+static void fmdn_provisioning_state_set(bool provisioned)
+{
+	__ASSERT_NO_MSG(bt_fast_pair_is_ready());
+	__ASSERT_NO_MSG(bt_fast_pair_fmdn_is_provisioned() == provisioned);
+
+	if (fmdn_provisioned == provisioned) {
+		return;
+	}
+
+	LOG_INF("FMDN: state changed to %s",
+		provisioned ? "provisioned" : "unprovisioned");
+
+	app_ui_state_change_indicate(APP_UI_STATE_PROVISIONED, provisioned);
+	fmdn_provisioned = provisioned;
+}
 
 static void fmdn_factory_reset_prepare(void)
 {
@@ -100,9 +115,21 @@ static void fmdn_factory_reset_prepare(void)
 
 static void fmdn_factory_reset_executed(void)
 {
+	if (factory_reset_trigger != FACTORY_RESET_TRIGGER_NONE) {
+		LOG_INF("The device has been reset to factory settings");
+		LOG_INF("Please press a button to put the device in the Fast Pair discoverable "
+			"advertising mode");
+	}
+
 	/* Clear the trigger state for the scheduled factory reset operations. */
 	factory_reset_trigger = FACTORY_RESET_TRIGGER_NONE;
-	factory_reset_executed = true;
+
+	if (bt_fast_pair_is_ready()) {
+		fp_account_key_present = bt_fast_pair_has_account_key();
+	}
+	__ASSERT_NO_MSG(!fp_account_key_present);
+
+	__ASSERT_NO_MSG(!fmdn_provisioned);
 }
 
 APP_FACTORY_RESET_CALLBACKS_REGISTER(factory_reset_cbs, fmdn_factory_reset_prepare,
@@ -421,67 +448,35 @@ static void fmdn_conn_authenticated(struct bt_conn *conn)
 	fmdn_conn_auth_bm_conn_status_set(conn, true);
 }
 
-static bool fmdn_provisioning_state_is_first_cb_after_bootup(void)
-{
-	static bool first_cb_after_bootup = true;
-	bool is_first_cb_after_bootup = first_cb_after_bootup;
-
-	first_cb_after_bootup = false;
-
-	return is_first_cb_after_bootup;
-}
-
 static void fmdn_provisioning_state_changed(bool provisioned)
 {
-	bool clock_sync_required = fmdn_provisioning_state_is_first_cb_after_bootup() &&
-				   provisioned;
+	fmdn_provisioning_state_set(provisioned);
+	if (provisioned) {
+		/* Fast Pair Implementation Guidelines for the locator tag use case:
+		 * cancel the provisioning timeout.
+		 */
+		if (factory_reset_trigger == FACTORY_RESET_TRIGGER_PROVISIONING_TIMEOUT) {
+			fmdn_factory_reset_cancel();
+		}
 
-	LOG_INF("FMDN: state changed to %s",
-		provisioned ? "provisioned" : "unprovisioned");
+		app_fp_adv_request(&fp_adv_trigger_fmdn_provisioning, false);
 
-	app_ui_state_change_indicate(APP_UI_STATE_PROVISIONED, provisioned);
-	fmdn_provisioned = provisioned;
-
-	/* Fast Pair Implementation Guidelines for the locator tag use case:
-	 * cancel the provisioning timeout.
-	 */
-	if (provisioned &&
-	    (factory_reset_trigger == FACTORY_RESET_TRIGGER_PROVISIONING_TIMEOUT)) {
-		fmdn_factory_reset_cancel();
-	}
-
-	/* Fast Pair Implementation Guidelines for the locator tag use case:
-	 * trigger the reset to factory settings on the unprovisioning operation
-	 * or on the loss of the Owner Account Key.
-	 */
-	fp_account_key_present = bt_fast_pair_has_account_key();
-	if (fp_account_key_present != provisioned) {
-		/* Delay the factory reset operation to allow the local device
+		fp_adv_ui_request = false;
+		app_fp_adv_request(&fp_adv_trigger_ui, fp_adv_ui_request);
+	} else {
+		/* Fast Pair Implementation Guidelines for the locator tag use case:
+		 * trigger the reset to factory settings on the unprovisioning operation.
+		 *
+		 * Delay the factory reset operation to allow the local device
 		 * to send a response to the unprovisioning command and give
 		 * the connected peer necessary time to finalize its operations
 		 * and shutdown the connection.
 		 */
-		fmdn_factory_reset_schedule(
-			FACTORY_RESET_TRIGGER_KEY_STATE_MISMATCH,
-			K_SECONDS(FACTORY_RESET_DELAY));
-		return;
+		fmdn_factory_reset_schedule(FACTORY_RESET_TRIGGER_KEY_STATE_MISMATCH,
+					    K_SECONDS(FACTORY_RESET_DELAY));
+
+		app_fp_adv_request(&fp_adv_trigger_clock_sync, false);
 	}
-
-	/* Triggered on the unprovisioning operation. */
-	if (factory_reset_executed) {
-		LOG_INF("The device has been reset to factory settings");
-		LOG_INF("Please press a button to put the device in the Fast Pair discoverable "
-			"advertising mode");
-
-		factory_reset_executed = false;
-		return;
-	}
-
-	app_fp_adv_request(&fp_adv_trigger_clock_sync, clock_sync_required);
-	app_fp_adv_request(&fp_adv_trigger_fmdn_provisioning, false);
-
-	fp_adv_ui_request = !provisioned;
-	app_fp_adv_request(&fp_adv_trigger_ui, fp_adv_ui_request);
 }
 
 static struct bt_fast_pair_fmdn_info_cb fmdn_info_cb = {
@@ -489,6 +484,29 @@ static struct bt_fast_pair_fmdn_info_cb fmdn_info_cb = {
 	.conn_authenticated = fmdn_conn_authenticated,
 	.provisioning_state_changed = fmdn_provisioning_state_changed,
 };
+
+static void fmdn_provisioning_state_init(void)
+{
+	bool provisioned;
+
+	provisioned = bt_fast_pair_fmdn_is_provisioned();
+	fmdn_provisioning_state_set(provisioned);
+
+	/* Fast Pair Implementation Guidelines for the locator tag use case:
+	 * trigger the reset to factory settings on the mismatch between the
+	 * Owner Account Key and the FMDN provisioning state.
+	 */
+	fp_account_key_present = bt_fast_pair_has_account_key();
+	if (fp_account_key_present != provisioned) {
+		fmdn_factory_reset_schedule(FACTORY_RESET_TRIGGER_KEY_STATE_MISMATCH, K_NO_WAIT);
+		return;
+	}
+
+	app_fp_adv_request(&fp_adv_trigger_clock_sync, provisioned);
+
+	fp_adv_ui_request = !provisioned;
+	app_fp_adv_request(&fp_adv_trigger_ui, fp_adv_ui_request);
+}
 
 static void fp_adv_state_changed(bool enabled)
 {
@@ -685,6 +703,8 @@ static void init_work_handle(struct k_work *w)
 		LOG_ERR("FMDN: app_fp_adv_enable failed (err %d)", err);
 		return;
 	}
+
+	fmdn_provisioning_state_init();
 
 	k_sem_give(&init_work_sem);
 }

--- a/subsys/bluetooth/services/fast_pair/fmdn/beacon_actions.c
+++ b/subsys/bluetooth/services/fast_pair/fmdn/beacon_actions.c
@@ -229,7 +229,7 @@ static ssize_t provisioning_state_read_handle(struct bt_conn *conn,
 	struct fp_account_key account_key;
 	uint8_t eid[PROVISIONING_STATE_RSP_EID_LEN];
 	uint8_t provisioning_state_flags;
-	const bool provisioned = fp_fmdn_state_is_provisioned();
+	const bool provisioned = bt_fast_pair_fmdn_is_provisioned();
 	static const uint8_t req_data_len = PROVISIONING_STATE_REQ_PAYLOAD_LEN;
 	uint8_t rsp_data_len;
 	enum provisioning_state_bit_flag {
@@ -348,7 +348,7 @@ static ssize_t ephemeral_identity_key_set_handle(struct bt_conn *conn,
 	struct fp_account_key account_key;
 	uint8_t *encrypted_eik;
 	uint8_t new_eik[EPHEMERAL_IDENTITY_KEY_SET_REQ_EIK_LEN];
-	const bool provisioned = fp_fmdn_state_is_provisioned();
+	const bool provisioned = bt_fast_pair_fmdn_is_provisioned();
 	const uint8_t req_data_len = provisioned ?
 		EPHEMERAL_IDENTITY_KEY_SET_REQ_PROVISIONED_PAYLOAD_LEN :
 		EPHEMERAL_IDENTITY_KEY_SET_REQ_UNPROVISIONED_PAYLOAD_LEN;
@@ -483,7 +483,7 @@ static ssize_t ephemeral_identity_key_clear_handle(struct bt_conn *conn,
 	struct fp_account_key account_key;
 	uint8_t *current_eik_hash;
 	uint8_t *random_nonce;
-	const bool provisioned = fp_fmdn_state_is_provisioned();
+	const bool provisioned = bt_fast_pair_fmdn_is_provisioned();
 	static const uint8_t req_data_len = EPHEMERAL_IDENTITY_KEY_CLEAR_REQ_PAYLOAD_LEN;
 	static const uint8_t rsp_data_len = EPHEMERAL_IDENTITY_KEY_CLEAR_RSP_PAYLOAD_LEN;
 
@@ -933,7 +933,7 @@ static ssize_t activate_utp_mode_handle(struct bt_conn *conn,
 		return BT_GATT_ERR(BEACON_ACTIONS_ATT_ERR_INVALID_VALUE);
 	}
 
-	if (!fp_fmdn_state_is_provisioned()) {
+	if (!bt_fast_pair_fmdn_is_provisioned()) {
 		LOG_ERR("Beacon Actions: Activate Unwanted Tracking Protection mode request:"
 			" Device is not provisioned");
 
@@ -1029,7 +1029,7 @@ static ssize_t deactivate_utp_mode_handle(struct bt_conn *conn,
 		return BT_GATT_ERR(BEACON_ACTIONS_ATT_ERR_INVALID_VALUE);
 	}
 
-	if (!fp_fmdn_state_is_provisioned()) {
+	if (!bt_fast_pair_fmdn_is_provisioned()) {
 		LOG_ERR("Beacon Actions: Deactivate Unwanted Tracking Protection mode request:"
 			" Device is not provisioned");
 
@@ -1139,7 +1139,7 @@ int bt_fast_pair_fmdn_ring_state_update(
 	}
 
 	/* Check if connected peers should be notified about the ring state change. */
-	if (!fp_fmdn_state_is_provisioned()) {
+	if (!bt_fast_pair_fmdn_is_provisioned()) {
 		return 0;
 	}
 

--- a/subsys/bluetooth/services/fast_pair/fmdn/include_priv/fp_fmdn_state.h
+++ b/subsys/bluetooth/services/fast_pair/fmdn/include_priv/fp_fmdn_state.h
@@ -67,12 +67,6 @@ uint8_t fp_fmdn_state_ecc_type_encode(void);
  */
 int8_t fp_fmdn_state_tx_power_encode(void);
 
-/** Check if the beacon is provisioned with the Ephemeral Identity Key (EIK).
- *
- * @return True if the beacon is provisioned with the EIK, False Otherwise.
- */
-bool fp_fmdn_state_is_provisioned(void);
-
 /** Provision or unprovision the beacon with the Ephemeral Identity Key (EIK).
  *
  * @param[in] eik Ephemeral Identity Key (EIK).

--- a/subsys/bluetooth/services/fast_pair/fmdn/read_mode.c
+++ b/subsys/bluetooth/services/fast_pair/fmdn/read_mode.c
@@ -165,7 +165,7 @@ int bt_fast_pair_fmdn_read_mode_enter(enum bt_fast_pair_fmdn_read_mode mode)
 		return -EINVAL;
 	}
 
-	if (!fp_fmdn_state_is_provisioned()) {
+	if (!bt_fast_pair_fmdn_is_provisioned()) {
 		return -EACCES;
 	}
 
@@ -185,7 +185,7 @@ int fp_fmdn_read_mode_recovery_mode_request(bool *accepted)
 {
 	__ASSERT_NO_MSG(bt_fast_pair_is_ready());
 
-	if (!fp_fmdn_state_is_provisioned()) {
+	if (!bt_fast_pair_fmdn_is_provisioned()) {
 		return -EACCES;
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -197,7 +197,7 @@ manifest:
           compare-by-default: false
     - name: find-my
       repo-path: sdk-find-my
-      revision: 0f91f3c24984bddcd7938a3bb840c0f81f18a35c
+      revision: 5ee887e759229327f7f92df8073831de61a74cad
       groups:
         - find-my
     - name: azure-sdk-for-c


### PR DESCRIPTION
Added the new FMDN API - bt_fast_pair_fmdn_is_provisioneda. The API can be used to check the device provisioning in the synchronous manner.

Changed the bt_fast_pair_fmdn_info_cb.provisioning_state_changed callback behaviour. The callback no longer reports the initil provisioning state after the Fast Pair subsystem is enabled with the bt_fast_pair_enable API.

Aligned the affected Fast Pair projects that use the FMDN extension.

Ref: NCSDK-30856