### PR TITLE
NCSDK-32785: Fix current measurement at LFRC test

### DIFF
--- a/tests/benchmarks/current_consumption/lfrc_idle/src/main.c
+++ b/tests/benchmarks/current_consumption/lfrc_idle/src/main.c
@@ -46,9 +46,9 @@ int main(void)
 		__ASSERT(ret == 0, "return code: %d", ret);
 		__ASSERT(res == 0, "response: %d", res);
 		k_msleep(1000);
-		gpio_pin_toggle_dt(&led);
 		ret = nrf_clock_control_release(lfclk_dev, clk_spec);
 		__ASSERT(ret == ONOFF_STATE_ON, "return code: %d", ret);
+		gpio_pin_toggle_dt(&led);
 	}
 
 	return 0;


### PR DESCRIPTION
Move a LED state change after handling the clock change request.