### PR TITLE
doc: crypto: add crypto_driver_contexts_* API

### DIFF
--- a/doc/nrf/libraries/security/nrf_security/doc/drivers.rst
+++ b/doc/nrf/libraries/security/nrf_security/doc/drivers.rst
@@ -121,3 +121,10 @@ Additionally, either :kconfig:option:`CONFIG_CC3XX_BACKEND` or :kconfig:option:`
 
 .. note::
    Enabling the CryptoCell by using :kconfig:option:`CONFIG_CC3XX_BACKEND` in a non-secure image of a TF-M build will have no effect.
+
+API documentation
+*****************
+
+| Header files: :file:`subsys/nrf_security/include/psa/crypto_driver_contexts_*.h`
+
+.. doxygengroup:: nrf_security_api_structures

--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -959,7 +959,10 @@ WARN_LOGFILE           =
 INPUT                  = @DOCSET_SOURCE_BASE@/applications \
                          @DOCSET_SOURCE_BASE@/lib \
                          @DOCSET_SOURCE_BASE@/include \
-                         @DOCSET_SOURCE_BASE@/subsys/nrf_security/include
+                         @DOCSET_SOURCE_BASE@/subsys/nrf_security/include/psa/crypto_driver_contexts_composites.h \
+                         @DOCSET_SOURCE_BASE@/subsys/nrf_security/include/psa/crypto_driver_contexts_key_derivation.h \
+                         @DOCSET_SOURCE_BASE@/subsys/nrf_security/include/psa/crypto_driver_contexts_primitives.h \
+                         @DOCSET_SOURCE_BASE@/subsys/nrf_security/include/nrf_security_api_structure.h
 
 # This tag can be used to specify the character encoding of the source files
 # that Doxygen parses. Internally Doxygen uses the UTF-8 encoding. Doxygen uses

--- a/subsys/nrf_security/include/nrf_security_api_structure.h
+++ b/subsys/nrf_security/include/nrf_security_api_structure.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @defgroup nrf_security_api_structures Nordic-specific PSA API structures
+ * @brief Platform Security Architecture (PSA) API structures for nRF Security
+ *
+ * The nRF Security subsystem provides integration between Mbed TLS and
+ * hardware-accelerated cryptographic libraries through PSA drivers. These structures
+ * define the implementation-specific context types used in the PSA Crypto API.
+ *
+ * The `crypto_driver_contexts_*` files are Nordic-specific implementations
+ * for the corresponding `crypto_driver_contexts_*` files in the Oberon API. This API is defined
+ * in sdk-nrf at https://github.com/nrfconnect/sdk-nrf/tree/main/subsys/nrf_security/include/psa and
+ * should be consulted together with the three Nordic-specific files.
+ *
+ * Nordic-specific implementations are designed to extend available cryptographic features
+ * with hardware acceleration or alternative implementations. The supported drivers include:
+ *   - Arm CryptoCell cc3xx (hardware acceleration for nRF52840, nRF91 Series, and nRF5340)
+ *   - nrf_oberon (optimized cryptographic algorithms)
+ *   - CRACEN (hardware acceleration for nRF54L Series)
+ *
+ * For detailed documentation on these drivers, see the nRF Connect SDK documentation:
+ * https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/security/nrf_security/index.html
+ *
+ * The Nordic-specific implementation also uses files located at:
+ * - https://github.com/nrfconnect/sdk-nrf/blob/main/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
+ *
+ * @{
+ */
+
+/**
+ * @defgroup psa_crypto_drivers PSA Crypto Drivers
+ * @brief PSA Crypto driver context structures
+ *
+ * @{
+ */
+
+/**
+ * @defgroup psa_crypto_driver_primitives Primitive Crypto Drivers
+ * @brief Driver context structures for primitive cryptographic operations
+ *
+ * These structures define the contexts for primitive cryptographic operations,
+ * which do not rely on other contexts. They include contexts for hash operations
+ * and cipher operations implemented by various drivers such as cc3xx, Oberon,
+ * and CRACEN.
+ *
+ * @file crypto_driver_contexts_primitives.h
+ */
+
+/**
+ * @defgroup psa_crypto_driver_composites Composite Crypto Drivers
+ * @brief Driver context structures for composite cryptographic operations
+ *
+ * These structures define the contexts for composite operations,
+ * which make use of other primitive operations. They include contexts for MAC
+ * and AEAD operations implemented by various drivers such as cc3xx, Oberon,
+ * and CRACEN.
+ *
+ * @file crypto_driver_contexts_composites.h
+ */
+
+/**
+ * @defgroup psa_crypto_driver_key_derivation Key Derivation Crypto Drivers
+ * @brief Driver context structures for key derivation operations
+ *
+ * These structures define the contexts for key derivation, PAKE, and random
+ * generation operations implemented by various drivers such as Oberon and CRACEN.
+ *
+ * @file crypto_driver_contexts_key_derivation.h
+ */
+
+/** @} */
+
+/** @} */


### PR DESCRIPTION
Added a container for Nordic-specific crypto driver contexts. This container adds doxygen groups for the crypto driver contexts files at subsys/nrf_security/include/psa. It also links directly to the Oberon API module and other files used in the Nordic implementation. NCSDK-30040.

----

- Doxygen API doc quality in the headers will be improved in NCSDK-33026
- No changelog entry

