### PR TITLE
tests: drivers: uart: uart_baudrate_test: keep high freq

### DIFF
--- a/tests/drivers/uart/uart_baudrate_test/testcase.yaml
+++ b/tests/drivers/uart/uart_baudrate_test/testcase.yaml
@@ -16,6 +16,8 @@ tests:
     extra_configs:
       - CONFIG_PM_DEVICE=y
       - CONFIG_PM_DEVICE_RUNTIME=y
+      - CONFIG_CLOCK_CONTROL_NRF2_GLOBAL_HSFLL_REQ_LOW_FREQ=n
+      - CONFIG_NRFS_LOCAL_DOMAIN_DVFS_SCALE_DOWN_AFTER_INIT=n
   drivers.uart.baudrate_test.uart135:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Prevent enabled clock control to scale down freq,
as this affects gpio polling time.