### PR TITLE
test_spec: Run Bluetooth tests on nrf_security changes

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -214,6 +214,7 @@
       - "!include/bluetooth/mesh/**/*"
   - "subsys/nrf_rpc/**/*"
   - "subsys/mpsl/**/*"
+  - "subsys/nrf_security/**/*"
   - "drivers/mpsl/**/*"
 
 "CI-ble-samples-test":


### PR DESCRIPTION
The test coverage for nrf_security plans does not cover basic functionality used by Bluetooth.

https://github.com/nrfconnect/sdk-nrf/pull/21266 broke Bluetooth. Therefore we now extend the test scope
to prevent this from happening again.