### PR TITLE
crypto: CRACEN: Ensure KMU status is not busy after reset

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen.c
@@ -120,6 +120,13 @@ int cracen_init(void)
 		return 0;
 	}
 
+#if defined(NRF54LM20A_ENGA_XXAA) || defined(NRF54LV10A_ENGA_XXAA)
+	/* Can be removed once NCSDK-33222 is addressed */
+	while (NRF_KMU->STATUS == KMU_STATUS_STATUS_Busy) {
+		/* Do nothing */
+	}
+#endif /* NRF54LM20A_ENGA_XXAA || NRF54LV10A_ENGA_XXAA */
+
 	cracen_acquire();
 	cracen_interrupts_init();
 


### PR DESCRIPTION
-Wait for KMU busy signal for nRF54L20A and nRF54LV10A devices after
 reset. This is a circumvention until this is added in MDK. This is done
 in cracen_init which is called by psa_crypto_init.

Note: crypto_init is only run once in the system after reset

ref: NCSDK-33222