### PR TITLE
Nrfx none improve test filter

### DIFF
--- a/samples/zephyr/drivers/jesd216/sample.yaml
+++ b/samples/zephyr/drivers/jesd216/sample.yaml
@@ -14,6 +14,8 @@ common:
 tests:
   sample.drivers.spi.jesd216.sqspi:
     filter: CONFIG_MSPI_SQSPI and dt_compat_enabled("jedec,mspi-nor")
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:

--- a/samples/zephyr/drivers/spi_flash/sample.yaml
+++ b/samples/zephyr/drivers/spi_flash/sample.yaml
@@ -17,6 +17,8 @@ common:
 tests:
   sample.drivers.spi.flash.sqspi:
     filter: CONFIG_MSPI_SQSPI and dt_compat_enabled("jedec,mspi-nor")
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:


### PR DESCRIPTION
Current filter doesn't work as expected.
Samples are build for nrf54l20pdk and nrf54l09pdk.
After applying
boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
devicetree error is reported - undefined node label 'mx25r64'.

Add platform_allow section.
Limit execution of the sample to nrf54l15dk only.