### PR TITLE
[Backport v2.9-branch] samples: matter: lock: Use correct settings backend

### DIFF
--- a/samples/matter/lock/src/access/access_storage.cpp
+++ b/samples/matter/lock/src/access/access_storage.cpp
@@ -11,11 +11,11 @@
 #include <zephyr/sys/cbprintf.h>
 
 #ifdef CONFIG_LOCK_PRINT_STORAGE_STATUS
-#ifdef CONFIG_NVS
+#ifdef CONFIG_SETTINGS_NVS
 #include <zephyr/fs/nvs.h>
-#elif CONFIG_ZMS
+#elif CONFIG_SETTINGS_ZMS
 #include <zephyr/fs/zms.h>
-#endif /* CONFIG_NVS */
+#endif /* CONFIG_SETTINGS_NVS */
 #include <zephyr/logging/log.h>
 #include <zephyr/settings/settings.h>
 
@@ -31,11 +31,11 @@ bool GetStorageFreeSpace(size_t &freeBytes)
 		LOG_ERR("AccessStorage: Cannot read NVS free space [error: %d]", status);
 		return false;
 	}
-#ifdef CONFIG_NVS
+#ifdef CONFIG_SETTINGS_NVS
 	freeBytes = nvs_calc_free_space(static_cast<nvs_fs *>(storage));
-#elif CONFIG_ZMS
+#elif CONFIG_SETTINGS_ZMS
 	freeBytes = zms_calc_free_space(static_cast<zms_fs *>(storage));
-#endif /* NVS */
+#endif /* CONFIG_SETTINGS_NVS */
 	return true;
 }
 } /* namespace */


### PR DESCRIPTION
Backport d5d91c8c5f34ec2d233a945776b088a86ae39c8a from #20976.