### PR TITLE
tests: benchmarks: lfrc_idle: Disable test on lfxo setup

### DIFF
--- a/tests/benchmarks/current_consumption/lfrc_idle/testcase.yaml
+++ b/tests/benchmarks/current_consumption/lfrc_idle/testcase.yaml
@@ -12,6 +12,6 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     harness: pytest
     harness_config:
-      fixture: ppk_power_measure
+      fixture: lfclk_at_lfrc
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_lfclk_source_change"


### PR DESCRIPTION
Run test only on lfrc setup