### PR TITLE
samples: bluetooth: fast_pair: locator_tag: enable lto in debug config

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -436,7 +436,7 @@ Bluetooth Fast Pair samples
 
   * Updated:
 
-    * The partition layout for the ``nrf5340dk/nrf5340/cpuapp/ns`` and ``thingy53/nrf5340/cpuapp/ns`` board targets to accommodate the partitions needed due to change in the TF-M profile configuration.
+    * The partition layout for the ``nrf5340dk/nrf5340/cpuapp/ns`` and ``thingy53/nrf5340/cpuapp/ns`` board targets to accommodate the partitions needed due to a change in the TF-M profile configuration.
     * The debug (default) configuration of the main image to enable the Link Time Optimization (LTO) with the :kconfig:option:`CONFIG_LTO` Kconfig option.
       This change ensures consistency with the sample release configuration that has the LTO feature enabled by default.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -434,7 +434,11 @@ Bluetooth Fast Pair samples
       Integrated the new connection authentication callback from the FMDN module and the Device Information Service (DIS) to support firmware version read operation over the Firmware Revision characteristic.
       For further details on the Android intent feature for firmware updates, see the :ref:`ug_bt_fast_pair_provisioning_register_firmware_update_intent` section of the Fast Pair integration guide.
 
-  * Updated the partition layout for the ``nrf5340dk/nrf5340/cpuapp/ns`` and ``thingy53/nrf5340/cpuapp/ns`` board targets to accommodate the partitions needed due to change in the TF-M profile configuration.
+  * Updated:
+
+    * The partition layout for the ``nrf5340dk/nrf5340/cpuapp/ns`` and ``thingy53/nrf5340/cpuapp/ns`` board targets to accommodate the partitions needed due to change in the TF-M profile configuration.
+    * The debug (default) configuration of the main image to enable the Link Time Optimization (LTO) with the :kconfig:option:`CONFIG_LTO` Kconfig option.
+      This change ensures consistency with the sample release configuration that has the LTO feature enabled by default.
 
 Bluetooth Mesh samples
 ----------------------

--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -535,8 +535,6 @@ The build will use the :file:`prj_release.conf` configuration file instead of :f
 Check the contents of both files to learn which configuration changes you should apply when preparing the production build of your end product.
 
 The release build reduces the code size and RAM usage of the sample by disabling logging functionality and performing other optimizations.
-Additionally, it enables the Link Time Optimization (LTO) configuration through the :kconfig:option:`CONFIG_LTO` Kconfig option, which further reduces the code size.
-LTO is an advanced compilation technique that optimizes across all compiled units of an application at the link stage, rather than optimizing each unit separately.
 
 See :ref:`cmake_options` for detailed instructions on how to add the ``FILE_SUFFIX=release`` option to your build.
 For example, when building from the command line, you can add it as follows:

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/prj.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/prj.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor
+# Copyright (c) 2024-2025 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -15,6 +15,10 @@ CONFIG_NCS_APPLICATION_BOOT_BANNER_STRING="NCS locator tag"
 
 # Error handling configuration
 CONFIG_RESET_ON_FATAL_ERROR=n
+
+# Activate LTO
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
 
 # Enable settings to store data in non-volatile memory
 CONFIG_FLASH=y


### PR DESCRIPTION
Enabled the Link Time Optimization (LTO) in the debug (default) configuration of the Fast Pair Locator Tag sample to get it aligned with the release configuration.