### PR TITLE
doc: sml: fast_pair: update for NCS v3.0.0

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -1779,8 +1779,8 @@ The following table indicates the software maturity levels of the support for Go
         - Experimental
         - Experimental
         - Experimental
-        - --
-        - --
+        - Experimental
+        - Experimental
         - Experimental
         - --
         - --
@@ -1795,9 +1795,9 @@ The following table indicates the software maturity levels of the support for Go
         - Supported
         - Supported
         - Experimental
-        - --
-        - --
-        - --
+        - Experimental
+        - Experimental
+        - Experimental
         - Supported
         - --
         - --
@@ -1840,8 +1840,8 @@ The following table indicates the software maturity levels of the support for ea
         - Supported
         - Experimental
         - Experimental
-        - --
-        - --
+        - Experimental
+        - Experimental
         - Supported
         - --
         - --
@@ -1856,8 +1856,8 @@ The following table indicates the software maturity levels of the support for ea
         - Experimental
         - Experimental
         - Experimental
-        - --
-        - --
+        - Experimental
+        - Experimental
         - Experimental
         - --
         - --
@@ -1872,8 +1872,8 @@ The following table indicates the software maturity levels of the support for ea
         - Experimental
         - Experimental
         - Experimental
-        - --
-        - --
+        - Experimental
+        - Experimental
         - Experimental
         - --
         - --
@@ -1888,8 +1888,8 @@ The following table indicates the software maturity levels of the support for ea
         - Experimental
         - Experimental
         - Experimental
-        - --
-        - --
+        - Experimental
+        - Experimental
         - Experimental
         - --
         - --
@@ -1903,9 +1903,9 @@ The following table indicates the software maturity levels of the support for ea
         - Supported
         - Supported
         - Experimental
-        - --
-        - --
-        - --
+        - Experimental
+        - Experimental
+        - Experimental
         - Supported
         - --
         - --


### PR DESCRIPTION
Updated the Software Maturity tables for the Google Fast Pair category to align the documentation with the current status of nRF Connect SDK v3.0.0 codebase.