### PR TITLE
applications: nrf5340_audio: Print broadcast_ID when starting source

### DIFF
--- a/applications/nrf5340_audio/broadcast_source/main.c
+++ b/applications/nrf5340_audio/broadcast_source/main.c
@@ -610,7 +610,13 @@ int main(void)
 				per_adv_buf_cnt, false);
 	ERR_CHK_MSG(ret, "Failed to start first advertiser");
 
-	LOG_INF("Broadcast source: %s started", CONFIG_BT_AUDIO_BROADCAST_NAME);
+	uint32_t broadcast_id = 0;
+
+	ret = broadcast_source_id_get(0, &broadcast_id);
+	ERR_CHK_MSG(ret, "Failed to get broadcast ID");
+
+	LOG_INF("Broadcast source: %s started, ID: 0x%06x", CONFIG_BT_AUDIO_BROADCAST_NAME,
+		broadcast_id);
 
 	return 0;
 }

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -198,9 +198,10 @@ Matter bridge
 
 nRF5340 Audio
 -------------
-* Updated:
 
-  * The application to use the ``NFC.TAGHEADER0`` value from FICR as the broadcast ID instead of using a random ID.
+* Added print of broadcast ID when starting a :ref:`broadcast source <nrf53_audio_broadcast_source_app>`.
+
+* Updated the application to use the ``NFC.TAGHEADER0`` value from FICR as the broadcast ID instead of using a random ID.
 
 nRF Desktop
 -----------


### PR DESCRIPTION
- Get and print broadcast ID when source is started
- OCT-3254