### PR TITLE
ci: remove rebases from actions

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -16,6 +16,7 @@ jobs:
       with:
         git-fetch-depth: 0
         git-ref: ${{ github.event.pull_request.head.sha }}
+        rebase: true
 
     - name: cache-pip
       uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3
@@ -38,14 +39,9 @@ jobs:
         BASE_REF: ${{ github.base_ref }}
       working-directory: ncs/nrf
       run: |
-        git remote -v
         # Ensure there's no merge commits in the PR
         [[ "$(git rev-list --merges --count origin/${BASE_REF}..)" == "0" ]] || \
         (echo "::error ::Merge commits not allowed, rebase instead";false)
-
-        git rebase origin/${BASE_REF}
-        # debug
-        git log  --pretty=oneline | head -n 10
 
     - name: Run CODEOWNERS test
       id: codeowners

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -37,14 +37,6 @@ jobs:
         with:
           git-fetch-depth: 0
 
-      - name: Rebase
-        if: github.event_name == 'pull_request'
-        working-directory: ncs/nrf
-        run: |
-          git config --global user.email "bot@github.com"
-          git config --global user.name "Github Actions"
-          git rebase origin/${{ github.base_ref }}
-
       - name: cache-pip
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:

--- a/.github/workflows/license-reusable.yml
+++ b/.github/workflows/license-reusable.yml
@@ -40,7 +40,6 @@ jobs:
       uses: nrfconnect/action-checkout-west-update@main
       with:
         git-fetch-depth: 0
-        git-ref: ${{ github.event.pull_request.head.sha }}
         path: ncs/${{ inputs.path }}
         west-update-args: '-n zephyr bsim'
 
@@ -58,17 +57,6 @@ jobs:
         pip3 install -U wheel
         pip3 install --user -U west
         pip3 show -f west
-
-    - name: Git rebase
-      env:
-        BASE_REF: ${{ github.base_ref }}
-      working-directory: ncs/${{ inputs.path }}
-      run: |
-        git remote -v
-        git branch
-        git rebase origin/${BASE_REF}
-        # debug
-        git log --pretty=oneline | head -n 10
 
     - name: West zephyr-export
       working-directory: ncs

--- a/.github/workflows/validate-pip-requirements-fixed-file.yml
+++ b/.github/workflows/validate-pip-requirements-fixed-file.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Checkout sources
         uses: nrfconnect/action-checkout-west-update@main
         with:
-          git-ref: ${{ github.event.pull_request.head.sha }}
           west-update-args: '--narrow mcuboot zephyr'
 
       - name: Get python version

--- a/.github/workflows/west-commands.yml
+++ b/.github/workflows/west-commands.yml
@@ -17,7 +17,6 @@ jobs:
         uses: nrfconnect/action-checkout-west-update@main
         with:
           path: ncs/nrf
-          git-ref: ${{ github.event.pull_request.head.sha }}
           git-fetch-depth: 0
       - name: Install python dependencies
         working-directory: ncs/nrf


### PR DESCRIPTION
We use mostly on pull_request  will already checkouts merged code when checkout action is used without arguments. Trying to align all the actions to use same approach except compliance workflow which checks that no merge commits are created.