### PR TITLE
[Backport v3.0-branch] samples: matter: Fixed DFU for nRF54L10

### DIFF
--- a/samples/matter/manufacturer_specific/pm_static_nrf54l15dk_nrf54l10_cpuapp.yml
+++ b/samples/matter/manufacturer_specific/pm_static_nrf54l15dk_nrf54l10_cpuapp.yml
@@ -5,11 +5,11 @@ mcuboot:
 mcuboot_pad:
   address: 0xD000
   region: flash_primary
-  size: 0x800
+  size: 0x1000
 app:
-  address: 0xD800
+  address: 0xE000
   region: flash_primary
-  size: 0xE7000
+  size: 0xE6000
 mcuboot_primary:
   orig_span: &id001
   - mcuboot_pad
@@ -17,40 +17,44 @@ mcuboot_primary:
   span: *id001
   address: 0xD000
   region: flash_primary
-  size: 0xE7800
+  size: 0xE7000
 mcuboot_primary_app:
   orig_span: &id002
   - app
   span: *id002
-  address: 0xD800
+  address: 0xE000
   region: flash_primary
-  size: 0xE7000
+  size: 0xE6000
 factory_data:
-  address: 0xF4800
+  address: 0xF4000
   region: flash_primary
   size: 0x1000
 settings_storage:
-  address: 0xF5800
+  address: 0xF5000
   region: flash_primary
   size: 0xA000
+reserved:
+  address: 0xFF000
+  region: flash_primary
+  size: 0x800
 mcuboot_secondary:
   address: 0x0
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: external_flash
-  size: 0xE7800
+  size: 0xE7000
   span: *id003
 mcuboot_secondary_pad:
   region: external_flash
   address: 0x0
-  size: 0x800
+  size: 0x1000
 mcuboot_secondary_app:
   region: external_flash
-  address: 0x800
-  size: 0xE7000
+  address: 0x1000
+  size: 0xE6000
 external_flash:
-  address: 0xE7800
-  size: 0x718800
+  address: 0xE7000
+  size: 0x719000
   device: MX25R64
   region: external_flash

--- a/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -27,3 +27,6 @@ CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
+
+# Mcuboot padding size is modified to 0x1000 in pm_static file.
+CONFIG_PM_PARTITION_SIZE_MCUBOOT_PAD=0x1000

--- a/samples/matter/smoke_co_alarm/pm_static_nrf54l15dk_nrf54l10_cpuapp.yml
+++ b/samples/matter/smoke_co_alarm/pm_static_nrf54l15dk_nrf54l10_cpuapp.yml
@@ -5,11 +5,11 @@ mcuboot:
 mcuboot_pad:
   address: 0xD000
   region: flash_primary
-  size: 0x800
+  size: 0x1000
 app:
-  address: 0xD800
+  address: 0xE000
   region: flash_primary
-  size: 0xE7000
+  size: 0xE6000
 mcuboot_primary:
   orig_span: &id001
   - mcuboot_pad
@@ -17,40 +17,44 @@ mcuboot_primary:
   span: *id001
   address: 0xD000
   region: flash_primary
-  size: 0xE7800
+  size: 0xE7000
 mcuboot_primary_app:
   orig_span: &id002
   - app
   span: *id002
-  address: 0xD800
+  address: 0xE000
   region: flash_primary
-  size: 0xE7000
+  size: 0xE6000
 factory_data:
-  address: 0xF4800
+  address: 0xF4000
   region: flash_primary
   size: 0x1000
 settings_storage:
-  address: 0xF5800
+  address: 0xF5000
   region: flash_primary
   size: 0xA000
+reserved:
+  address: 0xFF000
+  region: flash_primary
+  size: 0x800
 mcuboot_secondary:
   address: 0x0
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: external_flash
-  size: 0xE7800
+  size: 0xE7000
   span: *id003
 mcuboot_secondary_pad:
   region: external_flash
   address: 0x0
-  size: 0x800
+  size: 0x1000
 mcuboot_secondary_app:
   region: external_flash
-  address: 0x800
-  size: 0xE7000
+  address: 0x1000
+  size: 0xE6000
 external_flash:
-  address: 0xE7800
-  size: 0x718800
+  address: 0xE7000
+  size: 0x719000
   device: MX25R64
   region: external_flash

--- a/samples/matter/smoke_co_alarm/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/smoke_co_alarm/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -30,3 +30,6 @@ CONFIG_TICKLESS_KERNEL=y
 
 # Low Power mode
 CONFIG_POWEROFF=y
+
+# Mcuboot padding size is modified to 0x1000 in pm_static file.
+CONFIG_PM_PARTITION_SIZE_MCUBOOT_PAD=0x1000

--- a/samples/matter/template/pm_static_nrf54l15dk_nrf54l10_cpuapp.yml
+++ b/samples/matter/template/pm_static_nrf54l15dk_nrf54l10_cpuapp.yml
@@ -5,11 +5,11 @@ mcuboot:
 mcuboot_pad:
   address: 0xD000
   region: flash_primary
-  size: 0x800
+  size: 0x1000
 app:
-  address: 0xD800
+  address: 0xE000
   region: flash_primary
-  size: 0xE7000
+  size: 0xE6000
 mcuboot_primary:
   orig_span: &id001
   - mcuboot_pad
@@ -17,40 +17,44 @@ mcuboot_primary:
   span: *id001
   address: 0xD000
   region: flash_primary
-  size: 0xE7800
+  size: 0xE7000
 mcuboot_primary_app:
   orig_span: &id002
   - app
   span: *id002
-  address: 0xD800
+  address: 0xE000
   region: flash_primary
-  size: 0xE7000
+  size: 0xE6000
 factory_data:
-  address: 0xF4800
+  address: 0xF4000
   region: flash_primary
   size: 0x1000
 settings_storage:
-  address: 0xF5800
+  address: 0xF5000
   region: flash_primary
   size: 0xA000
+reserved:
+  address: 0xFF000
+  region: flash_primary
+  size: 0x800
 mcuboot_secondary:
   address: 0x0
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: external_flash
-  size: 0xE7800
+  size: 0xE7000
   span: *id003
 mcuboot_secondary_pad:
   region: external_flash
   address: 0x0
-  size: 0x800
+  size: 0x1000
 mcuboot_secondary_app:
   region: external_flash
-  address: 0x800
-  size: 0xE7000
+  address: 0x1000
+  size: 0xE6000
 external_flash:
-  address: 0xE7800
-  size: 0x718800
+  address: 0xE7000
+  size: 0x719000
   device: MX25R64
   region: external_flash

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -27,3 +27,6 @@ CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
+
+# Mcuboot padding size is modified to 0x1000 in pm_static file.
+CONFIG_PM_PARTITION_SIZE_MCUBOOT_PAD=0x1000


### PR DESCRIPTION
Backport fa55dd6e46cf8e5850a4c0bc853424d20809c431 from #21748.