### PR TITLE
test: zephyr: drivers: i2s: Add testing with audiopll

### DIFF
--- a/tests/zephyr/drivers/i2s/i2s_api/boards/tdm_audiopll.overlay
+++ b/tests/zephyr/drivers/i2s/i2s_api/boards/tdm_audiopll.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&tdm130 {
+	clock-source = "ACLK";
+};
+
+&audiopll {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/i2s/i2s_api/testcase.yaml
+++ b/tests/zephyr/drivers/i2s/i2s_api/testcase.yaml
@@ -22,3 +22,13 @@ tests:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+
+  nrf.extended.drivers.i2s.i2s_api.gpio_loopback.54h.audiopll:
+    harness_config:
+      fixture: i2s_loopback
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="boards/tdm_audiopll.overlay"

--- a/tests/zephyr/drivers/i2s/i2s_speed/boards/tdm_audiopll.overlay
+++ b/tests/zephyr/drivers/i2s/i2s_speed/boards/tdm_audiopll.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&tdm130 {
+	clock-source = "ACLK";
+};
+
+&audiopll {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/i2s/i2s_speed/testcase.yaml
+++ b/tests/zephyr/drivers/i2s/i2s_speed/testcase.yaml
@@ -22,3 +22,13 @@ tests:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+
+  nrf.extended.drivers.i2s.i2s_speed.gpio_loopback.54h.audiopll:
+    harness_config:
+      fixture: i2s_loopback
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="boards/tdm_audiopll.overlay"


### PR DESCRIPTION
Add testcase with audioPLL enabled for nRF54H20 appcore.