### PR TITLE
sdfw_services: device_info: fix structure names

### DIFF
--- a/subsys/sdfw_services/services/device_info/CMakeLists.txt
+++ b/subsys/sdfw_services/services/device_info/CMakeLists.txt
@@ -7,6 +7,6 @@
 zephyr_sources(device_info_service.c)
 
 generate_and_add_cbor_files(device_info_service.cddl zcbor_generated
-  device_info_service_req
-  device_info_service_rsp
+  device_info_req
+  device_info_resp
 )


### PR DESCRIPTION
The message structure names referenced by the cmake code for generating the zcbor code did not match those in the CDDL schema, causing a build failure when trying to generate the code with CONFIG_SSF_ZCBOR_GENERATE=y.