### PR TITLE
tests: drivers: audio: pdm_loopback: add tests for audio clocks

### DIFF
--- a/tests/drivers/audio/pdm_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_audiopll_44k1.overlay
+++ b/tests/drivers/audio/pdm_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_audiopll_44k1.overlay
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	gpio_test {
+		compatible = "gpio-leds";
+		pulse_counter: pulse_counter {
+			gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinctrl {
+	pdm0_default_alt: pdm0_default_alt {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 1, 2)>,
+				<NRF_PSEL(PDM_DIN, 1, 4)>;
+		};
+	};
+};
+
+pdm_dev: &pdm0 {
+	status = "okay";
+	pinctrl-0 = <&pdm0_default_alt>;
+	pinctrl-names = "default";
+	clock-source = "ACLK";
+	memory-regions = <&cpuapp_dma_region>;
+};
+
+&audiopll {
+	status = "okay";
+	frequency = <NRFS_AUDIOPLL_FREQ_AUDIO_44K1>;
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpiote130 {
+	owned-channels = <0>;
+	status = "okay";
+};
+
+&timer130 {
+	status = "okay";
+};
+
+&dppic130 {
+	owned-channels = <0>;
+	source-channels = <0>;
+	status = "okay";
+};
+
+&dppic133 {
+	owned-channels = <0>;
+	sink-channels = <0>;
+	status = "okay";
+};

--- a/tests/drivers/audio/pdm_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_audiopll_48k.overlay
+++ b/tests/drivers/audio/pdm_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_audiopll_48k.overlay
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	gpio_test {
+		compatible = "gpio-leds";
+		pulse_counter: pulse_counter {
+			gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinctrl {
+	pdm0_default_alt: pdm0_default_alt {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 1, 2)>,
+				<NRF_PSEL(PDM_DIN, 1, 4)>;
+		};
+	};
+};
+
+pdm_dev: &pdm0 {
+	status = "okay";
+	pinctrl-0 = <&pdm0_default_alt>;
+	pinctrl-names = "default";
+	clock-source = "ACLK";
+	memory-regions = <&cpuapp_dma_region>;
+};
+
+&audiopll {
+	status = "okay";
+	frequency = <NRFS_AUDIOPLL_FREQ_AUDIO_48K>;
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpiote130 {
+	owned-channels = <0>;
+	status = "okay";
+};
+
+&timer130 {
+	status = "okay";
+};
+
+&dppic130 {
+	owned-channels = <0>;
+	source-channels = <0>;
+	status = "okay";
+};
+
+&dppic133 {
+	owned-channels = <0>;
+	sink-channels = <0>;
+	status = "okay";
+};

--- a/tests/drivers/audio/pdm_loopback/boards/nrf54l20pdk_nrf54l20_cpuapp_aclk.overlay
+++ b/tests/drivers/audio/pdm_loopback/boards/nrf54l20pdk_nrf54l20_cpuapp_aclk.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	gpio_test {
+		compatible = "gpio-leds";
+		pulse_counter: pulse_counter {
+			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinctrl {
+	pdm20_default_alt: pdm20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 1, 10)>,
+				<NRF_PSEL(PDM_DIN, 1, 12)>;
+		};
+	};
+};
+
+pdm_dev: &pdm20 {
+	status = "okay";
+	pinctrl-0 = <&pdm20_default_alt>;
+	pinctrl-names = "default";
+	clock-source = "ACLK";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&timer00 {
+	status = "okay";
+};

--- a/tests/drivers/audio/pdm_loopback/testcase.yaml
+++ b/tests/drivers/audio/pdm_loopback/testcase.yaml
@@ -74,6 +74,28 @@ tests:
       - CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1600000
       - CONFIG_TEST_PDM_SAMPLING_TIME=10
       - CONFIG_TEST_USE_DMM=y
+  drivers.audio.pdm_loopback.nrf54h20.audiopll.44k1hz:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - CONFIG_NRFX_TIMER130=y
+      - CONFIG_TEST_PDM_SAMPLING_RATE=44100
+      - CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1411200
+      - CONFIG_TEST_PDM_SAMPLING_TIME=10
+      - CONFIG_CLOCK_CONTROL=y
+      - CONFIG_TEST_USE_DMM=y
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_audiopll_44k1.overlay"
+  drivers.audio.pdm_loopback.nrf54h20.audiopll.48khz:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - CONFIG_NRFX_TIMER130=y
+      - CONFIG_TEST_PDM_SAMPLING_RATE=48000
+      - CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1536000
+      - CONFIG_TEST_PDM_SAMPLING_TIME=10
+      - CONFIG_CLOCK_CONTROL=y
+      - CONFIG_TEST_USE_DMM=y
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_audiopll_48k.overlay"
   drivers.audio.pdm_loopback.nrf54h20.no_dmm:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/drivers/audio/pdm_loopback/testcase.yaml
+++ b/tests/drivers/audio/pdm_loopback/testcase.yaml
@@ -35,6 +35,29 @@ tests:
       - CONFIG_NRFX_TIMER00=y
       - CONFIG_TEST_PDM_SAMPLING_RATE=32000
       - CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1600000
+  drivers.audio.pdm_loopback.nrf54l20.aclk.1000khz:
+    platform_allow:
+      - nrf54l20pdk/nrf54l20/cpuapp
+    extra_args:
+      - CONFIG_NRFX_TIMER00=y
+      - CONFIG_TEST_PDM_SAMPLING_RATE=20000
+      - DTC_OVERLAY_FILE="boards/nrf54l20pdk_nrf54l20_cpuapp_aclk.overlay"
+  drivers.audio.pdm_loopback.nrf54l20.aclk.1280khz:
+    platform_allow:
+      - nrf54l20pdk/nrf54l20/cpuapp
+    extra_args:
+      - CONFIG_NRFX_TIMER00=y
+      - CONFIG_TEST_PDM_SAMPLING_RATE=16000
+      - CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1280000
+      - DTC_OVERLAY_FILE="boards/nrf54l20pdk_nrf54l20_cpuapp_aclk.overlay"
+  drivers.audio.pdm_loopback.nrf54l20.aclk.1600khz:
+    platform_allow:
+      - nrf54l20pdk/nrf54l20/cpuapp
+    extra_args:
+      - CONFIG_NRFX_TIMER00=y
+      - CONFIG_TEST_PDM_SAMPLING_RATE=32000
+      - CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1600000
+      - DTC_OVERLAY_FILE="boards/nrf54l20pdk_nrf54l20_cpuapp_aclk.overlay"
   drivers.audio.pdm_loopback.nrf54h20.1000khz:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Added test cases for ACLK on nRF54L20 and AudioPLL on nRF54H20.