### PR TITLE
[Backport v3.0-branch] samples: wifi: coex: Fix shield configuration for CPUNET

### DIFF
--- a/samples/wifi/ble_coex/README.rst
+++ b/samples/wifi/ble_coex/README.rst
@@ -170,12 +170,14 @@ Add the following SHIELD options for the nRF7002 EK and nRF7001 EK.
   .. code-block:: console
 
      -Dble_coex_SHIELD="nrf7002ek;nrf7002ek_coex"
+     -Dipc_radio_SHIELD="nrf7002ek_coex"
 
 * For nRF7001 EK:
 
   .. code-block:: console
 
      -Dble_coex_SHIELD="nrf7002ek_nrf7001;nrf7002ek_coex"
+     -Dipc_radio_SHIELD="nrf7002ek_coex"
 
 The generated HEX file to be used is :file:`ble_coex/build/merged.hex`.
 

--- a/samples/wifi/ble_coex/sample.yaml
+++ b/samples/wifi/ble_coex/sample.yaml
@@ -52,6 +52,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     extra_args:
       - ble_coex_SHIELD="nrf7002ek;nrf7002ek_coex"
+      - ipc_radio_SHIELD="nrf7002ek_coex"
       - CONFIG_MPSL_CX=y
       - ipc_radio_CONFIG_MPSL_CX=y
       - CONFIG_COEX_SEP_ANTENNAS=y
@@ -67,6 +68,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     extra_args:
       - ble_coex_SHIELD="nrf7002ek_nrf7001;nrf7002ek_coex"
+      - ipc_radio_SHIELD="nrf7002ek_coex"
       - CONFIG_MPSL_CX=y
       - ipc_radio_CONFIG_MPSL_CX=y
       - CONFIG_COEX_SEP_ANTENNAS=y

--- a/samples/wifi/thread_coex/README.rst
+++ b/samples/wifi/thread_coex/README.rst
@@ -157,12 +157,14 @@ Add the following SHIELD options for the nRF7002 EK and nRF7001 EK.
   .. code-block:: console
 
      -Dthread_coex_SHIELD="nrf7002ek;nrf7002ek_coex"
+     -Dipc_radio_SHIELD="nrf7002ek_coex"
 
 * For nRF7001 EK:
 
   .. code-block:: console
 
      -Dthread_coex_SHIELD="nrf7002ek_nrf7001;nrf7002ek_coex"
+     -Dipc_radio_SHIELD="nrf7002ek_coex"
 
 * Overlay files
 

--- a/samples/wifi/thread_coex/sample.yaml
+++ b/samples/wifi/thread_coex/sample.yaml
@@ -39,6 +39,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     extra_args:
       - thread_coex_SHIELD="nrf7002ek;nrf7002ek_coex"
+      - ipc_radio_SHIELD="nrf7002ek_coex"
       - CONFIG_MPSL_CX=y
       - ipc_radio_CONFIG_MPSL_CX=y
       - CONFIG_COEX_SEP_ANTENNAS=y
@@ -55,6 +56,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     extra_args:
       - thread_coex_SHIELD="nrf7002ek_nrf7001;nrf7002ek_coex"
+      - ipc_radio_SHIELD="nrf7002ek_coex"
       - CONFIG_MPSL_CX=y
       - ipc_radio_CONFIG_MPSL_CX=y
       - CONFIG_COEX_SEP_ANTENNAS=y


### PR DESCRIPTION
Backport 8191bcc5039aea89f92385062fa9db85deacc855 from #21649.