### PR TITLE
tests: zephyr: drivers: timer: nrf_grtc_timer: enable for LM20 DK

### DIFF
--- a/tests/zephyr/drivers/timer/nrf_grtc_timer/testcase.yaml
+++ b/tests/zephyr/drivers/timer/nrf_grtc_timer/testcase.yaml
@@ -7,6 +7,7 @@ tests:
       - nrf54l09pdk/nrf54l09/cpuflpr
       - nrf54l20pdk/nrf54l20/cpuflpr
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
     integration_platforms:
       - nrf54l20pdk/nrf54l20/cpuflpr


### PR DESCRIPTION
LM20 DK