### PR TITLE
[Backport v3.0-branch] Bluetooth: Mesh: Fix provisioning failed issue on non-secure nRF5340DK variant after P2P DFU

### DIFF
--- a/doc/nrf/protocols/bt/bt_mesh/dfu_over_ble.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/dfu_over_ble.rst
@@ -16,6 +16,12 @@ This happens if the device is not advertising the SMP service UUID and the filte
 The device can still be discovered through a service discovery, for example using the `nRF Connect for Mobile`_ app.
 See `Discovering Bluetooth Mesh devices in nRF Connect Device Manager`_ for more details.
 
+Before performing a FOTA update, make sure that you have disabled the option to erase application settings.
+Otherwise, the device will be unprovisioned after the update.
+
+* In the `nRF Connect for Mobile`_ mobile app, open the :guilabel:`Settings` tab, select :guilabel:`Mcu Manager options`, and disable the **Erase application settings** option.
+* In the `nRF Connect Device Manager`_ mobile app, open the :guilabel:`Image` tab, tap the arrow icon next to **Firmware Upgrade**, and disable the **Erase application settings** option.
+
 Point-to point DFU over Bluetooth Low Energy in Bluetooth Mesh samples
 **********************************************************************
 

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -40,6 +40,8 @@ The configuration overlay file :file:`overlay-dfu.conf` and the :ref:`sysbuild <
 * nrf52840dk/nrf52840
 * nrf21540dk/nrf52840
 * nrf54l15dk/nrf54l15/cpuapp
+* nrf5340dk/nrf5340/cpuapp
+* nrf5340dk/nrf5340/cpuapp/ns
 
 While this overlay configuration is only applicable for the mentioned platforms in this sample, DFU over Bluetooth Low Energy may be used on other platforms as well.
 

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -39,11 +39,15 @@ tests:
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
     extra_args:
       - EXTRA_CONF_FILE=overlay-dfu.conf
       - SB_CONF_FILE=sysbuild-dfu.conf


### PR DESCRIPTION
This is a manual backport of #21522 PR to v3.0-branch since backport PR bot is not working.