### PR TITLE
(3.0) treewide: remove nrf54l20pdk from the docs

### DIFF
--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -243,7 +243,3 @@
 .. nrf54l15dk_nrf54l15_cpuflpr
 
 | :ref:`nRF54L15 DK <ug_nrf54l>` | PCA10156 | :ref:`nrf54l15dk <zephyr:nrf54l15dk_nrf54l15>` | ``nrf54l15dk/nrf54l15/cpuflpr`` |
-
-.. nrf54l20pdk_nrf54l20_cpuapp
-
-| nRF54L20 PDK |   | :ref:`nrf54l20pdk <zephyr:nrf54l20pdk_nrf54l20>` | ``nrf54l20pdk/nrf54l20/cpuapp`` |

--- a/samples/crypto/aes_cbc/sample.yaml
+++ b/samples/crypto/aes_cbc/sample.yaml
@@ -59,7 +59,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.aes_cbc.cracen.crypto_service:

--- a/samples/crypto/aes_ccm/sample.yaml
+++ b/samples/crypto/aes_ccm/sample.yaml
@@ -59,7 +59,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.aes_ccm.cracen.crypto_service:

--- a/samples/crypto/aes_ctr/sample.yaml
+++ b/samples/crypto/aes_ctr/sample.yaml
@@ -59,7 +59,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.aes_ctr.cracen.crypto_service:

--- a/samples/crypto/aes_gcm/sample.yaml
+++ b/samples/crypto/aes_gcm/sample.yaml
@@ -79,7 +79,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.aes_gcm.cracen.crypto_service:

--- a/samples/crypto/chachapoly/sample.yaml
+++ b/samples/crypto/chachapoly/sample.yaml
@@ -59,7 +59,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.chachapoly.cracen.crypto_service:

--- a/samples/crypto/ecdh/sample.yaml
+++ b/samples/crypto/ecdh/sample.yaml
@@ -59,7 +59,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.ecdh.cracen.crypto_service:

--- a/samples/crypto/ecdsa/sample.yaml
+++ b/samples/crypto/ecdsa/sample.yaml
@@ -75,7 +75,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.ecdsa.cracen.crypto_service:

--- a/samples/crypto/ecjpake/sample.yaml
+++ b/samples/crypto/ecjpake/sample.yaml
@@ -58,7 +58,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.ecjpake.cracen.crypto_service:

--- a/samples/crypto/eddsa/sample.yaml
+++ b/samples/crypto/eddsa/sample.yaml
@@ -75,7 +75,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.eddsa.cracen.crypto_service:

--- a/samples/crypto/hkdf/sample.yaml
+++ b/samples/crypto/hkdf/sample.yaml
@@ -57,7 +57,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.hkdf.cracen.crypto_service:

--- a/samples/crypto/hmac/sample.yaml
+++ b/samples/crypto/hmac/sample.yaml
@@ -59,7 +59,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.hmac.cracen.crypto_service:

--- a/samples/crypto/pbkdf2/sample.yaml
+++ b/samples/crypto/pbkdf2/sample.yaml
@@ -57,7 +57,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.pbkdf2.cracen.crypto_service:

--- a/samples/crypto/persistent_key_usage/sample.yaml
+++ b/samples/crypto/persistent_key_usage/sample.yaml
@@ -60,6 +60,5 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp

--- a/samples/crypto/psa_tls/sample.yaml
+++ b/samples/crypto/psa_tls/sample.yaml
@@ -194,7 +194,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
@@ -218,7 +217,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
@@ -243,7 +241,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
@@ -267,7 +264,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
@@ -336,7 +332,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
     tags:
       - ci_build
@@ -356,7 +351,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
     tags:
       - ci_build

--- a/samples/crypto/rng/sample.yaml
+++ b/samples/crypto/rng/sample.yaml
@@ -57,7 +57,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.rng.cracen.crypto_service:

--- a/samples/crypto/rsa/sample.yaml
+++ b/samples/crypto/rsa/sample.yaml
@@ -58,6 +58,5 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp

--- a/samples/crypto/sha256/sample.yaml
+++ b/samples/crypto/sha256/sample.yaml
@@ -79,7 +79,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   # Build integration regression protection.

--- a/samples/crypto/spake2p/sample.yaml
+++ b/samples/crypto/spake2p/sample.yaml
@@ -57,7 +57,6 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
   sample.spake2p.cracen.crypto_service:

--- a/samples/keys/hw_unique_key/sample.yaml
+++ b/samples/keys/hw_unique_key/sample.yaml
@@ -33,7 +33,6 @@ common:
     - nrf52840dk/nrf52840
     - nrf21540dk/nrf52840
     - nrf54l15dk/nrf54l15/cpuapp
-    - nrf54l20pdk/nrf54l20/cpuapp
     - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l05/cpuapp
   harness: console

--- a/samples/zephyr/drivers/adc/adc_dt/sample.yaml
+++ b/samples/zephyr/drivers/adc/adc_dt/sample.yaml
@@ -8,7 +8,6 @@ tests:
     # depends_on: adc
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp

--- a/samples/zephyr/drivers/adc/adc_sequence/sample.yaml
+++ b/samples/zephyr/drivers/adc/adc_sequence/sample.yaml
@@ -8,7 +8,6 @@ tests:
     # depends_on: adc
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp

--- a/samples/zephyr/drivers/i2c/rtio_loopback/sample.yaml
+++ b/samples/zephyr/drivers/i2c/rtio_loopback/sample.yaml
@@ -16,8 +16,6 @@ tests:
   nrf.extended.sample.drivers.i2c.rtio_loopback.l20:
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp
-    integration_platforms:
-      - nrf54l20pdk/nrf54l20/cpuapp
   nrf.extended.sample.drivers.i2c.rtio_loopback.l09:
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp

--- a/samples/zephyr/drivers/mbox/sample.yaml
+++ b/samples/zephyr/drivers/mbox/sample.yaml
@@ -11,8 +11,6 @@ tests:
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
-    integration_platforms:
-      - nrf54l20pdk/nrf54l20/cpuapp
     extra_args: mbox_SNIPPET=nordic-flpr
     sysbuild: true
     harness: console
@@ -26,8 +24,6 @@ tests:
   nrf.extended.sample.drivers.mbox.nrf54l_no_multithreading:
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
-    integration_platforms:
       - nrf54l20pdk/nrf54l20/cpuapp
     extra_args:
       - mbox_SNIPPET=nordic-flpr
@@ -45,8 +41,6 @@ tests:
   nrf.extended.sample.drivers.mbox.nrf54l_remote_no_multithreading:
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
-    integration_platforms:
       - nrf54l20pdk/nrf54l20/cpuapp
     extra_args:
       - mbox_SNIPPET=nordic-flpr

--- a/samples/zephyr/sensor/qdec/sample.yaml
+++ b/samples/zephyr/sensor/qdec/sample.yaml
@@ -12,8 +12,6 @@ tests:
   nrf.extended.sample.sensor.nrf_qdec_sensor:
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp
-    integration_platforms:
-      - nrf54l20pdk/nrf54l20/cpuapp
     harness_config:
       fixture: gpio_loopback
       type: multi_line

--- a/samples/zephyr/subsys/usb/hid-keyboard/sample.yaml
+++ b/samples/zephyr/subsys/usb/hid-keyboard/sample.yaml
@@ -48,7 +48,6 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE="large_out_report.overlay"
   nrf.extended.sample.usbd.hid-keyboard.l20:
     integration_platforms:
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp
@@ -61,7 +60,6 @@ tests:
         - "HID keyboard sample is initialized"
   nrf.extended.sample.usbd.hid-keyboard.out-report.l20:
     integration_platforms:
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp
@@ -76,7 +74,6 @@ tests:
         - "HID keyboard sample is initialized"
   nrf.extended.sample.usbd.hid-keyboard.large-report.l20:
     integration_platforms:
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp
@@ -91,7 +88,6 @@ tests:
         - "HID keyboard sample is initialized"
   nrf.extended.sample.usbd.hid-keyboard.large-out-report.l20:
     integration_platforms:
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp

--- a/samples/zephyr/subsys/usb/hid-mouse/sample.yaml
+++ b/samples/zephyr/subsys/usb/hid-mouse/sample.yaml
@@ -32,7 +32,6 @@ tests:
     # depends_on:
     #   - usbd
     integration_platforms:
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp

--- a/tests/drivers/gpio/gpio_more_loops/testcase.yaml
+++ b/tests/drivers/gpio/gpio_more_loops/testcase.yaml
@@ -22,7 +22,6 @@ tests:
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf7120pdk/nrf7120/cpuapp

--- a/tests/drivers/gpio/gpio_nfct/testcase.yaml
+++ b/tests/drivers/gpio/gpio_nfct/testcase.yaml
@@ -19,6 +19,5 @@ tests:
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf7120pdk/nrf7120/cpuapp

--- a/tests/drivers/lpuart/testcase.yaml
+++ b/tests/drivers/lpuart/testcase.yaml
@@ -31,7 +31,6 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     extra_configs:
@@ -52,7 +51,6 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     extra_configs:

--- a/tests/drivers/uart/uart_baudrate_test/testcase.yaml
+++ b/tests/drivers/uart/uart_baudrate_test/testcase.yaml
@@ -51,19 +51,13 @@ tests:
   drivers.uart.baudrate_test.l20_uart00:
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp
-    integration_platforms:
-      - nrf54l20pdk/nrf54l20/cpuapp
     extra_args: DTC_OVERLAY_FILE="boards/nrf54l20pdk_nrf54l20_cpuapp_uart00.overlay"
   drivers.uart.baudrate_test.l20_uart21:
     platform_allow:
       - nrf54l20pdk/nrf54l20/cpuapp
-    integration_platforms:
-      - nrf54l20pdk/nrf54l20/cpuapp
     extra_args: DTC_OVERLAY_FILE="boards/nrf54l20pdk_nrf54l20_cpuapp_uart21.overlay"
   drivers.uart.baudrate_test.l20_uart22:
     platform_allow:
-      - nrf54l20pdk/nrf54l20/cpuapp
-    integration_platforms:
       - nrf54l20pdk/nrf54l20/cpuapp
     extra_args: DTC_OVERLAY_FILE="boards/nrf54l20pdk_nrf54l20_cpuapp_uart22.overlay"
   drivers.uart.baudrate_test.l09_uart21:

--- a/tests/zephyr/boards/nrf/comp/testcase.yaml
+++ b/tests/zephyr/boards/nrf/comp/testcase.yaml
@@ -12,4 +12,3 @@ tests:
       - nrf54l20pdk/nrf54l20/cpuapp
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp

--- a/tests/zephyr/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/zephyr/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -9,7 +9,6 @@ tests:
     #   fixture: adc_ref_volt
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp

--- a/tests/zephyr/drivers/comparator/gpio_loopback/testcase.yaml
+++ b/tests/zephyr/drivers/comparator/gpio_loopback/testcase.yaml
@@ -13,7 +13,6 @@ tests:
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp
     integration_platforms:
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp
   nrf.extended.drivers.comparator.gpio_loopback.nrf_lpcomp:
     extra_args:
@@ -22,5 +21,4 @@ tests:
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp
     integration_platforms:
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp

--- a/tests/zephyr/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/zephyr/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -12,7 +12,6 @@ tests:
   nrf.extended.drivers.gpio.2pin:
     integration_platforms:
       - nrf54l09pdk/nrf54l09/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp


### PR DESCRIPTION
Make sure it doesn't appear as a supported board in the documentation.

For that, it needs to be removed from the `integration_platforms` in the YAML files.