### PR TITLE
log_rpc: add RPC command to sync log timestamps

### DIFF
--- a/include/logging/log_rpc.h
+++ b/include/logging/log_rpc.h
@@ -169,8 +169,26 @@ int log_rpc_get_crash_log(size_t offset, char *buffer, size_t buffer_length);
  * This function issues an nRF RPC command that requests the remote device to
  * generate a log message with the given level. This function can be used to
  * test other functions of Logging over nRF RPC library.
+ *
+ * @param level		Logging level, see @ref log_rpc_level.
+ * @param message	Log message C string.
  */
 void log_rpc_echo(enum log_rpc_level level, const char *message);
+
+/**
+ * @brief Sets the current time used for log timestamping.
+ *
+ * This function issues an nRF RPC command that configures the remote device
+ * with the current time that should be used for timestamping new log messages.
+ *
+ * @note The remote device may enable log buffering and log messages are time-
+ *	 stamped before they are enqueued in the log buffer, so this function
+ *	 may not have an immediate effect and you may still observe a few
+ *	 messages timestamped with the old time after this function exits.
+ *
+ * @param now_us	The current time in microseconds.
+ */
+void log_rpc_set_time(uint64_t now_us);
 
 #ifdef __cplusplus
 }

--- a/samples/nrf_rpc/protocols_serialization/client/src/log_rpc_shell.c
+++ b/samples/nrf_rpc/protocols_serialization/client/src/log_rpc_shell.c
@@ -182,6 +182,27 @@ static int cmd_log_rpc_echo(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_log_rpc_time(const struct shell *sh, size_t argc, char *argv[])
+{
+	int rc = 0;
+	uint64_t time_us;
+
+	if (strcmp(argv[1], "now") == 0) {
+		time_us = k_ticks_to_us_near64(k_uptime_ticks());
+	} else {
+		time_us = shell_strtoull(argv[1], 10, &rc);
+	}
+
+	if (rc) {
+		shell_error(sh, "Invalid argument: %d", rc);
+		return -EINVAL;
+	}
+
+	log_rpc_set_time(time_us);
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	log_rpc_cmds,
 	SHELL_CMD_ARG(stream_level, NULL, "Set log streaming level <0-4>", cmd_log_rpc_stream_level,
@@ -196,6 +217,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(crash, NULL, "Retrieve remote device crash log", cmd_log_rpc_crash, 1, 0),
 	SHELL_CMD_ARG(echo, NULL, "Generate log message on remote <0-4> <msg>", cmd_log_rpc_echo, 3,
 		      0),
+	SHELL_CMD_ARG(time, NULL, "Set current time <time_us|now>", cmd_log_rpc_time, 2, 0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_ARG_REGISTER(log_rpc, &log_rpc_cmds, "RPC logging commands", NULL, 1, 0);

--- a/subsys/logging/log_forwarder_rpc.c
+++ b/subsys/logging/log_forwarder_rpc.c
@@ -256,3 +256,13 @@ void log_rpc_set_history_usage_threshold(log_rpc_history_threshold_reached_handl
 	nrf_rpc_cbor_cmd_no_err(&log_rpc_group, LOG_RPC_CMD_SET_HISTORY_USAGE_THRESHOLD, &ctx,
 				nrf_rpc_rsp_decode_void, NULL);
 }
+
+void log_rpc_set_time(uint64_t now_us)
+{
+	struct nrf_rpc_cbor_ctx ctx;
+
+	NRF_RPC_CBOR_ALLOC(&log_rpc_group, ctx, 1 + sizeof(now_us));
+	nrf_rpc_encode_uint64(&ctx, now_us);
+	nrf_rpc_cbor_cmd_no_err(&log_rpc_group, LOG_RPC_CMD_SET_TIME, &ctx, nrf_rpc_rsp_decode_void,
+				NULL);
+}

--- a/subsys/logging/log_rpc_group.h
+++ b/subsys/logging/log_rpc_group.h
@@ -45,6 +45,7 @@ enum log_rpc_cmd_backend {
 	LOG_RPC_CMD_STOP_FETCH_HISTORY,
 	LOG_RPC_CMD_GET_CRASH_LOG,
 	LOG_RPC_CMD_ECHO,
+	LOG_RPC_CMD_SET_TIME,
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add RPC command to set the current time on the remote device that should be used for log timestamping.