### PR TITLE
tests: zephyr: drivers: uart: uart_async_api: fast uart at LM20

### DIFF
--- a/tests/drivers/uart/uart_baudrate_test/boards/nrf54lm20apdk_nrf54lm20a_cpuapp_uart00.overlay
+++ b/tests/drivers/uart/uart_baudrate_test/boards/nrf54lm20apdk_nrf54lm20a_cpuapp_uart00.overlay
@@ -1,11 +1,11 @@
 /*
  * Test requires wire connection between:
- *  - uart00 TX at P2.08 <-> GPIO input at P2.09
+ *  - uart00 TX at P2.02 <-> GPIO input at P2.00
  */
 
 / {
 	zephyr,user {
-		gpios = <&gpio2 9 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio2 0 GPIO_ACTIVE_HIGH>;
 	};
 };
 
@@ -16,16 +16,16 @@
 &pinctrl {
 	uart00_default: uart00_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 2, 8)>,
-				<NRF_PSEL(UART_RX, 2, 7)>;
+			psels = <NRF_PSEL(UART_TX, 2, 2)>,
+				<NRF_PSEL(UART_RX, 2, 1)>;
 				bias-pull-up;
 		};
 	};
 
 	uart00_sleep: uart00_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 2, 8)>,
-				<NRF_PSEL(UART_RX, 2, 7)>;
+			psels = <NRF_PSEL(UART_TX, 2, 2)>,
+				<NRF_PSEL(UART_RX, 2, 1)>;
 			low-power-enable;
 		};
 	};

--- a/tests/drivers/uart/uart_baudrate_test/testcase.yaml
+++ b/tests/drivers/uart/uart_baudrate_test/testcase.yaml
@@ -69,9 +69,13 @@ tests:
   drivers.uart.baudrate_test.lm20_uart00:
     platform_allow:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54lm20apdk/nrf54lm20a/cpuapp
     extra_args: DTC_OVERLAY_FILE="boards/nrf54lm20apdk_nrf54lm20a_cpuapp_uart00.overlay"
+    harness: ztest
+    harness_config:
+      fixture: uart_fast_loopback
   drivers.uart.baudrate_test.lm20_uart21:
     platform_allow:
       - nrf54lm20apdk/nrf54lm20a/cpuapp

--- a/tests/zephyr/drivers/uart/uart_async_api/boards/nrf54lm20apdk_nrf54lm20a_cpuapp_uart00.overlay
+++ b/tests/zephyr/drivers/uart/uart_async_api/boards/nrf54lm20apdk_nrf54lm20a_cpuapp_uart00.overlay
@@ -1,0 +1,31 @@
+&pinctrl {
+	uart00_default_alt: uart00_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 2, 2)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 2, 0)>;
+			bias-pull-up;
+		};
+	};
+
+	uart00_sleep_alt: uart00_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 2, 2)>,
+				<NRF_PSEL(UART_RX, 2, 0)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart00 {
+	status = "okay";
+	pinctrl-0 = <&uart00_default_alt>;
+	pinctrl-1 = <&uart00_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	current-speed = <4000000>;
+};
+
+&gpio2 {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/zephyr/drivers/uart/uart_async_api/testcase.yaml
@@ -18,6 +18,18 @@ tests:
     harness_config:
       fixture: gpio_loopback
     depends_on: gpio
+  nrf.extended.drivers.uart.async_api.fast:
+    platform_allow:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
+    integration_platforms:
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/nrf54lm20apdk_nrf54lm20a_cpuapp_uart00.overlay"
+    filter: CONFIG_SERIAL_SUPPORT_ASYNC and not CONFIG_UART_MCUX_LPUART
+    harness: ztest
+    harness_config:
+      fixture: uart_fast_loopback
   nrf.extended.drivers.uart.async_api.rtt:
     platform_allow:
       - nrf7120pdk/nrf7120/cpuapp


### PR DESCRIPTION
Fast uart at LM20 DK.