### PR TITLE
manifest: pull in nRF54H20 USB hibernation fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3e19706cb5fb1ab4cfccd610ebd1a0d89e94a166
+      revision: cd267a7cf509e0785e3c7ab12d6c79646ef30e9c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
NCS v3.0.0-rc1 has a bug in nRF54H20 driver that results in dead USB device if the cable is disconnected while hibernated. Pull in the fix that makes USB work just fine when connected again after the cable was disconnected while hibernated.