### PR TITLE
manifest: Bring TF-M with less cmake output

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -148,7 +148,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 0002817d4e50c8832028c280996dfeac47938138
+      revision: pull/189/head
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
This suppresses the cmake Installing: ...
messages output when CONFIG_TFM_BUILD_LOG_QUIET=y.