### PR TITLE
doc: wifi: Fix Low-level API doc

### DIFF
--- a/doc/nrf/drivers/wifi/low_level_api.rst
+++ b/doc/nrf/drivers/wifi/low_level_api.rst
@@ -1,5 +1,14 @@
-Low-Level API
+.. _nrf70_wifi_low_level_api:
+
+Low-level API
 #############
+
+.. contents::
+   :local:
+   :depth: 2
+
+The nRF70 Series Wi-Fi® driver provides a low-level API for applications that need direct access to the nRF70 Series device.
+This is intended for users who want to use the nRF70 Series device on a platform other than Zephyr.
 
 Common
 ******


### PR DESCRIPTION
Fixed style issues in the Low-level API doc
under the Wi-Fi drivers section.