### PR TITLE
samples: nrf_rpc: ps_server: turn off alive LED on fatal error

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/server/CMakeLists.txt
+++ b/samples/nrf_rpc/protocols_serialization/server/CMakeLists.txt
@@ -13,11 +13,16 @@ project(protocols_serialization_server)
 target_sources(app PRIVATE src/main.c)
 
 if(CONFIG_NRF_PS_SERVER_FATAL_ERROR_TRIGGER)
-    target_sources(app PRIVATE src/fatal_error_trigger.c)
+  target_sources(app PRIVATE src/fatal_error_trigger.c)
+endif()
+
+if(CONFIG_NRF_PS_SERVER_RPC_ALIVE_LED)
+  # Wrap z_fatal_error to turn off the RPC alive LED on fatal error
+  target_link_options(app INTERFACE -Wl,--wrap=z_fatal_error)
 endif()
 # NORDIC SDK APP END
 
 # Link OpenThread CLI even though OPENTHREAD_SHELL is not selected
 if(CONFIG_OPENTHREAD_RPC)
-    zephyr_link_libraries(openthread-cli-ftd)
+  zephyr_link_libraries(openthread-cli-ftd)
 endif()

--- a/samples/nrf_rpc/protocols_serialization/server/src/main.c
+++ b/samples/nrf_rpc/protocols_serialization/server/src/main.c
@@ -29,6 +29,17 @@ void nrf_rpc_uart_initialized_hook(const struct device *uart_dev)
 		LOG_ERR("Failed to configure RPC alive GPIO: %d", ret);
 	}
 }
+
+void __real_z_fatal_error(unsigned int reason, const struct arch_esf *esf);
+
+void __wrap_z_fatal_error(unsigned int reason, const struct arch_esf *esf)
+{
+	const struct gpio_dt_spec alive_gpio = GPIO_DT_SPEC_GET(DT_ALIAS(rpc_alive_led), gpios);
+
+	(void)gpio_pin_configure_dt(&alive_gpio, GPIO_OUTPUT_INACTIVE);
+
+	__real_z_fatal_error(reason, esf);
+}
 #endif
 
 int main(void)


### PR DESCRIPTION
Wrap z_fatal_error() in order to turn off the RPC alive LED as soon as the fatal error occurs.