### PR TITLE
samples: crypto: aes_gcm: fix Oberon test scenario for nRF54L15

### DIFF
--- a/samples/crypto/aes_gcm/sample.yaml
+++ b/samples/crypto/aes_gcm/sample.yaml
@@ -27,7 +27,7 @@ tests:
     sysbuild: true
     extra_args:
       - CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
-      - CONFIG_PSA_CRYPTO_DRIVER_CRACEN=n
+      - CONFIG_PSA_USE_CRACEN_AEAD_DRIVER=n
     tags:
       - introduction
       - psa


### PR DESCRIPTION
Disabling the CRACEN driver altogether makes the key generation fail. Only disable the CRACEN AEAD driver instead.

(fixup of https://github.com/nrfconnect/sdk-nrf/pull/21413)