### PR TITLE
[Backport v3.0-branch] doc: samples: fast_pair: locator_tag: Update the DFU signature type

### DIFF
--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -198,11 +198,15 @@ The configuration of the signature algorithm and the public key storage solution
 +================================+===================================================================+===========================+===========================+
 | RSA-2048                       | * ``nrf52dk/nrf52832`` (only ``release`` configuration)           | Bootloader partition      | SW calculation,           |
 |                                | * ``nrf52833dk/nrf52833`` (only ``release`` configuration)        |                           | Signature derived from    |
-|                                | * ``nrf52840dk/nrf52840``                                         |                           | image hash                |
-|                                | * ``nrf5340dk/nrf5340/cpuapp``                                    |                           |                           |
+|                                | * ``nrf5340dk/nrf5340/cpuapp``                                    |                           | image hash                |
 |                                | * ``nrf5340dk/nrf5340/cpuapp/ns``                                 |                           |                           |
 |                                | * ``thingy53/nrf5340/cpuapp``                                     |                           |                           |
 |                                | * ``thingy53/nrf5340/cpuapp/ns``                                  |                           |                           |
++--------------------------------+-------------------------------------------------------------------+---------------------------+---------------------------+
+| ECDSA-P256                     | * ``nrf52840dk/nrf52840``                                         | Bootloader partition      | HW-accelerated            |
+|                                |                                                                   |                           | (Cryptocell 310),         |
+|                                |                                                                   |                           | Signature derived from    |
+|                                |                                                                   |                           | image hash                |
 +--------------------------------+-------------------------------------------------------------------+---------------------------+---------------------------+
 | ED25519                        | * ``nrf54l15dk/nrf54l05/cpuapp`` (only ``release`` configuration) | Key Management Unit (KMU) | HW-accelerated (CRACEN),  |
 |                                | * ``nrf54l15dk/nrf54l10/cpuapp``                                  |                           | Signature derived from    |


### PR DESCRIPTION
Backport c6546981e01489ee9efbee43f664721d5bcabd05 from #21487.