### PR TITLE
Bluetooth: Mesh: Increase MBEDTLS_HEAP_SIZE for NLC samples

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -24,7 +24,10 @@ config BT_MESH_MBEDTLS_BACKEND_ENABLE
 	imply MBEDTLS_ENABLE_HEAP
 	imply PSA_WANT_GENERATE_RANDOM
 
+# NLC profile support requires more netkeys and appkeys thus more HEAP is needed by
+# MEBEDTLS to accommodate minimum number of keys needed by NLC profile support.
 config MBEDTLS_HEAP_SIZE
+	default 1152 if BT_MESH_NLC_PERF_CONF
 	default 1024
 
 if BT_SETTINGS


### PR DESCRIPTION
Increasing the default MBEDTLS_HEAP_SIZE to 1152 to accommodate all the keys used by NLC profile.