### PR TITLE
[v3.0-branch] clang: Fix multiple warnings

### DIFF
--- a/subsys/net/openthread/rpc/server/ot_rpc_netdiag.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_netdiag.c
@@ -72,6 +72,7 @@ static size_t ot_rpc_network_diag_tlv_size(otNetworkDiagTlv *aNetworkDiagTlv)
 static void ot_rpc_encode_network_diag_tlv(struct nrf_rpc_cbor_ctx *ctx,
 					   otNetworkDiagTlv *aNetworkDiagTlv)
 {
+	uint8_t mode;
 	nrf_rpc_encode_uint(ctx, aNetworkDiagTlv->mType);
 
 	switch (aNetworkDiagTlv->mType) {
@@ -83,7 +84,7 @@ static void ot_rpc_encode_network_diag_tlv(struct nrf_rpc_cbor_ctx *ctx,
 		nrf_rpc_encode_buffer(ctx, aNetworkDiagTlv->mData.mEui64.m8, OT_EXT_ADDRESS_SIZE);
 		break;
 	case OT_NETWORK_DIAGNOSTIC_TLV_MODE:
-		uint8_t mode = 0;
+		mode = 0;
 
 		WRITE_BIT(mode, 0, aNetworkDiagTlv->mData.mMode.mRxOnWhenIdle);
 		WRITE_BIT(mode, 1, aNetworkDiagTlv->mData.mMode.mDeviceType);
@@ -210,7 +211,7 @@ static void ot_rpc_encode_network_diag_tlv(struct nrf_rpc_cbor_ctx *ctx,
 		nrf_rpc_encode_uint(ctx, aNetworkDiagTlv->mData.mChildTable.mCount);
 		zcbor_list_start_encode(ctx->zs, aNetworkDiagTlv->mData.mChildTable.mCount);
 		for (int i = 0; i < aNetworkDiagTlv->mData.mChildTable.mCount; i++) {
-			uint8_t mode = 0;
+			mode = 0;
 
 			nrf_rpc_encode_uint(ctx,
 				aNetworkDiagTlv->mData.mChildTable.mTable[i].mTimeout);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecdsa.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ecdsa.c
@@ -370,6 +370,7 @@ static int run_deterministic_ecdsa_hmac_step(const struct sxhashalg *hashalg, si
 	uint8_t *V = K + digestsz;
 	uint8_t *T = V + digestsz;
 	uint8_t step = hmac_op->step;
+	size_t copylen;
 
 	switch (step) {
 	case 0: /* K = HMAC_K(V || 0x00 || privkey || h1) */
@@ -404,7 +405,7 @@ static int run_deterministic_ecdsa_hmac_step(const struct sxhashalg *hashalg, si
 		break;
 
 	case 5: /* T = T || V */
-		size_t copylen = MIN(digestsz, opsz - hmac_op->tlen);
+		copylen = MIN(digestsz, opsz - hmac_op->tlen);
 
 		memcpy(T + hmac_op->tlen, V, copylen);
 		hmac_op->tlen += copylen;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -500,44 +500,61 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 	psa_set_key_usage_flags(key_attr, usage_flags);
 
 	switch (metadata->algorithm) {
+#ifdef CONFIG_PSA_WANT_ALG_STREAM_CIPHER
 	case METADATA_ALG_CHACHA20:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_CHACHA20);
 		psa_set_key_algorithm(key_attr, PSA_ALG_STREAM_CIPHER);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305
 	case METADATA_ALG_CHACHA20_POLY1305:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_CHACHA20);
 		psa_set_key_algorithm(key_attr, PSA_ALG_CHACHA20_POLY1305);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_GCM
 	case METADATA_ALG_AES_GCM:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_GCM);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CCM
 	case METADATA_ALG_AES_CCM:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_CCM);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_ECB_NO_PADDING
 	case METADATA_ALG_AES_ECB:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_ECB_NO_PADDING);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CTR
 	case METADATA_ALG_AES_CTR:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_CTR);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CBC_NO_PADDING
 	case METADATA_ALG_AES_CBC:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_CBC_NO_PADDING);
 		break;
-#ifdef PSA_ALG_SP800_108_COUNTER_CMAC
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC
 	case METADATA_ALG_SP800_108_COUNTER_CMAC:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_SP800_108_COUNTER_CMAC);
 		break;
 #endif
+#ifdef CONFIG_PSA_WANT_ALG_CMAC
 	case METADATA_ALG_CMAC:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
 		psa_set_key_algorithm(key_attr, PSA_ALG_CMAC);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_PURE_EDDSA
 	case METADATA_ALG_ED25519:
 		/* If the key can sign it is assumed it is a private key */
 		psa_set_key_type(
@@ -547,6 +564,8 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 				: PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_TWISTED_EDWARDS));
 		psa_set_key_algorithm(key_attr, PSA_ALG_PURE_EDDSA);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_ED25519PH
 	case METADATA_ALG_ED25519PH:
 		/* If the key can sign it is assumed it is a private key */
 		psa_set_key_type(
@@ -556,6 +575,8 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 				: PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_TWISTED_EDWARDS));
 		psa_set_key_algorithm(key_attr, PSA_ALG_ED25519PH);
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_ECDSA
 	case METADATA_ALG_ECDSA:
 		psa_set_key_type(key_attr,
 				 can_sign(key_attr)
@@ -563,10 +584,13 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 					 : PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_SECP_R1));
 		psa_set_key_algorithm(key_attr, PSA_ALG_ECDSA(PSA_ALG_ANY_HASH));
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_HMAC
 	case METADATA_ALG_HMAC:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_HMAC);
 		psa_set_key_algorithm(key_attr, PSA_ALG_HMAC(PSA_ALG_SHA_256));
 		break;
+#endif
 	default:
 		return PSA_ERROR_HARDWARE_FAILURE;
 	}
@@ -641,49 +665,63 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 	}
 
 	switch (psa_get_key_algorithm(key_attr)) {
+#ifdef CONFIG_PSA_WANT_ALG_STREAM_CIPHER
 	case PSA_ALG_STREAM_CIPHER:
 		metadata->algorithm = METADATA_ALG_CHACHA20;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_CHACHA20) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305
 	case PSA_ALG_CHACHA20_POLY1305:
 		metadata->algorithm = METADATA_ALG_CHACHA20_POLY1305;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_CHACHA20) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_GCM
 	case PSA_ALG_GCM:
 		metadata->algorithm = METADATA_ALG_AES_GCM;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CCM
 	case PSA_ALG_CCM:
 		metadata->algorithm = METADATA_ALG_AES_CCM;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_ECB_NO_PADDING
 	case PSA_ALG_ECB_NO_PADDING:
 		metadata->algorithm = METADATA_ALG_AES_ECB;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CTR
 	case PSA_ALG_CTR:
 		metadata->algorithm = METADATA_ALG_AES_CTR;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_CBC_NO_PADDING
 	case PSA_ALG_CBC_NO_PADDING:
 		metadata->algorithm = METADATA_ALG_AES_CBC;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		break;
-#ifdef PSA_ALG_SP800_108_COUNTER_CMAC
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC
 	case PSA_ALG_SP800_108_COUNTER_CMAC:
 		metadata->algorithm = METADATA_ALG_SP800_108_COUNTER_CMAC;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
@@ -691,6 +729,7 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		}
 		break;
 #endif
+#ifdef CONFIG_PSA_WANT_ALG_CMAC
 	case PSA_ALG_CMAC:
 		metadata->algorithm = METADATA_ALG_CMAC;
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
@@ -698,6 +737,22 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		}
 		break;
 
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_ED25519PH
+	case PSA_ALG_ED25519PH:
+		if (PSA_KEY_TYPE_ECC_GET_FAMILY(psa_get_key_type(key_attr)) !=
+		    PSA_ECC_FAMILY_TWISTED_EDWARDS) {
+			return PSA_ERROR_NOT_SUPPORTED;
+		}
+		/* Don't support private keys that are only used for verify */
+		if (!can_sign(key_attr) &&
+		    PSA_KEY_TYPE_IS_ECC_KEY_PAIR(psa_get_key_type(key_attr))) {
+			return PSA_ERROR_NOT_SUPPORTED;
+		}
+		metadata->algorithm = METADATA_ALG_ED25519PH;
+		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_PURE_EDDSA
 	case PSA_ALG_PURE_EDDSA:
 		if (PSA_KEY_TYPE_ECC_GET_FAMILY(psa_get_key_type(key_attr)) !=
 		    PSA_ECC_FAMILY_TWISTED_EDWARDS) {
@@ -710,20 +765,8 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		}
 		metadata->algorithm = METADATA_ALG_ED25519;
 		break;
-
-	case PSA_ALG_ED25519PH:
-		if (PSA_KEY_TYPE_ECC_GET_FAMILY(psa_get_key_type(key_attr)) !=
-		PSA_ECC_FAMILY_TWISTED_EDWARDS) {
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		/* Don't support private keys that are only used for verify */
-		if (!can_sign(key_attr) &&
-			PSA_KEY_TYPE_IS_ECC_KEY_PAIR(psa_get_key_type(key_attr))) {
-			return PSA_ERROR_NOT_SUPPORTED;
-		}
-		metadata->algorithm = METADATA_ALG_ED25519PH;
-	break;
-
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_ECDSA
 	case PSA_ALG_ECDSA(PSA_ALG_ANY_HASH):
 	case PSA_ALG_ECDSA(PSA_ALG_SHA_256):
 		if (PSA_KEY_TYPE_ECC_GET_FAMILY(psa_get_key_type(key_attr)) !=
@@ -738,12 +781,15 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		}
 		metadata->algorithm = METADATA_ALG_ECDSA;
 		break;
+#endif
+#ifdef CONFIG_PSA_WANT_ALG_HMAC
 	case PSA_ALG_HMAC(PSA_ALG_SHA_256):
 		if (!can_sign(key_attr) && PSA_ALG_IS_HMAC(psa_get_key_type(key_attr))) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
 		metadata->algorithm = METADATA_ALG_HMAC;
 		break;
+#endif
 	default:
 		return PSA_ERROR_NOT_SUPPORTED;
 	}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -294,11 +294,14 @@ static psa_status_t get_kmu_slot_id_and_metadata(mbedtls_svc_key_id_t key_id,
 	return read_primary_slot_metadata(*slot_id, metadata);
 }
 
+#if defined(CONFIG_PSA_WANT_ALG_PURE_EDDSA) || defined(CONFIG_PSA_WANT_ALG_ED25519PH) || \
+	defined CONFIG_PSA_WANT_ALG_ECDSA || defined(CONFIG_PSA_WANT_ALG_HMAC)
 static bool can_sign(const psa_key_attributes_t *key_attr)
 {
 	return (psa_get_key_usage_flags(key_attr) & PSA_KEY_USAGE_SIGN_MESSAGE) ||
 	       (psa_get_key_usage_flags(key_attr) & PSA_KEY_USAGE_SIGN_HASH);
 }
+#endif /* defined(CONFIG_PSA_WANT_ALG_PURE_EDDSA) || define(CONFIG_PSA_WANT_ALG_ED25519PH) */
 
 /**
  * @brief Check provisioning state, and delete slots that were not completely provisioned.

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/sign.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/sign.c
@@ -38,6 +38,7 @@
 #define SI_PSA_IS_KEY_FLAG(flag, attr) ((flag) == (psa_get_key_usage_flags((attr)) & (flag)))
 #define SI_PSA_IS_KEY_TYPE(flag, attr) ((flag) == (psa_get_key_type((attr)) & (flag)))
 
+#if PSA_MAX_RSA_KEY_BITS > 0
 static int cracen_signature_set_hashalgo(const struct sxhashalg **hashalg, psa_algorithm_t alg)
 {
 	return hash_get_algo(PSA_ALG_SIGN_GET_HASH(alg), hashalg);
@@ -81,6 +82,7 @@ static int cracen_signature_set_hashalgo_from_digestsz(const struct sxhashalg **
 
 	return SX_OK;
 }
+#endif /* PSA_MAX_RSA_KEY_BITS > 0 */
 
 static int cracen_signature_prepare_ec_prvkey(struct si_sig_privkey *privkey, char *key_buffer,
 					      size_t key_buffer_size,

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 9ad6673058ccaee61f976bcb3d6d203be94bfdc7
+      revision: 4ff1c3616aeecb52617d87bfdf2da0435f36fb17
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -144,7 +144,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: b90a6248dcb5caa7e8b17d1e24b01703508170e4
+      revision: 5f9842bf8fa8e1ed1883c1e65e7a61fcb1c7e4e2
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Backport of #21616

Including backport of https://github.com/nrfconnect/sdk-nrf/pull/21099 to match other clang warning backport fixes.