### PR TITLE
tests: zephyr: drivers: i2s: Enable tests on PCA10197

### DIFF
--- a/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0.yaml
+++ b/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0.yaml
@@ -17,6 +17,7 @@ supported:
   - dmic
   - gpio
   - i2c
+  - i2s
   - pwm
   - spi
   - watchdog

--- a/tests/zephyr/drivers/i2s/i2s_api/boards/nrf54lm20apdk_nrf54lm20a_cpuapp_0_0_0.overlay
+++ b/tests/zephyr/drivers/i2s/i2s_api/boards/nrf54lm20apdk_nrf54lm20a_cpuapp_0_0_0.overlay
@@ -15,10 +15,10 @@
 &pinctrl {
 	tdm_default_alt: tdm_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TDM_SCK_M, 1, 18)>,
-				<NRF_PSEL(TDM_FSYNC_M, 1, 16)>,
-				<NRF_PSEL(TDM_SDOUT, 1, 30)>,  /* TDM_SDOUT shorted to TDM_SDIN */
-				<NRF_PSEL(TDM_SDIN, 1, 31)>;
+			psels = <NRF_PSEL(TDM_SCK_M, 1, 3)>,
+				<NRF_PSEL(TDM_FSYNC_M, 1, 6)>,
+				<NRF_PSEL(TDM_SDOUT, 1, 14)>,  /* TDM_SDOUT shorted to TDM_SDIN */
+				<NRF_PSEL(TDM_SDIN, 1, 15)>;
 		};
 	};
 };

--- a/tests/zephyr/drivers/i2s/i2s_api/testcase.yaml
+++ b/tests/zephyr/drivers/i2s/i2s_api/testcase.yaml
@@ -20,6 +20,7 @@ tests:
       fixture: gpio_loopback
     platform_allow:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
 

--- a/tests/zephyr/drivers/i2s/i2s_speed/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/i2s/i2s_speed/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -15,10 +15,10 @@
 &pinctrl {
 	tdm_default_alt: tdm_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TDM_SCK_M, 1, 3)>,
-				<NRF_PSEL(TDM_FSYNC_M, 1, 6)>,
-				<NRF_PSEL(TDM_SDOUT, 1, 14)>,
-				<NRF_PSEL(TDM_SDIN, 1, 15)>;
+			psels = <NRF_PSEL(TDM_SCK_M, 1, 18)>,
+				<NRF_PSEL(TDM_FSYNC_M, 1, 16)>,
+				<NRF_PSEL(TDM_SDOUT, 1, 30)>,  /* TDM_SDOUT shorted to TDM_SDIN */
+				<NRF_PSEL(TDM_SDIN, 1, 31)>;
 		};
 	};
 };

--- a/tests/zephyr/drivers/i2s/i2s_speed/boards/nrf54lm20apdk_nrf54lm20a_cpuapp_0_0_0.overlay
+++ b/tests/zephyr/drivers/i2s/i2s_speed/boards/nrf54lm20apdk_nrf54lm20a_cpuapp_0_0_0.overlay
@@ -15,10 +15,10 @@
 &pinctrl {
 	tdm_default_alt: tdm_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TDM_SCK_M, 1, 18)>,
-				<NRF_PSEL(TDM_FSYNC_M, 1, 16)>,
-				<NRF_PSEL(TDM_SDOUT, 1, 30)>,  /* TDM_SDOUT shorted to TDM_SDIN */
-				<NRF_PSEL(TDM_SDIN, 1, 31)>;
+			psels = <NRF_PSEL(TDM_SCK_M, 1, 3)>,
+				<NRF_PSEL(TDM_FSYNC_M, 1, 6)>,
+				<NRF_PSEL(TDM_SDOUT, 1, 14)>,  /* TDM_SDOUT shorted to TDM_SDIN */
+				<NRF_PSEL(TDM_SDIN, 1, 15)>;
 		};
 	};
 };

--- a/tests/zephyr/drivers/i2s/i2s_speed/testcase.yaml
+++ b/tests/zephyr/drivers/i2s/i2s_speed/testcase.yaml
@@ -20,6 +20,7 @@ tests:
       fixture: gpio_loopback
     platform_allow:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
 


### PR DESCRIPTION
Add overlays required to run I2S tests on nrf54lm20a PDK.