### PR TITLE
applications: serial_lte_modem: Add more configurations to sample.yaml

### DIFF
--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -12,12 +12,90 @@ tests:
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
     integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+  applications.serial_lte_modem.extmcu:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="overlay-external-mcu.overlay"
+    extra_configs:
+      - CONFIG_SLM_POWER_PIN=31
+      - CONFIG_SLM_INDICATE_PIN=30
+    platform_allow:
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+  applications.serial_lte_modem.ppp_without_cmux:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-ppp.conf"
+      - EXTRA_DTC_OVERLAY_FILE="overlay-ppp-without-cmux.overlay"
+    platform_allow:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
       - nrf9131ek/nrf9131/ns
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+  applications.serial_lte_modem.ppp_cmux_linux:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-ppp-cmux-linux.conf"
+    platform_allow:
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151/ns
+      - nrf9131ek/nrf9131/ns
+      - thingy91/nrf9160/ns
+      - thingy91x/nrf9151/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+  applications.serial_lte_modem.ppp_cmux_zephyr_with_extmcu:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-cmux.conf;overlay-ppp.conf;overlay-zephyr-modem.conf"
+      - EXTRA_DTC_OVERLAY_FILE="overlay-external-mcu.overlay"
+    platform_allow:
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151/ns
+      - nrf9131ek/nrf9131/ns
+      - thingy91/nrf9160/ns
+      - thingy91x/nrf9151/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+  applications.serial_lte_modem.ppp_cmux_zephyr_with_nrf52840_on_nrf9160dk:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-cmux.conf;overlay-ppp.conf;overlay-zephyr-modem.conf;overlay-zephyr-modem-nrf9160dk-nrf52840.conf"
+      - EXTRA_DTC_OVERLAY_FILE="overlay-zephyr-modem-nrf9160dk-nrf52840.overlay"
+    platform_allow:
+      - nrf9160dk/nrf9160/ns
+    integration_platforms:
+      - nrf9160dk/nrf9160/ns
     tags:
       - ci_build
       - sysbuild
@@ -26,17 +104,17 @@ tests:
     build_only: true
     extra_args:
       - EXTRA_CONF_FILE=overlay-memfault.conf
+    extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="dummy-key"
     platform_allow:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
       - nrf9131ek/nrf9131/ns
+      - thingy91/nrf9160/ns
+      - thingy91x/nrf9151/ns
     integration_platforms:
-      - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
-      - nrf9131ek/nrf9131/ns
     tags:
       - ci_build
       - sysbuild
@@ -51,8 +129,7 @@ tests:
       - nrf9131ek/nrf9131/ns
       - thingy91x/nrf9151/ns
     integration_platforms:
-      - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151/ns
     tags:
       - ci_build
       - sysbuild
@@ -67,8 +144,7 @@ tests:
       - nrf9131ek/nrf9131/ns
       - thingy91x/nrf9151/ns
     integration_platforms:
-      - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151/ns
     tags:
       - ci_build
       - sysbuild
@@ -80,6 +156,7 @@ tests:
       - SB_EXTRA_CONF_FILE=sysbuild-softbank.conf
     platform_allow:
       - nrf9160dk/nrf9160/ns
+      - nrf9151dk/nrf9151/ns
     integration_platforms:
       - nrf9160dk/nrf9160/ns
     tags:


### PR DESCRIPTION
Only basic configuration and lwm2m carrier library related configs were in place.
Adding Ext MCU, PPP, PPP+CMUX and few more.

Jira: LRCS-96