### PR TITLE
scripts: generate psa key attributes strips to many zeros

### DIFF
--- a/scripts/generate_psa_key_attributes.py
+++ b/scripts/generate_psa_key_attributes.py
@@ -242,7 +242,9 @@ def main() -> None:
     if args.trng_key:
         value  = f'TRNG:{int(math.ceil(args.size / 8))}'
     elif args.key:
-        key = args.key.strip("0x")
+        key = args.key
+        while key.startswith("0x"):
+            key = key.removeprefix("0x")
         if not is_valid_hexa_code(key):
             print("Invalid KEY value")
             return


### PR DESCRIPTION
Turns out that the string strip function in python doesn't just strip any occurrence of any sub string which is equal to the string I pass in but also also any occurrence of any of the characters I pass in to the function. Replaced the strip function with a function that strips away only the sub-string I pass in to the function from the beginning of the string.