### PR TITLE
net: downloader: Don't expect DTLS even if sec_tag provided

### DIFF
--- a/subsys/net/lib/downloader/src/transports/coap.c
+++ b/subsys/net/lib/downloader/src/transports/coap.c
@@ -391,8 +391,7 @@ static int dl_coap_init(struct downloader *dl, struct downloader_host_cfg *dl_ho
 	coap->sock.proto = IPPROTO_UDP;
 	coap->sock.type = SOCK_DGRAM;
 
-	if (strncmp(url, COAPS, (sizeof(COAPS) - 1)) == 0 ||
-	    (dl_host_cfg->sec_tag_count != 0 && dl_host_cfg->sec_tag_list != NULL)) {
+	if (strncmp(url, COAPS, (sizeof(COAPS) - 1)) == 0) {
 		coap->sock.proto = IPPROTO_DTLS_1_2;
 		coap->sock.type = SOCK_DGRAM;
 


### PR DESCRIPTION
Configure protocol type to DTLS/1.2 only if URI is coaps:// and then require sec_tag to be set.

If sec_tag is provided, but URI is coap:// just use normal UDP/DGRAM.

Does this need to be in NCS 3.0?