### PR TITLE
[Backport v3.0-branch] samples: wifi: shutdown: Remove support for the 54L target

### DIFF
--- a/samples/wifi/shutdown/sample.yaml
+++ b/samples/wifi/shutdown/sample.yaml
@@ -27,24 +27,8 @@ tests:
       - shutdown_SNIPPET=nrf70-wifi
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-    tags:
-      - ci_build
-      - sysbuild
-      - ci_samples_wifi
-  sample.nrf7002eb2.shutdown:
-    sysbuild: true
-    build_only: true
-    extra_args:
-      - shutdown_SHIELD="nrf7002eb2"
-      - shutdown_SNIPPET=nrf70-wifi
-    integration_platforms:
-      - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow:
-      - nrf54l15dk/nrf54l15/cpuapp
     tags:
       - ci_build
       - sysbuild


### PR DESCRIPTION
Backport f9c53060f2289b182039507b4c1c83edd882c7ae from #21840.