### PR TITLE
samples: bluetooth: direct_test_mode: Add support for nRF54LM20PDK

### DIFF
--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -247,3 +247,7 @@
 .. nrf54l20pdk_nrf54l20_cpuapp
 
 | nRF54L20 PDK |   | :ref:`nrf54l20pdk <zephyr:nrf54l20pdk_nrf54l20>` | ``nrf54l20pdk/nrf54l20/cpuapp`` |
+
+.. nrf54lm20pdk_nrf54lm20a_cpuapp
+
+| nRF54LM20 PDK |   | nrf54lm20pdk | ``nrf54lm20pdk/nrf54lm20a/cpuapp`` |

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -248,6 +248,10 @@ Bluetooth samples
   * Fixed an issue where the sample would assert with the :kconfig:option:`CONFIG_ASSERT` Kconfig option enabled.
     This was due to calling the :c:func:`bt_iso_chan_send` function from a timer ISR handler and sending SDUs to the controller with invalid timestamps.
 
+* :ref:`direct_test_mode` sample:
+
+   * Added support for the nRF54LM20 PDK.
+
 |no_changes_yet_note|
 
 Bluetooth Mesh samples

--- a/samples/bluetooth/direct_test_mode/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
+++ b/samples/bluetooth/direct_test_mode/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unsupported driver
+CONFIG_NRFX_TIMER0=n
+CONFIG_NRFX_TIMER1=n
+CONFIG_NRFX_TIMER2=n
+
+# Use necessary peripherals
+CONFIG_NRFX_TIMER20=y
+CONFIG_NRFX_TIMER10=y

--- a/samples/bluetooth/direct_test_mode/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.overlay
+++ b/samples/bluetooth/direct_test_mode/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		ncs,dtm-uart = &uart20;
+	};
+};
+
+&uart20 {
+	status = "okay";
+	current-speed = <19200>;
+};
+
+&radio {
+	status = "okay";
+	/* This is a number of antennas that are available on antenna matrix
+	 * designed by Nordic. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 12 (in antenna matrix designed
+	 * by Nordic) for PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 4 0>;
+	dfegpio1-gpios = <&gpio0 5 0>;
+	dfegpio2-gpios = <&gpio0 6 0>;
+	dfegpio3-gpios = <&gpio0 7 0>;
+};

--- a/samples/bluetooth/direct_test_mode/sample.yaml
+++ b/samples/bluetooth/direct_test_mode/sample.yaml
@@ -12,6 +12,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
     platform_allow:
       - nrf5340dk/nrf5340/cpunet
@@ -20,6 +21,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
     tags:
       - bluetooth


### PR DESCRIPTION
Add support for nRF54LM20PDK in DTM sample.
