### PR TITLE
tests: drivers: pwm: gpio_loopback: enable for LM20 DK

### DIFF
--- a/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0.overlay
+++ b/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0.overlay
@@ -65,3 +65,18 @@
 &gpio3 {
 	gpio-reserved-ranges = <0 12>;
 };
+
+&pinctrl {
+	/omit-if-no-ref/ pwm20_default: pwm20_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 29)>;
+		};
+	};
+
+	/omit-if-no-ref/ pwm20_sleep: pwm20_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 29)>;
+			low-power-enable;
+		};
+	};
+};

--- a/tests/drivers/pwm/gpio_loopback/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/pwm/gpio_loopback/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -7,31 +7,10 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
 
-&pinctrl {
-	pwm20_alt: pwm20_alt {
-		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 1, 10)>;
-		};
-	};
-
-	pwm20_alt_sleep: pwm20_alt_sleep {
-		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 1, 10)>;
-			low-power-enable;
-		};
-	};
-};
-
-&pwm20 {
-	pinctrl-0 = <&pwm20_alt>;
-	pinctrl-1 = <&pwm20_alt_sleep>;
-	pinctrl-names = "default", "sleep";
-};
-
 / {
 	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
 		compatible = "test-pwm-to-gpio-loopback";
 		pwms = <&pwm20 0 0 PWM_POLARITY_NORMAL>;
-		gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio1 19 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/tests/drivers/pwm/gpio_loopback/boards/nrf54lm20apdk_nrf54lm20a_cpuapp_0_0_0.overlay
+++ b/tests/drivers/pwm/gpio_loopback/boards/nrf54lm20apdk_nrf54lm20a_cpuapp_0_0_0.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+&pinctrl {
+	pwm20_alt: pwm20_alt {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 10)>;
+		};
+	};
+
+	pwm20_alt_sleep: pwm20_alt_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 10)>;
+			low-power-enable;
+		};
+	};
+};
+
+&pwm20 {
+	pinctrl-0 = <&pwm20_alt>;
+	pinctrl-1 = <&pwm20_alt_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm20 0 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/tests/drivers/pwm/gpio_loopback/testcase.yaml
+++ b/tests/drivers/pwm/gpio_loopback/testcase.yaml
@@ -17,6 +17,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Align PWM output for LED1 pin.