### PR TITLE
Nrfx 7309 run tests on nrf54lm20apdk and nrf54lv10apdk pt.3

### DIFF
--- a/boards/nordic/nrf54lv10apdk/nrf54lv10apdk_nrf54lv10a_cpuapp.yaml
+++ b/boards/nordic/nrf54lv10apdk/nrf54lv10apdk_nrf54lv10a_cpuapp.yaml
@@ -12,5 +12,9 @@ sysbuild: true
 ram: 192
 flash: 200
 supported:
+  - adc
   - counter
   - gpio
+  - i2c
+  - spi
+  - watchdog

--- a/samples/zephyr/drivers/adc/adc_dt/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/samples/zephyr/drivers/adc/adc_dt/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>, <&adc 1>, <&adc 2>, <&adc 7>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN4>; /* P1.11 */
+		zephyr,resolution = <10>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>; /* P1.06 */
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_VDD>;
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
+
+	channel@7 {
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN6>; /* P1.13 */
+		zephyr,input-negative = <NRF_SAADC_AIN7>; /* P1.14 */
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/zephyr/drivers/adc/adc_dt/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
+++ b/samples/zephyr/drivers/adc/adc_dt/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>, <&adc 1>, <&adc 2>, <&adc 7>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN4>; /* P1.11 */
+		zephyr,resolution = <10>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>; /* P1.06 */
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_VDD>;
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
+
+	channel@7 {
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN6>; /* P1.13 */
+		zephyr,input-negative = <NRF_SAADC_AIN7>; /* P1.14 */
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/zephyr/drivers/adc/adc_dt/sample.yaml
+++ b/samples/zephyr/drivers/adc/adc_dt/sample.yaml
@@ -9,9 +9,13 @@ tests:
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
     harness: console
     timeout: 10
     harness_config:

--- a/samples/zephyr/drivers/adc/adc_sequence/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/samples/zephyr/drivers/adc/adc_sequence/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>, <&adc 1>, <&adc 2>, <&adc 7>;
+	};
+};
+
+/ {
+	aliases {
+		adc0 = &adc;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN4>; /* P1.11 */
+		zephyr,resolution = <10>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>; /* P1.06 */
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_DVDD>; /* 0.9 V internal */
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
+
+	channel@7 {
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN6>; /* P1.13 */
+		zephyr,input-negative = <NRF_SAADC_AIN7>; /* P1.14 */
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/zephyr/drivers/adc/adc_sequence/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
+++ b/samples/zephyr/drivers/adc/adc_sequence/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>, <&adc 1>, <&adc 2>, <&adc 7>;
+	};
+};
+
+/ {
+	aliases {
+		adc0 = &adc;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN4>; /* P1.11 */
+		zephyr,resolution = <10>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>; /* P1.06 */
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_DVDD>; /* 0.9 V internal */
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
+
+	channel@7 {
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN6>; /* P1.13 */
+		zephyr,input-negative = <NRF_SAADC_AIN7>; /* P1.14 */
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/zephyr/drivers/adc/adc_sequence/sample.yaml
+++ b/samples/zephyr/drivers/adc/adc_sequence/sample.yaml
@@ -9,9 +9,13 @@ tests:
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
     harness: console
     timeout: 10
     harness_config:

--- a/samples/zephyr/sensor/qdec/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/samples/zephyr/sensor/qdec/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,38 @@
+/ {
+	aliases {
+		qdec0 = &qdec20;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+		phase_a: phase_a {
+			gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+		};
+		phase_b: phase_b {
+			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinctrl {
+	qdec_pinctrl: qdec_pinctrl {
+		group1 {
+			psels = <NRF_PSEL(QDEC_A, 1, 9)>,
+				<NRF_PSEL(QDEC_B, 1, 11)>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&qdec20 {
+	status = "okay";
+	pinctrl-0 = <&qdec_pinctrl>;
+	pinctrl-names = "default";
+	steps = <120>;
+	led-pre = <500>;
+};

--- a/samples/zephyr/sensor/qdec/sample.yaml
+++ b/samples/zephyr/sensor/qdec/sample.yaml
@@ -12,8 +12,10 @@ tests:
   nrf.extended.sample.sensor.nrf_qdec_sensor:
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
     harness_config:
       fixture: gpio_loopback
       type: multi_line

--- a/tests/zephyr/boards/nrf/qdec/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/boards/nrf/qdec/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		qdec0 = &qdec20;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+		phase_a: phase_a {
+			gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		};
+		phase_b: phase_b {
+			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinctrl {
+	qdec_pinctrl: qdec_pinctrl {
+		group1 {
+			psels = <NRF_PSEL(QDEC_A, 1, 8)>,
+				<NRF_PSEL(QDEC_B, 1, 10)>;
+		};
+	};
+
+	qdec_sleep_pinctrl: qdec_sleep_pinctrl {
+		group1 {
+			psels = <NRF_PSEL(QDEC_A, 1, 8)>,
+				<NRF_PSEL(QDEC_B, 1, 10)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&qdec20 {
+	status = "okay";
+	pinctrl-0 = <&qdec_pinctrl>;
+	pinctrl-1 = <&qdec_sleep_pinctrl>;
+	pinctrl-names = "default", "sleep";
+	steps = <127>;
+	led-pre = <500>;
+	zephyr,pm-device-runtime-auto;
+};

--- a/tests/zephyr/boards/nrf/qdec/testcase.yaml
+++ b/tests/zephyr/boards/nrf/qdec/testcase.yaml
@@ -1,8 +1,10 @@
 common:
   platform_allow:
     - nrf54l20pdk/nrf54l20/cpuflpr
+    - nrf54lm20apdk/nrf54lm20a/cpuapp
   integration_platforms:
     - nrf54l20pdk/nrf54l20/cpuflpr
+    - nrf54lm20apdk/nrf54lm20a/cpuapp
   harness: ztest
   harness_config:
     fixture: gpio_loopback

--- a/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>;
+		reference_mv = <1800>;
+		expected_accuracy = <64>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_2";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>;
+		zephyr,resolution = <14>;
+	};
+};

--- a/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
+++ b/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>;
+		reference_mv = <1800>;
+		expected_accuracy = <64>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_2";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>;
+		zephyr,resolution = <14>;
+	};
+};

--- a/tests/zephyr/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/zephyr/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -10,6 +10,10 @@ tests:
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp

--- a/tests/zephyr/drivers/adc/adc_api/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/adc/adc_api/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>, <&adc 1> , <&adc 2>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 10)>;
+		zephyr,input-positive = <NRF_SAADC_AIN1>;
+		zephyr,resolution = <10>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN4>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_2_3";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 10)>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>;
+		zephyr,resolution = <10>;
+	};
+};

--- a/tests/zephyr/drivers/adc/adc_api/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
+++ b/tests/zephyr/drivers/adc/adc_api/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>, <&adc 1> , <&adc 2>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 10)>;
+		zephyr,input-positive = <NRF_SAADC_AIN1>;
+		zephyr,resolution = <10>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN4>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_2_3";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 10)>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>;
+		zephyr,resolution = <10>;
+	};
+};

--- a/tests/zephyr/drivers/adc/adc_api/testcase.yaml
+++ b/tests/zephyr/drivers/adc/adc_api/testcase.yaml
@@ -8,5 +8,9 @@ tests:
   nrf.extended.drivers.adc:
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp

--- a/tests/zephyr/drivers/adc/adc_error_cases/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/adc/adc_error_cases/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		adc = &adc;
+	};
+};
+
+&adc {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/adc/adc_error_cases/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
+++ b/tests/zephyr/drivers/adc/adc_error_cases/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		adc = &adc;
+	};
+};
+
+&adc {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/adc/adc_error_cases/testcase.yaml
+++ b/tests/zephyr/drivers/adc/adc_error_cases/testcase.yaml
@@ -7,5 +7,9 @@ tests:
   nrf.extended.drivers.adc_error_cases:
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp

--- a/tests/zephyr/drivers/sensor/temp_sensor/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/sensor/temp_sensor/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+temp_sensor: &temp {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/sensor/temp_sensor/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
+++ b/tests/zephyr/drivers/sensor/temp_sensor/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+temp_sensor: &temp {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/sensor/temp_sensor/testcase.yaml
+++ b/tests/zephyr/drivers/sensor/temp_sensor/testcase.yaml
@@ -6,6 +6,10 @@ tests:
       - ci_tests_zephyr_drivers_sensors
     filter: dt_nodelabel_enabled("temp_sensor")
     platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp

--- a/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,5 +1,11 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
 &pinctrl {
-	spi21_default_alt: spi21_default_alt {
+	spi22_default_alt: spi22_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
 				<NRF_PSEL(SPIM_MISO, 1, 10)>,
@@ -7,7 +13,7 @@
 		};
 	};
 
-	spi21_sleep_alt: spi21_sleep_alt {
+	spi22_sleep_alt: spi22_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
 				<NRF_PSEL(SPIM_MISO, 1, 10)>,
@@ -16,7 +22,7 @@
 		};
 	};
 
-	spi20_default_alt: spi20_default_alt {
+	spi21_default_alt: spi21_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
 				<NRF_PSEL(SPIS_MISO, 1, 11)>,
@@ -25,7 +31,7 @@
 		};
 	};
 
-	spi20_sleep_alt: spi20_sleep_alt {
+	spi21_sleep_alt: spi21_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
 				<NRF_PSEL(SPIS_MISO, 1, 11)>,
@@ -41,10 +47,10 @@
 	status = "okay";
 };
 
-&spi21 {
+&spi22 {
 	status = "okay";
-	pinctrl-0 = <&spi21_default_alt>;
-	pinctrl-1 = <&spi21_sleep_alt>;
+	pinctrl-0 = <&spi22_default_alt>;
+	pinctrl-1 = <&spi22_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
@@ -56,13 +62,17 @@
 	};
 };
 
-dut_spis: &spi20 {
+dut_spis: &spi21 {
 	compatible = "nordic,nrf-spis";
 	status = "okay";
 	def-char = <0x00>;
-	pinctrl-0 = <&spi20_default_alt>;
-	pinctrl-1 = <&spi20_sleep_alt>;
+	pinctrl-0 = <&spi21_default_alt>;
+	pinctrl-1 = <&spi21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	/delete-property/rx-delay-supported;
 	/delete-property/rx-delay;
+};
+
+&uicr {
+	nfct-pins-as-gpios;
 };

--- a/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
 &pinctrl {
 	spi21_default_alt: spi21_default_alt {
 		group1 {

--- a/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf7120pdk_nrf7120_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf7120pdk_nrf7120_cpuapp.overlay
@@ -40,7 +40,6 @@
 			low-power-enable;
 		};
 	};
-
 };
 
 &gpio2 {

--- a/tests/zephyr/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/zephyr/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -11,12 +11,15 @@ common:
 tests:
   nrf.extended.drivers.spi.spi_mode0:
     platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     extra_configs:
       - CONFIG_TESTED_SPI_MODE=0
     extra_args: EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_TEST_DIR}/boards/250khz.overlay"
+
   nrf.extended.drivers.spi.spi_mode0.l09:
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
@@ -30,10 +33,25 @@ tests:
     tags:
       - nrf54l09-switch-uart
 
+  nrf.extended.drivers.spi.spi_mode0.lv10:
+    platform_allow:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    integration_platforms:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=0
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_TEST_DIR}/boards/250khz.overlay"
+      - SNIPPET=nrf54lv10-switch-uart
+    tags:
+      - nrf54lv10-switch-uart
+
   nrf.extended.drivers.spi.spi_mode1:
     platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     extra_configs:
       - CONFIG_TESTED_SPI_MODE=1
@@ -52,10 +70,25 @@ tests:
     tags:
       - nrf54l09-switch-uart
 
+  nrf.extended.drivers.spi.spi_mode1.lv10:
+    platform_allow:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    integration_platforms:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=1
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_TEST_DIR}/boards/500khz.overlay"
+      - SNIPPET=nrf54lv10-switch-uart
+    tags:
+      - nrf54lv10-switch-uart
+
   nrf.extended.drivers.spi.spi_mode2:
     platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     extra_configs:
       - CONFIG_TESTED_SPI_MODE=2
@@ -74,10 +107,25 @@ tests:
     tags:
       - nrf54l09-switch-uart
 
+  nrf.extended.drivers.spi.spi_mode2.lv10:
+    platform_allow:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    integration_platforms:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=2
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_TEST_DIR}/boards/1mhz.overlay"
+      - SNIPPET=nrf54lv10-switch-uart
+    tags:
+      - nrf54lv10-switch-uart
+
   nrf.extended.drivers.spi.spi_mode3:
     platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     extra_configs:
       - CONFIG_TESTED_SPI_MODE=3
@@ -96,10 +144,25 @@ tests:
     tags:
       - nrf54l09-switch-uart
 
+  nrf.extended.drivers.spi.spi_mode3.lv10:
+    platform_allow:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    integration_platforms:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=3
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_TEST_DIR}/boards/2mhz.overlay"
+      - SNIPPET=nrf54lv10-switch-uart
+    tags:
+      - nrf54lv10-switch-uart
+
   nrf.extended.drivers.spi.spi_4MHz:
     platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     extra_configs:
       - CONFIG_TESTED_SPI_MODE=2
@@ -118,10 +181,25 @@ tests:
     tags:
       - nrf54l09-switch-uart
 
+  nrf.extended.drivers.spi.spi_4MHz.lv10:
+    platform_allow:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    integration_platforms:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=2
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_TEST_DIR}/boards/4mhz.overlay"
+      - SNIPPET=nrf54lv10-switch-uart
+    tags:
+      - nrf54lv10-switch-uart
+
   nrf.extended.drivers.spi.spi_8MHz:
     platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     extra_configs:
       - CONFIG_TESTED_SPI_MODE=1
@@ -140,10 +218,25 @@ tests:
     tags:
       - nrf54l09-switch-uart
 
+  nrf.extended.drivers.spi.spi_8MHz.lv10:
+    platform_allow:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    integration_platforms:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=1
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="${ZEPHYR_TEST_DIR}/boards/8mhz.overlay"
+      - SNIPPET=nrf54lv10-switch-uart
+    tags:
+      - nrf54lv10-switch-uart
+
   nrf.extended.drivers.spi.pm_runtime:
     platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     extra_configs:
       - CONFIG_PM_DEVICE=y
@@ -161,3 +254,16 @@ tests:
       - SNIPPET=nrf54l09-switch-uart
     tags:
       - nrf54l09-switch-uart
+
+  nrf.extended.drivers.spi.pm_runtime.lv10:
+    platform_allow:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    integration_platforms:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    extra_configs:
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
+    extra_args:
+      - SNIPPET=nrf54lv10-switch-uart
+    tags:
+      - nrf54lv10-switch-uart

--- a/tests/zephyr/drivers/spi/spi_error_cases/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_error_cases/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,5 +1,11 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
 &pinctrl {
-	spi21_default_alt: spi21_default_alt {
+	spi22_default_alt: spi22_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
 				<NRF_PSEL(SPIM_MISO, 1, 10)>,
@@ -7,7 +13,7 @@
 		};
 	};
 
-	spi21_sleep_alt: spi21_sleep_alt {
+	spi22_sleep_alt: spi22_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
 				<NRF_PSEL(SPIM_MISO, 1, 10)>,
@@ -16,7 +22,7 @@
 		};
 	};
 
-	spi20_default_alt: spi20_default_alt {
+	spi21_default_alt: spi21_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
 				<NRF_PSEL(SPIS_MISO, 1, 11)>,
@@ -25,7 +31,7 @@
 		};
 	};
 
-	spi20_sleep_alt: spi20_sleep_alt {
+	spi21_sleep_alt: spi21_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
 				<NRF_PSEL(SPIS_MISO, 1, 11)>,
@@ -41,13 +47,13 @@
 	status = "okay";
 };
 
-&spi21 {
+&spi22 {
 	status = "okay";
-	pinctrl-0 = <&spi21_default_alt>;
-	pinctrl-1 = <&spi21_sleep_alt>;
+	pinctrl-0 = <&spi22_default_alt>;
+	pinctrl-1 = <&spi22_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
-	cs-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
@@ -55,13 +61,17 @@
 	};
 };
 
-dut_spis: &spi20 {
+dut_spis: &spi21 {
 	compatible = "nordic,nrf-spis";
 	status = "okay";
 	def-char = <0x00>;
-	pinctrl-0 = <&spi20_default_alt>;
-	pinctrl-1 = <&spi20_sleep_alt>;
+	pinctrl-0 = <&spi21_default_alt>;
+	pinctrl-1 = <&spi21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	/delete-property/rx-delay-supported;
 	/delete-property/rx-delay;
+};
+
+&uicr {
+	nfct-pins-as-gpios;
 };

--- a/tests/zephyr/drivers/spi/spi_error_cases/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_error_cases/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
 &pinctrl {
 	spi21_default_alt: spi21_default_alt {
 		group1 {

--- a/tests/zephyr/drivers/spi/spi_error_cases/boards/nrf7120pdk_nrf7120_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_error_cases/boards/nrf7120pdk_nrf7120_cpuapp.overlay
@@ -40,7 +40,6 @@
 			low-power-enable;
 		};
 	};
-
 };
 
 &gpio2 {

--- a/tests/zephyr/drivers/spi/spi_error_cases/testcase.yaml
+++ b/tests/zephyr/drivers/spi/spi_error_cases/testcase.yaml
@@ -10,9 +10,12 @@ common:
 tests:
   nrf.extended.drivers.spi.spi_error_cases:
     platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
+
   nrf.extended.drivers.spi.spi_error_cases.l09:
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
@@ -22,3 +25,13 @@ tests:
       - SNIPPET=nrf54l09-switch-uart
     tags:
       - nrf54l09-switch-uart
+
+  nrf.extended.drivers.spi.spi_error_cases.lv10:
+    platform_allow:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    integration_platforms:
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+    extra_args:
+      - SNIPPET=nrf54lv10-switch-uart
+    tags:
+      - nrf54lv10-switch-uart

--- a/tests/zephyr/drivers/spi/spi_loopback/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_loopback/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&pinctrl {
+	spi00_default: spi00_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
+				<NRF_PSEL(SPIM_MISO, 2, 9)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 8)>;
+		};
+	};
+
+	spi00_sleep: spi00_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
+				<NRF_PSEL(SPIM_MISO, 2, 9)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 8)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi00 {
+	status = "okay";
+	pinctrl-0 = <&spi00_default>;
+	pinctrl-1 = <&spi00_sleep>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	zephyr,pm-device-runtime-auto;
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(2)>;
+	};
+	dut_fast: fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/spi/spi_loopback/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_loopback/boards/nrf54lv10apdk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&pinctrl {
+	spi21_default: spi21_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 6)>,
+				<NRF_PSEL(SPIM_MISO, 1, 9)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 8)>;
+		};
+	};
+
+	spi21_sleep: spi21_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 6)>,
+				<NRF_PSEL(SPIM_MISO, 1, 9)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 8)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi21 {
+	status = "okay";
+	pinctrl-0 = <&spi21_default>;
+	pinctrl-1 = <&spi21_sleep>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	zephyr,pm-device-runtime-auto;
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(2)>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/zephyr/drivers/spi/spi_loopback/testcase.yaml
@@ -12,9 +12,13 @@ common:
     fixture: spi_loopback
   platform_allow:
     - nrf54l09pdk/nrf54l09/cpuapp
+    - nrf54lm20apdk/nrf54lm20a/cpuapp
+    - nrf54lv10apdk/nrf54lv10a/cpuapp
     - nrf7120pdk/nrf7120/cpuapp
   integration_platforms:
     - nrf54l09pdk/nrf54l09/cpuapp
+    - nrf54lm20apdk/nrf54lm20a/cpuapp
+    - nrf54lv10apdk/nrf54lv10a/cpuapp
     - nrf7120pdk/nrf7120/cpuapp
 
 tests:


### PR DESCRIPTION
Enable test execution on nRF54LM20A and nRF54LV10A.

No. | Name | nrf54LM20A | nrf54LV10A
-- | -- | -- | --
1 | drivers.spi.dt_spec | OK | OK
2 | nrf.extended.sample.drivers.adc.adc_dt | OK | OK
3 | nrf.extended.sample.drivers.adc.adc_sequence | OK | OK
4 | nrf.extended.sample.sensor.nrf_qdec_sensor | OK | no QDEC
5 | nrf.extended.drivers.sensor.qdec | OK | no QDEC
6 | nrf.extended.drivers.sensor.qdec.pm_runtime | OK | no QDEC
7 | nrf.extended.drivers.adc | OK | OK
8 | nrf.extended.drivers.adc.accuracy.ref_volt | Quarantine (FPGA limitation) | Quarantine (FPGA limitation)
9 | nrf.extended.drivers.adc_error_cases | OK | OK
10 | nrf.extended.drivers.sensor.temp_sensor | Quarantine (FPGA limitation) | Quarantine (FPGA limitation)
11 | nrf.extended.drivers.spi.spi_mode0 | OK | OK
12 | nrf.extended.drivers.spi.spi_mode1 | OK | OK
13 | nrf.extended.drivers.spi.spi_mode2 | OK | OK
14 | nrf.extended.drivers.spi.spi_mode3 | OK | OK
15 | nrf.extended.drivers.spi.spi_4MHz | OK | OK
16 | nrf.extended.drivers.spi.spi_8MHz | OK | OK
17 | nrf.extended.drivers.spi.pm_runtime | OK | OK
18 | nrf.extended.drivers.spi.spi_error_cases | OK | OK
19 | nrf.extended.drivers.spi.loopback | OK | OK
20 | nrf.extended.drivers.spi.nrf_pm_runtime | OK | OK