### PR TITLE
cmake: disable c99-extension warning

### DIFF
--- a/modules/openthread/CMakeLists.txt
+++ b/modules/openthread/CMakeLists.txt
@@ -199,6 +199,7 @@ target_compile_definitions(ot-config INTERFACE
 target_compile_options(ot-config INTERFACE
     $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>
     $<TARGET_PROPERTY:compiler,no_builtin>
+    $<$<CXX_COMPILER_ID:Clang>:-Wno-c99-extensions>
     -imacros ${AUTOCONF_H}
 )
 


### PR DESCRIPTION
OpenThread defines -Wc99-extension warning to warn in case OpenThread itself tries to use GNU c99 extensions.

However, this compile option propagates to Zephyr headers when those are included in an OpenThread build. This happens through mbed TLS where NCS provides a glue for mbedTLS threading to use Zephyr's threading mechanism. Zephyr itself uses GNU c99 extensions in a few places.

Therefore, disable -Wc99-extension when building OpenThread with clang.

Note, the warning is only supported by clang and not by gcc and therefore the warning is never seen with gcc, although the same GNU c99 extensions are used in this case.