### PR TITLE
doc: final archiving update for nRF CLT

### DIFF
--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -369,20 +369,6 @@ Tier definitions
      Not applicable
        The specified architecture is not supported for the respective operating system.
 
-.. _requirements_clt:
-
-nRF Command Line Tools
-======================
-
-`nRF Command Line Tools`_ is a package of tools used for development, programming, and debugging of Nordic Semiconductor's nRF51, nRF52, nRF53, nRF54H, and nRF91 Series devices.
-Among others, this package includes the nrfjprog executable and library, which the west command uses by default to program the development kits.
-For more information on nrfjprog, see `Programming SoCs with nrfjprog`_.
-
-.. note::
-    |nrf_CLT_deprecation_note|
-
-It is recommended to use the latest version of the package when you :ref:`installing_vsc`.
-
 .. _requirements_nrfvsc:
 
 nRF Connect for Visual Studio Code

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -388,7 +388,6 @@
 .. _`nRF5x Command Line Tools Windows 32`:
 .. _`nRF5x Command Line Tools Windows 64`:
 .. _`nRF5x Command Line Tools OSX`: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Command-Line-Tools
-.. _`nRF Command Line Tools Downloads`: https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools/Download?lang=en#infotabs
 
 .. _`nRF Util development tool`: https://www.nordicsemi.com/Products/Development-tools/nrf-util
 .. _`nRF Util Downloads`: https://www.nordicsemi.com/Products/Development-tools/nRF-Util/Download#infotabs

--- a/doc/nrf/protocols/wifi/regulatory_certification/test_setup.rst
+++ b/doc/nrf/protocols/wifi/regulatory_certification/test_setup.rst
@@ -138,8 +138,7 @@ This describes the flashing, running, and use of the appropriate console ports w
 Programming firmware in the nRF7002 setup
 =========================================
 
-Before you begin, make sure you have the nrfjprog tool installed on your computer.
-You can download it at `nRF Command Line Tools Downloads`_.
+Before you begin, make sure you have the ``nrfjprog`` that is part of the archived `nRF Command Line Tools`_.
 
 To program firmware in the nRF7002 DK or EK setup, complete the following steps.
 

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_3.0.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_3.0.rst
@@ -113,6 +113,17 @@ Recommended changes
 
 The following changes are recommended for your application to work optimally after the migration.
 
+.. _requirements_clt:
+
+IDE, OS, and tool support
+=========================
+
+.. toggle::
+
+   |nrf_CLT_deprecation_note|
+
+   It is recommended to install the latest version of `nRF Util`_, as listed in the :ref:`installing_vsc` section of the installation page.
+
 Build system
 ============
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -43,6 +43,8 @@ IDE, OS, and tool support
     * The command-line instructions now use the ``nrfutil sdk-manager`` command instead of the ``nrfutil toolchain-manager`` command.
       You can read more about the new command in the `nRF Util documentation <sdk-manager command_>`_.
 
+  * Mentions of commands that use tools from the nRF Command Line Tools to use nRF Util.
+    |nrf_CLT_deprecation_note|
 
 Board support
 =============

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -88,8 +88,10 @@
 .. |nrfjprog_deprecation_note| replace:: Starting with the |NCS| v2.8.0, nrfjprog is in the process of being archived.
    It will remain available for download, but `nRF Util (device command) <Device command overview_>`_ will gradually replace it.
 
-.. |nrf_CLT_deprecation_note| replace:: Starting with the |NCS| v2.8.0, the nRF Command Line Tools are in the process of being archived.
-   They will remain available for download, but `nRF Util`_ will gradually replace them.
+.. |nrf_CLT_deprecation_note| replace:: The `nRF Command Line Tools`_ have been archived and replaced by `nRF Util`_.
+   No further updates will be made to the nRF Command Line Tools.
+   Last supported operating systems are Windows 10, Linux Ubuntu 22.04, and macOS 13.
+   The nRF Command Line Tools will remain available for download, but do not install the SEGGER J-Link version they provide if you have a newer version installed.
 
 .. ### Thread usage shortcuts
 


### PR DESCRIPTION
Removed nRF Command Line Tools section from recommended_versions.rst. Updated archiving notes to phrasing approved by stakeholders. Updated other pages to match phrasing.
NCSDK-30153.