### PR TITLE
applications: nrf_desktop: Add static PM memory maps for single-image

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/pm_static.yml
+++ b/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/pm_static.yml
@@ -1,0 +1,6 @@
+app:
+  address: 0x0000
+  size: 0x3e000
+settings_storage:
+  address: 0x3e000
+  size: 0x2000

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/pm_static.yml
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/pm_static.yml
@@ -1,0 +1,6 @@
+app:
+  address: 0x0000
+  size: 0x3e000
+settings_storage:
+  address: 0x3e000
+  size: 0x2000

--- a/applications/nrf_desktop/configuration/nrf52dmouse_nrf52832/pm_static.yml
+++ b/applications/nrf_desktop/configuration/nrf52dmouse_nrf52832/pm_static.yml
@@ -1,0 +1,6 @@
+app:
+  address: 0x0000
+  size: 0x7e000
+settings_storage:
+  address: 0x7e000
+  size: 0x2000

--- a/applications/nrf_desktop/configuration/nrf52dmouse_nrf52832/pm_static_release.yml
+++ b/applications/nrf_desktop/configuration/nrf52dmouse_nrf52832/pm_static_release.yml
@@ -1,0 +1,6 @@
+app:
+  address: 0x0000
+  size: 0x7e000
+settings_storage:
+  address: 0x7e000
+  size: 0x2000

--- a/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/pm_static.yml
+++ b/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/pm_static.yml
@@ -1,0 +1,6 @@
+app:
+  address: 0x0000
+  size: 0x7e000
+settings_storage:
+  address: 0x7e000
+  size: 0x2000

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -295,6 +295,10 @@ nRF Desktop
   * Requirement for zero latency in Zephyr's :ref:`zephyr:pm-system` while USB is active (:ref:`CONFIG_DESKTOP_USB_PM_REQ_NO_PM_LATENCY <config_desktop_app_options>` Kconfig option of the :ref:`nrf_desktop_usb_state_pm`).
     The feature is enabled by default if Zephyr power management (:kconfig:option:`CONFIG_PM`) is enabled.
     It prevents entering power states that introduce wakeup latency and ensure high performance.
+  * Static Partition Manager memory maps for single-image configurations (without bootloader and separate radio/network core image).
+    In the |NCS|, the Partition Manager is enabled by default for single-image sysbuild builds.
+    The static memory map ensures control over settings partition placement and size.
+    The introduced static memory maps may not be consistent with the ``storage_partition`` defined by the board-level DTS configuration.
 
 * Updated:
 


### PR DESCRIPTION
Change introduces static Partition Manager memory maps for single-image configurations. This is done to ensure that dynamic partitioning is not used.

Jira: NCSDK-30908