### PR TITLE
partition_manager: Remove hardware model v1 workaround

### DIFF
--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -32,25 +32,6 @@ config SRAM_BASE_ADDRESS
 	hex
 	depends on !PARTITION_MANAGER_ENABLED
 
-# Workaround for the hardware model v1 which is not aware of the new
-# TrustZone definitions. Since nRF54L15 is not supported with the
-# hardware model v1, the values are set to the SPU values
-# since both nRF53 and nRF9X series are using the SPU for configuring
-# secure/non-secure regions.
-# TODO: Remove this when support for hardware model v1 is removed.
-# Tracked by NCSDK-28541
-if "$(HWM_SCHEME)" = "v1"
-config NRF_TRUSTZONE_FLASH_REGION_SIZE
-	hex
-	default 0x0 if !BUILD_WITH_TFM
-	default NRF_SPU_FLASH_REGION_SIZE if BUILD_WITH_TFM
-
-config NRF_TRUSTZONE_RAM_REGION_SIZE
-	hex
-	default 0x0 if !BUILD_WITH_TFM
-	default NRF_SPU_RAM_REGION_SIZE if BUILD_WITH_TFM
-endif
-
 menu "Zephyr subsystem configurations"
 
 DT_CHOSEN_Z_IPC_SHM := zephyr,ipc_shm


### PR DESCRIPTION
Remove the workaround done for the TrustZone region size since it is no longer needed.

Ref: NCSDK-28541