### PR TITLE
[Backport v3.0-branch] tests: benchmarks: multicore: idle_pwm_loopback: add missing fixture

### DIFF
--- a/tests/benchmarks/multicore/idle_pwm_loopback/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_pwm_loopback/testcase.yaml
@@ -54,6 +54,7 @@ tests:
       - idle_pwm_loopback_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_1.overlay"
     harness: console
     harness_config:
+      fixture: spi_loopback
       type: multi_line
       ordered: true
       regex:


### PR DESCRIPTION
Backport dc28c690549286e17aec7f2c4f264221f84f7118 from #21959.