### PR TITLE
samples: Add nRF2220EK support for RT and DTM samples

### DIFF
--- a/doc/nrf/includes/sample_dtm_radio_test_fem.txt
+++ b/doc/nrf/includes/sample_dtm_radio_test_fem.txt
@@ -1,9 +1,10 @@
-You can add support for the nRF21540 front-end module (FEM) to the sample.
+You can add support for the nRF21540 or nRF2220 front-end module (FEM) to the sample.
 
-To add support for the nRF21540 FEM, build the sample for a board containing nRF21540 FEM like :ref:`nrf21540dk/nrf52840 <zephyr:nrf21540dk_nrf52840>` or create a devicetree overlay file describing how FEM is connected to nRF5 SoC in your device.
+To add support for the FEM, build the sample for a board containing FEM like :ref:`nRF21540 DK/nRF52840 <zephyr:nrf21540dk_nrf52840>` or create a devicetree overlay file describing how FEM is connected to the nRF52 Series SoC in your device.
 
 .. note::
    If you use the nRF21540 EK, append ``nrf21540ek`` shield to your build command instructing build system to append the appropriate devicetree overlay file.
+   If you use the nRF2220 EK, append the ``nrf2220ek`` shield to your build command instructing the build system to append the appropriate devicetree overlay file.
    If you use the nRF21540 DK, build your application for the :ref:`nrf21540dk/nrf52840 <zephyr:nrf21540dk_nrf52840>` board target.
    The devicetree for the nRF21540 DK already contains the required FEM configuration, so you do not need to set an additional build option.
 
@@ -19,3 +20,4 @@ For more details refer to the following documentation:
 * :ref:`ug_radio_fem_direct_support`
 * :ref:`ug_radio_fem_nrf21540_spi_gpio`
 * :ref:`ug_radio_fem_nrf21540ek`
+* :ref:`ug_radio_fem_nrf2220ek`

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -426,7 +426,10 @@ Bluetooth samples
 
 * :ref:`direct_test_mode` sample:
 
-  * Added loading of radio trims and a fix of a hardware errata for the nRF54H20 SoC to improve the RF performance.
+  * Added:
+
+    * Loading of radio trims and a fix of a hardware errata for the nRF54H20 SoC to improve the RF performance.
+    * Support for the :ref:`nRF2220 front-end module <ug_radio_fem_nrf2220ek>`.
 
 * :ref:`central_uart` sample:
 
@@ -635,7 +638,10 @@ Peripheral samples
 
 * :ref:`radio_test` sample:
 
-  * Added loading of radio trims and a fix of a hardware errata for the nRF54H20 SoC to improve the RF performance.
+  * Added:
+
+    * Loading of radio trims and a fix of a hardware errata for the nRF54H20 SoC to improve the RF performance.
+    * Support for the :ref:`nRF2220 front-end module <ug_radio_fem_nrf2220ek>`.
 
 PMIC samples
 ------------

--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -250,12 +250,15 @@ The following table presents the patterns that you can use to switch antennas on
 | RFU    | 15 (0b1111)  |
 +--------+--------------+
 
-nRF21540 front-end module
-=========================
+Front-end module
+================
 
 .. include:: /includes/sample_dtm_radio_test_fem.txt
 
-You can configure the transmitted power gain, antenna output and activation delay in nRF21540 using vendor-specific commands, see `Vendor-specific packet payload`_.
+You can configure the transmitted power gain, antenna output, and activation delay in FEMs using vendor-specific commands, see `Vendor-specific packet payload`_.
+
+.. note::
+   Each front-end module (FEM) has different capabilities and operating modes, so some commands may not be supported by a specific FEM and those supported may work differently on different FEMs.
 
 Skyworks front-end module
 =========================

--- a/samples/bluetooth/direct_test_mode/sample.yaml
+++ b/samples/bluetooth/direct_test_mode/sample.yaml
@@ -104,3 +104,30 @@ tests:
       - bluetooth
       - ci_build
       - sysbuild
+  sample.bluetooth.direct_test_mode.nrf2220:
+    sysbuild: true
+    build_only: true
+    extra_args: SHIELD=nrf2220ek
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpunet
+      - nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
+  sample.bluetooth.direct_test_mode.nrf5340_nrf2220_usb:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - SHIELD=nrf2220ek
+      - FILE_SUFFIX=usb
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpunet
+    platform_allow: nrf5340dk/nrf5340/cpunet
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -38,12 +38,15 @@ The sample also requires one of the following testing devices:
    You can perform the radio test also using a spectrum analyzer.
    This method of testing is not covered by this documentation.
 
-nRF21540 front-end module
-=========================
+Front-end module
+================
 
 .. include:: /includes/sample_dtm_radio_test_fem.txt
 
-You can configure the nRF21540 front-end module (FEM) transmitted power control, antenna output and activation delay using the main shell commands of the :ref:`radio_test_ui`.
+You can configure the front-end module (FEM) transmitted power control, antenna output, and activation delay using the main shell commands of the :ref:`radio_test_ui`.
+
+.. note::
+   Each front-end module (FEM) has different capabilities and operating modes, so some commands may not be supported by a specific FEM and those supported may work differently on different FEMs.
 
 Skyworks front-end module
 =========================

--- a/samples/peripheral/radio_test/sample.yaml
+++ b/samples/peripheral/radio_test/sample.yaml
@@ -75,3 +75,30 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_peripheral_radio_test
+  sample.peripheral.radio_test.nrf2220:
+    sysbuild: true
+    build_only: true
+    extra_args: SHIELD=nrf2220ek
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpunet
+      - nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_peripheral_radio_test
+  sample.peripheral.radio_test.nrf5340_nrf2220_usb:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - SHIELD=nrf2220ek
+      - FILE_SUFFIX=usb
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpunet
+    platform_allow: nrf5340dk/nrf5340/cpunet
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_peripheral_radio_test


### PR DESCRIPTION
Add nRF2220EK support for:
- direct_test_mode
- radio_test samples.

Jira: NCSDK-31910