### PR TITLE
[Backport v3.0-branch] applications: nrf_desktop: Disable UDC DWC2 DMA on nRF54H20 DK

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj.conf
@@ -90,6 +90,10 @@ CONFIG_LED=y
 # PWM not supported on this target, using GPIO instead.
 CONFIG_LED_GPIO=y
 
+# The UDC DWC2 DMA support is experimental. Disable the feature to improve USB stability. Since nRF
+# Desktop uses only small HID reports (size < 64 bytes), the DMA doesn't improve performance.
+CONFIG_UDC_DWC2_DMA=n
+
 CONFIG_BT_MAX_PAIRED=2
 CONFIG_BT_ID_MAX=3
 

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_dongle.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_dongle.conf
@@ -75,6 +75,10 @@ CONFIG_LED=y
 # PWM not supported on this target, using GPIO instead.
 CONFIG_LED_GPIO=y
 
+# The UDC DWC2 DMA support is experimental. Disable the feature to improve USB stability. Since nRF
+# Desktop uses only small HID reports (size < 64 bytes), the DMA doesn't improve performance.
+CONFIG_UDC_DWC2_DMA=n
+
 CONFIG_BT_PRIVACY=y
 
 CONFIG_BT_BUF_ACL_TX_SIZE=35

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_release.conf
@@ -84,6 +84,10 @@ CONFIG_LED=y
 # PWM not supported on this target, using GPIO instead.
 CONFIG_LED_GPIO=y
 
+# The UDC DWC2 DMA support is experimental. Disable the feature to improve USB stability. Since nRF
+# Desktop uses only small HID reports (size < 64 bytes), the DMA doesn't improve performance.
+CONFIG_UDC_DWC2_DMA=n
+
 CONFIG_BT_MAX_PAIRED=2
 CONFIG_BT_ID_MAX=3
 

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_release_dongle.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_release_dongle.conf
@@ -74,6 +74,10 @@ CONFIG_LED=y
 # PWM not supported on this target, using GPIO instead.
 CONFIG_LED_GPIO=y
 
+# The UDC DWC2 DMA support is experimental. Disable the feature to improve USB stability. Since nRF
+# Desktop uses only small HID reports (size < 64 bytes), the DMA doesn't improve performance.
+CONFIG_UDC_DWC2_DMA=n
+
 CONFIG_BT_PRIVACY=y
 
 CONFIG_BT_BUF_ACL_TX_SIZE=35


### PR DESCRIPTION
Backport a6c4c44dd3eba90a2acf0f2fd203794731017947 from #21466.