### PR TITLE
[Backport v3.0-branch] applications: serial_lte_modem: doc: Improve PIN assignment instructions

### DIFF
--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -594,7 +594,10 @@ Use the following UART configuration:
 
 .. note::
    The GPIO output level on the nRF91 Series device side must be 3 V.
-   You can set the VDD voltage with the **VDD IO** switch (**SW9**).
+
+   For nRF91x1 DK, you can set the VDD voltage with the `Board Configurator app`_.
+
+   For nRF9160 DK, you can set the VDD voltage with the **VDD IO** switch (**SW9**).
    See the `VDD supply rail section in the nRF9160 DK User Guide`_ for more information related to nRF9160 DK.
 
 .. _slm_connecting_thingy91:

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -559,31 +559,58 @@ To connect with an external MCU using UART_2, change the configuration files for
              pinctrl-names = "default", "sleep";
           };
 
-The following table shows how to connect an nRF52 Series development kit to an nRF91 Series development kit to be able to communicate through UART:
+The following table shows how to connect selected development kit to an nRF91 Series development kit to be able to communicate through UART:
 
-.. list-table::
-   :align: center
-   :header-rows: 1
+.. tabs::
 
-   * - nRF52 Series DK
-     - nRF91 Series DK
-   * - UART TX P0.6
-     - UART RX P0.11
-   * - UART RX P0.8
-     - UART TX P0.10
-   * - UART CTS P0.7
-     - UART RTS P0.12
-   * - UART RTS P0.5
-     - UART CTS P0.13
-   * - GPIO OUT P0.27
-     - GPIO IN P0.31
-   * - GPIO IN P0.26
-     - GPIO OUT P0.30
+   .. group-tab:: nRF52 DK
+
+      .. list-table::
+         :header-rows: 1
+
+         * - nRF52 Series DK
+           - nRF91 Series DK
+         * - UART TX P1.02
+           - UART RX P0.11
+         * - UART RX P1.01
+           - UART TX P0.10
+         * - UART CTS P1.06
+           - UART RTS P0.12
+         * - UART RTS P1.07
+           - UART CTS P0.13
+         * - GPIO OUT P0.11
+           - GPIO IN P0.31
+         * - GPIO IN P0.13
+           - GPIO OUT P0.30
+         * - GPIO GND
+           - GPIO GND
+
+   .. group-tab:: nRF53 DK
+
+      .. list-table::
+         :header-rows: 1
+
+         * - nRF53 Series DK
+           - nRF91 Series DK
+         * - UART TX P1.04
+           - UART RX P0.11
+         * - UART RX P1.05
+           - UART TX P0.10
+         * - UART CTS P1.06
+           - UART RTS P0.12
+         * - UART RTS P1.07
+           - UART CTS P0.13
+         * - GPIO OUT P0.23
+           - GPIO IN P0.31
+         * - GPIO IN P0.28
+           - GPIO OUT P0.30
+         * - GPIO GND
+           - GPIO GND
 
 Use the following UART devices:
 
-* nRF52840 or nRF52832 - UART0
-* nRF9160 or nRF91x1 - UART2
+* nRF52 or nRF53 Series DK - UART0
+* nRF91 Series DK - UART2
 
 Use the following UART configuration:
 
@@ -595,10 +622,9 @@ Use the following UART configuration:
 .. note::
    The GPIO output level on the nRF91 Series device side must be 3 V.
 
-   For nRF91x1 DK, you can set the VDD voltage with the `Board Configurator app`_.
-
-   For nRF9160 DK, you can set the VDD voltage with the **VDD IO** switch (**SW9**).
-   See the `VDD supply rail section in the nRF9160 DK User Guide`_ for more information related to nRF9160 DK.
+   * For nRF91x1 DK, you can set the VDD voltage with the `Board Configurator app`_.
+   * For nRF9160 DK, you can set the VDD voltage with the **VDD IO** switch (**SW9**).
+     See the `VDD supply rail section in the nRF9160 DK User Guide`_ for more information related to nRF9160 DK.
 
 .. _slm_connecting_thingy91:
 

--- a/doc/nrf/libraries/modem/modem_slm.rst
+++ b/doc/nrf/libraries/modem/modem_slm.rst
@@ -66,7 +66,10 @@ The library sends the termination character automatically after an AT command.
 Shell usage
 ***********
 
-To send AT commands in shell, use the following syntax:
+SLM
+---
+
+Send AT commands for SLM in shell:
 
   .. code-block:: console
 
@@ -82,6 +85,27 @@ To send AT commands in shell, use the following syntax:
      OK
 
 SLM accepts AT command characters in upper, lower, or mixed case.
+
+Host
+----
+
+Use ``slmsh`` command to see commands for the Modem SLM library functions.
+
+Request toggling of the power pin from the Modem SLM library to put the SLM device to sleep and then wake it up:
+
+  .. code-block:: console
+
+     uart:~$ slmsh powerpin
+     [00:00:17.973,510] <inf> mdm_slm: Enable power pin
+     [00:00:18.078,887] <inf> mdm_slm: Disable power pin
+
+     uart:~$ slmsh powerpin
+     [00:00:33.038,604] <inf> mdm_slm: Enable power pin
+     [00:00:33.143,951] <inf> mdm_slm: Disable power pin
+     Ready
+
+     [00:00:34.538,513] <inf> app: Data received (len=7): Ready
+     uart:~$
 
 SLM Monitor usage
 *****************

--- a/samples/cellular/slm_shell/README.rst
+++ b/samples/cellular/slm_shell/README.rst
@@ -7,88 +7,99 @@ Cellular: SLM Shell
    :local:
    :depth: 2
 
-The SLM Shell sample demonstrates how to send AT commands to modem through the :ref:`Serial LTE Modem <slm_description>` application running on nRF9160 SiP.
+The SLM Shell sample demonstrates how to send AT commands to modem through the :ref:`Serial LTE Modem <slm_description>` application running on nRF91 Series SiP.
 This sample enables an external MCU to send modem or SLM proprietary AT commands for LTE connection and IP services.
+See more information on the functionality of this sample from the :ref:`lib_modem_slm` library, which provides the core functionality for this sample.
 
 Requirements
 ************
 
-The SLM application should be configured to use UART_2 on the nRF9160 side with no hardware flow control.
+The SLM application should be configured to use UART_2 on the nRF91 Series DK side with no hardware flow control.
 
 The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
-Connect the DK with a nRF9160 DK based on the pin configuration in DTS overlay files of both sides.
+Connect the DK with an nRF91 Series DK based on the pin configuration in DTS overlay files of both sides.
 
-The following table shows how to connect PCA10056 UART_1 to nRF9160 UART_2 for communication through UART:
+The following table shows how to connect UART_1 of the DK to the nRF91 Series DK's UART_2 for communication through UART:
 
-.. list-table::
-   :align: center
-   :header-rows: 1
+.. tabs::
 
-   * - nRF52840 DK
-     - nRF9160 DK
-   * - UART TX P1.02
-     - UART RX P0.11
-   * - UART RX P1.01
-     - UART TX P0.10
-   * - GPIO OUT P0.11 (Button1)
-     - GPIO IN P0.31
-   * - GPIO IN P0.13 (LED1 optional)
-     - GPIO OUT P0.30 (optional)
-   * - GPIO GND
-     - GPIO GND
+   .. group-tab:: nRF52840 DK
 
-.. note::
-   The GPIO output level on the nRF9160 side must be 3 V to work with the nRF52 series DK.
-   You can set the VDD voltage with the **VDD IO** switch (**SW9**).
+      .. list-table::
+         :header-rows: 1
 
-The following table shows how to connect PCA10095 UART_2 to nRF9160 UART_2 for communication through UART:
+         * - nRF52840 DK
+           - nRF91 Series DK
+         * - UART TX P1.02
+           - UART RX P0.11
+         * - UART RX P1.01
+           - UART TX P0.10
+         * - GPIO OUT P0.11 (Button1)
+           - GPIO IN P0.31
+         * - GPIO IN P0.13 (LED1 optional)
+           - GPIO OUT P0.30 (optional)
+         * - GPIO GND
+           - GPIO GND
 
-.. list-table::
-   :align: center
-   :header-rows: 1
+      .. note::
+         The GPIO output level on the nRF91 Series device side must be 3 V to work with the nRF52 Series DK.
 
-   * - nRF5340 DK
-     - nRF9160 DK
-   * - UART TX P1.04
-     - UART RX P0.11
-   * - UART RX P1.05
-     - UART TX P0.10
-   * - GPIO OUT P0.23 (Button1)
-     - GPIO IN P0.31
-   * - GPIO IN P0.28 (LED1 optional)
-     - GPIO OUT P0.30 (optional)
-   * - GPIO GND
-     - GPIO GND
+         * For nRF91x1 DK, you can set the VDD voltage with the `Board Configurator app`_.
+         * For nRF9160 DK, you can set the VDD voltage with the **VDD IO** switch (**SW9**).
+           See the `VDD supply rail section in the nRF9160 DK User Guide`_ for more information related to nRF9160 DK.
 
-.. note::
-   The GPIO output level on the nRF9160 side must be 3 V to work with the nRF53 series DK.
-   You can set the VDD voltage with the **VDD IO** switch (**SW9**).
+   .. group-tab:: nRF5340 DK
 
-The following table shows how to connect PCA10143 UART_2 to nRF9160 UART_2 for communication through UART:
+      .. list-table::
+         :header-rows: 1
 
-.. list-table::
-   :align: center
-   :header-rows: 1
+         * - nRF5340 DK
+           - nRF91 Series DK
+         * - UART TX P1.04
+           - UART RX P0.11
+         * - UART RX P1.05
+           - UART TX P0.10
+         * - GPIO OUT P0.23 (Button1)
+           - GPIO IN P0.31
+         * - GPIO IN P0.28 (LED1 optional)
+           - GPIO OUT P0.30 (optional)
+         * - GPIO GND
+           - GPIO GND
 
-   * - nRF7002 DK
-     - nRF9160 DK
-   * - UART TX P1.04
-     - UART RX P0.11
-   * - UART RX P1.05
-     - UART TX P0.10
-   * - GPIO OUT P0.31
-     - GPIO IN P0.31
-   * - GPIO IN P0.30 (optional)
-     - GPIO OUT P0.30 (optional)
-   * - GPIO GND
-     - GPIO GND
+      .. note::
+         The GPIO output level on the nRF91 Series device side must be 3 V to work with the nRF53 Series DK.
 
-.. note::
-   The GPIO output level on the nRF9160 side must be 1.8 V to work with the nRF70 series DK.
-   You can set the VDD voltage with the **VDD IO** switch (**SW9**).
+         * For nRF91x1 DK, you can set the VDD voltage with the `Board Configurator app`_.
+         * For nRF9160 DK, you can set the VDD voltage with the **VDD IO** switch (**SW9**).
+           See the `VDD supply rail section in the nRF9160 DK User Guide`_ for more information related to nRF9160 DK
+
+   .. group-tab:: nRF7002 DK
+
+      .. list-table::
+         :header-rows: 1
+
+         * - nRF7002 DK
+           - nRF91 Series DK
+         * - UART TX P1.04
+           - UART RX P0.11
+         * - UART RX P1.05
+           - UART TX P0.10
+         * - GPIO OUT P0.31
+           - GPIO IN P0.31
+         * - GPIO IN P0.30 (optional)
+           - GPIO OUT P0.30 (optional)
+         * - GPIO GND
+           - GPIO GND
+
+      .. note::
+         The GPIO output level on the nRF91 Series device side must be 1.8 V to work with the nRF7002 DK.
+
+         * For nRF91x1 DK, you can set the VDD voltage with the `Board Configurator app`_.
+         * For nRF9160 DK, you can set the VDD voltage with the **VDD IO** switch (**SW9**).
+           See the `VDD supply rail section in the nRF9160 DK User Guide`_ for more information related to nRF9160 DK.
 
 References
 **********


### PR DESCRIPTION
Backport 66bb9d9c7812300cd57addc09cc5d06ee59ed1e9~4..66bb9d9c7812300cd57addc09cc5d06ee59ed1e9 from #21464.