### PR TITLE
samples: wifi: ble_coex: Fix BLE disconnection reason code

### DIFF
--- a/samples/wifi/ble_coex/src/bt_throughput_test.c
+++ b/samples/wifi/ble_coex/src/bt_throughput_test.c
@@ -642,7 +642,5 @@ int bt_throughput_test_exit(void)
 		return err;
 	}
 
-	bt_disable();
-
 	return 0;
 }


### PR DESCRIPTION
Disabling BLE after disconnection was causing incorrect disconnection reason codes at the central (0x0) and the peripheral (0x8). With this fix, the disconnection reason codes are now correctly reported as 0x16 at the central and 0x13 at the peripheral.