### PR TITLE
doc: install: simplify prerequisites section

### DIFF
--- a/doc/nrf/app_dev/programming.rst
+++ b/doc/nrf/app_dev/programming.rst
@@ -58,7 +58,9 @@ If you want to change the runner used by ``west flash``, you can use one of the 
 
      west flash -r nrfjprog
 
-In either case, make sure you have the required tools installed on your system: `nRF Util`_ for ``-r nrfutil`` or the archived `nRF Command Line Tools`_ for ``-r nrfjprog``.
+In either case, make sure you have the required tools installed on your system.
+`nRF Util`_ is a :ref:`prerequisite <installing_vsc>` for the |NCS|.
+For ``-r nrfjprog``, you need the archived `nRF Command Line Tools`_.
 
 To see which runners are available for your board, run the following command:
 

--- a/doc/nrf/includes/install_sdk_common_prerequisites.txt
+++ b/doc/nrf/includes/install_sdk_common_prerequisites.txt
@@ -1,0 +1,18 @@
+* All operating systems:
+
+  * The latest version of nRF Util, a unified command-line utility for Nordic Semiconductor products.
+    Check :ref:`operating system versions that support this tool <additional_nordic_sw_tools>` and `download the executable <nRF Util Downloads_>`_.
+
+    .. note::
+        After downloading the nRF Util executable, move it to a directory that is in the system :envvar:`PATH`.
+        On macOS and Linux, the downloaded file also needs to be given execute permission by typing `chmod +x nrfutil` or by checking the checkbox in the file properties.
+
+  * In nRF Util, the latest version of the ``device`` command.
+    Check `Installing and upgrading nRF Util commands`_ for installation information.
+  * The |jlink_ver| of SEGGER J-Link.
+    Download it from the `J-Link Software and Documentation Pack`_ page.
+    On Windows, `install it manually together with SEGGER USB Driver for J-Link <nRF Util prerequisites_>`_.
+
+* Additionally, for Windows users: SEGGER USB Driver for J-Link, required for support of older Nordic Semiconductor devices.
+  For information on how to install the USB Driver, see the `nRF Util prerequisites`_ documentation.
+* Additionally, for Linux users: the `nrf-udev`_ module with udev rules required to access USB ports on Nordic Semiconductor devices and program the firmware.

--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -44,45 +44,17 @@ Depending on your preferred development environment, install the following softw
 
    .. group-tab:: nRF Connect for Visual Studio Code
 
-      * All operating systems:
+      .. include:: /includes/install_sdk_common_prerequisites.txt
 
-        * The latest version of the :ref:`requirements_clt` package.
-          Check :ref:`operating system versions that support this tool <additional_nordic_sw_tools>` and `download the installer <nRF Command Line Tools Downloads_>`_.
-        * The |jlink_ver_vsc| of SEGGER J-Link.
-          Download it from the `J-Link Software and Documentation Pack`_ page.
-          On Windows, `install it manually together with SEGGER USB Driver for J-Link <nRF Util prerequisites_>`_.
-        * The latest version of |VSC| for your operating system from the `Visual Studio Code download page`_ or `using this direct link <start VS Code walkthrough_>`_.
-        * In |VSC|, the latest version of the `nRF Connect for VS Code Extension Pack`_.
-          The |nRFVSC| comes with its own bundled version of some of the nRF Util commands.
+      Additionally, install |VSC|:
 
-      * Additionally, for Windows users: SEGGER USB Driver for J-Link, required for support of older Nordic Semiconductor devices in nRF Util.
-        For information on how to install the USB Driver, see the `nRF Util prerequisites`_ documentation.
-      * Additionally, for Linux users: the `nrf-udev`_ module with udev rules required to access USB ports on Nordic Semiconductor devices and program the firmware.
+      * The latest version of |VSC| for your operating system from the `Visual Studio Code download page`_ or `using this direct link <start VS Code walkthrough_>`_.
+      * In |VSC|, the latest version of the `nRF Connect for VS Code Extension Pack`_.
+        The |nRFVSC| comes with its own bundled version of some of the nRF Util commands.
 
    .. group-tab:: Command line
 
-      * All operating systems:
-
-        * The latest version of nRF Util, a unified command-line utility for Nordic Semiconductor products.
-          Check :ref:`operating system versions that support this tool <additional_nordic_sw_tools>` and `download the installer <nRF Util Downloads_>`_.
-
-          .. note::
-              After downloading the nRF Util executable, move it to a directory that is in the system :envvar:`PATH`.
-              On macOS and Linux, the downloaded file also needs to be given execute permission by typing `chmod +x nrfutil` or by checking the checkbox in the file properties.
-
-        * The latest version of the :ref:`requirements_clt` package.
-          Check :ref:`operating system versions that support this tool <additional_nordic_sw_tools>` and `download the installer <nRF Command Line Tools Downloads_>`_.
-
-         .. note::
-               After downloading and installing the tools, add nrfjprog to the system :envvar:`PATH` in the environment variables.
-
-        * The |jlink_ver| of SEGGER J-Link.
-          Download it from the `J-Link Software and Documentation Pack`_ page.
-          On Windows, `install it manually together with SEGGER USB Driver for J-Link <nRF Util prerequisites_>`_.
-
-      * Additionally, for Windows users: SEGGER USB Driver for J-Link, required for support of older Nordic Semiconductor devices in nRF Util.
-        For information on how to install the USB Driver, see the `nRF Util prerequisites`_ documentation.
-      * Additionally, for Linux users: the `nrf-udev`_ module with udev rules required to access USB ports on Nordic Semiconductor devices and program the firmware.
+      .. include:: /includes/install_sdk_common_prerequisites.txt
 
 .. _gs_installing_toolchain:
 .. _gs_installing_tools:

--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -285,7 +285,7 @@ J-Link Software and Documentation Pack
 SEGGER's `J-Link Software and Documentation Pack`_ is a package of tools that is required for SEGGER J-Link to work correctly with both Intel and ARM assemblies.
 Among others, this package includes the J-Link RTT Viewer, which can be used for :ref:`test_and_optimize`.
 
-For the SEGGER J-Link version to use with your preferred development environment, see the :ref:`installing_vsc` section on the |NCS| installation page.
+Use the J-Link |jlink_ver| when working with the |NCS|, as also listed in the :ref:`installing_vsc` section on the |NCS| installation page.
 
 On Windows, you also need to install SEGGER USB Driver for J-Link, which is required for support of older Nordic Semiconductor devices in :ref:`requirements_nrf_util`.
 For information on how to install the USB Driver, see the `nRF Util prerequisites`_ documentation.
@@ -413,8 +413,13 @@ Its functionality is provided through installable and upgradeable commands that 
 The utility follows its own release cycle and has its own `operating system requirements <nRF Util_>`_.
 Use the latest available release for development.
 
-nRF Util provides |NCS| toolchain packages for each |NCS| release through the ``toolchain-manager`` command.
-See the :ref:`install_ncs` page for information about how to use this command.
+When you :ref:`install the nRF Connect SDK <install_ncs>`, you need to install the following nRF Util commands:
+
+* `Device command <Device command overview_>`_ (``device``) - The latest version is required as the default :ref:`west runner <programming_selecting_runner>`.
+* `Toolchain Manager command`_ (``toolchain-manager``) - The latest version is required for working with |NCS| toolchain packages.
+  You only need to install this command if you are working with command line in the |NCS|.
+
+See `Installing and upgrading nRF Util commands`_ for information about how to install these commands.
 
 .. _requirements_ncd:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -36,7 +36,8 @@ IDE, OS, and tool support
 * Updated:
 
   * The required `SEGGER J-Link`_ version to v8.18.
-  * The :ref:`installing_vsc` section on the :ref:`installation` page with the Windows-only requirement to install SEGGER USB Driver for J-Link.
+  * The :ref:`installing_vsc` section on the :ref:`installation` page with a list valid for both development environments.
+    The list now includes nRF Util as an additional requirement for :ref:`west runner <programming_selecting_runner>` for the |nRFVSC|, and the Windows-only requirement to install SEGGER USB Driver for J-Link for both development environments.
 
 Board support
 =============

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -7,7 +7,6 @@
 .. |release_number_tt| replace:: ``2.9.0-nRF54H20-1-rc3``
 
 .. |jlink_ver| replace:: v8.18
-.. |jlink_ver_vsc| replace:: v7.94i
 
 .. ### Config shortcuts
 


### PR DESCRIPTION
Moved the common prerequisites for installing the SDK to a separate file and removed the VSC-specific J-Link version shortcut. VSC-2894.