### PR TITLE
snippet: sdp: mspi: add reset timings

### DIFF
--- a/snippets/sdp/mspi/board/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/snippets/sdp/mspi/board/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -24,6 +24,8 @@
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <35000>;
 		reset-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		t-reset-pulse = <10000>;
+		t-reset-recovery = <35000>;
 
 		mspi-max-frequency = <DT_FREQ_M(13)>;
 		mspi-io-mode = "MSPI_IO_MODE_QUAD_1_4_4";


### PR DESCRIPTION
Include reset timings to ensure flash memory is correctly reset and able to recover before usage.