### PR TITLE
tests: fix unstable KMU revocation test on nrf54l15

### DIFF
--- a/tests/subsys/kmu/pytest/test_kmu_revoke_in_app.py
+++ b/tests/subsys/kmu/pytest/test_kmu_revoke_in_app.py
@@ -10,11 +10,7 @@ from pathlib import Path
 import pytest
 from twister_harness import DeviceAdapter
 from twister_harness.helpers.utils import match_lines, match_no_lines, find_in_config
-from common import (
-    provision_keys_for_kmu,
-    reset_board,
-    APP_KEYS_FOR_KMU
-)
+from common import provision_keys_for_kmu, reset_board, APP_KEYS_FOR_KMU
 
 logger = logging.getLogger(__name__)
 
@@ -25,30 +21,32 @@ def test_kmu_policy_revokable(dut: DeviceAdapter):
     revoke keys and verify that the device does not boot.
     """
     logger.info("Provision keys with 'revokable' policy")
-    sysbuild_config = Path(dut.device_config.build_dir) / 'zephyr' / '.config'
-    key_file = find_in_config(sysbuild_config, 'SB_CONFIG_BOOT_SIGNATURE_KEY_FILE')
+    sysbuild_config = Path(dut.device_config.build_dir) / "zephyr" / ".config"
+    key_file = find_in_config(sysbuild_config, "SB_CONFIG_BOOT_SIGNATURE_KEY_FILE")
     provision_keys_for_kmu(
         keys=[key_file],
         keyname="UROT_PUBKEY",
-        policy='revokable',
-        dev_id=dut.device_config.id
+        policy="revokable",
+        dev_id=dut.device_config.id,
     )
     dut.clear_buffer()
     reset_board(dut.device_config.id)
 
     lines = dut.readlines_until(
-        regex='Unable to find bootable image|Destroy ok',
-        print_output=True, timeout=20)
-    match_lines(lines, ['Destroy ok'])
-    match_no_lines(lines, ['Unable to find bootable image'])
+        regex="Unable to find bootable image|Destroy ok", print_output=True, timeout=20
+    )
+    match_lines(lines, ["Destroy ok"])
+    match_no_lines(lines, ["Unable to find bootable image"])
     logger.info("Revoked keys, reboot once again")
 
     dut.clear_buffer()
     reset_board(dut.device_config.id)
     lines = dut.readlines_until(
-        regex='Unable to find bootable image|Destroy ok|Destroy failed',
-        print_output=True, timeout=20)
-    match_lines(lines, ['Unable to find bootable image'])
+        regex="Unable to find bootable image|Image version",
+        print_output=True,
+        timeout=20,
+    )
+    match_lines(lines, ["Unable to find bootable image"])
     logger.info("Passed: not booted with revoked keys")
 
 
@@ -59,36 +57,38 @@ def test_kmu_policy_lock(dut: DeviceAdapter):
     and the device boots successfully.
     """
     logger.info("Provision keys with 'lock' policy")
-    sysbuild_config = Path(dut.device_config.build_dir) / 'zephyr' / '.config'
-    key_file = find_in_config(sysbuild_config, 'SB_CONFIG_BOOT_SIGNATURE_KEY_FILE')
+    sysbuild_config = Path(dut.device_config.build_dir) / "zephyr" / ".config"
+    key_file = find_in_config(sysbuild_config, "SB_CONFIG_BOOT_SIGNATURE_KEY_FILE")
     provision_keys_for_kmu(
         keys=[key_file],
         keyname="UROT_PUBKEY",
-        policy='lock',
-        dev_id=dut.device_config.id
+        policy="lock",
+        dev_id=dut.device_config.id,
     )
     dut.clear_buffer()
     reset_board(dut.device_config.id)
 
     lines = dut.readlines_until(
-        regex='Unable to find bootable image|Destroy ok|Destroy failed',
-        print_output=True, timeout=20)
-    match_lines(lines, ['Destroy failed'])
-    match_no_lines(lines, ['Unable to find bootable image'])
+        regex="Unable to find bootable image|Destroy ok|Destroy failed",
+        print_output=True,
+        timeout=20,
+    )
+    match_lines(lines, ["Destroy failed"])
+    match_no_lines(lines, ["Unable to find bootable image"])
     logger.info("Keys not destroyed, reboot once again")
 
     dut.clear_buffer()
     reset_board(dut.device_config.id)
     lines = dut.readlines_until(
-        regex='Unable to find bootable image|Destroy ok|Destroy failed',
-        print_output=True, timeout=20)
-    match_no_lines(lines, ['Unable to find bootable image'])
+        regex="Unable to find bootable image|Destroy ok|Destroy failed",
+        print_output=True,
+        timeout=20,
+    )
+    match_no_lines(lines, ["Unable to find bootable image"])
     logger.info("Passed: locked keys not destroyed, booted successfully")
 
 
-@pytest.mark.parametrize(
-    'test_option', ['use_last_key', 'use_revoked_key']
-)
+@pytest.mark.parametrize("test_option", ["use_last_key", "use_revoked_key"])
 def test_kmu_policy_lock_last(dut: DeviceAdapter, test_option):
     """
     Upload keys using 'lock-last' policy,
@@ -97,48 +97,52 @@ def test_kmu_policy_lock_last(dut: DeviceAdapter, test_option):
     and not booted if revoked key is used.
     """
     logger.info("Provision keys with revokable policy")
-    sysbuild_config = Path(dut.device_config.build_dir) / 'zephyr' / '.config'
-    key_file = find_in_config(sysbuild_config, 'SB_CONFIG_BOOT_SIGNATURE_KEY_FILE')
+    sysbuild_config = Path(dut.device_config.build_dir) / "zephyr" / ".config"
+    key_file = find_in_config(sysbuild_config, "SB_CONFIG_BOOT_SIGNATURE_KEY_FILE")
 
-    if test_option == 'use_last_key':
+    if test_option == "use_last_key":
         keys = [
-            APP_KEYS_FOR_KMU / 'root-ed25519-1.pem',
-            APP_KEYS_FOR_KMU / 'root-ed25519-2.pem',
-            key_file
+            APP_KEYS_FOR_KMU / "root-ed25519-1.pem",
+            APP_KEYS_FOR_KMU / "root-ed25519-2.pem",
+            key_file,
         ]
     else:
         keys = [
             key_file,
-            APP_KEYS_FOR_KMU / 'root-ed25519-1.pem',
-            APP_KEYS_FOR_KMU / 'root-ed25519-2.pem'
+            APP_KEYS_FOR_KMU / "root-ed25519-1.pem",
+            APP_KEYS_FOR_KMU / "root-ed25519-2.pem",
         ]
 
     provision_keys_for_kmu(
         keys=keys,
         keyname="UROT_PUBKEY",
-        policy='lock-last',
-        dev_id=dut.device_config.id
+        policy="lock-last",
+        dev_id=dut.device_config.id,
     )
     dut.clear_buffer()
     reset_board(dut.device_config.id)
 
     lines = dut.readlines_until(
-        regex='Unable to find bootable image|Destroy failed',
-        print_output=True, timeout=20)
-    match_lines(lines, ['Destroy ok', 'Destroy failed'])
-    match_no_lines(lines, ['Unable to find bootable image'])
+        regex="Unable to find bootable image|Destroy failed",
+        print_output=True,
+        timeout=20,
+    )
+    match_lines(lines, ["Destroy ok", "Destroy failed"])
+    match_no_lines(lines, ["Unable to find bootable image"])
     logger.info("Revoked keys but not all, reboot once again")
 
     dut.clear_buffer()
     reset_board(dut.device_config.id)
 
     lines = dut.readlines_until(
-        regex='Unable to find bootable image|Destroy ok|Destroy failed',
-        print_output=True, timeout=20)
+        regex="Unable to find bootable image|Destroy ok|Destroy failed",
+        print_output=True,
+        timeout=20,
+    )
 
-    if test_option == 'use_last_key':
-        match_no_lines(lines, ['Unable to find bootable image'])
+    if test_option == "use_last_key":
+        match_no_lines(lines, ["Unable to find bootable image"])
         logger.info("Passed: last key not destroyed, booted successfully")
     else:
-        match_lines(lines, ['Unable to find bootable image'])
+        match_lines(lines, ["Unable to find bootable image"])
         logger.info("Passed: not booted with revoked key")


### PR DESCRIPTION
The tests were occasionally failing due to timing issues between buffer clearing and board reset operations. In some instances, a "Destroy failed" message would be received after calling clear_buffer() but before reset_board() completed. This message was incorrectly matched, causing the test to not wait for the actual expected response, resulting in false negative test results.