### PR TITLE
nrf_security: cracen: clean up and refactor

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/cracenpsa.cmake
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/cracenpsa.cmake
@@ -51,6 +51,7 @@ if(CONFIG_PSA_NEED_CRACEN_ASYMMETRIC_SIGNATURE_DRIVER)
     ${CMAKE_CURRENT_LIST_DIR}/src/ecc.c
     ${CMAKE_CURRENT_LIST_DIR}/src/ed25519.c
     ${CMAKE_CURRENT_LIST_DIR}/src/hmac.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/rndinrange.c
   )
 endif()
 
@@ -81,11 +82,10 @@ endif()
 
 if(CONFIG_PSA_NEED_CRACEN_KEY_MANAGEMENT_DRIVER OR CONFIG_PSA_NEED_CRACEN_KMU_DRIVER OR CONFIG_MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS)
   list(APPEND cracen_driver_sources
-    ${CMAKE_CURRENT_LIST_DIR}/src/ed25519.c
     ${CMAKE_CURRENT_LIST_DIR}/src/key_management.c
-    ${CMAKE_CURRENT_LIST_DIR}/src/ed25519.c
     ${CMAKE_CURRENT_LIST_DIR}/src/ecdsa.c
     ${CMAKE_CURRENT_LIST_DIR}/src/ecc.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/rndinrange.c
   )
 endif()
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_ecdsa.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_ecdsa.h
@@ -9,28 +9,28 @@
 
 #include <psa/crypto.h>
 
-int cracen_ecdsa_verify_message(const char *pubkey, const struct sxhashalg *hashalg,
+int cracen_ecdsa_verify_message(const uint8_t *pubkey, const struct sxhashalg *hashalg,
 				const uint8_t *message, size_t message_length,
 				const struct sx_pk_ecurve *curve, const uint8_t *signature);
 
-int cracen_ecdsa_verify_digest(const char *pubkey, const uint8_t *digest, size_t digestsz,
+int cracen_ecdsa_verify_digest(const uint8_t *pubkey, const uint8_t *digest, size_t digestsz,
 			       const struct sx_pk_ecurve *curve, const uint8_t *signature);
 
-int cracen_ecdsa_sign_message(const struct ecc_priv_key *privkey, const struct sxhashalg *hashalg,
-			      const struct sx_pk_ecurve *curve, const uint8_t *message,
-			      size_t message_length, uint8_t *signature);
+int cracen_ecdsa_sign_message(const struct cracen_ecc_priv_key *privkey,
+			      const struct sxhashalg *hashalg, const struct sx_pk_ecurve *curve,
+			      const uint8_t *message, size_t message_length, uint8_t *signature);
 
-int cracen_ecdsa_sign_digest(const struct ecc_priv_key *privkey, const struct sxhashalg *hashalg,
-			     const struct sx_pk_ecurve *curve, const uint8_t *digest,
-			     size_t digest_length, uint8_t *signature);
+int cracen_ecdsa_sign_digest(const struct cracen_ecc_priv_key *privkey,
+			     const struct sxhashalg *hashalg, const struct sx_pk_ecurve *curve,
+			     const uint8_t *digest, size_t digest_length, uint8_t *signature);
 
-int cracen_ecdsa_sign_message_deterministic(const struct ecc_priv_key *privkey,
+int cracen_ecdsa_sign_message_deterministic(const struct cracen_ecc_priv_key *privkey,
 					    const struct sxhashalg *hashalg,
 					    const struct sx_pk_ecurve *curve,
 					    const uint8_t *message, size_t message_length,
 					    uint8_t *signature);
 
-int cracen_ecdsa_sign_digest_deterministic(const struct ecc_priv_key *privkey,
+int cracen_ecdsa_sign_digest_deterministic(const struct cracen_ecc_priv_key *privkey,
 					   const struct sxhashalg *hashalg,
 					   const struct sx_pk_ecurve *curve, const uint8_t *digest,
 					   size_t digestsz, uint8_t *signature);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_eddsa.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_eddsa.h
@@ -4,18 +4,25 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <psa/crypto.h>
+#ifndef CRACEN_PSA_EDDSA_H
+#define CRACEN_PSA_EDDSA_H
 
-int cracen_ed25519_sign(const uint8_t *priv_key, char *signature, const uint8_t *message,
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+int cracen_ed25519_sign(const uint8_t *priv_key, uint8_t *signature, const uint8_t *message,
 			size_t message_length);
 
-int cracen_ed25519_verify(const uint8_t *pub_key, const char *message, size_t message_length,
-			  const char *signature);
+int cracen_ed25519_verify(const uint8_t *pub_key, const uint8_t *message, size_t message_length,
+			  const uint8_t *signature);
 
-int cracen_ed25519ph_sign(const uint8_t *priv_key, char *signature, const uint8_t *message,
+int cracen_ed25519ph_sign(const uint8_t *priv_key, uint8_t *signature, const uint8_t *message,
 			  size_t message_length, bool is_message);
 
-int cracen_ed25519ph_verify(const uint8_t *pub_key, const char *message, size_t message_length,
-			    const char *signature, bool is_message);
+int cracen_ed25519ph_verify(const uint8_t *pub_key, const uint8_t *message, size_t message_length,
+			    const uint8_t *signature, bool is_message);
 
 int cracen_ed25519_create_pubkey(const uint8_t *priv_key, uint8_t *pub_key);
+
+#endif /* CRACEN_PSA_EDDSA_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
@@ -373,25 +373,25 @@ struct cracen_pake_operation {
 };
 typedef struct cracen_pake_operation cracen_pake_operation_t;
 
-struct ecdsa_signature {
+struct cracen_ecdsa_signature {
 	size_t sz; /** Total signature size, in bytes. */
-	char *r;   /** Signature element "r". */
-	char *s;   /** Signature element "s". */
+	uint8_t *r;   /** Signature element "r". */
+	uint8_t *s;   /** Signature element "s". */
 };
 
-struct ecc_priv_key {
+struct cracen_ecc_priv_key {
 	const struct sx_pk_ecurve *curve;
-	const char *d; /** Private key value d */
+	const uint8_t *d; /** Private key value d */
 };
 
-struct ecc_pub_key {
+struct cracen_ecc_pub_key {
 	const struct sx_pk_ecurve *curve;
-	char *qx; /** x coordinate of a point on the curve */
-	char *qy; /** y coordinate of a point on the curve */
+	uint8_t *qx; /** x coordinate of a point on the curve */
+	uint8_t *qy; /** y coordinate of a point on the curve */
 };
 
-struct ecc_keypair {
-	struct ecc_priv_key priv_key;
-	struct ecc_pub_key pub_key;
+struct cracen_ecc_keypair {
+	struct cracen_ecc_priv_key priv_key;
+	struct cracen_ecc_pub_key pub_key;
 };
 #endif /* CRACEN_PSA_PRIMITIVES_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
@@ -37,7 +37,7 @@ LOG_MODULE_DECLARE(cracen, CONFIG_CRACEN_LOG_LEVEL);
 
 #ifdef CONFIG_PSA_NEED_CRACEN_PLATFORM_KEYS
 /* Address from the IPS. May come from the MDK in the future. */
-#define DEVICE_SECRET_LENGTH 4
+#define DEVICE_SECRET_LENGTH  4
 #define DEVICE_SECRET_ADDRESS ((uint32_t *)0x0E001620)
 #endif
 
@@ -397,7 +397,7 @@ psa_status_t rnd_in_range(uint8_t *n, size_t sz, const uint8_t *upperlimit, size
 		}
 		n[0] &= msb_mask;
 
-		int ge = si_be_cmp(n, upperlimit, sz, 0);
+		int ge = cracen_be_cmp(n, upperlimit, sz, 0);
 
 		if (ge == -1) {
 
@@ -903,7 +903,7 @@ psa_status_t cracen_get_opaque_size(const psa_key_attributes_t *attributes, size
 	return PSA_ERROR_INVALID_ARGUMENT;
 }
 
-void be_add(unsigned char *v, size_t sz, size_t summand)
+void cracen_be_add(uint8_t *v, size_t sz, size_t summand)
 {
 	while (sz > 0) {
 		sz--;
@@ -913,7 +913,7 @@ void be_add(unsigned char *v, size_t sz, size_t summand)
 	}
 }
 
-int be_cmp(const unsigned char *a, const unsigned char *b, size_t sz, int carry)
+int cracen_be_cmp(const uint8_t *a, const uint8_t *b, size_t sz, int carry)
 {
 	unsigned int neq = 0;
 	unsigned int gt = 0;
@@ -937,9 +937,9 @@ int be_cmp(const unsigned char *a, const unsigned char *b, size_t sz, int carry)
 	return (gt ? 1 : 0) - (lt ? 1 : 0);
 }
 
-int hash_all_inputs_with_context(struct sxhash *hashopctx, const char *inputs[],
-				 const size_t inputs_lengths[], size_t input_count,
-				 const struct sxhashalg *hashalg, char *digest)
+int cracen_hash_all_inputs_with_context(struct sxhash *hashopctx, const uint8_t *inputs[],
+					const size_t input_lengths[], size_t input_count,
+					const struct sxhashalg *hashalg, uint8_t *digest)
 {
 	int status;
 
@@ -949,7 +949,7 @@ int hash_all_inputs_with_context(struct sxhash *hashopctx, const char *inputs[],
 	}
 
 	for (size_t i = 0; i < input_count; i++) {
-		status = sx_hash_feed(hashopctx, inputs[i], inputs_lengths[i]);
+		status = sx_hash_feed(hashopctx, inputs[i], input_lengths[i]);
 		if (status != SX_OK) {
 			return status;
 		}
@@ -964,23 +964,25 @@ int hash_all_inputs_with_context(struct sxhash *hashopctx, const char *inputs[],
 	return status;
 }
 
-int hash_all_inputs(const char *inputs[], const size_t inputs_lengths[], size_t input_count,
-		    const struct sxhashalg *hashalg, char *digest)
+int cracen_hash_all_inputs(const uint8_t *inputs[], const size_t input_lengths[],
+			   size_t input_count, const struct sxhashalg *hashalg, uint8_t *digest)
 {
 	struct sxhash hashopctx;
 
-	return hash_all_inputs_with_context(&hashopctx, inputs, inputs_lengths, input_count,
-					    hashalg, digest);
+	return cracen_hash_all_inputs_with_context(&hashopctx, inputs, input_lengths, input_count,
+						   hashalg, digest);
 }
 
-int hash_input(const char *input, const size_t input_length, const struct sxhashalg *hashalg,
-	       char *digest)
+int cracen_hash_input(const uint8_t *input, const size_t input_length,
+		      const struct sxhashalg *hashalg, uint8_t *digest)
 {
-	return hash_all_inputs(&input, &input_length, 1, hashalg, digest);
+	return cracen_hash_all_inputs(&input, &input_length, 1, hashalg, digest);
 }
 
-int hash_input_with_context(struct sxhash *hashopctx, const char *input, const size_t input_length,
-			    const struct sxhashalg *hashalg, char *digest)
+int cracen_hash_input_with_context(struct sxhash *hashopctx, const uint8_t *input,
+				   const size_t input_length, const struct sxhashalg *hashalg,
+				   uint8_t *digest)
 {
-	return hash_all_inputs_with_context(hashopctx, &input, &input_length, 1, hashalg, digest);
+	return cracen_hash_all_inputs_with_context(hashopctx, &input, &input_length, 1, hashalg,
+						   digest);
 }

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.h
@@ -55,7 +55,7 @@ enum asn1_tags {
  * \param[in]  curve_bits   Curve bits.
  * \param[out] sicurve      Pointer to curve struct for Cracen.
  *
- * \return PSA_SUCCESS on success or a valid PSA error code.
+ * \return PSA_SUCCESS on success or a valid PSA status code.
  */
 psa_status_t cracen_ecc_get_ecurve_from_psa(psa_ecc_family_t curve_family, size_t curve_bits,
 					    const struct sx_pk_ecurve **sicurve);
@@ -98,7 +98,7 @@ static inline size_t cracen_ecc_wstr_expected_pub_key_bytes(size_t priv_key_size
  * \param[in] in_pnt The public key to check.
  *
  * \return  PSA_SUCCESS if the public key passed the check, a valid
- *          PSA error code otherwise.
+ *          PSA status code otherwise.
  *
  */
 psa_status_t cracen_ecc_check_public_key(const struct sx_pk_ecurve *curve,
@@ -115,7 +115,7 @@ psa_status_t cracen_ecc_check_public_key(const struct sx_pk_ecurve *curve,
  * \param[out] modulus             Modulus (n) operand of n.
  * \param[out] exponent            Public or private exponent, depending on \ref extract_pubkey.
  *
- * \return sicrypto statuscode.
+ * \return sxsymcrypt status code.
  */
 int cracen_signature_get_rsa_key(struct si_rsa_key *rsa, bool extract_pubkey, bool is_key_pair,
 				 const unsigned char *key, size_t keylen, struct sx_buf *modulus,
@@ -146,7 +146,7 @@ int cracen_signature_asn1_get_operand(unsigned char **p, const unsigned char *en
  *
  * @note Output number and upper limit must be big endian numbers of size @ref sz.
  *
- * @return psa_status_t
+ * @return PSA status code.
  */
 psa_status_t rnd_in_range(uint8_t *n, size_t sz, const uint8_t *upperlimit, size_t retrylimit);
 
@@ -162,17 +162,26 @@ void cracen_xorbytes(char *a, const char *b, size_t sz);
 /**
  * @brief Loads key buffer and attributes.
  *
- * @return psa_status_t
+ * @return PSA status code.
  */
 psa_status_t cracen_load_keyref(const psa_key_attributes_t *attributes, const uint8_t *key_buffer,
 				size_t key_buffer_size, struct sxkeyref *k);
+
+/**
+ * @brief Do ECB operation.
+ *
+ * @return PSA status code.
+ */
+psa_status_t cracen_cipher_crypt_ecb(const struct sxkeyref *key, const uint8_t *input,
+				     size_t input_length, uint8_t *output, size_t output_size,
+				     size_t *output_length, enum cipher_operation dir);
 
 /**
  * @brief Prepare ik key.
  *
  * @param user_data    Owner ID.
  *
- * @return sxsymcrypt error code.
+ * @return sxsymcrypt status code.
  */
 int cracen_prepare_ik_key(const uint8_t *user_data);
 
@@ -187,7 +196,7 @@ int cracen_prepare_ik_key(const uint8_t *user_data);
  * @param summand	Summand.
  *
  */
-void be_add(unsigned char *v, size_t v_size, size_t summand);
+void cracen_be_add(uint8_t *v, size_t v_size, size_t summand);
 
 /**
  * @brief Big-Endian compare with carry.
@@ -202,21 +211,21 @@ void be_add(unsigned char *v, size_t v_size, size_t summand);
  * \retval 1 if a > b.
  * \retval -1 if a < b.
  */
-int be_cmp(const unsigned char *a, const unsigned char *b, size_t sz, int carry);
+int cracen_be_cmp(const uint8_t *a, const uint8_t *b, size_t sz, int carry);
 
 /**
  * @brief Hash several elements at different locations in memory
  *
  * @param inputs[in]		Array of pointers to elements that will be hashed.
- * @param inputs_lengths[in]	Array of lengths of elements to be hashed.
+ * @param input_lengths[in]	Array of lengths of elements to be hashed.
  * @param input_count[in]	Number of elements to be hashed.
  * @param hashalg[in]		Hash algorithm to be used in sxhashalg format.
  * @param digest[out]		Buffer of at least sx_hash_get_alg_digestsz(hashalg) bytes.
  *
  * @return sxsymcrypt status code.
  */
-int hash_all_inputs(const char *inputs[], const size_t inputs_lengths[], size_t input_count,
-		    const struct sxhashalg *hashalg, char *digest);
+int cracen_hash_all_inputs(const uint8_t *inputs[], const size_t input_lengths[],
+			   size_t input_count, const struct sxhashalg *hashalg, uint8_t *digest);
 
 /**
  * @brief Hash several elements at different locations in memory with a previously created hash
@@ -224,29 +233,29 @@ int hash_all_inputs(const char *inputs[], const size_t inputs_lengths[], size_t 
  *
  * @param sxhashopctx[in]	Pointer to the sxhash context.
  * @param inputs[in]		Array of pointers to elements that will be hashed.
- * @param inputs_lengths[in]	Array of lengths of elements to be hashed.
+ * @param input_lengths[in]	Array of lengths of elements to be hashed.
  * @param input_count[in]	Number of elements to be hashed.
  * @param hashalg[in]		Hash algorithm to be used in sxhashalg format.
  * @param digest[out]		Buffer of at least sx_hash_get_alg_digestsz(hashalg) bytes.
  *
  * @return sxsymcrypt status code.
  */
-int hash_all_inputs_with_context(struct sxhash *sxhashopctx, const char *inputs[],
-				 const size_t inputs_lengths[], size_t input_count,
-				 const struct sxhashalg *hashalg, char *digest);
+int cracen_hash_all_inputs_with_context(struct sxhash *sxhashopctx, const uint8_t *inputs[],
+					const size_t input_lengths[], size_t input_count,
+					const struct sxhashalg *hashalg, uint8_t *digest);
 
 /**
  * @brief Hash a single element
  *
- * @param inputs[in]		Pointer to the element that will be hashed.
+ * @param input[in]		Pointer to the element that will be hashed.
  * @param input_length[in]	Length of the element to be hashed.
  * @param hashalg[in]		Hash algorithm to be used in sxhashalg format.
  * @param digest[out]		Buffer of at least sx_hash_get_alg_digestsz(hashalg) bytes.
  *
  * @return sxsymcrypt status code.
  */
-int hash_input(const char *input, const size_t input_length, const struct sxhashalg *hashalg,
-	       char *digest);
+int cracen_hash_input(const uint8_t *input, const size_t input_length,
+		      const struct sxhashalg *hashalg, uint8_t *digest);
 
 /**
  * @brief Hash a single element with a previously created hash context(sxhash)
@@ -259,8 +268,9 @@ int hash_input(const char *input, const size_t input_length, const struct sxhash
  *
  * @return sxsymcrypt status code.
  */
-int hash_input_with_context(struct sxhash *hashopctx, const char *input, const size_t input_length,
-			    const struct sxhashalg *hashalg, char *digest);
+int cracen_hash_input_with_context(struct sxhash *hashopctx, const uint8_t *input,
+				   const size_t input_length, const struct sxhashalg *hashalg,
+				   uint8_t *digest);
 
 /**
  * @brief Generate a random number within the specified range.
@@ -275,6 +285,6 @@ int hash_input_with_context(struct sxhash *hashopctx, const char *input, const s
  * @param out[out]      Buffer to store the generated random number.
  *                      The size of `out` should be at least `nsz`.
  *
- * @return sxsymcrypt status code:
+ * @return sxsymcrypt status code.
  */
-int rndinrange_create(const unsigned char *n, size_t nsz, unsigned char *out);
+int cracen_get_rnd_in_range(const uint8_t *n, size_t nsz, uint8_t *out);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecc.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecc.c
@@ -12,32 +12,33 @@
 #include <silexpk/iomem.h>
 #include <silexpk/cmddefs/ecc.h>
 #include <cracen/statuscodes.h>
-#include "cracen_psa.h"
+#include <cracen_psa.h>
 #include "ecc.h"
 #include "common.h"
 
 #define MAX_ECC_ATTEMPTS 10
 
-int ecc_create_genpubkey(const char *priv_key, char *pub_key, const struct sx_pk_ecurve *curve)
+int ecc_genpubkey(const uint8_t *priv_key, uint8_t *pub_key, const struct sx_pk_ecurve *curve)
 {
-	const char **outputs;
+	const uint8_t **outputs;
 	struct sx_pk_acq_req pkreq;
 	struct sx_pk_inops_ecp_mult inputs;
 	int opsz;
-	int status;
+	int status = SX_ERR_NOT_INVERTIBLE;
+	int attempts = 0;
 
-	for (int i = 0; i <= MAX_ECC_ATTEMPTS; i++) {
+	opsz = sx_pk_curve_opsize(curve);
+
+	while (status == SX_ERR_NOT_INVERTIBLE) {
 		pkreq = sx_pk_acquire_req(SX_PK_CMD_ECC_PTMUL);
 		if (pkreq.status) {
 			return pkreq.status;
 		}
-		pkreq.status = sx_pk_list_ecc_inslots(pkreq.req, curve, 0,
-						     (struct sx_pk_slot *)&inputs);
+		pkreq.status =
+			sx_pk_list_ecc_inslots(pkreq.req, curve, 0, (struct sx_pk_slot *)&inputs);
 		if (pkreq.status) {
 			return pkreq.status;
 		}
-
-		opsz = sx_pk_curve_opsize(curve);
 
 		/* Write the private key (random) into ba414ep device memory */
 		sx_wrpkmem(inputs.k.addr, priv_key, opsz);
@@ -49,41 +50,41 @@ int ecc_create_genpubkey(const char *priv_key, char *pub_key, const struct sx_pk
 		if (status != SX_OK) {
 			return status;
 		}
-		outputs = sx_pk_get_output_ops(pkreq.req);
+		outputs = (const uint8_t **)sx_pk_get_output_ops(pkreq.req);
 
 		/* When countermeasures are used, the operation may fail with error code
 		 * SX_ERR_NOT_INVERTIBLE. In this case we can try again.
 		 */
 		if (status == SX_ERR_NOT_INVERTIBLE) {
 			sx_pk_release_req(pkreq.req);
-			if (i == MAX_ECC_ATTEMPTS) {
-				return SX_ERR_TOO_MANY_ATTEMPTS;
+			if (++attempts == MAX_ECC_ATTEMPTS) {
+				status = SX_ERR_TOO_MANY_ATTEMPTS;
 			}
-		} else {
-			break;
 		}
 	}
-	sx_rdpkmem(pub_key, outputs[0], opsz);
-	sx_rdpkmem(pub_key + opsz, outputs[1], opsz);
+	if (status == SX_OK) {
+		sx_rdpkmem(pub_key, outputs[0], opsz);
+		sx_rdpkmem(pub_key + opsz, outputs[1], opsz);
+	}
 	sx_pk_release_req(pkreq.req);
 	return status;
 }
 
-int ecc_create_genprivkey(const struct sx_pk_ecurve *curve, char *priv_key, size_t priv_key_size)
+int ecc_genprivkey(const struct sx_pk_ecurve *curve, uint8_t *priv_key, size_t priv_key_size)
 {
 	int status;
 	int opsz = sx_pk_curve_opsize(curve);
-	const char *curve_n = sx_pk_curve_order(curve);
-	size_t keysz = (size_t)sx_pk_curve_opsize(curve);
+	const uint8_t *curve_n = (const uint8_t *)sx_pk_curve_order(curve);
+	size_t key_size = (size_t)sx_pk_curve_opsize(curve);
 
-	if (priv_key_size < keysz) {
+	if (priv_key_size < key_size) {
 		return SX_ERR_OUTPUT_BUFFER_TOO_SMALL;
 	}
 
 	/* generate private key, a random number in [1, n-1], where n is the curve
 	 * order
 	 */
-	status = rndinrange_create((const unsigned char *)curve_n, opsz, priv_key);
+	status = cracen_get_rnd_in_range(curve_n, opsz, priv_key);
 
 	return status;
 }

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecc.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecc.h
@@ -8,8 +8,8 @@
 
 #include <psa/crypto.h>
 
-int ecc_create_genpubkey(const char *priv_key, char *pub_key, const struct sx_pk_ecurve *curve);
+int ecc_genpubkey(const uint8_t *priv_key, uint8_t *pub_key, const struct sx_pk_ecurve *curve);
 
-int ecc_create_genprivkey(const struct sx_pk_ecurve *curve, char *priv_key, size_t priv_key_size);
+int ecc_genprivkey(const struct sx_pk_ecurve *curve, uint8_t *priv_key, size_t priv_key_size);
 
 #endif /* ECC_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecdsa.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecdsa.c
@@ -27,24 +27,20 @@
 #include <silexpk/iomem.h>
 #include <silexpk/cmddefs/ecc.h>
 #include <cracen/statuscodes.h>
-#include "sxsymcrypt/hash.h"
-#include "cracen_psa_ecdsa.h"
-#include "cracen_psa_primitives.h"
-#include "sxsymcrypt/hashdefs.h"
+#include <sxsymcrypt/hash.h>
+#include <cracen_psa_ecdsa.h>
+#include <cracen_psa_primitives.h>
+#include <sxsymcrypt/hashdefs.h>
 #include "common.h"
 #include "hmac.h"
 
-#define INTERNAL_OCTET_NOT_USED	 ((uint8_t)0xFFu)
 #define DETERMINISTIC_HMAC_STEPS 6
-
-#ifndef MAX_ECDSA_ATTEMPTS
-#define MAX_ECDSA_ATTEMPTS 255
-#endif
+#define MAX_ECDSA_ATTEMPTS	 255
 
 typedef enum {
+	INTERNAL_OCTET_NOT_USED,
 	INTERNAL_OCTET_ZERO,
 	INTERNAL_OCTET_ONE,
-	INTERNAL_OCTET_UNUSED,
 } internal_octet_t;
 
 struct ecdsa_hmac_operation {
@@ -77,7 +73,7 @@ static int clz_u8(uint8_t i)
  * As the digest size is expressed in bytes, this procedure does not
  * work for curves which have sizes not multiples of 8 bits.
  */
-static void digest2op(const char *digest, size_t sz, char *dst, size_t opsz)
+static void digest2op(const uint8_t *digest, size_t sz, uint8_t *dst, size_t opsz)
 {
 	if (opsz > sz) {
 		sx_clrpkmem(dst, opsz - sz);
@@ -124,7 +120,7 @@ void bits2octets(const uint8_t *data, size_t data_len, uint8_t *out_data, const 
 {
 	bits2int(data, data_len, out_data, order_len * 8 - clz_u8(order[0]));
 
-	int ge = be_cmp(out_data, order, order_len, 0);
+	int ge = cracen_be_cmp(out_data, order, order_len, 0);
 
 	if (ge >= 0) {
 		uint8_t carry = 0;
@@ -144,41 +140,67 @@ void bits2octets(const uint8_t *data, size_t data_len, uint8_t *out_data, const 
 	}
 }
 
-static void ecdsa_write_pk(const char *pubkey, char *x, char *y, size_t opsz)
+static void ecdsa_write_pk(const uint8_t *pubkey, uint8_t *x, uint8_t *y, size_t opsz)
 {
 	sx_wrpkmem(x, pubkey, opsz);
 	sx_wrpkmem(y, pubkey + opsz, opsz);
 }
 
-static void ecdsa_write_sig(const struct ecdsa_signature *sig, char *r, char *s, size_t opsz)
+static void ecdsa_write_sig(const struct cracen_ecdsa_signature *sig, uint8_t *r, uint8_t *s,
+			    size_t opsz)
 {
 	sx_wrpkmem(r, sig->r, opsz);
 	sx_wrpkmem(s, sig->s, opsz);
 }
 
-static void ecdsa_write_sk(const struct ecc_priv_key *sk, char *d, size_t opsz)
+static void ecdsa_write_sk(const struct cracen_ecc_priv_key *sk, uint8_t *d, size_t opsz)
 {
 	sx_wrpkmem(d, sk->d, opsz);
 }
 
-static void ecdsa_read_sig(struct ecdsa_signature *sig, const char *r, const char *s, size_t opsz)
+static void ecdsa_read_sig(struct cracen_ecdsa_signature *sig, const uint8_t *r, const uint8_t *s,
+			   size_t opsz)
 {
-	sx_rdpkmem((char *)sig->r, (char *)r, opsz);
+	sx_rdpkmem(sig->r, r, opsz);
 	if (!sig->s) {
 		sig->s = sig->r + opsz;
 	}
-	sx_rdpkmem((char *)sig->s, (char *)s, opsz);
+	sx_rdpkmem(sig->s, s, opsz);
 }
 
-int cracen_ecdsa_sign_message(const struct ecc_priv_key *privkey, const struct sxhashalg *hashalg,
-			      const struct sx_pk_ecurve *curve, const uint8_t *message,
-			      size_t message_length, uint8_t *signature)
+static int ecdsa_run_generate_sign(struct sx_pk_acq_req *pkreq,
+				   const struct cracen_ecc_priv_key *privkey,
+				   const struct sx_pk_ecurve *curve, const uint8_t *workmem,
+				   size_t digestsz, size_t opsz,
+				   struct sx_pk_inops_ecdsa_generate *inputs)
+{
+	*pkreq = sx_pk_acquire_req(SX_PK_CMD_ECDSA_GEN);
+	if (pkreq->status) {
+		return pkreq->status;
+	}
+
+	pkreq->status = sx_pk_list_ecc_inslots(pkreq->req, curve, 0, (struct sx_pk_slot *)inputs);
+	if (pkreq->status) {
+		return pkreq->status;
+	}
+
+	ecdsa_write_sk(privkey, inputs->d.addr, opsz);
+	sx_wrpkmem(inputs->k.addr, workmem + digestsz, opsz);
+	digest2op(workmem, digestsz, inputs->h.addr, opsz);
+	sx_pk_run(pkreq->req);
+
+	return SX_OK;
+}
+
+int cracen_ecdsa_sign_message(const struct cracen_ecc_priv_key *privkey,
+			      const struct sxhashalg *hashalg, const struct sx_pk_ecurve *curve,
+			      const uint8_t *message, size_t message_length, uint8_t *signature)
 {
 	int status;
-	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
-	char digest[digestsz];
+	const size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
+	uint8_t digest[digestsz];
 
-	status = hash_input(message, message_length, hashalg, digest);
+	status = cracen_hash_input(message, message_length, hashalg, digest);
 	if (status != SX_OK) {
 		return status;
 	}
@@ -186,19 +208,19 @@ int cracen_ecdsa_sign_message(const struct ecc_priv_key *privkey, const struct s
 	return cracen_ecdsa_sign_digest(privkey, hashalg, curve, digest, digestsz, signature);
 }
 
-int cracen_ecdsa_sign_digest(const struct ecc_priv_key *privkey, const struct sxhashalg *hashalg,
-			     const struct sx_pk_ecurve *curve, const uint8_t *digest,
-			     size_t digest_length, uint8_t *signature)
+int cracen_ecdsa_sign_digest(const struct cracen_ecc_priv_key *privkey,
+			     const struct sxhashalg *hashalg, const struct sx_pk_ecurve *curve,
+			     const uint8_t *digest, size_t digest_length, uint8_t *signature)
 {
 	int status;
-	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
+	const size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
 	size_t opsz = sx_pk_curve_opsize(curve);
 	struct sx_pk_acq_req pkreq;
 	struct sx_pk_inops_ecdsa_generate inputs;
-	const char *curve_n;
-	size_t workmem_requirement = digestsz + opsz;
-	struct ecdsa_signature internal_signature = {0};
-	char workmem[workmem_requirement];
+	const uint8_t *curve_n;
+	const size_t workmem_requirement = digestsz + opsz;
+	struct cracen_ecdsa_signature internal_signature = {0};
+	uint8_t workmem[workmem_requirement];
 
 	memcpy(workmem, digest, digest_length);
 	curve_n = sx_pk_curve_order(curve);
@@ -207,32 +229,19 @@ int cracen_ecdsa_sign_digest(const struct ecc_priv_key *privkey, const struct sx
 	internal_signature.s = signature + opsz;
 
 	for (int i = 0; i <= MAX_ECDSA_ATTEMPTS; i++) {
-		status =
-			rndinrange_create((const unsigned char *)curve_n, opsz, workmem + digestsz);
+		status = cracen_get_rnd_in_range(curve_n, opsz, workmem + digestsz);
 		if (status != SX_OK) {
 			return status;
 		}
-		pkreq = sx_pk_acquire_req(SX_PK_CMD_ECDSA_GEN);
-		if (pkreq.status) {
-			return pkreq.status;
-		}
-		pkreq.status =
-			sx_pk_list_ecc_inslots(pkreq.req, curve, 0, (struct sx_pk_slot *)&inputs);
-		if (pkreq.status) {
-			return pkreq.status;
-		}
+		status = ecdsa_run_generate_sign(&pkreq, privkey, curve, workmem, digestsz, opsz,
+						 &inputs);
 
-		ecdsa_write_sk(privkey, inputs.d.addr, opsz);
-		sx_wrpkmem(inputs.k.addr, workmem + digestsz, opsz);
-		digest2op(workmem, digestsz, inputs.h.addr, opsz);
-		sx_pk_run(pkreq.req);
+		if (status != SX_OK) {
+			return status;
+		}
 		status = sx_pk_wait(pkreq.req);
 		if (status != SX_OK) {
-			return status;
-		}
-		status = sx_pk_has_finished(pkreq.req);
-		if (status == SX_ERR_BUSY) {
-			return SX_ERR_HW_PROCESSING;
+			sx_pk_release_req(pkreq.req);
 		}
 
 		/* SX_ERR_NOT_INVERTIBLE may be due to silexpk countermeasures. */
@@ -250,7 +259,7 @@ int cracen_ecdsa_sign_digest(const struct ecc_priv_key *privkey, const struct sx
 		return status;
 	}
 
-	const char **outputs = sx_pk_get_output_ops(pkreq.req);
+	const uint8_t **outputs = (const uint8_t **)sx_pk_get_output_ops(pkreq.req);
 
 	ecdsa_read_sig(&internal_signature, outputs[0], outputs[1], opsz);
 	sx_pk_release_req(pkreq.req);
@@ -259,120 +268,68 @@ int cracen_ecdsa_sign_digest(const struct ecc_priv_key *privkey, const struct sx
 	return SX_OK;
 }
 
-static int run_deterministic_ecdsa_hmac_step(const struct sxhashalg *hashalg, size_t opsz,
-					     const char *curve_n, size_t digestsz, size_t blocksz,
-					     char *workmem, struct ecdsa_hmac_operation *hmac_op,
-					     const struct ecc_priv_key *privkey);
-
 static int deterministic_ecdsa_hmac(const struct sxhashalg *hashalg, const uint8_t *key,
-				    const uint8_t *v, size_t hash_len,
-				    internal_octet_t internal_octet, const uint8_t *sk,
-				    const uint8_t *hash, size_t key_len, uint8_t *hmac);
-
-int cracen_ecdsa_sign_digest_deterministic(const struct ecc_priv_key *privkey,
-					   const struct sxhashalg *hashalg,
-					   const struct sx_pk_ecurve *curve, const uint8_t *digest,
-					   size_t digestsz, uint8_t *signature)
+				    const uint8_t *v, size_t hash_len, uint8_t internal_octet,
+				    const uint8_t *sk, const uint8_t *hash, size_t key_len,
+				    uint8_t *hmac)
 {
 	int status;
-	int attempts = MAX_ECDSA_ATTEMPTS;
-	size_t opsz = (size_t)sx_pk_curve_opsize(curve);
-	size_t blocksz = sx_hash_get_alg_blocksz(hashalg);
-	size_t workmem_requirement = digestsz * 4 + opsz + blocksz;
-	const char *curve_n = sx_pk_curve_order(curve);
-	char workmem[workmem_requirement];
+	struct sxhash hashopctx;
+	const size_t workmem_requirement =
+		sx_hash_get_alg_digestsz(hashalg) + sx_hash_get_alg_blocksz(hashalg);
+	uint8_t workmem[workmem_requirement];
 
-	struct sx_pk_acq_req pkreq;
-	struct sx_pk_inops_ecdsa_generate inputs;
-	struct ecdsa_signature internal_signature = {0};
-
-	internal_signature.r = signature;
-	internal_signature.s = signature + opsz;
-	memcpy(workmem, digest, digestsz);
-
-	do {
-		struct ecdsa_hmac_operation hmac_op = {0};
-
-		hmac_op.attempts = MAX_ECDSA_ATTEMPTS;
-
-		uint8_t *h1 = workmem + digestsz + blocksz;
-
-		memcpy(h1, workmem, digestsz);
-		while (hmac_op.step <= DETERMINISTIC_HMAC_STEPS) {
-			status = run_deterministic_ecdsa_hmac_step(hashalg, opsz, curve_n, digestsz,
-								   blocksz, workmem, &hmac_op,
-								   privkey);
-			if (status != SX_OK && status != SX_ERR_HW_PROCESSING) {
-				return status;
-			}
-		}
-
-		pkreq = sx_pk_acquire_req(SX_PK_CMD_ECDSA_GEN);
-		if (pkreq.status) {
-			return pkreq.status;
-		}
-		pkreq.status =
-			sx_pk_list_ecc_inslots(pkreq.req, curve, 0, (struct sx_pk_slot *)&inputs);
-		if (pkreq.status) {
-			return pkreq.status;
-		}
-		ecdsa_write_sk(privkey, inputs.d.addr, opsz);
-		sx_wrpkmem(inputs.k.addr, workmem + digestsz, opsz);
-		digest2op(workmem, digestsz, inputs.h.addr, opsz);
-		sx_pk_run(pkreq.req);
-		status = sx_pk_wait(pkreq.req);
-		if (status != SX_OK) {
-			sx_pk_release_req(pkreq.req);
-		}
-
-	} while ((attempts--) && ((pkreq.status == SX_ERR_INVALID_SIGNATURE) ||
-				  (pkreq.status == SX_ERR_NOT_INVERTIBLE)));
-
-	if (status == SX_OK) {
-		const char **outputs = sx_pk_get_output_ops(pkreq.req);
-
-		ecdsa_read_sig(&internal_signature, outputs[0], outputs[1], opsz);
+	status = mac_create_hmac(hashalg, &hashopctx, key, hash_len, workmem, workmem_requirement);
+	if (status != SX_OK) {
+		return status;
 	}
-
-	sx_pk_release_req(pkreq.req);
-	safe_memzero(workmem, workmem_requirement);
-
-	return status;
-}
-
-int cracen_ecdsa_sign_message_deterministic(const struct ecc_priv_key *privkey,
-					    const struct sxhashalg *hashalg,
-					    const struct sx_pk_ecurve *curve,
-					    const uint8_t *message, size_t message_length,
-					    uint8_t *signature)
-{
-	int status;
-	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
-	char digest[digestsz];
-
-	status = hash_input(message, message_length, hashalg, digest);
+	/* The hash context is initialized in mac_create_hmac */
+	status = sx_hash_feed(&hashopctx, v, hash_len);
 	if (status != SX_OK) {
 		return status;
 	}
 
-	return cracen_ecdsa_sign_digest_deterministic(privkey, hashalg, curve, digest, digestsz,
-						      signature);
+	if (internal_octet != INTERNAL_OCTET_NOT_USED) {
+		static uint8_t internal_octet_values[] = {
+			[INTERNAL_OCTET_ZERO] = 0,
+			[INTERNAL_OCTET_ONE] = 1,
+		};
+		status = sx_hash_feed(&hashopctx, &internal_octet_values[internal_octet],
+				      sizeof(*internal_octet_values));
+		if (status != SX_OK) {
+			return status;
+		}
+	}
+	if (sk) {
+		status = sx_hash_feed(&hashopctx, sk, key_len);
+		if (status != SX_OK) {
+			return status;
+		}
+	}
+	if (hash) {
+		status = sx_hash_feed(&hashopctx, hash, key_len);
+		if (status != SX_OK) {
+			return status;
+		}
+	}
+
+	return hmac_produce(&hashopctx, hashalg, hmac, hash_len, workmem);
 }
 
 static int run_deterministic_ecdsa_hmac_step(const struct sxhashalg *hashalg, size_t opsz,
-					     const char *curve_n, size_t digestsz, size_t blocksz,
-					     char *workmem, struct ecdsa_hmac_operation *hmac_op,
-					     const struct ecc_priv_key *privkey)
+					     const uint8_t *curve_n, const size_t digestsz,
+					     size_t blocksz, uint8_t *workmem,
+					     struct ecdsa_hmac_operation *hmac_op,
+					     const struct cracen_ecc_priv_key *privkey)
 {
 	int status = SX_OK;
-	uint8_t *h1 = workmem + digestsz + blocksz;
+	uint8_t *h1 = &workmem[digestsz + blocksz];
 	uint8_t *K = h1 + digestsz;
 	uint8_t *V = K + digestsz;
 	uint8_t *T = V + digestsz;
-	uint8_t step = hmac_op->step;
 	size_t copylen;
 
-	switch (step) {
+	switch (hmac_op->step) {
 	case 0: /* K = HMAC_K(V || 0x00 || privkey || h1) */
 		for (size_t i = 0; i < digestsz; i++) {
 			K[i] = 0x0; /* Initialize K = 0x00 0x00 ... */
@@ -431,7 +388,7 @@ static int run_deterministic_ecdsa_hmac_step(const struct sxhashalg *hashalg, si
 				break;
 			}
 		}
-		int ge = be_cmp(T, curve_n, opsz, 0);
+		int ge = cracen_be_cmp(T, curve_n, opsz, 0);
 		bool must_retry =
 			hmac_op->deterministic_retries < (MAX_ECDSA_ATTEMPTS - hmac_op->attempts);
 		if (is_zero || ge >= 0 || must_retry) {
@@ -448,74 +405,104 @@ static int run_deterministic_ecdsa_hmac_step(const struct sxhashalg *hashalg, si
 		memcpy(workmem + digestsz, T, opsz);
 		break;
 	}
-	default:
-		status = SX_ERR_INVALID_PARAM;
 	}
 	hmac_op->step++;
 	return status;
 }
 
-static int deterministic_ecdsa_hmac(const struct sxhashalg *hashalg, const uint8_t *key,
-				    const uint8_t *v, size_t hash_len, uint8_t internal_octet,
-				    const uint8_t *sk, const uint8_t *hash, size_t key_len,
-				    uint8_t *hmac)
+int cracen_ecdsa_sign_digest_deterministic(const struct cracen_ecc_priv_key *privkey,
+					   const struct sxhashalg *hashalg,
+					   const struct sx_pk_ecurve *curve, const uint8_t *digest,
+					   const size_t digestsz, uint8_t *signature)
 {
-
-	struct sxhash hashopctx;
-	size_t workmemsz = sx_hash_get_alg_digestsz(hashalg) + sx_hash_get_alg_blocksz(hashalg);
-	char workmem[workmemsz];
 	int status;
+	size_t opsz = (size_t)sx_pk_curve_opsize(curve);
+	size_t blocksz = sx_hash_get_alg_blocksz(hashalg);
+	const size_t workmem_requirement = digestsz * 4 + opsz + blocksz;
+	const uint8_t *curve_n = sx_pk_curve_order(curve);
+	uint8_t workmem[workmem_requirement];
 
-	status = mac_create_hmac(hashalg, &hashopctx, key, hash_len, workmem, workmemsz);
-	if (status != SX_OK) {
-		return status;
-	}
-	/* The hash function is initialized in mac_create_hmac */
-	status = sx_hash_feed(&hashopctx, v, hash_len);
-	if (status != SX_OK) {
-		return status;
-	}
+	struct sx_pk_acq_req pkreq;
+	struct sx_pk_inops_ecdsa_generate inputs;
+	struct cracen_ecdsa_signature internal_signature = {0};
+	struct ecdsa_hmac_operation hmac_op;
 
-	if (internal_octet != INTERNAL_OCTET_NOT_USED) {
+	hmac_op.attempts = MAX_ECDSA_ATTEMPTS;
 
-		static uint8_t internal_octet_values[] = {
-			[INTERNAL_OCTET_ZERO] = 0,
-			[INTERNAL_OCTET_ONE] = 1,
-			[INTERNAL_OCTET_UNUSED] = 0xFF,
+	internal_signature.r = signature;
+	internal_signature.s = signature + opsz;
+	memcpy(workmem, digest, digestsz);
 
-		};
-		uint8_t value = internal_octet_values[internal_octet];
+	do {
+		hmac_op.deterministic_retries = 0;
+		hmac_op.step = 0;
+		hmac_op.tlen = 0;
+		uint8_t *h1 = workmem + digestsz + blocksz;
 
-		status = sx_hash_feed(&hashopctx, &value, sizeof(value));
+		memcpy(h1, workmem, digestsz);
+		while (hmac_op.step <= DETERMINISTIC_HMAC_STEPS) {
+			status = run_deterministic_ecdsa_hmac_step(hashalg, opsz, curve_n, digestsz,
+								   blocksz, workmem, &hmac_op,
+								   privkey);
+			if (status != SX_OK && status != SX_ERR_HW_PROCESSING) {
+				return status;
+			}
+		}
+		status = ecdsa_run_generate_sign(&pkreq, privkey, curve, workmem, digestsz, opsz,
+						 &inputs);
+
 		if (status != SX_OK) {
 			return status;
 		}
-	}
-	if (sk) {
-		status = sx_hash_feed(&hashopctx, sk, key_len);
+		status = sx_pk_wait(pkreq.req);
+
 		if (status != SX_OK) {
-			return status;
+			sx_pk_release_req(pkreq.req);
 		}
-	}
-	if (hash) {
-		status = sx_hash_feed(&hashopctx, hash, key_len);
-		if (status != SX_OK) {
-			return status;
-		}
+
+	} while (--hmac_op.attempts &&
+		 (status == SX_ERR_INVALID_SIGNATURE || status == SX_ERR_NOT_INVERTIBLE));
+
+	if (status == SX_OK) {
+		const uint8_t **outputs = (const uint8_t **)sx_pk_get_output_ops(pkreq.req);
+
+		ecdsa_read_sig(&internal_signature, outputs[0], outputs[1], opsz);
 	}
 
-	return hmac_produce(&hashopctx, hashalg, hmac, hash_len, workmem);
+	sx_pk_release_req(pkreq.req);
+	safe_memzero(workmem, workmem_requirement);
+
+	return status;
 }
 
-int cracen_ecdsa_verify_message(const char *pubkey, const struct sxhashalg *hashalg,
+int cracen_ecdsa_sign_message_deterministic(const struct cracen_ecc_priv_key *privkey,
+					    const struct sxhashalg *hashalg,
+					    const struct sx_pk_ecurve *curve,
+					    const uint8_t *message, size_t message_length,
+					    uint8_t *signature)
+{
+	int status;
+	const size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
+	uint8_t digest[digestsz];
+
+	status = cracen_hash_input(message, message_length, hashalg, digest);
+	if (status != SX_OK) {
+		return status;
+	}
+
+	return cracen_ecdsa_sign_digest_deterministic(privkey, hashalg, curve, digest, digestsz,
+						      signature);
+}
+
+int cracen_ecdsa_verify_message(const uint8_t *pubkey, const struct sxhashalg *hashalg,
 				const uint8_t *message, size_t message_length,
 				const struct sx_pk_ecurve *curve, const uint8_t *signature)
 {
 	int status;
-	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
-	char digest[digestsz];
+	const size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
+	uint8_t digest[digestsz];
 
-	status = hash_input(message, message_length, hashalg, digest);
+	status = cracen_hash_input(message, message_length, hashalg, digest);
 	if (status != SX_OK) {
 		return status;
 	}
@@ -523,7 +510,7 @@ int cracen_ecdsa_verify_message(const char *pubkey, const struct sxhashalg *hash
 	return cracen_ecdsa_verify_digest(pubkey, digest, digestsz, curve, signature);
 }
 
-int cracen_ecdsa_verify_digest(const char *pubkey, const uint8_t *digest, size_t digestsz,
+int cracen_ecdsa_verify_digest(const uint8_t *pubkey, const uint8_t *digest, const size_t digestsz,
 			       const struct sx_pk_ecurve *curve, const uint8_t *signature)
 {
 	int status;
@@ -531,10 +518,10 @@ int cracen_ecdsa_verify_digest(const char *pubkey, const uint8_t *digest, size_t
 
 	struct sx_pk_acq_req pkreq;
 	struct sx_pk_inops_ecdsa_verify inputs;
-	struct ecdsa_signature internal_signature = {0};
+	struct cracen_ecdsa_signature internal_signature = {0};
 
-	internal_signature.r = (char *)signature;
-	internal_signature.s = (char *)signature + opsz;
+	internal_signature.r = (uint8_t *)signature;
+	internal_signature.s = (uint8_t *)signature + opsz;
 
 	pkreq = sx_pk_acquire_req(SX_PK_CMD_ECDSA_VER);
 	if (pkreq.status) {

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/hmac.c
@@ -4,7 +4,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  *
- * Workmem layout for the HMAC task:
+ * Workmem layout for the HMAC operation:
  *      1. Area used to store values obtained from processing the key.
  *         Size: hash algorithm block size.
  *      2. Area used to store the intermediate hash value.
@@ -20,7 +20,7 @@
 #include "common.h"
 
 /* xor bytes in 'buf' with a constant 'v', in place */
-static void xorbuf(char *buf, char v, size_t sz)
+static void xorbuf(uint8_t *buf, uint8_t v, size_t sz)
 {
 	for (size_t i = 0; i < sz; i++) {
 		*buf = *buf ^ v;
@@ -28,15 +28,15 @@ static void xorbuf(char *buf, char v, size_t sz)
 	}
 }
 
-int hmac_produce(struct sxhash *hashctx, const struct sxhashalg *hashalg, char *digest, size_t sz,
-		 char *workmem)
+int hmac_produce(struct sxhash *hashctx, const struct sxhashalg *hashalg, uint8_t *digest,
+		 size_t output_buffer_size, uint8_t *workmem)
 {
 	int status;
 	size_t blocksz;
 	size_t digestsz;
 
 	digestsz = sx_hash_get_alg_digestsz(hashalg);
-	if (sz < digestsz) {
+	if (output_buffer_size < digestsz) {
 		sx_hash_free(hashctx);
 		return SX_ERR_OUTPUT_BUFFER_TOO_SMALL;
 	}
@@ -57,16 +57,17 @@ int hmac_produce(struct sxhash *hashctx, const struct sxhashalg *hashalg, char *
 	/* compute K0 xor opad (0x36 ^ 0x5C = 0x6A) */
 	xorbuf(workmem, 0x6A, blocksz);
 
-	return hash_input_with_context(hashctx, workmem, blocksz + digestsz, hashalg, digest);
+	return cracen_hash_input_with_context(hashctx, workmem, blocksz + digestsz, hashalg,
+					      digest);
 }
 
 static int internal_start_hmac_computation(struct sxhash *hashopctx,
-					   const struct sxhashalg *hashalg, char *workmem)
+					   const struct sxhashalg *hashalg, uint8_t *workmem)
 {
 	int status;
 	size_t blocksz;
 
-	/* task for computing the 1st hash in the HMAC algorithm */
+	/* Create hash context for computing the 1st hash in the HMAC algorithm */
 	status = sx_hash_create(hashopctx, hashalg, sizeof(*hashopctx));
 	if (status != SX_OK) {
 		return status;
@@ -79,14 +80,14 @@ static int internal_start_hmac_computation(struct sxhash *hashopctx,
 	 */
 	xorbuf(workmem, 0x36, blocksz);
 
-	/* start feeding the hash task */
+	/* start feeding the hash operation */
 	status = sx_hash_feed(hashopctx, workmem, blocksz);
 
 	return status;
 }
 
-int mac_create_hmac(const struct sxhashalg *hashalg, struct sxhash *hashopctx, const char *key,
-		    size_t keysz, char *workmem, size_t workmemsz)
+int mac_create_hmac(const struct sxhashalg *hashalg, struct sxhash *hashopctx, const uint8_t *key,
+		    size_t keysz, uint8_t *workmem, size_t workmemsz)
 {
 	int status;
 	size_t digestsz;
@@ -100,7 +101,7 @@ int mac_create_hmac(const struct sxhashalg *hashalg, struct sxhash *hashopctx, c
 	 */
 	if (keysz > blocksz) {
 		/* hash the key */
-		status = hash_input_with_context(hashopctx, key, keysz, hashalg, workmem);
+		status = cracen_hash_input_with_context(hashopctx, key, keysz, hashalg, workmem);
 		if (status != SX_OK) {
 			return status;
 		}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/hmac.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/hmac.h
@@ -3,10 +3,16 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+#ifndef HMAC_H
+#define HMAC_H
+
 #include <psa/crypto.h>
 
-int mac_create_hmac(const struct sxhashalg *hashalg, struct sxhash *hashopctx, const char *key,
-		    size_t keysz, char *workmem, size_t workmemsz);
+int mac_create_hmac(const struct sxhashalg *hashalg, struct sxhash *hashopctx, const uint8_t *key,
+		    size_t keysz, uint8_t *workmem, size_t workmemsz);
 
-int hmac_produce(struct sxhash *hashctx, const struct sxhashalg *hashalg, char *out, size_t sz,
-		 char *workmem);
+int hmac_produce(struct sxhash *hashctx, const struct sxhashalg *hashalg, uint8_t *out, size_t sz,
+		 uint8_t *workmem);
+
+#endif /* HMAC_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ikg_signature.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ikg_signature.c
@@ -48,7 +48,7 @@ static void digest2op(const uint8_t *digest, size_t sz, uint8_t *dst, size_t ops
 	sx_wrpkmem(dst, digest, opsz);
 }
 
-static void ecdsa_read_sig(struct ecdsa_signature *sig, const uint8_t *r, const uint8_t *s,
+static void ecdsa_read_sig(struct cracen_ecdsa_signature *sig, const uint8_t *r, const uint8_t *s,
 			   size_t opsz)
 {
 	sx_rdpkmem(sig->r, r, opsz);
@@ -86,7 +86,7 @@ int cracen_ikg_sign_message(int identity_key_index, const struct sxhashalg *hash
 	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
 	uint8_t digest[digestsz];
 
-	status = hash_input(message, message_length, hashalg, digest);
+	status = cracen_hash_input(message, message_length, hashalg, digest);
 	if (status != SX_OK) {
 		return status;
 	}
@@ -106,7 +106,7 @@ int cracen_ikg_sign_digest(int identity_key_index, const struct sxhashalg *hasha
 	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
 	const uint8_t *curve_n;
 	uint8_t workmem[digestsz];
-	struct ecdsa_signature internal_signature = {0};
+	struct cracen_ecdsa_signature internal_signature = {0};
 
 	memcpy(workmem, digest, digest_length);
 	curve_n = sx_pk_curve_order(curve);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/sign.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/sign.c
@@ -140,8 +140,7 @@ static int cracen_signature_prepare_ec_pubkey(const char *key_buffer, size_t key
 				return SX_OK;
 
 			} else {
-				status = ecc_create_genpubkey(key_buffer, pubkey_buffer, *sicurve);
-				return status;
+				status = ecc_genpubkey(key_buffer, pubkey_buffer, *sicurve);
 			}
 		}
 	}
@@ -243,13 +242,12 @@ static psa_status_t handle_ecdsa_sign(bool is_message, const uint8_t *key_buffer
 				      uint8_t *signature, size_t *signature_length)
 {
 	int status;
-	struct ecc_priv_key privkey;
+	struct cracen_ecc_priv_key privkey;
 	struct sxhashalg hashalg = {0};
 	const struct sxhashalg *hashalgpointer = &hashalg;
 
-	privkey.d = (const char *)key_buffer;
+	privkey.d = key_buffer;
 	status = hash_get_algo(alg, &hashalgpointer);
-
 	if (status != PSA_SUCCESS) {
 		return status;
 	}
@@ -366,21 +364,21 @@ static psa_status_t cracen_signature_ecc_verify(bool is_message,
 		return status;
 	}
 
-	size_t public_key_size =
+	const size_t public_key_size =
 		PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(key_type, psa_get_key_bits(attributes));
 	if (public_key_size == 0) {
 		return PSA_ERROR_NOT_SUPPORTED;
 	}
 
-	char pubkey_buffer[public_key_size];
+	uint8_t pubkey_buffer[public_key_size];
 	const struct sx_pk_ecurve *curve = NULL;
 
-	int sx_status = cracen_signature_prepare_ec_pubkey(
-		(const char *)key_buffer, key_buffer_size, &curve, alg, attributes, pubkey_buffer);
+	int sx_status =
+		cracen_signature_prepare_ec_pubkey(key_buffer, key_buffer_size,
+						   &curve, alg, attributes, pubkey_buffer);
 	if (sx_status != SX_OK) {
 		return silex_statuscodes_to_psa(sx_status);
 	}
-
 	if (signature_length != 2 * curve->sz) {
 		return PSA_ERROR_INVALID_SIGNATURE;
 	}
@@ -405,18 +403,15 @@ static psa_status_t cracen_signature_ecc_verify(bool is_message,
 		if (status != PSA_SUCCESS) {
 			return status;
 		}
-
 		status = hash_get_algo(alg, &hash_algorithm_ptr);
 		if (status != PSA_SUCCESS) {
 			return status;
 		}
-
 		sx_status = is_message ? cracen_ecdsa_verify_message(pubkey_buffer,
 								     hash_algorithm_ptr, input,
 								     input_length, curve, signature)
 				       : cracen_ecdsa_verify_digest(pubkey_buffer, input,
 								    input_length, curve, signature);
-
 	} else {
 		return PSA_ERROR_NOT_SUPPORTED;
 	}

--- a/subsys/nrf_security/src/drivers/cracen/sicrypto/src/ecdsa.c
+++ b/subsys/nrf_security/src/drivers/cracen/sicrypto/src/ecdsa.c
@@ -670,6 +670,7 @@ static unsigned short int get_key_opsz(const struct si_sig_privkey *privkey)
 	return sx_pk_curve_opsize(privkey->key.eckey.curve);
 }
 
+
 const struct si_sig_def *const si_sig_def_ecdsa = &(const struct si_sig_def){
 	.sign = si_sig_create_ecdsa_sign,
 	.sign_digest = si_sig_create_ecdsa_sign_digest,

--- a/subsys/nrf_security/src/drivers/cracen/sicrypto/src/hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/sicrypto/src/hmac.c
@@ -13,6 +13,7 @@
 
 #include <string.h>
 #include <sxsymcrypt/hash.h>
+#include <sxsymcrypt/hashdefs.h>
 #include <cracen/statuscodes.h>
 #include <cracen/mem_helpers.h>
 #include "../include/sicrypto/hmac.h"

--- a/subsys/nrf_security/src/drivers/cracen/sicrypto/src/rndinrange.c
+++ b/subsys/nrf_security/src/drivers/cracen/sicrypto/src/rndinrange.c
@@ -22,7 +22,6 @@
  */
 
 #include <string.h>
-#include "../include/sicrypto/sicrypto.h"
 #include <cracen/statuscodes.h>
 #include <cracen/mem_helpers.h>
 #include <cracen_psa.h>

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hash.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hash.c
@@ -3,13 +3,14 @@
  *
  *  SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#include "../include/sxsymcrypt/hash.h"
-#include "../include/sxsymcrypt/hashdefs.h"
+#include <sxsymcrypt/hash.h>
+#include <sxsymcrypt/hashdefs.h>
+#include <sxsymcrypt/internal.h>
 #include <cracen/statuscodes.h>
-#include "../include/sxsymcrypt/internal.h"
 #include "crypmasterregs.h"
 #include "hw.h"
 #include "cmdma.h"
+#include "macdefs.h"
 
 #define BA413_HMAC_CONF (1 << 8)
 #define HASH_HW_PAD	(1 << 9)

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hmac.c
@@ -3,9 +3,9 @@
  *
  *  SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#include "../include/sxsymcrypt/hash.h"
-#include "../include/sxsymcrypt/hashdefs.h"
-#include "../include/sxsymcrypt/hmac.h"
+#include <sxsymcrypt/hash.h>
+#include <sxsymcrypt/hashdefs.h>
+#include <sxsymcrypt/hmac.h>
 #include <cracen/statuscodes.h>
 #include "crypmasterregs.h"
 #include "hw.h"

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/sha3.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/sha3.c
@@ -3,8 +3,8 @@
  *
  *  SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#include "../include/sxsymcrypt/hash.h"
-#include "../include/sxsymcrypt/hashdefs.h"
+#include <sxsymcrypt/hash.h>
+#include <sxsymcrypt/hashdefs.h>
 #include <cracen/statuscodes.h>
 #include "crypmasterregs.h"
 #include "hw.h"

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/sxsymcrypt.cmake
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/sxsymcrypt.cmake
@@ -18,5 +18,4 @@ list(APPEND cracen_driver_sources
 
 list(APPEND cracen_driver_include_dirs
     ${CMAKE_CURRENT_LIST_DIR}/include
-    ${CMAKE_CURRENT_LIST_DIR}/src
 )


### PR DESCRIPTION
Various small fixes
Refactor of names to be more consistent

Follows up on comments from: https://github.com/nrfconnect/sdk-nrf/pull/21303