### PR TITLE
nrf_compress: fix processing of the 'last part'

### DIFF
--- a/include/nrf_compress/implementation.h
+++ b/include/nrf_compress/implementation.h
@@ -30,16 +30,20 @@ extern "C" {
 #endif
 
 /**
- * @typedef		nrf_compress_init_func_t
- * @brief		Initialize compression implementation.
+ * @typedef			nrf_compress_init_func_t
+ * @brief			Initialize compression implementation.
  *
- * @param[in] inst	Implementation specific initialization context.
- *			Concrete implementation may cast it to predefined type.
+ * @param[in] inst		Implementation specific initialization context.
+ *				Concrete implementation may cast it to predefined type.
+ * @param[in] decompressed_size	Expected size of entire decompressed data stream. It is used
+ *				for checking that output produced during streaming does not
+ *				exceed the expected size. Set it to 0 if the size is not known;
+ *				there will be no output size checking then.
  *
- * @retval		0 Success.
- * @retval		-errno Negative errno code on other failure.
+ * @retval			0 Success.
+ * @retval			-errno Negative errno code on other failure.
  */
-typedef int (*nrf_compress_init_func_t)(void *inst);
+typedef int (*nrf_compress_init_func_t)(void *inst, size_t decompressed_size);
 
 /**
  * @typedef		nrf_compress_deinit_func_t
@@ -54,17 +58,21 @@ typedef int (*nrf_compress_init_func_t)(void *inst);
 typedef int (*nrf_compress_deinit_func_t)(void *inst);
 
 /**
- * @typedef		nrf_compress_reset_func_t
- * @brief		Reset compression state function. Used to abort current compression or
- *			decompression task before starting a new one.
+ * @typedef			nrf_compress_reset_func_t
+ * @brief			Reset compression state function. Used to abort current
+ *				compression or decompression task before starting a new one.
  *
- * @param[in] inst	Implementation specific initialization context.
- *			Concrete implementation may cast it to predefined type.
+ * @param[in] inst		Implementation specific initialization context.
+ *				Concrete implementation may cast it to predefined type.
+ * @param[in] decompressed_size	Expected size of entire decompressed data stream. It is used
+ *				for checking that output produced during streaming does not
+ *				exceed the expected size. Set it to 0 if the size is not known;
+ *				there will be no output size checking then.
  *
- * @retval		0 Success.
- * @retval		-errno Negative errno code on other failure.
+ * @retval			0 Success.
+ * @retval			-errno Negative errno code on other failure.
  */
-typedef int (*nrf_compress_reset_func_t)(void *inst);
+typedef int (*nrf_compress_reset_func_t)(void *inst, size_t decompressed_size);
 
 /**
  * @typedef		nrf_compress_compress_func_t

--- a/subsys/suit/stream/stream_filters/src/suit_decompress_filter.c
+++ b/subsys/suit/stream/stream_filters/src/suit_decompress_filter.c
@@ -150,7 +150,8 @@ static suit_plat_err_t erase(void *ctx)
 		suit_plat_err_t size_ret;
 
 		codec_impl = decompress_ctx->codec_impl;
-		(void)codec_impl->reset(decompress_ctx->codec_ctx);
+		(void)codec_impl->reset(decompress_ctx->codec_ctx,
+					decompress_ctx->decompressed_image_size);
 
 		zeroize(decompress_ctx->last_chunk, sizeof(decompress_ctx->last_chunk));
 		decompress_ctx->last_chunk_size = 0;
@@ -348,7 +349,8 @@ static suit_plat_err_t flush(void *ctx)
 		res = SUIT_PLAT_ERR_CRASH;
 	}
 
-	(void)codec_impl->reset(decompress_ctx->codec_ctx);
+	(void)codec_impl->reset(decompress_ctx->codec_ctx,
+				decompress_ctx->decompressed_image_size);
 
 	if (res == SUIT_PLAT_SUCCESS) {
 		LOG_INF("Firmware decompression successful");
@@ -448,7 +450,7 @@ suit_plat_err_t suit_decompress_filter_get(struct stream_sink *in_sink,
 		return SUIT_PLAT_ERR_CRASH;
 	}
 
-	rc = ctx.codec_impl->init(ctx.codec_ctx);
+	rc = ctx.codec_impl->init(ctx.codec_ctx, compress_info->decompressed_image_size);
 	if (rc != 0) {
 		LOG_ERR("Failed to initialize lzma codec");
 		ctx.codec_impl = NULL;

--- a/tests/subsys/nrf_compress/decompression/arm_thumb/src/main.c
+++ b/tests/subsys/nrf_compress/decompression/arm_thumb/src/main.c
@@ -34,7 +34,7 @@ ZTEST(nrf_compress_decompression, test_valid_implementation)
 
 	zassert_not_equal(implementation, NULL, "Expected implementation to not be NULL");
 
-	rc = implementation->init(NULL);
+	rc = implementation->init(NULL, 0);
 	zassert_ok(rc, "Expected init to be successful");
 
 	while (pos < sizeof(input_compressed)) {

--- a/tests/subsys/nrf_compress/decompression/lzma/CMakeLists.txt
+++ b/tests/subsys/nrf_compress/decompression/lzma/CMakeLists.txt
@@ -19,8 +19,8 @@ generate_inc_file_for_target(
 
 generate_inc_file_for_target(
   app
-  ${ZEPHYR_NRFXLIB_MODULE_DIR}/tests/subsys/nrf_compress/decompression/dummy_data_input_too_large.txt.lzma
-  ${ZEPHYR_BINARY_DIR}/include/generated/dummy_data_input_too_large.inc
+  ${ZEPHYR_NRFXLIB_MODULE_DIR}/tests/subsys/nrf_compress/decompression/dummy_data_input_large.txt.lzma
+  ${ZEPHYR_BINARY_DIR}/include/generated/dummy_data_input_large.inc
   )
 
 generate_inc_file_for_target(

--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: e92888b3388147c0010017fcb78c5775ffebb9e5
+      revision: e110d7640aa34f207ced48ace1807054aa8492a9
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR
@@ -144,7 +144,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 0d84fe136fbfa9bb2793644103cdcac603b338d2
+      revision: 5e42daeb14322dde433cb8e1149750dbc20f0f7f
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
This PR fixes the processing of the 'last part' of compressed input.
Previously, LZMA_FINISH_END was incorectly enforced and it caused
issues if decompression output reached 'dicLimit' during this
'last part' processing. Please refer to following discussion for the
detailed rationale:
https://github.com/nrfconnect/sdk-nrf/pull/20582#discussion_r1969656717

nrf_compress API was extended to support decompressed output limit
checking. This is the correct way to use LZMA_FINISH_END flag.
Also, decompression status at the end of input stream processing is now
checked.

ref: NCSDK-32340