### PR TITLE
mgmt: suit: Fix starting new candidate upload before ending previous

### DIFF
--- a/subsys/mgmt/suitfu/src/suitfu_mgmt_priv.h
+++ b/subsys/mgmt/suitfu/src/suitfu_mgmt_priv.h
@@ -121,6 +121,11 @@ int suitfu_mgmt_suit_envelope_upload(struct smp_streamer *ctx);
 void suitfu_mgmt_suit_image_fetch_init(void);
 
 /**
+ * @brief	Stops Image fetching if it is in progress
+ */
+void suitfu_mgmt_suit_image_fetch_stop(void);
+
+/**
  * @brief	Process Get Missing Image State Request.
  *
  * @note	SMP Client sends that request periodically,

--- a/subsys/mgmt/suitfu/src/suitfu_mgmt_suit_cand_env_upload.c
+++ b/subsys/mgmt/suitfu/src/suitfu_mgmt_suit_cand_env_upload.c
@@ -94,7 +94,7 @@ int suitfu_mgmt_suit_envelope_upload(struct smp_streamer *ctx)
 		}
 
 		/* Erases dfu_partition and dfu_cache_partition_0, leaves
-		 * dfu_partition_1..dfu_partition_n intact. suitfu_mgmt_claenup() may be used
+		 * dfu_partition_1..dfu_partition_n intact. suitfu_mgmt_cleanup() may be used
 		 * instead.
 		 */
 		int rc = suitfu_mgmt_erase(&device_info, req.size);


### PR DESCRIPTION
This commit fixes the issue with starting a new envelope transfer while the old one has not yet finished its cleanup.

This is done interrupting any image fetching which was in progress and waiting until the cleanup has finished.