### PR TITLE
samples,tests: drop references to 'rts-pin' and 'cts-pin'

### DIFF
--- a/samples/cellular/modem_shell/bt.overlay
+++ b/samples/cellular/modem_shell/bt.overlay
@@ -19,8 +19,6 @@
 &uart2 {
 	current-speed = <1000000>;
 	status = "okay";
-	/delete-property/ rts-pin;
-	/delete-property/ cts-pin;
 	/delete-property/ hw-flow-control;
 
 	pinctrl-0 = <&uart2_default_alt>;

--- a/tests/drivers/lpuart/boards/nrf9160dk_nrf9160.overlay
+++ b/tests/drivers/lpuart/boards/nrf9160dk_nrf9160.overlay
@@ -14,8 +14,6 @@
 	status = "okay";
 	pinctrl-0 = <&uart2_default_alt>; /* <&interface_to_nrf52840 1 0> */
 	pinctrl-1 = <&uart2_sleep_alt>; /* <&interface_to_nrf52840 0 0> */
-	/delete-property/ rts-pin;
-	/delete-property/ cts-pin;
 	/delete-property/ hw-flow-control;
 
 	lpuart: nrf-sw-lpuart {

--- a/tests/drivers/lpuart/boards/nrf9160dk_nrf9160_loopback.overlay
+++ b/tests/drivers/lpuart/boards/nrf9160dk_nrf9160_loopback.overlay
@@ -14,8 +14,6 @@
 	status = "okay";
 	pinctrl-0 = <&uart2_default_alt>;
 	pinctrl-1 = <&uart2_sleep_alt>;
-	/delete-property/ rts-pin;
-	/delete-property/ cts-pin;
 	/delete-property/ hw-flow-control;
 
 	lpuart: nrf-sw-lpuart {


### PR DESCRIPTION
Those are not specified anymore after migration to configuration via
pinctrl properties.