### PR TITLE
doc: Added information about Matter WP and OOP for Matter

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -152,6 +152,8 @@
 .. _`Matter SDK tagged as v1.0.0`: https://github.com/project-chip/connectedhomeip/releases/tag/v1.0.0
 .. _`Testing with Apple Devices`: https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/darwin.md
 .. _`chip-tool`: https://docs.nordicsemi.com/bundle/ncs-latest/page/matter/chip_tool_guide.html
+.. _`Online Power Profiler for Matter over Thread`: https://devzone.nordicsemi.com/power/w/opp/16/online-power-profiler-for-matter-over-thread
+.. _`nWP049 - Matter over Thread: Power consumption and battery life`: https://docs.nordicsemi.com/bundle/nwp_049/page/WP/nwp_049/intro.html
 
 .. _`CoreMark GitHub`: https://github.com/eembc/coremark
 

--- a/doc/nrf/protocols/matter/getting_started/low_power_configuration.rst
+++ b/doc/nrf/protocols/matter/getting_started/low_power_configuration.rst
@@ -20,6 +20,11 @@ The following Matter samples and applications use the low power configuration by
 * :ref:`Matter window covering sample <matter_window_covering_sample>`
 * :ref:`Matter weather station application <matter_weather_station_app>`
 
+The following additional materials and tools might help you to optimize, estimate, and measure the power consumption of your device are:
+
+* `nWP049 - Matter over Thread: Power consumption and battery life`_
+* :ref:`ug_matter_gs_tools_opp`
+
 .. _ug_matter_device_low_power_icd:
 
 Enable Matter Intermittently Connected Devices support

--- a/doc/nrf/protocols/matter/getting_started/tools.rst
+++ b/doc/nrf/protocols/matter/getting_started/tools.rst
@@ -408,3 +408,13 @@ nRF Thread Topology Monitor
 .. include:: ../../thread/tools.rst
     :start-after: ttm_shortdesc_start
     :end-before: ttm_shortdesc_end
+
+.. _ug_matter_gs_tools_opp:
+
+Online Power Profiler for Matter over Thread
+********************************************
+
+`Online Power Profiler for Matter over Thread`_ is a web tool that allows you to estimate the power consumption of your Matter devices.
+It provides a graphical interface for configuring the parameters of your device, such as TX power, voltage supply, or ICD configuration and simulating its power consumption based on the simplified, theoretical model.
+The tool supports the nRF52840, nRF5340 and nRF54L15 platforms.
+It allows you to also estimate the power consumption of your device in a selected period of time and use the output for estimating the lifetime of the battery used as a power source.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -218,8 +218,12 @@ Matter
   * :ref:`ug_matter_debug_snippet`.
   * Storing Matter key materials in the :ref:`matter_platforms_security_kmu`.
   * A new section :ref:`ug_matter_device_low_power_calibration_period` in the :ref:`ug_matter_device_low_power_configuration` page.
+  * A new section :ref:`ug_matter_gs_tools_opp` in the :ref:`ug_matter_gs_tools` page.
 
-* Updated by disabling the :ref:`mpsl` before performing factory reset to speed up the process.
+* Updated:
+
+  * By disabling the :ref:`mpsl` before performing factory reset to speed up the process.
+  * The `ug_matter_device_low_power_configuration` page to mention the `nWP049 - Matter over Thread: Power consumption and battery life`_ and `Online Power Profiler for Matter over Thread`_ as a useful resources in optimizing the power consumption of a Matter device.
 
 Matter fork
 +++++++++++


### PR DESCRIPTION
Updated the Matter pages to mention the Matter over Thread power consumption whitepaper and Online Power Profiler for Matter tool as a resources that are useful in a process of optimizing and estimating the power consumption of a Matter device.