### PR TITLE
applications: sdp: mspi: extend MSPI API with reset functions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -346,6 +346,7 @@
 /include/drivers/flash/flash_ipuc.h       @nrfconnect/ncs-co-drivers @nrfconnect/ncs-charon
 /include/drivers/gpio/                    @nrfconnect/ncs-co-drivers @nrfconnect/ncs-ll-ursus
 /include/drivers/bme68x_iaq.h             @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
+/include/drivers/mspi/nrf_mspi.h          @nrfconnect/ncs-co-drivers @nrfconnect/ncs-ll-ursus
 /include/drivers/mspi/nrfe_mspi.h         @nrfconnect/ncs-co-drivers @nrfconnect/ncs-ll-ursus
 /include/drivers/sensor_sim.h             @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia
 /include/drivers/sensor_stub.h            @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia

--- a/applications/sdp/mspi/src/hrt/hrt-nrf54l15.s
+++ b/applications/sdp/mspi/src/hrt/hrt-nrf54l15.s
@@ -400,150 +400,153 @@ hrt_read:
 	mv	s0,a0
 	div	s1,s1,a5
 	lbu	a5,83(a0)
-	lbu	a4,83(a0)
-	lw	t0,64(a0)
-	lbu	t1,88(a0)
+	lbu	a3,83(a0)
+	lw	t1,64(a0)
+	lbu	a2,88(a0)
 	lw	a1,60(a0)
-	lbu	a3,89(a0)
-	lbu	a2,87(a0)
+	lbu	a4,89(a0)
+	lbu	a0,87(a0)
 	andi	a5,a5,0xff
-	andi	a4,a4,0xff
-	andi	t1,t1,0xff
+	andi	a3,a3,0xff
+	andi	a2,a2,0xff
 	addi	s1,s1,-1
 	andi	s1,s1,0xff
-	bne	a3,zero,.L46
-	li	a3,1
-	sll	a3,a3,a2
-	slli	a3,a3,16
-	srli	a3,a3,16
+	bne	a4,zero,.L46
+	li	a4,1
+	sll	a4,a4,a0
+	slli	a4,a4,16
+	srli	a4,a4,16
  #APP
-	csrc 3008, a3
+	csrc 3008, a4
  #NO_APP
 .L47:
 	sw	a1,20(sp)
-	sw	t1,16(sp)
-	sw	t0,12(sp)
-	sw	a4,8(sp)
+	sw	a2,16(sp)
+	sw	t1,12(sp)
+	sw	a3,8(sp)
 	sw	a5,4(sp)
  #APP
-	csrr a5, 3008
+	csrr a4, 3008
  #NO_APP
-	li	a3,1
+	slli	a4,a4,16
+	li	t0,1
+	srli	a4,a4,16
 	sw	zero,64(s0)
-	sb	a3,88(s0)
+	srli	a5,a4,1
+	sb	t0,88(s0)
 	mv	a0,s0
 	sw	a5,0(sp)
 	call	hrt_write
-	lw	t0,12(sp)
-	lw	t1,16(sp)
-	li	a3,1
-	sw	t0,64(s0)
-	sb	t1,88(s0)
-	lbu	a0,83(s0)
+	lw	t1,12(sp)
+	lw	a2,16(sp)
+	li	t0,1
+	sw	t1,64(s0)
+	sb	a2,88(s0)
+	lbu	a2,83(s0)
 	lw	a5,4(sp)
-	lw	a4,8(sp)
+	lw	a3,8(sp)
 	lw	a1,20(sp)
-	bne	a0,a3,.L48
-	lhu	a3,90(s0)
-	slli	a3,a3,16
-	srli	a3,a3,16
-	andi	a3,a3,-5
-	slli	a3,a3,16
-	srli	a3,a3,16
-	sh	a3,90(s0)
-	lhu	a3,90(s0)
+	bne	a2,t0,.L48
+	lhu	a2,90(s0)
+	slli	a2,a2,16
+	srli	a2,a2,16
+	andi	a2,a2,-5
+	slli	a2,a2,16
+	srli	a2,a2,16
+	sh	a2,90(s0)
+	lhu	a2,90(s0)
 .L76:
  #APP
-	csrw 3009, a3
+	csrw 3009, a2
 	csrw 3011, 2
  #NO_APP
-	li	a3,2031616
-	slli	a4,a4,16
-	and	a4,a4,a3
-	ori	a3,a4,4
+	li	a2,2031616
+	slli	a3,a3,16
+	and	a3,a3,a2
+	ori	a2,a3,4
  #APP
-	csrw 3043, a3
+	csrw 3043, a2
 	csrw 3022, 1
 	csrw 2000, 2
 	csrw 2001, 2
  #NO_APP
-	lhu	a3,84(s0)
-	slli	a3,a3,16
-	srli	a3,a3,16
+	lhu	a2,84(s0)
+	slli	a2,a2,16
+	srli	a2,a2,16
  #APP
 	csrr a0, 2003
  #NO_APP
 	li	t1,-65536
 	and	a0,a0,t1
-	or	a3,a3,a0
+	or	a2,a2,a0
  #APP
-	csrw 2003, a3
+	csrw 2003, a2
  #NO_APP
-	lhu	a3,84(s0)
-	slli	a3,a3,16
-	srli	a3,a3,16
+	lhu	a2,84(s0)
+	slli	a2,a2,16
+	srli	a2,a2,16
  #APP
 	csrr a0, 2003
  #NO_APP
-	slli	a3,a3,1
+	slli	a2,a2,1
 	slli	a0,a0,16
-	addi	a3,a3,1
+	addi	a2,a2,1
 	srli	a0,a0,16
-	slli	a3,a3,16
-	or	a3,a3,a0
+	slli	a2,a2,16
+	or	a2,a2,a0
  #APP
-	csrw 2003, a3
+	csrw 2003, a2
  #NO_APP
-	li	a3,126976
+	li	a2,126976
 	slli	a5,a5,12
-	and	a5,a5,a3
+	and	a5,a5,a2
 	li	a0,2097152
-	andi	a3,s1,63
-	or	a3,a3,a5
+	andi	a2,s1,63
+	or	a2,a2,a5
 	addi	a0,a0,1024
-	or	a3,a3,a0
+	or	a2,a2,a0
  #APP
-	csrw 3019, a3
+	csrw 3019, a2
 	csrw 3017, 0
  #NO_APP
 	lw	a0,64(s0)
-	li	a3,1
-	beq	a0,a3,.L50
+	li	a2,1
+	beq	a0,a2,.L50
 .L52:
 	li	t1,2097152
 	addi	a0,a1,-4
-	li	a2,1
+	li	a4,1
 	li	a1,0
 	li	t0,32
 	addi	t1,t1,1024
 	li	t2,65536
 .L51:
-	lw	a3,64(s0)
-	bgtu	a3,a1,.L64
+	lw	a2,64(s0)
+	bgtu	a2,a1,.L64
 .L65:
  #APP
-	csrr a3, 3021
+	csrr a2, 3021
  #NO_APP
-	andi	a3,a3,0xff
-	bne	a3,zero,.L65
+	andi	a2,a2,0xff
+	bne	a2,zero,.L65
  #APP
-	csrr a3, 2005
+	csrr a2, 2005
  #NO_APP
-	slli	a3,a3,16
-	srli	a3,a3,16
+	slli	a2,a2,16
+	srli	a2,a2,16
 .L66:
  #APP
 	csrr a0, 2005
  #NO_APP
-	mv	a1,a3
-	slli	a3,a0,16
-	srli	a3,a3,16
-	bne	a3,a1,.L66
-	lw	a3,0(sp)
-	slli	a2,a3,24
+	mv	a1,a2
+	slli	a2,a0,16
+	srli	a2,a2,16
+	bne	a2,a1,.L66
+	lw	a4,0(sp)
+	slli	a4,a4,24
  #APP
-	csrw 3017, a2
-	csrw 3043, a4
+	csrw 3017, a4
+	csrw 3043, a3
 	csrr a4, 3018
  #NO_APP
 	lbu	a2,68(s0)
@@ -555,51 +558,51 @@ hrt_read:
 	sw	a4,72(s0)
 	j	.L56
 .L46:
-	li	a3,1
-	sll	a3,a3,a2
-	slli	a3,a3,16
-	srli	a3,a3,16
+	li	a4,1
+	sll	a4,a4,a0
+	slli	a4,a4,16
+	srli	a4,a4,16
  #APP
-	csrs 3008, a3
+	csrs 3008, a4
  #NO_APP
 	j	.L47
 .L48:
-	lhu	a3,92(s0)
+	lhu	a2,92(s0)
 	j	.L76
 .L50:
 	lbu	a0,68(s0)
-	li	a3,2
-	bne	a0,a3,.L52
-	lhu	a3,84(s0)
+	li	a2,2
+	bne	a0,a2,.L52
+	lhu	a2,84(s0)
 	li	a1,65536
-	add	a3,a3,a1
+	add	a2,a2,a1
  #APP
-	csrw 2002, a3
+	csrw 2002, a2
  #NO_APP
 .L53:
  #APP
-	csrr a3, 3021
+	csrr a2, 3021
  #NO_APP
-	andi	a3,a3,0xff
-	bne	a3,zero,.L53
+	andi	a2,a2,0xff
+	bne	a2,zero,.L53
  #APP
-	csrr a3, 2005
+	csrr a2, 2005
  #NO_APP
-	slli	a3,a3,16
-	srli	a3,a3,16
+	slli	a2,a2,16
+	srli	a2,a2,16
 .L54:
  #APP
 	csrr a0, 2005
  #NO_APP
-	mv	a1,a3
-	slli	a3,a0,16
-	srli	a3,a3,16
-	bne	a3,a1,.L54
-	lw	a3,0(sp)
-	slli	a2,a3,24
+	mv	a1,a2
+	slli	a2,a0,16
+	srli	a2,a2,16
+	bne	a2,a1,.L54
+	lw	a4,0(sp)
+	slli	a4,a4,24
  #APP
-	csrw 3017, a2
-	csrw 3043, a4
+	csrw 3017, a4
+	csrw 3043, a3
  #NO_APP
 	lbu	a3,83(s0)
 	li	a4,8
@@ -661,11 +664,11 @@ hrt_read:
 	sb	a4,0(a3)
 	j	.L56
 .L64:
-	lw	a3,64(s0)
-	sub	a3,a3,a1
-	beq	a3,a2,.L58
+	lw	a2,64(s0)
+	sub	a2,a2,a1
+	beq	a2,a4,.L58
 	li	s1,2
-	beq	a3,s1,.L59
+	beq	a2,s1,.L59
 	lbu	s1,83(s0)
 	div	s1,t0,s1
 	j	.L77
@@ -675,19 +678,19 @@ hrt_read:
 	addi	s1,s1,-1
 	andi	s1,s1,0xff
 	bne	a1,zero,.L62
-	addi	a3,s1,-2
-	andi	s1,a3,0xff
-	andi	a3,a3,63
-	or	a3,a3,a5
-	or	a3,a3,t1
+	addi	a2,s1,-2
+	andi	s1,a2,0xff
+	andi	a2,a2,63
+	or	a2,a2,a5
+	or	a2,a2,t1
  #APP
-	csrw 3019, a3
+	csrw 3019, a2
  #NO_APP
-	lhu	a3,84(s0)
-	add	a3,a3,t2
+	lhu	a2,84(s0)
+	add	a2,a2,t2
  #APP
-	csrw 2002, a3
-	csrr a3, 3018
+	csrw 2002, a2
+	csrr a2, 3018
  #NO_APP
 .L63:
 	addi	a1,a1,1
@@ -697,14 +700,14 @@ hrt_read:
 	lbu	s1,69(s0)
 	j	.L77
 .L62:
-	andi	a3,s1,63
-	or	a3,a3,a5
-	or	a3,a3,t1
+	andi	a2,s1,63
+	or	a2,a2,a5
+	or	a2,a2,t1
  #APP
-	csrw 3019, a3
-	csrr a3, 3018
+	csrw 3019, a2
+	csrr a2, 3018
  #NO_APP
-	sw	a3,0(a0)
+	sw	a2,0(a0)
 	j	.L63
 .L68:
 	li	a5,1

--- a/applications/sdp/mspi/src/hrt/hrt.c
+++ b/applications/sdp/mspi/src/hrt/hrt.c
@@ -263,7 +263,7 @@ void hrt_read(volatile hrt_xfer_t *hrt_xfer_params)
 	}
 
 	/* Get state of all VIO to reset it correctly after transfer. */
-	prev_out = nrf_vpr_csr_vio_out_get();
+	prev_out = nrf_vpr_csr_vio_out_get() >> 1;
 
 	/* Write only command address and dummy cycles and keep CS active. */
 	hrt_xfer_params->xfer_data[HRT_FE_DATA].word_count = 0;

--- a/applications/sdp/mspi/src/main.c
+++ b/applications/sdp/mspi/src/main.c
@@ -423,8 +423,9 @@ static void ep_recv(const void *data, size_t len, void *priv)
 
 	(void)priv;
 	(void)len;
-	uint8_t opcode = *(uint8_t *)data;
+	uint32_t opcode = *(uint32_t *)data;
 	uint32_t num_bytes = 0;
+	uint32_t *resp_buff = (uint32_t *)response_buffer;
 
 #if defined(CONFIG_SDP_MSPI_FAULT_TIMER)
 	if (fault_timer != NULL) {
@@ -483,7 +484,8 @@ static void ep_recv(const void *data, size_t len, void *priv)
 		}
 
 		/* If there is reset defined on any data line, assume it is no longer valid and
-		 * clear it. */
+		 * clear it.
+		 */
 		if (dev_config->dev_config.io_mode != MSPI_IO_MODE_SINGLE &&
 		    reset_configs[dev_config->device_index].pin_number != PIN_UNUSED) {
 			nrf_vpr_csr_vio_out_clear_set(
@@ -545,7 +547,7 @@ static void ep_recv(const void *data, size_t len, void *priv)
 		break;
 	}
 
-	response_buffer[0] = opcode;
+	resp_buff[0] = opcode;
 	ipc_service_send(&ep, (const void *)response_buffer,
 			 sizeof(nrfe_mspi_opcode_t) + num_bytes);
 

--- a/drivers/mspi/mspi_nrfe.c
+++ b/drivers/mspi/mspi_nrfe.c
@@ -1063,13 +1063,12 @@ static int nrfe_mspi_init(const struct device *dev)
 }
 
 static const struct nrf_mspi_driver_api drv_api = {
-	.std_api =
-		{
-			.config = api_config,
-			.dev_config = api_dev_config,
-			.get_channel_status = api_get_channel_status,
-			.transceive = api_transceive,
-		},
+	.std_api = {
+		.config = api_config,
+		.dev_config = api_dev_config,
+		.get_channel_status = api_get_channel_status,
+		.transceive = api_transceive,
+	},
 	.reset_pin_config = api_reset_config,
 	.reset_pin_set = api_reset_set,
 };

--- a/include/drivers/mspi/nrf_mspi.h
+++ b/include/drivers/mspi/nrf_mspi.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MSPI_NRF_MSPI_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MSPI_NRF_MSPI_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/mspi.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int (*mspi_api_reset_pin_config)(const struct device *dev, const struct mspi_dev_id *dev_id,
+					 const struct gpio_dt_spec *spec, uint8_t gpio_port_num,
+					 gpio_flags_t extra_flags);
+typedef int (*mspi_api_reset_pin_set)(const struct device *dev, const struct gpio_dt_spec *spec,
+				      const struct mspi_dev_id *dev_id, int value);
+
+__subsystem struct nrf_mspi_driver_api {
+	struct mspi_driver_api std_api;
+
+	mspi_api_reset_pin_config reset_pin_config;
+	mspi_api_reset_pin_set reset_pin_set;
+};
+
+/**
+ * @brief Configure reset pin. It is mandatory when reset pin overlaps with any data pin.
+ *
+ * @param dev pointer to the mspi device structure.
+ * @param psel pin number
+ *
+ * @retval non-negative the observed state of the on-off service associated
+ *                      with the clock machine at the time the request was
+ *                      processed (see onoff_release()), if successful.
+ * @retval -EIO if service has recorded an error.
+ * @retval -ENOTSUP if the service is not in a state that permits release.
+ */
+static inline int nrf_mspi_reset_pin_config(const struct device *dev,
+					    const struct mspi_dev_id *dev_id,
+					    const struct gpio_dt_spec *spec, uint8_t gpio_port_num,
+					    gpio_flags_t extra_flags)
+{
+	const struct nrf_mspi_driver_api *api = (const struct nrf_mspi_driver_api *)dev->api;
+
+	return api->reset_pin_config(dev, dev_id, spec, gpio_port_num, extra_flags);
+}
+
+/**
+ * @brief Set reset pin state.
+ *
+ * @param dev pointer to the mspi device structure.
+ * @param psel pin number
+ *
+ * @retval non-negative the observed state of the on-off service associated
+ *                      with the clock machine at the time the request was
+ *                      processed (see onoff_release()), if successful.
+ * @retval -EIO if service has recorded an error.
+ * @retval -ENOTSUP if the service is not in a state that permits release.
+ */
+static inline int nrf_mspi_reset_pin_set(const struct device *dev, const struct gpio_dt_spec *spec,
+					 const struct mspi_dev_id *dev_id, int value)
+{
+	const struct nrf_mspi_driver_api *api = (const struct nrf_mspi_driver_api *)dev->api;
+
+	return api->reset_pin_set(dev, spec, dev_id, value);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MSPI_NRF_MSPI_H_ */

--- a/include/drivers/mspi/nrf_mspi.h
+++ b/include/drivers/mspi/nrf_mspi.h
@@ -28,16 +28,25 @@ __subsystem struct nrf_mspi_driver_api {
 };
 
 /**
- * @brief Configure reset pin. It is mandatory when reset pin overlaps with any data pin.
+ * @brief Configure reset pin. It should be used if there is a chance that reset pin overlaps with
+ * any data pin.
  *
- * @param dev pointer to the mspi device structure.
- * @param psel pin number
+ * Function checks if given reset pin overlap with any pin used by MSPI. If it does and can be used
+ * as reset in SINGLE mode (for example, ovelaps with data line DQ3), then it is saved in MSPI
+ * driver. If it does not overlap, then gpio_pin_configure_dt() is called.
  *
- * @retval non-negative the observed state of the on-off service associated
- *                      with the clock machine at the time the request was
- *                      processed (see onoff_release()), if successful.
- * @retval -EIO if service has recorded an error.
- * @retval -ENOTSUP if the service is not in a state that permits release.
+ * @param dev Pointer to the MSPI device structure.
+ * @param dev_id Pointer to the device ID of the MSPI device.
+ * @param spec GPIO specification from devicetree.
+ * @param gpio_port_num GPIO port number of the selected reset pin.
+ * @param extra_flags Additional GPIO flags.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOTSUP Return value from gpio_pin_configure_dt().
+ * @retval -EINVAL If reset pin overlaps with MSPI pin that cannot be used as reset (e.g. CLK) or a
+ * return value from gpio_pin_configure_dt().
+ * @retval -EIO Return value from gpio_pin_configure_dt().
+ * @retval -EWOULDBLOCK Return value from gpio_pin_configure_dt().
  */
 static inline int nrf_mspi_reset_pin_config(const struct device *dev,
 					    const struct mspi_dev_id *dev_id,
@@ -50,16 +59,20 @@ static inline int nrf_mspi_reset_pin_config(const struct device *dev,
 }
 
 /**
- * @brief Set reset pin state.
+ * @brief Set reset pin state. It should be used if there is a chance that reset pin overlaps with
+ * any data pin.
  *
- * @param dev pointer to the mspi device structure.
- * @param psel pin number
+ * If reset pin does not overlap with any MSPI pin, gpio_pin_set_dt() is called.
+ * Assumes that nrf_mspi_reset_pin_config() was called before.
  *
- * @retval non-negative the observed state of the on-off service associated
- *                      with the clock machine at the time the request was
- *                      processed (see onoff_release()), if successful.
- * @retval -EIO if service has recorded an error.
- * @retval -ENOTSUP if the service is not in a state that permits release.
+ * @param dev Pointer to the MSPI device structure.
+ * @param spec GPIO specification from devicetree.
+ * @param dev_id Pointer to the device ID of the MSPI device.
+ * @param value Value assigned to the pin.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO Return value from gpio_pin_set_dt().
+ * @retval -EWOULDBLOCK Return value from gpio_pin_set_dt().
  */
 static inline int nrf_mspi_reset_pin_set(const struct device *dev, const struct gpio_dt_spec *spec,
 					 const struct mspi_dev_id *dev_id, int value)

--- a/include/drivers/mspi/nrfe_mspi.h
+++ b/include/drivers/mspi/nrfe_mspi.h
@@ -7,8 +7,8 @@
 #ifndef DRIVERS_MSPI_NRFE_MSPI_H
 #define DRIVERS_MSPI_NRFE_MSPI_H
 
+#include <drivers/mspi/nrf_mspi.h>
 #include <zephyr/drivers/pinctrl.h>
-#include <zephyr/drivers/mspi.h>
 #include <hal/nrf_timer.h>
 
 #ifdef __cplusplus
@@ -25,10 +25,12 @@ extern "C" {
 typedef enum {
 	NRFE_MSPI_EP_BOUNDED = 0,
 	NRFE_MSPI_CONFIG_TIMER_PTR, /* nrfe_mspi_flpr_timer_msg_t */
-	NRFE_MSPI_CONFIG_PINS,      /* nrfe_mspi_pinctrl_soc_pin_msg_t */
-	NRFE_MSPI_CONFIG_DEV,       /* nrfe_mspi_dev_config_msg_t */
-	NRFE_MSPI_CONFIG_XFER,      /* nrfe_mspi_xfer_config_msg_t */
-	NRFE_MSPI_TX,	            /* nrfe_mspi_xfer_packet_msg_t + data buffer at the end */
+	NRFE_MSPI_CONFIG_PINS,	    /* nrfe_mspi_pinctrl_soc_pin_msg_t */
+	NRFE_MSPI_CONFIG_RESET,	    /* nrfe_mspi_reset_config_msg_t */
+	NRFE_MSPI_SET_RESET,	    /* nrfe_mspi_reset_set_msg_t */
+	NRFE_MSPI_CONFIG_DEV,	    /* nrfe_mspi_dev_config_msg_t */
+	NRFE_MSPI_CONFIG_XFER,	    /* nrfe_mspi_xfer_config_msg_t */
+	NRFE_MSPI_TX,		    /* nrfe_mspi_xfer_packet_msg_t + data buffer at the end */
 	NRFE_MSPI_TXRX,
 	NRFE_MSPI_SDP_APP_HARD_FAULT,
 	NRFE_MSPI_WRONG_OPCODE,
@@ -36,6 +38,11 @@ typedef enum {
 	/* This is to make sizeof(nrfe_mspi_opcode_t)==32bit, for alignment purpouse. */
 	NREE_MSPI_OPCODES_MAX = 0xFFFFFFFFU,
 } nrfe_mspi_opcode_t;
+
+typedef struct {
+	uint8_t pin_number;
+	bool inversed;
+} nrfe_mspi_reset_config_t;
 
 typedef struct {
 	enum mspi_io_mode io_mode;
@@ -64,6 +71,18 @@ typedef struct {
 	uint8_t pins_count;
 	pinctrl_soc_pin_t pin[NRFE_MSPI_PINS_MAX];
 } nrfe_mspi_pinctrl_soc_pin_msg_t;
+
+typedef struct {
+	nrfe_mspi_opcode_t opcode; /* NRFE_MSPI_CONFIG_RESET */
+	uint8_t device_index;
+	nrfe_mspi_reset_config_t reset_config;
+} nrfe_mspi_reset_config_msg_t;
+
+typedef struct {
+	nrfe_mspi_opcode_t opcode; /* NRFE_MSPI_SET_RESET */
+	uint8_t device_index;
+	int value;
+} nrfe_mspi_reset_set_msg_t;
 
 typedef struct {
 	nrfe_mspi_opcode_t opcode; /* NRFE_MSPI_CONFIG_DEV */


### PR DESCRIPTION
Extend MSPI API with custom functions handling reset pins.

~Needs changes from ~#20870 (https://github.com/nrfconnect/sdk-nrf/pull/20870/commits/d033f9023ced4f189d1ffdb659cf52e75f682da9 commit)~ https://github.com/nrfconnect/sdk-nrf/pull/21205, otherwise stack overflow in ICMsg happens.~ (merged)