### PR TITLE
Nrfx 7309 run tests on nrf54lm20apdk pt.2

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -927,6 +927,7 @@
 /tests/subsys/suit/                       @nrfconnect/ncs-charon
 /tests/tfm/                               @nrfconnect/ncs-aegir @stephen-nordic @magnev
 /tests/unity/                             @nordic-krch
+/tests/zephyr/boards/nrf/                 @nrfconnect/ncs-low-level-test
 /tests/zephyr/drivers/adc/                @nrfconnect/ncs-low-level-test
 /tests/zephyr/drivers/audio/              @nrfconnect/ncs-low-level-test
 /tests/zephyr/drivers/clock_control/      @nrfconnect/ncs-low-level-test
@@ -939,7 +940,6 @@
 /tests/zephyr/drivers/i2c/i2c_target_api/ @nrfconnect/ncs-low-level-test
 /tests/zephyr/drivers/i2s/                @nrfconnect/ncs-low-level-test
 /tests/zephyr/drivers/mspi/api/           @nrfconnect/ncs-low-level-test @nrfconnect/ncs-ll-ursus
-/tests/zephyr/boards/nrf/                 @nrfconnect/ncs-low-level-test
 /tests/zephyr/drivers/retained_mem/       @nrfconnect/ncs-low-level-test
 /tests/zephyr/drivers/sensor/             @nrfconnect/ncs-low-level-test
 /tests/zephyr/drivers/spi/                @nrfconnect/ncs-low-level-test

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -928,6 +928,7 @@
 /tests/tfm/                               @nrfconnect/ncs-aegir @stephen-nordic @magnev
 /tests/unity/                             @nordic-krch
 /tests/zephyr/drivers/adc/                @nrfconnect/ncs-low-level-test
+/tests/zephyr/drivers/audio/              @nrfconnect/ncs-low-level-test
 /tests/zephyr/drivers/clock_control/      @nrfconnect/ncs-low-level-test
 /tests/zephyr/drivers/comparator/         @nrfconnect/ncs-low-level-test
 /tests/zephyr/drivers/counter/            @nrfconnect/ncs-low-level-test

--- a/dts/common/nordic/nrf54lm20a.dtsi
+++ b/dts/common/nordic/nrf54lm20a.dtsi
@@ -65,6 +65,12 @@
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(128)>;
 		};
+
+		aclk: aclk {
+			compatible = "nordic,nrf-aclk";
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(24)>;
+		};
 	};
 
 	soc {

--- a/samples/zephyr/drivers/audio/dmic/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/samples/zephyr/drivers/audio/dmic/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&pinctrl {
+	pdm20_default_alt: pdm20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 1, 10)>,
+				<NRF_PSEL(PDM_DIN, 1, 11)>;
+		};
+	};
+};
+
+dmic_dev: &pdm20 {
+	status = "okay";
+	pinctrl-0 = <&pdm20_default_alt>;
+	pinctrl-names = "default";
+	clock-source = "PCLK32M";
+};

--- a/samples/zephyr/drivers/audio/dmic/sample.yaml
+++ b/samples/zephyr/drivers/audio/dmic/sample.yaml
@@ -2,8 +2,6 @@ sample:
   name: DMIC sample
 tests:
   nrf.extended.sample.drivers.audio.dmic:
-    depends_on:
-      - future_target
     tags:
       - dmic
       - ci_samples_zephyr_drivers_audio_dmic
@@ -15,3 +13,7 @@ tests:
       regex:
         - "DMIC sample"
         - "Exiting"
+    platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+    integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -1405,6 +1405,11 @@ ci_samples_zephyr_drivers_audio_dmic:
     - nrf/samples/zephyr/drivers/audio/dmic/
     - zephyr/samples/drivers/audio/dmic/
 
+ci_tests_zephyr_drivers_audio_dmic_api:
+  files:
+    - nrf/tests/zephyr/drivers/audio/dmic_api/
+    - zephyr/tests/drivers/audio/dmic_api/
+
 ci_tests_zephyr_drivers_i2c_i2c_bme688:
   files:
     - nrf/tests/zephyr/drivers/i2c/i2c_bme688

--- a/tests/drivers/audio/pdm_loopback/boards/nrf54l_aclk.overlay
+++ b/tests/drivers/audio/pdm_loopback/boards/nrf54l_aclk.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&pdm_dev {
+	clock-source = "ACLK";
+};

--- a/tests/drivers/audio/pdm_loopback/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/audio/pdm_loopback/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -26,7 +26,7 @@ pdm_dev: &pdm20 {
 	status = "okay";
 	pinctrl-0 = <&pdm20_default_alt>;
 	pinctrl-names = "default";
-	clock-source = "ACLK";
+	clock-source = "PCLK32M";
 };
 
 &gpio1 {

--- a/tests/drivers/audio/pdm_loopback/testcase.yaml
+++ b/tests/drivers/audio/pdm_loopback/testcase.yaml
@@ -12,10 +12,12 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     extra_args: CONFIG_NRFX_TIMER00=y
   drivers.audio.pdm_loopback.nrf54l20.1000khz:
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     extra_args:
       - CONFIG_NRFX_TIMER00=y
       - CONFIG_TEST_PDM_SAMPLING_RATE=20000
@@ -23,6 +25,7 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     extra_args:
       - CONFIG_NRFX_TIMER00=y
       - CONFIG_TEST_PDM_SAMPLING_RATE=16000
@@ -31,6 +34,7 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     extra_args:
       - CONFIG_NRFX_TIMER00=y
       - CONFIG_TEST_PDM_SAMPLING_RATE=32000
@@ -38,26 +42,29 @@ tests:
   drivers.audio.pdm_loopback.nrf54l20.aclk.1000khz:
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     extra_args:
       - CONFIG_NRFX_TIMER00=y
       - CONFIG_TEST_PDM_SAMPLING_RATE=20000
-      - DTC_OVERLAY_FILE="boards/nrf54l20pdk_nrf54l20_cpuapp_aclk.overlay"
+      - EXTRA_DTC_OVERLAY_FILE="boards/nrf54l_aclk.overlay"
   drivers.audio.pdm_loopback.nrf54l20.aclk.1280khz:
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     extra_args:
       - CONFIG_NRFX_TIMER00=y
       - CONFIG_TEST_PDM_SAMPLING_RATE=16000
       - CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1280000
-      - DTC_OVERLAY_FILE="boards/nrf54l20pdk_nrf54l20_cpuapp_aclk.overlay"
+      - EXTRA_DTC_OVERLAY_FILE="boards/nrf54l_aclk.overlay"
   drivers.audio.pdm_loopback.nrf54l20.aclk.1600khz:
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     extra_args:
       - CONFIG_NRFX_TIMER00=y
       - CONFIG_TEST_PDM_SAMPLING_RATE=32000
       - CONFIG_TEST_PDM_EXPECTED_FREQUENCY=1600000
-      - DTC_OVERLAY_FILE="boards/nrf54l20pdk_nrf54l20_cpuapp_aclk.overlay"
+      - EXTRA_DTC_OVERLAY_FILE="boards/nrf54l_aclk.overlay"
   drivers.audio.pdm_loopback.nrf54h20.1000khz:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/drivers/pwm/gpio_loopback/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/pwm/gpio_loopback/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+&pinctrl {
+	pwm20_alt: pwm20_alt {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 10)>;
+		};
+	};
+
+	pwm20_alt_sleep: pwm20_alt_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 10)>;
+			low-power-enable;
+		};
+	};
+};
+
+&pwm20 {
+	pinctrl-0 = <&pwm20_alt>;
+	pinctrl-1 = <&pwm20_alt_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm20 0 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/tests/drivers/pwm/gpio_loopback/testcase.yaml
+++ b/tests/drivers/pwm/gpio_loopback/testcase.yaml
@@ -16,10 +16,12 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
 
   drivers.pwm.gpio_loopback.fast_p7_0:

--- a/tests/zephyr/drivers/audio/dmic_api/CMakeLists.txt
+++ b/tests/zephyr/drivers/audio/dmic_api/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(dmic_api)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/tests/drivers/audio/dmic_api/src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/zephyr/drivers/audio/dmic_api/README.txt
+++ b/tests/zephyr/drivers/audio/dmic_api/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/tests/drivers/audio/dmic_api.

--- a/tests/zephyr/drivers/audio/dmic_api/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/audio/dmic_api/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		dmic-dev = &pdm20;
+	};
+};
+
+&pinctrl {
+	pdm20_default_alt: pdm20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 1, 10)>,
+				<NRF_PSEL(PDM_DIN, 1, 11)>;
+		};
+	};
+};
+
+dmic_dev: &pdm20 {
+	status = "okay";
+	pinctrl-0 = <&pdm20_default_alt>;
+	pinctrl-names = "default";
+	clock-source = "PCLK32M";
+};

--- a/tests/zephyr/drivers/audio/dmic_api/prj.conf
+++ b/tests/zephyr/drivers/audio/dmic_api/prj.conf
@@ -1,0 +1,9 @@
+CONFIG_TEST=y
+CONFIG_ZTEST=y
+CONFIG_AUDIO=y
+CONFIG_AUDIO_DMIC=y
+
+# Use deferred logging mode so the TC_PRINT calls while reading from DMIC
+# do not block
+CONFIG_LOG=y
+CONFIG_LOG_MODE_DEFERRED=y

--- a/tests/zephyr/drivers/audio/dmic_api/testcase.yaml
+++ b/tests/zephyr/drivers/audio/dmic_api/testcase.yaml
@@ -1,0 +1,10 @@
+tests:
+  nrf.extended.drivers.audio.dmic_api:
+    tags:
+      - dmic
+      - ci_tests_zephyr_drivers_audio_dmic_api
+    harness: ztest
+    platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+    integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp

--- a/tests/zephyr/drivers/i2s/i2s_api/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/i2s/i2s_api/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* i2s-node0 is the transmitter/receiver */
+
+/ {
+	aliases {
+		i2s-node0 = &tdm;
+	};
+};
+
+&pinctrl {
+	tdm_default_alt: tdm_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TDM_SCK_M, 1, 3)>,
+				<NRF_PSEL(TDM_FSYNC_M, 1, 6)>,
+				<NRF_PSEL(TDM_SDOUT, 1, 14)>,
+				<NRF_PSEL(TDM_SDIN, 1, 15)>;
+		};
+	};
+};
+
+&tdm {
+	status = "okay";
+	pinctrl-0 = <&tdm_default_alt>;
+	pinctrl-names = "default";
+};

--- a/tests/zephyr/drivers/i2s/i2s_api/testcase.yaml
+++ b/tests/zephyr/drivers/i2s/i2s_api/testcase.yaml
@@ -1,14 +1,24 @@
+common:
+  tags:
+    - drivers
+    - i2s
+    - ci_tests_zephyr_drivers_i2s
+  filter: CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
+  harness: ztest
+
 tests:
-  nrf.extended.drivers.i2s.i2s_api.gpio_loopback:
-    tags:
-      - drivers
-      - i2s
-      - ci_tests_zephyr_drivers_i2s
-    filter: CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
-    harness: ztest
+  nrf.extended.drivers.i2s.i2s_api.gpio_loopback.54h:
     harness_config:
       fixture: i2s_loopback
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
+
+  nrf.extended.drivers.i2s_api.gpio_loopback.54l:
+    harness_config:
+      fixture: gpio_loopback
+    platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+    integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp

--- a/tests/zephyr/drivers/i2s/i2s_speed/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/i2s/i2s_speed/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* i2s-node0 is the transmitter/receiver */
+
+/ {
+	aliases {
+		i2s-node0 = &tdm;
+	};
+};
+
+&pinctrl {
+	tdm_default_alt: tdm_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TDM_SCK_M, 1, 3)>,
+				<NRF_PSEL(TDM_FSYNC_M, 1, 6)>,
+				<NRF_PSEL(TDM_SDOUT, 1, 14)>,
+				<NRF_PSEL(TDM_SDIN, 1, 15)>;
+		};
+	};
+};
+
+&tdm {
+	status = "okay";
+	pinctrl-0 = <&tdm_default_alt>;
+	pinctrl-names = "default";
+};

--- a/tests/zephyr/drivers/i2s/i2s_speed/testcase.yaml
+++ b/tests/zephyr/drivers/i2s/i2s_speed/testcase.yaml
@@ -1,14 +1,24 @@
+common:
+  tags:
+    - drivers
+    - i2s
+    - ci_tests_zephyr_drivers_i2s
+  filter: CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
+  harness: ztest
+
 tests:
-  nrf.extended.drivers.i2s.i2s_speed.gpio_loopback:
-    tags:
-      - drivers
-      - i2s
-      - ci_tests_zephyr_drivers_i2s
-    filter: CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
-    harness: ztest
+  nrf.extended.drivers.i2s.i2s_speed.gpio_loopback.54h:
     harness_config:
       fixture: i2s_loopback
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
+
+  nrf.extended.drivers.i2s.i2s_speed.gpio_loopback.54l:
+    harness_config:
+      fixture: gpio_loopback
+    platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+    integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp


### PR DESCRIPTION
Enable test execution on nRF54LM20A (no PDM, TDM nor PWM on nRF54LV10A).

No. | Name | nrf54LM20A
-- | -- | --
1 | nrf.extended.sample.drivers.audio.dmic | OK
2 | drivers.audio.pdm_loopback.nrf54l.1000khz | quarantine (NRFX-7154)
3 | drivers.audio.pdm_loopback.nrf54l20.1000khz | OK
4 | drivers.audio.pdm_loopback.nrf54l.1280khz | OK
5 | drivers.audio.pdm_loopback.nrf54l.1600khz | OK
6 | drivers.pwm.gpio_loopback | OK
7 | nrf.extended.drivers.audio.dmic_api | OK
8 | nrf.extended.drivers.i2s.i2s_api.gpio_loopback.54l | OK
9 | nrf.extended.drivers.i2s.i2s_speed.gpio_loopback.54l | quarantine (NRFX-7243)
