### PR TITLE
doc: Remove [EXPERIMENTAL] tag from Channel Sounding Kconfigs

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -708,7 +708,7 @@ The following table indicates the software maturity levels of the support for ea
         - --
         - --
         - --
-        - Experimental
+        - Supported
         - --
         - --
         - --

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -547,13 +547,12 @@ config BT_CTLR_SDC_CIS_SUBEVENT_LENGTH_US
 	  is chosen by the controller.
 
 config BT_CTLR_CHANNEL_SOUNDING
-	bool "Channel Sounding support [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Channel Sounding support"
 	help
 	  Enable Channel Sounding support.
 
 config BT_CTLR_SDC_CS_COUNT
-	int "Number of concurrent connections supporting CS procedure [EXPERIMENTAL]"
+	int "Number of concurrent connections supporting CS procedures"
 	default 1
 	range 1 BT_MAX_CONN
 	depends on BT_CTLR_CHANNEL_SOUNDING
@@ -562,7 +561,7 @@ config BT_CTLR_SDC_CS_COUNT
 	  Needs to be equal to or less than BT_MAX_CONN.
 
 config BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS
-	int "Max number of Channel Sounding antenna paths supported by the controller [EXPERIMENTAL]"
+	int "Max number of Channel Sounding antenna paths supported by the controller"
 	default 1
 	range 1 4
 	depends on BT_CTLR_CHANNEL_SOUNDING
@@ -574,7 +573,7 @@ config BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS
 	  Reducing the value of this kconfig will reduce the RAM usage per CS context.
 
 config BT_CTLR_SDC_CS_NUM_ANTENNAS
-	int "Number of antennas used in Channel Sounding procedure supported by the controller [EXPERIMENTAL]"
+	int "Number of antennas used in Channel Sounding procedure supported by the controller"
 	default 1
 	range 1 BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS
 	depends on BT_CTLR_CHANNEL_SOUNDING
@@ -594,9 +593,8 @@ config BT_CTLR_SDC_CS_MULTIPLE_ANTENNA_SUPPORT
 	  Internal helper config. Not intended for use.
 
 config BT_CTLR_SDC_CS_STEP_MODE3
-	bool "Enable optional step mode-3 support [EXPERIMENTAL]"
+	bool "Enable optional step mode-3 support"
 	depends on BT_CTLR_CHANNEL_SOUNDING
-	select EXPERIMENTAL
 	help
 	  Enable optional step mode-3 support. Channel sounding will not automatically start using step mode-3 if this
 	  config is set. To use step mode-3, modify the configuration which is created using the LE CS Create config command.

--- a/subsys/bluetooth/services/ras/Kconfig.ras
+++ b/subsys/bluetooth/services/ras/Kconfig.ras
@@ -5,10 +5,9 @@
 #
 
 menuconfig BT_RAS
-	bool "Ranging Service [EXPERIMENTAL]"
+	bool "Ranging Service"
 	depends on BT_CHANNEL_SOUNDING
 	select BT_NRF_SERVICES
-	select EXPERIMENTAL
 	help
 	  Bluetooth GATT Ranging Service modules - RREQ and RRSP.
 

--- a/subsys/bluetooth/services/ras/rreq/Kconfig.ras_rreq
+++ b/subsys/bluetooth/services/ras/rreq/Kconfig.ras_rreq
@@ -5,8 +5,7 @@
 #
 
 menuconfig BT_RAS_RREQ
-	bool "GATT Ranging Requester Client [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "GATT Ranging Requester Client"
 	select BT_GATT_DM
 	select BT_GATT_CLIENT
 

--- a/subsys/bluetooth/services/ras/rrsp/Kconfig.ras_rrsp
+++ b/subsys/bluetooth/services/ras/rrsp/Kconfig.ras_rrsp
@@ -5,8 +5,7 @@
 #
 
 menuconfig BT_RAS_RRSP
-	bool "GATT Ranging Responder Server [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "GATT Ranging Responder Server"
 
 if BT_RAS_RRSP
 


### PR DESCRIPTION
We dont want to make Channel Sounding an adopted feature