### PR TITLE
ci: add west update to compliance

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -44,6 +44,7 @@ jobs:
         (echo "::error ::Merge commits not allowed, rebase instead";false)
 
         git rebase origin/${BASE_REF}
+        west update
         # debug
         git log  --pretty=oneline | head -n 10
 


### PR DESCRIPTION
It is possible that rebase brings changes to west.yml thus west update is needed.