### PR TITLE
dts: common: nordic: nrf54lm20a: Add CS radio capability

### DIFF
--- a/dts/common/nordic/nrf54lm20a.dtsi
+++ b/dts/common/nordic/nrf54lm20a.dtsi
@@ -227,6 +227,7 @@
 				ieee802154-supported;
 				ble-2mbps-supported;
 				ble-coded-phy-supported;
+				cs-supported;
 
 				ieee802154: ieee802154 {
 					compatible = "nordic,nrf-ieee802154";


### PR DESCRIPTION
The radio in this product supports channel sounding.