### PR TITLE
[Backport v3.0-branch] samples: wifi: ble_coex: Remove stale DTS overlay

### DIFF
--- a/samples/wifi/ble_coex/CMakeLists.txt
+++ b/samples/wifi/ble_coex/CMakeLists.txt
@@ -6,8 +6,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(EXTRA_DTC_OVERLAY_FILE "dts.overlay")
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf_wifi_sta)
 

--- a/samples/wifi/ble_coex/dts.overlay
+++ b/samples/wifi/ble_coex/dts.overlay
@@ -1,3 +1,0 @@
-&uart0 {
-     /delete-property/ hw-flow-control;
-};

--- a/samples/wifi/thread_coex/CMakeLists.txt
+++ b/samples/wifi/thread_coex/CMakeLists.txt
@@ -6,8 +6,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(EXTRA_DTC_OVERLAY_FILE "dts.overlay")
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf_wifi_thread_coex)
 

--- a/samples/wifi/thread_coex/dts.overlay
+++ b/samples/wifi/thread_coex/dts.overlay
@@ -1,4 +1,0 @@
-&uart0 {
-	/* Disabling hardware flow control to free up pins for other purposes. */
-     /delete-property/ hw-flow-control;
-};


### PR DESCRIPTION
Backport 58cc904f237b4d6ffc33abf5e7ae098a48a5cb7e from #21849.