### PR TITLE
Revert "ci: add west update to compliance"

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -44,7 +44,6 @@ jobs:
         (echo "::error ::Merge commits not allowed, rebase instead";false)
 
         git rebase origin/${BASE_REF}
-        west update
         # debug
         git log  --pretty=oneline | head -n 10
 


### PR DESCRIPTION
This commit is causing submodule fetch issues.

This reverts commit 67bf95fbdd7dc0e95244cb756b923bfb0d592e9d.