### PR TITLE
doc: fast_pair and fmdn - Remove ref from SYS_INIT

### DIFF
--- a/include/bluetooth/services/fast_pair/fast_pair.h
+++ b/include/bluetooth/services/fast_pair/fast_pair.h
@@ -303,7 +303,7 @@ int bt_fast_pair_battery_set(enum bt_fast_pair_battery_comp battery_comp,
  *  API.
  *
  *  This function must be called in the cooperative thread context or in the system initialization
- *  context (@ref SYS_INIT macro).
+ *  context (SYS_INIT macro).
  *
  *  @param cb Callback struct.
  *

--- a/include/bluetooth/services/fast_pair/fmdn.h
+++ b/include/bluetooth/services/fast_pair/fmdn.h
@@ -238,7 +238,7 @@ struct bt_fast_pair_fmdn_ring_cb {
  *  (see @ref bt_fast_pair_is_ready function).
  *
  *  This function must be called in the cooperative thread context or in the system initialization
- *  context (@ref SYS_INIT macro).
+ *  context (SYS_INIT macro).
  *
  *  @param cb Ringing callback structure.
  *
@@ -362,7 +362,7 @@ struct bt_fast_pair_fmdn_motion_detector_cb {
  *  (see @ref bt_fast_pair_is_ready function).
  *
  *  This function must be called in the cooperative thread context or in the system initialization
- *  context (@ref SYS_INIT macro).
+ *  context (SYS_INIT macro).
  *
  *  @param cb Motion detector callback structure.
  *
@@ -582,7 +582,7 @@ bool bt_fast_pair_fmdn_is_provisioned(void);
  *  register multiple instances of information callbacks.
  *
  *  This function must be called in the cooperative thread context or in the system initialization
- *  context (@ref SYS_INIT macro).
+ *  context (SYS_INIT macro).
  *
  *  @param cb Information callback structure.
  *
@@ -621,7 +621,7 @@ struct bt_fast_pair_fmdn_read_mode_cb {
  *  (see @ref bt_fast_pair_is_ready function).
  *
  *  This function must be called in the cooperative thread context or in the system initialization
- *  context (@ref SYS_INIT macro).
+ *  context (SYS_INIT macro).
  *
  *  @param cb Read mode callback structure.
  *


### PR DESCRIPTION
fast_pair and fmdn header files- Remove ref from the SYS_INIT marco