### PR TITLE
[Backport v3.0-branch] Manual backport of soc: nordic: nrf54h: Change PM_DEVICE_RUNTIME default

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: cd267a7cf509e0785e3c7ab12d6c79646ef30e9c
+      revision: pull/2727/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Manual backport of https://github.com/nrfconnect/sdk-zephyr/pull/2727