### PR TITLE
bluetooth: fast_pair: fmdn: Fix Kconfig dependency misalignment

### DIFF
--- a/doc/nrf/libraries/bluetooth/services/fast_pair.rst
+++ b/doc/nrf/libraries/bluetooth/services/fast_pair.rst
@@ -88,7 +88,7 @@ With the :kconfig:option:`CONFIG_BT_FAST_PAIR` Kconfig option enabled, the follo
     * :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_RING_REQ_TIMEOUT_DULT_BT_GATT` - The option configures the ringing timeout for connected peers that use DULT-based ringing mechanism.
       This option can only be used when the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_DULT` is enabled.
     * :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_RING_REQ_TIMEOUT_DULT_MOTION_DETECTOR` - The option configures the ringing timeout for ringing requests from the DULT motion detector.
-      This option can only be used when the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_DULT` is enabled.
+      This option can only be used when the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR` Kconfig option is enabled.
 
   * There are following beacon clock service configuration options for the FMDN extension (see :ref:`ug_bt_fast_pair_prerequisite_ops_fmdn_clock_svc`):
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -245,7 +245,9 @@ Bluetooth Mesh samples
 Bluetooth Fast Pair samples
 ---------------------------
 
-|no_changes_yet_note|
+* :ref:`fast_pair_locator_tag` sample:
+
+  * Added possibility to build and run the sample without the motion detector support (with the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR` Kconfig option disabled).
 
 Cellular samples
 ----------------
@@ -387,7 +389,12 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
-|no_changes_yet_note|
+* :ref:`bt_fast_pair_readme` library:
+
+  * Updated:
+
+    * The :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_RING_REQ_TIMEOUT_DULT_MOTION_DETECTOR` Kconfig option dependency.
+      The dependency has been updated from the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_DULT` Kconfig option to the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR` Kconfig option.
 
 Common Application Framework
 ----------------------------

--- a/samples/bluetooth/fast_pair/locator_tag/src/main.c
+++ b/samples/bluetooth/fast_pair/locator_tag/src/main.c
@@ -18,9 +18,12 @@
 #include "app_dfu.h"
 #include "app_factory_reset.h"
 #include "app_fp_adv.h"
-#include "app_motion_detector.h"
 #include "app_ring.h"
 #include "app_ui.h"
+
+#ifdef CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR
+#include "app_motion_detector.h"
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(fp_fmdn, LOG_LEVEL_INF);

--- a/subsys/bluetooth/services/fast_pair/fmdn/Kconfig
+++ b/subsys/bluetooth/services/fast_pair/fmdn/Kconfig
@@ -408,7 +408,7 @@ config BT_FAST_PAIR_FMDN_RING_REQ_TIMEOUT_DULT_BT_GATT
 config BT_FAST_PAIR_FMDN_RING_REQ_TIMEOUT_DULT_MOTION_DETECTOR
 	int "Timeout in milliseconds in ringing request from DULT motion detector source"
 	default 1000
-	depends on BT_FAST_PAIR_FMDN_DULT
+	depends on BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR
 	help
 	  The default timeout parameter in milliseconds is used in the start
 	  ringing request that originates from the motion detector DULT source.

--- a/subsys/bluetooth/services/fast_pair/fmdn/ring.c
+++ b/subsys/bluetooth/services/fast_pair/fmdn/ring.c
@@ -16,6 +16,13 @@ LOG_MODULE_REGISTER(fp_fmdn_ring, CONFIG_BT_FAST_PAIR_LOG_LEVEL);
 #include "fp_fmdn_ring.h"
 #include "fp_fmdn_dult_integration.h"
 
+#ifdef CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR
+#define DULT_MOTION_DETECTOR_RING_REQ_TIMEOUT \
+	(CONFIG_BT_FAST_PAIR_FMDN_RING_REQ_TIMEOUT_DULT_MOTION_DETECTOR)
+#else
+#define DULT_MOTION_DETECTOR_RING_REQ_TIMEOUT (-1)
+#endif
+
 /* Maximum timeout for the ringing request in deciseconds (10 minutes). */
 #define MAX_TIMEOUT_DSEC BT_FAST_PAIR_FMDN_RING_TIMEOUT_MS_TO_DS(10 * 60 * MSEC_PER_SEC)
 
@@ -385,7 +392,15 @@ static void dult_sound_start(enum dult_sound_src src)
 
 		break;
 	case DULT_SOUND_SRC_MOTION_DETECTOR:
-		ring_timeout = CONFIG_BT_FAST_PAIR_FMDN_RING_REQ_TIMEOUT_DULT_MOTION_DETECTOR;
+		if (!IS_ENABLED(CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR)) {
+			__ASSERT(false, "FMDN Ring: Motion detector DULT source is not supported");
+			return;
+		}
+
+		__ASSERT(DULT_MOTION_DETECTOR_RING_REQ_TIMEOUT >= 0,
+			 "FMDN Ring: Motion detector DULT: ringing timeout is invalid");
+
+		ring_timeout = DULT_MOTION_DETECTOR_RING_REQ_TIMEOUT;
 		fmdn_ring_src = BT_FAST_PAIR_FMDN_RING_SRC_DULT_MOTION_DETECTOR;
 		/* No specific guidelines at the moment. */
 		dult_ring_req_param.active_comp_bm = BT_FAST_PAIR_FMDN_RING_COMP_BM_ALL;


### PR DESCRIPTION
Fixes the CONFIG_BT_FAST_PAIR_FMDN_RING_REQ_TIMEOUT_DULT_MOTION_DETECTOR dependency. Now it depends on
CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR. Aligns documentation. Also allows the locator tag sample to be built without motion detector support.

Jira: NCSDK-29944