### PR TITLE
bluetooth: services: Set RTT estimate to NAN if negative

### DIFF
--- a/subsys/bluetooth/cs_de/cs_de.c
+++ b/subsys/bluetooth/cs_de/cs_de.c
@@ -272,7 +272,9 @@ static void calculate_dist_rtt(cs_de_report_t *p_report)
 		float rtt_distance_m = tof_ns * (SPEED_OF_LIGHT_M_PER_S / 1e9f);
 
 		for (uint8_t ap = 0; ap < p_report->n_ap; ap++) {
-			p_report->distance_estimates[ap].rtt = rtt_distance_m;
+			if (rtt_distance_m >= 0.0f) {
+				p_report->distance_estimates[ap].rtt = rtt_distance_m;
+			}
 		}
 	}
 }


### PR DESCRIPTION
With the new MLT 2.1 metal fix we've observed that changes in internal delays have caused us to produce negative TOF in some cases.

It's not possible for users to make sense of such results. To avoid confusion we should set these as bad.