### PR TITLE
cmake: LLVM now defaults to compiler_rt lib and LLD as linker

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -9,6 +9,7 @@
 # boards in sdk-nrf are sourced properly in those occasions.
 orsource "./$(BOARD_DIR)/Kconfig.board"
 orsource "./$(BOARD_DIR)/Kconfig"
+orsource "./cmake/toolchain/$(ZEPHYR_TOOLCHAIN_VARIANT)/Kconfig.defconfig"
 
 rsource "boards/shields/*/Kconfig.shield"
 rsource "subsys/net/openthread/Kconfig.defconfig"

--- a/cmake/toolchain/llvm/Kconfig.defconfig
+++ b/cmake/toolchain/llvm/Kconfig.defconfig
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# When using LLVM with NCS we want to default to Compiler RT lib and LLD.
+choice LLVM_LINKER
+	default LLVM_USE_LLD
+endchoice
+
+choice RTLIB_IMPLEMENTATION
+	default COMPILER_RT_RTLIB
+endchoice


### PR DESCRIPTION
LLVM  now defaults to compiler_rt lib and LLD as linker. This means that Arm LLVM toolchain can be used out-of-the-box for nRF devices without having to pass `-DCONFIG_COMPILER_RT_RTLIB=y` and `-DCONFIG_LLVM_USE_LLD=y` on command line.