### PR TITLE
manifest: sdk-hostap: Switch to sdk-hostap

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -91,7 +91,6 @@ manifest:
           - hal_st # required for ST sensors (unrelated to STM32 MCUs)
           - hal_tdk # required for Invensense sensors such as ICM42670
           - hal_wurthelektronik
-          - hostap
           - liblc3
           - libmetal
           - littlefs
@@ -116,6 +115,10 @@ manifest:
     #
     # Some of these are also Zephyr modules which have NCS-specific
     # changes.
+    - name: hostap
+      repo-path: sdk-hostap
+      path: modules/lib/hostap
+      revision: 8cd83053a3723d12c1d4ace712dfced687cb0b9b
     - name: wfa-qt-control-app
       repo-path: sdk-wi-fiquicktrack-controlappc
       path: modules/lib/wfa-qt-control-app


### PR DESCRIPTION
Use the nrfconnect/sdk-hostap instead of sdk-zephyr/hostap to accomodate the fix for BTM testcase in QT.