### PR TITLE
applications: nrf_desktop: Imply CONFIG_BT_CONN_TX_NOTIFY_WQ

### DIFF
--- a/applications/nrf_desktop/Kconfig.ble
+++ b/applications/nrf_desktop/Kconfig.ble
@@ -15,12 +15,18 @@ config DESKTOP_BT
 	select BT_SETTINGS
 	select BT_SIGNING
 	select BT_SMP
+	imply BT_CONN_TX_NOTIFY_WQ if BT_LL_SOFTDEVICE
 	help
 	  Enable support for Bluetooth connectivity in the nRF Desktop
 	  application. Specific Bluetooth configurations and application
 	  modules are selected according to the HID device role. Apart from
 	  that, the defaults of Bluetooth-related Kconfigs are aligned with
 	  the nRF Desktop use case.
+
+	  nRF Desktop conditionally implies using a separate workqueue for
+	  connection TX notify processing. This is done to work around HCI
+	  command timeout e.g. while erasing secondary image slot in the
+	  background.
 
 if DESKTOP_BT
 


### PR DESCRIPTION
Change conditionally implies CONFIG_BT_CONN_TX_NOTIFY_WQ to work around HCI command timeout while erasing secondary image slot in background.

Jira: NCSDK-32945