### PR TITLE
[Backport v3.0-branch] applications: nrf_desktop: Workaround nrf52840dk mcuboot_smp RTT issues

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_mcuboot_smp.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_mcuboot_smp.conf
@@ -19,8 +19,13 @@ CONFIG_FLASH=y
 CONFIG_FPROTECT=y
 CONFIG_SOC_FLASH_NRF_EMULATE_ONE_BYTE_WRITE_ACCESS=y
 
+# Using RTT for logs in both application and bootloader leads to issues.
+# Disable RTT in bootloader as a workaround.
+CONFIG_USE_SEGGER_RTT=n
 # Logger
-CONFIG_USE_SEGGER_RTT=y
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
 CONFIG_LOG=y
 CONFIG_LOG_MAX_LEVEL=3
 CONFIG_LOG_PRINTK=y


### PR DESCRIPTION
Backport 64f6d6305865f9cacdbc30d86cb75f19ceb5f8de from #21874.