### PR TITLE
[Backport v3.0-branch] cmake: disable c99-extension warning

### DIFF
--- a/modules/openthread/CMakeLists.txt
+++ b/modules/openthread/CMakeLists.txt
@@ -199,6 +199,7 @@ target_compile_definitions(ot-config INTERFACE
 target_compile_options(ot-config INTERFACE
     $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>
     $<TARGET_PROPERTY:compiler,no_builtin>
+    $<$<CXX_COMPILER_ID:Clang>:-Wno-c99-extensions>
     -imacros ${AUTOCONF_H}
 )
 


### PR DESCRIPTION
Backport 055626798b3c26a210a3fbe1ccce90630367eccd from #21604.