### PR TITLE
[CI ONLY] manifest: rebase: update mcuboot and zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: cbdef1a1053be02883a9ec52a5b05c3415105ce2
+      revision: pull/2804/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -130,7 +130,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: bf852c9bb388771121c6fdee2a5d35a5700ab64f
+      revision: pull/423/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Point to rebased revisions of mcuboot and zephyr v3.0 release branches for CI testing.