### PR TITLE
[Backport v3.0-branch] mpsl: init: Correct MPSL_LOW_PRIO_IRQN for 54h20

### DIFF
--- a/subsys/mpsl/init/Kconfig
+++ b/subsys/mpsl/init/Kconfig
@@ -69,7 +69,7 @@ config MPSL_LOW_PRIO_IRQN
 	int
 	default 25 if SOC_COMPATIBLE_NRF52X # SWI5
 	default 26 if SOC_COMPATIBLE_NRF53X # SWI0
-	default 404 if SOC_SERIES_NRF54HX # QDEC130
+	default 88 if SOC_SERIES_NRF54HX # SWI0
 	default 28 if SOC_COMPATIBLE_NRF54LX # SWI00
 	help
 	  This option sets the low priority interrupt that MPSL will use.


### PR DESCRIPTION
Backport 652fdf4e751be71a3a0a2f3e70a58beb8ead19a0 from #21387.