### PR TITLE
bluetooth: services: Add helper ft for getting the ranging counter

### DIFF
--- a/include/bluetooth/services/ras.h
+++ b/include/bluetooth/services/ras.h
@@ -564,6 +564,17 @@ void bt_ras_rreq_rd_subevent_data_parse(struct net_buf_simple *peer_ranging_data
 					bt_ras_rreq_subevent_header_cb_t subevent_header_cb,
 					bt_ras_rreq_step_data_cb_t step_data_cb, void *user_data);
 
+/** @brief Convert CS procedure counter to RAS ranging counter
+ *
+ * @param[in] procedure_counter Procedure counter
+ *
+ * @retval RAS ranging counter
+ */
+static inline uint16_t bt_ras_rreq_get_ranging_counter(uint16_t procedure_counter)
+{
+	return procedure_counter & 0xFFF;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/bluetooth/channel_sounding_ras_initiator/src/main.c
+++ b/samples/bluetooth/channel_sounding_ras_initiator/src/main.c
@@ -160,7 +160,8 @@ static void subevent_result_cb(struct bt_conn *conn, struct bt_conn_le_cs_subeve
 		return;
 	}
 
-	if (most_recent_local_ranging_counter != result->header.procedure_counter) {
+	if (most_recent_local_ranging_counter
+		!= bt_ras_rreq_get_ranging_counter(result->header.procedure_counter)) {
 		int sem_state = k_sem_take(&sem_local_steps, K_NO_WAIT);
 
 		if (sem_state < 0) {
@@ -169,7 +170,8 @@ static void subevent_result_cb(struct bt_conn *conn, struct bt_conn_le_cs_subeve
 			return;
 		}
 
-		most_recent_local_ranging_counter = result->header.procedure_counter;
+		most_recent_local_ranging_counter =
+			bt_ras_rreq_get_ranging_counter(result->header.procedure_counter);
 	}
 
 	if (result->header.subevent_done_status == BT_CONN_LE_CS_SUBEVENT_ABORTED) {
@@ -193,7 +195,8 @@ static void subevent_result_cb(struct bt_conn *conn, struct bt_conn_le_cs_subeve
 	dropped_ranging_counter = PROCEDURE_COUNTER_NONE;
 
 	if (result->header.procedure_done_status == BT_CONN_LE_CS_PROCEDURE_COMPLETE) {
-		most_recent_local_ranging_counter = result->header.procedure_counter;
+		most_recent_local_ranging_counter =
+			bt_ras_rreq_get_ranging_counter(result->header.procedure_counter);
 	} else if (result->header.procedure_done_status == BT_CONN_LE_CS_PROCEDURE_ABORTED) {
 		LOG_WRN("Procedure %u aborted", result->header.procedure_counter);
 		net_buf_simple_reset(&latest_local_steps);


### PR DESCRIPTION
The ranging counter is the lower 12 bits of the procedure counter. This fixes an issue where procedure counter and ranging counter values were compared directly.