### PR TITLE
tests: current_consumption: nrf54l: add test for Errata 30 workaround

### DIFF
--- a/tests/benchmarks/current_consumption/nrf54l_errata30_idle/CMakeLists.txt
+++ b/tests/benchmarks/current_consumption/nrf54l_errata30_idle/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(nrf54l_errata30_idle)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/benchmarks/current_consumption/nrf54l_errata30_idle/prj.conf
+++ b/tests/benchmarks/current_consumption/nrf54l_errata30_idle/prj.conf
@@ -1,0 +1,9 @@
+CONFIG_CONSOLE=n
+CONFIG_UART_CONSOLE=n
+CONFIG_SERIAL=n
+
+# Enable periodic HFINT calibration to activate Errata 30 workaround
+CONFIG_CLOCK_CONTROL_NRF_HFINT_CALIBRATION=y
+# Make calibration period low so it impacts power consumption.
+# This should be much higher for actual application.
+CONFIG_CLOCK_CONTROL_NRF_HFINT_CALIBRATION_PERIOD=300

--- a/tests/benchmarks/current_consumption/nrf54l_errata30_idle/src/main.c
+++ b/tests/benchmarks/current_consumption/nrf54l_errata30_idle/src/main.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+
+int main(void)
+{
+	/* Return immediately - sleep forever */
+	return 0;
+}

--- a/tests/benchmarks/current_consumption/nrf54l_errata30_idle/testcase.yaml
+++ b/tests/benchmarks/current_consumption/nrf54l_errata30_idle/testcase.yaml
@@ -1,0 +1,18 @@
+common:
+  sysbuild: true
+  tags:
+    - ci_tests_benchmarks_current_consumption
+    - ppk_power_measure
+tests:
+  benchmarks.current_consumption.nrf54l_errata30_idle:
+    platform_allow:
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    harness: pytest
+    harness_config:
+      fixture: ppk_power_measure
+      pytest_root:
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_clock_calibration_54l"


### PR DESCRIPTION
Workaround for nRF54L Errata 30 might negatively impact power consumption. Create a test to verify it.