### PR TITLE
boards: nordic: nrf54lm20apdk: Fix Button0 PCB mistake

### DIFF
--- a/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0.overlay
+++ b/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0.overlay
@@ -29,7 +29,7 @@
 		compatible = "gpio-keys";
 
 		button0: button_0 {
-			gpios = <&gpio1 26 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			gpios = <&gpio1 24 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		};
 
 		button1: button_1 {


### PR DESCRIPTION
There is a mistake on PCA10197. Any occurrence of P1.26 is in fact MCU's P1.24.