### PR TITLE
doc: Adding links to Developing with PMICs table

### DIFF
--- a/doc/nrf/app_dev/device_guides/pmic/index.rst
+++ b/doc/nrf/app_dev/device_guides/pmic/index.rst
@@ -25,10 +25,11 @@ Zephyr and the |NCS| provides support for developing applications with the follo
        | `nPM1300 EK get started`_
      - | `nPM1300 EK product page`_
        | `nPM1300 Power Management IC (PMIC) <nPM1300 product website_>`_
-   * - --
+   * - `nPM2100 EK <nPM2100 EK User Guide_>`_
      - PCA10170
      - See :ref:`ug_npm2100_compatible_boards`
      - | `Datasheet <nPM2100 Datasheet_>`_
+       | `User Guide <nPM2100 EK User Guide_>`_
      - | `nPM2100 EK product page`_
        | `nPM2100 Power Management IC (PMIC) <nPM2100 product website_>`_
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -345,7 +345,8 @@
 
 .. _`nPM2100 product website`: https://www.nordicsemi.com/Products/nPM2100
 .. _`nPM2100 Datasheet`: https://docs.nordicsemi.com/bundle/ps_npm2100/page/keyfeatures_html5.html
-.. _`nPM2100 EK product page`: https://docs.nordicsemi.com/bundle/ug_npm2100_ek/page/UG/nPM2100_EK/intro/intro.html
+.. _`nPM2100 EK product page`: https://www.nordicsemi.com/Products/Development-hardware/nPM2100-EK/Development-hardware
+.. _`nPM2100 EK User Guide`: https://docs.nordicsemi.com/bundle/ug_npm2100_ek/page/UG/nPM2100_EK/intro/intro.html
 .. _`Connect and use the nPM2100 EK`: https://docs.nordicsemi.com/bundle/ug_npm2100_ek/page/UG/nPM2100_EK/connect_ek/connect_ek.html
 .. _`Using the nPM2100 Fuel Gauge`: https://docs.nordicsemi.com/bundle/nan_048/page/APP/nan_048/intro.html
 


### PR DESCRIPTION
Adding a couple of links to the table.
The shield doc for nPM2100 in Zephyr is still missing.
Therefore, using same link twice in two places