### PR TITLE
esb: Use NRF_TIMER_TASK_SHUTDOWN if supported

### DIFF
--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -503,8 +503,12 @@ static void esb_fem_for_tx_ack(void)
 
 static void esb_fem_reset(void)
 {
+#if NRF_TIMER_HAS_SHUTDOWN
+	nrf_timer_task_trigger(esb_timer.p_reg, NRF_TIMER_TASK_SHUTDOWN);
+#else
 	nrf_timer_task_trigger(esb_timer.p_reg, NRF_TIMER_TASK_STOP);
 	nrf_timer_task_trigger(esb_timer.p_reg, NRF_TIMER_TASK_CLEAR);
+#endif
 
 	mpsl_fem_lna_configuration_clear();
 	mpsl_fem_pa_configuration_clear();
@@ -517,8 +521,12 @@ static void esb_fem_reset(void)
 
 static void esb_fem_lna_reset(void)
 {
+#if NRF_TIMER_HAS_SHUTDOWN
+	nrf_timer_task_trigger(esb_timer.p_reg, NRF_TIMER_TASK_SHUTDOWN);
+#else
 	nrf_timer_task_trigger(esb_timer.p_reg, NRF_TIMER_TASK_STOP);
 	nrf_timer_task_trigger(esb_timer.p_reg, NRF_TIMER_TASK_CLEAR);
+#endif
 
 	esb_ppi_for_fem_clear();
 
@@ -530,8 +538,12 @@ static void esb_fem_pa_reset(void)
 {
 	mpsl_fem_pa_configuration_clear();
 
+#if NRF_TIMER_HAS_SHUTDOWN
+	nrf_timer_task_trigger(esb_timer.p_reg, NRF_TIMER_TASK_SHUTDOWN);
+#else
 	nrf_timer_task_trigger(esb_timer.p_reg, NRF_TIMER_TASK_STOP);
 	nrf_timer_task_trigger(esb_timer.p_reg, NRF_TIMER_TASK_CLEAR);
+#endif
 
 	esb_ppi_for_fem_clear();
 
@@ -1398,8 +1410,12 @@ static void on_radio_disabled_tx_wait_for_ack(void)
 		}
 	} else {
 		if (retransmits_remaining-- == 0) {
+#if NRF_TIMER_HAS_SHUTDOWN
+			nrf_timer_task_trigger(esb_timer.p_reg, NRF_TIMER_TASK_SHUTDOWN);
+#else
 			nrf_timer_task_trigger(esb_timer.p_reg, NRF_TIMER_TASK_STOP);
 			nrf_timer_task_trigger(esb_timer.p_reg, NRF_TIMER_TASK_CLEAR);
+#endif
 
 			/* All retransmits are expended, and the TX operation is
 			 * suspended


### PR DESCRIPTION
Implementing back the usage of NRF_TIMER_TASK_SHUTDOWN for nRF52 family for the reason of FTPAN-78.

JIRA: NCSDK-31724