### PR TITLE
tests: zephyr: drivers: spi: LM20@0.2.0 DK

### DIFF
--- a/tests/zephyr/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/zephyr/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -13,6 +13,7 @@ tests:
   nrf.extended.drivers.spi.spi_mode0:
     platform_allow:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
@@ -50,6 +51,7 @@ tests:
   nrf.extended.drivers.spi.spi_mode1:
     platform_allow:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
@@ -87,6 +89,7 @@ tests:
   nrf.extended.drivers.spi.spi_mode2:
     platform_allow:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
@@ -124,6 +127,7 @@ tests:
   nrf.extended.drivers.spi.spi_mode3:
     platform_allow:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
@@ -161,6 +165,7 @@ tests:
   nrf.extended.drivers.spi.spi_4MHz:
     platform_allow:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
@@ -198,6 +203,7 @@ tests:
   nrf.extended.drivers.spi.spi_8MHz:
     platform_allow:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
@@ -235,6 +241,7 @@ tests:
   nrf.extended.drivers.spi.pm_runtime:
     platform_allow:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp

--- a/tests/zephyr/drivers/spi/spi_error_cases/testcase.yaml
+++ b/tests/zephyr/drivers/spi/spi_error_cases/testcase.yaml
@@ -7,10 +7,12 @@ common:
   harness: ztest
   harness_config:
     fixture: gpio_spi_loopback
+  timeout: 30
 tests:
   nrf.extended.drivers.spi.spi_error_cases:
     platform_allow:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp

--- a/tests/zephyr/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/zephyr/drivers/spi/spi_loopback/testcase.yaml
@@ -13,6 +13,7 @@ common:
   platform_allow:
     - nrf54l09pdk/nrf54l09/cpuapp
     - nrf54lm20apdk/nrf54lm20a/cpuapp
+    - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     - nrf54lv10apdk/nrf54lv10a/cpuapp
     - nrf7120pdk/nrf7120/cpuapp
   integration_platforms:


### PR DESCRIPTION
Allow twister execution at @0.2.0