### PR TITLE
modules: openthread: Fix ECDSA issue in OpenThread.

### DIFF
--- a/modules/openthread/platform/crypto_psa.c
+++ b/modules/openthread/platform/crypto_psa.c
@@ -104,6 +104,16 @@ static otError getKeyRef(otCryptoKeyRef *aInputKeyRef, psa_key_attributes_t *aAt
 		if (psa_get_key_algorithm(aAttributes) == 0) {
 			psa_set_key_algorithm(aAttributes, PSA_ALG_HMAC(PSA_ALG_SHA_256));
 		}
+
+		/* KMU does not support deterministic ECDSA, so we need to set it to
+		 * PSA_ALG_ECDSA(PSA_ALG_SHA_256).
+		 * To keep backward compatibility with the previous functionality we must
+		 * leave PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_256) for the ITS purposes.
+		 */
+		if (psa_get_key_algorithm(aAttributes) ==
+		    PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_256)) {
+			psa_set_key_algorithm(aAttributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
+		}
 	}
 #endif /* CONFIG_OPENTHREAD_PSA_NVM_BACKEND */
 
@@ -680,9 +690,14 @@ otError otPlatCryptoEcdsaSignUsingKeyRef(otCryptoKeyRef aKeyRef,
 
 	GET_KEY_REF(&aKeyRef, NULL);
 
-	status = psa_sign_hash(aKeyRef, PSA_ALG_ECDSA(PSA_ALG_SHA_256), aHash->m8,
-			       OT_CRYPTO_SHA256_HASH_SIZE, aSignature->m8,
-			       OT_CRYPTO_ECDSA_SIGNATURE_SIZE, &signature_length);
+#if defined(CONFIG_OPENTHREAD_PSA_NVM_BACKEND_KMU)
+	psa_algorithm_t algorithm = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
+#else
+	psa_algorithm_t algorithm = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_256);
+#endif
+
+	status = psa_sign_hash(aKeyRef, algorithm, aHash->m8, OT_CRYPTO_SHA256_HASH_SIZE,
+			       aSignature->m8, OT_CRYPTO_ECDSA_SIGNATURE_SIZE, &signature_length);
 	if (status != PSA_SUCCESS) {
 		goto out;
 	}
@@ -700,7 +715,13 @@ otError otPlatCryptoEcdsaVerifyUsingKeyRef(otCryptoKeyRef aKeyRef,
 
 	GET_KEY_REF(&aKeyRef, NULL);
 
-	status = psa_verify_hash(aKeyRef, PSA_ALG_ECDSA(PSA_ALG_SHA_256), aHash->m8,
+#if defined(CONFIG_OPENTHREAD_PSA_NVM_BACKEND_KMU)
+	psa_algorithm_t algorithm = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
+#else
+	psa_algorithm_t algorithm = PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_256);
+#endif
+
+	status = psa_verify_hash(aKeyRef, algorithm, aHash->m8,
 				 OT_CRYPTO_SHA256_HASH_SIZE, aSignature->m8,
 				 OT_CRYPTO_ECDSA_SIGNATURE_SIZE);
 	if (status != PSA_SUCCESS) {
@@ -739,7 +760,7 @@ otError otPlatCryptoEcdsaGenerateAndImportKey(otCryptoKeyRef aKeyRef)
 	psa_key_id_t key_id = (psa_key_id_t)aKeyRef;
 
 	psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_VERIFY_HASH | PSA_KEY_USAGE_SIGN_HASH);
-	psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
+	psa_set_key_algorithm(&attributes, PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_256));
 	psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
 	psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_PERSISTENT);
 	psa_set_key_bits(&attributes, 256);
@@ -747,6 +768,7 @@ otError otPlatCryptoEcdsaGenerateAndImportKey(otCryptoKeyRef aKeyRef)
 	GET_KEY_REF(&key_id, &attributes);
 
 	psa_set_key_id(&attributes, key_id);
+
 	status = psa_generate_key(&attributes, &key_id);
 	if (status != PSA_SUCCESS) {
 		goto out;

--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -63,7 +63,7 @@ config OPENTHREAD_NRF_SECURITY_PSA
 	  functions if available as well as fast oberon backend for software encryption.
 
 config OPENTHREAD_NRF_SECURITY_PSA
-	select MBEDTLS_PSA_CRYPTO_STORAGE_C if (!PSA_SSF_CRYPTO_CLIENT && !BUILD_WITH_TFM)
+	imply MBEDTLS_PSA_CRYPTO_STORAGE_C if (!PSA_SSF_CRYPTO_CLIENT && !BUILD_WITH_TFM)
 	imply TRUSTED_STORAGE if (!PSA_SSF_CRYPTO_CLIENT && !BUILD_WITH_TFM)
 	# TRUSTED_STORAGE requires Settings
 	imply SETTINGS


### PR DESCRIPTION
To keep backward compatibility, we must use deterministic ECDSA and convert it to pure ECDSA for KMU only.

Also, once KMU can be used to store OpenThread crypto materials, we can allow disabling MBEDTLS_PSA_CRYPTO_STORAGE_C by the application, so changed select to imply.