### PR TITLE
tests: drivers: lpuart: Add user specific configuration test

### DIFF
--- a/tests/drivers/lpuart/testcase.yaml
+++ b/tests/drivers/lpuart/testcase.yaml
@@ -140,3 +140,30 @@ tests:
     extra_args: OVERLAY_CONFIG=dbg.conf
     extra_configs:
       - CONFIG_TEST_LPUART_TIMEOUT=10
+  lpuart.user_specific_config:
+    sysbuild: true
+    platform_allow:
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54lv10apdk/nrf54lv10a/cpuapp
+      - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp
+    extra_configs:
+      - CONFIG_UART_INTERRUPT_DRIVEN=y
+      - CONFIG_NRF_SW_LPUART_INT_DRIVEN=n
+      - CONFIG_TEST_LPUART_LOOPBACK=y
+    harness: ztest
+    harness_config:
+      fixture: gpio_loopback


### PR DESCRIPTION
The configuration defined here casued a build failure in NCS 2.5.0. The issue was corrected. Testing is added to assure error will not come back.