### PR TITLE
drivers: mpsl: flash_sync: Fix missing if

### DIFF
--- a/drivers/mpsl/flash_sync/CMakeLists.txt
+++ b/drivers/mpsl/flash_sync/CMakeLists.txt
@@ -4,8 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_NRF_RADIO_SYNC_MPSL flash_sync_mpsl.c)
-zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_NRF_RADIO_SYNC_RPC_HOST flash_sync_rpc_host.c)
-zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_NRF_RADIO_SYNC_RPC_CONTROLLER flash_sync_rpc_controller.c)
-zephyr_include_directories(${ZEPHYR_BASE}/drivers/flash)
+if(CONFIG_SOC_FLASH_NRF_RADIO_SYNC_MPSL OR CONFIG_SOC_FLASH_NRF_RADIO_SYNC_RPC_HOST OR CONFIG_SOC_FLASH_NRF_RADIO_SYNC_RPC_CONTROLLER)
+  zephyr_library()
+  zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_NRF_RADIO_SYNC_MPSL flash_sync_mpsl.c)
+  zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_NRF_RADIO_SYNC_RPC_HOST flash_sync_rpc_host.c)
+  zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_NRF_RADIO_SYNC_RPC_CONTROLLER flash_sync_rpc_controller.c)
+  zephyr_include_directories(${ZEPHYR_BASE}/drivers/flash)
+endif()


### PR DESCRIPTION
Fixes an issue where an if was missing which would continually emit a warning about an empty library