### PR TITLE
tests: Align with reverted memory ranges

### DIFF
--- a/tests/benchmarks/multicore/idle/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/benchmarks/multicore/idle/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpurad_ram0x_region {
+	reg = <0x2f010000 0x1000>;
+	ranges = <0x0 0x2f010000 0x1000>;
+};
+
+&cpuapp_ram0x_region {
+	reg = <0x2f011000 0x41000>;
+	ranges = <0x0 0x2f011000 0x41000>;
+};
+
+&cpuapp_data {
+	reg = <0x1000 0x40000>;
+};

--- a/tests/benchmarks/multicore/idle/boards/nrf54h20dk_nrf54h20_cpuapp_ram_high_usage.overlay
+++ b/tests/benchmarks/multicore/idle/boards/nrf54h20dk_nrf54h20_cpuapp_ram_high_usage.overlay
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+&cpurad_ram0x_region {
+	reg = <0x2f010000 0x1000>;
+	ranges = <0x0 0x2f010000 0x1000>;
+};
+
 &cpuapp_ram0x_region {
 	reg = <0x2f011000 0x91000>;
 	ranges = <0x0 0x2f011000 0x91000>;

--- a/tests/benchmarks/multicore/idle/boards/nrf54h20dk_nrf54h20_cpuapp_ram_low_usage.overlay
+++ b/tests/benchmarks/multicore/idle/boards/nrf54h20dk_nrf54h20_cpuapp_ram_low_usage.overlay
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+&cpurad_ram0x_region {
+	reg = <0x2f010000 0x1000>;
+	ranges = <0x0 0x2f010000 0x1000>;
+};
+
 &cpuapp_ram0x_region {
 	reg = <0x2f011000 0x21000>;
 	ranges = <0x0 0x2f011000 0x21000>;

--- a/tests/benchmarks/multicore/idle/remote/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/benchmarks/multicore/idle/remote/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpurad_ram0x_region {
+	reg = <0x2f010000 0x1000>;
+	ranges = <0x0 0x2f010000 0x1000>;
+};
+
+&cpuapp_ram0x_region {
+	reg = <0x2f011000 0x41000>;
+	ranges = <0x0 0x2f011000 0x41000>;
+};

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a4c6476531c1c3054d7ff44b905105aadd47411e
+      revision: a4c30ef0bda4bfe77e61f5db4b7f53df8f414301
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Align overlays inside tests with the reverted RAM memory map.

Ref: NCSDK-32650