### PR TITLE
manifest: update sdk-mcuboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 4a10c05b2a133333a301676ff87ec8ac02947448
+      revision: pull/418/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Introduces version which disables UARTE pins cleanup on nRF54l SoCs.