### PR TITLE
[Backport v3.0-branch] nrf_security: Fix for PSA MAC context in Cracen

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
@@ -190,7 +190,7 @@ struct cracen_mac_operation_s {
 	size_t bytes_left_for_next_block;
 
 	/* Buffer for input data to fill up the next block */
-	uint8_t input_buffer[SX_HASH_MAX_ENABLED_BLOCK_SIZE];
+	uint8_t input_buffer[SX_MAX(SX_HASH_MAX_ENABLED_BLOCK_SIZE, SX_BLKCIPHER_PRIV_SZ)];
 
 	union {
 		struct {
@@ -214,7 +214,7 @@ struct cracen_key_derivation_operation {
 	psa_algorithm_t alg;
 	enum cracen_kd_state state;
 	uint64_t capacity;
-	uint8_t output_block[SX_HASH_MAX_ENABLED_BLOCK_SIZE];
+	uint8_t output_block[SX_MAX(SX_HASH_MAX_ENABLED_BLOCK_SIZE, SX_BLKCIPHER_PRIV_SZ)];
 	uint8_t output_block_available_bytes;
 	union{
 		cracen_mac_operation_t mac_op;

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/internal.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/internal.h
@@ -21,6 +21,8 @@ extern "C" {
 #define SX_BLKCIPHER_PRIV_SZ (16)
 #define SX_AEAD_PRIV_SZ	     (70)
 
+#define SX_MAX(p, q) ((p >= q) ? p : q)
+
 /** Mode Register value for context loading */
 #define BA417_MODEID_CTX_LOAD (1u << 5)
 /** Mode Register value for context saving */


### PR DESCRIPTION
Backport 99b35cb2b34ea5626544ad9049df993828b631d3 from #21685.