### PR TITLE
Redefine kconfig for cs buffer

### DIFF
--- a/samples/bluetooth/channel_sounding_ras_initiator/prj.conf
+++ b/samples/bluetooth/channel_sounding_ras_initiator/prj.conf
@@ -40,11 +40,6 @@ CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS=1
 CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS=1
 CONFIG_BT_CTLR_SDC_CS_STEP_MODE3=n
 
-# This size assumes the largest step size is mode 2 with one antenna path:
-# 12 bytes * 160 steps in a subevent. Change or remove this if using mode 3
-# or multiantenna.
-CONFIG_BT_CHANNEL_SOUNDING_REASSEMBLY_BUFFER_SIZE=1920
-
 # This allows CS and ACL to use different PHYs
 CONFIG_BT_TRANSMIT_POWER_CONTROL=y
 

--- a/samples/bluetooth/channel_sounding_ras_reflector/prj.conf
+++ b/samples/bluetooth/channel_sounding_ras_reflector/prj.conf
@@ -31,11 +31,6 @@ CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS=1
 CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS=1
 CONFIG_BT_CTLR_SDC_CS_STEP_MODE3=n
 
-# This size assumes the largest step size is mode 2 with one antenna path:
-# 12 bytes * 160 steps in a subevent. Change or remove this if using mode 3
-# or multiantenna.
-CONFIG_BT_CHANNEL_SOUNDING_REASSEMBLY_BUFFER_SIZE=1920
-
 # This allows CS and ACL to use different PHYs
 CONFIG_BT_TRANSMIT_POWER_CONTROL=y
 

--- a/subsys/bluetooth/services/ras/Kconfig.ras
+++ b/subsys/bluetooth/services/ras/Kconfig.ras
@@ -33,4 +33,25 @@ config BT_RAS_MODE_3_SUPPORTED
 	  Must match the supported CS capabilities of the local device.
 	  This affects the per-instance memory usage of RAS.
 
+# CONFIG_BT_CHANNEL_SOUNDING_REASSEMBLY_BUFFER_SIZE is declared in Zephyr and also
+# here for a second time, to set a different range for the CS subevent result reassembly
+# buffer. Default values are also set based on RAS configs to help users reduce RAM usage.
+config BT_CHANNEL_SOUNDING_REASSEMBLY_BUFFER_SIZE
+	int "Subevent result reassembly buffer size"
+	depends on BT_CHANNEL_SOUNDING
+	range 239 4800
+	default 1920 if BT_RAS_MAX_ANTENNA_PATHS=1 && !BT_RAS_MODE_3_SUPPORTED
+	default 2560 if BT_RAS_MAX_ANTENNA_PATHS=2 && !BT_RAS_MODE_3_SUPPORTED
+	default 3200 if BT_RAS_MAX_ANTENNA_PATHS=3 && !BT_RAS_MODE_3_SUPPORTED
+	default 3840 if BT_RAS_MAX_ANTENNA_PATHS=4 && !BT_RAS_MODE_3_SUPPORTED
+	default 2880 if BT_RAS_MAX_ANTENNA_PATHS=1 && BT_RAS_MODE_3_SUPPORTED
+	default 3520 if BT_RAS_MAX_ANTENNA_PATHS=2 && BT_RAS_MODE_3_SUPPORTED
+	default 4160 if BT_RAS_MAX_ANTENNA_PATHS=3 && BT_RAS_MODE_3_SUPPORTED
+	default 4800
+	help
+	  When the results for a CS subevent cannot fit into a single HCI event,
+	  it will be split up into multiple events and consequently, reassembled into a
+	  full CS subevent. This config sets the size of the reassembly buffer.
+
+
 endif # BT_RAS


### PR DESCRIPTION
suggestion for how to simplify usage of the BT_CHANNEL_SOUNDING_REASSEMBLY_BUFFER_SIZE in our CS samples