### PR TITLE
manifest: sdk-zephyr: Pull nRF70 SPI clock switching feature

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3475ff5b973770f39f0c723581bc510311edea4e
+      revision: ee38edfd357f7995727a4fe2ce2cecfd7d74b3d5
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Needed to use higher SPI frequencies.