### PR TITLE
samples: bootloader: Align end of S1 partition

### DIFF
--- a/samples/bootloader/pm.yml
+++ b/samples/bootloader/pm.yml
@@ -30,16 +30,12 @@ s1_pad:
   share_size: mcuboot_pad
   placement:
     after: s0
-    align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
 
 s1_image:
   share_size: {one_of: [mcuboot, s0_image]}
   placement:
     after: [s1_pad, s0]
-#ifndef CONFIG_NCS_MCUBOOT_IN_BUILD
-    align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
-#endif
-    align_next: CONFIG_FPROTECT_BLOCK_SIZE
+    align: {end: CONFIG_FPROTECT_BLOCK_SIZE}
 
 s1:
   # Partition which contains the whole S1 partition.


### PR DESCRIPTION
As both S0 and S1 partitions are protected using
fprotect_area(), with one call, but not separately, then we need to ensure that beginning of S0 is aligned as well as end of S1.

Beginning of S1 partition does not need to be aligned. This would allow end of S0 and beginning of S1 to be within a same SPU protection block.

With this change, I would be able to remove [hard coding of fprotect](https://github.com/nrfconnect/sdk-mcuboot/blob/main/boot/zephyr/main.c#L636-L646) call that protects the whole section between S0 start to MCUboot slot1 start.
