### PR TITLE
lib: modem_slm: Refactor UART implementation.

### DIFF
--- a/doc/nrf/libraries/modem/modem_slm.rst
+++ b/doc/nrf/libraries/modem/modem_slm.rst
@@ -32,7 +32,8 @@ The library is enabled and configured entirely using the Kconfig system.
 Configure the following Kconfig options to enable this library:
 
 * :kconfig:option:`CONFIG_MODEM_SLM` - Enables the Modem SLM library.
-* :kconfig:option:`CONFIG_MODEM_SLM_DMA_MAXLEN` - Configures UART RX EasyDMA buffer size, which is configured to 1024 bytes by default.
+* :kconfig:option:`CONFIG_MODEM_SLM_AT_CMD_RESP_MAX_SIZE` - Configures the size of the AT command response buffer.
+  The default size is 2100 bytes, which is aligned with SLM.
 * :kconfig:option:`CONFIG_MODEM_SLM_POWER_PIN` - Configures the mandatory power pin GPIO, which is not configured by default.
 * :kconfig:option:`CONFIG_MODEM_SLM_POWER_PIN_TIME` - Sets the toggle time value in milliseconds for power pin GPIO, by default 100 ms.
 
@@ -40,6 +41,12 @@ Optionally configure the following Kconfig options based on need:
 
 * :kconfig:option:`CONFIG_MODEM_SLM_SHELL` - Enables the shell function in the Modem SLM library, which is not enabled by default.
 * :kconfig:option:`CONFIG_MODEM_SLM_INDICATE_PIN` - Configures the optional indicator GPIO, which is not configured by default.
+* :kconfig:option:`CONFIG_MODEM_SLM_UART_RX_BUF_COUNT` - Configures the number of RX buffers for the UART device.
+  The default value is 3.
+* :kconfig:option:`CONFIG_MODEM_SLM_UART_RX_BUF_SIZE` - Configures the size of the RX buffer for the UART device.
+  The default value is 256 bytes.
+* :kconfig:option:`CONFIG_MODEM_SLM_UART_TX_BUF_SIZE` - Configures the size of the TX buffer for the UART device.
+  The default value is 256 bytes.
 
 The application must use Zephyr ``chosen`` nodes in devicetree to select UART device.
 Additionally, GPIO can also be selected.
@@ -115,8 +122,6 @@ The SLM Monitor has similar functions to the :ref:`at_monitor_readme` library, e
   .. code-block:: console
 
      SLM_MONITOR(network, "\r\n+CEREG:", cereg_mon);
-
-     SLM_MONITOR(download, "\r\n#XDFUGET: 0,", download_mon, MON_PAUSED);
 
 API documentation
 *****************

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -428,6 +428,23 @@ Modem libraries
     Even within the same network, the PDN connection establishment method (PCO vs ePCO) might change when the device operates in NB-IoT or LTE Cat-M1, resulting in missing DNS addresses when one method is used, but not the other.
     Having a fallback DNS address ensures that the device always has a DNS to fallback to.
 
+* :ref:`lib_modem_slm` library:
+
+  * Added:
+
+      * The :kconfig:option:`CONFIG_MODEM_SLM_UART_RX_BUF_COUNT` Kconfig option for configuring RX buffer count.
+      * The :kconfig:option:`CONFIG_MODEM_SLM_UART_RX_BUF_SIZE` Kconfig option for configuring RX buffer size.
+      * The :kconfig:option:`CONFIG_MODEM_SLM_UART_TX_BUF_SIZE` Kconfig option for configuring TX buffer size.
+      * The :kconfig:option:`CONFIG_MODEM_SLM_AT_CMD_RESP_MAX_SIZE` Kconfig option for buffering AT command responses.
+
+  * Updated the UART implementation between the host device, using the :ref:`lib_modem_slm` library, and the device running the :ref:`Serial LTE Modem <slm_description>` application.
+
+  * Removed:
+
+      * The ``CONFIG_MODEM_SLM_DMA_MAXLEN`` Kconfig option.
+        Use :kconfig:option:`CONFIG_MODEM_SLM_UART_RX_BUF_SIZE` instead.
+      * The ``modem_slm_reset_uart`` function as there is no longer need to reset the UART.
+
 Multiprotocol Service Layer libraries
 -------------------------------------
 

--- a/include/modem/modem_slm.h
+++ b/include/modem/modem_slm.h
@@ -99,12 +99,6 @@ int modem_slm_register_ind(slm_ind_handler_t handler, bool wakeup);
 int modem_slm_power_pin_toggle(void);
 
 /**
- * @brief Reset the RX function of the serial interface
- *
- */
-void modem_slm_reset_uart(void);
-
-/**
  * @brief Function to send an AT command in SLM command mode
  *
  * This function wait until command result is received. The response of the AT command is received

--- a/lib/modem_slm/Kconfig
+++ b/lib/modem_slm/Kconfig
@@ -9,16 +9,42 @@ menuconfig MODEM_SLM
 	depends on UART_ASYNC_API
 	depends on RING_BUFFER
 	select EXPERIMENTAL
+	select UART_USE_RUNTIME_CONFIGURE
 	bool "Modem SLM Library for MCU [EXPERIMENTAL]"
 
 if MODEM_SLM
 
-config MODEM_SLM_DMA_MAXLEN
-	int "Buffer size for UART RX EasyDMA"
-	range 256 2048
-	default 1024
+#
+# UART buffers
+#
+config MODEM_SLM_UART_RX_BUF_COUNT
+	int "Receive buffers for UART"
+	range 2 4
+	default 3
 	help
-	  The maximum number of bytes in receive buffer.
+	  Number of buffers for receiving (RX) UART traffic.
+	  If the buffers are full, UART RX will be disabled until the buffers are processed.
+
+config MODEM_SLM_UART_RX_BUF_SIZE
+	int "Receive buffer size for UART"
+	range 16 4096
+	default 256
+	help
+	  Amount of received (RX), unprocessed, UART traffic that can be held by a single buffer.
+
+config MODEM_SLM_UART_TX_BUF_SIZE
+	int "Send buffer size for UART"
+	range 16 4096
+	default 256
+	help
+	  Amount of UART traffic waiting to be sent (TX), which can be held.
+	  If the buffers are full, all messages will be sent synchronously.
+
+config MODEM_SLM_AT_CMD_RESP_MAX_SIZE
+	int "Maximum size of AT command response from SLM"
+	default 2100
+	help
+	  The maximum size of the AT command response.
 
 config MODEM_SLM_SHELL
 	bool "SLM Shell"

--- a/samples/cellular/slm_shell/README.rst
+++ b/samples/cellular/slm_shell/README.rst
@@ -14,7 +14,7 @@ See more information on the functionality of this sample from the :ref:`lib_mode
 Requirements
 ************
 
-The SLM application should be configured to use UART_2 on the nRF91 Series DK side with no hardware flow control.
+The SLM application should be configured to use UART2 on the nRF91 Series DK side with hardware flow control.
 
 The sample supports the following development kits:
 
@@ -22,7 +22,7 @@ The sample supports the following development kits:
 
 Connect the DK with an nRF91 Series DK based on the pin configuration in DTS overlay files of both sides.
 
-The following table shows how to connect UART_1 of the DK to the nRF91 Series DK's UART_2 for communication through UART:
+The following table shows how to connect UART1 of the DK to the nRF91 Series DK's UART2 for communication through UART:
 
 .. tabs::
 
@@ -37,6 +37,10 @@ The following table shows how to connect UART_1 of the DK to the nRF91 Series DK
            - UART RX P0.11
          * - UART RX P1.01
            - UART TX P0.10
+         * - UART CTS P1.06
+           - UART RTS P0.12
+         * - UART RTS P1.07
+           - UART CTS P0.13
          * - GPIO OUT P0.11 (Button1)
            - GPIO IN P0.31
          * - GPIO IN P0.13 (LED1 optional)
@@ -62,6 +66,10 @@ The following table shows how to connect UART_1 of the DK to the nRF91 Series DK
            - UART RX P0.11
          * - UART RX P1.05
            - UART TX P0.10
+         * - UART CTS P1.06
+           - UART RTS P0.12
+         * - UART RTS P1.07
+           - UART CTS P0.13
          * - GPIO OUT P0.23 (Button1)
            - GPIO IN P0.31
          * - GPIO IN P0.28 (LED1 optional)
@@ -87,6 +95,10 @@ The following table shows how to connect UART_1 of the DK to the nRF91 Series DK
            - UART RX P0.11
          * - UART RX P1.05
            - UART TX P0.10
+         * - UART CTS P1.06
+           - UART RTS P0.12
+         * - UART RTS P1.07
+           - UART CTS P0.13
          * - GPIO OUT P0.31
            - GPIO IN P0.31
          * - GPIO IN P0.30 (optional)

--- a/samples/cellular/slm_shell/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/cellular/slm_shell/boards/nrf52840dk_nrf52840.overlay
@@ -11,10 +11,18 @@
 	};
 };
 
+/* Shell UART */
+&uart0 {
+	current-speed = <115200>;
+	status = "okay";
+};
+
+/* SLM Shell <-> SLM UART */
 &uart1 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
+	hw-flow-control;
 
 	pinctrl-0 = <&uart1_default>;
 	pinctrl-1 = <&uart1_sleep>;
@@ -24,18 +32,22 @@
 &pinctrl {
 	uart1_default: uart1_default {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 1, 1)>;
-			bias-pull-up;
+			psels = <NRF_PSEL(UART_TX, 1, 2)>,
+				<NRF_PSEL(UART_RTS, 1, 6)>;
 		};
 		group2 {
-			psels = <NRF_PSEL(UART_TX, 1, 2)>;
+			psels = <NRF_PSEL(UART_RX, 1, 1)>,
+				<NRF_PSEL(UART_CTS, 1, 7)>;
+			bias-pull-up;
 		};
 	};
 
 	uart1_sleep: uart1_sleep {
 		group1 {
 			psels = <NRF_PSEL(UART_RX, 1, 1)>,
-				<NRF_PSEL(UART_TX, 1, 2)>;
+				<NRF_PSEL(UART_TX, 1, 2)>,
+				<NRF_PSEL(UART_RTS, 1, 6)>,
+				<NRF_PSEL(UART_CTS, 1, 7)>;
 			low-power-enable;
 		};
 	};

--- a/samples/cellular/slm_shell/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/cellular/slm_shell/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Configuration file for nRF53400DK.
+# Configuration file for nRF5340DK.
 # This file is merged with prj.conf in the application folder, and options
 # set here will take precedence if they are present in both files.
 

--- a/samples/cellular/slm_shell/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/cellular/slm_shell/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -11,11 +11,18 @@
 	};
 };
 
+/* Shell UART */
+&uart0 {
+	current-speed = <115200>;
+	status = "okay";
+};
+
+/* SLM Shell <-> SLM UART */
 &uart2 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
-
+	hw-flow-control;
 	pinctrl-0 = <&uart2_default>;
 	pinctrl-1 = <&uart2_sleep>;
 	pinctrl-names = "default", "sleep";
@@ -24,10 +31,12 @@
 &pinctrl {
 	uart2_default: uart2_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 4)>;
+			psels = <NRF_PSEL(UART_TX, 1, 4)>,
+				<NRF_PSEL(UART_RTS, 1, 6)>;
 		};
 		group2 {
-			psels = <NRF_PSEL(UART_RX, 1, 5)>;
+			psels = <NRF_PSEL(UART_RX, 1, 5)>,
+				<NRF_PSEL(UART_CTS, 1, 7)>;
 			bias-pull-up;
 		};
 	};
@@ -35,7 +44,9 @@
 	uart2_sleep: uart2_sleep {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 4)>,
-				<NRF_PSEL(UART_RX, 1, 5)>;
+				<NRF_PSEL(UART_RX, 1, 5)>,
+				<NRF_PSEL(UART_RTS, 1, 6)>,
+				<NRF_PSEL(UART_CTS, 1, 7)>;
 			low-power-enable;
 		};
 	};

--- a/samples/cellular/slm_shell/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/cellular/slm_shell/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -11,10 +11,18 @@
 	};
 };
 
+/* Shell UART */
+&uart0 {
+	current-speed = <115200>;
+	status = "okay";
+};
+
+/* SLM Shell <-> SLM UART */
 &uart2 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
+	hw-flow-control;
 
 	pinctrl-0 = <&uart2_default>;
 	pinctrl-1 = <&uart2_sleep>;
@@ -24,10 +32,13 @@
 &pinctrl {
 	uart2_default: uart2_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 4)>;
+			psels = <NRF_PSEL(UART_TX, 1, 4)>,
+				<NRF_PSEL(UART_RTS, 1, 6)>;
+
 		};
 		group2 {
-			psels = <NRF_PSEL(UART_RX, 1, 5)>;
+			psels = <NRF_PSEL(UART_RX, 1, 5)>,
+				<NRF_PSEL(UART_CTS, 1, 7)>;
 			bias-pull-up;
 		};
 	};
@@ -35,7 +46,9 @@
 	uart2_sleep: uart2_sleep {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 4)>,
-				<NRF_PSEL(UART_RX, 1, 5)>;
+				<NRF_PSEL(UART_RX, 1, 5)>,
+				<NRF_PSEL(UART_RTS, 1, 6)>,
+				<NRF_PSEL(UART_CTS, 1, 7)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Rewrite of the previously unstable UART implementation between host device, which is using modem_slm lib, and device with SLM.

Removed:
- CONFIG_MODEM_SLM_DMA_MAXLEN (RX buf size)
- modem_slm_reset_uart as there is no reason to reset UART.

Added Kconfigs for UART buffers:
- CONFIG_MODEM_SLM_UART_RX_BUF_COUNT
- CONFIG_MODEM_SLM_UART_RX_BUF_SIZE
- CONFIG_MODEM_SLM_UART_TX_BUF_SIZE

Added Kconfig for buffering AT-responses:
- CONFIG_MODEM_SLM_AT_CMD_RESP_MAX_SIZE

Jira: LRCS-10