### PR TITLE
samples: nrf_provisioning: Add thingy91x

### DIFF
--- a/samples/cellular/nrf_provisioning/sample.yaml
+++ b/samples/cellular/nrf_provisioning/sample.yaml
@@ -7,10 +7,12 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9161dk/nrf9161/ns
+      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
+      - thingy91x/nrf9151/ns
     tags:
       - sysbuild
       - ci_samples_cellular


### PR DESCRIPTION
Add the thingy91x as a supported board.