### PR TITLE
doc: Fixed docs for matter diagnostic logs snippet

### DIFF
--- a/doc/nrf/protocols/matter/end_product/test_event_triggers.rst
+++ b/doc/nrf/protocols/matter/end_product/test_event_triggers.rst
@@ -81,21 +81,21 @@ The following table lists the available triggers and their activation codes:
       The maximum time is UINT16_MAX s.
       The value is provided in HEX format.
   * - Diagnostic Logs User Data
-    - Enabled ``Diagnostic Logs`` cluster, and either the snippet ``matter-diagnostic-logs`` attached (``-D<application_name>_SNIPPET=matter-diagnostic-logs``) or both :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS>` = ``y`` and :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS>` = ``y``.
+    - Enabled ``Diagnostic Logs`` cluster, and either the snippet ``diagnostic-logs`` attached (``-D<application_name>_SNIPPET=diagnostic-logs``) or both :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS>` = ``y`` and :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_END_USER_LOGS>` = ``y``.
     - Trigger writing a specific number of ``u`` characters to the user diagnostics logs.
       The number of characters is determined by the value at the end of the event trigger value.
       The current supported maximum is 1023 bytes for single trigger call, and 4096 bytes of total data written.
     - ``0xFFFFFFFF40000000`` - ``0xFFFFFFFF40000400``
     - The range of ``0x0000`` - ``0x0400`` (from 1 Bytes to 1024 Bytes), ``0x0000`` to clear logs.
   * - Diagnostic Logs Network Data
-    - Enabled ``Diagnostic Logs`` cluster, and either the snippet ``matter-diagnostic-logs`` attached (``-D<application_name>_SNIPPET=matter-diagnostic-logs``) or both :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS>` = ``y`` and :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS>` = ``y``.
+    - Enabled ``Diagnostic Logs`` cluster, and either the snippet ``diagnostic-logs`` attached (``-D<application_name>_SNIPPET=diagnostic-logs``) or both :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS>` = ``y`` and :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_NETWORK_LOGS>` = ``y``.
     - Trigger writing a specific number of ``n`` characters to the network diagnostics logs.
       The number of characters is determined by the value at the end of the event trigger value.
       The current supported maximum is 1023 bytes for single trigger call, and 4096 bytes of total data written.
     - ``0xFFFFFFFF50000000`` - ``0xFFFFFFFF50000400``
     - The range of ``0x0000`` - ``0x0400`` (from 1 Bytes to 1024 Bytes), ``0x0000`` to clear logs.
   * - Diagnostic Crash Logs
-    - Either the snippet ``matter-diagnostic-logs`` attached (``-D<application_name>_SNIPPET=matter-diagnostic-logs``) or both :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS>` = ``y`` and :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_CRASH_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_CRASH_LOGS>` = ``y``, and enabled ``Diagnostic Logs`` cluster.
+    - Either the snippet ``diagnostic-logs`` attached (``-D<application_name>_SNIPPET=diagnostic-logs``) or both :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS>` = ``y`` and :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_CRASH_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS_CRASH_LOGS>` = ``y``, and enabled ``Diagnostic Logs`` cluster.
     - Trigger a simple crash that relies on execution of the undefined instruction attempt.
     - ``0xFFFFFFFF60000000``
     - No additional value supported.

--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -318,14 +318,14 @@ Deferred logs mode (:kconfig:option:`CONFIG_LOG_MODE_DEFERRED`) is enabled becau
   You cannot set the :ref:`CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS<CONFIG_NCS_SAMPLE_MATTER_DIAGNOSTIC_LOGS>` Kconfig option separately without adding the devicetree overlays contained in the snippet.
   Instead, if you want to use just some of the diagnostic logs functionality, use the snippet and set the Kconfig options for the other functionalities to ``n``.
 
-To use the snippet when building a sample, add ``-D<project_name>_SNIPPET=matter-diagnostic-logs`` to the west arguments list.
+To use the snippet when building a sample, add ``-D<project_name>_SNIPPET=diagnostic-logs`` to the west arguments list.
 
 Example for the ``nrf52840dk/nrf52840`` board target and the :ref:`matter_lock_sample` sample:
 
 .. parsed-literal::
    :class: highlight
 
-   west build -b nrf52840dk/nrf52840 -- -Dlock_SNIPPET=matter-diagnostic-logs
+   west build -b nrf52840dk/nrf52840 -- -Dlock_SNIPPET=diagnostic-logs
 
 .. _ug_matter_debug_snippet:
 

--- a/samples/matter/common/config.rst
+++ b/samples/matter/common/config.rst
@@ -238,13 +238,13 @@ The snippets are in the :file:`nrf/snippets` directory of the |NCS|.
 For more information about using snippets, see :ref:`zephyr:using-snippets` in the Zephyr documentation.
 
 Specify the corresponding snippet names in the :makevar:`SNIPPET` CMake option for the application configuration.
-The following is an example command for the ``nrf52840dk/nrf52840`` board target that adds the ``matter-diagnostic-logs`` snippet to the :ref:`matter_lock_sample` sample:
+The following is an example command for the ``nrf52840dk/nrf52840`` board target that adds the ``diagnostic-logs`` snippet to the :ref:`matter_lock_sample` sample:
 
 .. code-block::
 
-   west build -b nrf52840dk/nrf52840 -- -Dlock_SNIPPET=matter-diagnostic-logs
+   west build -b nrf52840dk/nrf52840 -- -Dlock_SNIPPET=diagnostic-logs
 
 The following snippets are available:
 
-* ``matter-diagnostic-logs`` - Enables the set of configurations needed for full Matter diagnostic logs support.
+* ``diagnostic-logs`` - Enables the set of configurations needed for full Matter diagnostic logs support.
   See :ref:`ug_matter_diagnostic_logs_snippet` in the Matter protocol section for more information.


### PR DESCRIPTION
The documentation for matter diagnostic logs snippet contains invalid snippet name.