### PR TITLE
samples: peripheral_uart: central_uart: Add support for nRF54LM20PDK

### DIFF
--- a/samples/bluetooth/central_uart/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.conf
+++ b/samples/bluetooth/central_uart/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unspupported UART0 driver
+CONFIG_NRFX_UARTE0=n

--- a/samples/bluetooth/central_uart/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/samples/bluetooth/central_uart/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,nus-uart = &uart20;
+	};
+};

--- a/samples/bluetooth/peripheral_uart/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.conf
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unspupported UART0 driver
+CONFIG_NRFX_UARTE0=n

--- a/samples/bluetooth/peripheral_uart/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54lm20apdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,nus-uart = &uart20;
+	};
+};


### PR DESCRIPTION
Add support for nRF54LM20PDK in peripheral and central UART samples.