### PR TITLE
manifest: sdk-zephyr: Pull nRF70 zero-copy fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 4575fc863ae46dc0f65593cb741660ddab1ba344
+      revision: pull/2761/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fixes zero-copy feature (no data flowing and crashes).

Fix SHEL-3581.