### PR TITLE
samples: wifi: provisioning: Fix MbedTLS heap size

### DIFF
--- a/samples/wifi/provisioning/ble/prj.conf
+++ b/samples/wifi/provisioning/ble/prj.conf
@@ -105,3 +105,5 @@ CONFIG_BT_PERIPHERAL_PREF_TIMEOUT=75
 
 # Similar to shell sample, add this option to ensure the event can get served.
 CONFIG_NET_MGMT_EVENT_QUEUE_TIMEOUT=5000
+# BT enables MbedTLS heap but uses the default heap size which is not enough for Wi-Fi.
+CONFIG_MBEDTLS_HEAP_SIZE=8192


### PR DESCRIPTION
BLE crypto uses MbedTLS heap but doesn't configure the heap size and default heap is not enough for Wi-Fi.

Increase the heap size to accomodate both BLE and Wi-Fi.

Fixes SHEL-3560.