### PR TITLE
manifest: update zephyr to contain nrf21540 tx-en timing fix

### DIFF
--- a/doc/nrf/app_dev/device_guides/fem/fem_nrf21540_gpio.rst
+++ b/doc/nrf/app_dev/device_guides/fem/fem_nrf21540_gpio.rst
@@ -84,7 +84,11 @@ To use nRF21540 in GPIO mode, complete the following steps:
    The nRF54L devices contain only four PPIB channels between PERI Power Domain and Low Power Domain.
    Due to this limitation, only two out of three pins from group ``tx-en-gpios``, ``rx-en-gpios`` and ``pdn-gpios`` (for example, ``tx-en-gpios`` and ``rx-en-gpios``) can be controlled by GPIO P0.
    Select other GPIO port for the one remaining pin of the pin group (for example ``pdn-gpios``).
-   To ensure proper timing, set the ``tx-en-settle-time-us`` and ``rx-en-settle-time-us`` devicetree properties of the ``nrf_radio_fem`` node to the value ``12``.
+   To ensure proper timing, set the following devicetree properties of the ``nrf_radio_fem`` node:
+
+   * ``tx-en-settle-time-us`` to the value ``27``.
+   * ``rx-en-settle-time-us`` to the value ``12``.
+
    Enable appropriate instances of the ``DPPIC`` and ``PPIB`` peripherals in the devicetree file:
 
    .. code-block:: devicetree

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 59a8d2d1692d43086c0343e9ba87a800a2e93bc4
+      revision: 4575fc863ae46dc0f65593cb741660ddab1ba344
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This PR brings Zephyr with updated default `tx-en-settle-time-us` for the nrf21540 FEM to fix the spurious emission issue.