### PR TITLE
samples: nrf_rpc: ps_client: add throughput service

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/client/CMakeLists.txt
+++ b/samples/nrf_rpc/protocols_serialization/client/CMakeLists.txt
@@ -19,4 +19,5 @@ zephyr_library_sources_ifdef(CONFIG_MPSL_CX_SOFTWARE src/coex_shell.c)
 zephyr_library_sources_ifdef(CONFIG_LOG_FORWARDER_RPC src/log_rpc_shell.c)
 zephyr_library_sources_ifdef(CONFIG_NFC_RPC src/nfc_shell.c)
 zephyr_library_sources_ifdef(CONFIG_NRF_RPC_DEV_INFO src/dev_info_shell.c)
+zephyr_library_sources_ifdef(CONFIG_BT_THROUGHPUT src/bt_throughput_shell.c)
 # NORDIC SDK APP START

--- a/samples/nrf_rpc/protocols_serialization/client/snippets/ble/ble.conf
+++ b/samples/nrf_rpc/protocols_serialization/client/snippets/ble/ble.conf
@@ -10,25 +10,28 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2144
 CONFIG_BT=y
 CONFIG_BT_RPC_STACK=y
 CONFIG_BT_RPC_INITIALIZE_NRF_RPC=n
-
 CONFIG_BT_PERIPHERAL=y
-CONFIG_BT_DEVICE_NAME="Nordic_UART_Service"
-CONFIG_BT_DEVICE_APPEARANCE=833
 CONFIG_BT_MAX_CONN=1
-CONFIG_BT_MAX_PAIRED=1
 CONFIG_BT_LL_SOFTDEVICE=n
 CONFIG_BT_SHELL=y
+
+# Device name and appearance shall be the same as on the server side
+CONFIG_BT_DEVICE_NAME="Nordic_PS"
 
 # Enable the NUS service
 CONFIG_BT_NUS=y
 CONFIG_BT_NUS_LOG_LEVEL_DBG=y
 
-# Enable bonding
-CONFIG_BT_SETTINGS=y
+# Enable the Throughput service
+CONFIG_BT_THROUGHPUT=y
+CONFIG_BT_THROUGHPUT_LOG_LEVEL_DBG=y
+
+# Enable SMP that is required by the Throughput service.
 CONFIG_SETTINGS=y
 CONFIG_FLASH=y
-CONFIG_FLASH_PAGE_LAYOUT=y
 CONFIG_FLASH_MAP=y
+CONFIG_BT_SETTINGS=y
+CONFIG_BT_SMP=y
 
-# TODO check why this is needed when OT is turned on
+# Disable HCI-based entropy driver (unavailable for BT_RPC_STACK)
 CONFIG_ENTROPY_BT_HCI=n

--- a/samples/nrf_rpc/protocols_serialization/client/src/bt_throughput_shell.c
+++ b/samples/nrf_rpc/protocols_serialization/client/src/bt_throughput_shell.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <bluetooth/services/throughput.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/sys/__assert.h>
+
+static const struct bt_data ad[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_THROUGHPUT_VAL),
+};
+
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
+static int advertise(void);
+
+static void connected(struct bt_conn *conn, uint8_t hci_err)
+{
+	int rc;
+
+	if (hci_err) {
+		return;
+	}
+
+	rc = bt_conn_set_security(conn, BT_SECURITY_L2);
+	__ASSERT(rc == 0, "Failed to set BLE security level: %d", rc);
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	ARG_UNUSED(conn);
+	ARG_UNUSED(reason);
+
+	advertise();
+}
+
+static struct bt_conn_cb conn_cb = {
+	.connected = connected,
+	.disconnected = disconnected,
+};
+
+static int advertise(void)
+{
+	int rc;
+
+	(void)bt_conn_cb_register(&conn_cb);
+	rc = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+
+	if (rc) {
+		(void)bt_conn_cb_unregister(&conn_cb);
+	}
+
+	return rc;
+}
+
+static int cmd_advertise(const struct shell *sh, size_t argc, char *argv[])
+{
+	bool start;
+	int rc;
+
+	if (!strcmp(argv[1], "on")) {
+		start = true;
+	} else if (!strcmp(argv[1], "off")) {
+		start = false;
+	} else {
+		shell_error(sh, "Invalid argument: %s", argv[1]);
+		return -EINVAL;
+	}
+
+	if (start) {
+		rc = advertise();
+	} else {
+		rc = bt_le_adv_stop();
+		(void)bt_conn_cb_unregister(&conn_cb);
+	}
+
+	if (rc < 0) {
+		shell_error(sh, "Failed to %s advertising: %d", start ? "start" : "stop", rc);
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "Advertising %s", start ? "started" : "stopped");
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(bt_throughput_cmds,
+			       SHELL_CMD_ARG(advertise, NULL, "on|off", cmd_advertise, 2, 0),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(bt_throughput, &bt_throughput_cmds, "BLE throughput commands", NULL, 2, 0);

--- a/samples/nrf_rpc/protocols_serialization/server/snippets/ble/ble.conf
+++ b/samples/nrf_rpc/protocols_serialization/server/snippets/ble/ble.conf
@@ -12,18 +12,15 @@ CONFIG_BT_RPC_INITIALIZE_NRF_RPC=n
 
 CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_MAX_CONN=1
-CONFIG_BT_MAX_PAIRED=1
-CONFIG_BT_SMP=n
-CONFIG_BT_DEVICE_APPEARANCE=833
 
-# BT Device name must be the same as on the client side
-CONFIG_BT_DEVICE_NAME="Nordic_UART_Service"
+# Device name and appearance shall be the same as on the client side
+CONFIG_BT_DEVICE_NAME="Nordic_PS"
 # Host side registers all GATT services using dynamic database
 CONFIG_BT_GATT_DYNAMIC_DB=y
 
-# Enable bonding
+# Enable SMP that is required by the Throughput service.
 CONFIG_BT_SETTINGS=y
-CONFIG_FLASH_PAGE_LAYOUT=y
+CONFIG_BT_SMP=y
 
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
 CONFIG_HEAP_MEM_POOL_SIZE=4096


### PR DESCRIPTION
Make it possible to run BLE throughput tests using the BLE over RPC architecture.

1. Clean BLE configuration of protocols serialization samples by removing unnecessary or default settings. Also, set the device name to "Nordic_PS".
2. Add BLE throughput service to the client sample. This requires enabline BT_SMP for both samples.
3. Add "bt_throughput advertise on" shell command, which is a replacement of "bt advertise on" that advertises the throughput service UUID.