### PR TITLE
snippet: Add a way to migrate between releases

### DIFF
--- a/snippets/migration-nrf54h20-290-300/README.rst
+++ b/snippets/migration-nrf54h20-290-300/README.rst
@@ -1,0 +1,27 @@
+.. _migration-nrf54h20-290-300:
+
+Snippet allowing migration of applications built for nRF54H20 from SDK v2.9.0-H20-1 to v3.0.0 using DFU
+#######################################################################################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+Overview
+********
+
+The default memory map has changed between SDK v2.9.0-H20-1 and v3.0.0.
+Apart from that, a communication between radio and secure core has ben enablet to provide a true entropy source for network stacks.
+This snippet allows you to build a DFU package for your application built and deployed using SDK v2.9.0-H20-1 release.
+
+.. warning::
+   Do not apply this snippet if your application defines its own RAM memory map and/or already enabled the communication in the previous version of the SDK.
+   In such cases, a proper investigation between output device tree files must be performed.
+   The device is upgradeable only if the UCIR binaries between the two builds matches.
+
+Supported SoCs
+**************
+
+Currently, the following SoCs from Nordic Semiconductor are supported for use with the snippet:
+
+* :ref:`zephyr:nrf54h20dk_nrf54h20`

--- a/snippets/migration-nrf54h20-290-300/boards/nrf54h20dk_nrf54h20-mem-map-move.dtsi
+++ b/snippets/migration-nrf54h20-290-300/boards/nrf54h20dk_nrf54h20-mem-map-move.dtsi
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuapp_ram0x_region {
+	reg = <0x2f010000 DT_SIZE_K(260)>;
+	ranges = <0x0 0x2f010000 0x41000>;
+};
+
+&cpurad_ram0x_region {
+	reg = <0x2f051000 DT_SIZE_K(4)>;
+	ranges = <0x0 0x2f051000 0x1000>;
+};

--- a/snippets/migration-nrf54h20-290-300/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/snippets/migration-nrf54h20-290-300/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Included because partitions must be moved on both cores App and Rad cores to avoid memory
+ * regions overlapping.
+ */
+#include "nrf54h20dk_nrf54h20-mem-map-move.dtsi"

--- a/snippets/migration-nrf54h20-290-300/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/snippets/migration-nrf54h20-290-300/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Included because partitions must be moved on both cores App and Rad cores to avoid memory
+ * regions overlapping.
+ */
+#include "nrf54h20dk_nrf54h20-mem-map-move.dtsi"
+
+/* Switch back to the pseudo-random entropy source. */
+/ {
+	chosen {
+		zephyr,entropy = &prng;
+	};
+
+	/delete-node/ psa-rng;
+
+	prng: prng {
+		compatible = "nordic,entropy-prng";
+		status = "okay";
+	};
+
+};
+
+/* Disable IPC between cpusec <-> cpurad. */
+&cpusec_cpurad_ipc {
+	status = "disabled";
+};
+
+&cpurad_ram0x_region {
+	status = "disabled";
+};
+
+&cpusec_bellboard {
+	status = "disabled";
+};

--- a/snippets/migration-nrf54h20-290-300/snippet.yml
+++ b/snippets/migration-nrf54h20-290-300/snippet.yml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+name: migration-nrf54h20-290-300
+
+boards:
+  nrf54h20dk/nrf54h20/cpurad:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf54h20dk_nrf54h20_cpurad.overlay
+  nrf54h20dk/nrf54h20/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf54h20dk_nrf54h20_cpuapp.overlay


### PR DESCRIPTION
Add a snippet that aligns memory maps between SDK v2.9.0-H20-1 and v3.0.0.

Ref: NCSDK-32650