### PR TITLE
treewide: cellular: add support for debug sectags

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -595,7 +595,7 @@ static int handle_at_udp_client(enum at_parser_cmd_type cmd_type, struct at_pars
 
 			if (param_count > 4) {
 				if (at_parser_num_get(parser, 4, &proxy.sec_tag)
-				|| proxy.sec_tag == INVALID_SEC_TAG || proxy.sec_tag < 0) {
+				|| proxy.sec_tag == INVALID_SEC_TAG) {
 					return -EINVAL;
 				}
 			}

--- a/samples/cellular/http_update/modem_delta_update/src/main.c
+++ b/samples/cellular/http_update/modem_delta_update/src/main.c
@@ -287,7 +287,7 @@ static int update_download(void)
 	int err;
 	const char *file;
 	int sec_tag = SEC_TAG;
-	uint8_t sec_tag_count = sec_tag < 0 ? 0 : 1;
+	uint8_t sec_tag_count = 1;
 
 	err = modem_info_string_get(MODEM_INFO_FW_VERSION, modem_version,
 				    MAX_MODEM_VERSION_LEN);

--- a/samples/cellular/http_update/modem_full_update/src/main.c
+++ b/samples/cellular/http_update/modem_full_update/src/main.c
@@ -429,7 +429,7 @@ static int update_download(void)
 	int err;
 	const char *file;
 	int sec_tag = SEC_TAG;
-	uint8_t sec_tag_count = sec_tag < 0 ? 0 : 1;
+	uint8_t sec_tag_count = 1;
 	const struct dfu_target_full_modem_params params = {
 		.buf = fmfu_buf,
 		.len = sizeof(fmfu_buf),

--- a/samples/cellular/modem_shell/src/sock/sock.c
+++ b/samples/cellular/modem_shell/src/sock/sock.c
@@ -260,7 +260,7 @@ static int sock_validate_parameters(
 			return -EINVAL;
 		}
 
-		if (sec_tag < 0) {
+		if (sec_tag == -1) {
 			mosh_error("Security tag must be given when security is enabled");
 			return -EINVAL;
 		}

--- a/samples/cellular/modem_shell/src/sock/sock_shell.c
+++ b/samples/cellular/modem_shell/src/sock/sock_shell.c
@@ -433,7 +433,7 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 	int arg_bind_port = 0;
 	int arg_pdn_cid = 0;
 	bool arg_secure = false;
-	uint32_t arg_sec_tag = 0;
+	uint32_t arg_sec_tag = -1;
 	bool arg_session_cache = false;
 	bool arg_keep_open = false;
 	int arg_peer_verify = 2;

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -601,7 +601,7 @@ int fota_download_start(const char *host, const char *file, int sec_tag, uint8_t
 			size_t fragment_size)
 {
 	int sec_tag_list[1] = { sec_tag };
-	uint8_t sec_tag_count = sec_tag < 0 ? 0 : 1;
+	uint8_t sec_tag_count = 1;
 
 	return fota_download_any(host, file, sec_tag_list, sec_tag_count, pdn_id, fragment_size);
 }
@@ -611,7 +611,7 @@ int fota_download_start_with_image_type(const char *host, const char *file,
 					const enum dfu_target_image_type expected_type)
 {
 	int sec_tag_list[1] = { sec_tag };
-	uint8_t sec_tag_count = sec_tag < 0 ? 0 : 1;
+	uint8_t sec_tag_count = 1;
 
 	return fota_download(host, file, sec_tag_list, sec_tag_count, pdn_id, fragment_size,
 			     expected_type);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
@@ -875,7 +875,7 @@ static int start_job(struct nrf_cloud_fota_job *const job, const bool send_evt)
 		.path = job->info.path,
 		.dl_host_conf = {
 			.sec_tag_list = &sec_tag,
-			.sec_tag_count = (sec_tag < 0 ? 0 : 1),
+			.sec_tag_count = 1,
 			.pdn_id = 0,
 			.range_override = CONFIG_NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE,
 		},

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_poll.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_poll.c
@@ -535,7 +535,7 @@ static int start_download(void)
 		.path = job.path,
 		.dl_host_conf = {
 			.sec_tag_list = &sec_tag,
-			.sec_tag_count = (sec_tag < 0 ? 0 : 1),
+			.sec_tag_count = 1,
 			.pdn_id = 0,
 			.range_override =
 				ctx_ptr->fragment_size


### PR DESCRIPTION
nRF91 modems support special sectags to trace TLS ephemeral keys,
but these checks mark those as invalid.
This patch removes checks and changes some of them to check for -1,
which is not one of the debug sectags.