### PR TITLE
[Backport v3.0-branch] sdfw_services: psa_crypto: Fix cddl

### DIFF
--- a/subsys/sdfw_services/services/psa_crypto/psa_crypto_service.cddl
+++ b/subsys/sdfw_services/services/psa_crypto/psa_crypto_service.cddl
@@ -674,7 +674,7 @@ psa_crypto_req = [
         psa_pake_output_req /
         psa_pake_input_req /
         psa_pake_get_shared_key_req /
-        psa_pake_abort_req /
+        psa_pake_abort_req
     ),
 ]
 


### PR DESCRIPTION
Backport 71ba02927aca3417da697bb1315cc1c3147d4d3a from #21375.