### PR TITLE
nrf_security: drivers: cracen: fix compilation warnings

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ctr_drbg.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ctr_drbg.c
@@ -90,6 +90,7 @@ static psa_status_t ctr_drbg_update(uint8_t *data)
 	char temp[CRACEN_PRNG_ENTROPY_SIZE + CRACEN_PRNG_NONCE_SIZE] __aligned(
 		CONFIG_DCACHE_LINE_SIZE);
 	size_t temp_length = 0;
+	_Static_assert(sizeof(temp) % SX_BLKCIPHER_AES_BLK_SZ == 0, "");
 
 	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
 
@@ -99,7 +100,6 @@ static psa_status_t ctr_drbg_update(uint8_t *data)
 
 	while (temp_length < sizeof(temp)) {
 		si_be_add(prng.V, SX_BLKCIPHER_AES_BLK_SZ, 1);
-		_Static_assert((sizeof(temp) % SX_BLKCIPHER_AES_BLK_SZ) == 0);
 
 		status = sx_blkcipher_ecb_simple(prng.key, sizeof(prng.key), prng.V, sizeof(prng.V),
 						 temp + temp_length, SX_BLKCIPHER_AES_BLK_SZ);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
@@ -189,36 +189,6 @@ static void write_tag_and_length(struct sx_buf *buf, uint8_t tag)
 	memcpy(outbuf, ((uint8_t *)&length) + sizeof(length) - len_bytes, len_bytes);
 }
 
-static size_t calc_key_bits_from_pub_key_buffer_size(psa_ecc_family_t curve, size_t pub_key_size)
-{
-	switch (curve) {
-	case PSA_ECC_FAMILY_BRAINPOOL_P_R1:
-	case PSA_ECC_FAMILY_SECP_R1: {
-		size_t priv_key_size = (pub_key_size - 1) / 2;
-
-		if (priv_key_size == PSA_BITS_TO_BYTES(521)) {
-			/* The secpr1p521 is a special case since the number of
-			 * bits are not divisible by 8
-			 */
-			return 521;
-		}
-		return PSA_BYTES_TO_BITS(priv_key_size);
-	}
-	case PSA_ECC_FAMILY_MONTGOMERY:
-		if (pub_key_size == PSA_BITS_TO_BYTES(255)) {
-			return 255;
-		}
-		return PSA_BYTES_TO_BITS(pub_key_size);
-	case PSA_ECC_FAMILY_TWISTED_EDWARDS:
-		if (pub_key_size == PSA_BITS_TO_BYTES(255)) {
-			return 255;
-		}
-		return 0;
-	default:
-		return 0;
-	}
-}
-
 static psa_status_t import_ecc_private_key(const psa_key_attributes_t *attributes,
 					   const uint8_t *data, size_t data_length,
 					   uint8_t *key_buffer, size_t key_buffer_size,

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -98,6 +98,8 @@ static const psa_key_usage_t metadata_usage_flags_mapping[] = {
 	/* EXPORT */ PSA_KEY_USAGE_EXPORT,
 	/* COPY */ PSA_KEY_USAGE_COPY};
 
+#ifdef PSA_NEED_CRACEN_KMU_ENCRYPTED_KEYS
+
 /**
  * @brief Retrieve the encryption key used to encrypt the key for a KMU slot.
  *
@@ -207,6 +209,8 @@ static psa_status_t cracen_kmu_decrypt(kmu_metadata *metadata, size_t number_of_
 				   sizeof(kmu_push_area), &outlen);
 }
 
+#endif /* PSA_NEED_CRACEN_KMU_ENCRYPTED_KEYS */
+
 /* Used internally in sxsymcrypt so we use sx return codes here. */
 int cracen_kmu_prepare_key(const uint8_t *user_data)
 {
@@ -266,7 +270,7 @@ static bool is_secondary_slot(kmu_metadata *metadata)
 {
 	const uint32_t value = SECONDARY_SLOT_METADATA_VALUE;
 
-	_Static_assert(sizeof(value) == sizeof(*metadata));
+	_Static_assert(sizeof(value) == sizeof(*metadata), "");
 	return memcmp(&value, metadata, sizeof(value)) == 0;
 }
 


### PR DESCRIPTION
Fix compilation warnings when building with the LLVM toolchain:
- add messages to uses of `_Static_assert()`
- remove unused `calc_key_bits_from_pub_key_buffer_size()`
- `#ifdef` functions only used when `PSA_NEED_CRACEN_KMU_ENCRYPTED_KEYS`