### PR TITLE
boards: Select SDC for nRF54LM20A board

### DIFF
--- a/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp.dts
+++ b/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &cpuapp_sram;
+		zephyr,bt-hci = &bt_hci_sdc;
 	};
 };
 


### PR DESCRIPTION
Commit https://github.com/nrfconnect/sdk-nrf/commit/b828ce71eafcfa3a00300226ac970adc1c725b0e enabled `bt_hci_sdc` and disabled `bt_hci_controller`, but `bt_hci_controller` is still set as the default controller.  
 
This commit updates the configuration to select `bt_hci_sdc` as the default controller.
