### PR TITLE
samples: bluetooth: fast_pair: locator_tag: fix DFU for nRF53 NS targets

### DIFF
--- a/samples/bluetooth/fast_pair/locator_tag/configuration/pm_static_nrf5340dk_nrf5340_cpuapp_ns.yml
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/pm_static_nrf5340dk_nrf5340_cpuapp_ns.yml
@@ -71,19 +71,19 @@ mcuboot_primary_1:
 
 mcuboot_secondary:
   address: 0x0
-  size: 0xef000
+  size: 0xe8000
   device: MX25R64
   region: external_flash
 
 mcuboot_secondary_1:
-  address: 0xef000
+  address: 0xe8000
   size: 0x40000
   device: MX25R64
   region: external_flash
 
 external_flash:
-  address: 0x12f000
-  size: 0x6d1000
+  address: 0x128000
+  size: 0x6d8000
   device: MX25R64
   region: external_flash
 

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/pm_static_thingy53_nrf5340_cpuapp_ns.yml
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/pm_static_thingy53_nrf5340_cpuapp_ns.yml
@@ -71,19 +71,19 @@ mcuboot_primary_1:
 
 mcuboot_secondary:
   address: 0x0
-  size: 0xef000
+  size: 0xe8000
   device: MX25R64
   region: external_flash
 
 mcuboot_secondary_1:
-  address: 0xef000
+  address: 0xe8000
   size: 0x40000
   device: MX25R64
   region: external_flash
 
 external_flash:
-  address: 0x12f000
-  size: 0x6d1000
+  address: 0x128000
+  size: 0x6d8000
   device: MX25R64
   region: external_flash
 


### PR DESCRIPTION
Fixed the DFU issue for the non-secure targets that are based on the nRF53 SoC:

- thingy53/nrf5340/cpuapp/ns
- nrf5340dk/nrf5340/cpuapp/ns

Due to the misaligned partition size of the Primary and the Secondary slots, the MCUboot bootloader was unable to boot the new firmware correctly.

Aligned the size of the Primary and the Secondary slots to fix this issue.

Ref: NCSDK-33065