### PR TITLE
applications: nrf_desktop: Use const pointer in ble_scan_def headers

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/ble_scan_def.h
+++ b/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/ble_scan_def.h
@@ -15,7 +15,7 @@ const struct {} ble_scan_include_once;
 
 #include "ble_event.h"
 
-static const char *peer_name[] = {
+static const char * const peer_name[] = {
 	[PEER_TYPE_MOUSE] = "Mouse nRF Desktop",
 	[PEER_TYPE_KEYBOARD] = "Keyboard nRF Desktop",
 };

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/ble_scan_def.h
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/ble_scan_def.h
@@ -15,7 +15,7 @@ const struct {} ble_scan_include_once;
 
 #include "ble_event.h"
 
-static const char *peer_name[] = {
+static const char * const peer_name[] = {
 	[PEER_TYPE_MOUSE] = "Mouse nRF Desktop",
 	[PEER_TYPE_KEYBOARD] = "Keyboard nRF Desktop",
 };

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/ble_scan_def.h
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/ble_scan_def.h
@@ -15,7 +15,7 @@ const struct {} ble_scan_include_once;
 
 #include "ble_event.h"
 
-static const char *peer_name[] = {
+static const char * const peer_name[] = {
 	[PEER_TYPE_MOUSE] = "Mouse nRF Desktop",
 	[PEER_TYPE_KEYBOARD] = "Keyboard nRF Desktop",
 };

--- a/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/ble_scan_def.h
+++ b/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/ble_scan_def.h
@@ -15,7 +15,7 @@ const struct {} ble_scan_include_once;
 
 #include "ble_event.h"
 
-static const char *peer_name[] = {
+static const char * const peer_name[] = {
 	[PEER_TYPE_MOUSE] = "Mouse nRF Desktop",
 	[PEER_TYPE_KEYBOARD] = "Keyboard nRF Desktop",
 };

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/ble_scan_def.h
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/ble_scan_def.h
@@ -15,7 +15,7 @@ const struct {} ble_scan_include_once;
 
 #include "ble_event.h"
 
-static const char *peer_name[] = {
+static const char * const peer_name[] = {
 	[PEER_TYPE_MOUSE] = "Mouse nRF Desktop",
 	[PEER_TYPE_KEYBOARD] = "Keyboard nRF Desktop",
 };

--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/ble_scan_def.h
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/ble_scan_def.h
@@ -15,7 +15,7 @@ const struct {} ble_scan_include_once;
 
 #include "ble_event.h"
 
-static const char *peer_name[] = {
+static const char * const peer_name[] = {
 	[PEER_TYPE_MOUSE] = "Mouse nRF Desktop",
 	[PEER_TYPE_KEYBOARD] = "Keyboard nRF Desktop",
 };


### PR DESCRIPTION
Change introduces using const pointer in ble_scan_def headers. This fixes compliance issues.

Jira: NCSDK-31539