### PR TITLE
net: openthread: rpc: standarize resources allocation

### DIFF
--- a/subsys/net/openthread/rpc/client/ot_rpc_coap.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_coap.c
@@ -42,7 +42,7 @@ static ot_rpc_coap_request_key ot_rpc_coap_request_alloc(otCoapResponseHandler h
 otMessage *otCoapNewMessage(otInstance *aInstance, const otMessageSettings *aSettings)
 {
 	struct nrf_rpc_cbor_ctx ctx;
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, OT_RPC_MESSAGE_SETTINGS_LENGTH);
 	ot_rpc_encode_message_settings(&ctx, aSettings);
@@ -59,12 +59,12 @@ void otCoapMessageInit(otMessage *aMessage, otCoapType aType, otCoapCode aCode)
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t cbor_buffer_size = 0;
 
-	cbor_buffer_size += 1 + sizeof(ot_msg_key); /* aMessage */
-	cbor_buffer_size += 1;			   /* aType */
-	cbor_buffer_size += 1 + sizeof(aCode);	   /* aCode */
+	cbor_buffer_size += 1 + sizeof(ot_rpc_res_tab_key); /* aMessage */
+	cbor_buffer_size += 1;				    /* aType */
+	cbor_buffer_size += 1 + sizeof(aCode);		    /* aCode */
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aMessage);
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aMessage);
 	nrf_rpc_encode_uint(&ctx, aType);
 	nrf_rpc_encode_uint(&ctx, aCode);
 
@@ -79,14 +79,14 @@ otError otCoapMessageInitResponse(otMessage *aResponse, const otMessage *aReques
 	size_t cbor_buffer_size = 0;
 	otError error;
 
-	cbor_buffer_size += 1 + sizeof(ot_msg_key); /* aResponse */
-	cbor_buffer_size += 1 + sizeof(ot_msg_key); /* aRequest */
-	cbor_buffer_size += 1;			   /* aType */
-	cbor_buffer_size += 1 + sizeof(aCode);	   /* aCode */
+	cbor_buffer_size += 1 + sizeof(ot_rpc_res_tab_key); /* aResponse */
+	cbor_buffer_size += 1 + sizeof(ot_rpc_res_tab_key); /* aRequest */
+	cbor_buffer_size += 1;				    /* aType */
+	cbor_buffer_size += 1 + sizeof(aCode);		    /* aCode */
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aResponse);
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aRequest);
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aResponse);
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aRequest);
 	nrf_rpc_encode_uint(&ctx, aType);
 	nrf_rpc_encode_uint(&ctx, aCode);
 
@@ -102,11 +102,11 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
 	size_t cbor_buffer_size = 0;
 	otError error;
 
-	cbor_buffer_size += 1 + sizeof(ot_msg_key); /* aMessage */
-	cbor_buffer_size += 2 + strlen(aUriPath);  /* aUriPath */
+	cbor_buffer_size += 1 + sizeof(ot_rpc_res_tab_key); /* aMessage */
+	cbor_buffer_size += 2 + strlen(aUriPath);	    /* aUriPath */
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aMessage);
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aMessage);
 	nrf_rpc_encode_str(&ctx, aUriPath, -1);
 
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_MESSAGE_APPEND_URI_PATH_OPTIONS, &ctx,
@@ -120,8 +120,8 @@ otError otCoapMessageSetPayloadMarker(otMessage *aMessage)
 	struct nrf_rpc_cbor_ctx ctx;
 	otError error;
 
-	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 1 + sizeof(ot_msg_key));
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aMessage);
+	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 1 + sizeof(ot_rpc_res_tab_key));
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aMessage);
 
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_MESSAGE_SET_PAYLOAD_MARKER, &ctx,
 				ot_rpc_decode_error, &error);
@@ -134,8 +134,8 @@ otCoapType otCoapMessageGetType(const otMessage *aMessage)
 	struct nrf_rpc_cbor_ctx ctx;
 	otCoapType type = 0;
 
-	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 1 + sizeof(ot_msg_key));
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aMessage);
+	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 1 + sizeof(ot_rpc_res_tab_key));
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aMessage);
 
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_COAP_MESSAGE_GET_TYPE, &ctx);
 	nrf_rpc_rsp_decode_uint(&ot_group, &ctx, &type, sizeof(type));
@@ -149,8 +149,8 @@ otCoapCode otCoapMessageGetCode(const otMessage *aMessage)
 	struct nrf_rpc_cbor_ctx ctx;
 	otCoapCode code = 0;
 
-	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 1 + sizeof(ot_msg_key));
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aMessage);
+	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 1 + sizeof(ot_rpc_res_tab_key));
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aMessage);
 
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_COAP_MESSAGE_GET_CODE, &ctx);
 	nrf_rpc_rsp_decode_uint(&ot_group, &ctx, &code, sizeof(code));
@@ -164,8 +164,8 @@ uint16_t otCoapMessageGetMessageId(const otMessage *aMessage)
 	struct nrf_rpc_cbor_ctx ctx;
 	uint16_t id = 0;
 
-	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 1 + sizeof(ot_msg_key));
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aMessage);
+	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 1 + sizeof(ot_rpc_res_tab_key));
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aMessage);
 
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_MESSAGE_GET_MESSAGE_ID, &ctx,
 				nrf_rpc_rsp_decode_u16, &id);
@@ -178,8 +178,8 @@ uint8_t otCoapMessageGetTokenLength(const otMessage *aMessage)
 	struct nrf_rpc_cbor_ctx ctx;
 	uint8_t token_length = 0;
 
-	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 1 + sizeof(ot_msg_key));
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aMessage);
+	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 1 + sizeof(ot_rpc_res_tab_key));
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aMessage);
 
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN_LENGTH, &ctx,
 				nrf_rpc_rsp_decode_u8, &token_length);
@@ -192,8 +192,8 @@ const uint8_t *otCoapMessageGetToken(const otMessage *aMessage)
 	struct nrf_rpc_cbor_ctx ctx;
 	static uint8_t token[OT_COAP_MAX_TOKEN_LENGTH];
 
-	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 1 + sizeof(ot_msg_key));
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aMessage);
+	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, 1 + sizeof(ot_rpc_res_tab_key));
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aMessage);
 
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN, &ctx);
 
@@ -370,7 +370,7 @@ void otCoapSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandle
 static void ot_rpc_cmd_coap_default_handler(const struct nrf_rpc_group *group,
 					    struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	otMessageInfo message_info;
 
 	message_rep = nrf_rpc_decode_uint(ctx);
@@ -407,12 +407,12 @@ otError otCoapSendRequestWithParameters(otInstance *aInstance, otMessage *aMessa
 		return OT_ERROR_NO_BUFS;
 	}
 
-	cbor_buffer_size += 1 + sizeof(ot_msg_key); /* aMessage */
+	cbor_buffer_size += 1 + sizeof(ot_rpc_res_tab_key); /* aMessage */
 	cbor_buffer_size += OT_RPC_MESSAGE_INFO_LENGTH(aMessageInfo);
 	cbor_buffer_size += 1 + sizeof(ot_rpc_coap_request_key);
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aMessage);
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aMessage);
 	ot_rpc_encode_message_info(&ctx, aMessageInfo);
 	nrf_rpc_encode_uint(&ctx, request_rep);
 	/* Ignore aTXParameters as it is NULL for otCoapSendRequest() that we only need for now */
@@ -474,11 +474,11 @@ otError otCoapSendResponseWithParameters(otInstance *aInstance, otMessage *aMess
 	size_t cbor_buffer_size = 0;
 	otError error = OT_ERROR_PARSE;
 
-	cbor_buffer_size += 1 + sizeof(ot_msg_key); /* aMessage */
+	cbor_buffer_size += 1 + sizeof(ot_rpc_res_tab_key); /* aMessage */
 	cbor_buffer_size += OT_RPC_MESSAGE_INFO_LENGTH(aMessageInfo);
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aMessage);
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aMessage);
 	ot_rpc_encode_message_info(&ctx, aMessageInfo);
 	/* Ignore aTXParameters as it is NULL for otCoapSendResponse() that we only need for now */
 	ARG_UNUSED(aTxParameters);

--- a/subsys/net/openthread/rpc/client/ot_rpc_message.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_message.c
@@ -19,7 +19,7 @@
 otError otMessageAppend(otMessage *aMessage, const void *aBuf, uint16_t aLength)
 {
 	struct nrf_rpc_cbor_ctx ctx;
-	ot_msg_key key = (ot_msg_key)aMessage;
+	ot_rpc_res_tab_key key = (ot_rpc_res_tab_key)aMessage;
 	otError error = OT_ERROR_NONE;
 
 	if (aLength == 0 || aBuf == NULL) {
@@ -39,7 +39,7 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 {
 	otMessage *msg = NULL;
 	struct nrf_rpc_cbor_ctx ctx;
-	ot_msg_key key;
+	ot_rpc_res_tab_key key;
 
 	ARG_UNUSED(aInstance);
 
@@ -62,9 +62,9 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 void otMessageFree(otMessage *aMessage)
 {
 	struct nrf_rpc_cbor_ctx ctx;
-	ot_msg_key key = (ot_msg_key)aMessage;
+	ot_rpc_res_tab_key key = (ot_rpc_res_tab_key)aMessage;
 
-	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, sizeof(ot_msg_key) + 1);
+	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, sizeof(ot_rpc_res_tab_key) + 1);
 
 	nrf_rpc_encode_uint(&ctx, key);
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_MESSAGE_FREE, &ctx);
@@ -77,7 +77,7 @@ void otMessageFree(otMessage *aMessage)
 uint16_t otMessageGetLength(const otMessage *aMessage)
 {
 	struct nrf_rpc_cbor_ctx ctx;
-	ot_msg_key key = (ot_msg_key)aMessage;
+	ot_rpc_res_tab_key key = (ot_rpc_res_tab_key)aMessage;
 	uint16_t ret = 0;
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, sizeof(uint32_t) + 1);
@@ -98,7 +98,7 @@ uint16_t otMessageGetLength(const otMessage *aMessage)
 uint16_t otMessageGetOffset(const otMessage *aMessage)
 {
 	struct nrf_rpc_cbor_ctx ctx;
-	ot_msg_key key = (ot_msg_key)aMessage;
+	ot_rpc_res_tab_key key = (ot_rpc_res_tab_key)aMessage;
 	uint16_t ret = 0;
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, sizeof(uint32_t) + 1);
@@ -119,7 +119,7 @@ uint16_t otMessageGetOffset(const otMessage *aMessage)
 uint16_t otMessageRead(const otMessage *aMessage, uint16_t aOffset, void *aBuf, uint16_t aLength)
 {
 	struct nrf_rpc_cbor_ctx ctx;
-	ot_msg_key key = (ot_msg_key)aMessage;
+	ot_rpc_res_tab_key key = (ot_rpc_res_tab_key)aMessage;
 	size_t size = 0;
 	const void *buf = NULL;
 

--- a/subsys/net/openthread/rpc/client/ot_rpc_netdiag.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_netdiag.c
@@ -192,8 +192,9 @@ otError otThreadGetNextDiagnosticTlv(const otMessage *aMessage, otNetworkDiagIte
 	struct nrf_rpc_cbor_ctx ctx;
 	otError error;
 
-	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, sizeof(ot_msg_key) + 2 + sizeof(otNetworkDiagIterator));
-	nrf_rpc_encode_uint(&ctx, (ot_msg_key)aMessage);
+	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, sizeof(ot_rpc_res_tab_key) + 2 +
+					   sizeof(otNetworkDiagIterator));
+	nrf_rpc_encode_uint(&ctx, (ot_rpc_res_tab_key)aMessage);
 	nrf_rpc_encode_uint(&ctx, *aIterator);
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_THREAD_GET_NEXT_DIAGNOSTIC_TLV, &ctx);
 

--- a/subsys/net/openthread/rpc/client/ot_rpc_udp.c
+++ b/subsys/net/openthread/rpc/client/ot_rpc_udp.c
@@ -90,7 +90,7 @@ static void ot_rpc_cmd_udp_receive_cb(const struct nrf_rpc_group *group,
 				      struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
 	otMessageInfo message_info;
-	ot_msg_key msg_key = 0;
+	ot_rpc_res_tab_key msg_key = 0;
 	ot_socket_key soc_key = 0;
 	otUdpSocket *socket;
 
@@ -143,7 +143,7 @@ otError otUdpSend(otInstance *aInstance, otUdpSocket *aSocket, otMessage *aMessa
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	ot_socket_key soc_key = (ot_socket_key)aSocket;
-	ot_msg_key msg_key = (ot_msg_key)aMessage;
+	ot_rpc_res_tab_key msg_key = (ot_rpc_res_tab_key)aMessage;
 	otError error = OT_ERROR_NONE;
 
 	ARG_UNUSED(aInstance);

--- a/subsys/net/openthread/rpc/common/ot_rpc_types.h
+++ b/subsys/net/openthread/rpc/common/ot_rpc_types.h
@@ -30,9 +30,9 @@ enum ot_rpc_link_mode_offsets {
 	OT_RPC_LINK_MODE_NETWORK_DATA_OFFSET = 2,
 };
 
-/** @brief Key type of internal otMesage registry.
+/** @brief Key type for internal registry.
  */
-typedef uint32_t ot_msg_key;
+typedef uint32_t ot_rpc_res_tab_key;
 
 /** @brief Key type of internal otUdpSocket registry.
  */

--- a/subsys/net/openthread/rpc/server/ot_rpc_coap.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_coap.c
@@ -60,7 +60,7 @@ static void ot_rpc_cmd_coap_new_message(const struct nrf_rpc_group *group,
 	otMessageSettings settings_buf;
 	otMessageSettings *settings;
 	otMessage *message;
-	ot_msg_key message_rep = 0;
+	ot_rpc_res_tab_key message_rep = 0;
 
 	settings = ot_rpc_decode_message_settings(ctx, &settings_buf);
 
@@ -71,7 +71,7 @@ static void ot_rpc_cmd_coap_new_message(const struct nrf_rpc_group *group,
 
 	openthread_api_mutex_lock(openthread_get_default_context());
 	message = otCoapNewMessage(openthread_get_default_instance(), settings);
-	message_rep = ot_reg_msg_alloc(message);
+	message_rep = ot_res_tab_msg_alloc(message);
 
 	if ((message != NULL) && !message_rep) {
 		/*
@@ -92,7 +92,7 @@ NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_new_message, OT_RPC_CMD_COAP_
 static void ot_rpc_cmd_coap_message_init(const struct nrf_rpc_group *group,
 					 struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	otCoapType type;
 	otCoapCode code;
 	otMessage *message;
@@ -106,7 +106,7 @@ static void ot_rpc_cmd_coap_message_init(const struct nrf_rpc_group *group,
 		return;
 	}
 
-	message = ot_msg_get(message_rep);
+	message = ot_res_tab_msg_get(message_rep);
 
 	if (!message) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_INIT);
@@ -126,8 +126,8 @@ NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_message_init, OT_RPC_CMD_COAP
 static void ot_rpc_cmd_coap_message_init_response(const struct nrf_rpc_group *group,
 						  struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
-	ot_msg_key response_rep;
-	ot_msg_key request_rep;
+	ot_rpc_res_tab_key response_rep;
+	ot_rpc_res_tab_key request_rep;
 	otCoapType type;
 	otCoapCode code;
 	otMessage *response;
@@ -144,8 +144,8 @@ static void ot_rpc_cmd_coap_message_init_response(const struct nrf_rpc_group *gr
 		return;
 	}
 
-	response = ot_msg_get(response_rep);
-	request = ot_msg_get(request_rep);
+	response = ot_res_tab_msg_get(response_rep);
+	request = ot_res_tab_msg_get(request_rep);
 
 	if (!response || !request) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_INIT_RESPONSE);
@@ -167,7 +167,7 @@ static void ot_rpc_cmd_coap_message_append_uri_path_options(const struct nrf_rpc
 							    struct nrf_rpc_cbor_ctx *ctx,
 							    void *handler_data)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	char uri[OT_RPC_COAP_MAX_URI_LENGTH + 1];
 	otMessage *message;
 	otError error;
@@ -180,7 +180,7 @@ static void ot_rpc_cmd_coap_message_append_uri_path_options(const struct nrf_rpc
 		return;
 	}
 
-	message = ot_msg_get(message_rep);
+	message = ot_res_tab_msg_get(message_rep);
 
 	if (!message) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_APPEND_URI_PATH_OPTIONS);
@@ -202,7 +202,7 @@ static void ot_rpc_cmd_coap_message_set_payload_marker(const struct nrf_rpc_grou
 						       struct nrf_rpc_cbor_ctx *ctx,
 						       void *handler_data)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	otMessage *message;
 	otError error;
 
@@ -213,7 +213,7 @@ static void ot_rpc_cmd_coap_message_set_payload_marker(const struct nrf_rpc_grou
 		return;
 	}
 
-	message = ot_msg_get(message_rep);
+	message = ot_res_tab_msg_get(message_rep);
 
 	if (!message) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_SET_PAYLOAD_MARKER);
@@ -234,7 +234,7 @@ NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_message_set_payload_marker,
 static void ot_rpc_cmd_coap_message_get_type(const struct nrf_rpc_group *group,
 					     struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	otMessage *message;
 	otCoapType type;
 
@@ -245,7 +245,7 @@ static void ot_rpc_cmd_coap_message_get_type(const struct nrf_rpc_group *group,
 		return;
 	}
 
-	message = ot_msg_get(message_rep);
+	message = ot_res_tab_msg_get(message_rep);
 
 	if (!message) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TYPE);
@@ -265,7 +265,7 @@ NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_message_get_type,
 static void ot_rpc_cmd_coap_message_get_code(const struct nrf_rpc_group *group,
 					     struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	otMessage *message;
 	otCoapCode code;
 
@@ -276,7 +276,7 @@ static void ot_rpc_cmd_coap_message_get_code(const struct nrf_rpc_group *group,
 		return;
 	}
 
-	message = ot_msg_get(message_rep);
+	message = ot_res_tab_msg_get(message_rep);
 
 	if (!message) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_CODE);
@@ -296,7 +296,7 @@ NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_message_get_code,
 static void ot_rpc_cmd_coap_message_get_message_id(const struct nrf_rpc_group *group,
 						   struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	otMessage *message;
 	uint16_t id;
 
@@ -307,7 +307,7 @@ static void ot_rpc_cmd_coap_message_get_message_id(const struct nrf_rpc_group *g
 		return;
 	}
 
-	message = ot_msg_get(message_rep);
+	message = ot_res_tab_msg_get(message_rep);
 
 	if (!message) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_MESSAGE_ID);
@@ -329,7 +329,7 @@ static void ot_rpc_cmd_coap_message_get_token_length(const struct nrf_rpc_group 
 						     struct nrf_rpc_cbor_ctx *ctx,
 						     void *handler_data)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	otMessage *message;
 	uint8_t token_length;
 
@@ -340,7 +340,7 @@ static void ot_rpc_cmd_coap_message_get_token_length(const struct nrf_rpc_group 
 		return;
 	}
 
-	message = ot_msg_get(message_rep);
+	message = ot_res_tab_msg_get(message_rep);
 
 	if (!message) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN_LENGTH);
@@ -361,7 +361,7 @@ NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_message_get_token_length,
 static void ot_rpc_cmd_coap_message_get_token(const struct nrf_rpc_group *group,
 					      struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	otMessage *message;
 	uint8_t token[OT_COAP_MAX_TOKEN_LENGTH];
 	uint8_t token_length;
@@ -374,7 +374,7 @@ static void ot_rpc_cmd_coap_message_get_token(const struct nrf_rpc_group *group,
 		return;
 	}
 
-	message = ot_msg_get(message_rep);
+	message = ot_res_tab_msg_get(message_rep);
 
 	if (!message) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_MESSAGE_GET_TOKEN);
@@ -441,12 +441,12 @@ NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_stop, OT_RPC_CMD_COAP_STOP, o
 static void ot_rpc_coap_resource_handler(void *aContext, otMessage *aMessage,
 					 const otMessageInfo *aMessageInfo)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	const char *uri = aContext;
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t cbor_buffer_size = 0;
 
-	message_rep = ot_reg_msg_alloc(aMessage);
+	message_rep = ot_res_tab_msg_alloc(aMessage);
 
 	if (!message_rep) {
 		nrf_rpc_err(-ENOMEM, NRF_RPC_ERR_SRC_SEND, &ot_group,
@@ -455,7 +455,7 @@ static void ot_rpc_coap_resource_handler(void *aContext, otMessage *aMessage,
 	}
 
 	cbor_buffer_size += 2 + strlen(uri);
-	cbor_buffer_size += 1 + sizeof(ot_msg_key);		      /* aMessage */
+	cbor_buffer_size += 1 + sizeof(ot_rpc_res_tab_key);	      /* aMessage */
 	cbor_buffer_size += OT_RPC_MESSAGE_INFO_LENGTH(aMessageInfo); /* aMessageInfo */
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
@@ -465,7 +465,7 @@ static void ot_rpc_coap_resource_handler(void *aContext, otMessage *aMessage,
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_RESOURCE_HANDLER, &ctx,
 				nrf_rpc_rsp_decode_void, NULL);
 
-	ot_msg_free(message_rep);
+	ot_res_tab_msg_free(message_rep);
 }
 
 static void ot_rpc_cmd_coap_add_resource(const struct nrf_rpc_group *group,
@@ -548,11 +548,11 @@ NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_remove_resource, OT_RPC_CMD_C
 static void ot_rpc_coap_default_handler(void *aContext, otMessage *aMessage,
 					const otMessageInfo *aMessageInfo)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t cbor_buffer_size = 0;
 
-	message_rep = ot_reg_msg_alloc(aMessage);
+	message_rep = ot_res_tab_msg_alloc(aMessage);
 
 	if (!message_rep) {
 		nrf_rpc_err(-ENOMEM, NRF_RPC_ERR_SRC_SEND, &ot_group,
@@ -560,7 +560,7 @@ static void ot_rpc_coap_default_handler(void *aContext, otMessage *aMessage,
 		return;
 	}
 
-	cbor_buffer_size += 1 + sizeof(ot_msg_key);		      /* aMessage */
+	cbor_buffer_size += 1 + sizeof(ot_rpc_res_tab_key);	      /* aMessage */
 	cbor_buffer_size += OT_RPC_MESSAGE_INFO_LENGTH(aMessageInfo); /* aMessageInfo */
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
@@ -569,7 +569,7 @@ static void ot_rpc_coap_default_handler(void *aContext, otMessage *aMessage,
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_DEFAULT_HANDLER, &ctx,
 				nrf_rpc_rsp_decode_void, NULL);
 
-	ot_msg_free(message_rep);
+	ot_res_tab_msg_free(message_rep);
 }
 
 static void ot_rpc_cmd_coap_set_default_handler(const struct nrf_rpc_group *group,
@@ -600,11 +600,11 @@ static void ot_rpc_coap_response_handler(void *context, otMessage *message,
 					 const otMessageInfo *message_info, otError error)
 {
 	ot_rpc_coap_request_key request_rep = (ot_rpc_coap_request_key)context;
-	ot_msg_key message_rep = 0;
+	ot_rpc_res_tab_key message_rep = 0;
 	struct nrf_rpc_cbor_ctx ctx;
 	size_t cbor_buffer_size = 0;
 
-	message_rep = ot_reg_msg_alloc(message);
+	message_rep = ot_res_tab_msg_alloc(message);
 	/*
 	 * Ignore message handle allocation failure. It seems safer to call the client's response
 	 * handler without the response (which indicates response timeout) than not to call the
@@ -612,7 +612,7 @@ static void ot_rpc_coap_response_handler(void *context, otMessage *message,
 	 */
 
 	cbor_buffer_size += 1 + sizeof(ot_rpc_coap_request_key);
-	cbor_buffer_size += 1 + sizeof(ot_msg_key);
+	cbor_buffer_size += 1 + sizeof(ot_rpc_res_tab_key);
 	cbor_buffer_size += OT_RPC_MESSAGE_INFO_LENGTH(message_info);
 
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
@@ -623,13 +623,13 @@ static void ot_rpc_coap_response_handler(void *context, otMessage *message,
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_RESPONSE_HANDLER, &ctx,
 				nrf_rpc_rsp_decode_void, NULL);
 
-	ot_msg_free(message_rep);
+	ot_res_tab_msg_free(message_rep);
 }
 
 static void ot_rpc_cmd_coap_send_request(const struct nrf_rpc_group *group,
 					 struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	otMessageInfo message_info;
 	ot_rpc_coap_request_key request_rep;
 	otMessage *message;
@@ -644,7 +644,7 @@ static void ot_rpc_cmd_coap_send_request(const struct nrf_rpc_group *group,
 		return;
 	}
 
-	message = ot_msg_get(message_rep);
+	message = ot_res_tab_msg_get(message_rep);
 
 	if (!message) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_SEND_REQUEST);
@@ -656,7 +656,7 @@ static void ot_rpc_cmd_coap_send_request(const struct nrf_rpc_group *group,
 				  ot_rpc_coap_response_handler, (void *)request_rep);
 
 	if (error == OT_ERROR_NONE) {
-		ot_msg_free(message_rep);
+		ot_res_tab_msg_free(message_rep);
 	}
 
 	openthread_api_mutex_unlock(openthread_get_default_context());
@@ -669,7 +669,7 @@ NRF_RPC_CBOR_CMD_DECODER(ot_group, ot_rpc_cmd_coap_send_request, OT_RPC_CMD_COAP
 static void ot_rpc_cmd_coap_send_response(const struct nrf_rpc_group *group,
 					  struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	otMessageInfo message_info;
 	otMessage *message;
 	otError error;
@@ -682,7 +682,7 @@ static void ot_rpc_cmd_coap_send_response(const struct nrf_rpc_group *group,
 		return;
 	}
 
-	message = ot_msg_get(message_rep);
+	message = ot_res_tab_msg_get(message_rep);
 
 	if (!message) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_COAP_SEND_RESPONSE);
@@ -693,7 +693,7 @@ static void ot_rpc_cmd_coap_send_response(const struct nrf_rpc_group *group,
 	error = otCoapSendResponse(openthread_get_default_instance(), message, &message_info);
 
 	if (error == OT_ERROR_NONE) {
-		ot_msg_free(message_rep);
+		ot_res_tab_msg_free(message_rep);
 	}
 
 	openthread_api_mutex_unlock(openthread_get_default_context());

--- a/subsys/net/openthread/rpc/server/ot_rpc_message.h
+++ b/subsys/net/openthread/rpc/server/ot_rpc_message.h
@@ -8,10 +8,8 @@
 #define OT_RPC_OT_MESSAGE_
 
 #include <openthread/message.h>
-#include <ot_rpc_types.h>
+#include "ot_rpc_resource.h"
 
-ot_msg_key ot_reg_msg_alloc(otMessage *msg);
-void ot_msg_free(ot_msg_key key);
-otMessage *ot_msg_get(ot_msg_key key);
+OT_RPC_RESOURCE_TABLE_DECLARE(msg, otMessage);
 
 #endif

--- a/subsys/net/openthread/rpc/server/ot_rpc_netdiag.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_netdiag.c
@@ -238,7 +238,7 @@ static void ot_rpc_cmd_get_next_diagnostic_tlv(const struct nrf_rpc_group *group
 					       struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
 	otError error;
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 	const otMessage *message;
 	otNetworkDiagIterator iterator;
 	otNetworkDiagTlv tlv;
@@ -252,7 +252,7 @@ static void ot_rpc_cmd_get_next_diagnostic_tlv(const struct nrf_rpc_group *group
 		return;
 	}
 
-	message = ot_msg_get(message_rep);
+	message = ot_res_tab_msg_get(message_rep);
 
 	if (!message) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_THREAD_GET_NEXT_DIAGNOSTIC_TLV);
@@ -281,11 +281,11 @@ void handle_receive_diagnostic_get(otError aError, otMessage *aMessage,
 					  const otMessageInfo *aMessageInfo, void *aContext)
 {
 	struct nrf_rpc_cbor_ctx ctx;
-	ot_msg_key message_rep;
+	ot_rpc_res_tab_key message_rep;
 
 	ARG_UNUSED(aContext);
 
-	message_rep = ot_reg_msg_alloc(aMessage);
+	message_rep = ot_res_tab_msg_alloc(aMessage);
 
 	if (message_rep == 0) {
 		nrf_rpc_err(-ENOMEM, NRF_RPC_ERR_SRC_SEND, &ot_group,
@@ -303,7 +303,7 @@ void handle_receive_diagnostic_get(otError aError, otMessage *aMessage,
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_THREAD_SEND_DIAGNOSTIC_GET_CB, &ctx,
 				nrf_rpc_rsp_decode_void, NULL);
 
-	ot_msg_free(message_rep);
+	ot_res_tab_msg_free(message_rep);
 }
 
 static void ot_rpc_cmd_send_diagnostic_get(const struct nrf_rpc_group *group,

--- a/subsys/net/openthread/rpc/server/ot_rpc_resource.h
+++ b/subsys/net/openthread/rpc/server/ot_rpc_resource.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef OT_RPC_RESOURCE_
+#define OT_RPC_RESOURCE_
+
+#include <ot_rpc_types.h>
+
+#define OT_RPC_RESOURCE_TABLE_DECLARE(name, type)                                                  \
+	ot_rpc_res_tab_key ot_res_tab_##name##_alloc(type * ptr);                                  \
+	void ot_res_tab_##name##_free(ot_rpc_res_tab_key key);                                     \
+	type *ot_res_tab_##name##_get(ot_rpc_res_tab_key key);
+
+#define OT_RPC_RESOURCE_TABLE_REGISTER(name, type, size)                                           \
+	static type *ot_##name##_res_tab[size];                                                    \
+												   \
+	ot_rpc_res_tab_key ot_res_tab_##name##_alloc(type *ptr)                                    \
+	{                                                                                          \
+		if (ptr == NULL) {                                                                 \
+			return 0;                                                                  \
+		}                                                                                  \
+												   \
+		for (ot_rpc_res_tab_key i = 0; i < size; i++) {                                    \
+			if (ot_##name##_res_tab[i] == NULL) {                                      \
+				ot_##name##_res_tab[i] = ptr;                                      \
+				return i + 1;                                                      \
+			}                                                                          \
+		}                                                                                  \
+		return 0;                                                                          \
+	}                                                                                          \
+												   \
+	void ot_res_tab_##name##_free(ot_rpc_res_tab_key key)                                      \
+	{                                                                                          \
+		if (key == 0 || key > size) {                                                      \
+			return;                                                                    \
+		}                                                                                  \
+												   \
+		ot_##name##_res_tab[key - 1] = NULL;                                               \
+	}                                                                                          \
+												   \
+	type *ot_res_tab_##name##_get(ot_rpc_res_tab_key key)                                      \
+	{                                                                                          \
+		if (key == 0 || key > size) {                                                      \
+			return NULL;                                                               \
+		}                                                                                  \
+												   \
+		return ot_##name##_res_tab[key - 1];                                               \
+	}
+
+#endif /* OT_RPC_RESOURCE_ */

--- a/subsys/net/openthread/rpc/server/ot_rpc_udp.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_udp.c
@@ -67,7 +67,7 @@ static void handle_udp_receive(void *context, otMessage *message, const otMessag
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	nrf_udp_socket *socket = (nrf_udp_socket *)context;
-	ot_msg_key msg_key = ot_reg_msg_alloc(message);
+	ot_rpc_res_tab_key msg_key = ot_res_tab_msg_alloc(message);
 	ot_socket_key soc_key = socket->mKey;
 
 	if (msg_key == 0) {
@@ -87,7 +87,7 @@ static void handle_udp_receive(void *context, otMessage *message, const otMessag
 	}
 
 exit:
-	ot_msg_free(msg_key); /* This is NULL safe. */
+	ot_res_tab_msg_free(msg_key); /* This is NULL safe. */
 }
 
 static void ot_rpc_udp_open(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
@@ -132,7 +132,7 @@ static void ot_rpc_udp_send(const struct nrf_rpc_group *group, struct nrf_rpc_cb
 	struct nrf_rpc_cbor_ctx rsp_ctx;
 	otError error;
 	ot_socket_key soc_key;
-	ot_msg_key msg_key;
+	ot_rpc_res_tab_key msg_key;
 	nrf_udp_socket *socket;
 	otMessageInfo message_info;
 	otMessage *message;
@@ -149,7 +149,7 @@ static void ot_rpc_udp_send(const struct nrf_rpc_group *group, struct nrf_rpc_cb
 	}
 
 	socket = nrf_udp_find_socket(soc_key);
-	message = ot_msg_get(msg_key);
+	message = ot_res_tab_msg_get(msg_key);
 
 	if (socket == NULL || message == NULL) {
 		error = OT_ERROR_INVALID_ARGS;
@@ -162,7 +162,7 @@ static void ot_rpc_udp_send(const struct nrf_rpc_group *group, struct nrf_rpc_cb
 	openthread_api_mutex_unlock(openthread_get_default_context());
 
 	if (error == OT_ERROR_NONE) {
-		ot_msg_free(msg_key);
+		ot_res_tab_msg_free(msg_key);
 	}
 
 exit:

--- a/tests/subsys/net/openthread/rpc/server/src/coap_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/coap_suite.c
@@ -90,8 +90,8 @@ static void tc_setup(void *f)
 	FFF_RESET_HISTORY();
 
 	/* Unit tests take up to two message slots. */
-	ot_msg_free(1);
-	ot_msg_free(2);
+	ot_res_tab_msg_free(1);
+	ot_res_tab_msg_free(2);
 }
 
 /*
@@ -125,7 +125,7 @@ ZTEST(ot_rpc_coap, test_otCoapNewMessage_max)
 	mock_nrf_rpc_tr_expect_done();
 
 	zassert_equal(otCoapNewMessage_fake.call_count, 1);
-	zassert_not_null(ot_msg_get(1));
+	zassert_not_null(ot_res_tab_msg_get(1));
 }
 
 /*
@@ -133,7 +133,7 @@ ZTEST(ot_rpc_coap, test_otCoapNewMessage_max)
  */
 ZTEST(ot_rpc_coap, test_otCoapMessageInit)
 {
-	ot_msg_key message_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key message_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
 
 	mock_nrf_rpc_tr_expect_add(RPC_RSP(), NO_RSP);
 	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_COAP_MESSAGE_INIT, message_rep,
@@ -153,8 +153,8 @@ ZTEST(ot_rpc_coap, test_otCoapMessageInit)
  */
 ZTEST(ot_rpc_coap, test_otCoapMessageInitResponse)
 {
-	ot_msg_key response_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
-	ot_msg_key request_rep = ot_reg_msg_alloc((otMessage *)(MSG_ADDR - 1));
+	ot_rpc_res_tab_key response_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key request_rep = ot_res_tab_msg_alloc((otMessage *)(MSG_ADDR - 1));
 
 	otCoapMessageInitResponse_fake.return_val = OT_ERROR_INVALID_ARGS;
 
@@ -187,7 +187,7 @@ otError append_uri_path_options_fake(otMessage *message, const char *uri_path)
 
 ZTEST(ot_rpc_coap, test_otCoapMessageAppendUriPathOptions)
 {
-	ot_msg_key message_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key message_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
 
 	otCoapMessageAppendUriPathOptions_fake.custom_fake = append_uri_path_options_fake;
 
@@ -205,7 +205,7 @@ ZTEST(ot_rpc_coap, test_otCoapMessageAppendUriPathOptions)
  */
 ZTEST(ot_rpc_coap, test_otCoapMessageSetPayloadMarker)
 {
-	ot_msg_key message_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key message_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
 
 	otCoapMessageSetPayloadMarker_fake.return_val = OT_ERROR_INVALID_ARGS;
 
@@ -223,7 +223,7 @@ ZTEST(ot_rpc_coap, test_otCoapMessageSetPayloadMarker)
  */
 ZTEST(ot_rpc_coap, test_otCoapMessageGetType)
 {
-	ot_msg_key message_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key message_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
 
 	otCoapMessageGetType_fake.return_val = OT_COAP_TYPE_RESET;
 
@@ -241,7 +241,7 @@ ZTEST(ot_rpc_coap, test_otCoapMessageGetType)
  */
 ZTEST(ot_rpc_coap, test_otCoapMessageGetCode)
 {
-	ot_msg_key message_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key message_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
 
 	otCoapMessageGetCode_fake.return_val = OT_COAP_CODE_PROXY_NOT_SUPPORTED;
 
@@ -259,7 +259,7 @@ ZTEST(ot_rpc_coap, test_otCoapMessageGetCode)
  */
 ZTEST(ot_rpc_coap, test_otCoapMessageGetMessageId)
 {
-	ot_msg_key message_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key message_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
 
 	otCoapMessageGetMessageId_fake.return_val = UINT16_MAX;
 
@@ -277,7 +277,7 @@ ZTEST(ot_rpc_coap, test_otCoapMessageGetMessageId)
  */
 ZTEST(ot_rpc_coap, test_otCoapMessageGetTokenLength)
 {
-	ot_msg_key message_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key message_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
 
 	otCoapMessageGetTokenLength_fake.return_val = OT_COAP_MAX_TOKEN_LENGTH;
 
@@ -295,7 +295,7 @@ ZTEST(ot_rpc_coap, test_otCoapMessageGetTokenLength)
  */
 ZTEST(ot_rpc_coap, test_otCoapMessageGetToken)
 {
-	ot_msg_key message_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key message_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
 	uint8_t token[] = {TOKEN};
 
 	otCoapMessageGetToken_fake.return_val = token;
@@ -365,7 +365,7 @@ ZTEST(ot_rpc_coap, test_otCoapAddResource_otCoapRemoveResource)
 	 * Message key is allocated by the resource handler encoder function but we know that
 	 * the first free slot will be selected so it will be 1.
 	 */
-	ot_msg_key message_rep = 1;
+	ot_rpc_res_tab_key message_rep = 1;
 	otMessageInfo message_info = {
 		.mSockAddr = {.mFields.m8 = {ADDR_1}},
 		.mPeerAddr = {.mFields.m8 = {ADDR_2}},
@@ -394,7 +394,7 @@ ZTEST(ot_rpc_coap, test_otCoapAddResource_otCoapRemoveResource)
 	otCoapAddResource_fake.arg1_val->mHandler(otCoapAddResource_fake.arg1_val->mContext,
 						  (otMessage *)MSG_ADDR, &message_info);
 	mock_nrf_rpc_tr_expect_done();
-	zassert_is_null(ot_msg_get(message_rep));
+	zassert_is_null(ot_res_tab_msg_get(message_rep));
 
 	/* Test reception of otCoapRemoveResource() */
 	otCoapRemoveResource_fake.custom_fake = otCoapRemoveResource_custom_func;
@@ -415,7 +415,7 @@ ZTEST(ot_rpc_coap, test_otCoapSetDefaultHandler)
 	 * Message key is allocated by the default handler encoder function but we know that
 	 * the first free slot will be selected so it will be 1.
 	 */
-	ot_msg_key message_rep = 1;
+	ot_rpc_res_tab_key message_rep = 1;
 	otMessageInfo message_info = {
 		.mSockAddr = {.mFields.m8 = {ADDR_1}},
 		.mPeerAddr = {.mFields.m8 = {ADDR_2}},
@@ -442,7 +442,7 @@ ZTEST(ot_rpc_coap, test_otCoapSetDefaultHandler)
 	otCoapSetDefaultHandler_fake.arg1_val(otCoapSetDefaultHandler_fake.arg2_val,
 					      (otMessage *)MSG_ADDR, &message_info);
 	mock_nrf_rpc_tr_expect_done();
-	zassert_is_null(ot_msg_get(message_rep));
+	zassert_is_null(ot_res_tab_msg_get(message_rep));
 
 	/* Test reception of otCoapSetDefaultHandler() command that unsets the default handler */
 	RESET_FAKE(otCoapSetDefaultHandler);
@@ -463,12 +463,12 @@ ZTEST(ot_rpc_coap, test_otCoapSetDefaultHandler)
 ZTEST(ot_rpc_coap, test_otCoapSendRequest)
 {
 	ot_rpc_coap_request_key request_rep = 3;
-	ot_msg_key message_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key message_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
 	/*
 	 * The request message slot is freed when otCoapSendRequest() succeeds,
 	 * so we know that the same slot will be used to relay the response message.
 	 */
-	ot_msg_key response_rep = message_rep;
+	ot_rpc_res_tab_key response_rep = message_rep;
 	otMessageInfo message_info = {
 		.mSockAddr = {.mFields.m8 = {ADDR_1}},
 		.mPeerAddr = {.mFields.m8 = {ADDR_2}},
@@ -511,7 +511,7 @@ ZTEST(ot_rpc_coap, test_otCoapSendRequest)
 ZTEST(ot_rpc_coap, test_otCoapSendRequest_failed)
 {
 	ot_rpc_coap_request_key request_rep = 3;
-	ot_msg_key message_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key message_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
 
 	otCoapSendRequestWithParameters_fake.return_val = OT_ERROR_INVALID_STATE;
 
@@ -524,7 +524,7 @@ ZTEST(ot_rpc_coap, test_otCoapSendRequest_failed)
 	zexpect_equal(otCoapSendRequestWithParameters_fake.arg1_val, (otMessage *)MSG_ADDR);
 	zexpect_not_null(otCoapSendRequestWithParameters_fake.arg2_val);
 	zexpect_not_null(otCoapSendRequestWithParameters_fake.arg3_val);
-	zassert_not_null(ot_msg_get(message_rep));
+	zassert_not_null(ot_res_tab_msg_get(message_rep));
 }
 
 /*
@@ -534,7 +534,7 @@ ZTEST(ot_rpc_coap, test_otCoapSendRequest_failed)
  */
 ZTEST(ot_rpc_coap, test_otCoapSendResponse)
 {
-	ot_msg_key message_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key message_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
 
 	otCoapSendResponseWithParameters_fake.return_val = OT_ERROR_NONE;
 
@@ -545,7 +545,7 @@ ZTEST(ot_rpc_coap, test_otCoapSendResponse)
 	zassert_equal(otCoapSendResponseWithParameters_fake.call_count, 1);
 	zexpect_equal(otCoapSendResponseWithParameters_fake.arg1_val, (otMessage *)MSG_ADDR);
 	zexpect_not_null(otCoapSendResponseWithParameters_fake.arg2_val);
-	zassert_is_null(ot_msg_get(message_rep));
+	zassert_is_null(ot_res_tab_msg_get(message_rep));
 }
 
 /*
@@ -555,7 +555,7 @@ ZTEST(ot_rpc_coap, test_otCoapSendResponse)
  */
 ZTEST(ot_rpc_coap, test_otCoapSendResponse_failed)
 {
-	ot_msg_key message_rep = ot_reg_msg_alloc((otMessage *)MSG_ADDR);
+	ot_rpc_res_tab_key message_rep = ot_res_tab_msg_alloc((otMessage *)MSG_ADDR);
 
 	otCoapSendResponseWithParameters_fake.return_val = OT_ERROR_INVALID_STATE;
 
@@ -566,7 +566,7 @@ ZTEST(ot_rpc_coap, test_otCoapSendResponse_failed)
 	zassert_equal(otCoapSendResponseWithParameters_fake.call_count, 1);
 	zexpect_equal(otCoapSendResponseWithParameters_fake.arg1_val, (otMessage *)MSG_ADDR);
 	zexpect_not_null(otCoapSendResponseWithParameters_fake.arg2_val);
-	zassert_not_null(ot_msg_get(message_rep));
+	zassert_not_null(ot_res_tab_msg_get(message_rep));
 }
 
 ZTEST_SUITE(ot_rpc_coap, NULL, NULL, tc_setup, NULL, NULL);

--- a/tests/subsys/net/openthread/rpc/server/src/message_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/message_suite.c
@@ -115,30 +115,30 @@ ZTEST(ot_rpc_message, test_otUdpNewMessage_free_working)
 	zassert_equal(otMessageFree_fake.call_count, 2);
 }
 
-ZTEST(ot_rpc_message, test_ot_reg_msg_alloc_free)
+ZTEST(ot_rpc_message, test_ot_res_tab_msg_alloc_free)
 {
 
 	for (size_t i = 1; i < CONFIG_OPENTHREAD_RPC_MESSAGE_POOL + 1; i++) {
-		zassert_equal(ot_reg_msg_alloc((otMessage *)i), i);
+		zassert_equal(ot_res_tab_msg_alloc((otMessage *)i), i);
 	}
 
-	zassert_equal(ot_reg_msg_alloc((otMessage *)UINT32_MAX), 0);
+	zassert_equal(ot_res_tab_msg_alloc((otMessage *)UINT32_MAX), 0);
 
 	for (size_t i = 1; i < CONFIG_OPENTHREAD_RPC_MESSAGE_POOL + 1; i++) {
-		ot_msg_free(i);
+		ot_res_tab_msg_free(i);
 	}
 }
 
-ZTEST(ot_rpc_message, test_ot_reg_msg_get)
+ZTEST(ot_rpc_message, test_ot_res_tab_msg_get)
 {
 
-	zassert_equal(ot_reg_msg_alloc((otMessage *)1), 1);
+	zassert_equal(ot_res_tab_msg_alloc((otMessage *)1), 1);
 
-	zassert_equal(ot_msg_get(1), (otMessage *)1);
+	zassert_equal(ot_res_tab_msg_get(1), (otMessage *)1);
 
-	zassert_equal(ot_msg_get(CONFIG_OPENTHREAD_RPC_MESSAGE_POOL), NULL);
+	zassert_equal(ot_res_tab_msg_get(CONFIG_OPENTHREAD_RPC_MESSAGE_POOL), NULL);
 
-	ot_msg_free(1);
+	ot_res_tab_msg_free(1);
 }
 
 ZTEST(ot_rpc_message, test_get_length_offset)


### PR DESCRIPTION
Add macros to declare/define necessary functions for internal resource tables on server.