### PR TITLE
applications: connectivity_bridge: Improve documentation

### DIFF
--- a/applications/connectivity_bridge/README.rst
+++ b/applications/connectivity_bridge/README.rst
@@ -54,7 +54,7 @@ The sample supports the following nRF52840-based device:
 
 .. table-from-sample-yaml::
 
-The sample also requires a USB host which can communicate with CDC ACM devices, such as a Windows or Linux PC.
+The sample also requires a USB host that can communicate with CDC ACM devices, such as a Windows or Linux PC or a Mac.
 
 
 Building and running
@@ -70,7 +70,7 @@ Testing
 After programming the sample to your kit, test it by performing the following steps:
 
 1. Connect the kit to the host using a USB cable.
-#. Observe that the CDC ACM devices enumerate on the USB host (COM ports on Windows, /dev/tty* on Linux).
+#. Observe that the CDC ACM devices enumerate on the USB host (COM ports on Windows, /dev/tty* on Linux and Mac).
 #. Use a serial client on the USB host to communicate over the kit's UART pins.
 
 

--- a/applications/connectivity_bridge/README_TEMPLATE.txt
+++ b/applications/connectivity_bridge/README_TEMPLATE.txt
@@ -1,6 +1,6 @@
 ==============================
   Nordic Connectivity Bridge
-=============================
+==============================
 
 This device is running Nordic's Connectivity bridge application.
 

--- a/applications/connectivity_bridge/boards/thingy91_nrf52840_readme.txt
+++ b/applications/connectivity_bridge/boards/thingy91_nrf52840_readme.txt
@@ -11,15 +11,15 @@ This USB interface has the following functions:
 * CMSIS-DAP 2.1 compliant debug probe interface for accessing the nRF91 SiP
 
 COM Ports
-====================
+=========
 
 This USB interface exposes two COM ports mapped to the physical UART interfaces between the nRF91 Series and nRF52840 devices.
-When opening these ports manually (without using the LTE Link Monitor), be aware that the USB COM port baud rate selection is applied to the UART.
+When opening these ports manually (without using the nRF Connect Serial Terminal), be aware that the USB COM port baud rate selection is applied to the UART.
 
 Bluetooth® LE Central UART Service
 ==================================
 
-This device advertises as "Thingy:91 UART".
+This device advertises as configured in BLE_NAME in Config.txt, default being "Thingy:91 UART".
 Connect using a Bluetooth LE Central device, for example a phone running the nRF Connect app:
 https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Connect-for-mobile/
 

--- a/applications/connectivity_bridge/boards/thingy91x_nrf5340_cpuapp_readme.txt
+++ b/applications/connectivity_bridge/boards/thingy91x_nrf5340_cpuapp_readme.txt
@@ -1,6 +1,6 @@
-=====================
+======================
   Nordic Thingy:91 X
-=====================
+======================
 
 This USB interface has the following functions:
 * Disk drive containing this file and others
@@ -8,14 +8,14 @@ This USB interface has the following functions:
 * CMSIS-DAP 2.1 compliant debug probe interface for accessing the nRF91 SiP
 
 COM Ports
-====================
+=========
 This USB interface exposes two COM ports mapped to the physical UART interfaces between the nRF91 Series and nRF5340 devices.
-When opening these ports manually (without using the LTE Link Monitor), be aware that the USB COM port baud rate selection is applied to the UART.
+When opening these ports manually (without using the nRF Connect Serial Terminal), be aware that the USB COM port baud rate selection is applied to the UART.
 
 Bluetooth® LE Central UART Service
 ==================================
 
-This device advertises as "Thingy:91 X UART".
+This device advertises as configured in BLE_NAME in Config.txt, default being "Thingy:91 X UART".
 Connect using a Bluetooth LE Central device, for example a phone running the nRF Connect app:
 https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Connect-for-mobile/
 

--- a/applications/connectivity_bridge/src/disk/config.c
+++ b/applications/connectivity_bridge/src/disk/config.c
@@ -110,13 +110,13 @@ static struct cfg_option configs[] = {
 };
 
 static const char file_contents_header[] =
-"=========================\r\n"
+"==========================================\r\n"
 "          Configuration options\r\n"
 "==========================================\r\n"
 "The parameters below can be changed at runtime.\r\n"
 "\r\n"
-"NOTE: For changes to take effect,\r\n"
-"safely disconnect (unmount) the drive and disconnect the USB cable.\r\n"
+"NOTE: For changes to take effect, safely disconnect\r\n"
+"(unmount) the drive and disconnect the USB cable.\r\n"
 "==========================================\r\n";
 
 static bool ble_enable_opt_cb(char *opt)


### PR DESCRIPTION
Improve layout in USB drive Config.txt and README.txt. Document that the device advertises as the configured BLE_NAME. Change from "LTE Link Monitor" to "nRF Connect Serial Terminal".

Document that USB host is also available on Mac.