### PR TITLE
[Backport v3.0-branch] lib: Implied NRF_FORCE_RAM_ON_REBOOT by RAM_POWER_DOWN_LIBRARY

### DIFF
--- a/lib/ram_pwrdn/Kconfig
+++ b/lib/ram_pwrdn/Kconfig
@@ -11,6 +11,7 @@ menuconfig RAM_POWER_DOWN_LIBRARY
 	# for security reasons. If necessary, this limitation could be
 	# addressed by a secure service in the future.
 	depends on ! BUILD_WITH_TFM
+	imply NRF_FORCE_RAM_ON_REBOOT
 	help
 	  This allows application to call API for disabling unused RAM segments
 	  in the System ON mode. Effectively the application looses possibility

--- a/samples/matter/light_switch/boards/nrf5340dk_nrf5340_cpuapp_release.conf
+++ b/samples/matter/light_switch/boards/nrf5340dk_nrf5340_cpuapp_release.conf
@@ -1,8 +1,0 @@
-#
-# Copyright (c) 2024 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-# Do not enable RAM power-down library for nRF5340 DK due to DFU failures.
-CONFIG_RAM_POWER_DOWN_LIBRARY=n

--- a/samples/matter/light_switch/boards/nrf7002dk_nrf5340_cpuapp_release.conf
+++ b/samples/matter/light_switch/boards/nrf7002dk_nrf5340_cpuapp_release.conf
@@ -1,8 +1,0 @@
-#
-# Copyright (c) 2024 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-# Do not enable RAM power-down library for nRF7002 DK due to incompatible WiFi configuration.
-CONFIG_RAM_POWER_DOWN_LIBRARY=n

--- a/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp_release.conf
+++ b/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp_release.conf
@@ -1,8 +1,0 @@
-#
-# Copyright (c) 2024 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-# Do not enable RAM power-down library for nRF5340 DK due to DFU failures.
-CONFIG_RAM_POWER_DOWN_LIBRARY=n

--- a/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp_release.conf
+++ b/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp_release.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Do not enable RAM power-down library for nRF7002 DK due to incompatible WiFi configuration.
-CONFIG_RAM_POWER_DOWN_LIBRARY=n
-
 # Enable LTO to decrease the flash usage.
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/samples/matter/lock/prj_thread_wifi_switched.conf
+++ b/samples/matter/lock/prj_thread_wifi_switched.conf
@@ -56,6 +56,3 @@ CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
 # Enforce the use of mbedTLS crypto backend instead of PSA Crypto by
 # building OpenThread from sources. Wi-Fi stack does not support PSA Crypto yet.
 CONFIG_OPENTHREAD_SOURCES=y
-
-# Do not enable RAM power-down library for nRF7002 DK due to incompatible WiFi configuration.
-CONFIG_RAM_POWER_DOWN_LIBRARY=n

--- a/samples/matter/smoke_co_alarm/boards/nrf5340dk_nrf5340_cpuapp_release.conf
+++ b/samples/matter/smoke_co_alarm/boards/nrf5340dk_nrf5340_cpuapp_release.conf
@@ -1,8 +1,0 @@
-#
-# Copyright (c) 2024 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-# Do not enable RAM power-down library for nRF5340 DK due to DFU failures.
-CONFIG_RAM_POWER_DOWN_LIBRARY=n

--- a/samples/matter/window_covering/boards/nrf5340dk_nrf5340_cpuapp_release.conf
+++ b/samples/matter/window_covering/boards/nrf5340dk_nrf5340_cpuapp_release.conf
@@ -1,8 +1,0 @@
-#
-# Copyright (c) 2024 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-# Do not enable RAM power-down library for nRF5340 DK due to DFU failures.
-CONFIG_RAM_POWER_DOWN_LIBRARY=n


### PR DESCRIPTION
Backport a582b9997c1b0e6cd459e389063ac4042c6c569f from #21640.