### PR TITLE
[Backport v3.0-branch] sysbuild/Kconfig.mcuboot: allow to disable external crypoto usage

### DIFF
--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -473,10 +473,12 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
         if(SB_CONFIG_SOC_SERIES_NRF54LX)
           set_config_bool(mcuboot CONFIG_BOOT_ECDSA_TINYCRYPT y)
         else()
-          add_overlay_config(
-            mcuboot
-            ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/zephyr/external_crypto.conf
-            )
+          if(SB_CONFIG_BOOT_SHARED_CRYPTO_ECDSA_P256)
+            add_overlay_config(
+              mcuboot
+              ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/zephyr/external_crypto.conf
+              )
+            endif()
         endif()
       else()
         message(WARNING "MCUboot and secure boot (application core) are enabled but MCUboot signing key type is not set to ECDSA-P256, this is a non-optimal configuration")

--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -169,6 +169,12 @@ config MCUBOOT_SIGNATURE_USING_KMU
 	help
 	  The device needs to be provisioned with proper set of keys.
 
+config BOOT_SHARED_CRYPTO_ECDSA_P256
+	bool "Use external crypto from NSIB for ECDSA P256 signature"
+	depends on SECURE_BOOT_APPCORE && SECURE_BOOT_SIGNATURE_TYPE_ECDSA
+	depends on BOOT_SIGNATURE_TYPE_ECDSA_P256 && !SOC_SERIES_NRF54LX
+	default y
+
 endif
 
 config MCUBOOT_USE_ALL_AVAILABLE_RAM


### PR DESCRIPTION
Backport 115d4d77fc3aa6746dc51d7c624dfe205c01aa2d from #21432.