### PR TITLE
ci: Adding yamllint aciton

### DIFF
--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -1,0 +1,11 @@
+name: Lint yaml files
+
+on:
+  pull_request:
+
+jobs:
+  lint_yaml:
+    runs-on: ubuntu-latest
+    name: Execute yamllint
+    steps:
+      - uses: nrfconnect/action-yamllint@main


### PR DESCRIPTION
* The intention is to catch yaml files that are not parsable
* [yamllint action with all the rules definition](https://github.com/nrfconnect/action-yamllint/blob/main/action.yml)

Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>
