### PR TITLE
mpsl: fem: nrf21540: add MPSL_FEM_NRF21540_PA_LEAD_TIME_ADDITIONAL_US

### DIFF
--- a/subsys/mpsl/fem/Kconfig
+++ b/subsys/mpsl/fem/Kconfig
@@ -208,6 +208,18 @@ config MPSL_FEM_NRF21540_RUNTIME_PA_GAIN_CONTROL
 
 	  If this option is disabled the PA gain is constant and equal MPSL_FEM_NRF21540_TX_GAIN_DB.
 
+config MPSL_FEM_NRF21540_PA_LEAD_TIME_ADDITIONAL_US
+	int "Additional lead time in microseconds by which the PA of the nRF21540 is enabled earlier."
+	default 15
+	help
+	  Radio protocol drivers in the nRF Connect SDK usually set the target time point
+	  when the PA of a Front-End Module is expected to be fully ramped-up and ready
+	  for a transmission as the moment of the EVENTS_READY event of the RADIO peripheral.
+	  However the RF power on the SoC output starts to rise before this event.
+	  To avoid any spurious emission, at the moment when RF power starts to rise
+	  on the SoC output the PA of the FEM should be fully ramped-up.
+	  This parameter is added to the PA tx-en-settle-time-us device tree property
+	  to enable the PA of the FEM earlier and avoid spurious emission.
 
 endif   # (MPSL_FEM_NRF21540_GPIO || MPSL_FEM_NRF21540_GPIO_SPI) && MPSL_FEM
 

--- a/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
+++ b/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
@@ -63,7 +63,8 @@ static int fem_nrf21540_gpio_configure(void)
 		.fem_config = {
 			.pa_time_gap_us  =
 				DT_PROP(DT_NODELABEL(nrf_radio_fem),
-					tx_en_settle_time_us),
+					tx_en_settle_time_us) +
+					CONFIG_MPSL_FEM_NRF21540_PA_LEAD_TIME_ADDITIONAL_US,
 			.lna_time_gap_us =
 				DT_PROP(DT_NODELABEL(nrf_radio_fem),
 					rx_en_settle_time_us),

--- a/subsys/mpsl/fem/nrf21540_gpio_spi/mpsl_fem_nrf21540_gpio_spi.c
+++ b/subsys/mpsl/fem/nrf21540_gpio_spi/mpsl_fem_nrf21540_gpio_spi.c
@@ -144,7 +144,8 @@ static int fem_nrf21540_gpio_spi_configure(void)
 		.fem_config = {
 			.pa_time_gap_us  =
 				DT_PROP(DT_NODELABEL(nrf_radio_fem),
-					tx_en_settle_time_us),
+					tx_en_settle_time_us) +
+					CONFIG_MPSL_FEM_NRF21540_PA_LEAD_TIME_ADDITIONAL_US,
 			.lna_time_gap_us =
 				DT_PROP(DT_NODELABEL(nrf_radio_fem),
 					rx_en_settle_time_us),


### PR DESCRIPTION
The SoC output power starts to rise earlier than at the EVENTS_READY of the RADIO. To compensate this phenomenon and avoid spurious emission issue additional Kconfig option for the nRF21540 FEM MPSL_FEM_NRF21540_PA_LEAD_TIME_ADDITIONAL_US is added.

The default value is selected so that the TX_EN pin of the nrf21540 is enabled 26us before EVENTS_READY.

In the NCS 3.0 release the same spurious emission issue has been fixed by simply setting default value of `tx-en-settle-time-us` to 26. https://github.com/nrfconnect/sdk-zephyr/blob/v4.0.99-ncs1-branch/dts/bindings/net/wireless/nordic%2Cnrf21540-fem.yaml#L98 . However, to provide the fix without [nrf noup] commit (unwanted, see [here](https://github.com/nrfconnect/sdk-zephyr/pull/2762#discussion_r2043770407) ) the additional parameter on the nRF Connect SDK level is proposed.

Ref: KRKNWK-17752