### PR TITLE
[Backport v3.0-branch] Nrfx none improve test filter

### DIFF
--- a/samples/zephyr/drivers/jesd216/sample.yaml
+++ b/samples/zephyr/drivers/jesd216/sample.yaml
@@ -14,6 +14,8 @@ common:
 tests:
   sample.drivers.spi.jesd216.sqspi:
     filter: CONFIG_MSPI_SQSPI and dt_compat_enabled("jedec,mspi-nor")
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:

--- a/samples/zephyr/drivers/spi_flash/sample.yaml
+++ b/samples/zephyr/drivers/spi_flash/sample.yaml
@@ -17,6 +17,8 @@ common:
 tests:
   sample.drivers.spi.flash.sqspi:
     filter: CONFIG_MSPI_SQSPI and dt_compat_enabled("jedec,mspi-nor")
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:


### PR DESCRIPTION
Backport 9ba5ae2ed7933d122c34d917b384986c9fe24485~2..9ba5ae2ed7933d122c34d917b384986c9fe24485 from #21672.