### PR TITLE
[Backport v3.0-branch] net: downloader: Don't expect DTLS even if sec_tag provided

### DIFF
--- a/subsys/net/lib/downloader/src/transports/coap.c
+++ b/subsys/net/lib/downloader/src/transports/coap.c
@@ -391,8 +391,7 @@ static int dl_coap_init(struct downloader *dl, struct downloader_host_cfg *dl_ho
 	coap->sock.proto = IPPROTO_UDP;
 	coap->sock.type = SOCK_DGRAM;
 
-	if (strncmp(url, COAPS, (sizeof(COAPS) - 1)) == 0 ||
-	    (dl_host_cfg->sec_tag_count != 0 && dl_host_cfg->sec_tag_list != NULL)) {
+	if (strncmp(url, COAPS, (sizeof(COAPS) - 1)) == 0) {
 		coap->sock.proto = IPPROTO_DTLS_1_2;
 		coap->sock.type = SOCK_DGRAM;
 


### PR DESCRIPTION
Backport cc1ca45d29f9272df734b586c529ca8656274a81 from #21465.