### PR TITLE
tests: benchmarks: Increase 'idle outside of main' test  timeout

### DIFF
--- a/tests/benchmarks/multicore/idle_outside_of_main/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_outside_of_main/testcase.yaml
@@ -17,6 +17,7 @@ tests:
       fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_s2ram_outside_of_main"
+    timeout: 120
 
   benchmarks.multicore.idle_outside_of_main.nrf54h20dk_cpuapp_cpurad.s2ram.cooperative:
     harness: pytest
@@ -32,3 +33,4 @@ tests:
       fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_s2ram_outside_of_main"
+    timeout: 120


### PR DESCRIPTION
The python based test procedure will
require more time to execute after its update.