### PR TITLE
scripts: quarantine: add bluetooth.direction_finding_central_nrf.aod

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -37,6 +37,7 @@
 
 - scenarios:
     - sample.bluetooth.direction_finding_central_nrf
+    - sample.bluetooth.direction_finding_central_nrf.aod
   platforms:
     - nrf52833dk/nrf52820
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-32042"


### PR DESCRIPTION
sample.bluetooth.direction_finding_central_nrf.aod

The RAM overflow started to occur also in AOD test scenario.