### PR TITLE
nrf_security: Fix for PSA MAC context in Cracen

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
@@ -190,7 +190,7 @@ struct cracen_mac_operation_s {
 	size_t bytes_left_for_next_block;
 
 	/* Buffer for input data to fill up the next block */
-	uint8_t input_buffer[SX_HASH_MAX_ENABLED_BLOCK_SIZE];
+	uint8_t input_buffer[SX_MAX(SX_HASH_MAX_ENABLED_BLOCK_SIZE, SX_BLKCIPHER_PRIV_SZ)];
 
 	union {
 		struct {
@@ -214,7 +214,7 @@ struct cracen_key_derivation_operation {
 	psa_algorithm_t alg;
 	enum cracen_kd_state state;
 	uint64_t capacity;
-	uint8_t output_block[SX_HASH_MAX_ENABLED_BLOCK_SIZE];
+	uint8_t output_block[SX_MAX(SX_HASH_MAX_ENABLED_BLOCK_SIZE, SX_BLKCIPHER_PRIV_SZ)];
 	uint8_t output_block_available_bytes;
 	union{
 		cracen_mac_operation_t mac_op;

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/internal.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/internal.h
@@ -21,6 +21,8 @@ extern "C" {
 #define SX_BLKCIPHER_PRIV_SZ (16)
 #define SX_AEAD_PRIV_SZ	     (70)
 
+#define SX_MAX(p, q) ((p >= q) ? p : q)
+
 /** Mode Register value for context loading */
 #define BA417_MODEID_CTX_LOAD (1u << 5)
 /** Mode Register value for context saving */


### PR DESCRIPTION
There is an input_buffer in the Cracen MAC driver
which is used to store intermediate data when needed. The size of this buffer was chosen based on the maximum hash block size. Since there was some hash optimizations merged earlier the maximum hash block size can now be 1 and this is problematic for cases where only CMAC is being used.

This fixes this by setting the buffer accortingly when only CMAC is enabled.