### PR TITLE
applications: serial_lte_modem: Disable hwfc for Thingy:91 X

### DIFF
--- a/applications/serial_lte_modem/boards/thingy91x_nrf9151_ns.conf
+++ b/applications/serial_lte_modem/boards/thingy91x_nrf9151_ns.conf
@@ -11,5 +11,5 @@
 # Configuration related to external sensors.
 CONFIG_SLM_POWER_PIN=26
 
-# Increase buffer space as hardware flow control is not necessarily used with Thingy:91 X.
+# Increase buffer space as hardware flow control is not used with Thingy:91 X.
 CONFIG_SLM_UART_RX_BUF_SIZE=2048

--- a/applications/serial_lte_modem/boards/thingy91x_nrf9151_ns.overlay
+++ b/applications/serial_lte_modem/boards/thingy91x_nrf9151_ns.overlay
@@ -12,7 +12,6 @@
 
 &uart0 {
 	status = "okay";
-	hw-flow-control;
 };
 
 &button0 {


### PR DESCRIPTION
New versions of Thingy:91 X use connectivity bridge, which does not support hw-flow-control.