### PR TITLE
tests: zephyr: drivers: gpio: LM20@0.2.0 DK

### DIFF
--- a/tests/drivers/gpio/gpio_more_loops/testcase.yaml
+++ b/tests/drivers/gpio/gpio_more_loops/testcase.yaml
@@ -19,6 +19,7 @@ tests:
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l20pdk/nrf54l20/cpuflpr
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf7120pdk/nrf7120/cpuapp

--- a/tests/zephyr/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/zephyr/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -22,5 +22,6 @@ tests:
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l20pdk/nrf54l20/cpuflpr
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp


### PR DESCRIPTION
Allow twister execution at @0.2.0