### PR TITLE
samples: nrf_rpc: ps_server: RPC alive LED

### DIFF
--- a/include/nrf_rpc/nrf_rpc_uart.h
+++ b/include/nrf_rpc/nrf_rpc_uart.h
@@ -32,6 +32,19 @@ extern "C" {
 #define NRF_RPC_UART_TRANSPORT(node_id) _CONCAT(nrf_rpc_tr_, DT_DEP_ORD(node_id))
 
 /**
+ * @brief Notifies that nRF RPC UART transport is ready to receive packets.
+ *
+ * This function is called by the nRF RPC UART transport implementation as soon as
+ * a transport instance is initialized and ready to receive nRF RPC packets.
+ *
+ * @note The nRF RPC transport implementation provides an empty, weak definition of this
+ *       function, which the application can override if needed.
+ *
+ * @param uart_dev The UART device for which the transport has just been initialized.
+ */
+extern void nrf_rpc_uart_initialized_hook(const struct device *uart_dev);
+
+/**
  * @}
  */
 

--- a/samples/nrf_rpc/protocols_serialization/server/Kconfig
+++ b/samples/nrf_rpc/protocols_serialization/server/Kconfig
@@ -15,6 +15,14 @@ config NRF_PS_SERVER_FATAL_ERROR_TRIGGER
 	  provides an RPC client with access to the crash log stored in the retained
 	  RAM partition.
 
+config NRF_PS_SERVER_RPC_ALIVE_LED
+	bool "RPC alive LED"
+	default y
+	depends on $(dt_alias_enabled,rpc-alive-led)
+	help
+	  Turns on the LED selected with "/alias/rpc-alive-led" DTS property when
+	  the UART transport is alive and ready to receive nRF RPC packets.
+
 module = NRF_PS_SERVER
 module-str = nrf_ps_server
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/samples/nrf_rpc/protocols_serialization/server/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/nrf_rpc/protocols_serialization/server/boards/nrf52840dk_nrf52840.overlay
@@ -7,6 +7,10 @@
 	chosen {
 		nordic,rpc-uart = &uart1;
 	};
+
+	aliases {
+		rpc-alive-led = &led0;
+	};
 };
 
 &uart1 {

--- a/samples/nrf_rpc/protocols_serialization/server/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/nrf_rpc/protocols_serialization/server/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -8,8 +8,10 @@
 		nordic,rpc-uart = &uart21;
 	};
 
-	/* delete all buttons except button0 to free GPIO pins assigned to uart21 below */
 	aliases {
+		rpc-alive-led = &led0;
+
+		/* delete all buttons except button0 to free GPIO pins assigned to uart21 below */
 		/delete-property/ sw1;
 		/delete-property/ sw2;
 		/delete-property/ sw3;

--- a/samples/nrf_rpc/protocols_serialization/server/src/main.c
+++ b/samples/nrf_rpc/protocols_serialization/server/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/logging/log.h>
 
 #include <nrf_rpc.h>
@@ -14,6 +15,21 @@ static void err_handler(const struct nrf_rpc_err_report *report)
 {
 	LOG_ERR("nRF RPC error %d ocurred. See nRF RPC logs for more details", report->code);
 }
+
+#ifdef CONFIG_NRF_PS_SERVER_RPC_ALIVE_LED
+void nrf_rpc_uart_initialized_hook(const struct device *uart_dev)
+{
+	const struct gpio_dt_spec alive_gpio = GPIO_DT_SPEC_GET(DT_ALIAS(rpc_alive_led), gpios);
+	int ret;
+
+	__ASSERT_NO_MSG(uart_dev == DEVICE_DT_GET(DT_CHOSEN(nordic_rpc_uart)));
+	ret = gpio_pin_configure_dt(&alive_gpio, GPIO_OUTPUT_ACTIVE);
+
+	if (ret) {
+		LOG_ERR("Failed to configure RPC alive GPIO: %d", ret);
+	}
+}
+#endif
 
 int main(void)
 {

--- a/subsys/nrf_rpc/nrf_rpc_uart.c
+++ b/subsys/nrf_rpc/nrf_rpc_uart.c
@@ -353,6 +353,7 @@ static int init(const struct nrf_rpc_tr *transport, nrf_rpc_tr_receive_handler_t
 	uart_tr->hdlc_state = HDLC_STATE_UNSYNC;
 	uart_tr->rx_packet_len = 0;
 	uart_irq_rx_enable(uart_tr->uart);
+	nrf_rpc_uart_initialized_hook(uart_tr->uart);
 
 	return 0;
 }
@@ -447,6 +448,10 @@ static void tx_buf_free(const struct nrf_rpc_tr *transport, void *buf)
 	ARG_UNUSED(transport);
 
 	k_free(buf);
+}
+
+__weak void nrf_rpc_uart_initialized_hook(const struct device *uart_dev)
+{
 }
 
 const struct nrf_rpc_tr_api nrf_rpc_uart_service_api = {


### PR DESCRIPTION
1. Add nrf_rpc_uart_initialized_hook() that is called when an nRF RPC UART transport instance gets ready to receive packets.
2. Use the hook in the PS server sample to toggle the LED selected with /alias/rpc-alive-led DTS property when the RPC transport is ready.