### PR TITLE
manifest: bump sdk-mcuboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: d995e3e3bca389c8bbeef00c22c0f1221ef30bbb
+      revision: 31bcbd8084d2f8af6fc8fbb234824d0868e6af07
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
brings fix which  allows to build MCUboot for nrf7002dk/nrf5340/cpuapp
with default configuration.