### PR TITLE
ci: use different token in stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.NCS_GITHUB_TOKEN }}
         stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 7 days. Note, that you can always re-open a closed pull request at any time.'
         stale-issue-message: 'This issue has been marked as stale because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 7 days. Note, that you can always re-open a closed issue at any time.'
         days-before-stale: 30


### PR DESCRIPTION
Problem with using default token is that docremove action is not triggered when PR gets closed. Changing token should fix this problem.