### PR TITLE
[Backport v3.0-branch] manifest: update sdk-zephyr to have fix for nRF54L Errata 30

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 7e4d86b35547b78a78d2901189179f41d0cce4a2
+      revision: 3e19706cb5fb1ab4cfccd610ebd1a0d89e94a166
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated sdk-zephyr contains optional HFINT calibration procedure that contains a fix for nRF54L Errata 30.