### PR TITLE
[Backport v3.0-branch] applications: serial_lte_modem: Add all boards to integration_platforms

### DIFF
--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -12,7 +12,12 @@ tests:
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
     integration_platforms:
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
       - nrf9151dk/nrf9151/ns
+      - nrf9131ek/nrf9131/ns
+      - thingy91/nrf9160/ns
+      - thingy91x/nrf9151/ns
     tags:
       - ci_build
       - sysbuild

--- a/samples/cellular/slm_shell/sample.yaml
+++ b/samples/cellular/slm_shell/sample.yaml
@@ -10,7 +10,9 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
     integration_platforms:
+      - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp
     tags:
       - ci_build
       - sysbuild


### PR DESCRIPTION
Backport ce698d85cd6ac118d94bb4ac7cbf23ef610dcf41 from #21973.