### PR TITLE
samples: bluetooth: Enable PSA RNG on 54H in the LLPM sample

### DIFF
--- a/samples/bluetooth/llpm/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/bluetooth/llpm/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -10,3 +10,12 @@ CONFIG_BT_LL_SOFTDEVICE=n
 
 # Required to allow use of 1ms connection interval in conn_param argument of bt_conn_le_creat
 CONFIG_BT_CONN_PARAM_ANY=y
+
+# Enable PSA RNG
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+CONFIG_MBEDTLS_PSA_CRYPTO_C=y
+CONFIG_NRF_SECURITY=y
+# More receive buffers are needed, possibly due to broken flow control in the HCI over IPC implementation.
+CONFIG_BT_BUF_EVT_RX_COUNT=22

--- a/samples/bluetooth/llpm/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/bluetooth/llpm/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,13 @@
+// Enable PSA RNG
+/ {
+	chosen {
+		zephyr,entropy = &psa_rng;
+	};
+
+	psa_rng: psa-rng {
+		compatible = "zephyr,psa-crypto-rng";
+		status = "okay";
+	};
+
+	/delete-node/ prng;
+};

--- a/samples/bluetooth/llpm/sysbuild/ipc_radio/boards/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/samples/bluetooth/llpm/sysbuild/ipc_radio/boards/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable PSA RNG
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+CONFIG_PSA_SSF_CRYPTO_CLIENT=y
+CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED=y
+CONFIG_MBEDTLS_PSA_CRYPTO_C=y
+CONFIG_NRF_SECURITY=y

--- a/samples/bluetooth/llpm/sysbuild/ipc_radio/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/bluetooth/llpm/sysbuild/ipc_radio/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,13 @@
+// Enable PSA RNG
+/ {
+	chosen {
+		zephyr,entropy = &psa_rng;
+	};
+
+	psa_rng: psa-rng {
+		compatible = "zephyr,psa-crypto-rng";
+		status = "okay";
+	};
+
+	/delete-node/ prng;
+};


### PR DESCRIPTION
The PSA RNG is a cryptographically secure random number generator. It will be enabled by default, eventually.  For now, enable it manually.

This sample requires an increase in the number of buffers available for incoming HCI events from the controller, a workaround for a possible flow control issue in the HCI over IPC implementation.