### PR TITLE
applications: serial_lte_modem: Fix asserts when pressing power pin

### DIFF
--- a/lib/modem_slm/modem_slm.c
+++ b/lib/modem_slm/modem_slm.c
@@ -65,7 +65,7 @@ static void gpio_wakeup_wk(struct k_work *work)
 	if (gpio_pin_set(gpio_dev, CONFIG_MODEM_SLM_WAKEUP_PIN, 0) != 0) {
 		LOG_WRN("GPIO set error");
 	}
-	LOG_DBG("Stop wake-up");
+	LOG_INF("Stop wake-up");
 }
 
 static void slm_data_wk(struct k_work *work)
@@ -525,6 +525,26 @@ int modem_slm_shell(const struct shell *shell, size_t argc, char **argv)
 	return modem_slm_send_cmd((char *)argv[1], 0);
 }
 
-SHELL_CMD_REGISTER(slm, NULL, "SLM Shell", modem_slm_shell);
+int modem_slm_shell_slmsh_powerpin(const struct shell *shell, size_t argc, char **argv)
+{
+	int err;
+
+	err = modem_slm_wake_up();
+	if (err) {
+		LOG_ERR("Failed to toggle power pin");
+	}
+	return 0;
+}
+
+SHELL_CMD_REGISTER(slm, NULL, "Send AT commands to SLM device", modem_slm_shell);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_slmsh,
+	SHELL_CMD(powerpin, NULL, "Toggle power pin configured with CONFIG_SLM_POWER_PIN",
+		  modem_slm_shell_slmsh_powerpin),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(slmsh, &sub_slmsh, "Commands handled in SLM shell device", NULL);
 
 #endif /* CONFIG_MODEM_SLM_SHELL */


### PR DESCRIPTION
Asserts were enabled with PR https://github.com/nrfconnect/sdk-nrf/pull/20040.
This has caused an assert to occur when pressing power pin, because GPIO callback (`power_pin_callback_wakeup()`) called `slm_at_host_power_on()`, which called `k_sleep()`, which has an assert that it's not called from interrupt context. Added most of the wake up operation into a worker.

Also added a command to `modem_slm` library for toggling power pin. In addition, adding main command for operations done in SLM shell device. Toggling power pin is done as follows:
"slmsh powerpin"

I have some follow-up PRs for SLM shell so I'll also update its documentation then regarding the new command. I'd like to get these changes in whenever they are technically OK so that test engineers can proceed testing the power pin.

Jira: LRCS-70
Jira: LRCS-84