### PR TITLE
samples: Add HMPAN216 workaround in the radio_test and bluetooth/direct_test_mode samples

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -481,6 +481,7 @@ Bluetooth samples
 
     * Loading of radio trims and a fix of a hardware errata for the nRF54H20 SoC to improve the RF performance.
     * Support for the :ref:`nRF2220 front-end module <ug_radio_fem_nrf2220ek>`.
+    * Workaround for the hardware errata HMPAN-216 for the nRF54H20 SoC.
 
 * :ref:`central_uart` sample:
 
@@ -713,6 +714,7 @@ Peripheral samples
 
     * Loading of radio trims and a fix of a hardware errata for the nRF54H20 SoC to improve the RF performance.
     * Support for the :ref:`nRF2220 front-end module <ug_radio_fem_nrf2220ek>`.
+    * Workaround for the hardware errata HMPAN-216 for the nRF54H20 SoC.
 
 PMIC samples
 ------------

--- a/samples/bluetooth/direct_test_mode/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/bluetooth/direct_test_mode/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -48,3 +48,12 @@
 	dfegpio2-gpios = <&gpio0 6 0>;
 	dfegpio3-gpios = <&gpio0 7 0>;
 };
+
+/ {
+	cpurad_cpusys_errata216_mboxes: errata216_mboxes {
+		compatible = "zephyr,mbox-ipm";
+		status = "okay";
+		mboxes = < &cpusys_vevif 0x14 >, < &cpusys_vevif 0x15 >;
+		mbox-names = "on_req", "off_req";
+	};
+};

--- a/samples/peripheral/radio_test/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/peripheral/radio_test/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -35,3 +35,12 @@ cpurad_dma_region_alt: &cpuapp_dma_region {
 	source-channels = < 0 1 >;
 	sink-channels = < 2 3 >;
 };
+
+/ {
+	cpurad_cpusys_errata216_mboxes: errata216_mboxes {
+		compatible = "zephyr,mbox-ipm";
+		status = "okay";
+		mboxes = < &cpusys_vevif 0x14 >, < &cpusys_vevif 0x15 >;
+		mbox-names = "on_req", "off_req";
+	};
+};

--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -190,6 +190,7 @@ static int cmd_time_set(const struct shell *shell, size_t argc, char **argv)
 static int cmd_cancel(const struct shell *shell, size_t argc, char **argv)
 {
 	radio_test_cancel();
+	test_in_progress = false;
 	return 0;
 }
 


### PR DESCRIPTION
Implement the HMPAN-216 workaround for nRF54H20 in Radio Test and DTM using mbox, Timer CC1 and a binary sempahore to block test execution for the time required by the errata specification.