### PR TITLE
tests: zephyr: drivers: retained_mem: Enable on PCA10175

### DIFF
--- a/samples/zephyr/boards/nordic/system_off/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/samples/zephyr/boards/nordic/system_off/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,7 +1,7 @@
 / {
-	cpuapp_sram@2007ec00 {
+	cpuapp_sram@2006ec00 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x2007ec00 DT_SIZE_K(4)>;
+		reg = <0x2006ec00 DT_SIZE_K(4)>;
 		zephyr,memory-region = "RetainedMem";
 		status = "okay";
 
@@ -18,8 +18,9 @@
 
 &cpuapp_sram {
 	/* Shrink SRAM size to avoid overlap with retained memory region:
-	 * 511 - 4 = 507KB = 0x7ec00
+	 * Available - FLPR - retainedmem0
+	 * 511 - 64 - 4 = 443KB = 0x6ec00
 	 */
-	reg = <0x20000000 DT_SIZE_K(507)>;
-	ranges = <0x0 0x20000000 0x7ec00>;
+	reg = <0x20000000 DT_SIZE_K(443)>;
+	ranges = <0x0 0x20000000 0x6ec00>;
 };

--- a/samples/zephyr/boards/nordic/system_off/sample.yaml
+++ b/samples/zephyr/boards/nordic/system_off/sample.yaml
@@ -11,10 +11,12 @@ tests:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     harness: console
     harness_config:
       type: multi_line
@@ -28,10 +30,12 @@ tests:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     extra_configs:
       - CONFIG_APP_USE_RETAINED_MEM=y
     harness: console
@@ -50,6 +54,7 @@ tests:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     extra_configs:
       - CONFIG_GRTC_WAKEUP_ENABLE=y
       - CONFIG_GPIO_WAKEUP_ENABLE=n
@@ -73,6 +78,7 @@ tests:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     extra_configs:
       - CONFIG_APP_USE_RETAINED_MEM=y
       - CONFIG_GRTC_WAKEUP_ENABLE=y

--- a/tests/zephyr/drivers/retained_mem/api/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/retained_mem/api/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,7 +1,7 @@
 / {
-	cpuapp_sram@2007ec00 {
+	cpuapp_sram@2006ec00 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x2007ec00 DT_SIZE_K(4)>;
+		reg = <0x2006ec00 DT_SIZE_K(4)>;
 		zephyr,memory-region = "RetainedMem";
 		status = "okay";
 
@@ -18,8 +18,9 @@
 
 &cpuapp_sram {
 	/* Shrink SRAM size to avoid overlap with retained memory region:
-	 * 511 - 4 = 507KB = 0x7ec00
+	 * Available - FLPR - retainedmem0
+	 * 511 - 64 - 4 = 443KB = 0x6ec00
 	 */
-	reg = <0x20000000 DT_SIZE_K(507)>;
-	ranges = <0x0 0x20000000 0x7ec00>;
+	reg = <0x20000000 DT_SIZE_K(443)>;
+	ranges = <0x0 0x20000000 0x6ec00>;
 };

--- a/tests/zephyr/drivers/retained_mem/api/testcase.yaml
+++ b/tests/zephyr/drivers/retained_mem/api/testcase.yaml
@@ -3,9 +3,11 @@ tests:
     platform_allow:
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     tags:
       - drivers
       - retained_mem


### PR DESCRIPTION
Add nrf54lm20a PDK to platform_allow list.

FLPR uses last 64k of SRAM.
Move retained mem to make space for FLPR ram.