### PR TITLE
applications: nrf_desktop: Fix dvfs module consuming event

### DIFF
--- a/applications/nrf_desktop/src/modules/dvfs.c
+++ b/applications/nrf_desktop/src/modules/dvfs.c
@@ -300,7 +300,7 @@ static bool handle_ble_peer_conn_params_event(const struct ble_peer_conn_params_
 	process_dvfs_states(DVFS_STATE_LLPM_CONNECTED,
 			    event->interval_min & REG_CONN_INTERVAL_LLPM_MASK);
 
-	return true;
+	return false;
 }
 static void dvfs_state_timeout_work_handler(struct k_work *work)
 {

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -335,6 +335,9 @@ nRF Desktop
     The negative impact of USB polling jitter is more visible in case of USB High-Speed.
   * The Fast Pair sysbuild configurations to align the application with the sysbuild Kconfig changes for controlling the Fast Pair provisioning process.
     The Nordic device models intended for demonstration purposes are now supplied by default in the nRF Desktop Fast Pair configurations.
+  * The :ref:`nrf_desktop_dvfs` to no longer consume the :c:struct:`ble_peer_conn_params_event`.
+    This allows to propagate the event to further listeners of the same or lower priority.
+    This prevents an issue where :ref:`nrf_desktop_ble_latency` is not informed about the connection parameter update (it might cause missing connection latency updates).
 
 * Removed:
 


### PR DESCRIPTION
FIX nrf_desktop dvfs module consuming
ble_peer_conn_params event when it should not.

JIRA: NCSDK-31478