### PR TITLE
  tests: benchmarks: idle_clock_control: Fix current measurement test

### DIFF
--- a/tests/benchmarks/multicore/idle_clock_control/Kconfig
+++ b/tests/benchmarks/multicore/idle_clock_control/Kconfig
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config AT_LFRC
+	bool "BICR configured to use LFRC at LFCLK"
+	help
+	  Use this option if custom BICR (LFRC at LFCLK) is programmed.
+
+source "Kconfig.zephyr"

--- a/tests/benchmarks/multicore/idle_clock_control/src/main.c
+++ b/tests/benchmarks/multicore/idle_clock_control/src/main.c
@@ -109,6 +109,13 @@ const struct nrf_clock_spec test_clk_specs_lfclk[] = {
 		.accuracy = 0,
 		.precision = NRF_CLOCK_CONTROL_PRECISION_DEFAULT,
 	},
+#if defined(CONFIG_AT_LFRC)
+	{
+		.frequency = 32768,
+		.accuracy = 30,
+		.precision = NRF_CLOCK_CONTROL_PRECISION_DEFAULT,
+	},
+#else
 	{
 		.frequency = 32768,
 		.accuracy = 20,
@@ -119,6 +126,7 @@ const struct nrf_clock_spec test_clk_specs_lfclk[] = {
 		.accuracy = 20,
 		.precision = NRF_CLOCK_CONTROL_PRECISION_HIGH,
 	},
+#endif
 };
 
 static const struct test_clk_ctx lfclk_test_clk_ctx[] = {

--- a/tests/benchmarks/multicore/idle_clock_control/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_clock_control/testcase.yaml
@@ -14,7 +14,7 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     harness_config:
-      fixture: ppk_power_measure
+      fixture: lfclk_at_lfxo
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_clock_control"
     timeout: 90
@@ -41,7 +41,54 @@ tests:
       - remote_CONFIG_BOOT_BANNER=n
       - remote_CONFIG_CLOCK_CONTROL=n
     harness_config:
-      fixture: ppk_power_measure
+      fixture: lfclk_at_lfxo
+      pytest_root:
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_clock_control"
+    timeout: 90
+
+  benchmarks.multicore.idle_clock_control.app.lfrc:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - ppk_power_measure
+    filter: not CONFIG_COVERAGE
+    harness: pytest
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    harness_config:
+      fixture: lfclk_at_lfrc
+      pytest_root:
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_clock_control"
+    timeout: 90
+    extra_args:
+      - CONFIG_AT_LFRC=y
+
+  # note: in this scenario cpuapp is the 'remote'
+  benchmarks.multicore.idle_clock_control.rad.lfrc:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - ppk_power_measure
+    filter: not CONFIG_COVERAGE
+    harness: pytest
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpurad
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpurad
+    extra_args:
+      - CONFIG_PM_S2RAM=n
+      - CONFIG_PM_S2RAM_CUSTOM_MARKING=n
+      - CONFIG_AT_LFRC=y
+      - remote_CONFIG_PM_S2RAM=y
+      - remote_CONFIG_PM_S2RAM_CUSTOM_MARKING=y
+      - remote_CONFIG_PM_DEVICE=y
+      - remote_CONFIG_PM_DEVICE_RUNTIME=y
+      - remote_CONFIG_BOOT_BANNER=n
+      - remote_CONFIG_CLOCK_CONTROL=n
+    harness_config:
+      fixture: lfclk_at_lfrc
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_clock_control"
     timeout: 90


### PR DESCRIPTION
Use fixtures to differentiate regular and lfrc setup