### PR TITLE
esb: Fix timer shorts configuration for CONFIG_ESB_NEVER_DISABLE_TX

### DIFF
--- a/doc/nrf/protocols/esb/index.rst
+++ b/doc/nrf/protocols/esb/index.rst
@@ -338,3 +338,5 @@ It changes the ESB driver's behavior.
 If a packet is not acknowledged, the radio peripheral remains in TXIDLE state instead of TXDISABLE when transmission is pending.
 Using this experimental feature can reduce transmission delay below 100 µs for a 32 bits (four bytes) payload.
 However, this process consumes more energy, because the radio transmitter stage remains enabled when transmission is taking place.
+In this mode, the :c:member:`esb_config.retransmit_delay` field specifies the delay between consecutive packet transmissions from the TX FIFO.
+Depending on the reception processing time, a minimum value might be required.

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -420,6 +420,16 @@ static void esb_fem_for_tx_set(bool ack)
 		nrf_timer_cc_set(esb_timer.p_reg, NRF_TIMER_CC_CHANNEL2, ramp_up);
 	}
 
+	if (IS_ENABLED(CONFIG_ESB_NEVER_DISABLE_TX)) {
+		uint32_t cc1 = nrfx_timer_capture_get(&esb_timer, NRF_TIMER_CC_CHANNEL1);
+		uint32_t cc2 = nrfx_timer_capture_get(&esb_timer, NRF_TIMER_CC_CHANNEL2);
+
+		if (cc1 > cc2) {
+			timer_shorts = NRF_TIMER_SHORT_COMPARE1_STOP_MASK;
+			timer_shorts |= NRF_TIMER_SHORT_COMPARE1_CLEAR_MASK;
+		}
+	}
+
 	nrf_timer_shorts_set(esb_timer.p_reg, timer_shorts);
 }
 


### PR DESCRIPTION
This change fixes the conﬁguration of timer shorts for CONFIG_ESB_NEVER_DISABLE_TX mode.
