### PR TITLE
Bluetooth Peripheral HIDS keyboard: making the NFC Kconfig available

### DIFF
--- a/samples/bluetooth/peripheral_hids_keyboard/app.overlay
+++ b/samples/bluetooth/peripheral_hids_keyboard/app.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&nfct {
+	status = "okay";
+};

--- a/samples/bluetooth/peripheral_hids_keyboard/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_hids_keyboard/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&nfct {
+	status = "okay";
+	memory-regions = <&cpuapp_dma_region>;
+};


### PR DESCRIPTION
I dedicate this change to @MarekPieta, who wanted to make this feature work for NCS 3.0.

Notes:
- The commit adding the `app.overlay` would be reverted once the change from the following Zephyr PR is moved to NCS:

https://github.com/zephyrproject-rtos/zephyr/pull/88637

- Remove the v3.0 release from the affected releases list in the corresponding known issue that is part of the following PR:

https://github.com/nrfconnect/sdk-nrf/pull/21388

- Create a comment with a changelog entry suggestion in the release note PR:

https://github.com/nrfconnect/sdk-nrf/pull/21339