### PR TITLE
dect: dect_phy: hello_dect: Transmit null-termination character

### DIFF
--- a/samples/dect/dect_phy/hello_dect/src/main.c
+++ b/samples/dect/dect_phy/hello_dect/src/main.c
@@ -391,7 +391,7 @@ int main(void)
 	while (1) {
 		/** Transmitting message */
 		LOG_INF("Transmitting %d", tx_counter_value);
-		tx_len = sprintf(tx_buf, "Hello DECT! %d", tx_counter_value);
+		tx_len = sprintf(tx_buf, "Hello DECT! %d", tx_counter_value) + 1; /* Include \0 */
 
 		err = transmit(tx_handle, tx_buf, tx_len);
 		if (err) {


### PR DESCRIPTION
Transmit null-termination character. This is to avoid reading outside of the buffer when the received message is printed as a string.