### PR TITLE
samples: wifi: Replace nrfjprog with nrfutil

### DIFF
--- a/doc/nrf/gsg_guides/nrf7002_gs.rst
+++ b/doc/nrf/gsg_guides/nrf7002_gs.rst
@@ -327,9 +327,9 @@ Programming the firmware to the DK
 Follow the instructions in the :ref:`building` page to build and the :ref:`programming` page to program applications.
 
 .. note::
-   To flash and debug applications on the nRF7002 DK, you must use the `nRF Command Line Tools`_ version 10.12.0 or above.
+   To flash and debug applications on the nRF7002 DK, you can use `nRF Util`_ or west.
 
-   |nrf_CLT_deprecation_note|
+   See `Installing nRF Util`_ and `Installing and upgrading nRF Util commands`_ for instructions on how to install the nRF Util device utility.
 
 Debugging
 =========

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -1070,6 +1070,7 @@ Documentation
   * The :ref:`ug_nrf91` documentation to use `nRF Util`_ instead of nrfjprog.
   * The :ref:`dm-revisions` section of the :ref:`dm_code_base` page with information about the preview release tag, which replaces the development tag.
   * The :ref:`ug_bt_mesh_configuring` page with the security toolbox section and the key importer functionality.
+  * The :ref:`ug_nrf7002_gs` documentation to use `nRF Util`_ instead of nrfjprog.
 
 * Removed:
 

--- a/samples/wifi/ble_coex/README.rst
+++ b/samples/wifi/ble_coex/README.rst
@@ -201,19 +201,27 @@ Testing
 
    .. code-block:: console
 
-      nrfjprog --com
-
-   .. note::
-         |nrfjprog_deprecation_note|
+      nrfutil device list
 
    This command returned the following output in the setup used to run the coexistence tests.
 
    .. code-block:: console
 
-      1050043161         /dev/ttyACM0    VCOM0
-      1050043161         /dev/ttyACM1    VCOM1
-      1050724225         /dev/ttyACM2    VCOM0
-      1050724225         /dev/ttyACM3    VCOM1
+      1050043161
+      product         J-Link
+      board version   PCA10095
+      ports           /dev/ttyACM0, vcom: 0
+                      /dev/ttyACM1, vcom: 1
+      traits          devkit, jlink, seggerUsb, serialPorts, usb
+
+      1050724225
+      product         J-Link
+      board version   PCA10143
+      ports           /dev/ttyACM2, vcom: 0
+                      /dev/ttyACM3, vcom: 1
+      traits          devkit, jlink, seggerUsb, serialPorts, usb
+
+      Found 2 supported device(s)
 
 
    In this example, ``1050043161`` is the serial number of the nRF5340 DK and ``1050724225`` is the serial number of the nRF7002 DK.

--- a/samples/wifi/shell/README.rst
+++ b/samples/wifi/shell/README.rst
@@ -92,16 +92,13 @@ The following is an example of the CLI commands:
 
    west build -b thingy91x/nrf5340/cpuapp -- -DSB_CONFIG_THINGY91X_STATIC_PARTITIONS_NRF53_EXTERNAL_FLASH=y
    # Set SWD switch to nRF91 and check if you are connected to an nRF91:
-   nrfjprog --deviceversion
-   # If you see NRF9120_xxAA_REV3, proceed with erasing:
-   nrfjprog --recover
+   nrfutil device device-info
+   # If you see deviceVersion as NRF9120_xxAA_REV3 in the above output, proceed with erasing:
+   nrfutil device --recover
    # Flip the SWD switch back to nRF53.
-   nrfjprog --deviceversion
-   # If you see NRF5340_xxAA_REV1, proceed with flashing:
+   nrfutil device device-info
+   # If you see deviceVersion as NRF5340_xxAA_REV1 in the above output, proceed with flashing:
    west flash --erase
-
-.. note::
-    |nrfjprog_deprecation_note|
 
 See also :ref:`cmake_options` for instructions on how to provide CMake options.
 

--- a/samples/wifi/thread_coex/README.rst
+++ b/samples/wifi/thread_coex/README.rst
@@ -184,19 +184,27 @@ Testing
 
    .. code-block:: console
 
-      nrfjprog --com
-
-   .. note::
-         |nrfjprog_deprecation_note|
+      nrfutil device list
 
    This command returned the following output in the setup used to run the coexistence tests.
 
    .. code-block:: console
 
-      1050779496         /dev/ttyACM0    VCOM0
-      1050779496         /dev/ttyACM1    VCOM1
-      1050759502         /dev/ttyACM2    VCOM0
-      1050759502         /dev/ttyACM3    VCOM1
+      1050779496
+      product         J-Link
+      board version   PCA10143
+      ports           /dev/ttyACM0, vcom: 0
+                      /dev/ttyACM1, vcom: 1
+      traits          devkit, jlink, seggerUsb, serialPorts, usb
+
+      1050759502
+      product         J-Link
+      board version   PCA10143
+      ports           /dev/ttyACM2, vcom: 0
+                      /dev/ttyACM3, vcom: 1
+      traits          devkit, jlink, seggerUsb, serialPorts, usb
+
+      Found 2 supported device(s)
 
    In this example, ``1050779496`` is the serial number of the first nRF7002 DK and ``1050759502`` is the serial number of the other one.
 


### PR DESCRIPTION
Replace all instances of `nrfjprog` commands with
`nrfutil` commands as nrfjprog is going to be deprecated.

Fixes SHEL-3520.