### PR TITLE
ci: compliance action: lock setuptools becuase of failed install

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -27,8 +27,8 @@ jobs:
       working-directory: ncs/nrf
       run: |
         pip3 install -U pip
-        pip3 install -U setuptools
         pip3 install -U wheel
+        grep -E "^setuptools" scripts/requirements-fixed.txt | cut -d ' ' -f '1' | xargs pip3 install -U
         grep -E "^python-magic=|^junitparser|^lxml|^gitlint|^pylint|^pykwalify|^yamllint|^unidiff" scripts/requirements-fixed.txt | cut -d ' ' -f '1' | xargs pip3 install -U
         grep -E "^west" scripts/requirements-fixed.txt | cut -d ' ' -f '1' | xargs pip3 install -U
         pip3 show -f west


### PR DESCRIPTION
setuptools 77.0 release on March19 caused some packages to fail to install

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>
