### PR TITLE
.github: test-spec: Extend CI-rs-test with nrf_security changes

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -329,6 +329,10 @@
   - "subsys/mpsl/**/*"
   - "subsys/ieee802154/**/*"
   - "subsys/nrf_rpc/**/*"
+  - any:
+      - "subsys/nrf_security/**/*"
+      - "!subsys/nrf_security/doc/**/*"
+      - "!subsys/nrf_security/*.rst"
   - "drivers/mpsl/**/*"
   - "dts/bindings/radio_fem/**/*"
   - "applications/ipc_radio/**/*"


### PR DESCRIPTION
Trigger ci on all code changes without documentation