### PR TITLE
applications: nrf_desktop: Enable GATT long/reliable writes

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/prj_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/prj_fast_pair.conf
@@ -130,6 +130,10 @@ CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 CONFIG_BT_ATT_TX_COUNT=4
 CONFIG_BT_CONN_TX_MAX=4
 
+# Support for GATT long (reliable) writes allows to perform fwupd DFU over Bluetooth LE with GATT
+# Clients that do not perform MTU exchange. Needed to support fwupd BLE DFU with ChromeOS and Floss.
+CONFIG_BT_ATT_PREPARE_COUNT=2
+
 CONFIG_BT_FAST_PAIR=y
 CONFIG_BT_FAST_PAIR_USE_CASE_MOUSE=y
 CONFIG_BT_FAST_PAIR_LOG_LEVEL_DBG=y

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/prj_wwcb.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/prj_wwcb.conf
@@ -101,6 +101,10 @@ CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 CONFIG_BT_ATT_TX_COUNT=4
 CONFIG_BT_CONN_TX_MAX=4
 
+# Support for GATT long (reliable) writes allows to perform fwupd DFU over Bluetooth LE with GATT
+# Clients that do not perform MTU exchange. Needed to support fwupd BLE DFU with ChromeOS and Floss.
+CONFIG_BT_ATT_PREPARE_COUNT=2
+
 CONFIG_ENTROPY_CC3XX=n
 
 CONFIG_FW_INFO=y

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/prj_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/prj_fast_pair.conf
@@ -172,6 +172,10 @@ CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 CONFIG_BT_ATT_TX_COUNT=4
 CONFIG_BT_CONN_TX_MAX=4
 
+# Support for GATT long (reliable) writes allows to perform fwupd DFU over Bluetooth LE with GATT
+# Clients that do not perform MTU exchange. Needed to support fwupd BLE DFU with ChromeOS and Floss.
+CONFIG_BT_ATT_PREPARE_COUNT=2
+
 CONFIG_BT_FAST_PAIR=y
 CONFIG_BT_FAST_PAIR_USE_CASE_MOUSE=y
 CONFIG_BT_FAST_PAIR_LOG_LEVEL_DBG=y

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/prj_release_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/prj_release_fast_pair.conf
@@ -166,6 +166,10 @@ CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 CONFIG_BT_ATT_TX_COUNT=4
 CONFIG_BT_CONN_TX_MAX=4
 
+# Support for GATT long (reliable) writes allows to perform fwupd DFU over Bluetooth LE with GATT
+# Clients that do not perform MTU exchange. Needed to support fwupd BLE DFU with ChromeOS and Floss.
+CONFIG_BT_ATT_PREPARE_COUNT=2
+
 CONFIG_BT_FAST_PAIR=y
 CONFIG_BT_FAST_PAIR_USE_CASE_MOUSE=y
 CONFIG_BT_PRIVACY=y

--- a/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/prj_release_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/prj_release_fast_pair.conf
@@ -132,6 +132,10 @@ CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 CONFIG_BT_ATT_TX_COUNT=6
 CONFIG_BT_CONN_TX_MAX=6
 
+# Support for GATT long (reliable) writes allows to perform fwupd DFU over Bluetooth LE with GATT
+# Clients that do not perform MTU exchange. Needed to support fwupd BLE DFU with ChromeOS and Floss.
+CONFIG_BT_ATT_PREPARE_COUNT=2
+
 CONFIG_BT_FAST_PAIR=y
 # The Google Fast Pair specification does not support the keyboard device type.
 # Due to this limitation, this configuration uses the generic input device use case.

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release_fast_pair.conf
@@ -107,6 +107,10 @@ CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 CONFIG_BT_ATT_TX_COUNT=4
 CONFIG_BT_CONN_TX_MAX=4
 
+# Support for GATT long (reliable) writes allows to perform fwupd DFU over Bluetooth LE with GATT
+# Clients that do not perform MTU exchange. Needed to support fwupd BLE DFU with ChromeOS and Floss.
+CONFIG_BT_ATT_PREPARE_COUNT=2
+
 CONFIG_STREAM_FLASH=y
 CONFIG_IMG_MANAGER=y
 CONFIG_MCUBOOT_IMG_MANAGER=y

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/prj_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/prj_fast_pair.conf
@@ -121,6 +121,10 @@ CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 CONFIG_BT_ATT_TX_COUNT=4
 CONFIG_BT_CONN_TX_MAX=4
 
+# Support for GATT long (reliable) writes allows to perform fwupd DFU over Bluetooth LE with GATT
+# Clients that do not perform MTU exchange. Needed to support fwupd BLE DFU with ChromeOS and Floss.
+CONFIG_BT_ATT_PREPARE_COUNT=2
+
 CONFIG_BT_FAST_PAIR=y
 # Use PSA crypto APIs for improved security
 CONFIG_BT_FAST_PAIR_CRYPTO_PSA=y

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/prj_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/prj_fast_pair.conf
@@ -121,6 +121,10 @@ CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 CONFIG_BT_ATT_TX_COUNT=4
 CONFIG_BT_CONN_TX_MAX=4
 
+# Support for GATT long (reliable) writes allows to perform fwupd DFU over Bluetooth LE with GATT
+# Clients that do not perform MTU exchange. Needed to support fwupd BLE DFU with ChromeOS and Floss.
+CONFIG_BT_ATT_PREPARE_COUNT=2
+
 CONFIG_BT_FAST_PAIR=y
 # Use PSA crypto APIs for improved security
 CONFIG_BT_FAST_PAIR_CRYPTO_PSA=y

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -305,6 +305,8 @@ nRF Desktop
     In the |NCS|, the Partition Manager is enabled by default for single-image sysbuild builds.
     The static memory map ensures control over settings partition placement and size.
     The introduced static memory maps may not be consistent with the ``storage_partition`` defined by the board-level DTS configuration.
+  * Support for GATT long (reliable) writes (:kconfig:option:`CONFIG_BT_ATT_PREPARE_COUNT`) to Fast Pair and Works With ChromeBook (WWCB) configurations.
+    This allows performing :ref:`fwupd <nrf_desktop_fwupd>` DFU image upload over Bluetooth LE with GATT clients that do not perform MTU exchange (for example, ChromeOS using the Floss Bluetooth stack).
 
 * Updated:
 


### PR DESCRIPTION
Support for GATT long/reliable writes allows to perform fwupd DFU over Bluetooth LE with GATT Clients that do not perform MTU exchange. This is needed to support fwupd BLE DFU with ChromeOS and Floss.

Jira: NCSDK-32719