### PR TITLE
nrf_security: cracen: Size optimizations kmu

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -497,44 +497,61 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 	psa_set_key_usage_flags(key_attr, usage_flags);
 
 	switch (metadata->algorithm) {
+#ifdef CONFIG_PSA_WANT_ALG_STREAM_CIPHER
 	case METADATA_ALG_CHACHA20:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_CHACHA20);
 		psa_set_key_algorithm(key_attr, PSA_ALG_STREAM_CIPHER);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305
 	case METADATA_ALG_CHACHA20_POLY1305:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_CHACHA20);
 		psa_set_key_algorithm(key_attr, PSA_ALG_CHACHA20_POLY1305);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_GCM
 	case METADATA_ALG_AES_GCM:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_GCM);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CCM
 	case METADATA_ALG_AES_CCM:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_CCM);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_ECB_NO_PADDING
 	case METADATA_ALG_AES_ECB:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_ECB_NO_PADDING);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CTR
 	case METADATA_ALG_AES_CTR:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_CTR);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CBC_NO_PADDING
 	case METADATA_ALG_AES_CBC:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_CBC_NO_PADDING);
 		break;
-#ifdef PSA_ALG_SP800_108_COUNTER_CMAC
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC
 	case METADATA_ALG_SP800_108_COUNTER_CMAC:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_SP800_108_COUNTER_CMAC);
 		break;
 #endif
+#ifdef CONFIG_PSA_WANT_ALG_CMAC
 	case METADATA_ALG_CMAC:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_CMAC);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_PURE_EDDSA
 	case METADATA_ALG_ED25519:
 		/* If the key can sign it is assumed it is a private key */
 		psa_set_key_type(
@@ -544,6 +561,8 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 				: PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_TWISTED_EDWARDS));
 		psa_set_key_algorithm(key_attr, PSA_ALG_PURE_EDDSA);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_ED25519PH
 	case METADATA_ALG_ED25519PH:
 		/* If the key can sign it is assumed it is a private key */
 		psa_set_key_type(
@@ -553,6 +572,8 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 				: PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_TWISTED_EDWARDS));
 		psa_set_key_algorithm(key_attr, PSA_ALG_ED25519PH);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_ECDSA
 	case METADATA_ALG_ECDSA:
 		psa_set_key_type(key_attr,
 				 can_sign(key_attr)
@@ -560,10 +581,13 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 					 : PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_SECP_R1));
 		psa_set_key_algorithm(key_attr, PSA_ALG_ECDSA(PSA_ALG_ANY_HASH));
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_HMAC
 	case METADATA_ALG_HMAC:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_HMAC);
 		psa_set_key_algorithm(key_attr, PSA_ALG_HMAC(PSA_ALG_SHA_256));
 		break;
+#endif
 	default:
 		return PSA_ERROR_HARDWARE_FAILURE;
 	}
@@ -638,49 +662,63 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 	}
 
 	switch (psa_get_key_algorithm(key_attr)) {
+#ifdef CONFIG_PSA_WANT_ALG_STREAM_CIPHER
 	case PSA_ALG_STREAM_CIPHER:
 		metadata->algorithm = METADATA_ALG_CHACHA20;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_CHACHA20) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305
 	case PSA_ALG_CHACHA20_POLY1305:
 		metadata->algorithm = METADATA_ALG_CHACHA20_POLY1305;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_CHACHA20) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_GCM
 	case PSA_ALG_GCM:
 		metadata->algorithm = METADATA_ALG_AES_GCM;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CCM
 	case PSA_ALG_CCM:
 		metadata->algorithm = METADATA_ALG_AES_CCM;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_ECB_NO_PADDING
 	case PSA_ALG_ECB_NO_PADDING:
 		metadata->algorithm = METADATA_ALG_AES_ECB;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CTR
 	case PSA_ALG_CTR:
 		metadata->algorithm = METADATA_ALG_AES_CTR;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CBC_NO_PADDING
 	case PSA_ALG_CBC_NO_PADDING:
 		metadata->algorithm = METADATA_ALG_AES_CBC;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
-#ifdef PSA_ALG_SP800_108_COUNTER_CMAC
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC
 	case PSA_ALG_SP800_108_COUNTER_CMAC:
 		metadata->algorithm = METADATA_ALG_SP800_108_COUNTER_CMAC;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
@@ -688,6 +726,7 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		}
 		break;
 #endif
+#ifdef CONFIG_PSA_WANT_ALG_CMAC
 	case PSA_ALG_CMAC:
 		metadata->algorithm = METADATA_ALG_CMAC;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
@@ -695,6 +734,22 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		}
 		break;
 
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_ED25519PH
+	case PSA_ALG_ED25519PH:
+		if (PSA_KEY_TYPE_ECC_GET_FAMILY(psa_get_key_type(key_attr)) !=
+		    PSA_ECC_FAMILY_TWISTED_EDWARDS) {
+			return PSA_ERROR_NOT_SUPPORTED;
+		}
+		/* Don't support private keys that are only used for verify */
+		if (!can_sign(key_attr) &&
+		    PSA_KEY_TYPE_IS_ECC_KEY_PAIR(psa_get_key_type(key_attr))) {
+			return PSA_ERROR_NOT_SUPPORTED;
+		}
+		metadata->algorithm = METADATA_ALG_ED25519PH;
+		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_PURE_EDDSA
 	case PSA_ALG_PURE_EDDSA:
 		if (PSA_KEY_TYPE_ECC_GET_FAMILY(psa_get_key_type(key_attr)) !=
 		    PSA_ECC_FAMILY_TWISTED_EDWARDS) {
@@ -707,20 +762,8 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		}
 		metadata->algorithm = METADATA_ALG_ED25519;
 		break;
-
-	case PSA_ALG_ED25519PH:
-		if (PSA_KEY_TYPE_ECC_GET_FAMILY(psa_get_key_type(key_attr)) !=
-		PSA_ECC_FAMILY_TWISTED_EDWARDS) {
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		/* Don't support private keys that are only used for verify */
-		if (!can_sign(key_attr) &&
-			PSA_KEY_TYPE_IS_ECC_KEY_PAIR(psa_get_key_type(key_attr))) {
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		metadata->algorithm = METADATA_ALG_ED25519PH;
-	break;
-
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_ECDSA
 	case PSA_ALG_ECDSA(PSA_ALG_ANY_HASH):
 	case PSA_ALG_ECDSA(PSA_ALG_SHA_256):
 		if (PSA_KEY_TYPE_ECC_GET_FAMILY(psa_get_key_type(key_attr)) !=
@@ -735,12 +778,15 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		}
 		metadata->algorithm = METADATA_ALG_ECDSA;
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_HMAC
 	case PSA_ALG_HMAC(PSA_ALG_SHA_256):
 		if (!can_sign(key_attr) && PSA_ALG_IS_HMAC(psa_get_key_type(key_attr))) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		metadata->algorithm = METADATA_ALG_HMAC;
 		break;
+#endif
 	default:
 		return PSA_ERROR_NOT_SUPPORTED;
 	}


### PR DESCRIPTION
Add compiler definitions around algorithm selection in kmu. This means only needed algorithms are checked at runtime.Also means algorithm configs are required for importing keys which reduces size in most use cases