### PR TITLE
nrf_security: Have psa_crypto_init.c be configurable

### DIFF
--- a/subsys/nrf_security/Kconfig.psa
+++ b/subsys/nrf_security/Kconfig.psa
@@ -104,6 +104,19 @@ config PSA_ITS_ENCRYPTED
 	help
 	  Enables authenticated encryption for PSA Internal Trusted Storage files
 
+config PSA_CRYPTO_SYS_INIT
+	bool "Invoke psa_crypto_init during system initialization"
+	default y
+	help
+	  Enable a Zephyr SYS_INIT that invokes psa_crypto_init. This
+	  allows PSA Crypto API users that run after POST_KERNEL to omit
+	  their psa_crypto_init calls.
+
+	  This option can be disabled to allow finer grained control of
+	  how an error from psa_crypto_init should be handled. The
+	  SYS_INIT will invoke k_oops() when psa_crypto_init fails, which
+	  may not be desired behaviour.
+
 config PSA_CRYPTO_DRIVER_ALG_PRNG_TEST
 	bool
 	help

--- a/subsys/nrf_security/src/zephyr/CMakeLists.txt
+++ b/subsys/nrf_security/src/zephyr/CMakeLists.txt
@@ -34,10 +34,12 @@ if(CONFIG_MBEDTLS_ENTROPY_POLL)
   )
 endif()
 
-# Include a late initialization of psa_crypto_init just-in-case
-list(APPEND src_zephyr
-  psa_crypto_init.c
-)
+if(CONFIG_PSA_CRYPTO_SYS_INIT)
+  # Include a late initialization of psa_crypto_init just-in-case
+  list(APPEND src_zephyr
+    psa_crypto_init.c
+  )
+endif()
 
 if(CONFIG_BUILD_WITH_TFM)
   # For some reason $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR> does not work here


### PR DESCRIPTION
Allow users to disable the Zephyr SYS_INIT that invokes psa_crypto_init.

See kconfig help text for details.