### PR TITLE
snippets: sdp: mspi: remove definition of reset-gpio

### DIFF
--- a/snippets/sdp/mspi/board/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/snippets/sdp/mspi/board/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -23,9 +23,6 @@
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <35000>;
-		reset-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
-		t-reset-pulse = <10000>;
-		t-reset-recovery = <35000>;
 
 		mspi-max-frequency = <DT_FREQ_M(13)>;
 		mspi-io-mode = "MSPI_IO_MODE_QUAD_1_4_4";


### PR DESCRIPTION
Remove definition of reset gpio for nRF54L15 external flash. It is on the same pin as one of data lines, and thus it should not be defined as reset gpio in dts. Instead, the MSPI driver should handle it.