### PR TITLE
nrf_security: drivers: cracen: Implement ECDSA in cracenpsa

### DIFF
--- a/subsys/nrf_security/src/core/lite/psa_core_lite.c
+++ b/subsys/nrf_security/src/core/lite/psa_core_lite.c
@@ -9,6 +9,7 @@
 #include <psa_crypto_driver_wrappers.h>
 #include <cracen_psa_kmu.h>
 #include <cracen/mem_helpers.h>
+#include <cracen_psa_eddsa.h>
 
 #if defined(CONFIG_PSA_CORE_LITE_NSIB_ED25519_OPTIMIZATIONS)
 #include "cracen_psa.h"

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/cracenpsa.cmake
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/cracenpsa.cmake
@@ -15,6 +15,8 @@ list(APPEND cracen_driver_sources
   ${CMAKE_CURRENT_LIST_DIR}/src/common.c
   ${CMAKE_CURRENT_LIST_DIR}/src/mem_helpers.c
   ${CMAKE_CURRENT_LIST_DIR}/src/ec_helpers.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/ecc.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/rndinrange.c
 
   # Note: We always need to have blkcipher.c and ctr_drbg.c since it
   # is used directly by many Cracen drivers.
@@ -44,7 +46,10 @@ endif()
 if(CONFIG_PSA_NEED_CRACEN_ASYMMETRIC_SIGNATURE_DRIVER)
   list(APPEND cracen_driver_sources
     ${CMAKE_CURRENT_LIST_DIR}/src/sign.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/ecdsa.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/ecc.c
     ${CMAKE_CURRENT_LIST_DIR}/src/ed25519.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/hmac.c
   )
 endif()
 
@@ -62,8 +67,11 @@ endif()
 
 if(CONFIG_PSA_NEED_CRACEN_KEY_MANAGEMENT_DRIVER OR CONFIG_PSA_NEED_CRACEN_KMU_DRIVER OR CONFIG_MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS)
   list(APPEND cracen_driver_sources
+    ${CMAKE_CURRENT_LIST_DIR}/src/ed25519.c
     ${CMAKE_CURRENT_LIST_DIR}/src/key_management.c
     ${CMAKE_CURRENT_LIST_DIR}/src/ed25519.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/ecdsa.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/ecc.c
   )
 endif()
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa.h
@@ -361,18 +361,4 @@ psa_status_t cracen_spake2p_get_shared_key(cracen_spake2p_operation_t *operation
 
 psa_status_t cracen_spake2p_abort(cracen_spake2p_operation_t *operation);
 
-int cracen_ed25519_sign(const uint8_t *priv_key, char *signature, const uint8_t *message,
-			size_t message_length);
-
-int cracen_ed25519_verify(const uint8_t *pub_key, const char *message, size_t message_length,
-			  const char *signature);
-
-int cracen_ed25519ph_sign(const uint8_t *priv_key, char *signature, const uint8_t *message,
-			  size_t message_length, bool is_message);
-
-int cracen_ed25519ph_verify(const uint8_t *pub_key, const char *message, size_t message_length,
-			    const char *signature, bool is_message);
-
-int cracen_ed25519_create_pubkey(const uint8_t *priv_key, uint8_t *pub_key);
-
 #endif /* CRACEN_PSA_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_ecdsa.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_ecdsa.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef CRACEN_PSA_ECDSA_H
+#define CRACEN_PSA_ECDSA_H
+
+#include <psa/crypto.h>
+
+int cracen_ecdsa_verify_message(const char *pubkey, const struct sxhashalg *hashalg,
+				const uint8_t *message, size_t message_length,
+				const struct sx_pk_ecurve *curve, const uint8_t *signature);
+
+int cracen_ecdsa_verify_digest(const char *pubkey, const uint8_t *digest, size_t digestsz,
+			       const struct sx_pk_ecurve *curve, const uint8_t *signature);
+
+int cracen_ecdsa_sign_message(const struct ecc_priv_key *privkey, const struct sxhashalg *hashalg,
+			      const struct sx_pk_ecurve *curve, const uint8_t *message,
+			      size_t message_length, uint8_t *signature);
+
+int cracen_ecdsa_sign_digest(const struct ecc_priv_key *privkey, const struct sxhashalg *hashalg,
+			     const struct sx_pk_ecurve *curve, const uint8_t *digest,
+			     size_t digest_length, uint8_t *signature);
+
+int cracen_ecdsa_sign_message_deterministic(const struct ecc_priv_key *privkey,
+					    const struct sxhashalg *hashalg,
+					    const struct sx_pk_ecurve *curve,
+					    const uint8_t *message, size_t message_length,
+					    uint8_t *signature);
+
+int cracen_ecdsa_sign_digest_deterministic(const struct ecc_priv_key *privkey,
+					   const struct sxhashalg *hashalg,
+					   const struct sx_pk_ecurve *curve, const uint8_t *digest,
+					   size_t digestsz, uint8_t *signature);
+
+#endif /* CRACEN_PSA_ECDSA_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_eddsa.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_eddsa.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <psa/crypto.h>
+
+int cracen_ed25519_sign(const uint8_t *priv_key, char *signature, const uint8_t *message,
+			size_t message_length);
+
+int cracen_ed25519_verify(const uint8_t *pub_key, const char *message, size_t message_length,
+			  const char *signature);
+
+int cracen_ed25519ph_sign(const uint8_t *priv_key, char *signature, const uint8_t *message,
+			  size_t message_length, bool is_message);
+
+int cracen_ed25519ph_verify(const uint8_t *pub_key, const char *message, size_t message_length,
+			    const char *signature, bool is_message);
+
+int cracen_ed25519_create_pubkey(const uint8_t *priv_key, uint8_t *pub_key);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
@@ -371,4 +371,26 @@ struct cracen_pake_operation {
 	};
 };
 typedef struct cracen_pake_operation cracen_pake_operation_t;
+
+struct ecdsa_signature {
+	size_t sz; /** Total signature size, in bytes. */
+	char *r;   /** Signature element "r". */
+	char *s;   /** Signature element "s". */
+};
+
+struct ecc_priv_key {
+	const struct sx_pk_ecurve *curve;
+	const char *d; /** Private key value d */
+};
+
+struct ecc_pub_key {
+	const struct sx_pk_ecurve *curve;
+	char *qx; /** x coordinate of a point on the curve */
+	char *qy; /** y coordinate of a point on the curve */
+};
+
+struct ecc_keypair {
+	struct ecc_priv_key priv_key;
+	struct ecc_pub_key pub_key;
+};
 #endif /* CRACEN_PSA_PRIMITIVES_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.h
@@ -186,3 +186,106 @@ psa_status_t cracen_cipher_crypt_ecb(const struct sxkeyref *key, const uint8_t *
  * @return sxsymcrypt error code.
  */
 int cracen_prepare_ik_key(const uint8_t *user_data);
+
+/**
+ * @brief Compute v = v + summand.
+ * \note  v is an unsigned integer stored as a big endian byte array of sz bytes.
+ *        Summand must be less than or equal to the maximum value of a size_t minus 255.
+ *        The final carry is discarded: addition is modulo 2^(sz*8).
+ *
+ * @param v		Big-endian Value
+ * @param v_size	size of v
+ * @param summand	Summand.
+ *
+ */
+void be_add(unsigned char *v, size_t v_size, size_t summand);
+
+/**
+ * @brief Big-Endian compare with carry.
+ * \note
+ *
+ * @param a		First value to be compared
+ * @param b		Second value to be compared
+ * @param size		Size of a and b.
+ * @param carry		Value of the carry.
+ *
+ * \retval 0 if equal.
+ * \retval 1 if a > b.
+ * \retval -1 if a < b.
+ */
+int be_cmp(const unsigned char *a, const unsigned char *b, size_t sz, int carry);
+
+/**
+ * @brief Hash several elements at different locations in memory
+ *
+ * @param inputs[in]		Array of pointers to elements that will be hashed.
+ * @param inputs_lengths[in]	Array of lengths of elements to be hashed.
+ * @param input_count[in]	Number of elements to be hashed.
+ * @param hashalg[in]		Hash algorithm to be used in sxhashalg format.
+ * @param digest[out]		Buffer of at least sx_hash_get_alg_digestsz(hashalg) bytes.
+ *
+ * @return sxsymcrypt status code.
+ */
+int hash_all_inputs(const char *inputs[], const size_t inputs_lengths[], size_t input_count,
+		    const struct sxhashalg *hashalg, char *digest);
+
+/**
+ * @brief Hash several elements at different locations in memory with a previously created hash
+ * context(sxhash)
+ *
+ * @param sxhashopctx[in]	Pointer to the sxhash context.
+ * @param inputs[in]		Array of pointers to elements that will be hashed.
+ * @param inputs_lengths[in]	Array of lengths of elements to be hashed.
+ * @param input_count[in]	Number of elements to be hashed.
+ * @param hashalg[in]		Hash algorithm to be used in sxhashalg format.
+ * @param digest[out]		Buffer of at least sx_hash_get_alg_digestsz(hashalg) bytes.
+ *
+ * @return sxsymcrypt status code.
+ */
+int hash_all_inputs_with_context(struct sxhash *sxhashopctx, const char *inputs[],
+				 const size_t inputs_lengths[], size_t input_count,
+				 const struct sxhashalg *hashalg, char *digest);
+
+/**
+ * @brief Hash a single element
+ *
+ * @param inputs[in]		Pointer to the element that will be hashed.
+ * @param input_length[in]	Length of the element to be hashed.
+ * @param hashalg[in]		Hash algorithm to be used in sxhashalg format.
+ * @param digest[out]		Buffer of at least sx_hash_get_alg_digestsz(hashalg) bytes.
+ *
+ * @return sxsymcrypt status code.
+ */
+int hash_input(const char *input, const size_t input_length, const struct sxhashalg *hashalg,
+	       char *digest);
+
+/**
+ * @brief Hash a single element with a previously created hash context(sxhash)
+ *
+ * @param sxhashopctx[in]	Pointer to the sxhash context.
+ * @param input[in]		Pointer to element that will be hashed.
+ * @param input_length[in]	Length of element to be hashed.
+ * @param hashalg[in]		hash algorithm to be used in sxhashalg format.
+ * @param digest[out]		Buffer of at least sx_hash_get_alg_digestsz(hashalg) bytes.
+ *
+ * @return sxsymcrypt status code.
+ */
+int hash_input_with_context(struct sxhash *hashopctx, const char *input, const size_t input_length,
+			    const struct sxhashalg *hashalg, char *digest);
+
+/**
+ * @brief Generate a random number within the specified range.
+ *
+ * \note  This function generates a random number strictly less than the given upper limit (`n`).
+ *        The generated random number is evenly distributed over the range [0, n-1]. If the range
+ *        is invalid (e.g., `n` is zero, less than three, or even), an error code is returned.
+ *
+ * @param n[in]         Pointer to a buffer holding the upper limit of the random range.
+ *                      The upper limit must be a non-zero odd number.
+ * @param nsz[in]       Size of the upper limit buffer in bytes.
+ * @param out[out]      Buffer to store the generated random number.
+ *                      The size of `out` should be at least `nsz`.
+ *
+ * @return sxsymcrypt status code:
+ */
+int rndinrange_create(const unsigned char *n, size_t nsz, unsigned char *out);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecc.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecc.c
@@ -1,0 +1,89 @@
+/* ECC key pair generation.
+ * Based on FIPS 186-4, section B.4.2 "Key Pair Generation by Testing
+ * Candidates".
+ *
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <string.h>
+#include <silexpk/core.h>
+#include <silexpk/iomem.h>
+#include <silexpk/cmddefs/ecc.h>
+#include <cracen/statuscodes.h>
+#include "cracen_psa.h"
+#include "ecc.h"
+#include "common.h"
+
+#define MAX_ECC_ATTEMPTS 10
+
+int ecc_create_genpubkey(const char *priv_key, char *pub_key, const struct sx_pk_ecurve *curve)
+{
+	const char **outputs;
+	struct sx_pk_acq_req pkreq;
+	struct sx_pk_inops_ecp_mult inputs;
+	int opsz;
+	int status;
+
+	for (int i = 0; i <= MAX_ECC_ATTEMPTS; i++) {
+		pkreq = sx_pk_acquire_req(SX_PK_CMD_ECC_PTMUL);
+		if (pkreq.status) {
+			return pkreq.status;
+		}
+		pkreq.status = sx_pk_list_ecc_inslots(pkreq.req, curve, 0,
+						     (struct sx_pk_slot *)&inputs);
+		if (pkreq.status) {
+			return pkreq.status;
+		}
+
+		opsz = sx_pk_curve_opsize(curve);
+
+		/* Write the private key (random) into ba414ep device memory */
+		sx_wrpkmem(inputs.k.addr, priv_key, opsz);
+		sx_pk_write_curve_gen(pkreq.req, curve, inputs.px, inputs.py);
+
+		sx_pk_run(pkreq.req);
+
+		status = sx_pk_wait(pkreq.req);
+		if (status != SX_OK) {
+			return status;
+		}
+		outputs = sx_pk_get_output_ops(pkreq.req);
+
+		/* When countermeasures are used, the operation may fail with error code
+		 * SX_ERR_NOT_INVERTIBLE. In this case we can try again.
+		 */
+		if (status == SX_ERR_NOT_INVERTIBLE) {
+			sx_pk_release_req(pkreq.req);
+			if (i == MAX_ECC_ATTEMPTS) {
+				return SX_ERR_TOO_MANY_ATTEMPTS;
+			}
+		} else {
+			break;
+		}
+	}
+	sx_rdpkmem(pub_key, outputs[0], opsz);
+	sx_rdpkmem(pub_key + opsz, outputs[1], opsz);
+	sx_pk_release_req(pkreq.req);
+	return status;
+}
+
+int ecc_create_genprivkey(const struct sx_pk_ecurve *curve, char *priv_key, size_t priv_key_size)
+{
+	int status;
+	int opsz = sx_pk_curve_opsize(curve);
+	const char *curve_n = sx_pk_curve_order(curve);
+	size_t keysz = (size_t)sx_pk_curve_opsize(curve);
+
+	if (priv_key_size < keysz) {
+		return SX_ERR_OUTPUT_BUFFER_TOO_SMALL;
+	}
+
+	/* generate private key, a random number in [1, n-1], where n is the curve
+	 * order
+	 */
+	status = rndinrange_create((const unsigned char *)curve_n, opsz, priv_key);
+
+	return status;
+}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecc.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecc.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#ifndef ECC_H
+#define ECC_H
+
+#include <psa/crypto.h>
+
+int ecc_create_genpubkey(const char *priv_key, char *pub_key, const struct sx_pk_ecurve *curve);
+
+int ecc_create_genprivkey(const struct sx_pk_ecurve *curve, char *priv_key, size_t priv_key_size);
+
+#endif /* ECC_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecdsa.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecdsa.c
@@ -1,0 +1,564 @@
+/* ECDSA signature generation and verification.
+ *
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ * Workmem layout for the ECDSA sign task:
+ *      1. Hash digest of the message to be signed (size: digestsz).
+ *      2. Output of the rndinrange subtask (size: curve_op_size, which is the
+ *         max size in bytes of parameters and operands for the selected curve).
+ *
+ * Workmem layout for the ECDSA Deterministic sign task:
+ *      1. HMAC task requirements (size: digestsz + blocksz)
+ *      2. Hash digest of the message to be signed (size: digestsz).
+ *      4. K (HMAC key) (size: digestsz)
+ *      5. V (size: digestsz)
+ *      6. T (size: curve_op_size)
+ *
+ * Workmem layout for the ECDSA verify task:
+ *      1. Hash digest of the message whose signature is being verified
+ *         (size: digestsz).
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <silexpk/core.h>
+#include <silexpk/iomem.h>
+#include <silexpk/cmddefs/ecc.h>
+#include <cracen/statuscodes.h>
+#include "sxsymcrypt/hash.h"
+#include "cracen_psa_ecdsa.h"
+#include "cracen_psa_primitives.h"
+#include "sxsymcrypt/hash.h"
+#include "hashdefs.h"
+#include "common.h"
+#include "hmac.h"
+
+#define INTERNAL_OCTET_NOT_USED	 ((uint8_t)0xFFu)
+#define DETERMINISTIC_HMAC_STEPS 6
+
+#ifndef MAX_ECDSA_ATTEMPTS
+#define MAX_ECDSA_ATTEMPTS 255
+#endif
+
+typedef enum {
+	INTERNAL_OCTET_ZERO,
+	INTERNAL_OCTET_ONE,
+	INTERNAL_OCTET_UNUSED,
+} internal_octet_t;
+
+struct ecdsa_hmac_operation {
+	int attempts;
+	uint16_t tlen;
+	uint8_t step;
+	int deterministic_retries;
+};
+
+/* Counts leading zeroes in a u8 */
+static int clz_u8(uint8_t i)
+{
+	int r = 0;
+
+	while (((1 << (7 - r)) & i) == 0) {
+		r++;
+	}
+	return r;
+}
+
+/** Convert a digest into an operand for ECDSA
+ *
+ * The raw digest may need to be padded or truncated to fit the curve
+ * operand used for ECDSA.
+ *
+ * Conversion could also imply byte order inversion, but that is not
+ * implemented here. It's expected that SilexPK takes big endian
+ * operands here.
+ *
+ * As the digest size is expressed in bytes, this procedure does not
+ * work for curves which have sizes not multiples of 8 bits.
+ */
+static void digest2op(const char *digest, size_t sz, char *dst, size_t opsz)
+{
+	if (opsz > sz) {
+		sx_clrpkmem(dst, opsz - sz);
+		dst += opsz - sz;
+	}
+	sx_wrpkmem(dst, digest, opsz);
+}
+
+/**
+ * @brief Perform bits2int according to definition in RFC-6979.
+ */
+void bits2int(const uint8_t *data, size_t data_len, uint8_t *out_data, size_t qlen)
+{
+	size_t data_bitlen = data_len * 8;
+	size_t qbytes = ROUND_UP(qlen, 8) / 8;
+
+	if (data_bitlen > qlen) {
+		uint32_t rshift = qbytes * 8 - qlen;
+
+		memmove(out_data, data, qbytes);
+
+		if (rshift) {
+			uint8_t prev = 0;
+
+			for (size_t i = 0; i < qbytes; i++) {
+				uint8_t tmp = out_data[i];
+
+				out_data[i] = prev << (8 - rshift) | (tmp >> rshift);
+				prev = tmp;
+			}
+		}
+
+	} else {
+		memset(out_data, 0, qbytes - data_len);
+		memmove(out_data + (qbytes - data_len), data, data_len);
+	}
+}
+
+/**
+ * @brief Perform bits2octets according to definition in RFC-6979.
+ */
+void bits2octets(const uint8_t *data, size_t data_len, uint8_t *out_data, const uint8_t *order,
+		 size_t order_len)
+{
+	bits2int(data, data_len, out_data, order_len * 8 - clz_u8(order[0]));
+
+	int ge = be_cmp(out_data, order, order_len, 0);
+
+	if (ge >= 0) {
+		uint8_t carry = 0;
+
+		for (size_t i = order_len; i > 0; i--) {
+			uint32_t a = out_data[i - 1];
+			uint32_t b = order[i - 1] + carry;
+
+			if (b > a) {
+				a += 0x100;
+				carry = 1;
+			} else {
+				carry = 0;
+			}
+			out_data[i - 1] = a - b;
+		}
+	}
+}
+
+static void ecdsa_write_pk(const char *pubkey, char *x, char *y, size_t opsz)
+{
+	sx_wrpkmem(x, pubkey, opsz);
+	sx_wrpkmem(y, pubkey + opsz, opsz);
+}
+
+static void ecdsa_write_sig(const struct ecdsa_signature *sig, char *r, char *s, size_t opsz)
+{
+	sx_wrpkmem(r, sig->r, opsz);
+	sx_wrpkmem(s, sig->s, opsz);
+}
+
+static void ecdsa_write_sk(const struct ecc_priv_key *sk, char *d, size_t opsz)
+{
+	sx_wrpkmem(d, sk->d, opsz);
+}
+
+static void ecdsa_read_sig(struct ecdsa_signature *sig, const char *r, const char *s, size_t opsz)
+{
+	sx_rdpkmem((char *)sig->r, (char *)r, opsz);
+	if (!sig->s) {
+		sig->s = sig->r + opsz;
+	}
+	sx_rdpkmem((char *)sig->s, (char *)s, opsz);
+}
+
+int cracen_ecdsa_sign_message(const struct ecc_priv_key *privkey, const struct sxhashalg *hashalg,
+			      const struct sx_pk_ecurve *curve, const uint8_t *message,
+			      size_t message_length, uint8_t *signature)
+{
+	int status;
+	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
+	char digest[digestsz];
+
+	status = hash_input(message, message_length, hashalg, digest);
+	if (status != SX_OK) {
+		return status;
+	}
+
+	return cracen_ecdsa_sign_digest(privkey, hashalg, curve, digest, digestsz, signature);
+}
+
+int cracen_ecdsa_sign_digest(const struct ecc_priv_key *privkey, const struct sxhashalg *hashalg,
+			     const struct sx_pk_ecurve *curve, const uint8_t *digest,
+			     size_t digest_length, uint8_t *signature)
+{
+	int status;
+	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
+	size_t opsz = sx_pk_curve_opsize(curve);
+	struct sx_pk_acq_req pkreq;
+	struct sx_pk_inops_ecdsa_generate inputs;
+	const char *curve_n;
+	size_t workmem_requirement = digestsz + opsz;
+	struct ecdsa_signature internal_signature = {0};
+	char workmem[workmem_requirement];
+
+	memcpy(workmem, digest, digest_length);
+	curve_n = sx_pk_curve_order(curve);
+
+	internal_signature.r = signature;
+	internal_signature.s = signature + opsz;
+
+	for (int i = 0; i <= MAX_ECDSA_ATTEMPTS; i++) {
+		status =
+			rndinrange_create((const unsigned char *)curve_n, opsz, workmem + digestsz);
+		if (status != SX_OK) {
+			return status;
+		}
+		pkreq = sx_pk_acquire_req(SX_PK_CMD_ECDSA_GEN);
+		if (pkreq.status) {
+			return pkreq.status;
+		}
+		pkreq.status =
+			sx_pk_list_ecc_inslots(pkreq.req, curve, 0, (struct sx_pk_slot *)&inputs);
+		if (pkreq.status) {
+			return pkreq.status;
+		}
+
+		ecdsa_write_sk(privkey, inputs.d.addr, opsz);
+		sx_wrpkmem(inputs.k.addr, workmem + digestsz, opsz);
+		digest2op(workmem, digestsz, inputs.h.addr, opsz);
+		sx_pk_run(pkreq.req);
+		status = sx_pk_wait(pkreq.req);
+		if (status != SX_OK) {
+			return status;
+		}
+		status = sx_pk_has_finished(pkreq.req);
+		if (status == SX_ERR_BUSY) {
+			return SX_ERR_HW_PROCESSING;
+		}
+
+		/* SX_ERR_NOT_INVERTIBLE may be due to silexpk countermeasures. */
+		if ((status == SX_ERR_INVALID_SIGNATURE) || (status == SX_ERR_NOT_INVERTIBLE)) {
+			sx_pk_release_req(pkreq.req);
+			if (i == MAX_ECDSA_ATTEMPTS) {
+				return SX_ERR_TOO_MANY_ATTEMPTS;
+			}
+		} else {
+			break;
+		}
+	}
+	if (status != SX_OK) {
+		sx_pk_release_req(pkreq.req);
+		return status;
+	}
+
+	const char **outputs = sx_pk_get_output_ops(pkreq.req);
+
+	ecdsa_read_sig(&internal_signature, outputs[0], outputs[1], opsz);
+	sx_pk_release_req(pkreq.req);
+	safe_memzero(workmem, workmem_requirement);
+
+	return SX_OK;
+}
+
+static int run_deterministic_ecdsa_hmac_step(const struct sxhashalg *hashalg, size_t opsz,
+					     const char *curve_n, size_t digestsz, size_t blocksz,
+					     char *workmem, struct ecdsa_hmac_operation *hmac_op,
+					     const struct ecc_priv_key *privkey);
+
+static int deterministic_ecdsa_hmac(const struct sxhashalg *hashalg, const uint8_t *key,
+				    const uint8_t *v, size_t hash_len,
+				    internal_octet_t internal_octet, const uint8_t *sk,
+				    const uint8_t *hash, size_t key_len, uint8_t *hmac);
+
+int cracen_ecdsa_sign_digest_deterministic(const struct ecc_priv_key *privkey,
+					   const struct sxhashalg *hashalg,
+					   const struct sx_pk_ecurve *curve, const uint8_t *digest,
+					   size_t digestsz, uint8_t *signature)
+{
+	int status;
+	int attempts = MAX_ECDSA_ATTEMPTS;
+	size_t opsz = (size_t)sx_pk_curve_opsize(curve);
+	size_t blocksz = sx_hash_get_alg_blocksz(hashalg);
+	size_t workmem_requirement = digestsz * 4 + opsz + blocksz;
+	const char *curve_n = sx_pk_curve_order(curve);
+	char workmem[workmem_requirement];
+
+	struct sx_pk_acq_req pkreq;
+	struct sx_pk_inops_ecdsa_generate inputs;
+	struct ecdsa_signature internal_signature = {0};
+
+	internal_signature.r = signature;
+	internal_signature.s = signature + opsz;
+	memcpy(workmem, digest, digestsz);
+
+	do {
+		struct ecdsa_hmac_operation hmac_op = {0};
+
+		hmac_op.attempts = MAX_ECDSA_ATTEMPTS;
+
+		uint8_t *h1 = workmem + digestsz + blocksz;
+
+		memcpy(h1, workmem, digestsz);
+		while (hmac_op.step <= DETERMINISTIC_HMAC_STEPS) {
+			status = run_deterministic_ecdsa_hmac_step(hashalg, opsz, curve_n, digestsz,
+								   blocksz, workmem, &hmac_op,
+								   privkey);
+			if (status != SX_OK && status != SX_ERR_HW_PROCESSING) {
+				return status;
+			}
+		}
+
+		pkreq = sx_pk_acquire_req(SX_PK_CMD_ECDSA_GEN);
+		if (pkreq.status) {
+			return pkreq.status;
+		}
+		pkreq.status =
+			sx_pk_list_ecc_inslots(pkreq.req, curve, 0, (struct sx_pk_slot *)&inputs);
+		if (pkreq.status) {
+			return pkreq.status;
+		}
+		ecdsa_write_sk(privkey, inputs.d.addr, opsz);
+		sx_wrpkmem(inputs.k.addr, workmem + digestsz, opsz);
+		digest2op(workmem, digestsz, inputs.h.addr, opsz);
+		sx_pk_run(pkreq.req);
+		status = sx_pk_wait(pkreq.req);
+		if (status != SX_OK) {
+			sx_pk_release_req(pkreq.req);
+		}
+
+	} while ((attempts--) && ((pkreq.status == SX_ERR_INVALID_SIGNATURE) ||
+				  (pkreq.status == SX_ERR_NOT_INVERTIBLE)));
+
+	if (status == SX_OK) {
+		const char **outputs = sx_pk_get_output_ops(pkreq.req);
+
+		ecdsa_read_sig(&internal_signature, outputs[0], outputs[1], opsz);
+	}
+
+	sx_pk_release_req(pkreq.req);
+	safe_memzero(workmem, workmem_requirement);
+
+	return status;
+}
+
+int cracen_ecdsa_sign_message_deterministic(const struct ecc_priv_key *privkey,
+					    const struct sxhashalg *hashalg,
+					    const struct sx_pk_ecurve *curve,
+					    const uint8_t *message, size_t message_length,
+					    uint8_t *signature)
+{
+	int status;
+	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
+	char digest[digestsz];
+
+	status = hash_input(message, message_length, hashalg, digest);
+	if (status != SX_OK) {
+		return status;
+	}
+
+	return cracen_ecdsa_sign_digest_deterministic(privkey, hashalg, curve, digest, digestsz,
+						      signature);
+}
+
+static int run_deterministic_ecdsa_hmac_step(const struct sxhashalg *hashalg, size_t opsz,
+					     const char *curve_n, size_t digestsz, size_t blocksz,
+					     char *workmem, struct ecdsa_hmac_operation *hmac_op,
+					     const struct ecc_priv_key *privkey)
+{
+	int status = SX_OK;
+	uint8_t *h1 = workmem + digestsz + blocksz;
+	uint8_t *K = h1 + digestsz;
+	uint8_t *V = K + digestsz;
+	uint8_t *T = V + digestsz;
+	uint8_t step = hmac_op->step;
+
+	switch (step) {
+	case 0: /* K = HMAC_K(V || 0x00 || privkey || h1) */
+		for (size_t i = 0; i < digestsz; i++) {
+			K[i] = 0x0; /* Initialize K = 0x00 0x00 ... */
+			V[i] = 0x1; /* Initialize V = 0x01 0x01 ... */
+		}
+
+		/* The original h1 must be preserved for the sign operation. We reuse T for the
+		 * transformed value.
+		 */
+		bits2octets(h1, digestsz, T, curve_n, opsz);
+
+		status = deterministic_ecdsa_hmac(hashalg, K, V, digestsz, INTERNAL_OCTET_ZERO,
+						  privkey->d, T, opsz, K);
+		break;
+
+	case 1: /* V = HMAC_K(V) */
+		status = deterministic_ecdsa_hmac(hashalg, K, V, digestsz, INTERNAL_OCTET_NOT_USED,
+						  NULL, NULL, opsz, V);
+		break;
+
+	case 2: /* K = HMAC_K(V || 0x01 || privkey || h1) */
+		status = deterministic_ecdsa_hmac(hashalg, K, V, digestsz, INTERNAL_OCTET_ONE,
+						  privkey->d, T, opsz, K);
+		break;
+
+	case 3: /* V = HMAC_K(V) */
+	case 4: /* same as case 3. */
+		status = deterministic_ecdsa_hmac(hashalg, K, V, digestsz, INTERNAL_OCTET_NOT_USED,
+						  NULL, NULL, opsz, V);
+		break;
+
+	case 5: /* T = T || V */
+		size_t copylen = MIN(digestsz, opsz - hmac_op->tlen);
+
+		memcpy(T + hmac_op->tlen, V, copylen);
+		hmac_op->tlen += copylen;
+		if (hmac_op->tlen < opsz) {
+			/* We need more data. */
+			hmac_op->step = 4;
+			return SX_ERR_HW_PROCESSING;
+		}
+		break;
+
+	case 6: /* Verify that T is in range [1, q-1] */
+	{
+		int rshift = clz_u8(curve_n[0]);
+
+		/* Only use the first qlen bits that was generated. */
+		bits2int(T, opsz, T, opsz * 8 - rshift);
+
+		bool is_zero = true;
+
+		for (size_t i = 0; i < opsz; i++) {
+			if (T[i]) {
+				is_zero = false;
+				break;
+			}
+		}
+		int ge = be_cmp(T, curve_n, opsz, 0);
+		bool must_retry =
+			hmac_op->deterministic_retries < (MAX_ECDSA_ATTEMPTS - hmac_op->attempts);
+		if (is_zero || ge >= 0 || must_retry) {
+			/* T is out of range. Retry */
+			hmac_op->step = 3;
+			hmac_op->tlen = 0;
+			hmac_op->deterministic_retries++;
+			/* K = HMAC_K(V || 0x00) */
+			deterministic_ecdsa_hmac(hashalg, K, V, digestsz, INTERNAL_OCTET_ZERO, NULL,
+						 NULL, 0, K);
+			return SX_ERR_HW_PROCESSING;
+		}
+		memcpy(workmem, h1, digestsz);
+		memcpy(workmem + digestsz, T, opsz);
+		break;
+	}
+	default:
+		status = SX_ERR_INVALID_PARAM;
+	}
+	hmac_op->step++;
+	return status;
+}
+
+static int deterministic_ecdsa_hmac(const struct sxhashalg *hashalg, const uint8_t *key,
+				    const uint8_t *v, size_t hash_len, uint8_t internal_octet,
+				    const uint8_t *sk, const uint8_t *hash, size_t key_len,
+				    uint8_t *hmac)
+{
+
+	struct sxhash hashopctx;
+	size_t workmemsz = sx_hash_get_alg_digestsz(hashalg) + sx_hash_get_alg_blocksz(hashalg);
+	char workmem[workmemsz];
+	int status;
+
+	status = mac_create_hmac(hashalg, &hashopctx, key, hash_len, workmem, workmemsz);
+	if (status != SX_OK) {
+		return status;
+	}
+	/* The hash function is initialized in mac_create_hmac */
+	status = sx_hash_feed(&hashopctx, v, hash_len);
+	if (status != SX_OK) {
+		return status;
+	}
+
+	if (internal_octet != INTERNAL_OCTET_NOT_USED) {
+
+		static uint8_t internal_octet_values[] = {
+			[INTERNAL_OCTET_ZERO] = 0,
+			[INTERNAL_OCTET_ONE] = 1,
+			[INTERNAL_OCTET_UNUSED] = 0xFF,
+
+		};
+		uint8_t value = internal_octet_values[internal_octet];
+
+		status = sx_hash_feed(&hashopctx, &value, sizeof(value));
+		if (status != SX_OK) {
+			return status;
+		}
+	}
+	if (sk) {
+		status = sx_hash_feed(&hashopctx, sk, key_len);
+		if (status != SX_OK) {
+			return status;
+		}
+	}
+	if (hash) {
+		status = sx_hash_feed(&hashopctx, hash, key_len);
+		if (status != SX_OK) {
+			return status;
+		}
+	}
+
+	return hmac_produce(&hashopctx, hashalg, hmac, hash_len, workmem);
+}
+
+int cracen_ecdsa_verify_message(const char *pubkey, const struct sxhashalg *hashalg,
+				const uint8_t *message, size_t message_length,
+				const struct sx_pk_ecurve *curve, const uint8_t *signature)
+{
+	int status;
+	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
+	char digest[digestsz];
+
+	status = hash_input(message, message_length, hashalg, digest);
+	if (status != SX_OK) {
+		return status;
+	}
+
+	return cracen_ecdsa_verify_digest(pubkey, digest, digestsz, curve, signature);
+}
+
+int cracen_ecdsa_verify_digest(const char *pubkey, const uint8_t *digest, size_t digestsz,
+			       const struct sx_pk_ecurve *curve, const uint8_t *signature)
+{
+	int status;
+	size_t opsz = sx_pk_curve_opsize(curve);
+
+	struct sx_pk_acq_req pkreq;
+	struct sx_pk_inops_ecdsa_verify inputs;
+	struct ecdsa_signature internal_signature = {0};
+
+	internal_signature.r = (char *)signature;
+	internal_signature.s = (char *)signature + opsz;
+
+	pkreq = sx_pk_acquire_req(SX_PK_CMD_ECDSA_VER);
+	if (pkreq.status) {
+		sx_pk_release_req(pkreq.req);
+		return pkreq.status;
+	}
+	pkreq.status = sx_pk_list_ecc_inslots(pkreq.req, curve, 0, (struct sx_pk_slot *)&inputs);
+	if (pkreq.status) {
+		sx_pk_release_req(pkreq.req);
+		return pkreq.status;
+	}
+
+	opsz = sx_pk_curve_opsize(curve);
+	ecdsa_write_pk(pubkey, inputs.qx.addr, inputs.qy.addr, opsz);
+	ecdsa_write_sig(&internal_signature, inputs.r.addr, inputs.s.addr, opsz);
+
+	digest2op(digest, digestsz, inputs.h.addr, opsz);
+	sx_pk_run(pkreq.req);
+	status = sx_pk_wait(pkreq.req);
+	if (status != SX_OK) {
+		sx_pk_release_req(pkreq.req);
+		return status;
+	}
+	sx_pk_release_req(pkreq.req);
+
+	return pkreq.status;
+}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/hmac.c
@@ -1,0 +1,119 @@
+/* HMAC implementation, based on FIPS 198-1.
+ *
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ * Workmem layout for the HMAC task:
+ *      1. Area used to store values obtained from processing the key.
+ *         Size: hash algorithm block size.
+ *      2. Area used to store the intermediate hash value.
+ *         Size: hash algorithm digest size.
+ */
+
+#include <string.h>
+#include <sxsymcrypt/hash.h>
+#include <cracen/statuscodes.h>
+#include <cracen/mem_helpers.h>
+#include "cracen_psa_primitives.h"
+#include "cracen_psa.h"
+#include "common.h"
+
+/* xor bytes in 'buf' with a constant 'v', in place */
+static void xorbuf(char *buf, char v, size_t sz)
+{
+	for (size_t i = 0; i < sz; i++) {
+		*buf = *buf ^ v;
+		buf++;
+	}
+}
+
+int hmac_produce(struct sxhash *hashctx, const struct sxhashalg *hashalg, char *digest, size_t sz,
+		 char *workmem)
+{
+	int status;
+	size_t blocksz;
+	size_t digestsz;
+
+	digestsz = sx_hash_get_alg_digestsz(hashalg);
+	if (sz < digestsz) {
+		sx_hash_free(hashctx);
+		return SX_ERR_OUTPUT_BUFFER_TOO_SMALL;
+	}
+
+	blocksz = sx_hash_get_alg_blocksz(hashalg);
+
+	/* run hash (1st hash of HMAC algorithm), result inside workmem */
+	status = sx_hash_digest(hashctx, workmem + blocksz);
+	if (status != SX_OK) {
+		return status;
+	}
+
+	status = sx_hash_wait(hashctx);
+	if (status != SX_OK) {
+		return status;
+	}
+
+	/* compute K0 xor opad (0x36 ^ 0x5C = 0x6A) */
+	xorbuf(workmem, 0x6A, blocksz);
+
+	return hash_input_with_context(hashctx, workmem, blocksz + digestsz, hashalg, digest);
+}
+
+static int internal_start_hmac_computation(struct sxhash *hashopctx,
+					   const struct sxhashalg *hashalg, char *workmem)
+{
+	int status;
+	size_t blocksz;
+
+	/* task for computing the 1st hash in the HMAC algorithm */
+	status = sx_hash_create(hashopctx, hashalg, sizeof(*hashopctx));
+	if (status != SX_OK) {
+		return status;
+	}
+
+	blocksz = sx_hash_get_alg_blocksz(hashalg);
+
+	/* The "prepared" key (called K0 in FIPS 198-1) is available and
+	 * workmem points to it. Here we compute K0 xor ipad.
+	 */
+	xorbuf(workmem, 0x36, blocksz);
+
+	/* start feeding the hash task */
+	status = sx_hash_feed(hashopctx, workmem, blocksz);
+
+	return status;
+}
+
+int mac_create_hmac(const struct sxhashalg *hashalg, struct sxhash *hashopctx, const char *key,
+		    size_t keysz, char *workmem, size_t workmemsz)
+{
+	int status;
+	size_t digestsz;
+	size_t blocksz;
+
+	digestsz = sx_hash_get_alg_digestsz(hashalg);
+	blocksz = sx_hash_get_alg_blocksz(hashalg);
+
+	/* a key longer than hash block size needs an additional preparation
+	 * step
+	 */
+	if (keysz > blocksz) {
+		/* hash the key */
+		status = hash_input_with_context(hashopctx, key, keysz, hashalg, workmem);
+		if (status != SX_OK) {
+			return status;
+		}
+
+		/* zero padding */
+		safe_memset(workmem + digestsz, workmemsz - digestsz, 0, blocksz - digestsz);
+		status = internal_start_hmac_computation(hashopctx, hashalg, workmem);
+	} else {
+		memcpy(workmem, key, keysz);
+		/* zero padding */
+		safe_memset(workmem + keysz, workmemsz - keysz, 0, blocksz - keysz);
+
+		status = internal_start_hmac_computation(hashopctx, hashalg, workmem);
+	}
+	return status;
+}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/hmac.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/hmac.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <psa/crypto.h>
+
+int mac_create_hmac(const struct sxhashalg *hashalg, struct sxhash *hashopctx, const char *key,
+		    size_t keysz, char *workmem, size_t workmemsz);
+
+int hmac_produce(struct sxhash *hashctx, const struct sxhashalg *hashalg, char *out, size_t sz,
+		 char *workmem);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/rndinrange.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/rndinrange.c
@@ -1,0 +1,108 @@
+/**
+ * @file
+ *
+ * @copyright Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <string.h>
+#include "../include/sicrypto/sicrypto.h"
+#include <cracen/statuscodes.h>
+#include <cracen/mem_helpers.h>
+#include <cracen_psa.h>
+#include "common.h"
+
+/* Return 1 if the given byte string contains only zeros, 0 otherwise. */
+static int is_zero_bytestring(const char *a, size_t sz)
+{
+	int acc = 0;
+
+	for (size_t i = 0; i < sz; i++) {
+		acc |= a[i];
+	}
+	return !acc;
+}
+
+static int rndinrange_continue(unsigned char *out, size_t rndsz, const unsigned char *upper_limit,
+			       unsigned char msb_mask)
+{
+	int z;
+	int ge;
+
+	/* Set to zero excess high-order bits in the most significant byte */
+	out[0] &= msb_mask;
+
+	/* If the generated number is 0 or >= n, then discard it and repeat */
+	z = is_zero_bytestring((char *)out, rndsz);
+	ge = be_cmp(out, upper_limit, rndsz, 0);
+	if (z || (ge >= 0)) {
+		return SX_ERR_HW_PROCESSING;
+	}
+
+	/* The generated number is valid */
+	return SX_OK;
+}
+
+static psa_status_t rndinrange_getrnd(unsigned char *out, size_t rndsz,
+				      const unsigned char *upper_limit, unsigned char msb_mask)
+{
+	/* Get random octets from the PRNG in the environment.
+	 * Place them directly in the user's output buffer.
+	 */
+	int result;
+	psa_status_t status;
+
+	do {
+		status = cracen_get_random(NULL, out, rndsz);
+
+		if (status != PSA_SUCCESS) {
+			return SX_ERR_UNKNOWN_ERROR;
+		}
+		result = rndinrange_continue(out, rndsz, upper_limit, msb_mask);
+
+	} while (result == SX_ERR_HW_PROCESSING);
+
+	return result;
+}
+
+int rndinrange_create(const unsigned char *upper_limit, size_t upper_limit_sz, unsigned char *out)
+{
+	size_t index;
+	unsigned char msb_mask;
+
+	/* Error if the provided upper limit has size 0 */
+	if (upper_limit_sz == 0) {
+		return SX_ERR_INPUT_BUFFER_TOO_SMALL;
+	}
+
+	/* Get index of most significant non-zero byte in n */
+	for (index = 0; (upper_limit[index] == 0) && (index < upper_limit_sz); index++) {
+		/* Do nothing; just increment 'index' */
+	}
+
+	/* Error if the provided upper limit is 0 or if it is > 0 but < 3 */
+	if ((index == upper_limit_sz) ||
+	    ((index == upper_limit_sz - 1) && (upper_limit[index] < 3))) {
+		return SX_ERR_INPUT_BUFFER_TOO_SMALL;
+	}
+
+	/* Error if the provided upper limit is not odd */
+	if ((upper_limit[upper_limit_sz - 1] & 0x01) == 0) {
+		return SX_ERR_INVALID_ARG;
+	}
+
+	/* Get bit mask of the most significant non-zero byte in n */
+	for (msb_mask = 0xFF; upper_limit[index] & msb_mask; msb_mask <<= 1) {
+		/* Do nothing; just increment 'index' */
+	}
+	msb_mask = ~msb_mask;
+
+	size_t rndsz = upper_limit_sz - index;
+	const unsigned char *adjusted_upper_limit = upper_limit + index;
+	unsigned char *adjusted_out = out + index;
+
+	/* Write high-order zero bytes, if any, in the output buffer */
+	safe_memset(out, upper_limit_sz, 0, index);
+	return rndinrange_getrnd(adjusted_out, rndsz, adjusted_upper_limit, msb_mask);
+}

--- a/subsys/nrf_security/src/drivers/cracen/sicrypto/src/hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/sicrypto/src/hmac.c
@@ -31,7 +31,8 @@ static void xorbuf(char *buf, char v, size_t sz)
 
 static int finish_hmac_computation(struct sitask *t, struct siwq *wq)
 {
-	size_t blocksz, digestsz;
+	size_t blocksz;
+	size_t digestsz;
 	(void)wq;
 
 	if (t->statuscode) {

--- a/subsys/nrf_security/src/drivers/cracen/sicrypto/src/iksig.c
+++ b/subsys/nrf_security/src/drivers/cracen/sicrypto/src/iksig.c
@@ -279,6 +279,11 @@ static void create_pubkey(struct sitask *t, const struct si_sig_privkey *privkey
 	pubkey->key.eckey.curve = privkey->key.ref.curve;
 }
 
+const struct si_sig_def *const si_sig_def_ecdsa = &(const struct si_sig_def){
+	.pubkey = create_pubkey,
+	.sigcomponents = 2,
+};
+
 static const struct si_sig_def si_sig_def_ik = {
 	.sign = create_sign,
 	.sign_digest = create_sign_digest,

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/sxsymcrypt.cmake
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/sxsymcrypt.cmake
@@ -18,4 +18,5 @@ list(APPEND cracen_driver_sources
 
 list(APPEND cracen_driver_include_dirs
     ${CMAKE_CURRENT_LIST_DIR}/include
+    ${CMAKE_CURRENT_LIST_DIR}/src
 )


### PR DESCRIPTION
Add support for ECDSA in cracenpsa
Directly using silexpk/sxsymcrypt
This bypasses sicrypto, which saves on flash usage 
Adding support for hmac without sicrypto.
Remove sicrypto implementation of ECDSA being
accessible from cracenpsa.
Various refactors to support this