### PR TITLE
[Backport v4.0.99-ncs1-branch] manifest: Update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v4.0.99-ncs1-rc2
+      revision: cbdef1a1053be02883a9ec52a5b05c3415105ce2
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr with reduced restore time from s2ram.

Manual backport of #21497 and #21863