### PR TITLE
linker: replace ALIGN_WITH_INPUT with SECTION_DATA_PROLOGUE macro

### DIFF
--- a/applications/nrf_desktop/nrf_desktop.ld
+++ b/applications/nrf_desktop/nrf_desktop.ld
@@ -1,4 +1,4 @@
-config_channel_modules : ALIGN_WITH_INPUT
+SECTION_DATA_PROLOGUE(config_channel_modules,,)
 {
 	KEEP(*(SORT(config_channel_modules)));
 } GROUP_LINK_IN(ROMABLE_REGION)

--- a/subsys/app_event_manager/aem.ld
+++ b/subsys/app_event_manager/aem.ld
@@ -5,7 +5,7 @@ ITERABLE_SECTION_ROM(event_submit_hook, 4)
 ITERABLE_SECTION_ROM(event_preprocess_hook, 4)
 ITERABLE_SECTION_ROM(event_postprocess_hook, 4)
 
-event_subscribers_all : ALIGN_WITH_INPUT
+SECTION_DATA_PROLOGUE(event_subscribers_all,,)
 {
 	__start_event_subscribers_all = .;
 	KEEP(*(SORT(event_subscribers_*)));

--- a/subsys/event_manager_proxy/em_proxy.ld
+++ b/subsys/event_manager_proxy/em_proxy.ld
@@ -8,7 +8,7 @@ event_manager_proxy_event_type_pointer_size_section 0 (DSECT) :
 	KEEP(*(event_manager_proxy_event_type_pointer_size));
 }
 
-event_manager_proxy_array : ALIGN_WITH_INPUT
+SECTION_DATA_PROLOGUE(event_manager_proxy_array,,)
 {
 	_event_manager_proxy_array_list_start = .;
 	event_manager_proxy_array = .;


### PR DESCRIPTION
ALIGN_WITH_INPUT is not supported with LLD and therefore linker scripts containing this flag will fail.

For LLD, then linking with -omagic (-N) achives the same as what is needed for XIP systems using ALIGN_WITH_INPUT, therefore adopt ld snippets to use the Zephyr provided SECTION_DATA_PROLOGUE() macro.