### PR TITLE
applications: slm: Fix HWFC problems on nRF9151DK

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -201,6 +201,12 @@ config SLM_MODEM_PIPE_TIMEOUT
 
 endif
 
+config SLM_SKIP_READY_MSG
+	bool "Skip ready message"
+	help
+	  Skip sending the ready message when the application is powered on.
+
+
 module = SLM
 module-str = serial modem
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/applications/serial_lte_modem/overlay-cmux.conf
+++ b/applications/serial_lte_modem/overlay-cmux.conf
@@ -5,6 +5,7 @@
 #
 
 CONFIG_SLM_CMUX=y
+CONFIG_SLM_SKIP_READY_MSG=y
 
 # Zephyr modem subsystem
 CONFIG_MODEM_MODULES=y

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -910,9 +910,12 @@ int slm_at_host_init(void)
 		return err;
 	}
 
-	err = slm_at_send_str(SLM_SYNC_STR);
-	if (err) {
-		return err;
+	if (!IS_ENABLED(CONFIG_SLM_SKIP_READY_MSG)) {
+		/* Send Ready string to indicate that AT host is ready */
+		err = slm_at_send_str(SLM_SYNC_STR);
+		if (err) {
+			return err;
+		}
 	}
 
 	/* This is here and not earlier because in case of firmware

--- a/applications/serial_lte_modem/src/slm_cmux.c
+++ b/applications/serial_lte_modem/src/slm_cmux.c
@@ -114,6 +114,10 @@ static void init_dlci(size_t dlci_idx, uint16_t recv_buf_size,
 
 static int cmux_write_at_channel(const uint8_t *data, size_t len)
 {
+	if (cmux.dlcis[cmux.at_channel].instance.state != MODEM_CMUX_DLCI_STATE_OPEN) {
+		return 0;
+	}
+
 	int ret = modem_pipe_transmit(cmux.dlcis[cmux.at_channel].pipe, data, len);
 
 	if (ret != len) {


### PR DESCRIPTION
## Fix HWFC problems on nRF9151DK

nRF9151DK has interface chip that automatically detects if flow
control is enabled or not. On start up, HWFC pins are floating.

On Zephyr DTS side, nRF9151 CTS pin has pull-up enabled, so if
nRF91 app core boots faster than interface chip, the serial port
might be blocked because of flow control.

Change pull-up to pull-down so nRF91 is allowed to write if interface
chip still has not enabled the HWFC pins.

## Drop AT responsed to closed DLCI

If DLCI channel for AT commands has been closed, avoid sending
data to the pipe.

Channel is resumed once remote end connects to the DLCI channel.