### PR TITLE
samples: matter: lock: Add workaround for TC-DRLK 2.3

### DIFF
--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -216,17 +216,25 @@ void AppTask::UpdateClusterStateHandler(const BoltLockManager::StateData &stateD
 
 		Nullable<uint16_t> userId;
 		Nullable<List<const LockOpCredentials>> credentials;
+/* Don't pass credentials to SetLockState until TC-DRLK-2.3 is fixed.
+   https://github.com/project-chip/connectedhomeip/issues/38222 */
+#if 0
 		List<const LockOpCredentials> credentialList;
+#endif
 
 		if (!stateData.mValidatePINResult.IsNull()) {
 			userId = { stateData.mValidatePINResult.Value().mUserId };
 
+/* Don't pass credentials to SetLockState until TC-DRLK-2.3 is fixed.
+   https://github.com/project-chip/connectedhomeip/issues/38222 */
+#if 0
 			/* `DoorLockServer::SetLockState` exptects list of `LockOpCredentials`,
 			   however in case of PIN validation it makes no sense to have more than one
 			   credential corresponding to validation result. For simplicity we wrap single
 			   credential in list here. */
 			credentialList = { &stateData.mValidatePINResult.Value().mCredential, 1 };
 			credentials = { credentialList };
+#endif
 		}
 
 		if (!DoorLockServer::Instance().SetLockState(kLockEndpointId, newLockState, stateData.mSource, userId,


### PR DESCRIPTION
Don't pass credentials to `DoorLockServer::SetLockState` until project-chip/connectedhomeip#38222 is fixed.