### PR TITLE
tests: zephyr: boards: nrf: hwinfo: enable for LM20 DK

### DIFF
--- a/tests/zephyr/boards/nrf/hwinfo/reset_cause/testcase.yaml
+++ b/tests/zephyr/boards/nrf/hwinfo/reset_cause/testcase.yaml
@@ -38,6 +38,7 @@ tests:
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:


### PR DESCRIPTION
LM20 DK.