### PR TITLE
doc: Add information about Zephyr tests and samples

### DIFF
--- a/doc/nrf/includes/zephyr_sample_test.txt
+++ b/doc/nrf/includes/zephyr_sample_test.txt
@@ -1,0 +1,3 @@
+Additionally, the |NCS| contains |sample_test| that are built upon the corresponding Zephyr |sample_test|, extending their support with new Nordic development kits.
+These |sample_test| are placed under the |sample_test_file| folder.
+The source code and configuration files are located within the corresponding Zephyr |sample_test| folder under |zephyr_sample_test_file|.

--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -11,6 +11,14 @@ Zephyr also provides a variety of :zephyr:code-sample-category:`samples`, includ
 These samples are a good starting point for understanding how to put together your own application.
 However, Zephyr samples and applications are not tested and verified to work with the |NCS| releases.
 
+.. |sample_test| replace:: samples
+
+.. |sample_test_file| replace:: :file:`nrf/samples/zephyr`
+
+.. |zephyr_sample_test_file| replace:: :file:`zephyr/samples`
+
+.. include:: /includes/zephyr_sample_test.txt
+
 .. samples_general_info_start
 
 General information about samples in the |NCS|

--- a/doc/nrf/test_and_optimize.rst
+++ b/doc/nrf/test_and_optimize.rst
@@ -15,6 +15,14 @@ Testing and optimization
 Each application in the |NCS| comes with its own testing instructions.
 Follow these instructions to make sure that the application runs as expected.
 
+.. |sample_test| replace:: tests
+
+.. |sample_test_file| replace:: :file:`nrf/tests/zephyr`
+
+.. |zephyr_sample_test_file| replace:: :file:`zephyr/tests`
+
+.. include:: /includes/zephyr_sample_test.txt
+
 Information about the current state of the application is usually provided through LEDs, :term:`Universal Asynchronous Receiver/Transmitter (UART)`, or both.
 See the user interface section of the application's documentation for the LED states or available UART commands.
 


### PR DESCRIPTION
Add information about Zephyr tests and samples
that extend their support with new Nordic development kits.

NCSDK-32190