### PR TITLE
tests: Extend test-spec with new entry for CI-boot-test

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -176,6 +176,7 @@
   - "subsys/fw_info/**/*"
   - "subsys/mgmt/**/*"
   - "subsys/pcd/**/*"
+  - "subsys/nrf_security/**/*"
   - "subsys/nrf_compress/**/*"
   - "tests/subsys/bootloader/**/*"
   - "tests/subsys/dfu/**/*"


### PR DESCRIPTION
Trigger downstream bootloader tests when changes done in subsys/nrf_security

because bootloader tests were not triggered here: https://github.com/nrfconnect/sdk-nrf/pull/21266