### PR TITLE
Nrfx7105 enable nrf7120 build nrfx mramc

### DIFF
--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -79,3 +79,17 @@ module-str = Flash over nRF RPC
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
 endif # FLASH_RPC
+
+# To be added to Zephyr SOC_FLASH_NRF_MRAM Kconfig in the future
+config FLASH_NRF_MRAM
+	bool "Nordic Semiconductor flash driver for MRAM"
+	default y
+	depends on SOC_NRF7120_ENGA
+	select NRFX_MRAMC
+	select FLASH_HAS_DRIVER_ENABLED
+	select FLASH_HAS_PAGE_LAYOUT
+	select FLASH_HAS_NO_EXPLICIT_ERASE
+	imply MPU_ALLOW_FLASH_WRITE if ARM_MPU
+	help
+	  Enable NRFX driver for MRAM on nRF7120,
+	  Aligns to SOC_FLASH_NRF_MRAM in Zephyr

--- a/modules/Kconfig
+++ b/modules/Kconfig
@@ -6,3 +6,4 @@
 
 osource "$(NCS_MEMFAULT_FIRMWARE_SDK_KCONFIG)"
 rsource "wfa-qt/Kconfig"
+rsource "hal_nordic/nrfx/Kconfig"

--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -22,3 +22,6 @@ if(CONFIG_SOC_NRF7120_ENGA_CPUAPP)
   math(EXPR clock_frequency_mhz "${clock_frequency} / 1000000")
   zephyr_compile_definitions("NRF_CONFIG_CPU_FREQ_MHZ=${clock_frequency_mhz}")
 endif()
+
+set(SRC_DIR ${NRFX_DIR}/drivers/src)
+zephyr_library_sources_ifdef(CONFIG_NRFX_MRAMC   ${SRC_DIR}/nrfx_mramc.c)

--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2016 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config HAS_NRFX
+	bool
+
+menu "nrfx drivers"
+	depends on HAS_NRFX
+
+rsource "Kconfig.logging"
+
+config NRFX_MRAMC
+	bool "MRAMC driver"
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_MRAM))
+
+endmenu # "nrfx drivers"

--- a/modules/hal_nordic/nrfx/Kconfig.logging
+++ b/modules/hal_nordic/nrfx/Kconfig.logging
@@ -1,0 +1,11 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+menu "nrfx drivers logging"
+	depends on LOG
+
+config NRFX_MRAMC_LOG
+    bool "MRAMC driver logging"
+    depends on NRFX_MRAMC
+
+endmenu # "nrfx drivers logging"


### PR DESCRIPTION
Pull Request for adding MRAMC driver build for nrf7120 
some files are backport to sdk-nrf from sdk-zephyr:
-nrf/modules/hal_nordic/nrfx/Kconfig
-nrf/modules/hal_nordic/nrfx/Kconfig.logging
-nrf/drivers/flash/Kconfig:(Line83-95)

Commit messages:
1.modules: hal_nordic: Add support to build nrfx_mramc driver
    
    There are Kconfigs for mramc that will need to merge back to
    zephyr/modules/hal_nordic/nrfx/Kconfig and Kconfig.Logging

2. drivers: flash: Adding FLASH_NRF_MRAM to Kconfig
    Adding FLASH_NRF_MRAM KConfig aligns to SOC_FLASH_NRF_MRAM
    To avoid zephyr/drivers/flash/soc_flash_nrf_mram.c added into
    compilation with nrf7120 which break nrf7120 build.
    
    To resolve this in the future #ifdef can be added to
    zephyr/drivers/flash/soc_flash_nrf_mram.c when merging back to
    sdk-zephyr.

