### PR TITLE
mpsl: fem: nrf21540: prepare for PDN control from mpsl_fem_enable

### DIFF
--- a/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
+++ b/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
@@ -49,6 +49,7 @@ static int fem_nrf21540_gpio_configure(void)
 	}
 #endif
 
+#if !defined(_MPSL_FEM_CONFIG_NRF21540_GPIO_PDN_FROM_MPSL_FEM_ENABLE)
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), pdn_gpios)
 	uint8_t pdn_gpiote_channel;
 	const nrfx_gpiote_t pdn_gpiote = NRFX_GPIOTE_INSTANCE(
@@ -57,6 +58,7 @@ static int fem_nrf21540_gpio_configure(void)
 	if (nrfx_gpiote_channel_alloc(&pdn_gpiote, &pdn_gpiote_channel) != NRFX_SUCCESS) {
 		return -ENOMEM;
 	}
+#endif
 #endif
 
 	mpsl_fem_nrf21540_gpio_interface_config_t cfg = {
@@ -125,12 +127,18 @@ static int fem_nrf21540_gpio_configure(void)
 			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(pdn_gpios),
+#if !defined(_MPSL_FEM_CONFIG_NRF21540_GPIO_PDN_FROM_MPSL_FEM_ENABLE)
 			.gpiote_ch_id  = pdn_gpiote_channel,
 #if defined(NRF54L_SERIES)
 			.p_gpiote = pdn_gpiote.p_reg,
 #endif
+#endif
 #else
+#if !defined(_MPSL_FEM_CONFIG_NRF21540_GPIO_PDN_FROM_MPSL_FEM_ENABLE)
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
+#else
+			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
+#endif
 #endif
 		},
 		.mode_pin_config = {
@@ -187,11 +195,13 @@ static int fem_nrf21540_gpio_configure(void)
 	}
 #endif
 
+#if !defined(_MPSL_FEM_CONFIG_NRF21540_GPIO_PDN_FROM_MPSL_FEM_ENABLE)
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), pdn_gpios)
 	err = mpsl_fem_utils_gpiote_pin_init(&cfg.pdn_pin_config);
 	if (err) {
 		return err;
 	}
+#endif
 #endif
 
 	BUILD_ASSERT(

--- a/subsys/mpsl/fem/nrf21540_gpio_spi/mpsl_fem_nrf21540_gpio_spi.c
+++ b/subsys/mpsl/fem/nrf21540_gpio_spi/mpsl_fem_nrf21540_gpio_spi.c
@@ -130,6 +130,7 @@ static int fem_nrf21540_gpio_spi_configure(void)
 	}
 #endif
 
+#if !defined(_MPSL_FEM_CONFIG_NRF21540_GPIO_SPI_PDN_FROM_MPSL_FEM_ENABLE)
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), pdn_gpios)
 	uint8_t pdn_gpiote_channel;
 	const nrfx_gpiote_t pdn_gpiote = NRFX_GPIOTE_INSTANCE(
@@ -138,6 +139,7 @@ static int fem_nrf21540_gpio_spi_configure(void)
 	if (nrfx_gpiote_channel_alloc(&pdn_gpiote, &pdn_gpiote_channel) != NRFX_SUCCESS) {
 		return -ENOMEM;
 	}
+#endif
 #endif
 
 	mpsl_fem_nrf21540_gpio_spi_interface_config_t cfg = {
@@ -200,9 +202,15 @@ static int fem_nrf21540_gpio_spi_configure(void)
 			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(pdn_gpios),
+#if !defined(_MPSL_FEM_CONFIG_NRF21540_GPIO_SPI_PDN_FROM_MPSL_FEM_ENABLE)
 			.gpiote_ch_id  = pdn_gpiote_channel
+#endif
 #else
+#if !defined(_MPSL_FEM_CONFIG_NRF21540_GPIO_SPI_PDN_FROM_MPSL_FEM_ENABLE)
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
+#else
+			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
+#endif
 #endif
 		},
 		.mode_pin_config = {


### PR DESCRIPTION
An upcoming MPSL change (dragoon repo PR # 12543 ) will contain a change in public API of FEM configuration. The field `pdn_pin_config` of structures
`mpsl_fem_nrf21540_gpio_interface_config_t`
`mpsl_fem_nrf21540_gpio_spi_interface_config_t`
will be changed to `mpsl_fem_gpio_pin_t`.
This is to be signaled by existence of temporary macros `_MPSL_FEM_CONFIG_NRF21540_GPIO_PDN_FROM_MPSL_FEM_ENABLE` `_MPSL_FEM_CONFIG_NRF21540_GPIO_SPI_PDN_FROM_MPSL_FEM_ENABLE`. This commit prepares for seamless deploy of the MPSL containing mentioned change.
After deploy of the MPSL only the code "as the macros are defined" will be left, but the references to the macros will be removed.