### PR TITLE
samples: wifi: Update SHIELD configuration for coex samples

### DIFF
--- a/samples/wifi/ble_coex/README.rst
+++ b/samples/wifi/ble_coex/README.rst
@@ -169,13 +169,13 @@ Add the following SHIELD options for the nRF7002 EK and nRF7001 EK.
 
   .. code-block:: console
 
-     -DSHIELD=nrf7002ek
+     -Dble_coex_SHIELD="nrf7002ek;nrf7002ek_coex"
 
 * For nRF7001 EK:
 
   .. code-block:: console
 
-     -DSHIELD=nrf7002ek_nrf7001
+     -Dble_coex_SHIELD="nrf7002ek_nrf7001;nrf7002ek_coex"
 
 The generated HEX file to be used is :file:`ble_coex/build/merged.hex`.
 

--- a/samples/wifi/ble_coex/sample.yaml
+++ b/samples/wifi/ble_coex/sample.yaml
@@ -51,7 +51,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     extra_args:
-      - SHIELD=nrf7002ek
+      - ble_coex_SHIELD="nrf7002ek;nrf7002ek_coex"
       - CONFIG_MPSL_CX=y
       - ipc_radio_CONFIG_MPSL_CX=y
       - CONFIG_COEX_SEP_ANTENNAS=y
@@ -66,7 +66,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     extra_args:
-      - SHIELD=nrf7002ek_nrf7001
+      - ble_coex_SHIELD="nrf7002ek_nrf7001;nrf7002ek_coex"
       - CONFIG_MPSL_CX=y
       - ipc_radio_CONFIG_MPSL_CX=y
       - CONFIG_COEX_SEP_ANTENNAS=y

--- a/samples/wifi/thread_coex/README.rst
+++ b/samples/wifi/thread_coex/README.rst
@@ -156,13 +156,13 @@ Add the following SHIELD options for the nRF7002 EK and nRF7001 EK.
 
   .. code-block:: console
 
-     -DSHIELD=nrf7002ek
+     -Dthread_coex_SHIELD="nrf7002ek;nrf7002ek_coex"
 
 * For nRF7001 EK:
 
   .. code-block:: console
 
-     -DSHIELD=nrf7002ek_nrf7001
+     -Dthread_coex_SHIELD="nrf7002ek_nrf7001;nrf7002ek_coex"
 
 * Overlay files
 

--- a/samples/wifi/thread_coex/sample.yaml
+++ b/samples/wifi/thread_coex/sample.yaml
@@ -38,7 +38,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     extra_args:
-      - SHIELD=nrf7002ek
+      - thread_coex_SHIELD="nrf7002ek;nrf7002ek_coex"
       - CONFIG_MPSL_CX=y
       - ipc_radio_CONFIG_MPSL_CX=y
       - CONFIG_COEX_SEP_ANTENNAS=y
@@ -54,7 +54,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     extra_args:
-      - SHIELD=nrf7002ek_nrf7001
+      - thread_coex_SHIELD="nrf7002ek_nrf7001;nrf7002ek_coex"
       - CONFIG_MPSL_CX=y
       - ipc_radio_CONFIG_MPSL_CX=y
       - CONFIG_COEX_SEP_ANTENNAS=y


### PR DESCRIPTION
Update the SHIELD configuration in the coexistence samples to ensure the correct overlay files are included. This change addresses the issue of missing overlay files by specifying the sample name, such as `ble_coex_SHIELD` parameter.