### PR TITLE
samples: wifi: raw_tx_packet: Return in case of failure

### DIFF
--- a/samples/wifi/raw_tx_packet/src/main.c
+++ b/samples/wifi/raw_tx_packet/src/main.c
@@ -360,6 +360,7 @@ int main(void)
 			K_SECONDS(CONFIG_RAW_TX_PKT_SAMPLE_WIFI_IFACE_OPER_UP_TIMEOUT_S)) != 0) {
 		LOG_ERR("Timeout waiting for iface to become operational after %d seconds",
 			CONFIG_RAW_TX_PKT_SAMPLE_WIFI_IFACE_OPER_UP_TIMEOUT_S);
+		return -1;
 	}
 
 	wifi_send_raw_tx_packets();


### PR DESCRIPTION
Without this, we see error prints for each and every packet.