### PR TITLE
cmake: sysbuild: Add TF-M support for QSPI XIP split functionality

### DIFF
--- a/cmake/sysbuild/image_signing_split.cmake
+++ b/cmake/sysbuild/image_signing_split.cmake
@@ -143,12 +143,11 @@ function(zephyr_mcuboot_tasks)
   set(output_merged ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.signed)
 
   if(CONFIG_BUILD_WITH_TFM)
-#    set(input ${APPLICATION_BINARY_DIR}/zephyr/tfm_merged)
-    message(FATAL_ERROR "TFM is not currently supported with QSPI XIP")
-  else()
-    set(input_internal ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.internal)
-    set(input_external ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.external)
+    set(input_tfm_s ${ZEPHYR_BINARY_DIR}/../tfm/bin/tfm_s)
   endif()
+
+  set(input_internal ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.internal)
+  set(input_external ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.external)
 
   # List of additional build byproducts.
   set(byproducts)
@@ -168,7 +167,14 @@ function(zephyr_mcuboot_tasks)
 
   # Set up .hex outputs.
   if(CONFIG_BUILD_OUTPUT_HEX)
-    set(unconfirmed_internal_args ${input_internal}.hex ${output_internal}.hex)
+    if(CONFIG_BUILD_WITH_TFM)
+      # Merge the TFM secure hex file with the internal hex file
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py -o ${input_internal}.tfm.hex ${input_internal}.hex ${input_tfm_s}.hex)
+      set(unconfirmed_internal_args ${input_internal}.tfm.hex ${output_internal}.hex)
+    else()
+      set(unconfirmed_internal_args ${input_internal}.hex ${output_internal}.hex)
+    endif()
+
     set(unconfirmed_external_args ${input_external}.hex ${output_external}.hex)
     list(APPEND byproducts ${output_internal}.hex ${output_external}.hex)
 
@@ -199,7 +205,12 @@ function(zephyr_mcuboot_tasks)
       ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py -o ${output_merged}.hex ${output_internal}.hex ${output_external}.hex)
 
     if(NOT "${keyfile_enc}" STREQUAL "")
-      set(unconfirmed_internal_args ${input_internal}.hex ${output_internal}.encrypted.hex)
+      if(CONFIG_BUILD_WITH_TFM)
+        set(unconfirmed_internal_args ${input_internal}.tfm.hex ${output_internal}.encrypted.hex)
+      else()
+        set(unconfirmed_internal_args ${input_internal}.hex ${output_internal}.encrypted.hex)
+      endif()
+
       set(unconfirmed_external_args ${input_external}.hex ${output_external}.encrypted.hex)
       list(APPEND byproducts ${output_internal}.encrypted.hex ${output_external}.encrypted.hex)
       set(BYPRODUCT_KERNEL_SIGNED_ENCRYPTED_HEX_NAME "${output_merged}.encrypted.hex"

--- a/samples/nrf5340/extxip_smp_svr/README.rst
+++ b/samples/nrf5340/extxip_smp_svr/README.rst
@@ -52,6 +52,9 @@ Building and running
 The |NCS| build system generates all essential binaries, including the application for internal and external QSPI flash, the networking stack, and MCUboot.
 The build process involves signing all the application binaries except for MCUboot which does not require signing in this configuration.
 
+.. note::
+   When building for the nRF5340 non-secure (TF-M) target, only the swap MCUboot mode without network core image support will work.
+
 To upload MCUboot and a bundle of images to the nRF5340 SoC, use the ``west flash`` command.
 
 Testing

--- a/samples/nrf5340/extxip_smp_svr/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/nrf5340/extxip_smp_svr/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,5 @@
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/nrf5340/extxip_smp_svr/sample.yaml
+++ b/samples/nrf5340/extxip_smp_svr/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: Simple Management Protocol sample
-  name: smp svr
+  description: Simple Management Protocol sample (with external QSPI XIP flash support)
+  name: ext xip smp svr
 common:
   sysbuild: true
   harness: console
@@ -11,27 +11,23 @@ common:
       - "<inf> smp_sample: build time:"
   platform_allow:
     - nrf5340dk/nrf5340/cpuapp
+    - thingy53/nrf5340/cpuapp
   integration_platforms:
     - nrf5340dk/nrf5340/cpuapp
+    - thingy53/nrf5340/cpuapp
   tags:
     - ci_samples_nrf5340
 tests:
-  sample.mcumgr.smp_svr.ext_xip:
-    platform_allow:
-      - thingy53/nrf5340/cpuapp
-    integration_platforms:
-      - thingy53/nrf5340/cpuapp
+  # Network core update not supported on TF-M builds
+  sample.mcumgr.smp_svr.ext_xip: []
   sample.mcumgr.smp_svr.ext_xip.no_network_core:
     platform_allow:
-      - thingy53/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
     integration_platforms:
-      - thingy53/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
     extra_args:
       - FILE_SUFFIX=no_network_core
+  # direct-xip mode not supported on TF-M builds
   sample.mcumgr.smp_svr.ext_xip.no_network_core.directxip:
-    platform_allow:
-      - thingy53/nrf5340/cpuapp
-    integration_platforms:
-      - thingy53/nrf5340/cpuapp
     extra_args:
       - FILE_SUFFIX=no_network_core_directxip

--- a/samples/nrf5340/extxip_smp_svr/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/nrf5340/extxip_smp_svr/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,6 @@
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};


### PR DESCRIPTION
Merge TF-M secure .hex file with the splitted internal .hex file before signing the image.