### PR TITLE
Fix some C++ related build issues found.

### DIFF
--- a/include/dfu/dfu_target_full_modem.h
+++ b/include/dfu/dfu_target_full_modem.h
@@ -139,6 +139,10 @@ int dfu_target_full_modem_schedule_update(int img_num);
  */
 int dfu_target_full_modem_reset(void);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* DFU_TARGET_FULL_MODEM_H__ */
 
 /**@} */

--- a/include/net/nrf_cloud_alert.h
+++ b/include/net/nrf_cloud_alert.h
@@ -136,6 +136,7 @@ bool nrf_cloud_alert_control_get(void);
 /** @} */
 
 #ifdef __cplusplus
+}
 #endif
 
 #endif /* NRF_CLOUD_ALERT_H_ */


### PR DESCRIPTION
Fixes two header files where the C++ extern "C" guard is either incomplete or partially missing
leading to a build error.