### PR TITLE
nrf_security: Allow to enable MBEDTLS_X509_CRT_WRITE_C.

### DIFF
--- a/subsys/nrf_security/Kconfig.tls
+++ b/subsys/nrf_security/Kconfig.tls
@@ -60,6 +60,11 @@ config MBEDTLS_X509_CSR_WRITE_C
 	help
 	  Enable creating X.509 Certificate Signing Requests (CSR).
 
+config MBEDTLS_X509_CRT_WRITE_C
+	bool "X.509 - CRT writing"
+	help
+	  Enable creating X.509 Certificates (CRT).
+
 config MBEDTLS_X509_REMOVE_INFO
 	bool "X.509 - Remove info"
 	default y

--- a/subsys/nrf_security/cmake/legacy_crypto_config.cmake
+++ b/subsys/nrf_security/cmake/legacy_crypto_config.cmake
@@ -122,6 +122,7 @@ kconfig_check_and_set_base(MBEDTLS_X509_CRL_PARSE_C)
 kconfig_check_and_set_base(MBEDTLS_X509_CRT_PARSE_C)
 kconfig_check_and_set_base(MBEDTLS_X509_CSR_PARSE_C)
 kconfig_check_and_set_base(MBEDTLS_X509_CSR_WRITE_C)
+kconfig_check_and_set_base(MBEDTLS_X509_CRT_WRITE_C)
 kconfig_check_and_set_base(MBEDTLS_X509_REMOVE_INFO)
 
 kconfig_check_and_set_base(MBEDTLS_SSL_CLI_C)


### PR DESCRIPTION
Allows to enable MBEDTLS_X509_CRT_WRITE_C as we need this in our application and the ".c" file is actually
built.