### PR TITLE
[Backport v3.0-branch] applications: nrf5340_audio: Removed comment

### DIFF
--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -37,7 +37,6 @@ config AUDIO_MIN_PRES_DLY_US
 	help
 	  The minimum allowable presentation delay in microseconds.
 	  This needs to allow time for decoding and internal routing.
-	  For 48kHz sampling rate and 96kbps bitrate this is about 4000 us.
 
 config AUDIO_MAX_PRES_DLY_US
 	int "The maximum presentation delay"


### PR DESCRIPTION
Backport 464299064fba548c5a1275086ddc7b511c097c12 from #21298.