### PR TITLE
[Backport v3.0-branch] samples: wifi: radio_test: Fix RX capture crash

### DIFF
--- a/samples/wifi/radio_test/multi_domain/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/multi_domain/src/nrf_wifi_radio_test_shell.c
@@ -1579,7 +1579,7 @@ static int nrf_wifi_radio_test_rx_cap(const struct shell *shell,
 	ret = 0;
 out:
 	if (rx_cap_buf)
-		k_free(rx_cap_buf);
+		nrf_wifi_osal_mem_free(rx_cap_buf);
 
 	ctx->rf_test_run = false;
 	ctx->rf_test = NRF_WIFI_RF_TEST_MAX;


### PR DESCRIPTION
Backport fd3d09b52a53ab0699429ccbe59bf71157cfda53 from #21509.