### PR TITLE
nrfcloud: use app jwt library

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -955,7 +955,11 @@ Libraries for networking
 * :ref:`lib_nrf_cloud` library:
 
   * Added the :kconfig:option:`CONFIG_NRF_CLOUD` Kconfig option to prevent unintended inclusion of nRF Cloud Kconfig variables in non-nRF Cloud projects.
-  * Updated to use the :ref:`lib_downloader` library for CoAP downloads.
+
+  * Updated:
+
+    * To use the :ref:`lib_downloader` library for CoAP downloads.
+    * To use the :ref:`lib_app_jwt` library to generate JWT tokens.
 
 Libraries for NFC
 -----------------

--- a/lib/app_jwt/CMakeLists.txt
+++ b/lib/app_jwt/CMakeLists.txt
@@ -9,3 +9,5 @@ zephyr_library()
 zephyr_library_sources(
     app_jwt.c
 )
+
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)

--- a/lib/app_jwt/Kconfig
+++ b/lib/app_jwt/Kconfig
@@ -6,7 +6,6 @@
 
 menuconfig APP_JWT
 	bool "Application JWT Library"
-	depends on SSF_CLIENT && SSF_PSA_CRYPTO_SERVICE_ENABLED && SSF_DEVICE_INFO_SERVICE_ENABLED
 	select BASE64
 	# Needed for time and date
 	select DATE_TIME
@@ -15,6 +14,10 @@ menuconfig APP_JWT
 	# Needed to print integer values in JSON
 	select CJSON_LIB
 	select CBPRINTF_FP_SUPPORT
+	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT
+	select PSA_WANT_ALG_ECDSA
+	select PSA_WANT_ECC_SECP_R1_256
+	select PSA_WANT_ALG_SHA_256
 
 if APP_JWT
 

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -103,14 +103,7 @@ config NRF_CLOUD_JWT_SOURCE_CUSTOM
 	select EXPERIMENTAL
 	select TLS_CREDENTIALS
 	select BASE64
-	select TINYCRYPT
-	select TINYCRYPT_SHA256
-	select TINYCRYPT_ECC_DSA
-	select TINYCRYPT_CTR_PRNG
-	select TINYCRYPT_AES
-	select CJSON_LIB
-	depends on NEWLIB_LIBC_FLOAT_PRINTF || PICOLIBC_IO_FLOAT
-	depends on DATE_TIME
+	select APP_JWT
 	help
 	  JWTs are created and signed by the nRF Cloud library, not the modem.
 	  The signing key is obtained from the TLS credentials module.

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_jwt.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_jwt.c
@@ -7,8 +7,8 @@
 #include <net/nrf_cloud.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <modem/modem_jwt.h>
 #if defined(CONFIG_MODEM_JWT)
+#include <modem/modem_jwt.h>
 #include <nrf_modem_at.h>
 #endif
 #include "nrf_cloud_client_id.h"
@@ -23,25 +23,8 @@ LOG_MODULE_REGISTER(nrf_cloud_jwt, CONFIG_NRF_CLOUD_LOG_LEVEL);
 
 #if defined(CONFIG_NRF_CLOUD_JWT_SOURCE_CUSTOM)
 #include <zephyr/sys/base64.h>
-#include <zephyr/random/random.h>
-
-#include <tinycrypt/ctr_prng.h>
-#include <tinycrypt/sha256.h>
-#include <tinycrypt/ecc_dsa.h>
-#include <tinycrypt/constants.h>
-
-#include <date_time.h>
-#include <cJSON.h>
-
-#include "nrf_cloud_mem.h"
-
-#define ECDSA_SHA_256_SIG_SZ	(64)
-#define ECDSA_SHA_256_HASH_SZ	(32)
-#define BASE64_ENCODE_SZ(n)	(((4 * n / 3) + 3) & ~3)
-#define B64_SIG_SZ		(BASE64_ENCODE_SZ(ECDSA_SHA_256_SIG_SZ) + 1)
-
-/* JWT header for ES256 type: {"typ":"JWT","alg":"ES256"} */
-#define JWT_ES256_HDR		"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9"
+#include <psa/crypto.h>
+#include <app_jwt.h>
 
 /* Size of the ES256 private key material */
 #define PRV_KEY_SZ		(32)
@@ -49,98 +32,6 @@ LOG_MODULE_REGISTER(nrf_cloud_jwt, CONFIG_NRF_CLOUD_LOG_LEVEL);
 #define PRV_KEY_DER_SZ		(138)
 #define PRV_KEY_PEM_SZ		(256)
 #define PRV_KEY_DER_START_IDX	(36)
-
-static TCCtrPrng_t prng_state;
-
-static int setup_prng(void)
-{
-	static bool prng_init;
-	uint8_t entropy[TC_AES_KEY_SIZE + TC_AES_BLOCK_SIZE];
-
-	if (prng_init) {
-		return 0;
-	}
-
-	for (int i = 0; i < sizeof(entropy); i += sizeof(uint32_t)) {
-		uint32_t rv = sys_rand32_get();
-
-		memcpy(entropy + i, &rv, sizeof(uint32_t));
-	}
-
-	int res = tc_ctr_prng_init(&prng_state,
-				   (const uint8_t *)&entropy, sizeof(entropy),
-				   __FILE__, sizeof(__FILE__));
-
-	if (res != TC_CRYPTO_SUCCESS) {
-		LOG_ERR("tc_ctr_prng_init() failed, error: %d", res);
-		return -EINVAL;
-	}
-
-	prng_init = true;
-
-	return 0;
-}
-
-int default_CSPRNG(uint8_t *dest, unsigned int size)
-{
-	return tc_ctr_prng_generate(&prng_state, NULL, 0, dest, size);
-}
-
-static void base64_url_format(char *const base64_string)
-{
-	if (base64_string == NULL) {
-		return;
-	}
-
-	char *found = NULL;
-
-	/* replace '+' with "-" */
-	for (found = base64_string; (found = strchr(found, '+'));) {
-		*found = '-';
-	}
-
-	/* replace '/' with "_" */
-	for (found = base64_string; (found = strchr(found, '/'));) {
-		*found = '_';
-	}
-
-	/* remove padding '=' */
-	found = strchr(base64_string, '=');
-	if (found) {
-		*found = '\0';
-	}
-}
-
-static int sign_message_der(const char *const der_key, const char *const msg_in,
-			    char *const sig_out)
-{
-	struct tc_sha256_state_struct ctx;
-	uint8_t hash[ECDSA_SHA_256_HASH_SZ];
-	int res;
-
-	tc_sha256_init(&ctx);
-	tc_sha256_update(&ctx, msg_in, strlen(msg_in));
-	tc_sha256_final(hash, &ctx);
-
-	res = setup_prng();
-	if (res != 0) {
-		LOG_ERR("uECC_sign() failed, error: %d", res);
-		return res;
-	}
-
-	LOG_HEXDUMP_DBG(hash, sizeof(hash), "SHA256 hash: ");
-
-	uECC_set_rng(&default_CSPRNG);
-
-	/* Note that tinycrypt only supports P-256. */
-	res = uECC_sign(der_key, hash, sizeof(hash), sig_out, &curve_secp256r1);
-	if (res != TC_CRYPTO_SUCCESS) {
-		LOG_ERR("uECC_sign() failed, error: %d", res);
-		return -EINVAL;
-	}
-
-	return 0;
-}
 
 static void remove_newlines(char *const str)
 {
@@ -189,10 +80,10 @@ static int strip_non_key_data(char *const str)
 	return 0;
 }
 
-static int get_key_from_cred(const int sec_tag, char *const der_out)
+static int get_key_from_cred(const int sec_tag, uint8_t *const der_out)
 {
 	static char pem[PRV_KEY_PEM_SZ];
-	static char der[PRV_KEY_DER_SZ];
+	static uint8_t der[PRV_KEY_DER_SZ];
 	size_t pem_sz = sizeof(pem);
 	size_t der_sz;
 	int err;
@@ -225,10 +116,12 @@ static int get_key_from_cred(const int sec_tag, char *const der_out)
 
 	LOG_DBG("DER size = %u", der_sz);
 
+	const uint8_t expected_der_header[] = {0x30, 0x81, 0x87, 0x02};
+
 	/* NOTE: Hack, not actually parsing the ASN.1,
 	 * just verifying that key header has the expected format
 	 */
-	if (((der[0] == 0x30) && (der[1] == 0x81) && (der[2] == 0x87)) == false) {
+	if (memcmp(der, expected_der_header, sizeof(expected_der_header))) {
 		LOG_ERR("Unexpected DER format: 0x%X 0x%X 0x%X", der[0], der[1], der[2]);
 		return -EBADF;
 	}
@@ -239,224 +132,52 @@ static int get_key_from_cred(const int sec_tag, char *const der_out)
 	return 0;
 }
 
-static char *jwt_payload_create(const char *const sub, const char *const aud, int64_t exp)
-{
-	int err = 0;
-	char *pay_str = NULL;
-	cJSON *jwt_pay = cJSON_CreateObject();
-
-	if (sub && (cJSON_AddStringToObjectCS(jwt_pay, "sub", sub) == NULL)) {
-		err = -ENOMEM;
-	}
-
-	if (aud && (cJSON_AddStringToObjectCS(jwt_pay, "aud", aud) == NULL)) {
-		err = -ENOMEM;
-	}
-
-	if (exp > 0) {
-		/* Add expiration (exp) claim */
-		if (cJSON_AddNumberToObjectCS(jwt_pay, "exp", exp) == NULL) {
-			err = -ENOMEM;
-		}
-	}
-
-	if (err == 0) {
-		pay_str = cJSON_PrintUnformatted(jwt_pay);
-	}
-
-	cJSON_Delete(jwt_pay);
-	jwt_pay = NULL;
-
-	return pay_str;
-}
-
-static char *convert_str_to_b64_url(const char *const str)
-{
-	size_t str_len = strlen(str);
-	size_t b64_sz = BASE64_ENCODE_SZ(str_len) + 1;
-
-	char *b64_out = nrf_cloud_calloc(1, b64_sz);
-
-	if (b64_out) {
-		int err = base64_encode(b64_out, b64_sz, &b64_sz, str, strlen(str));
-
-		if (err) {
-			LOG_ERR("base64_encode failed, error: %d", err);
-		}
-	}
-
-	/* Convert to base64 URL */
-	base64_url_format(b64_out);
-
-	return b64_out;
-}
-
-static char *jwt_header_payload_combine(const char *const hdr, const char *const pay)
-{
-	/* Allocate buffer for the JWT header and payload to be signed */
-	size_t msg_sz = strlen(hdr) + 1 + strlen(pay) + 1;
-	char *msg_out = nrf_cloud_calloc(1, msg_sz);
-
-	/* Build the base64 URL JWT to sign:
-	 * <base64_header>.<base64_payload>
-	 */
-	if (msg_out) {
-		int ret = snprintk(msg_out, msg_sz, "%s.%s", hdr, pay);
-
-		if ((ret < 0) || (ret >= msg_sz)) {
-			LOG_ERR("Could not format JWT to be signed");
-			nrf_cloud_free(msg_out);
-			msg_out = NULL;
-		}
-	}
-
-	return msg_out;
-}
-
-static char *unsigned_jwt_create(struct jwt_data *const jwt)
-{
-	int err = 0;
-	int64_t exp_ts_s;
-
-	char *pay_str;
-	char *pay_b64;
-	char *unsigned_jwt;
-
-	/* Get expiration time stamp */
-	if (jwt->exp_delta_s > 0) {
-		err = date_time_now(&exp_ts_s);
-		if (!err) {
-			exp_ts_s += jwt->exp_delta_s;
-
-		} else {
-			LOG_ERR("date_time_now() failed, error: %d", err);
-			return NULL;
-		}
-	}
-
-	/* Create the payload */
-	pay_str = jwt_payload_create(jwt->subject, jwt->audience, exp_ts_s);
-	if (!pay_str) {
-		LOG_ERR("Failed to create JWT JSON payload");
-		return NULL;
-	}
-
-	/* Convert payload JSON string to base64 URL */
-	pay_b64 = convert_str_to_b64_url(pay_str);
-
-	cJSON_free(pay_str);
-	pay_str = NULL;
-
-	if (!pay_b64) {
-		LOG_ERR("Failed to convert string to base64");
-		return NULL;
-	}
-
-	/* Create the base64 URL data to be signed */
-	unsigned_jwt = jwt_header_payload_combine(JWT_ES256_HDR, pay_b64);
-
-	nrf_cloud_free(pay_b64);
-	pay_b64 = NULL;
-
-	return unsigned_jwt;
-}
-
-static int jwt_signature_get(const int sec_tag, const char *const jwt,
-			     char *const sig_buf, size_t sig_sz)
-{
-	int err;
-	size_t o_len;
-	char der_buf[PRV_KEY_SZ];
-	uint8_t sig_raw[ECDSA_SHA_256_SIG_SZ];
-
-	/* Get the key which will be used to sign the JWT */
-	err = get_key_from_cred(sec_tag, der_buf);
-	if (err) {
-		LOG_ERR("Failed to get private key material, error: %d", err);
-		return -EIDRM;
-	}
-
-	err = sign_message_der(der_buf, jwt, sig_raw);
-	if (err) {
-		LOG_ERR("Failed to sign JWT, error: %d", err);
-		return -ENOEXEC;
-	}
-
-	LOG_HEXDUMP_DBG(sig_raw, sizeof(sig_raw), "Signature: ");
-
-	/* Convert signature to base64 URL */
-	err = base64_encode(sig_buf, sig_sz, &o_len, sig_raw, sizeof(sig_raw));
-	if (err) {
-		LOG_ERR("base64_encode failed, error: %d", err);
-		return -EIO;
-	}
-
-	base64_url_format(sig_buf);
-	return 0;
-}
-
-static int jwt_signature_append(const char *const unsigned_jwt, const char *const sig,
-				char *const jwt_buf, size_t jwt_sz)
-{
-	int err = 0;
-
-	/* Get the size of the final, signed JWT: +1 for '.' and null-terminator */
-	size_t final_sz = strlen(unsigned_jwt) + 1 + strlen(sig) + 1;
-
-	if (final_sz > jwt_sz) {
-		/* Provided buffer is too small */
-		err = -E2BIG;
-	}
-
-	/* JWT final form:
-	 * <base64_header>.<base64_payload>.<base64_signature>
-	 */
-	if (err == 0) {
-		int ret = snprintk(jwt_buf, jwt_sz, "%s.%s", unsigned_jwt, sig);
-
-		if ((ret < 0) || (ret >= jwt_sz)) {
-			err = -ETXTBSY;
-		}
-	}
-
-	return err;
-}
-
 static int custom_jwt_generate(struct jwt_data *const jwt)
 {
 	int err = 0;
-	char *unsigned_jwt;
-	uint8_t jwt_sig[B64_SIG_SZ];
+	psa_key_id_t kid;
+	psa_key_attributes_t key_attributes = PSA_KEY_ATTRIBUTES_INIT;
+	uint8_t priv_key[PRV_KEY_SZ];
 
-	/* Create the JWT to be signed */
-	unsigned_jwt = unsigned_jwt_create(jwt);
-	if (!unsigned_jwt) {
-		LOG_ERR("Failed to create JWT to be signed");
-		return -EIO;
-	}
-
-	LOG_DBG("Message to sign: %s", unsigned_jwt);
-
-	/* Get the signature of the unsigned JWT */
-	err = jwt_signature_get(jwt->sec_tag, unsigned_jwt, jwt_sig, sizeof(jwt_sig));
+	/* Load private key from storage */
+	err = get_key_from_cred(jwt->sec_tag, priv_key);
 	if (err) {
-		LOG_ERR("Failed to get JWT signature, error: %d", err);
-		nrf_cloud_free(unsigned_jwt);
-		return -ENOEXEC;
+		LOG_ERR("Failed to get private key, error: %d", err);
+		return err;
 	}
 
-	/* Append the signature, creating the complete JWT */
-	err = jwt_signature_append(unsigned_jwt, jwt_sig, jwt->jwt_buf, jwt->jwt_sz);
-
-	nrf_cloud_free(unsigned_jwt);
-
-	if (!err) {
-		LOG_DBG("JWT:\n%s", jwt->jwt_buf);
-	} else {
-		LOG_ERR("Failed to append JWT signature, error: %d", err);
+	err = psa_crypto_init();
+	if (err != PSA_SUCCESS) {
+		LOG_ERR("psa_crypto_init failed! (Error: %d)", err);
+		return err;
 	}
 
-	return err;
+	psa_set_key_usage_flags(&key_attributes,
+				PSA_KEY_USAGE_SIGN_MESSAGE | PSA_KEY_USAGE_VERIFY_MESSAGE);
+	psa_set_key_lifetime(&key_attributes, PSA_KEY_LIFETIME_VOLATILE);
+	psa_set_key_algorithm(&key_attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
+	psa_set_key_type(&key_attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
+	psa_set_key_bits(&key_attributes, 256);
+
+	/* Import key into PSA */
+	err = psa_import_key(&key_attributes, priv_key, sizeof(priv_key), &kid);
+	if (err != PSA_SUCCESS) {
+		LOG_ERR("psa_import_key failed! (Error: %d)", err);
+		return err;
+	}
+
+	struct app_jwt_data _jwt_internal = {
+		.sec_tag = kid,
+		.key_type = JWT_KEY_TYPE_CLIENT_PRIV,
+		.alg = JWT_ALG_TYPE_ES256,
+		.validity_s = jwt->exp_delta_s,
+		.jwt_buf = jwt->jwt_buf,
+		.jwt_sz = jwt->jwt_sz,
+		.subject = jwt->subject,
+		.audience = jwt->audience,
+	};
+
+	return app_jwt_generate(&_jwt_internal);
 }
 #endif /* CONFIG_NRF_CLOUD_JWT_SOURCE_CUSTOM */
 


### PR DESCRIPTION
Replace internal JWT implementation with the app_jwt library.
Requires the usage of prime256v1 keys.
Adds a unit test for the app_jwt library.