### PR TITLE
caf: power_manager: Imply Device Runtime Power Management for nRF54H

### DIFF
--- a/subsys/caf/modules/Kconfig.power_manager
+++ b/subsys/caf/modules/Kconfig.power_manager
@@ -13,6 +13,7 @@ config CAF_POWER_MANAGER
 	imply POWEROFF if !SOC_SERIES_NRF54HX
 	imply PM if SOC_SERIES_NRF54HX
 	imply PM_DEVICE
+	imply PM_DEVICE_RUNTIME if SOC_SERIES_NRF54HX
 	help
 	  Enable power management, which will put the device to low-power mode
 	  if it is idle.

--- a/subsys/caf/modules/Kconfig.power_manager
+++ b/subsys/caf/modules/Kconfig.power_manager
@@ -8,11 +8,11 @@ menu "Power manager"
 
 config CAF_POWER_MANAGER
 	bool "Enable power management"
-	select PM_DEVICE
 	select CAF_PM_EVENTS
 	select CAF_POWER_MANAGER_EVENTS
 	imply POWEROFF if !SOC_SERIES_NRF54HX
 	imply PM if SOC_SERIES_NRF54HX
+	imply PM_DEVICE
 	help
 	  Enable power management, which will put the device to low-power mode
 	  if it is idle.

--- a/subsys/caf/modules/power_manager.c
+++ b/subsys/caf/modules/power_manager.c
@@ -6,7 +6,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 
-#include <zephyr/device.h>
 #if CONFIG_CAF_POWER_MANAGER_CLEAR_RESET_REASON
 #include <hal/nrf_power.h>
 #include <helpers/nrfx_reset_reason.h>


### PR DESCRIPTION
Change implies CONFIG_PM_DEVICE_RUNTIME for nRF54H SoC Series. This is done to allow using the framework to reduce power consumption. Enabling Device Runtime Power Management also prevents from using System-Managed Device Power Management by default. The System-Managed Device Power Management does not work properly with some drivers (e.g. nrfx UARTE).

PR also switches to using imply instead of select for `CONFIG_PM_DEVICE` (the option is not required by CAF Power Manager).

Jira: NCSDK-32519