### PR TITLE
samples: esb: Add support for the nRF54L05 and L10 build targets

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -615,7 +615,7 @@ Edge Impulse samples
 Enhanced ShockBurst samples
 ---------------------------
 
-|no_changes_yet_note|
+* Added support for the ``nrf54l15dk/nrf54l05/cpuapp`` and ``nrf54l15dk/nrf54l10/cpuapp`` board targets in all ESB samples.
 
 Gazell samples
 --------------

--- a/samples/esb/esb_prx/boards/nrf54l15dk_nrf54l05_cpuapp.conf
+++ b/samples/esb/esb_prx/boards/nrf54l15dk_nrf54l05_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable DPPI driver
+CONFIG_NRFX_DPPI10=y

--- a/samples/esb/esb_prx/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/esb/esb_prx/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable DPPI driver
+CONFIG_NRFX_DPPI10=y

--- a/samples/esb/esb_prx/sample.yaml
+++ b/samples/esb/esb_prx/sample.yaml
@@ -30,6 +30,8 @@ tests:
       - nrf5340dk/nrf5340/cpunet
       - nrf21540dk/nrf52840
       - nrf54h20dk/nrf54h20/cpurad
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
@@ -39,6 +41,8 @@ tests:
       - nrf5340dk/nrf5340/cpunet
       - nrf21540dk/nrf52840
       - nrf54h20dk/nrf54h20/cpurad
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     tags:
       - esb

--- a/samples/esb/esb_ptx/boards/nrf54l15dk_nrf54l05_cpuapp.conf
+++ b/samples/esb/esb_ptx/boards/nrf54l15dk_nrf54l05_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable DPPI driver
+CONFIG_NRFX_DPPI10=y

--- a/samples/esb/esb_ptx/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/esb/esb_ptx/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable DPPI driver
+CONFIG_NRFX_DPPI10=y

--- a/samples/esb/esb_ptx/sample.yaml
+++ b/samples/esb/esb_ptx/sample.yaml
@@ -30,6 +30,8 @@ tests:
       - nrf5340dk/nrf5340/cpunet
       - nrf21540dk/nrf52840
       - nrf54h20dk/nrf54h20/cpurad
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
@@ -39,6 +41,8 @@ tests:
       - nrf5340dk/nrf5340/cpunet
       - nrf21540dk/nrf52840
       - nrf54h20dk/nrf54h20/cpurad
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     tags:
       - esb


### PR DESCRIPTION
Adding build support for nRF54L05 and nRF54L10 devices on the nRF54L15DK boards with required configurations.