### PR TITLE
applications: nrf5340_audio: Use static address when privacy=n

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/bt_mgmt_adv.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/bt_mgmt_adv.c
@@ -437,6 +437,14 @@ int bt_mgmt_adv_start(uint8_t ext_adv_index, const struct bt_data *adv, size_t a
 	per_adv_local[ext_adv_index] = per_adv;
 	per_adv_local_size[ext_adv_index] = per_adv_size;
 
+	/* Only use fixed address if no privacy and it is the first ext adv set */
+	if (!IS_ENABLED(CONFIG_BT_PRIVACY) && ext_adv_index == 0) {
+		ext_adv_param.options |= BT_LE_ADV_OPT_USE_IDENTITY;
+	} else {
+		/* If privacy is enabled, use RPA */
+		ext_adv_param.options &= ~BT_LE_ADV_OPT_USE_IDENTITY;
+	}
+
 	if (connectable) {
 		ret = bt_le_ext_adv_create(LE_AUDIO_EXTENDED_ADV_CONN_NAME, &adv_cb,
 					   &ext_adv[ext_adv_index]);


### PR DESCRIPTION
- Add BT_LE_ADV_OPT_USE_IDENTITY when BT_PRIVACY=n
- This ensures a static address for debugging/testing purposes
- Removed old method of reading out FICR to set static addr manually
- OCT-3152