### PR TITLE
doc: make sure that cs_antenna_switch doxygen is compiled

### DIFF
--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -959,7 +959,8 @@ WARN_LOGFILE           =
 INPUT                  = @DOCSET_SOURCE_BASE@/applications \
                          @DOCSET_SOURCE_BASE@/lib \
                          @DOCSET_SOURCE_BASE@/include \
-                         @DOCSET_SOURCE_BASE@/subsys/zigbee/osif/zb_nrf_platform.h
+                         @DOCSET_SOURCE_BASE@/subsys/zigbee/osif/zb_nrf_platform.h \
+                         @DOCSET_SOURCE_BASE@/subsys/bluetooth/controller/cs_antenna_switch.h
 
 # This tag can be used to specify the character encoding of the source files
 # that Doxygen parses. Internally Doxygen uses the UTF-8 encoding. Doxygen uses

--- a/subsys/bluetooth/controller/cs_antenna_switch.h
+++ b/subsys/bluetooth/controller/cs_antenna_switch.h
@@ -8,10 +8,10 @@
 
 /** @brief Antenna switching Callback for use in Channel Sounding.
  *
- *  See also @ref sdc_support_channel_sounding
+ *  See also sdc_support_channel_sounding
  *
- *  @param[in] antenna_index the index of the antenna being switched to.
- *                           Valid range [0, @ref sdc_cfg_cs_cfg_t::num_antennas_supported - 1]
+ *  @param[in] antenna_number the index of the antenna being switched to.
+ *                           Valid range [0, sdc_cfg_cs_cfg_t::num_antennas_supported - 1]
  */
 void cs_antenna_switch_func(uint8_t antenna_number);
 


### PR DESCRIPTION
doxygen for cs_antenna_switch was not being compiled, added it to the doxyfile so that it gets compiled.

when compiling the doxygen a doxygen error was also found and fixed.