### PR TITLE
manifest: Add sysbuild for NS boards with pr #2768

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: aa04c0cae08f8d863c5c969cb1597f82610771c2
+      revision: pull/2768/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
-Modifies _ns.*.yaml to always set "sysbuild: true" to pass more
 tests in CI for ns targets. Without this additions PM was used
 by default causing build issues