### PR TITLE
[Backport v3.0-branch] samples: wifi: radio_test: Add command to read battery voltage

### DIFF
--- a/samples/wifi/radio_test/multi_domain/radio_test_subcommands.rst
+++ b/samples/wifi/radio_test/multi_domain/radio_test_subcommands.rst
@@ -271,6 +271,11 @@ Wi-Fi radio test subcommands
      - 0
      - Configuration
      - Allows configuration of PTA for different Wi-Fi operating bands, antenna modes, and Short-Range protocols.
+   * - get_voltage
+     - | No arguments required
+     - N/A
+     - Action
+     - Get battery voltage.
 
 .. _wifi_radio_test_stats:
 

--- a/samples/wifi/radio_test/multi_domain/sample_description.rst
+++ b/samples/wifi/radio_test/multi_domain/sample_description.rst
@@ -593,6 +593,18 @@ Testing
 
          To calculate the TX power without issuing ``tx_power`` command, see :ref:`nrf70_wifi_tx_power_calculation`.
 
+         * To read battery voltage in volts, execute the following sequence of commands:
+
+           .. code-block:: console
+
+              wifi_radio_test get_voltage
+
+           The sample shows the following output:
+
+           .. code-block:: console
+
+               wifi_nrf: The battery voltage is = 3.55000 Volt
+
       .. group-tab:: FICR/OTP programming
 
          * Use the following reference command interface to read or write the OTP params:

--- a/samples/wifi/radio_test/multi_domain/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/multi_domain/src/nrf_wifi_radio_test_shell.c
@@ -1708,7 +1708,38 @@ static int nrf_wifi_radio_get_temperature(const struct shell *shell,
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		shell_fprintf(shell,
 			      SHELL_ERROR,
-			      "DPD programming failed\n");
+			      "Temperature read failed\n");
+		goto out;
+	}
+
+	ret = 0;
+out:
+	ctx->rf_test_run = false;
+	ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
+
+	return ret;
+}
+
+static int nrf_wifi_radio_get_bat_volt(const struct shell *shell,
+					  size_t argc,
+					  const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	int ret = -ENOEXEC;
+
+	if (!check_test_in_prog(shell)) {
+		goto out;
+	}
+
+	ctx->rf_test_run = true;
+	ctx->rf_test = NRF_WIFI_RF_TEST_GET_BAT_VOLT;
+
+	status = nrf_wifi_rt_fmac_rf_get_bat_volt(ctx->rpu_ctx);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "Voltage read failed\n");
 		goto out;
 	}
 
@@ -2512,6 +2543,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      NULL,
 		      "No arguments required",
 		      nrf_wifi_radio_get_temperature,
+		      1,
+		      0),
+	SHELL_CMD_ARG(get_voltage,
+		      NULL,
+		      "No arguments required",
+		      nrf_wifi_radio_get_bat_volt,
 		      1,
 		      0),
 	SHELL_CMD_ARG(get_rf_rssi,


### PR DESCRIPTION
Backport 773bdf7a5a55ca9a56c93125fbd8cd7abaf7d1e0~2..773bdf7a5a55ca9a56c93125fbd8cd7abaf7d1e0 from #20876.