### PR TITLE
caf: modules: buttons: Add possibility to use more GPIOs

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -760,7 +760,11 @@ Bluetooth libraries and services
 Common Application Framework
 ----------------------------
 
-|no_changes_yet_note|
+* :ref:`caf_buttons`:
+
+  * Added possibility of using more GPIOs.
+    Earlier, only **GPIO0** and **GPIO1** devices were supported.
+    Now, the generic solution supports all GPIOs available in the DTS.
 
 Debug libraries
 ---------------


### PR DESCRIPTION
Adds option to use more GPIOs. Eralier only GPIO0 and GPIO1 were supported. Now, the generic solution supports all GPIOs available in DTS.

Jira: NCSDK-31766