### PR TITLE
samples: wifi: ble_coex: Remove stale DTS overlay

### DIFF
--- a/samples/wifi/ble_coex/CMakeLists.txt
+++ b/samples/wifi/ble_coex/CMakeLists.txt
@@ -6,8 +6,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(EXTRA_DTC_OVERLAY_FILE "dts.overlay")
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf_wifi_sta)
 

--- a/samples/wifi/ble_coex/dts.overlay
+++ b/samples/wifi/ble_coex/dts.overlay
@@ -1,3 +1,0 @@
-&uart0 {
-     /delete-property/ hw-flow-control;
-};

--- a/samples/wifi/thread_coex/CMakeLists.txt
+++ b/samples/wifi/thread_coex/CMakeLists.txt
@@ -6,8 +6,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(EXTRA_DTC_OVERLAY_FILE "dts.overlay")
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf_wifi_thread_coex)
 

--- a/samples/wifi/thread_coex/dts.overlay
+++ b/samples/wifi/thread_coex/dts.overlay
@@ -1,4 +1,0 @@
-&uart0 {
-	/* Disabling hardware flow control to free up pins for other purposes. */
-     /delete-property/ hw-flow-control;
-};


### PR DESCRIPTION
This was done at the beginning as a temporary fix and is definitely not cross-platform, so, remove it to avoid build errors for 54 Series.