### PR TITLE
codeowners: Cover .txt files in doc/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -283,6 +283,7 @@
 /doc/**/*.svg                             @nrfconnect/ncs-doc-leads
 /doc/**/*.png                             @nrfconnect/ncs-doc-leads
 /doc/**/*.webp                            @nrfconnect/ncs-doc-leads
+/doc/**/*.txt                             @nrfconnect/ncs-doc-leads
 
 # Drivers
 /drivers/bluetooth/                       @nrfconnect/ncs-co-drivers @nrfconnect/ncs-dragoon


### PR DESCRIPTION
Text files are also present in the doc/ folder, assign those to the doc leads.