### PR TITLE
samples: zephyr: boards: nordic: system_off: enable for 54lm20 and 54…

### DIFF
--- a/samples/zephyr/boards/nordic/system_off/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/samples/zephyr/boards/nordic/system_off/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,25 @@
+/ {
+	cpuapp_sram@2007ec00 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x2007ec00 DT_SIZE_K(4)>;
+		zephyr,memory-region = "RetainedMem";
+		status = "okay";
+
+		retainedmem0: retainedmem {
+			compatible = "zephyr,retained-ram";
+			status = "okay";
+		};
+	};
+
+	aliases {
+		retainedmemdevice = &retainedmem0;
+	};
+};
+
+&cpuapp_sram {
+	/* Shrink SRAM size to avoid overlap with retained memory region:
+	 * 511 - 4 = 507KB = 0x7ec00
+	 */
+	reg = <0x20000000 DT_SIZE_K(507)>;
+	ranges = <0x0 0x20000000 0x7ec00>;
+};

--- a/samples/zephyr/boards/nordic/system_off/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
+++ b/samples/zephyr/boards/nordic/system_off/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,25 @@
+/ {
+	cpuapp_sram@20023000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <20023000 DT_SIZE_K(4)>;
+		zephyr,memory-region = "RetainedMem";
+		status = "okay";
+
+		retainedmem0: retainedmem {
+			compatible = "zephyr,retained-ram";
+			status = "okay";
+		};
+	};
+
+	aliases {
+		retainedmemdevice = &retainedmem0;
+	};
+};
+
+&cpuapp_sram {
+	/* Shrink SRAM size to avoid overlap with retained memory region:
+	 * 144 - 4 = 140 = 0x23000
+	 */
+	reg = <0x20000000 DT_SIZE_K(140)>;
+	ranges = <0x0 0x20000000 0x23000>;
+};

--- a/samples/zephyr/boards/nordic/system_off/sample.yaml
+++ b/samples/zephyr/boards/nordic/system_off/sample.yaml
@@ -9,8 +9,12 @@ tests:
   nrf.extended.sample.boards.nrf.system_off:
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -22,8 +26,12 @@ tests:
   nrf.extended.sample.boards.nrf.system_off.retained_mem:
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     extra_configs:
       - CONFIG_APP_USE_RETAINED_MEM=y
     harness: console
@@ -40,6 +48,8 @@ tests:
   nrf.extended.sample.boards.nrf.system_off.grtc_wakeup:
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     extra_configs:
       - CONFIG_GRTC_WAKEUP_ENABLE=y
       - CONFIG_GPIO_WAKEUP_ENABLE=n
@@ -61,6 +71,8 @@ tests:
   nrf.extended.sample.boards.nrf.system_off.retained_mem.grtc_wakeup:
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     extra_configs:
       - CONFIG_APP_USE_RETAINED_MEM=y
       - CONFIG_GRTC_WAKEUP_ENABLE=y


### PR DESCRIPTION
…lv10

nrf54lv10a and nrf54lm20a.