### PR TITLE
quarantine: Add test overflowing ram on flpr

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -449,6 +449,7 @@
     - kernel.common.picolibc
     - kernel.common.tls
     - kernel.timer.timer
+    - libraries.encoding.jwt.rsa.psa
     - net.coap.server.common
     - net.http.server.common
     - net.http.server.crime


### PR DESCRIPTION
Test comes from zephyr.