### PR TITLE
applications: nrf_desktop: Workaround nrf52840dk mcuboot_smp boot fail

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_mcuboot_smp.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_mcuboot_smp.conf
@@ -33,9 +33,9 @@ CONFIG_NCS_BOOT_BANNER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Activate Link Time Optimization (LTO)
-CONFIG_LTO=y
-CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+# Disable Link Time Optimization (LTO). LTO causes application boot failures.
+CONFIG_LTO=n
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=n
 
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n


### PR DESCRIPTION
Change disables MCUboot LTO to workaround application boot failures.

Jira: NCSDK-32981