### PR TITLE
[Backport v3.0-branch] samples: wifi: shell: Increase network buffer pool sizes for nRF54H

### DIFF
--- a/samples/wifi/shell/Kconfig
+++ b/samples/wifi/shell/Kconfig
@@ -19,10 +19,11 @@ if NET_BUF_VARIABLE_DATA_SIZE
 # nRF52 and nRF54 Series targets have less memory
 # so smaller pool sizes are recommended for these targets.
 config NET_PKT_BUF_TX_DATA_POOL_SIZE
-	default 50000 if !SOC_SERIES_NRF52X && !SOC_SERIES_NRF54LX && !SOC_SERIES_NRF54HX
+	default 40000 if SOC_SERIES_NRF54HX
+	default 50000 if !SOC_SERIES_NRF52X && !SOC_SERIES_NRF54LX
 
 config NET_PKT_BUF_RX_DATA_POOL_SIZE
-	default 20000 if !SOC_SERIES_NRF52X && !SOC_SERIES_NRF54LX && !SOC_SERIES_NRF54HX
+	default 20000 if !SOC_SERIES_NRF52X && !SOC_SERIES_NRF54LX
 
 endif
 


### PR DESCRIPTION
Backport 338eb4aff970d7ed592f4663f0a683fd63256eb2 from #21956.