### PR TITLE
nrf_rpc: add crash generation functions

### DIFF
--- a/include/nrf_rpc/nrf_rpc_crash_gen.h
+++ b/include/nrf_rpc/nrf_rpc_crash_gen.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef NRF_RPC_CRASH_GEN_H_
+#define NRF_RPC_CRASH_GEN_H_
+
+#include <stdint.h>
+
+/**
+ * @defgroup nrf_rpc_crash_gen nRF RPC crash generator.
+ * @{
+ * @brief nRF RPC crash generator functions.
+ *
+ */
+
+/** @brief Generate assert on RPC server.
+ *
+ * @param[in] delay_ms Assertion timeout in milliseconds.
+ */
+void nrf_rpc_crash_gen_assert(uint32_t delay_ms);
+
+
+/** @brief Generate hard fault on RPC server.
+ *
+ * @param[in] delay_ms Hard fault timeout in milliseconds.
+ */
+void nrf_rpc_crash_hard_fault(uint32_t delay_ms);
+
+
+/** @brief Generate stack overflow on RPC server.
+ *
+ * @param[in] delay_ms Stack overflow timeout in milliseconds.
+ */
+void nrf_rpc_crash_gen_stack_overflow(uint32_t delay_ms);
+
+
+/**
+ * @}
+ */
+
+#endif /* NRF_RPC_CRASH_GEN_H_ */

--- a/samples/nrf_rpc/protocols_serialization/client/CMakeLists.txt
+++ b/samples/nrf_rpc/protocols_serialization/client/CMakeLists.txt
@@ -19,4 +19,5 @@ zephyr_library_sources_ifdef(CONFIG_MPSL_CX_SOFTWARE src/coex_shell.c)
 zephyr_library_sources_ifdef(CONFIG_LOG_FORWARDER_RPC src/log_rpc_shell.c)
 zephyr_library_sources_ifdef(CONFIG_NFC_RPC src/nfc_shell.c)
 zephyr_library_sources_ifdef(CONFIG_NRF_RPC_DEV_INFO src/dev_info_shell.c)
+zephyr_library_sources_ifdef(CONFIG_NRF_RPC_CRASH_GEN src/crash_gen_shell.c)
 # NORDIC SDK APP START

--- a/samples/nrf_rpc/protocols_serialization/client/snippets/crash_gen/crash_gen.conf
+++ b/samples/nrf_rpc/protocols_serialization/client/snippets/crash_gen/crash_gen.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NRF_RPC_CRASH_GEN=y
+CONFIG_NRF_RPC_CRASH_GEN_CLIENT=y

--- a/samples/nrf_rpc/protocols_serialization/client/snippets/crash_gen/snippet.yml
+++ b/samples/nrf_rpc/protocols_serialization/client/snippets/crash_gen/snippet.yml
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+name: crash_gen
+append:
+  EXTRA_CONF_FILE: crash_gen.conf

--- a/samples/nrf_rpc/protocols_serialization/client/src/crash_gen_shell.c
+++ b/samples/nrf_rpc/protocols_serialization/client/src/crash_gen_shell.c
@@ -1,0 +1,69 @@
+#include <zephyr/shell/shell.h>
+#include <nrf_rpc/nrf_rpc_dev_info.h>
+
+static int cmd_assert(const struct shell *sh, size_t argc, char *argv[])
+{
+	int rc = 0;
+	uint32_t delay = 0;
+
+	if (argc > 1) {
+		delay = shell_strtol(argv[1], 10, &rc);
+	}
+
+	if (rc) {
+		shell_print(sh, "Invalid argument: %s", argv[1]);
+		return -EINVAL;
+	}
+
+        nrf_rpc_crash_gen_assert(delay);
+
+        return 0;
+}
+
+static int cmd_hard_fault(const struct shell *sh, size_t argc, char *argv[])
+{
+	int rc = 0;
+	uint32_t delay = 0;
+
+	if (argc > 1) {
+		delay = shell_strtol(argv[1], 10, &rc);
+	}
+
+	if (rc) {
+		shell_print(sh, "Invalid argument: %s", argv[1]);
+		return -EINVAL;
+	}
+
+        nrf_rpc_crash_gen_hard_fault(delay);
+
+        return 0;
+}
+
+static int cmd_stack_overflow(const struct shell *sh, size_t argc, char *argv[])
+{
+	int rc = 0;
+	uint32_t delay = 0;
+
+	if (argc > 1) {
+		delay = shell_strtol(argv[1], 10, &rc);
+	}
+
+	if (rc) {
+		shell_print(sh, "Invalid argument: %s", argv[1]);
+		return -EINVAL;
+	}
+
+        nrf_rpc_crash_gen_stack_overflow(delay);
+
+        return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(crash_cmds,
+			       SHELL_CMD_ARG(assert, NULL, "Invoke assert", cmd_assert, 1, 1),
+			       SHELL_CMD_ARG(hard_fault, NULL, "Invoke hard fault", cmd_hard_fault,
+			       		     1, 1),
+			       SHELL_CMD_ARG(stack_overflow, NULL, "Invoke stack overflow",
+			       		     cmd_stack_overflow, 1, 1),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(crash_gen, &crash_cmds, "nRF RPC crash generator commands", NULL, 1, 0);

--- a/samples/nrf_rpc/protocols_serialization/server/snippets/crash_gen/crash_gen.conf
+++ b/samples/nrf_rpc/protocols_serialization/server/snippets/crash_gen/crash_gen.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NRF_RPC_CRASH_GEN=y
+CONFIG_NRF_RPC_CRASH_GEN_SERVER=y

--- a/samples/nrf_rpc/protocols_serialization/server/snippets/crash_gen/snippet.yml
+++ b/samples/nrf_rpc/protocols_serialization/server/snippets/crash_gen/snippet.yml
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+name: crash_gen
+append:
+  EXTRA_CONF_FILE: crash_gen.conf

--- a/subsys/nrf_rpc/CMakeLists.txt
+++ b/subsys/nrf_rpc/CMakeLists.txt
@@ -19,3 +19,4 @@ zephyr_library_sources_ifdef(CONFIG_NRF_RPC_CALLBACK_PROXY nrf_rpc_cbkproxy.c)
 zephyr_library_sources_ifdef(CONFIG_NRF_RPC_UART_TRANSPORT nrf_rpc_uart.c)
 
 add_subdirectory_ifdef(CONFIG_NRF_RPC_DEV_INFO dev_info)
+add_subdirectory_ifdef(CONFIG_NRF_RPC_CRASH_GEN crash_gen)

--- a/subsys/nrf_rpc/Kconfig
+++ b/subsys/nrf_rpc/Kconfig
@@ -188,6 +188,7 @@ source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 endif # NRF_RPC_CBOR
 
 rsource "dev_info/Kconfig"
+rsource "crash_gen/Kconfig"
 
 endif # NRF_RPC
 

--- a/subsys/nrf_rpc/crash_gen/CMakeLists.txt
+++ b/subsys/nrf_rpc/crash_gen/CMakeLists.txt
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+add_subdirectory(common)
+
+add_subdirectory_ifdef(CONFIG_NRF_RPC_CRASH_GEN_CLIENT client)
+add_subdirectory_ifdef(CONFIG_NRF_RPC_CRASH_GEN_SERVER server)

--- a/subsys/nrf_rpc/crash_gen/Kconfig
+++ b/subsys/nrf_rpc/crash_gen/Kconfig
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menuconfig NRF_RPC_CRASH_GEN
+	bool "nRF RPC crash generator"
+	depends on NRF_RPC
+	depends on NRF_RPC_CBOR
+	help
+	  nRF RPC crash generating functionalities
+
+if NRF_RPC_CRASH_GEN
+
+choice NRF_RPC_CRASH_GEN_ROLE_CHOICE
+	prompt "nRF RPC crash generator role selection"
+	default NRF_RPC_CRASH_GEN_CLIENT
+	help
+	  nRF RPC crash generator role selection
+
+config NRF_RPC_CRASH_GEN_SERVER
+	bool "nRF RPC crash generator server role"
+	help
+	  Enable nRF RPC crash generator server role.
+
+config NRF_RPC_CRASH_GEN_CLIENT
+	bool "nRF RPC crash generator client role"
+	help
+	  Enable nRF RPC crash generator client role.
+
+endchoice
+
+endif # NRF_RPC_CRASH_GEN

--- a/subsys/nrf_rpc/crash_gen/client/CMakeLists.txt
+++ b/subsys/nrf_rpc/crash_gen/client/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_library()
+
+zephyr_library_sources(
+  crash_gen_client.c
+)
+
+zephyr_library_include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../common
+)

--- a/subsys/nrf_rpc/crash_gen/client/crash_gen_client.c
+++ b/subsys/nrf_rpc/crash_gen/client/crash_gen_client.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <nrf_rpc/nrf_rpc_serialize.h>
+#include <nrf_rpc_cbor.h>
+
+#include <crash_gen_rpc_ids.h>
+
+NRF_RPC_GROUP_DECLARE(crash_gen_group);
+
+void nrf_rpc_crash_gen_assert(uint32_t delay_ms) {
+	struct nrf_rpc_cbor_ctx ctx;
+
+	NRF_RPC_CBOR_ALLOC(&crash_gen_group, ctx, 5);
+
+	nrf_rpc_encode_uint(&ctx, delay_ms);
+
+	nrf_rpc_cbor_cmd_no_err(&crash_gen_group, CRASH_GEN_RPC_ASSERT, &ctx,
+				nrf_rpc_rsp_decode_void, NULL);
+}
+
+void nrf_rpc_crash_gen_hard_fault(uint32_t delay_ms) {
+	struct nrf_rpc_cbor_ctx ctx;
+
+	NRF_RPC_CBOR_ALLOC(&crash_gen_group, ctx, 5);
+
+	nrf_rpc_encode_uint(&ctx, delay_ms);
+
+	nrf_rpc_cbor_cmd_no_err(&crash_gen_group, CRASH_GEN_RPC_HARD_FAULT, &ctx,
+				nrf_rpc_rsp_decode_void, NULL);
+}
+
+void nrf_rpc_crash_gen_stack_overflow(uint32_t delay_ms) {
+	struct nrf_rpc_cbor_ctx ctx;
+
+	NRF_RPC_CBOR_ALLOC(&crash_gen_group, ctx, 5);
+
+	nrf_rpc_encode_uint(&ctx, delay_ms);
+
+	nrf_rpc_cbor_cmd_no_err(&crash_gen_group, CRASH_GEN_RPC_STACK_OVERFLOW, &ctx,
+				nrf_rpc_rsp_decode_void, NULL);
+}

--- a/subsys/nrf_rpc/crash_gen/common/CMakeLists.txt
+++ b/subsys/nrf_rpc/crash_gen/common/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_library()
+
+zephyr_library_sources(
+  crash_gen_rpc.c
+)

--- a/subsys/nrf_rpc/crash_gen/common/crash_gen_rpc.c
+++ b/subsys/nrf_rpc/crash_gen/common/crash_gen_rpc.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#if CONFIG_NRF_RPC_IPC_SERVICE
+#include <nrf_rpc/nrf_rpc_ipc.h>
+#elif CONFIG_NRF_RPC_UART_TRANSPORT
+#include <nrf_rpc/nrf_rpc_uart.h>
+#elif CONFIG_MOCK_NRF_RPC_TRANSPORT
+#include <mock_nrf_rpc_transport.h>
+#endif
+#include <nrf_rpc_cbor.h>
+
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+
+#ifdef CONFIG_NRF_RPC_IPC_SERVICE
+NRF_RPC_IPC_TRANSPORT(crash_gen_rpc_tr, DEVICE_DT_GET(DT_NODELABEL(ipc0)), "crash_gen_rpc_ept");
+#elif defined(CONFIG_NRF_RPC_UART_TRANSPORT)
+#define crash_gen_rpc_tr NRF_RPC_UART_TRANSPORT(DT_CHOSEN(nordic_rpc_uart))
+#elif defined(CONFIG_MOCK_NRF_RPC_TRANSPORT)
+#define crash_gen_rpc_tr mock_nrf_rpc_tr
+#endif
+NRF_RPC_GROUP_DEFINE(crash_gen_group, "crash_gen", &crash_gen_rpc_tr, NULL, NULL, NULL);
+LOG_MODULE_REGISTER(crash_gen_rpc, LOG_LEVEL_DBG);
+
+static void err_handler(const struct nrf_rpc_err_report *report)
+{
+	LOG_ERR("nRF RPC error %d ocurred. See nRF RPC logs for more details", report->code);
+	k_oops();
+}
+
+static int serialization_init(void)
+{
+	int err;
+
+	err = nrf_rpc_init(err_handler);
+	if (err) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+SYS_INIT(serialization_init, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/subsys/nrf_rpc/crash_gen/common/crash_gen_rpc_ids.h
+++ b/subsys/nrf_rpc/crash_gen/common/crash_gen_rpc_ids.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef CRASH_GEN_RPC_IDS_H_
+#define CRASH_GEN_RPC_IDS_H_
+
+/** @brief Command IDs accepted by the crash generator over RPC server.
+ */
+enum crash_gen_rpc_cmd_server {
+	CRASH_GEN_RPC_ASSERT = 0,
+	CRASH_GEN_RPC_HARD_FAULT = 1,
+	CRASH_GEN_RPC_STACK_OVERFLOW = 2,
+};
+
+#endif /* CRASH_GEN_RPC_IDS_H_ */

--- a/subsys/nrf_rpc/crash_gen/server/CMakeLists.txt
+++ b/subsys/nrf_rpc/crash_gen/server/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_library()
+
+zephyr_library_sources(
+  crash_gen_server.c
+)
+
+zephyr_library_include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../common
+)

--- a/subsys/nrf_rpc/crash_gen/server/crash_gen_server.c
+++ b/subsys/nrf_rpc/crash_gen/server/crash_gen_server.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <nrf_rpc/nrf_rpc_serialize.h>
+#include <nrf_rpc_cbor.h>
+#include <zephyr/sys/__assert.h>
+
+#include <crash_gen_rpc_ids.h>
+
+NRF_RPC_GROUP_DECLARE(crash_gen_group);
+
+static void crash_work_handler(struct k_work *work);
+
+K_WORK_DELAYABLE_DEFINE(crash_work, crash_work_handler);
+
+static enum crash_gen_rpc_cmd_server last_command;
+
+static void do_stack_overflow(void)
+{
+	volatile uint8_t arr[(256 * 1024)] __attribute__((unused));
+}
+
+static void do_assert(void)
+{
+	__ASSERT_NO_MSG(false);
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdiv-by-zero"
+
+static void do_hardfault(void)
+{
+	volatile uint32_t value __attribute__((unused)) = 1 / 0;
+}
+
+#pragma GCC diagnostic pop
+
+static void crash_work_handler(struct k_work *work)
+{
+	switch (last_command) {
+	case CRASH_GEN_RPC_ASSERT:
+		do_assert();
+		break;
+	case CRASH_GEN_RPC_HARD_FAULT:
+		do_hardfault();
+		break;
+	case CRASH_GEN_RPC_STACK_OVERFLOW:
+		do_stack_overflow();
+		break;
+	}
+}
+
+static void generate_assert(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
+			    void *handler_data)
+{
+	uint32_t timeout_ms = nrf_rpc_decode_uint(ctx);
+
+	nrf_rpc_cbor_decoding_done(group, ctx);
+	nrf_rpc_rsp_send_void(group);
+
+	last_command = CRASH_GEN_RPC_ASSERT;
+	k_work_reschedule(&crash_work, K_MSEC(timeout_ms));
+}
+
+NRF_RPC_CBOR_CMD_DECODER(crash_gen_group, generate_assert, CRASH_GEN_RPC_ASSERT, generate_assert,
+			 NULL);
+
+static void generate_hard_fault(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
+			    void *handler_data)
+{
+	uint32_t timeout_ms = nrf_rpc_decode_uint(ctx);
+
+	nrf_rpc_cbor_decoding_done(group, ctx);
+	nrf_rpc_rsp_send_void(group);
+
+	last_command = CRASH_GEN_RPC_HARD_FAULT;
+	k_work_reschedule(&crash_work, K_MSEC(timeout_ms));
+}
+
+NRF_RPC_CBOR_CMD_DECODER(crash_gen_group, generate_hard_fault, CRASH_GEN_RPC_HARD_FAULT,
+			 generate_hard_fault, NULL);
+
+static void generate_stack_overflow(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
+			    void *handler_data)
+{
+	uint32_t timeout_ms = nrf_rpc_decode_uint(ctx);
+
+	nrf_rpc_cbor_decoding_done(group, ctx);
+	nrf_rpc_rsp_send_void(group);
+
+	last_command = CRASH_GEN_RPC_STACK_OVERFLOW;
+	k_work_reschedule(&crash_work, K_MSEC(timeout_ms));
+}
+
+NRF_RPC_CBOR_CMD_DECODER(crash_gen_group, generate_stack_overflow, CRASH_GEN_RPC_STACK_OVERFLOW,
+			 generate_stack_overflow, NULL);


### PR DESCRIPTION
This commit adds RPC interface to generate different crash types remotely.