### PR TITLE
[Backport v3.0-branch] manifest: softperipheral: Documentation

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -144,7 +144,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 3d5b6bd4f41e924fbfa311a387d676844667d422
+      revision: cccd436dcac86c19055a7b3b9780d363149197e9
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Documentation updates for sQSPI

Brings in: https://github.com/nrfconnect/sdk-nrfxlib/pull/1724