### PR TITLE
tests: zephyr: drivers: watchdog: support LM20@0.2.0 DK

### DIFF
--- a/samples/zephyr/drivers/watchdog/sample.yaml
+++ b/samples/zephyr/drivers/watchdog/sample.yaml
@@ -21,6 +21,7 @@ tests:
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54l09pdk/nrf54l09/cpuflpr
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf54l20pdk/nrf54l20/cpuflpr
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp

--- a/tests/zephyr/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/zephyr/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -10,6 +10,7 @@ tests:
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54l09pdk/nrf54l09/cpuflpr
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf54l20pdk/nrf54l20/cpuflpr
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp

--- a/tests/zephyr/drivers/watchdog/wdt_error_cases/testcase.yaml
+++ b/tests/zephyr/drivers/watchdog/wdt_error_cases/testcase.yaml
@@ -12,6 +12,7 @@ tests:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp


### PR DESCRIPTION
Allow twister execution at @0.2.0