### PR TITLE
scripts: hid_configurator: Update TYPE2BOARDLIST

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -931,7 +931,12 @@ Scripts
 
 This section provides detailed lists of changes by :ref:`script <scripts>`.
 
-|no_changes_yet_note|
+* :ref:`nrf_desktop_config_channel_script`:
+
+  * Removed HID device type mapping for Development Kits.
+    A Development Kit may use various HID roles (depending on configuration).
+    Assigning a fixed type per board may be misleading.
+    HID device type is still defined for boards that are always configured as the same HID device type.
 
 Integrations
 ============

--- a/scripts/hid_configurator/NrfHidManager.py
+++ b/scripts/hid_configurator/NrfHidManager.py
@@ -9,8 +9,8 @@ NORDIC_VID = 0x1915
 
 class NrfHidManager():
     TYPE2BOARDLIST = {
-        'gaming_mouse' : ['nrf52840gmouse', 'nrf52840dk', 'nrf54l15dk', 'nrf54h20dk'],
-        'dongle' : ['nrf52840dongle', 'nrf52833dongle', 'nrf52820dongle', 'nrf5340dk'],
+        'gaming_mouse' : ['nrf52840gmouse'],
+        'dongle' : ['nrf52840dongle', 'nrf52833dongle', 'nrf52820dongle'],
         'keyboard' : ['nrf52kbd'],
         'desktop_mouse' : ['nrf52dmouse', 'nrf52810dmouse'],
     }


### PR DESCRIPTION
Remove HID device type mapping for DKs. A DK may use various HID roles (depending on configuration). Assigning a fixed type per board may be misleading.

Jira: NCSDK-29958