### PR TITLE
manifest: pull in BMM350 driver

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -66,7 +66,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5319cfc0718146a1bb21a856415d9b50abbf979e
+      revision: pull/2633/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update Zephyr to include BMM350 driver for Thingy:91 X.