### PR TITLE
doc: Rename command wifi_cred to wifi cred

### DIFF
--- a/doc/nrf/includes/wifi_credentials_shell.txt
+++ b/doc/nrf/includes/wifi_credentials_shell.txt
@@ -9,7 +9,7 @@ Once you have flashed your device with this sample, connect to your device's UAR
 .. parsed-literal::
    :class: highlight
 
-   wifi_cred add -s *NetworkSSID* -k *SecurityMode* -p *NetworkPassword*
+   wifi cred add -s *NetworkSSID* -k *SecurityMode* -p *NetworkPassword*
 
 Where *NetworkSSID* is replaced with the SSID of the Wi-Fi access point you want your device to connect to, and *NetworkPassword* is its password.
 *SecurityMode* is replaced by the number as listed here:
@@ -28,10 +28,10 @@ Where *NetworkSSID* is replaced with the SSID of the Wi-Fi access point you want
 * 11: DPP
 
 If you are not sure which security mode to use, enable the :kconfig:option:`CONFIG_NET_L2_WIFI_SHELL` Kconfig option and use the ``wifi scan`` command to display a list of all accessible networks along with their corresponding security modes.
-Then either reboot the device or use the ``wifi_cred auto_connect`` command to manually trigger a connection attempt.
+Then either reboot the device or use the ``wifi cred auto_connect`` command to manually trigger a connection attempt.
 
 From now on, these credentials will be automatically used when the configured network is reachable.
 
 When building as firmware image for a non-secure board target, the Wi-Fi credentials backend will be set to PSA using TF-M.
 
-See the :ref:`wifi_shell_sample` sample document for more details on the ``wifi_cred`` command.
+See the :ref:`wifi_shell_sample` sample document for more details on the ``wifi cred`` command.

--- a/samples/net/http_server/README.rst
+++ b/samples/net/http_server/README.rst
@@ -289,8 +289,8 @@ The following serial UART output is displayed in the terminal emulator when runn
          *** Booting nRF Connect SDK v3.4.99-ncs1-4667-g883c3709f9c8 ***
          [00:00:00.529,632] <inf> http_server: HTTP Server sample started
          [00:00:00.554,504] <inf> http_server: Network interface brought up
-         uart:~$ wifi_cred add -s "cia-asusgold" -k 1 -p thingy91rocks
-         uart:~$ wifi_cred auto_connect
+         uart:~$ wifi cred add -s "cia-asusgold" -k 1 -p thingy91rocks
+         uart:~$ wifi cred auto_connect
          [00:00:53.984,100] <inf> http_server: Network connected
          [00:00:53.985,778] <inf> http_server: Waiting for IPv6 HTTP connections on port 81, sock 9
          [00:00:54.986,511] <inf> http_server: Waiting for IPv4 HTTP connections on port 80, sock 10

--- a/samples/wifi/shell/README.rst
+++ b/samples/wifi/shell/README.rst
@@ -273,7 +273,7 @@ Supported CLI commands
        | Set operation example for interface index 1 (setting channel 5)
        | wifi -i1 -c5
 
-``wifi_cred`` is an extension to the Wi-Fi command line.
+``wifi cred`` is an extension to the Wi-Fi command line.
 It adds the following subcommands to interact with the :ref:`lib_wifi_credentials` library:
 
 .. list-table:: Wi-Fi credentials shell subcommands


### PR DESCRIPTION
Wi-Fi cred shell has been renamed from wifi_cred to wifi cred.

SHEL-3589