### PR TITLE
doc/nrf/bootloader: nRF54L: updates on key management

### DIFF
--- a/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_adding_sysbuild.rst
+++ b/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_adding_sysbuild.rst
@@ -87,7 +87,8 @@ To specify a signature key file for this bootloader, set the ``SB_CONFIG_SECURE_
 
       Escaped quotations avoid malformed-string warnings from Kconfig.
 
-This option only accepts the private key of an ECDSA key pair, as the build system scripts automatically extract the public key at build time.
+This option accepts the private key of an Ed25519 key pair for nRF54L SoCs and private key of an ECDSA key pair for the others.
+The build system scripts automatically extract the public key at build time.
 
 The file argument must be a string and is specified in one of the following ways:
 
@@ -142,6 +143,8 @@ For example, if a directory named :file:`_keys` located in :file:`/home/user/ncs
 You can find specific configuration options for keys with this bootloader in :file:`nrf/sysbuild/Kconfig.secureboot`.
 
 See :ref:`ug_fw_update_keys` for information on how to generate custom keys for a project.
+
+For SoCs using KMU for NSIB (nRF54L Series devices), the private key must be provisioned in the KMU before NSIB can be run.
 
 Additionally, the |NSIB| supports the following methods for signing images with private keys:
 

--- a/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_signature_keys.rst
+++ b/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_signature_keys.rst
@@ -132,7 +132,9 @@ Key revocation can be a useful security measure for devices that have already be
 If a private key has been compromised or lost, you can invalidate its public key by uploading a new firmware image signed by another key known to the bootloader.
 
 These keys are kept internally by the bootloader, so the list of available public keys cannot change once it is deployed.
-See :kconfig:option:`CONFIG_SB_PUBLIC_KEY_FILES` for details on how this mechanism is implemented.
+For nRF54L SoCs, the KMU is used to store the public keys and to handle the revocation policy.
+For description, see the :kconfig:option:`CONFIG_SB_CRYPTO_KMU_KEYS_REVOCATION` Kconfig option.
+For other devices, see :kconfig:option:`CONFIG_SB_PUBLIC_KEY_FILES` for details on how this mechanism is implemented.
 
 You can add this feature to your own project and check its functionality as follows:
 
@@ -144,15 +146,31 @@ You can add this feature to your own project and check its functionality as foll
 
       Use only absolute paths for ``SB_CONFIG_SECURE_BOOT_SIGNING_KEY_FILE`` and ``SB_CONFIG_SECURE_BOOT_PUBLIC_KEY_FILES``.
 
-   .. code-block:: console
+.. tabs::
 
-      SB_CONFIG_SECURE_BOOT_APPCORE=y
-      SB_CONFIG_SECURE_BOOT_SIGNING_KEY_FILE="/path/to/priv_a.pem"
-      SB_CONFIG_SECURE_BOOT_PUBLIC_KEY_FILES="/path/to/pub_b.pem,/path/to/pub_c.pem"
+    .. group-tab:: software keys storage
+
+      .. code-block:: console
+
+         SB_CONFIG_SECURE_BOOT_APPCORE=y
+         SB_CONFIG_SECURE_BOOT_SIGNING_KEY_FILE="/path/to/priv_a.pem"
+         SB_CONFIG_SECURE_BOOT_PUBLIC_KEY_FILES="/path/to/pub_b.pem,/path/to/pub_c.pem"
+
+    .. group-tab:: KMU
+
+      .. code-block:: console
+
+         SB_CONFIG_SECURE_BOOT_APPCORE=y
+         b0_CONFIG_SB_CRYPTO_KMU_KEYS_REVOCATION=y
 
    .. caution::
 
       The public key associated with the original private signing key must not be included in the public key list.
+
+#. Provision KMU with the public keys.
+
+   You must do this for devices using KMU as keys storage.
+   This description assumes that KMU is provisioned with key files :file:`/path/to/priv_a.pem`, :file:`/path/to/pub_b.pem`, and :file:`/path/to/pub_c.pem`.
 
 #. Program the application to the target development kit and check its console output.
    With the first firmware version, ``priv_a.pem`` and ``pub_a.pem`` are used for signing and validating the image.

--- a/doc/nrf/app_dev/device_guides/nrf54l/kmu_basics.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/kmu_basics.rst
@@ -54,6 +54,8 @@ You may experience the following issues:
 By default, MCUboot uses a single key.
 You can configure the number of key generations that MCUboot uses for application verification with the ``CONFIG_BOOT_SIGNATURE_KMU_SLOTS`` MCUboot's Kconfig option.
 
+NSIB for nRF54L SoCs supports three key generations.
+
 Limitations on key types and trade-offs
 ***************************************
 

--- a/doc/nrf/app_dev/device_guides/nrf54l/kmu_provision.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/kmu_provision.rst
@@ -103,9 +103,20 @@ Once you have an unprovisioned SoC, upload keys to the board by running one of t
 
       For MCUboot, take note of the following:
 
+      * UROT_PUBKEY is the key name used by MCUboot.
       * By default, it uses one key.
+      * It might utilize multiple keys, which is intended for use with key revocation.
+        The number of keys is defined by the ``CONFIG_BOOT_SIGNATURE_KMU_SLOTS`` MCUboot's Kconfig option.
+        You can enable the key revocation mechanism with the  ``CONFIG_BOOT_KEYS_REVOCATION`` MCUboot's Kconfig option.
       * KMU support in its configuration needs to be enabled by setting the ``SB_CONFIG_MCUBOOT_SIGNATURE_USING_KMU`` sysbuild Kconfig option.
         Otherwise, MCUboot will fallback to the compiled-in key.
+
+      For NSIB, take note of the following:
+
+      * BL_PUBKEY is the key name used by NSIB.
+      * It utilizes tree keys, which is intended for use with key revocation.
+      * Keys must be provisioned before any run of the bootloader.
+        For details, see :ref:`note<ug_nrf54l_developing_basics_kmu_provisioning_keys>`.
 
       To provision one key to the board, run the following command:
 


### PR DESCRIPTION
Minimal doc update for NSIB@nRF54L on:
NSIB keys, NSIB key revocation, mcuboot key revocation.