### PR TITLE
[Backport v3.0-branch] manifest: Bring TF-M with less cmake output

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -148,7 +148,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: v2.1.1-ncs4-rc1
+      revision: c3d09bf80380b4b7909b06765e41ebe229adaa72
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
This suppresses the cmake Installing: ... messages output when CONFIG_TFM_BUILD_LOG_QUIET=y.