### PR TITLE
nrf_security: Fix wrong include header in Cracen PSA

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecdsa.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecdsa.c
@@ -30,8 +30,7 @@
 #include "sxsymcrypt/hash.h"
 #include "cracen_psa_ecdsa.h"
 #include "cracen_psa_primitives.h"
-#include "sxsymcrypt/hash.h"
-#include "hashdefs.h"
+#include "sxsymcrypt/hashdefs.h"
 #include "common.h"
 #include "hmac.h"
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/sign.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/sign.c
@@ -24,7 +24,6 @@
 #include <string.h>
 #include <sxsymcrypt/hashdefs.h>
 #include <sxsymcrypt/trng.h>
-#include "hashdefs.h"
 
 #include "common.h"
 #include "cracen_psa.h"


### PR DESCRIPTION
Fix the inclusion of of hashdefs.h.