### PR TITLE
boards: nordic: nrf54lm20a: Add 0.2.0.csp board revision

### DIFF
--- a/boards/nordic/nrf54lm20apdk/board.yml
+++ b/boards/nordic/nrf54lm20apdk/board.yml
@@ -5,8 +5,9 @@ board:
   socs:
   - name: nrf54lm20a
   revision:
-    format: major.minor.patch
+    format: custom
     default: "0.0.0"
     revisions:
     - name: "0.0.0"
     - name: "0.2.0"
+    - name: "0.2.0.csp"

--- a/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0.overlay
+++ b/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0.overlay
@@ -55,7 +55,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <10 5>, <22 2>, <25 4>;
+	gpio-reserved-ranges = <10 5>, <17 1>, <22 2>, <25 4>;
 };
 
 &gpio2 {

--- a/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0_csp.overlay
+++ b/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0_csp.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		led1: led_1 {
+			gpios = <&gpio1 25 GPIO_ACTIVE_HIGH>;
+		};
+
+		led2: led_2 {
+			gpios = <&gpio1 27 GPIO_ACTIVE_HIGH>;
+		};
+
+		led3: led_3 {
+			gpios = <&gpio1 28 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		button0: button_0 {
+			gpios = <&gpio1 26 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+
+		button1: button_1 {
+			gpios = <&gpio1 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+
+		button2: button_2 {
+			gpios = <&gpio1 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+
+		button3: button_3 {
+			gpios = <&gpio0 5 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+	};
+};
+
+&hfpll {
+	clock-frequency = <DT_FREQ_M(128)>;
+};
+
+&pinctrl {
+	/omit-if-no-ref/ uart20_default: uart20_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 16)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 1, 17)>;
+			bias-pull-up;
+		};
+	};
+
+	/omit-if-no-ref/ uart20_sleep: uart20_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 16)>,
+				<NRF_PSEL(UART_RX, 1, 17)>;
+			low-power-enable;
+		};
+	};
+	/omit-if-no-ref/ pwm20_default: pwm20_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 25)>;
+		};
+	};
+
+	/omit-if-no-ref/ pwm20_sleep: pwm20_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 25)>;
+			low-power-enable;
+		};
+	};
+};

--- a/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0_csp.yaml
+++ b/boards/nordic/nrf54lm20apdk/nrf54lm20apdk_nrf54lm20a_cpuapp_0_2_0_csp.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+identifier: nrf54lm20apdk@0.2.0.csp/nrf54lm20a/cpuapp
+name: nRF54LM20A-PDK-nRF54LM20A-Application (rev. 0.2.0.csp)
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - zephyr
+sysbuild: true
+ram: 512
+flash: 449
+supported:
+  - adc
+  - counter
+  - dmic
+  - gpio
+  - i2c
+  - i2s
+  - pwm
+  - spi
+  - watchdog

--- a/boards/nordic/nrf54lm20apdk/revision.cmake
+++ b/boards/nordic/nrf54lm20apdk/revision.cmake
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+set(REVISIONS "0.0.0" "0.2.0" "0.2.0.csp")
+if(NOT DEFINED BOARD_REVISION)
+  set(BOARD_REVISION "0.0.0")
+else()
+  if(NOT BOARD_REVISION IN_LIST REVISIONS)
+    message(FATAL_ERROR "${BOARD_REVISION} is not a valid nRF54LM20A PDK board revision. Accepted revisions: ${REVISIONS}")
+  endif()
+endif()

--- a/boards/nordic/nrf54lm20pdk/Kconfig.defconfig
+++ b/boards/nordic/nrf54lm20pdk/Kconfig.defconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+if BOARD_NRF54LM20PDK_NRF54LM20A_CPUAPP
+
+config ROM_START_OFFSET
+	default 0 if PARTITION_MANAGER_ENABLED
+	default 0x800 if BOOTLOADER_MCUBOOT
+
+config SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE
+	default y
+
+endif # BOARD_NRF54LM20PDK_NRF54LM20A_CPUAPP

--- a/boards/nordic/nrf54lm20pdk/Kconfig.nrf54lm20pdk
+++ b/boards/nordic/nrf54lm20pdk/Kconfig.nrf54lm20pdk
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+config BOARD_NRF54LM20PDK
+	select SOC_NRF54LM20A_ENGA_CPUAPP if BOARD_NRF54LM20PDK_NRF54LM20A_CPUAPP

--- a/boards/nordic/nrf54lm20pdk/board.cmake
+++ b/boards/nordic/nrf54lm20pdk/board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/nordic/nrf54lm20pdk/board.yml
+++ b/boards/nordic/nrf54lm20pdk/board.yml
@@ -1,0 +1,13 @@
+board:
+  name: nrf54lm20pdk
+  full_name: nRF54LM20 PDK
+  vendor: nordic
+  socs:
+  - name: nrf54lm20a
+  revision:
+    format: custom
+    default: "0.0.0"
+    revisions:
+    - name: "0.0.0"
+    - name: "0.2.0"
+    - name: "0.2.0.csp"

--- a/boards/nordic/nrf54lm20pdk/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20a_cpuapp_common.dtsi
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* This file is common to the secure and non-secure domain */
+
+#include <nordic/nrf54lm20a_enga_cpuapp.dtsi>
+#include "nrf54lm20pdk_nrf54lm20a-common.dtsi"
+
+/ {
+	chosen {
+		zephyr,console = &uart20;
+		zephyr,shell-uart = &uart20;
+		zephyr,uart-mcumgr = &uart20;
+		zephyr,bt-mon-uart = &uart20;
+		zephyr,bt-c2h-uart = &uart20;
+		zephyr,flash-controller = &rram_controller;
+		zephyr,flash = &cpuapp_rram;
+		zephyr,bt-hci = &bt_hci_controller;
+		zephyr,ieee802154 = &ieee802154;
+	};
+};
+
+&cpuapp_sram {
+	status = "okay";
+};
+
+&hfpll {
+	/* For now use 64 MHz clock for CPU and fast peripherals. */
+	clock-frequency = <DT_FREQ_M(64)>;
+};
+
+&lfxo {
+	load-capacitors = "internal";
+	load-capacitance-femtofarad = <15500>;
+};
+
+&hfxo {
+	load-capacitors = "internal";
+	load-capacitance-femtofarad = <15000>;
+};
+
+&grtc {
+	owned-channels = <0 1 2 3 4 5 6 7 8 9 10 11>;
+	/* Channels 7-11 reserved for Zero Latency IRQs, 3-4 for FLPR */
+	child-owned-channels = <3 4 7 8 9 10 11>;
+	status = "okay";
+};
+
+&cpuapp_rram {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x10000 DT_SIZE_K(449)>;
+		};
+
+		slot0_ns_partition: partition@80400 {
+			label = "image-0-nonsecure";
+			reg = <0x80400 DT_SIZE_K(449)>;
+		};
+
+		slot1_partition: partition@f0800 {
+			label = "image-1";
+			reg = <0xf0800 DT_SIZE_K(449)>;
+		};
+
+		slot1_ns_partition: partition@160c00 {
+			label = "image-1-nonsecure";
+			reg = <0x160c00 DT_SIZE_K(449)>;
+		};
+
+		storage_partition: partition@1d1000 {
+			label = "storage";
+			reg = <0x1d1000 DT_SIZE_K(36)>;
+		};
+	};
+};
+
+&uart20 {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpiote20 {
+	status = "okay";
+};
+
+&gpiote30 {
+	status = "okay";
+};
+
+&radio {
+	status = "okay";
+};
+
+&temp {
+	status = "okay";
+};
+
+&clock {
+	status = "okay";
+};
+
+&bt_hci_controller {
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+};
+
+zephyr_udc0: &usbhs {
+	status = "okay";
+};
+
+&spi00 {
+	status = "okay";
+	cs-gpios = <&gpio2 5 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&spi00_default>;
+	pinctrl-1 = <&spi00_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	mx25r64: mx25r6435f@0 {
+		compatible = "jedec,spi-nor";
+		status = "okay";
+		reg = <0>;
+		spi-max-frequency = <8000000>;
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 48 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+	};
+};

--- a/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a-common.dtsi
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a-common.dtsi
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54lm20pdk_nrf54lm20a-pinctrl.dtsi"
+
+/ {
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpio2 10 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 0";
+		};
+
+		led1: led_1 {
+			gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 1";
+		};
+
+		led2: led_2 {
+			gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 2";
+		};
+
+		led3: led_3 {
+			gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 3";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/*
+		 * PWM signal can be exposed on GPIO pin only within same domain.
+		 * There is only one domain which contains both PWM and GPIO:
+		 * PWM20/21/22 and GPIO Port P1/P3.
+		 * Only LEDs connected to P1/P3 can work with PWM, for example LED1.
+		 */
+		pwm_led1: pwm_led_1 {
+			pwms = <&pwm20 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		button0: button_0 {
+			gpios = <&gpio1 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 0";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+
+		button1: button_1 {
+			gpios = <&gpio1 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 1";
+			zephyr,code = <INPUT_KEY_1>;
+		};
+
+		button2: button_2 {
+			gpios = <&gpio1 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 2";
+			zephyr,code = <INPUT_KEY_2>;
+		};
+
+		button3: button_3 {
+			gpios = <&gpio0 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 3";
+			zephyr,code = <INPUT_KEY_3>;
+		};
+	};
+
+	aliases {
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
+		led3 = &led3;
+		pwm-led0 = &pwm_led1;
+		sw0 = &button0;
+		sw1 = &button1;
+		sw2 = &button2;
+		sw3 = &button3;
+		watchdog0 = &wdt31;
+	};
+};
+
+&uart20 {
+	current-speed = <115200>;
+	pinctrl-0 = <&uart20_default>;
+	pinctrl-1 = <&uart20_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&uart30 {
+	current-speed = <115200>;
+	pinctrl-0 = <&uart30_default>;
+	pinctrl-1 = <&uart30_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pwm20 {
+	status = "okay";
+	pinctrl-0 = <&pwm20_default>;
+	pinctrl-1 = <&pwm20_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a-pinctrl.dtsi
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a-pinctrl.dtsi
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&pinctrl {
+	/omit-if-no-ref/ uart20_default: uart20_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 4)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 1, 5)>;
+			bias-pull-up;
+		};
+	};
+
+	/omit-if-no-ref/ uart20_sleep: uart20_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 4)>,
+				<NRF_PSEL(UART_RX, 1, 5)>;
+			low-power-enable;
+		};
+	};
+
+	/omit-if-no-ref/ pwm20_default: pwm20_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 7)>;
+		};
+	};
+
+	/omit-if-no-ref/ pwm20_sleep: pwm20_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 7)>;
+			low-power-enable;
+		};
+	};
+
+	/omit-if-no-ref/ uart30_default: uart30_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 0)>,
+				<NRF_PSEL(UART_RTS, 0, 2)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 0, 1)>,
+				<NRF_PSEL(UART_CTS, 0, 3)>;
+			bias-pull-up;
+		};
+	};
+
+	/omit-if-no-ref/ uart30_sleep: uart30_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 0)>,
+				<NRF_PSEL(UART_RX, 0, 1)>,
+				<NRF_PSEL(UART_RTS, 0, 2)>,
+				<NRF_PSEL(UART_CTS, 0, 3)>;
+			low-power-enable;
+		};
+	};
+
+	/omit-if-no-ref/ spi00_default: spi00_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 1)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 2)>,
+				<NRF_PSEL(SPIM_MISO, 2, 4)>;
+		};
+	};
+
+	/omit-if-no-ref/ spi00_sleep: spi00_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 1)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 2)>,
+				<NRF_PSEL(SPIM_MISO, 2, 4)>;
+				low-power-enable;
+		};
+	};
+};

--- a/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp.dts
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp.dts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/dts-v1/;
+
+#include "nrf54lm20a_cpuapp_common.dtsi"
+
+/ {
+	compatible = "nordic,nrf54lm20pdk_nrf54lm20a-cpuapp";
+	model = "Nordic nRF54LM20 PDK nRF54LM20A Application MCU";
+
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+		zephyr,sram = &cpuapp_sram;
+	};
+};
+
+&bt_hci_sdc {
+	status = "okay";
+};
+
+&bt_hci_controller {
+	status = "disabled";
+};

--- a/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp_0_0_0.yaml
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp_0_0_0.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+identifier: nrf54lm20pdk@0.0.0/nrf54lm20a/cpuapp
+name: nRF54LM20-PDK-nRF54LM20A-Application (rev. 0.0.0)
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - zephyr
+sysbuild: true
+ram: 512
+flash: 449
+supported:
+  - adc
+  - counter
+  - dmic
+  - gpio
+  - i2c
+  - i2s
+  - pwm
+  - spi
+  - watchdog

--- a/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp_0_2_0.overlay
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp_0_2_0.overlay
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		led1: led_1 {
+			gpios = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+		};
+
+		led2: led_2 {
+			gpios = <&gpio1 30 GPIO_ACTIVE_HIGH>;
+		};
+
+		led3: led_3 {
+			gpios = <&gpio1 31 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		button0: button_0 {
+			gpios = <&gpio1 24 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+
+		button1: button_1 {
+			gpios = <&gpio1 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+
+		button2: button_2 {
+			gpios = <&gpio1 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+
+		button3: button_3 {
+			gpios = <&gpio0 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+	};
+};
+
+&hfpll {
+	clock-frequency = <DT_FREQ_M(128)>;
+};
+
+&gpio0 {
+	gpio-reserved-ranges = <0 3>;
+};
+
+&gpio1 {
+	gpio-reserved-ranges = <10 5>, <17 1>, <22 2>, <25 4>;
+};
+
+&gpio2 {
+	gpio-reserved-ranges = <6 4>;
+};
+
+&gpio3 {
+	gpio-reserved-ranges = <0 12>;
+};
+
+&pinctrl {
+	/omit-if-no-ref/ pwm20_default: pwm20_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 29)>;
+		};
+	};
+
+	/omit-if-no-ref/ pwm20_sleep: pwm20_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 29)>;
+			low-power-enable;
+		};
+	};
+};

--- a/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp_0_2_0.yaml
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp_0_2_0.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+identifier: nrf54lm20pdk@0.2.0/nrf54lm20a/cpuapp
+name: nRF54LM20-PDK-nRF54LM20A-Application (rev. 0.2.0)
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - zephyr
+sysbuild: true
+ram: 512
+flash: 449
+supported:
+  - adc
+  - counter
+  - dmic
+  - gpio
+  - i2c
+  - i2s
+  - pwm
+  - spi
+  - watchdog

--- a/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp_0_2_0_csp.overlay
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp_0_2_0_csp.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		led1: led_1 {
+			gpios = <&gpio1 25 GPIO_ACTIVE_HIGH>;
+		};
+
+		led2: led_2 {
+			gpios = <&gpio1 27 GPIO_ACTIVE_HIGH>;
+		};
+
+		led3: led_3 {
+			gpios = <&gpio1 28 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		button0: button_0 {
+			gpios = <&gpio1 26 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+
+		button1: button_1 {
+			gpios = <&gpio1 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+
+		button2: button_2 {
+			gpios = <&gpio1 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+
+		button3: button_3 {
+			gpios = <&gpio0 5 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		};
+	};
+};
+
+&hfpll {
+	clock-frequency = <DT_FREQ_M(128)>;
+};
+
+&pinctrl {
+	/omit-if-no-ref/ uart20_default: uart20_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 16)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 1, 17)>;
+			bias-pull-up;
+		};
+	};
+
+	/omit-if-no-ref/ uart20_sleep: uart20_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 16)>,
+				<NRF_PSEL(UART_RX, 1, 17)>;
+			low-power-enable;
+		};
+	};
+	/omit-if-no-ref/ pwm20_default: pwm20_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 25)>;
+		};
+	};
+
+	/omit-if-no-ref/ pwm20_sleep: pwm20_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 25)>;
+			low-power-enable;
+		};
+	};
+};

--- a/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp_0_2_0_csp.yaml
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp_0_2_0_csp.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+identifier: nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuapp
+name: nRF54LM20-PDK-nRF54LM20A-Application (rev. 0.2.0.csp)
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - zephyr
+sysbuild: true
+ram: 512
+flash: 449
+supported:
+  - adc
+  - counter
+  - dmic
+  - gpio
+  - i2c
+  - i2s
+  - pwm
+  - spi
+  - watchdog

--- a/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp_defconfig
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp_defconfig
@@ -1,0 +1,29 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable GPIO
+CONFIG_GPIO=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# MPU-based null-pointer dereferencing detection cannot
+# be applied as the (0x0 - 0x400) is unmapped for this target.
+CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
+
+# Enable Cache
+CONFIG_CACHE_MANAGEMENT=y
+CONFIG_EXTERNAL_CACHE=y
+
+# Start SYSCOUNTER on driver init
+CONFIG_NRF_GRTC_START_SYSCOUNTER=y

--- a/boards/nordic/nrf54lm20pdk/revision.cmake
+++ b/boards/nordic/nrf54lm20pdk/revision.cmake
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+set(REVISIONS "0.0.0" "0.2.0" "0.2.0.csp")
+if(NOT DEFINED BOARD_REVISION)
+  set(BOARD_REVISION "0.0.0")
+else()
+  if(NOT BOARD_REVISION IN_LIST REVISIONS)
+    message(FATAL_ERROR "${BOARD_REVISION} is not a valid nRF54LM20 PDK board revision. Accepted revisions: ${REVISIONS}")
+  endif()
+endif()


### PR DESCRIPTION
Added board revision 0.2.0.csp with wider access to GPIOs and changed pin assignment for UART20, LEDs and buttons.

Specific name/number for the board to be decided.