### PR TITLE
samples: matter: lock: Support all fields of LockOperation event

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -563,6 +563,7 @@ Matter samples
 * :ref:`matter_lock_sample` sample:
 
   * Removed support for nRF54H20 devices.
+  * Updated the API of ``AppTask``, ``BoltLockManager``, and ``AccessManager`` to provide additional information for the ``LockOperation`` event.
 
 Networking samples
 ------------------

--- a/samples/matter/lock/src/access/access_manager.cpp
+++ b/samples/matter/lock/src/access/access_manager.cpp
@@ -18,8 +18,8 @@ using namespace DoorLockData;
 
 template <CredentialsBits CRED_BIT_MASK>
 void AccessManager<CRED_BIT_MASK>::Init(SetCredentialCallback setCredentialClbk,
-					     ClearCredentialCallback clearCredentialClbk,
-					     ValidateCredentialCallback validateCredentialClbk)
+					ClearCredentialCallback clearCredentialClbk,
+					ValidateCredentialCallback validateCredentialClbk)
 {
 	InitializeAllCredentials();
 	mSetCredentialCallback = setCredentialClbk;
@@ -134,9 +134,8 @@ template <CredentialsBits CRED_BIT_MASK> void AccessManager<CRED_BIT_MASK>::SetR
 {
 	if (mRequirePINForRemoteOperation != require) {
 		mRequirePINForRemoteOperation = require;
-		if (!AccessStorage::Instance().Store(AccessStorage::Type::RequirePIN,
-							  &mRequirePINForRemoteOperation,
-							  sizeof(mRequirePINForRemoteOperation))) {
+		if (!AccessStorage::Instance().Store(AccessStorage::Type::RequirePIN, &mRequirePINForRemoteOperation,
+						     sizeof(mRequirePINForRemoteOperation))) {
 			LOG_ERR("Cannot store RequirePINforRemoteOperation.");
 		}
 	}
@@ -148,4 +147,4 @@ template class AccessManager<DoorLockData::PIN | DoorLockData::RFID>;
 template class AccessManager<DoorLockData::PIN | DoorLockData::RFID | DoorLockData::FINGER>;
 template class AccessManager<DoorLockData::PIN | DoorLockData::RFID | DoorLockData::FINGER | DoorLockData::VEIN>;
 template class AccessManager<DoorLockData::PIN | DoorLockData::RFID | DoorLockData::FINGER | DoorLockData::VEIN |
-				  DoorLockData::FACE>;
+			     DoorLockData::FACE>;

--- a/samples/matter/lock/src/access/access_manager.h
+++ b/samples/matter/lock/src/access/access_manager.h
@@ -13,6 +13,11 @@
 
 template <DoorLockData::CredentialsBits CRED_BIT_MASK> class AccessManager {
 public:
+	struct ValidatePINResult {
+		uint16_t mUserId;
+		LockOpCredentials mCredential;
+	};
+
 	/**
 	 * @brief Signature of the callback fired when the credential is set.
 	 *
@@ -234,9 +239,11 @@ public:
 	 *
 	 * @param pinCode PIN code data.
 	 * @param err specific error code enumeration.
+	 * @param result user and credential data set on success.
 	 * @return true on success, false otherwise.
 	 */
-	bool ValidatePIN(const Optional<chip::ByteSpan> &pinCode, OperationErrorEnum &err);
+	bool ValidatePIN(const Optional<chip::ByteSpan> &pinCode, OperationErrorEnum &err,
+			 Nullable<ValidatePINResult> &result);
 	bool ValidateCustom(CredentialTypeEnum type, chip::MutableByteSpan &secret);
 
 	/**

--- a/samples/matter/lock/src/app_task.h
+++ b/samples/matter/lock/src/app_task.h
@@ -41,6 +41,7 @@ private:
 	static void LockActionEventHandler();
 	static void ButtonEventHandler(Nrf::ButtonState state, Nrf::ButtonMask hasChanged);
 	static void LockStateChanged(const BoltLockManager::StateData &stateData);
+	static void UpdateClusterStateHandler(const BoltLockManager::StateData &stateData);
 
 #ifdef CONFIG_THREAD_WIFI_SWITCHING
 	static void SwitchTransportEventHandler();

--- a/samples/matter/lock/src/app_task.h
+++ b/samples/matter/lock/src/app_task.h
@@ -31,7 +31,7 @@ public:
 
 	CHIP_ERROR StartApp();
 
-	void UpdateClusterState(BoltLockManager::State state, BoltLockManager::OperationSource source);
+	void UpdateClusterState(const BoltLockManager::StateData &stateData);
 	static void IdentifyStartHandler(Identify *);
 	static void IdentifyStopHandler(Identify *);
 
@@ -40,7 +40,7 @@ private:
 
 	static void LockActionEventHandler();
 	static void ButtonEventHandler(Nrf::ButtonState state, Nrf::ButtonMask hasChanged);
-	static void LockStateChanged(BoltLockManager::State state, BoltLockManager::OperationSource source);
+	static void LockStateChanged(const BoltLockManager::StateData &stateData);
 
 #ifdef CONFIG_THREAD_WIFI_SWITCHING
 	static void SwitchTransportEventHandler();

--- a/samples/matter/lock/src/app_task.h
+++ b/samples/matter/lock/src/app_task.h
@@ -54,7 +54,8 @@ private:
 #endif
 
 #ifdef CONFIG_NCS_SAMPLE_MATTER_TEST_EVENT_TRIGGERS
-	constexpr static Nrf::Matter::TestEventTrigger::EventTriggerId kDoorLockJammedEventTriggerId = 0xFFFF'FFFF'3277'4000;
+	constexpr static Nrf::Matter::TestEventTrigger::EventTriggerId kDoorLockJammedEventTriggerId =
+		0xFFFF'FFFF'3277'4000;
 	static CHIP_ERROR DoorLockJammedEventCallback(Nrf::Matter::TestEventTrigger::TriggerValue);
 #endif
 };

--- a/samples/matter/lock/src/bolt_lock_manager.cpp
+++ b/samples/matter/lock/src/bolt_lock_manager.cpp
@@ -96,9 +96,10 @@ DlStatus BoltLockManager::SetHolidaySchedule(uint8_t holidayIndex, DlScheduleSta
 
 #endif /* CONFIG_LOCK_SCHEDULES */
 
-bool BoltLockManager::ValidatePIN(const Optional<ByteSpan> &pinCode, OperationErrorEnum &err)
+bool BoltLockManager::ValidatePIN(const Optional<chip::ByteSpan> &pinCode, OperationErrorEnum &err,
+				  Nullable<ValidatePINResult> &result)
 {
-	return AccessMgr::Instance().ValidatePIN(pinCode, err);
+	return AccessMgr::Instance().ValidatePIN(pinCode, err, result);
 }
 
 void BoltLockManager::SetRequirePIN(bool require)

--- a/samples/matter/lock/src/bolt_lock_manager.cpp
+++ b/samples/matter/lock/src/bolt_lock_manager.cpp
@@ -37,7 +37,7 @@ bool BoltLockManager::SetUser(uint16_t userIndex, FabricIndex creator, FabricInd
 			      size_t totalCredentials)
 {
 	return AccessMgr::Instance().SetUser(userIndex, creator, modifier, userName, uniqueId, userStatus, userType,
-					      credentialRule, credentials, totalCredentials);
+					     credentialRule, credentials, totalCredentials);
 }
 
 bool BoltLockManager::GetCredential(uint16_t credentialIndex, CredentialTypeEnum credentialType,
@@ -50,8 +50,8 @@ bool BoltLockManager::SetCredential(uint16_t credentialIndex, FabricIndex creato
 				    DlCredentialStatus credentialStatus, CredentialTypeEnum credentialType,
 				    const ByteSpan &secret)
 {
-	return AccessMgr::Instance().SetCredential(credentialIndex, creator, modifier, credentialStatus,
-						    credentialType, secret);
+	return AccessMgr::Instance().SetCredential(credentialIndex, creator, modifier, credentialStatus, credentialType,
+						   secret);
 }
 
 #ifdef CONFIG_LOCK_SCHEDULES
@@ -67,7 +67,7 @@ DlStatus BoltLockManager::SetWeekDaySchedule(uint8_t weekdayIndex, uint16_t user
 					     uint8_t endHour, uint8_t endMinute)
 {
 	return AccessMgr::Instance().SetWeekDaySchedule(weekdayIndex, userIndex, status, daysMask, startHour,
-							 startMinute, endHour, endMinute);
+							startMinute, endHour, endMinute);
 }
 
 DlStatus BoltLockManager::GetYearDaySchedule(uint8_t yearDayIndex, uint16_t userIndex,
@@ -91,11 +91,10 @@ DlStatus BoltLockManager::SetHolidaySchedule(uint8_t holidayIndex, DlScheduleSta
 					     uint32_t localEndTime, OperatingModeEnum operatingMode)
 {
 	return AccessMgr::Instance().SetHolidaySchedule(holidayIndex, status, localStartTime, localEndTime,
-							 operatingMode);
+							operatingMode);
 }
 
 #endif /* CONFIG_LOCK_SCHEDULES */
-
 
 bool BoltLockManager::ValidatePIN(const Optional<ByteSpan> &pinCode, OperationErrorEnum &err)
 {

--- a/samples/matter/lock/src/bolt_lock_manager.h
+++ b/samples/matter/lock/src/bolt_lock_manager.h
@@ -40,15 +40,24 @@ public:
 	};
 
 	using OperationSource = chip::app::Clusters::DoorLock::OperationSourceEnum;
-	using StateChangeCallback = void (*)(State, OperationSource);
 	using ValidatePINResult = AccessMgr::ValidatePINResult;
+
+	struct StateData {
+		State mState;
+		OperationSource mSource;
+		Nullable<chip::FabricIndex> mFabricIdx;
+		Nullable<chip::NodeId> mNodeId;
+		Nullable<ValidatePINResult> mValidatePINResult;
+	};
+
+	using StateChangeCallback = void (*)(const StateData &);
 
 	static constexpr uint32_t kActuatorMovementTimeMs = 2000;
 
 	void Init(StateChangeCallback callback);
 
-	State GetState() const { return mState; }
-	bool IsLocked() const { return mState == State::kLockingCompleted; }
+	const StateData &GetState() const { return mStateData; }
+	bool IsLocked() const { return mStateData.mState == State::kLockingCompleted; }
 
 	bool GetUser(uint16_t userIndex, EmberAfPluginDoorLockUserInfo &user);
 	bool SetUser(uint16_t userIndex, chip::FabricIndex creator, chip::FabricIndex modifier,
@@ -80,8 +89,12 @@ public:
 	bool ValidatePIN(const Optional<chip::ByteSpan> &pinCode, OperationErrorEnum &err,
 			 Nullable<ValidatePINResult> &result);
 
-	void Lock(OperationSource source);
-	void Unlock(OperationSource source);
+	void Lock(const OperationSource source, const Nullable<chip::FabricIndex> &fabricIdx = NullNullable,
+		  const Nullable<chip::NodeId> &nodeId = NullNullable,
+		  const Nullable<ValidatePINResult> &validatePINResult = NullNullable);
+	void Unlock(const OperationSource source, const Nullable<chip::FabricIndex> &fabricIdx = NullNullable,
+		    const Nullable<chip::NodeId> &nodeId = NullNullable,
+		    const Nullable<ValidatePINResult> &validatePINResult = NullNullable);
 
 	void SetRequirePIN(bool require);
 	bool GetRequirePIN();
@@ -91,15 +104,15 @@ public:
 private:
 	friend class AppTask;
 
-	void SetState(State state, OperationSource source);
+	void SetState(State state);
+	void SetStateData(const StateData &stateData);
 
 	static void ActuatorTimerEventHandler(k_timer *timer);
 	static void ActuatorAppEventHandler(const BoltLockManagerEvent &event);
 	friend BoltLockManager &BoltLockMgr();
 
-	State mState = State::kLockingCompleted;
+	StateData mStateData = { State::kLockingCompleted, OperationSource::kButton, {}, {}, {} };
 	StateChangeCallback mStateChangeCallback = nullptr;
-	OperationSource mActuatorOperationSource = OperationSource::kButton;
 	k_timer mActuatorTimer = {};
 
 	static BoltLockManager sLock;

--- a/samples/matter/lock/src/bolt_lock_manager.h
+++ b/samples/matter/lock/src/bolt_lock_manager.h
@@ -18,6 +18,8 @@
 struct BoltLockManagerEvent;
 
 class BoltLockManager {
+	using AccessMgr = AccessManager<DoorLockData::PIN>;
+
 public:
 	static constexpr size_t kMaxCredentialLength = 128;
 
@@ -39,6 +41,7 @@ public:
 
 	using OperationSource = chip::app::Clusters::DoorLock::OperationSourceEnum;
 	using StateChangeCallback = void (*)(State, OperationSource);
+	using ValidatePINResult = AccessMgr::ValidatePINResult;
 
 	static constexpr uint32_t kActuatorMovementTimeMs = 2000;
 
@@ -74,7 +77,8 @@ public:
 				    uint32_t localEndTime, OperatingModeEnum operatingMode);
 #endif /* CONFIG_LOCK_SCHEDULES */
 
-	bool ValidatePIN(const Optional<chip::ByteSpan> &pinCode, OperationErrorEnum &err);
+	bool ValidatePIN(const Optional<chip::ByteSpan> &pinCode, OperationErrorEnum &err,
+			 Nullable<ValidatePINResult> &result);
 
 	void Lock(OperationSource source);
 	void Unlock(OperationSource source);
@@ -85,7 +89,6 @@ public:
 	void FactoryReset();
 
 private:
-	using AccessMgr = AccessManager<DoorLockData::PIN>;
 	friend class AppTask;
 
 	void SetState(State state, OperationSource source);

--- a/samples/matter/lock/src/zcl_callbacks.cpp
+++ b/samples/matter/lock/src/zcl_callbacks.cpp
@@ -68,7 +68,7 @@ bool emberAfPluginDoorLockOnDoorLockCommand(EndpointId endpointId, const Nullabl
 
 	/* Handle changing attribute state on command reception */
 	if (success) {
-		BoltLockMgr().Lock(BoltLockManager::OperationSource::kRemote);
+		BoltLockMgr().Lock(BoltLockManager::OperationSource::kRemote, fabricIdx, nodeId, validatePINResult);
 	}
 
 	return success;
@@ -83,7 +83,7 @@ bool emberAfPluginDoorLockOnDoorUnlockCommand(EndpointId endpointId, const Nulla
 
 	/* Handle changing attribute state on command reception */
 	if (success) {
-		BoltLockMgr().Unlock(BoltLockManager::OperationSource::kRemote);
+		BoltLockMgr().Unlock(BoltLockManager::OperationSource::kRemote, fabricIdx, nodeId, validatePINResult);
 	}
 
 	return success;
@@ -124,8 +124,9 @@ void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
 		     "number of holiday schedules");
 #endif /* CONFIG_LOCK_SCHEDULES */
 
-	AppTask::Instance().UpdateClusterState(BoltLockMgr().GetState(),
-					       BoltLockManager::OperationSource::kUnspecified);
+	BoltLockManager::StateData state = BoltLockMgr().GetState();
+	state.mSource = BoltLockManager::OperationSource::kUnspecified;
+	AppTask::Instance().UpdateClusterState(state);
 }
 
 #ifdef CONFIG_LOCK_SCHEDULES

--- a/samples/matter/lock/src/zcl_callbacks.cpp
+++ b/samples/matter/lock/src/zcl_callbacks.cpp
@@ -25,19 +25,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &a
 {
 	VerifyOrReturn(attributePath.mClusterId == DoorLock::Id);
 
-	if (attributePath.mAttributeId == DoorLock::Attributes::LockState::Id) {
-		/* Post events only if current lock state is different than given */
-		switch (*value) {
-		case to_underlying(DlLockState::kLocked):
-			BoltLockMgr().Lock(BoltLockManager::OperationSource::kRemote);
-			break;
-		case to_underlying(DlLockState::kUnlocked):
-			BoltLockMgr().Unlock(BoltLockManager::OperationSource::kRemote);
-			break;
-		default:
-			break;
-		}
-	} else if (attributePath.mAttributeId == DoorLock::Attributes::RequirePINforRemoteOperation::Id) {
+	if (attributePath.mAttributeId == DoorLock::Attributes::RequirePINforRemoteOperation::Id) {
 		BoltLockMgr().SetRequirePIN(*value);
 	}
 }

--- a/samples/matter/lock/src/zcl_callbacks.cpp
+++ b/samples/matter/lock/src/zcl_callbacks.cpp
@@ -63,28 +63,30 @@ bool emberAfPluginDoorLockOnDoorLockCommand(EndpointId endpointId, const Nullabl
 					    const Nullable<chip::NodeId> &nodeId, const Optional<ByteSpan> &pinCode,
 					    OperationErrorEnum &err)
 {
-	bool result = BoltLockMgr().ValidatePIN(pinCode, err);
+	Nullable<BoltLockManager::ValidatePINResult> validatePINResult;
+	bool success = BoltLockMgr().ValidatePIN(pinCode, err, validatePINResult);
 
 	/* Handle changing attribute state on command reception */
-	if (result) {
+	if (success) {
 		BoltLockMgr().Lock(BoltLockManager::OperationSource::kRemote);
 	}
 
-	return result;
+	return success;
 }
 
 bool emberAfPluginDoorLockOnDoorUnlockCommand(EndpointId endpointId, const Nullable<chip::FabricIndex> &fabricIdx,
 					      const Nullable<chip::NodeId> &nodeId, const Optional<ByteSpan> &pinCode,
 					      OperationErrorEnum &err)
 {
-	bool result = BoltLockMgr().ValidatePIN(pinCode, err);
+	Nullable<BoltLockManager::ValidatePINResult> validatePINResult;
+	bool success = BoltLockMgr().ValidatePIN(pinCode, err, validatePINResult);
 
 	/* Handle changing attribute state on command reception */
-	if (result) {
+	if (success) {
 		BoltLockMgr().Unlock(BoltLockManager::OperationSource::kRemote);
 	}
 
-	return result;
+	return success;
 }
 
 void emberAfDoorLockClusterInitCallback(EndpointId endpoint)


### PR DESCRIPTION
* Remove redundant call to `BoltLockManager::[Lock|Unlock]` from
MatterPostAttributeChangeCallback.
* Return `ValidatePINResult` containing user id and credential used for
validation.
* Add support for `UserIndex`, `FabricIndex`, `SourceNode` and
`Credentials` fields.