### PR TITLE
tests: benchmarks: Test BT advertising with different VDDH for nrf54h

### DIFF
--- a/tests/benchmarks/current_consumption/beacon_vs_vddh/CMakeLists.txt
+++ b/tests/benchmarks/current_consumption/beacon_vs_vddh/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(beacon_vs_vddh)
+
+target_sources(app PRIVATE $ENV{ZEPHYR_BASE}/samples/bluetooth/beacon/src/main.c)

--- a/tests/benchmarks/current_consumption/beacon_vs_vddh/prj.conf
+++ b/tests/benchmarks/current_consumption/beacon_vs_vddh/prj.conf
@@ -1,0 +1,3 @@
+CONFIG_BT=y
+CONFIG_LOG=y
+CONFIG_BT_DEVICE_NAME="Test beacon"

--- a/tests/benchmarks/current_consumption/beacon_vs_vddh/testcase.yaml
+++ b/tests/benchmarks/current_consumption/beacon_vs_vddh/testcase.yaml
@@ -1,0 +1,20 @@
+common:
+  sysbuild: true
+  tags:
+    - ci_tests_benchmarks_current_consumption
+    - ppk_power_measure
+    - bluetooth
+tests:
+  benchmarks.current_consumption.beacon_vs_vddh:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - SB_CONFIG_NETCORE_IPC_RADIO=y
+      - SB_CONFIG_NETCORE_IPC_RADIO_BT_HCI_IPC=y
+    harness: pytest
+    harness_config:
+      fixture: ppk_power_measure
+      pytest_root:
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_power_consumption_beacon_vs_vddh_nrf54h"


### PR DESCRIPTION

Check advertising startup and average current consumption.