### PR TITLE
samples: matter: lock: Add Kconfig for passing credentials to SetLockState

### DIFF
--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -22,6 +22,12 @@ config LOCK_MAX_CREDENTIAL_LENGTH
 	int "Maximum length of the single credential supported by the lock"
 	default 10
 
+config LOCK_PASS_CREDENTIALS_TO_SET_LOCK_STATE
+	bool "Pass used credentials when setting the lock state"
+	help
+	  This option should stay disabled until TC-DRLK-2.3 is fixed.
+	  Related issue: https://github.com/project-chip/connectedhomeip/issues/38222
+
 config LOCK_SCHEDULES
 	bool "Support for WeekDay, YearDay and Holiday schedules in lock"
 	help

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -216,18 +216,14 @@ void AppTask::UpdateClusterStateHandler(const BoltLockManager::StateData &stateD
 
 		Nullable<uint16_t> userId;
 		Nullable<List<const LockOpCredentials>> credentials;
-/* Don't pass credentials to SetLockState until TC-DRLK-2.3 is fixed.
-   https://github.com/project-chip/connectedhomeip/issues/38222 */
-#if 0
+#ifdef CONFIG_LOCK_PASS_CREDENTIALS_TO_SET_LOCK_STATE
 		List<const LockOpCredentials> credentialList;
 #endif
 
 		if (!stateData.mValidatePINResult.IsNull()) {
 			userId = { stateData.mValidatePINResult.Value().mUserId };
 
-/* Don't pass credentials to SetLockState until TC-DRLK-2.3 is fixed.
-   https://github.com/project-chip/connectedhomeip/issues/38222 */
-#if 0
+#ifdef CONFIG_LOCK_PASS_CREDENTIALS_TO_SET_LOCK_STATE
 			/* `DoorLockServer::SetLockState` exptects list of `LockOpCredentials`,
 			   however in case of PIN validation it makes no sense to have more than one
 			   credential corresponding to validation result. For simplicity we wrap single


### PR DESCRIPTION
Replace `#if 0` with Kconfig.

This is a follow-up to #21654.