### PR TITLE
modules: memfault: Add support for uploading modem traces to Memfault

### DIFF
--- a/doc/nrf/libraries/debug/memfault_ncs.rst
+++ b/doc/nrf/libraries/debug/memfault_ncs.rst
@@ -72,6 +72,21 @@ This feature is useful when you want to post the coredump as soon as possible af
 Alternatively, you can manually trigger the coredump upload by calling the :c:func:`memfault_zephyr_port_post_data` function.
 You can use the :c:func:`memfault_coredump_has_valid_coredump` function to check whether a coredump is available.
 
+Automatic sending of modem trace to Memfault
+=============================================
+
+.. memfault_coredump_send_start
+
+To post modem traces to Memfault together with coredumps, set the :kconfig:option:`CONFIG_MEMFAULT_NCS_POST_MODEM_TRACE_ON_COREDUMP` Kconfig option to ``y``.
+This option is only supported for nRF91 Series devices.
+
+The modem trace will be posted as a CDR (Custom Data Record) to Memfault and depends on the :ref:`modem_trace_module` being configured to use a trace backend that persists traces across reboots.
+Depending on the Memfault account type you use, different rate limits are imposed on the number of CDRs that can be posted.
+During development you can enable Developer Mode for selected devices, allowing them to post more CDRs.
+For more information, see the `Memfault Server-Side Developer Mode`_.
+
+.. memfault_coredump_send_end
+
 Configuration options in Memfault SDK
 =====================================
 
@@ -107,6 +122,7 @@ Configuration options in |NCS|
 The Kconfig options for Memfault that are defined in |NCS| provide some additional features compared to the options that are already implemented in Memfault SDK:
 
 * :kconfig:option:`CONFIG_MEMFAULT_NCS_POST_COREDUMP_ON_NETWORK_CONNECTED`
+* :kconfig:option:`CONFIG_MEMFAULT_NCS_POST_MODEM_TRACE_ON_COREDUMP`
 * :kconfig:option:`CONFIG_MEMFAULT_NCS_PROJECT_KEY`
 * :kconfig:option:`CONFIG_MEMFAULT_NCS_PROVISION_CERTIFICATES`
 * :kconfig:option:`CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP`

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1355,6 +1355,7 @@
 .. _`Memfault: Collecting Device Metrics`: https://docs.memfault.com/docs/embedded/metrics-api
 .. _`Memfault: Error Tracking with Trace Events`: https://docs.memfault.com/docs/embedded/trace-events/
 .. _`Memfault Demo CLI`: https://docs.memfault.com/docs/mcu/demo-cli/
+.. _`Memfault Server-Side Developer Mode`: https://docs.memfault.com/docs/platform/rate-limiting#server-side-developer-mode
 
 .. _`Memfault debugging`: https://docs.memfault.com/docs/platform/introduction#debugging
 .. _`Memfault OTA`: https://docs.memfault.com/docs/platform/introduction#ota

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -1105,6 +1105,10 @@ Memfault integration
   To enable this feature, set the :kconfig:option:`CONFIG_MEMFAULT_NCS_POST_COREDUMP_ON_NETWORK_CONNECTED` Kconfig option to ``y``.
   Only supported for nRF91 Series devices.
 
+* Added a new feature to automatically capture and upload modem traces to Memfault with coredumps upon a crash.
+  To enable this feature, set the :kconfig:option:`CONFIG_MEMFAULT_NCS_POST_MODEM_TRACE_ON_COREDUMP` Kconfig option to ``y``.
+  Only supported for nRF91 Series devices.
+
 AVSystem integration
 --------------------
 

--- a/lib/nrf_modem_lib/shell/trace.c
+++ b/lib/nrf_modem_lib/shell/trace.c
@@ -146,7 +146,10 @@ static void modem_trace_dump_uart(const struct shell *sh, size_t argc, char **ar
 			return;
 		}
 
+#ifdef CONFIG_NRF_MODEM_LIB_SHELL_TRACE_UART
 		modem_trace_uart_send(sh, size);
+#endif /* CONFIG_NRF_MODEM_LIB_SHELL_TRACE_UART */
+
 	} else {
 		shell_error(sh, "Missing chosen node for nordic,modem-trace-uart. "
 			"Please configure which uart to use.");

--- a/modules/memfault-firmware-sdk/CMakeLists.txt
+++ b/modules/memfault-firmware-sdk/CMakeLists.txt
@@ -36,6 +36,10 @@ zephyr_library_sources_ifdef(
         memfault_lte_coredump.c)
 
 zephyr_library_sources_ifdef(
+        CONFIG_MEMFAULT_NCS_POST_MODEM_TRACE_ON_COREDUMP
+        memfault_lte_coredump_modem_trace.c)
+
+zephyr_library_sources_ifdef(
         CONFIG_MEMFAULT_NCS_ETB_CAPTURE
         memfault_etb_trace_capture.c)
 

--- a/modules/memfault-firmware-sdk/Kconfig
+++ b/modules/memfault-firmware-sdk/Kconfig
@@ -191,7 +191,7 @@ config MEMFAULT_NCS_IMPLEMENT_METRICS_COLLECTION
 	  Implement the Memfault 'memfault_metrics_heartbeat_collect_data()' function
 	  for the selected metrics. Disable this to override the implementation.
 
-config MEMFAULT_NCS_POST_COREDUMP_ON_NETWORK_CONNECTED
+menuconfig MEMFAULT_NCS_POST_COREDUMP_ON_NETWORK_CONNECTED
 	bool "Post coredump on network connected"
 	depends on PDN
 	depends on LTE_LINK_CONTROL
@@ -202,6 +202,17 @@ config MEMFAULT_NCS_POST_COREDUMP_ON_NETWORK_CONNECTED
 	help
 	  Post coredump to Memfault when the device is connected to LTE network.
 	  This option is only supported for nRF91 targets.
+
+if MEMFAULT_NCS_POST_COREDUMP_ON_NETWORK_CONNECTED
+
+config MEMFAULT_NCS_POST_MODEM_TRACE_ON_COREDUMP
+	bool "Post modem trace on coredump"
+	select MEMFAULT_CDR_ENABLE
+	depends on NRF_MODEM_LIB_TRACE
+	depends on NRF_MODEM_LIB_TRACE_BACKEND_FLASH || NRF_MODEM_LIB_TRACE_BACKEND_RAM
+	help
+	  Capture modem traces continuously to flash or RAM (no init RAM), and post the traces
+	  together with the coredump to Memfault in the event of a crash.
 
 config MEMFAULT_NCS_POST_COREDUMP_AFTER_INITIAL_DELAY
 	bool "Post coredump after initial delay"
@@ -227,6 +238,8 @@ config MEMFAULT_NCS_POST_COREDUMP_RETRY_INTERVAL_SECONDS
 config MEMFAULT_NCS_POST_COREDUMP_THREAD_STACK_SIZE
 	int "Post coredump thread size"
 	default 512
+
+endif # MEMFAULT_NCS_POST_COREDUMP_ON_NETWORK_CONNECTED
 
 config MEMFAULT_NCS_ETB_CAPTURE
 	bool "Enable ETB trace capture"

--- a/modules/memfault-firmware-sdk/include/memfault_lte_coredump_modem_trace.h
+++ b/modules/memfault-firmware-sdk/include/memfault_lte_coredump_modem_trace.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+
+/**
+ * @brief Memfault LTE coredump modem trace initialization. Shall only be called once.
+ *	  Ths function sets up a CDR (Custom Data Recording) source for modem traces.
+ *
+ * @retval -EALREADY if the module has already been initialized.
+ * @retval -EIO if the modem trace CDR source registration failed.
+ * @retval 0 if the modem trace backend was successfully initialized.
+ */
+int memfault_lte_coredump_modem_trace_init(void);
+
+/**
+ * @brief Prepare modem trace data for upload
+ *
+ * @retval -ENOTSUP if the current modem trace backend is not supported.
+ * @retval -ENODATA if there are no modem traces to send.
+ * @retval 0 if the modem trace data is ready for upload.
+ *
+ * @returns Negative error if an error occurred preparing the modem trace.
+ */
+int memfault_lte_coredump_modem_trace_prepare_for_upload(void);

--- a/modules/memfault-firmware-sdk/memfault_lte_coredump_modem_trace.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_coredump_modem_trace.c
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/task_wdt/task_wdt.h>
+#include <zephyr/zbus/zbus.h>
+#include "memfault/components.h"
+#include <memfault/ports/zephyr/http.h>
+#include <memfault/metrics/metrics.h>
+#include <memfault/core/data_packetizer.h>
+#include <memfault/core/trace_event.h>
+#include "memfault/panics/coredump.h"
+#include <modem/nrf_modem_lib_trace.h>
+#include <modem/nrf_modem_lib.h>
+
+LOG_MODULE_DECLARE(memfault_ncs, CONFIG_MEMFAULT_NCS_LOG_LEVEL);
+
+/* Forward declarations */
+static bool has_cdr_cb(sMemfaultCdrMetadata *metadata);
+static void mark_cdr_read_cb(void);
+static bool read_data_cb(uint32_t offset, void *buf, size_t buf_len);
+
+static const char * const mimetypes[] = {
+	MEMFAULT_CDR_BINARY
+};
+
+static sMemfaultCdrMetadata trace_recording_metadata = {
+	.start_time.type = kMemfaultCurrentTimeType_Unknown,
+	.mimetypes = (char const **)mimetypes,
+	.num_mimetypes = 1,
+	.data_size_bytes = 0,
+	.collection_reason = "modem traces",
+};
+
+static sMemfaultCdrSourceImpl recording = {
+	.has_cdr_cb = has_cdr_cb,
+	.read_data_cb = read_data_cb,
+	.mark_cdr_read_cb = mark_cdr_read_cb,
+};
+
+static int modem_trace_enable(void)
+{
+	int err;
+
+	err = nrf_modem_lib_trace_level_set(NRF_MODEM_LIB_TRACE_LEVEL_LTE_AND_IP);
+	if (err) {
+		LOG_ERR("nrf_modem_lib_trace_level_set, error: %d", err);
+		return err;
+	}
+
+	return 0;
+}
+
+/* Enable modem traces as soon as the modem is initialized if there is no valid coredump.
+ * Modem traces are disabled by default via CONFIG_NRF_MODEM_LIB_TRACE_LEVEL_OFF.
+ */
+NRF_MODEM_LIB_ON_INIT(memfault_init_hook, on_modem_lib_init, NULL)
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
+	int err;
+
+	if (memfault_coredump_has_valid_coredump(NULL)) {
+		return;
+	}
+
+	LOG_DBG("No coredump valid, clearing modem trace buffer");
+
+	err = nrf_modem_lib_trace_clear();
+	if (err) {
+		LOG_ERR("Failed to clear modem trace data: %d", err);
+		return;
+	}
+
+	err = modem_trace_enable();
+	if (err) {
+		LOG_ERR("Failed to enable modem traces: %d", err);
+		return;
+	}
+}
+
+static bool has_cdr_cb(sMemfaultCdrMetadata *metadata)
+{
+	if (trace_recording_metadata.data_size_bytes == 0) {
+		return false;
+	}
+
+	*metadata = trace_recording_metadata;
+	return true;
+}
+
+static void mark_cdr_read_cb(void)
+{
+	int err;
+
+	LOG_DBG("Modem trace data has been processed / uploaded");
+
+	/* It's not guaranteed that the trace backend clears the stored traces after readout,
+	 * so we clear them before enabling traces just in case.
+	 */
+	err = nrf_modem_lib_trace_clear();
+	if (err) {
+		LOG_ERR("Failed to clear modem trace data: %d", err);
+
+		/* Continue */
+	}
+
+	err = modem_trace_enable();
+	if (err) {
+		LOG_ERR("Failed to enable modem traces after upload: %d", err);
+
+		/* Continue */
+	}
+
+	/* Set CDR data length to 0 once the modem trace has been processed (uploaded) */
+	trace_recording_metadata.data_size_bytes = 0;
+}
+
+static bool read_data_cb(uint32_t offset, void *buf, size_t buf_len)
+{
+	ARG_UNUSED(offset);
+
+	int err = nrf_modem_lib_trace_read(buf, buf_len);
+
+	if (err == -ENODATA) {
+		LOG_WRN("No more modem trace data to read");
+		return false;
+	} else if (err < 0) {
+		LOG_ERR("Failed to read modem trace data: %d", err);
+		return false;
+	}
+
+	return true;
+}
+
+int memfault_lte_coredump_modem_trace_init(void)
+{
+	static bool initialized;
+
+	if (initialized) {
+		LOG_ERR("Already initialized");
+		return -EALREADY;
+	}
+
+	if (!memfault_cdr_register_source(&recording)) {
+		LOG_ERR("Failed to register modem trace CDR source, storage full");
+		return -EIO;
+	}
+
+	initialized = true;
+
+	LOG_DBG("Modem trace CDR source initialized");
+
+	return 0;
+}
+
+int memfault_lte_coredump_modem_trace_prepare_for_upload(void)
+{
+	size_t trace_size = 0;
+
+	trace_size = nrf_modem_lib_trace_data_size();
+
+	if (trace_size == -ENOTSUP) {
+		LOG_ERR("The current modem trace backend is not supported");
+		return -ENOTSUP;
+	} else if (trace_size < 0) {
+		LOG_ERR("Failed to get modem trace size: %d", trace_size);
+		return trace_size;
+	} else if (trace_size == 0) {
+		LOG_DBG("No modem traces to send");
+		return -ENODATA;
+	}
+
+	LOG_DBG("Preparing modem trace data upload of: %d bytes", trace_size);
+
+	trace_recording_metadata.duration_ms = 0;
+	trace_recording_metadata.data_size_bytes = trace_size;
+
+	return 0;
+}

--- a/samples/debug/memfault/README.rst
+++ b/samples/debug/memfault/README.rst
@@ -147,6 +147,16 @@ If :kconfig:option:`CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP` is enabl
    :start-after: modem_lib_sending_traces_UART_start
    :end-before: modem_lib_sending_traces_UART_end
 
+Automatic capture and upload modem traces with coredumps
+--------------------------------------------------------
+
+You can configure the sample to upload modem traces to Memfault when an application coredump is triggered.
+To enable this feature, include the :file:`overlay-modem_trace_to_memfault.conf` overlay in your project.
+
+.. include:: /libraries/debug/memfault_ncs.rst
+   :start-after: memfault_coredump_send_start
+   :end-before: memfault_coredump_send_end
+
 Building and running
 ********************
 

--- a/samples/debug/memfault/boards/nrf9151dk_nrf9151_ns.conf
+++ b/samples/debug/memfault/boards/nrf9151dk_nrf9151_ns.conf
@@ -31,3 +31,9 @@ CONFIG_NRF_MODEM_LIB_NET_IF=y
 # due to not being properly implemented for offloaded interfaces.
 CONFIG_NET_IPV6_NBR_CACHE=n
 CONFIG_NET_IPV6_MLD=n
+
+# Enable SPI for External flash for storing modem traces that are uploaded to Memfault
+CONFIG_SPI=y
+CONFIG_SPI_NOR=y
+CONFIG_SPI_NOR_SFDP_DEVICETREE=y
+CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y

--- a/samples/debug/memfault/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/samples/debug/memfault/boards/nrf9151dk_nrf9151_ns.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&gd25wb256 {
+	status = "okay";
+};
+
+/ {
+	aliases {
+		ext-flash = &gd25wb256;
+	};
+
+	/* Configure partition manager to use gd25wb256 as the external flash */
+	chosen {
+		nordic,pm-ext-flash = &gd25wb256;
+	};
+};

--- a/samples/debug/memfault/overlay-modem-trace-to-memfault.conf
+++ b/samples/debug/memfault/overlay-modem-trace-to-memfault.conf
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Continuously store modem traces to flash and upload them to Memfault upon a coredump
+
+# Memfault
+CONFIG_MEMFAULT_NCS_POST_MODEM_TRACE_ON_COREDUMP=y
+
+# nRF Modem lib trace
+CONFIG_FCB=y
+CONFIG_FLASH_MAP=y
+CONFIG_NRF_MODEM_LIB_TRACE=y
+# Set the default trace level to off preventing overwriting the trace leading up to the crash after
+# boot. The Memfault LTE coredump modem trace layer will ensure that traces are enabled once
+# the coredump/modem trace has been uploaded, or if there is no application coredump.
+CONFIG_NRF_MODEM_LIB_TRACE_LEVEL_OFF=y
+CONFIG_NRF_MODEM_LIB_SHELL_TRACE=y
+CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH=y
+CONFIG_NRF_MODEM_TRACE_FLASH_NOSPACE_ERASE_OLDEST=y
+CONFIG_NRF_MODEM_LIB_TRACE_STACK_SIZE=1024
+# Maximum number of sectors that the trace backend can handle
+CONFIG_NRF_MODEM_LIB_TRACE_FLASH_SECTORS=255
+# Modem trace flash partition size with 255 sectors of 4kB each
+CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH_PARTITION_SIZE=0xFF000

--- a/samples/debug/memfault/sample.yaml
+++ b/samples/debug/memfault/sample.yaml
@@ -48,3 +48,19 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_debug
+  sample.debug.memfault.modem_trace_to_memfault:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_MEMFAULT_NCS_PROJECT_KEY="dummy-key"
+    extra_args: OVERLAY_CONFIG=overlay-modem-trace-to-memfault.conf
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+      - thingy91x/nrf9151/ns
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+      - thingy91x/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_debug


### PR DESCRIPTION
Add support for uploading modem traces to Memfault upon a coredump. This is useful to get the full picture of what happened leading up to a crash.

The feature is optional and guarded by a Kconfig option. It is enabled by default in the overlay `overlay-modem_trace_to_memfault.conf` added to the memfault sample.

Tests and docs has been updated accordingly.