### PR TITLE
[Backport v3.0-branch] doc: 54H docs update removing Toolchain Manager

### DIFF
--- a/applications/ipc_radio/README.rst
+++ b/applications/ipc_radio/README.rst
@@ -122,9 +122,6 @@ For instructions on how to enable a specific configuration overlay file, see :re
 .. note::
    You cannot use :ref:`ble_rpc` together with the HCI :ref:`bluetooth_controller`.
 
-.. note::
-   |54H_engb_2_8|
-
 Dependencies
 ************
 

--- a/applications/nrf_desktop/description.rst
+++ b/applications/nrf_desktop/description.rst
@@ -900,9 +900,6 @@ The nRF Desktop application is built the same way to any other |NCS| application
 .. note::
    Information about the known issues in nRF Desktop can be found in |NCS|'s :ref:`release_notes` and on the :ref:`known_issues` page.
 
-.. note::
-   |54H_engb_2_8|
-
 .. _nrf_desktop_selecting_build_types:
 
 Selecting a build type

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_debugging.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_debugging.rst
@@ -89,10 +89,7 @@ To debug a specific core using ``JLinkExe`` do the following:
    You can find the ``SEGGER-ID`` as follows:
 
    * Check the ``SEGGER ID`` printed on the label on the bottom side of the DK.
-   * Run the ``nrfjprog --ids`` command.
-
-      .. note::
-         |nrfjprog_deprecation_note|
+   * Run the ``nrfutil device list`` command.
 
    If you connect just one DK to the machine, defining ``SEGGER-ID`` is not necessary.
 

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_gs.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_gs.rst
@@ -22,13 +22,8 @@ Make sure you have all the required hardware and that your computer has one of t
 Hardware
 ========
 
-* nRF54H20 DK version PCA10175 Engineering C - v0.9.0 and later revisions
-
+* nRF54H20 DK version PCA10175 Engineering C - v0.9.0 and later revisions.
   Check the version number on your DK's sticker to verify its compatibility with the |NCS|.
-
-.. note::
-   |54H_engb_2_8|
-
 * USB-C cable.
 
 Software
@@ -36,7 +31,7 @@ Software
 
 On your computer, one of the following operating systems:
 
-.. include:: ../../../../nrf/installation/recommended_versions.rst
+.. include:: ../../../installation/recommended_versions.rst
     :start-after: os_table_start
     :end-before: os_table_end
 
@@ -61,87 +56,21 @@ Installing the required software
 
 To work with the nRF54H20 DK, follow the instructions in the next sections to install the required tools.
 
-.. _ug_nrf54h20_install_toolchain:
+Install prerequisites
+=====================
 
-Installing the |NCS| and its toolchain
-======================================
-
-You can install the |NCS| and its toolchain by using Toolchain Manager.
-
-Toolchain Manager is a tool available from `nRF Connect for Desktop`_, a cross-platform tool that provides different applications that simplify installing the |NCS|.
-Both the tool and the application are available for Windows, Linux, and MacOS.
-
-To install the toolchain and the SDK using the Toolchain Manager app, complete the following steps:
-
-1. Install Toolchain Manager:
-
-   a. `Download nRF Connect for Desktop`_ for your operating system.
-   #. Install and run the tool on your machine.
-   #. In the :guilabel:`Apps` section, click :guilabel:`Install` next to Toolchain Manager.
-
-   The app installs on your machine, and the :guilabel:`Install` button changes to :guilabel:`Open`.
-
-#. Install the |NCS| source code:
-
-   a. Open Toolchain Manager in nRF Connect for Desktop.
-
-      .. figure:: ../../../../nrf/images/gs-assistant_tm.png
-         :alt: The Toolchain Manager window
-
-         The Toolchain Manager window
-
-   #. Click :guilabel:`SETTINGS` in the navigation bar to specify where you want to install the |NCS|.
-   #. In :guilabel:`SDK ENVIRONMENTS`, click the :guilabel:`Install` button next to the |NCS| version |release|.
-
-      The |NCS| version |release| installs on your machine.
-      The :guilabel:`Install` button changes to :guilabel:`Open VS Code`.
-
-#. Set up the preferred building method:
-
-   .. tabs::
-
-      .. tab:: nRF Connect for Visual Studio Code
-
-         To build on the |nRFVSC|, complete the following steps:
-
-         a. In Toolchain Manager, click the :guilabel:`Open VS Code` button.
-
-            A notification appears with a list of missing extensions that you need to install, including those from the `nRF Connect for Visual Studio Code`_ extension pack.
-         #. Click **Install missing extensions**, then close VS Code.
-         #. Once the extensions are installed, click **Open VS Code** button again.
-
-         You can then follow the instructions in :ref:`creating_vsc`.
-
-      .. tab:: Command line
-
-         To build on the command line, complete the following steps:
-
-         1. Restart the Toolchain Manager application.
-         #. Click the dropdown menu for the installed nRF Connect SDK version.
-
-            .. figure:: ../../../../nrf/images/gs-assistant_tm_dropdown.png
-               :alt: The Toolchain Manager dropdown menu for the installed nRF Connect SDK version, cropped
-
-               The Toolchain Manager dropdown menu options
-
-         #. Select :guilabel:`Open command prompt`.
-
-         You can then follow the instructions in :ref:`creating_cmd`.
-
-Installing a terminal application
-=================================
-
-Install a terminal emulator, such as the `Serial Terminal app`_ (from the nRF Connect for Desktop application) or the nRF Terminal (part of the `nRF Connect for Visual Studio Code`_ extension).
-Both of these terminal emulators start the required :ref:`toolchain environment <using_toolchain_environment>`.
+.. include:: ../../../installation/install_ncs.rst
+   :start-after: .. prerequisites-include-start
+   :end-before: .. prerequisites-include-end
 
 Installing nRF Util and its commands
-====================================
+------------------------------------
 
 Using the nRF54H20 DK with the |NCS| version |release| requires the following:
 
 * nRF Util v7.13.0 or higher
-* nRF Util ``device`` command v2.7.16
-* nRF Util ``trace`` command v3.1.0
+* nRF Util ``device`` command v2.8.8
+* nRF Util ``trace`` command v3.3.0
 * nRF Util ``suit`` command v0.9.0
 
 If you have not already installed nRF Util as part of :ref:`nRF Connect SDK prerequisites <installing_vsc>`, complete the following steps to install it:
@@ -170,6 +99,28 @@ If you have not already installed nRF Util as part of :ref:`nRF Connect SDK prer
    .. code-block::
 
       nrfutil install device=2.7.16 --force
+
+.. _ug_nrf54h20_install_toolchain:
+
+Installing the |NCS| toolchain
+==============================
+
+.. include:: ../../../installation/install_ncs.rst
+   :start-after: .. installncstoolchain-include-start
+   :end-before: .. installncstoolchain-include-end
+
+Getting the |NCS| code
+======================
+
+.. include:: ../../../installation/install_ncs.rst
+   :start-after: .. getncscode-include-start
+   :end-before: .. getncscode-include-end
+
+Installing a terminal application
+=================================
+
+Install a terminal emulator, such as the `Serial Terminal app`_ (from the nRF Connect for Desktop application) or the nRF Terminal (part of the `nRF Connect for Visual Studio Code`_ extension).
+Both of these terminal emulators start the required :ref:`toolchain environment <using_toolchain_environment>`.
 
 .. _ug_nrf54h20_gs_bringup:
 
@@ -211,7 +162,7 @@ After programming the BICR, program the nRF54H20 SoC with the :ref:`nRF54H20 SoC
 This bundle contains the precompiled firmware for the :ref:`Secure Domain <ug_nrf54h20_secure_domain>` and :ref:`System Controller <ug_nrf54h20_sys_ctrl>`.
 To program the nRF54H20 SoC binaries to the nRF54H20 DK, do the following:
 
-1. Download the `nRF54H20 SoC binaries v0.9.2`_, compatible with the nRF54H20 DK v0.9.0 and later revisions.
+1. Download the `nRF54H20 SoC binaries v0.9.6`_, compatible with the nRF54H20 DK v0.9.0 and later revisions.
 
    .. note::
       On MacOS, ensure that the ZIP file is not unpacked automatically upon download.

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_keys.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_keys.rst
@@ -55,15 +55,15 @@ To generate the keys, follow these steps:
 
    * For the application core::
 
-         python generate_psa_key_attributes.py --usage VERIFY_MESSAGE_EXPORT --id 0x40022100 --type ECC_TWISTED_EDWARDS --size 255 --algorithm EDDSA_PURE --location PERSISTENT_CRACEN --key-from-file MANIFEST_APPLICATION_GEN1_pub.pem  --file all_keys.json --cracen_usage RAW
+        python generate_psa_key_attributes.py --usage VERIFY_MESSAGE_EXPORT --id 0x40022100 --type ECC_TWISTED_EDWARDS --size 255 --algorithm EDDSA_PURE --location LOCATION_CRACEN --key-from-file MANIFEST_APPLICATION_GEN1_pub.pem  --file all_keys.json --cracen_usage RAW --lifetime PERSISTENCE_DEFAULT
 
    * For the radio core::
 
-         python generate_psa_key_attributes.py --usage VERIFY_MESSAGE_EXPORT --id 0x40032100 --type ECC_TWISTED_EDWARDS --size 255 --algorithm EDDSA_PURE --location PERSISTENT_CRACEN --key-from-file MANIFEST_RADIOCORE_GEN1_pub.pem --file all_keys.json --cracen_usage RAW
+        python generate_psa_key_attributes.py --usage VERIFY_MESSAGE_EXPORT --id 0x40032100 --type ECC_TWISTED_EDWARDS --size 255 --algorithm EDDSA_PURE --location LOCATION_CRACEN --key-from-file MANIFEST_RADIOCORE_GEN1_pub.pem --file all_keys.json --cracen_usage RAW --lifetime PERSISTENCE_DEFAULT
 
    * For the main root manifest::
 
-         python generate_psa_key_attributes.py --usage VERIFY_MESSAGE_EXPORT --id 0x4000AA00 --type ECC_TWISTED_EDWARDS --size 255 --algorithm EDDSA_PURE --location PERSISTENT_CRACEN --key-from-file MANIFEST_OEM_ROOT_GEN1_pub.pem --file all_keys.json --cracen_usage RAW
+        python generate_psa_key_attributes.py --usage VERIFY_MESSAGE_EXPORT --id 0x4000AA00 --type ECC_TWISTED_EDWARDS --size 255 --algorithm EDDSA_PURE --location LOCATION_CRACEN --key-from-file MANIFEST_OEM_ROOT_GEN1_pub.pem --file all_keys.json --cracen_usage RAW --lifetime PERSISTENCE_DEFAULT
 
 
 The generated key data is stored in a JSON file, which serves as an input for the next step.
@@ -78,8 +78,8 @@ In this scenario, nRF Util functions as a transport layer, transferring the key 
 The Secure Domain Firmware on the device handles the actual key provisioning using PSA Crypto's ``psa_import_key`` function.
 Provisioning a key calls the function to import the key:
 
-* The ``metadata`` field from the JSON file is used for the function's attributes argument
-* The ``value`` field is passed to the function's data argument
+* The ``metadata`` field from the JSON file is used for the function's attributes argument.
+* The ``value`` field is passed to the function's data argument.
 * The function's ``data_length`` is set to the length of the value field.
 
 To provision the keys from ``all_keys.json`` onto the KMU of the nRF54H20 SoC, use nRF Util as follows::

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_suit_customize_dfu.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_suit_customize_dfu.rst
@@ -47,10 +47,11 @@ Software requirements
 
 This guide requires the following software:
 
-* Toolchain Manager - For installing the full |NCS| toolchain.
+* The full |NCS| toolchain.
+  See :ref:`ug_nrf54h20_gs` for instructions on how to install the toolchain.
 * Microsoft's |VSC| - The recommended IDE for |NCS|.
 * |nRFVSC| - An add-on for |VSC| for developing |NCS| applications.
-* nRF Command Line Tools - Mandatory tools for working with |NCS|.
+* nRF Util.
 * **suit-generator** - A Python package by Nordic Semiconductor for generating SUIT envelopes and manifests.
 
 Download instructions are in the README file in the `suit-generator`_ repository.

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_suit_customize_qsg.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_suit_customize_qsg.rst
@@ -63,10 +63,11 @@ Software requirements
 
 For this quick start guide, we will install the following software:
 
-* Toolchain Manager - An application for installing the full |NCS| toolchain.
+* The full |NCS| toolchain.
+  See :ref:`ug_nrf54h20_gs` for instructions on how to install the toolchain.
 * Microsoft's |VSC| - The recommended IDE for the |NCS|.
 * |nRFVSC| - An add-on for |VSC| that allows you to develop applications for the |NCS|.
-* nRF Command Line Tools - A set of mandatory tools for working with the |NCS|.
+* nRF Util.
 * Any additional requirements described in the :ref:`nrf54h_suit_sample` sample.
 
 Building the SUIT sample

--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -38,6 +38,8 @@ Before you start setting up the toolchain, install available updates for your :r
 Install prerequisites
 *********************
 
+.. prerequisites-include-start
+
 Depending on your preferred development environment, install the following software tools.
 
 .. tabs::
@@ -56,6 +58,8 @@ Depending on your preferred development environment, install the following softw
 
       .. include:: /includes/install_sdk_common_prerequisites.txt
 
+.. prerequisites-include-end
+
 .. _gs_installing_toolchain:
 .. _gs_installing_tools:
 
@@ -63,6 +67,8 @@ Depending on your preferred development environment, install the following softw
 
 Install the |NCS| toolchain
 ***************************
+
+.. installncstoolchain-include-start
 
 The |NCS| :term:`toolchain` includes the Zephyr SDK and then adds tools and modules required to build |NCS| samples and applications on top of it.
 These include the :ref:`required SDK tools <requirements_toolchain_tools>`, the :ref:`Python dependencies <requirements_toolchain_python_deps>`, and the :ref:`GN tool <ug_matter_gs_tools_gn>` for creating :ref:`ug_matter` applications.
@@ -164,6 +170,8 @@ In this simplified structure preview, *<toolchain-installation>* corresponds to 
 
 You can check the versions of the required tools and Python dependencies on the :ref:`Requirements reference page <requirements_toolchain>`.
 
+.. installncstoolchain-include-end
+
 .. _cloning_the_repositories_win:
 .. _cloning_the_repositories:
 
@@ -171,6 +179,8 @@ You can check the versions of the required tools and Python dependencies on the 
 
 Get the |NCS| code
 ******************
+
+.. getncscode-include-start
 
 Every |NCS| release consists of a combination of :ref:`ncs_git_intro` repositories at different versions and revisions, managed together by :ref:`ncs_west_intro`.
 The revision of each of those repositories is determined by the current revision of the main (or :ref:`manifest <zephyr:west-manifests>`) repository, `sdk-nrf`_.
@@ -339,6 +349,8 @@ With the default location to install the toolchain (see the previous step) and t
 In this simplified structure preview, *<toolchain-installation>* corresponds to the toolchain version and *<west-workspace>* corresponds to the SDK version name.
 There are also additional directories, and the structure might change over time, for example if you later :ref:`change the state of development to a different revision <updating_repos>`.
 The full set of repositories and directories is defined in the :ref:`manifest file <zephyr:west-manifest-files>` (`see the file in the repository <west manifest file_>`_).
+
+.. getncscode-include-end
 
 .. _build_environment_cli:
 
@@ -623,5 +635,3 @@ To install the |NCS| system-wide, complete the following steps:
 #. If you want to build `Matter`_ applications, additionally install the `GN`_ meta-build system.
    This system generates the Ninja files that the |NCS| uses for Matter.
    See :ref:`manual_installation_gn` for more information.
-
-.. |install_latest_version| replace:: When you first install the |NCS|, it is recommended to install the latest released versions of the SDK and the toolchain.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1812,6 +1812,7 @@
 .. _`nRF54H20 SoC binaries v0.7.0 for EngB DKs`: https://files.nordicsemi.com/artifactory/SDSC/external/nrf54h20_soc_binaries_v0.7.0_engb.zip
 .. _`nRF54H20 SoC binaries v0.8.0`: https://files.nordicsemi.com/ui/native/SDSC/external/nrf54h20_soc_binaries_v0.8.0.zip
 .. _`nRF54H20 SoC binaries v0.9.2`: https://files.nordicsemi.com/ui/native/SDSC/external/nrf54h20_soc_binaries_v0.9.2.zip
+.. _`nRF54H20 SoC binaries v0.9.6`: https://files.nordicsemi.com/ui/native/SDSC/external/nrf54h20_soc_binaries_v0.9.6.zip
 
 .. _`BICR binary file`: https://files.nordicsemi.com/artifactory/SDSC/external/bicr_ext_loadcap.hex
 .. _`BICR new binary file`: https://files.nordicsemi.com/artifactory/SDSC/external/bicr/bicr.hex

--- a/doc/nrf/releases_and_maturity/abi_compatibility.rst
+++ b/doc/nrf/releases_and_maturity/abi_compatibility.rst
@@ -7,16 +7,17 @@ ABI compatibility
    :local:
    :depth: 2
 
-Application Binary Interface (ABI) compatibility defines how software components, like libraries and applications, interact at the machine code level through their low-level binary interface, including:
+Application Binary Interface (ABI) compatibility defines how software components, such as libraries and applications, interact at the machine code level through their low-level binary interface.
+This includes:
 
 * Function-calling conventions
 * Data structure layouts in memory
 * Exception handling mechanisms
 * Register usage conventions
 
-When ABI compatibility is maintained, binaries of one component can interface correctly with another without needing recompilation.
+When ABI compatibility is maintained, binaries of one component can interface correctly with another without requiring recompilation.
 For example, adding a new function to a library is typically an ABI-compatible change, as existing binaries remain functional.
-However, changes that affect data structure layouts, such as altering field order or size, break ABI compatibility as they change the memory layout expected by existing binaries.
+However, changes that affect data structure layouts, such as altering field order or size, break ABI compatibility because they change the memory layout expected by existing binaries.
 
 ABI compatibility matrix for the nRF54H20 SoC binaries
 ******************************************************
@@ -28,6 +29,8 @@ The following table illustrates ABI compatibility between different versions of 
 
    * - |NCS| versions
      - Compatible nRF54H20 SoC binaries version
+   * - |NCS| v3.0.0
+     - `nRF54H20 SoC binaries v0.9.6`_, compatible with the nRF54H20 DK v0.9.0 and later revisions.
    * - |NCS| v2.9.0-nRF54H20-1
      - `nRF54H20 SoC binaries v0.9.2`_, compatible with the nRF54H20 DK v0.9.0 and later revisions.
    * - |NCS| v2.9.0
@@ -44,15 +47,75 @@ The following table illustrates ABI compatibility between different versions of 
    * - |NCS| v2.6.99-cs2
      - `nRF54H20 SoC binaries v0.3.3`_
 
-ABI compatibility ensures that the Secure Domain and System Controller firmware binaries do not need to be recompiled each time the application, radio binaries, or both are recompiled, as long as they are based on a compatible |NCS| version.
+Maintaining ABI compatibility ensures that the Secure Domain and System Controller firmware binaries do not need to be recompiled each time the application, radio binaries, or both are recompiled, as long as they are based on a compatible |NCS| version.
 Additionally, maintaining ABI compatibility allows the nRF54H20 SoC binary components to work together without recompilation when updating to newer |NCS| versions.
+
+.. note::
+    The nRF54H20 SoC binaries only support specific versions of the |NCS| and do not support rollbacks to previous versions.
+    Upgrading the nRF54H20 SoC binaries on your development kit might break the DK's compatibility with applications developed for earlier versions of the |NCS|.
+
+nRF54H20 SoC binaries v0.9.6 changelog
+**************************************
+
+The following sections provide detailed lists of changes by component.
+
+Secure Domain Firmware (SDFW) v10.3.3
+=====================================
+
+* Updated BINDESC to a new version.
+
+Secure Domain Firmware (SDFW) v10.3.1
+=====================================
+
+Added
+-----
+
+* Enabled pulling of Secure Domain images during SUIT manifest processing.
+
+Fixed
+-----
+
+* Adjusted file URIs to prevent SUIT envelope size overflow.
+* Resolved an issue where the IPUC write setup was being erased, ensuring proper SUIT AB operation.
+
+System Controller Firmware (SCFW) v4.2.3
+=========================================
+
+* Removed changing ``VREG1V0 VOUT`` for the high-power radio in power management temperature monitoring.
+  The actual value is now set by the SysCtrl ROM from FICR.
+
+System Controller Firmware (SCFW) v4.2.1
+=========================================
+
+* Updated PCRM configuration to set the BLE active parameter to ``0x0E``.
+
+System Controller Firmware (SCFW) v4.2.0
+=========================================
+
+* Updated the ``PCRM.LOAD`` value for radio on-demand operations using dedicated VEVIF channels.
+* Implemented a workaround for ICPS-1304.
+
+System Controller Firmware (SCFW) v4.1.0
+=========================================
+
+Added
+-----
+
+* Audio PLL service for local domains.
+* LFRC support.
+
+Updated
+-------
+
+* Clock initialization tree to support a new 32k clock source - LFRC.
+
+Removed
+-------
+
+* Split image partition.
 
 nRF54H20 SoC binaries v0.9.2 changelog
 **************************************
-
-.. note::
-    The nRF54H20 SoC binaries only support specific versions of the |NCS| and do not support rollbacks to a previous version.
-    Upgrading the nRF54H20 SoC binaries on your development kit might break the DK's compatibility with applications developed for previous versions of the |NCS|.
 
 The following sections provide detailed lists of changes by component.
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -245,3 +245,5 @@
 .. |devicetree_bindings| replace:: The devicetree bindings provide the structure for the content of the devicetree nodes.
    The :ref:`compatible <zephyr:dt-bindings-compatible>` property defines the compatibility of a devicetree node with a devicetree binding.
    For more information, read the :ref:`documentation about devicetree bindings in Zephyr <zephyr:dt-binding-compat>`.
+
+.. |install_latest_version| replace:: When you first install the |NCS|, it is recommended to install the latest released versions of the SDK and the toolchain.

--- a/samples/app_event_manager/README.rst
+++ b/samples/app_event_manager/README.rst
@@ -54,9 +54,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/benchmarks/coremark/README.rst
+++ b/samples/benchmarks/coremark/README.rst
@@ -193,7 +193,6 @@ SB_CONFIG_APP_CPUNET_RUN - Enable the benchmark execution also for the network c
 SB_CONFIG_APP_CPUPPR_RUN - Enable the benchmark execution also for the PPR core
    This option is only available for board targets that support the PPR core (for example, ``nrf54h20dk/nrf54h20/cpuapp``) in this sample.
 
-
 .. note::
    PPR code is run from RAM.
 
@@ -209,9 +208,6 @@ When running the benchmark, an extra build flag (:kconfig:option:`CONFIG_COMPILE
 After flashing, messages describing the benchmark state will appear in the console.
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
-
-.. note::
-   |54H_engb_2_8|
 
 Alternative build configurations
 ================================

--- a/samples/bluetooth/central_and_peripheral_hr/README.rst
+++ b/samples/bluetooth/central_and_peripheral_hr/README.rst
@@ -86,9 +86,6 @@ Building and running
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 .. _central_and_peripheral_hrs_testing:
 
 Testing

--- a/samples/bluetooth/central_bas/README.rst
+++ b/samples/bluetooth/central_bas/README.rst
@@ -59,11 +59,7 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 .. _central_bas_testing:
-
 
 Testing
 =======

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -96,9 +96,6 @@ Building and Running
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/bluetooth/central_hr_coded/README.rst
+++ b/samples/bluetooth/central_hr_coded/README.rst
@@ -42,9 +42,6 @@ Building and running
 
 .. include:: /includes/ipc_radio_conf.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/bluetooth/central_uart/README.rst
+++ b/samples/bluetooth/central_uart/README.rst
@@ -59,9 +59,6 @@ Building and running
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 .. _central_uart_testing:
 
 Testing

--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -425,9 +425,6 @@ After programming the sample to your development kit, you can test it in three w
 .. note::
    For the |nRF5340DKnoref|, see :ref:`logging_cpunet` for information about the COM terminals on which the logging output is available.
 
-.. note::
-   |54H_engb_2_8|
-
 .. _direct_test_mode_testing_anritsu:
 
 Testing with a certified tester

--- a/samples/bluetooth/event_trigger/README.rst
+++ b/samples/bluetooth/event_trigger/README.rst
@@ -29,9 +29,6 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/bluetooth/llpm/README.rst
+++ b/samples/bluetooth/llpm/README.rst
@@ -99,9 +99,6 @@ Building and running
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/bluetooth/multiple_adv_sets/README.rst
+++ b/samples/bluetooth/multiple_adv_sets/README.rst
@@ -72,9 +72,6 @@ Building and running
 
 .. include:: /includes/ipc_radio_conf.txt
 
-.. note::
-   |54H_engb_2_8|
-
 .. _multiple_adv_sets_testing:
 
 Testing

--- a/samples/bluetooth/peripheral_ams_client/README.rst
+++ b/samples/bluetooth/peripheral_ams_client/README.rst
@@ -85,9 +85,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 .. _peripheral_ams_client_testing:
 
 Testing

--- a/samples/bluetooth/peripheral_ancs_client/README.rst
+++ b/samples/bluetooth/peripheral_ancs_client/README.rst
@@ -72,9 +72,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 .. _peripheral_ancs_client_testing:
 
 Testing

--- a/samples/bluetooth/peripheral_bms/README.rst
+++ b/samples/bluetooth/peripheral_bms/README.rst
@@ -52,9 +52,6 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-.. note::
-   |54H_engb_2_8|
-
 .. _peripheral_bms_testing:
 
 Testing

--- a/samples/bluetooth/peripheral_cgms/README.rst
+++ b/samples/bluetooth/peripheral_cgms/README.rst
@@ -31,9 +31,6 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_cgms`
 
-.. note::
-   |54H_engb_2_8|
-
 .. include:: /includes/build_and_run_ns.txt
 
 Testing

--- a/samples/bluetooth/peripheral_cts_client/README.rst
+++ b/samples/bluetooth/peripheral_cts_client/README.rst
@@ -27,7 +27,6 @@ The CTS client sample implements a Current Time Service client.
 It uses the Current Time Service to read the current time.
 The time received is printed on the UART.
 
-
 User interface
 **************
 
@@ -60,9 +59,6 @@ Building and running
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_cts_client`
 
 .. include:: /includes/build_and_run_ns.txt
-
-.. note::
-   |54H_engb_2_8|
 
 .. _peripheral_cts_client_testing:
 

--- a/samples/bluetooth/peripheral_gatt_dm/README.rst
+++ b/samples/bluetooth/peripheral_gatt_dm/README.rst
@@ -20,7 +20,6 @@ The sample supports the following development kits:
 
 The sample also requires a device to connect to the peripheral, for example, a phone or a tablet with `nRF Connect for Mobile`_ or `nRF Toolbox`_.
 
-
 Overview
 ********
 
@@ -31,9 +30,6 @@ Building and running
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_gatt_dm`
 
 .. include:: /includes/build_and_run_ns.txt
-
-.. note::
-   |54H_engb_2_8|
 
 .. _peripheral_gatt_dm_testing:
 

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -148,9 +148,6 @@ Building and running
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -106,9 +106,6 @@ Building and running
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 .. _peripheral_hids_mouse_bt_rpc_build:
 
 Bluetooth RPC build

--- a/samples/bluetooth/peripheral_hr_coded/README.rst
+++ b/samples/bluetooth/peripheral_hr_coded/README.rst
@@ -63,9 +63,6 @@ Building and running
 
 .. include:: /includes/ipc_radio_conf.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -117,9 +117,6 @@ Building and running
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Minimal build
 =============
 

--- a/samples/bluetooth/peripheral_nfc_pairing/README.rst
+++ b/samples/bluetooth/peripheral_nfc_pairing/README.rst
@@ -111,9 +111,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/bluetooth/peripheral_rscs/README.rst
+++ b/samples/bluetooth/peripheral_rscs/README.rst
@@ -57,9 +57,6 @@ Building and running
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 .. _peripheral_rscs_testing:
 
 Testing

--- a/samples/bluetooth/peripheral_status/README.rst
+++ b/samples/bluetooth/peripheral_status/README.rst
@@ -133,9 +133,6 @@ Building and running
 
 .. include:: /includes/ipc_radio_conf.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -180,9 +180,6 @@ Building and running
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Experimental nRF54H20 SoC radio core only build
 ===============================================
 

--- a/samples/bluetooth/radio_coex_1wire/README.rst
+++ b/samples/bluetooth/radio_coex_1wire/README.rst
@@ -65,9 +65,6 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/bluetooth/radio_notification_cb/README.rst
+++ b/samples/bluetooth/radio_notification_cb/README.rst
@@ -31,9 +31,6 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/bluetooth/shell_bt_nus/README.rst
+++ b/samples/bluetooth/shell_bt_nus/README.rst
@@ -35,9 +35,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 *******
 

--- a/samples/bluetooth/subrating/README.rst
+++ b/samples/bluetooth/subrating/README.rst
@@ -74,9 +74,6 @@ Building and running
 
 .. include:: /includes/ipc_radio_conf.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -122,9 +122,6 @@ Building and running
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/caf_sensor_manager/README.rst
+++ b/samples/caf_sensor_manager/README.rst
@@ -83,9 +83,6 @@ Complete the following steps to program the sample:
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/aes_cbc/README.rst
+++ b/samples/crypto/aes_cbc/README.rst
@@ -45,9 +45,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/aes_ccm/README.rst
+++ b/samples/crypto/aes_ccm/README.rst
@@ -46,9 +46,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/aes_ctr/README.rst
+++ b/samples/crypto/aes_ctr/README.rst
@@ -45,8 +45,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
 
 Testing
 =======

--- a/samples/crypto/aes_gcm/README.rst
+++ b/samples/crypto/aes_gcm/README.rst
@@ -45,9 +45,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/chachapoly/README.rst
+++ b/samples/crypto/chachapoly/README.rst
@@ -47,9 +47,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/ecdh/README.rst
+++ b/samples/crypto/ecdh/README.rst
@@ -41,9 +41,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/ecdsa/README.rst
+++ b/samples/crypto/ecdsa/README.rst
@@ -46,9 +46,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/ecjpake/README.rst
+++ b/samples/crypto/ecjpake/README.rst
@@ -34,9 +34,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/eddsa/README.rst
+++ b/samples/crypto/eddsa/README.rst
@@ -46,9 +46,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/hkdf/README.rst
+++ b/samples/crypto/hkdf/README.rst
@@ -41,9 +41,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/hmac/README.rst
+++ b/samples/crypto/hmac/README.rst
@@ -43,9 +43,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/pbkdf2/README.rst
+++ b/samples/crypto/pbkdf2/README.rst
@@ -42,9 +42,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/rng/README.rst
+++ b/samples/crypto/rng/README.rst
@@ -36,9 +36,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/sha256/README.rst
+++ b/samples/crypto/sha256/README.rst
@@ -37,9 +37,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/crypto/spake2p/README.rst
+++ b/samples/crypto/spake2p/README.rst
@@ -30,9 +30,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/crypto/spake2p`
 
-.. note::
-   |54H_engb_2_8|
-
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 =======

--- a/samples/esb/esb_prx/README.rst
+++ b/samples/esb/esb_prx/README.rst
@@ -52,9 +52,6 @@ See :ref:`building` and :ref:`programming` for information about how to build an
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 FEM support
 ===========
 

--- a/samples/esb/esb_ptx/README.rst
+++ b/samples/esb/esb_ptx/README.rst
@@ -52,9 +52,6 @@ See :ref:`building` and :ref:`programming` for information about how to build an
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 FEM support
 ===========
 

--- a/samples/event_manager_proxy/README.rst
+++ b/samples/event_manager_proxy/README.rst
@@ -79,7 +79,6 @@ Complete the following steps to program the sample:
 #. |open_terminal_window_with_environment|
 #. Run the following command to build the application code for the host and the remote:
 
-
    **nRF5340 DK**
 
    .. code-block:: console
@@ -107,9 +106,6 @@ Complete the following steps to program the sample:
       west flash
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
-
-.. note::
-   |54H_engb_2_8|
 
 Testing
 =======

--- a/samples/ipc/ipc_service/README.rst
+++ b/samples/ipc/ipc_service/README.rst
@@ -111,9 +111,6 @@ To build the sample to test IPC between the application and PPR core using the :
 
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/mpsl/timeslot/README.rst
+++ b/samples/mpsl/timeslot/README.rst
@@ -50,9 +50,6 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/nfc/record_launch_app/README.rst
+++ b/samples/nfc/record_launch_app/README.rst
@@ -57,9 +57,6 @@ Building and running
 .. note::
    |nfc_nfct_driver_note|
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/nfc/record_text/README.rst
+++ b/samples/nfc/record_text/README.rst
@@ -44,7 +44,6 @@ User interface
       LED 0:
          Indicates if an NFC field is present.
 
-
 Building and running
 ********************
 
@@ -56,9 +55,6 @@ Building and running
 
 .. note::
    |nfc_nfct_driver_note|
-
-.. note::
-   |54H_engb_2_8|
 
 Testing
 =======
@@ -75,7 +71,7 @@ After programming the sample to your development kit, complete the following ste
 
    .. group-tab:: nRF54 DKs
 
-      1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 0** is lit.
+      2. Touch the NFC antenna with the smartphone or tablet and observe that **LED 0** is lit.
       #. Observe that the smartphone or tablet displays the encoded text (in the most suitable language).
       #. Move the smartphone or tablet away from the NFC antenna and observe that **LED 0** turns off.
 

--- a/samples/nfc/shell/README.rst
+++ b/samples/nfc/shell/README.rst
@@ -78,8 +78,6 @@ Building and running
 .. note::
    |nfc_nfct_driver_note|
 
-.. note::
-   |54H_engb_2_8|
 
 Testing
 =======

--- a/samples/nfc/tnep_tag/README.rst
+++ b/samples/nfc/tnep_tag/README.rst
@@ -73,9 +73,6 @@ Building and running
 .. note::
    |nfc_nfct_driver_note|
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/nfc/writable_ndef_msg/README.rst
+++ b/samples/nfc/writable_ndef_msg/README.rst
@@ -73,9 +73,6 @@ Building and running
 .. note::
    |nfc_nfct_driver_note|
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -158,9 +158,6 @@ Building and running
 
 .. include:: /includes/ipc_radio_conf.txt
 
-.. note::
-   |54H_engb_2_8|
-
 To update the OpenThread libraries provided by ``nrfxlib``, use the following commands:
 
 .. parsed-literal::

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -197,9 +197,6 @@ Building and running
 .. include:: /includes/nRF54H20_erase_UICR.txt
 
 .. note::
-   |54H_engb_2_8|
-
-.. note::
    On the nRF5340 or nRF7002 development kit, the Radio Test sample requires the :ref:`nrf5340_remote_shell` sample on the application core.
    The Remote IPC shell sample is built and programmed automatically by default.
    If you want to program your custom solution for the application core, unset the :kconfig:option:`CONFIG_NCS_SAMPLE_REMOTE_SHELL_CHILD_IMAGE` Kconfig option.

--- a/samples/pmic/native/npm1300_fuel_gauge/README.rst
+++ b/samples/pmic/native/npm1300_fuel_gauge/README.rst
@@ -92,7 +92,6 @@ To connect your DK to the nPM1300 EK, complete the following steps:
    * On the **P14** pin header, connect **RSET2** and **VSET2** pins with a jumper.
 
 .. note::
-
    When using the :ref:`zephyr:nrf54l15dk_nrf54l15`, the nPM1300 **GPIO3** interrupt pin assignment uses the DK's **LED 1** pin.
 
 Building and running
@@ -101,9 +100,6 @@ Building and running
 .. |sample path| replace:: :file:`samples/pmic/native/npm1300_fuel_gauge`
 
 .. include:: /includes/build_and_run.txt
-
-.. note::
-   |54H_engb_2_8|
 
 Testing
 *******

--- a/samples/pmic/native/npm1300_one_button/README.rst
+++ b/samples/pmic/native/npm1300_one_button/README.rst
@@ -103,9 +103,6 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 *******
 

--- a/samples/suit/ab/README.rst
+++ b/samples/suit/ab/README.rst
@@ -422,9 +422,6 @@ Building and running
 This sample is located in the |sample path| directory in the |NCS| folder structure.
 
 .. note::
-   |54H_engb_2_8|
-
-.. note::
     |sysbuild_autoenabled_ncs|
 
 Building and programming using the command-line

--- a/samples/suit/smp_transfer/README.rst
+++ b/samples/suit/smp_transfer/README.rst
@@ -159,9 +159,6 @@ Building and running
 This sample can be found under |sample path| in the |NCS| folder structure.
 
 .. note::
-   |54H_engb_2_8|
-
-.. note::
     |sysbuild_autoenabled_ncs|
 
 Building and programming using the command line

--- a/samples/wifi/radio_test/multi_domain/sample_description.rst
+++ b/samples/wifi/radio_test/multi_domain/sample_description.rst
@@ -58,7 +58,6 @@ Currently, the following configurations are supported:
 * nRF7002 DK + QSPI
 * nRF7002 EK + SPIM
 
-
 To build for the nRF7002 DK, use the ``nrf7002dk/nrf5340/cpuapp`` board target.
 The following is an example of the CLI command:
 
@@ -74,10 +73,6 @@ The following is an example of the CLI command:
    west build -b nrf5340dk/nrf5340/cpuapp -- -DSHIELD=nrf7002ek
 
 See also :ref:`cmake_options` for instructions on how to provide CMake options.
-
-.. note::
-   |54H_engb_2_8|
-
 
 Testing
 =======

--- a/samples/wifi/scan/README.rst
+++ b/samples/wifi/scan/README.rst
@@ -76,9 +76,6 @@ The following are examples of the CLI commands:
 
    west build -b nrf7002dk/nrf5340/cpuapp -- -DCONFIG_WIFI_MGMT_RAW_SCAN_RESULTS=y
 
-.. note::
-   |54H_engb_2_8|
-
 Testing
 =======
 

--- a/samples/wifi/shell/README.rst
+++ b/samples/wifi/shell/README.rst
@@ -104,11 +104,6 @@ The following is an example of the CLI commands:
 
 See also :ref:`cmake_options` for instructions on how to provide CMake options.
 
-
-.. note::
-   |54H_engb_2_8|
-
-
 Supported CLI commands
 ======================
 

--- a/samples/wifi/sta/README.rst
+++ b/samples/wifi/sta/README.rst
@@ -105,11 +105,6 @@ The following is an example of the CLI command:
 
    west build -b nrf7002dk/nrf5340/cpuapp
 
-
-.. note::
-   |54H_engb_2_8|
-
-
 Testing
 =======
 


### PR DESCRIPTION
Backport ac09a0d5eb15f75921ee55dbc8e8950ac2cfe81d from #21657.