### PR TITLE
boards: nordic: nrf54lm20apdk: support spi at DK

### DIFF
--- a/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0.yaml
+++ b/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0.yaml
@@ -18,4 +18,5 @@ supported:
   - gpio
   - i2c
   - pwm
+  - spi
   - watchdog


### PR DESCRIPTION
Add info that DK supports spi.
Needed for test execution.