### PR TITLE
[v3.0-branch] cmake/sysbuild/b0_mcuboot_signing: fixed signing with PURE signature

### DIFF
--- a/cmake/sysbuild/b0_mcuboot_signing.cmake
+++ b/cmake/sysbuild/b0_mcuboot_signing.cmake
@@ -48,7 +48,7 @@ function(ncs_secure_boot_mcuboot_sign application bin_files signed_targets prefi
   set(encrypted_args)
 
   if(SB_CONFIG_SOC_SERIES_NRF54LX AND SB_CONFIG_BOOT_SIGNATURE_TYPE_ED25519)
-    if(NOT SB_CONFIG_SB_CONFIG_BOOT_SIGNATURE_TYPE_PURE)
+    if(NOT SB_CONFIG_BOOT_SIGNATURE_TYPE_PURE)
       set(imgtool_extra --sha 512 ${imgtool_extra})
     else()
       set(imgtool_extra --pure ${imgtool_extra})


### PR DESCRIPTION
Fix typo in Kconfig property check. Image was signed always as for a pre-hashed signature which caused that this didn't work for PURE ED25519.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>
(cherry picked from commit 73186d5a985df38ff5d0ba12344716a293fad16a)