### PR TITLE
boards: shields: Deprecate nRF7002eb interposer shield

### DIFF
--- a/boards/shields/nrf7002eb_interposer_p1/Kconfig.shield
+++ b/boards/shields/nrf7002eb_interposer_p1/Kconfig.shield
@@ -1,5 +1,9 @@
+#
 # Copyright (c) 2024 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
 
 config SHIELD_NRF7002EB_INTERPOSER_P1
+	select DEPRECATED
 	def_bool $(shields_list_contains,nrf7002eb_interposer_p1)


### PR DESCRIPTION
Deprecate nRF7002eb interposer shield for use with nRF54 series DKs