### PR TITLE
manifest: Pull MQTT 5.0 support from upstream

### DIFF
--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -424,7 +424,7 @@ static int do_mqtt_disconnect(void)
 		return -ENOTCONN;
 	}
 
-	err = mqtt_disconnect(&client);
+	err = mqtt_disconnect(&client, NULL);
 	if (err) {
 		LOG_ERR("ERROR: mqtt_disconnect %d", err);
 		return err;

--- a/subsys/net/lib/mqtt_helper/mqtt_helper.c
+++ b/subsys/net/lib/mqtt_helper/mqtt_helper.c
@@ -622,7 +622,7 @@ int mqtt_helper_disconnect(void)
 
 	mqtt_state_set(MQTT_STATE_DISCONNECTING);
 
-	err = mqtt_disconnect(&mqtt_client);
+	err = mqtt_disconnect(&mqtt_client, NULL);
 	if (err) {
 		/* Treat the sitation as an ungraceful disconnect */
 		LOG_ERR("Failed to send disconnection request, treating as disconnected");

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -1196,7 +1196,7 @@ int nct_disconnect(void)
 	LOG_DBG("Disconnecting");
 
 	dc_endpoint_free();
-	return mqtt_disconnect(&nct.client);
+	return mqtt_disconnect(&nct.client, NULL);
 }
 
 int nct_process(void)

--- a/tests/subsys/net/lib/mqtt_helper/src/mqtt_helper_test.c
+++ b/tests/subsys/net/lib/mqtt_helper/src/mqtt_helper_test.c
@@ -400,7 +400,7 @@ void test_on_publish_too_large_incoming_msg(void)
 
 void test_mqtt_helper_disconnect_when_connected(void)
 {
-	__cmock_mqtt_disconnect_ExpectAndReturn(&mqtt_client, 0);
+	__cmock_mqtt_disconnect_ExpectAndReturn(&mqtt_client, NULL, 0);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 
@@ -410,7 +410,7 @@ void test_mqtt_helper_disconnect_when_connected(void)
 
 void test_mqtt_helper_disconnect_when_connected_mqtt_api_error(void)
 {
-	__cmock_mqtt_disconnect_ExpectAndReturn(&mqtt_client, -1);
+	__cmock_mqtt_disconnect_ExpectAndReturn(&mqtt_client, NULL, -1);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 9442059bfd79de2f8e8ad858e7ad064694493bc1
+      revision: 1a2d42b0aa3b4bc2148d4c1ae2ccc977cf6282c5
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull MQTT 5.0 support from upstream and align NCS codebase.