### PR TITLE
nrf_security: cracen: Improve DCACHE handling

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/aead.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/aead.c
@@ -474,7 +474,8 @@ int sx_aead_status(struct sxaead *c)
 	}
 
 #if CONFIG_DCACHE
-	sys_cache_data_invd_range((void *)&c->extramem, sizeof(c->extramem));
+	sx_cmdma_outdescs_flush_and_invd_dcache(&c->dma);
+	sys_cache_data_flush_and_invd_range((void *)&c->extramem, sizeof(c->extramem));
 #endif
 
 	if (!(c->dma.dmamem.cfg & c->cfg->ctxsave) && c->expectedtag != NULL) {

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hash.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hash.c
@@ -235,7 +235,7 @@ static int start_hash_hw(struct sxhash *c)
 {
 	sx_cmdma_start(&c->dma, sizeof(c->descs) + sizeof(c->extramem), c->descs);
 
-	return 0;
+	return SX_OK;
 }
 
 int sx_hash_save_state(struct sxhash *c)
@@ -289,7 +289,8 @@ int sx_hash_status(struct sxhash *c)
 	}
 
 #if CONFIG_DCACHE
-	sys_cache_data_invd_range((void *)&c->extramem, sizeof(c->extramem));
+	sx_cmdma_outdescs_flush_and_invd_dcache(&c->dma);
+	sys_cache_data_flush_and_invd_range((void *)&c->extramem, sizeof(c->extramem));
 #endif
 
 	sx_hash_free(c);

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/mac.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/mac.c
@@ -179,7 +179,8 @@ int sx_mac_status(struct sxmac *c)
 	}
 
 #if CONFIG_DCACHE
-	sys_cache_data_invd_range((void *)&c->extramem, sizeof(c->extramem));
+	sx_cmdma_outdescs_flush_and_invd_dcache(&c->dma);
+	sys_cache_data_flush_and_invd_range((void *)&c->extramem, sizeof(c->extramem));
 #endif
 
 	sx_mac_free(c);


### PR DESCRIPTION
Calling plain invalidate isn't always safe, as there might be pending writes in the cache line that just get thrown away. Just switch to full cache line evasion, so writeback + invalidate just to be safe. Also iterate over the out descriptors to make sure all the buffers are cache handled on completing of the cracen operations.