### PR TITLE
applications: nrf5340_audio: Use new audio struct

### DIFF
--- a/applications/nrf5340_audio/broadcast_sink/main.c
+++ b/applications/nrf5340_audio/broadcast_sink/main.c
@@ -563,11 +563,9 @@ uint8_t stream_state_get(void)
 	return strm_state;
 }
 
-void streamctrl_send(void const *const data, size_t size, uint8_t num_ch)
+void streamctrl_send(struct audio_data const *const audio_frame)
 {
-	ARG_UNUSED(data);
-	ARG_UNUSED(size);
-	ARG_UNUSED(num_ch);
+	ARG_UNUSED(audio_frame);
 
 	LOG_WRN("Sending is not possible for broadcast sink");
 }

--- a/applications/nrf5340_audio/broadcast_source/main.c
+++ b/applications/nrf5340_audio/broadcast_source/main.c
@@ -494,15 +494,13 @@ uint8_t stream_state_get(void)
 	return strm_state;
 }
 
-void streamctrl_send(void const *const data, size_t size, uint8_t num_ch)
+void streamctrl_send(struct audio_data const *const audio_frame)
 {
 	int ret;
 	static int prev_ret;
 
-	struct le_audio_encoded_audio enc_audio = {.data = data, .size = size, .num_ch = num_ch};
-
 	if (strm_state == STATE_STREAMING) {
-		ret = broadcast_source_send(0, 0, enc_audio);
+		ret = broadcast_source_send(0, 0, audio_frame);
 
 		if (ret != 0 && ret != prev_ret) {
 			if (ret == -ECANCELED) {

--- a/applications/nrf5340_audio/src/audio/audio_datapath.h
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.h
@@ -13,6 +13,7 @@
 #include <data_fifo.h>
 
 #include "sw_codec_select.h"
+#include "audio_defines.h"
 
 /**
  * @brief Mixes a tone into the I2S TX stream
@@ -53,14 +54,9 @@ void audio_datapath_pres_delay_us_get(uint32_t *delay_us);
  *       and processed before being outputted over I2S. The audio is synchronized
  *       using sdu_ref_us
  *
- * @param buf Pointer to audio data frame
- * @param size Size of audio data frame in bytes
- * @param sdu_ref_us ISO timestamp reference from BLE controller
- * @param bad_frame Indicating if the audio frame is bad or not
- * @param recv_frame_ts_us Timestamp of when audio frame was received
+ * @param audio_frame Pointer to the audio data frame to be processed
  */
-void audio_datapath_stream_out(const uint8_t *buf, size_t size, uint32_t sdu_ref_us, bool bad_frame,
-			       uint32_t recv_frame_ts_us);
+void audio_datapath_stream_out(struct audio_data *audio_frame);
 
 /**
  * @brief Start the audio datapath module

--- a/applications/nrf5340_audio/src/audio/audio_system.h
+++ b/applications/nrf5340_audio/src/audio/audio_system.h
@@ -11,6 +11,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "audio_defines.h"
+
 #define VALUE_NOT_SET 0
 
 /**
@@ -66,13 +68,11 @@ int audio_system_config_set(uint32_t encoder_sample_rate_hz, uint32_t encoder_bi
 /**
  * @brief	Decode data and then add it to TX FIFO buffer.
  *
- * @param[in]	encoded_data		Pointer to encoded data.
- * @param[in]	encoded_data_size	Size of encoded data.
- * @param[in]	bad_frame		Indication on missed or incomplete frame.
+ * @param[in]	audio_frame	Pointer to the audio data.
  *
  * @return	0 on success, error otherwise.
  */
-int audio_system_decode(void const *const encoded_data, size_t encoded_data_size, bool bad_frame);
+int audio_system_decode(struct audio_data *audio_frame);
 
 /**
  * @brief	Initialize and start both HW and SW audio codec.

--- a/applications/nrf5340_audio/src/audio/le_audio_rx.c
+++ b/applications/nrf5340_audio/src/audio/le_audio_rx.c
@@ -4,30 +4,25 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include "le_audio_rx.h"
+
 #include <zephyr/kernel.h>
 #include <nrfx_clock.h>
+#include <zephyr/net_buf.h>
 
 #include "streamctrl.h"
 #include "audio_datapath.h"
 #include "macros_common.h"
 #include "audio_system.h"
 #include "audio_sync_timer.h"
+#include "audio_defines.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(le_audio_rx, CONFIG_LE_AUDIO_RX_LOG_LEVEL);
 
-struct ble_iso_data {
-	uint8_t data[CONFIG_BT_ISO_RX_MTU];
-	size_t data_size;
-	bool bad_frame;
-	uint32_t sdu_ref;
-	uint32_t recv_frame_ts;
-} __packed;
-
 struct rx_stats {
 	uint32_t recv_cnt;
 	uint32_t bad_frame_cnt;
-	uint32_t data_size_mismatch_cnt;
 };
 
 static bool initialized;
@@ -35,16 +30,16 @@ static struct k_thread audio_datapath_thread_data;
 static k_tid_t audio_datapath_thread_id;
 K_THREAD_STACK_DEFINE(audio_datapath_thread_stack, CONFIG_AUDIO_DATAPATH_STACK_SIZE);
 
-DATA_FIFO_DEFINE(ble_fifo_rx, CONFIG_BUF_BLE_RX_PACKET_NUM, WB_UP(sizeof(struct ble_iso_data)));
+DATA_FIFO_DEFINE(ble_fifo_rx, CONFIG_BUF_BLE_RX_PACKET_NUM, WB_UP(sizeof(struct audio_data)));
+NET_BUF_POOL_FIXED_DEFINE(ble_rx_pool, CONFIG_BUF_BLE_RX_PACKET_NUM, CONFIG_BT_ISO_RX_MTU, 0, NULL);
 
 /* Callback for handling ISO RX */
-void le_audio_rx_data_handler(uint8_t const *const p_data, size_t data_size, bool bad_frame,
-			      uint32_t sdu_ref, enum audio_channel channel_index,
-			      size_t desired_data_size)
+void le_audio_rx_data_handler(struct audio_data *audio_frame, uint8_t channel_index)
 {
 	int ret;
 	uint32_t blocks_alloced_num, blocks_locked_num;
-	struct ble_iso_data *iso_received = NULL;
+	struct audio_data *audio_frame_received = NULL;
+	struct net_buf *audio_buf;
 	static struct rx_stats rx_stats[AUDIO_CH_NUM];
 	static uint32_t num_overruns;
 	static uint32_t num_thrown;
@@ -54,27 +49,18 @@ void le_audio_rx_data_handler(uint8_t const *const p_data, size_t data_size, boo
 	}
 
 	/* Capture timestamp of when audio frame is received */
-	uint32_t recv_frame_ts = audio_sync_timer_capture();
+	audio_frame->meta.data_rx_ts_us = audio_sync_timer_capture();
 
 	rx_stats[channel_index].recv_cnt++;
 
-	if (data_size != desired_data_size) {
-		/* A valid frame should always be equal to desired_data_size, set bad_frame
-		 * if that is not the case
-		 */
-		bad_frame = true;
-		rx_stats[channel_index].data_size_mismatch_cnt++;
-	}
-
-	if (bad_frame) {
+	if (audio_frame->meta.bad_data) {
 		rx_stats[channel_index].bad_frame_cnt++;
 	}
 
 	if ((rx_stats[channel_index].recv_cnt % 100) == 0 && rx_stats[channel_index].recv_cnt) {
 		/* NOTE: The string below is used by the Nordic CI system */
-		LOG_DBG("ISO RX SDUs: Ch: %d Total: %d Bad: %d Size mismatch %d", channel_index,
-			rx_stats[channel_index].recv_cnt, rx_stats[channel_index].bad_frame_cnt,
-			rx_stats[channel_index].data_size_mismatch_cnt);
+		LOG_DBG("ISO RX SDUs: Ch: %d Total: %d Bad: %d", channel_index,
+			rx_stats[channel_index].recv_cnt, rx_stats[channel_index].bad_frame_cnt);
 	}
 
 	if (stream_state_get() != STATE_STREAMING) {
@@ -87,8 +73,8 @@ void le_audio_rx_data_handler(uint8_t const *const p_data, size_t data_size, boo
 		return;
 	}
 
-	if (channel_index != AUDIO_CH_L && (CONFIG_AUDIO_DEV == GATEWAY)) {
-		/* Only left channel RX data in use on gateway */
+	if (channel_index == 0 && (CONFIG_AUDIO_DEV == GATEWAY)) {
+		/* Only the first device will be used as mic input on gateway */
 		return;
 	}
 
@@ -97,8 +83,7 @@ void le_audio_rx_data_handler(uint8_t const *const p_data, size_t data_size, boo
 
 	if (blocks_alloced_num >= CONFIG_BUF_BLE_RX_PACKET_NUM) {
 		/* FIFO buffer is full, swap out oldest frame for a new one */
-
-		void *stale_data;
+		struct audio_data *stale_audio_frame;
 		size_t stale_size;
 		num_overruns++;
 
@@ -106,30 +91,36 @@ void le_audio_rx_data_handler(uint8_t const *const p_data, size_t data_size, boo
 			LOG_WRN("BLE ISO RX overrun: Num: %d", num_overruns);
 		}
 
-		ret = data_fifo_pointer_last_filled_get(&ble_fifo_rx, &stale_data, &stale_size,
-							K_NO_WAIT);
+		ret = data_fifo_pointer_last_filled_get(&ble_fifo_rx, (void *)&stale_audio_frame,
+							&stale_size, K_NO_WAIT);
 		ERR_CHK(ret);
 
-		data_fifo_block_free(&ble_fifo_rx, stale_data);
+		struct net_buf *stale_buf = stale_audio_frame->data;
+
+		net_buf_unref(stale_buf);
+		data_fifo_block_free(&ble_fifo_rx, stale_audio_frame);
 	}
 
-	ret = data_fifo_pointer_first_vacant_get(&ble_fifo_rx, (void *)&iso_received, K_NO_WAIT);
+	ret = data_fifo_pointer_first_vacant_get(&ble_fifo_rx, (void *)&audio_frame_received,
+						 K_NO_WAIT);
+
+	memcpy(audio_frame_received, audio_frame, sizeof(struct audio_data));
 	ERR_CHK_MSG(ret, "Unable to get FIFO pointer");
 
-	if (data_size > ARRAY_SIZE(iso_received->data)) {
-		ERR_CHK_MSG(-ENOMEM, "Data size too large for buffer");
+	audio_buf = net_buf_alloc(&ble_rx_pool, K_NO_WAIT);
+	if (audio_buf == NULL) {
+		LOG_WRN("Out of RX buffers");
 		return;
 	}
 
-	memcpy(iso_received->data, p_data, data_size);
+	if (audio_frame->data_size && !audio_frame->meta.bad_data) {
+		net_buf_add_mem(audio_buf, audio_frame->data, audio_frame->data_size);
+	}
 
-	iso_received->bad_frame = bad_frame;
-	iso_received->data_size = data_size;
-	iso_received->sdu_ref = sdu_ref;
-	iso_received->recv_frame_ts = recv_frame_ts;
+	audio_frame_received->data = audio_buf;
 
-	ret = data_fifo_block_lock(&ble_fifo_rx, (void *)&iso_received,
-				   sizeof(struct ble_iso_data));
+	ret = data_fifo_block_lock(&ble_fifo_rx, (void *)&audio_frame_received,
+				   sizeof(struct audio_data));
 	ERR_CHK_MSG(ret, "Failed to lock block");
 }
 
@@ -139,24 +130,25 @@ void le_audio_rx_data_handler(uint8_t const *const p_data, size_t data_size, boo
 static void audio_datapath_thread(void *dummy1, void *dummy2, void *dummy3)
 {
 	int ret;
-	struct ble_iso_data *iso_received = NULL;
-	size_t iso_received_size;
+	struct audio_data *audio_frame = NULL;
+	size_t audio_frame_recv_size;
 
 	while (1) {
-		ret = data_fifo_pointer_last_filled_get(&ble_fifo_rx, (void *)&iso_received,
-							&iso_received_size, K_FOREVER);
+		ret = data_fifo_pointer_last_filled_get(&ble_fifo_rx, (void *)&audio_frame,
+							&audio_frame_recv_size, K_FOREVER);
 		ERR_CHK(ret);
 
 		if (IS_ENABLED(CONFIG_AUDIO_SOURCE_USB) && (CONFIG_AUDIO_DEV == GATEWAY)) {
-			ret = audio_system_decode(iso_received->data, iso_received->data_size,
-						  iso_received->bad_frame);
+			ret = audio_system_decode(audio_frame);
 			ERR_CHK(ret);
 		} else {
-			audio_datapath_stream_out(iso_received->data, iso_received->data_size,
-						  iso_received->sdu_ref, iso_received->bad_frame,
-						  iso_received->recv_frame_ts);
+			audio_datapath_stream_out(audio_frame);
 		}
-		data_fifo_block_free(&ble_fifo_rx, (void *)iso_received);
+
+		struct net_buf *audio_buf = audio_frame->data;
+
+		net_buf_unref(audio_buf);
+		data_fifo_block_free(&ble_fifo_rx, (void *)audio_frame);
 
 		STACK_USAGE_PRINT("audio_datapath_thread", &audio_datapath_thread_data);
 	}

--- a/applications/nrf5340_audio/src/audio/le_audio_rx.h
+++ b/applications/nrf5340_audio/src/audio/le_audio_rx.h
@@ -7,19 +7,16 @@
 #ifndef _LE_AUDIO_RX_H_
 #define _LE_AUDIO_RX_H_
 
+#include <zephyr/bluetooth/audio/audio.h>
+#include <audio_defines.h>
+
 /**
  * @brief Data handler when ISO data has been received.
  *
- * @param[in] p_data		Pointer to the received data.
- * @param[in] data_size		Size of the received data.
- * @param[in] bad_frame		Bad frame flag. (I.e. set for missed ISO data).
- * @param[in] sdu_ref		SDU reference timestamp.
+ * @param[in] audio_frame	Pointer to the received data.
  * @param[in] channel_index	Which channel is received.
- * @param[in] desired_data_size	The expected data size.
  */
-void le_audio_rx_data_handler(uint8_t const *const p_data, size_t data_size, bool bad_frame,
-			      uint32_t sdu_ref, enum audio_channel channel_index,
-			      size_t desired_data_size);
+void le_audio_rx_data_handler(struct audio_data *audio_frame, uint8_t channel_index);
 
 /**
  * @brief Initialize the receive audio path.

--- a/applications/nrf5340_audio/src/audio/streamctrl.h
+++ b/applications/nrf5340_audio/src/audio/streamctrl.h
@@ -9,6 +9,7 @@
 
 #include <stddef.h>
 #include <zephyr/kernel.h>
+#include <audio_defines.h>
 
 /* State machine states for peer or stream. */
 enum stream_state {
@@ -26,10 +27,8 @@ uint8_t stream_state_get(void);
 /**
  * @brief Send audio data over the stream.
  *
- * @param data		Data to send.
- * @param size		Size of data.
- * @param num_ch	Number of audio channels.
+ * @param audio_frame		Pointer to the audio data to send.
  */
-void streamctrl_send(void const *const data, size_t size, uint8_t num_ch);
+void streamctrl_send(struct audio_data const *const audio_frame);
 
 #endif /* _STREAMCTRL_H_ */

--- a/applications/nrf5340_audio/src/audio/sw_codec_select.h
+++ b/applications/nrf5340_audio/src/audio/sw_codec_select.h
@@ -83,28 +83,22 @@ bool sw_codec_is_initialized(void);
  * @note	Takes in stereo PCM stream, will encode either one or two
  *		channels, based on channel_mode set during init.
  *
- * @param[in]	pcm_data	Pointer to PCM data.
- * @param[in]	pcm_size	Size of PCM data.
- * @param[out]	encoded_data	Pointer to buffer to store encoded data.
- * @param[out]	encoded_size	Size of encoded data.
+ * @param[in]	audio_frame	Pointer to audio data.
  *
  * @return	0 if success, error codes depends on sw_codec selected.
  */
-int sw_codec_encode(void *pcm_data, size_t pcm_size, uint8_t **encoded_data, size_t *encoded_size);
+int sw_codec_encode(struct audio_data *audio_frame);
 
 /**
  * @brief	Decode encoded data and output PCM data.
  *
- * @param[in]	encoded_data	Pointer to encoded data.
- * @param[in]	encoded_size	Size of encoded data.
- * @param[in]	bad_frame	Flag to indicate a missing/bad frame (only LC3).
+ * @param[in]	audio_frame	Pointer to audio data.
  * @param[out]	pcm_data	Pointer to buffer to store decoded PCM data.
  * @param[out]	pcm_size	Size of decoded data.
  *
  * @return	0 if success, error codes depends on sw_codec selected.
  */
-int sw_codec_decode(uint8_t const *const encoded_data, size_t encoded_size, bool bad_frame,
-		    void **pcm_data, size_t *pcm_size);
+int sw_codec_decode(struct audio_data const *const audio_frame, void **pcm_data, size_t *pcm_size);
 
 /**
  * @brief	Uninitialize the software codec and free the allocated space.

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
@@ -620,7 +620,7 @@ int broadcast_source_id_get(uint8_t big_index, uint32_t *broadcast_id)
 }
 
 int broadcast_source_send(uint8_t big_index, uint8_t subgroup_index,
-			  struct le_audio_encoded_audio enc_audio)
+			  struct audio_data const *const audio_frame)
 {
 	int ret;
 	uint8_t num_active_streams = 0;
@@ -664,7 +664,7 @@ int broadcast_source_send(uint8_t big_index, uint8_t subgroup_index,
 		return -ECANCELED;
 	}
 
-	ret = bt_le_audio_tx_send(tx, num_active_streams, enc_audio);
+	ret = bt_le_audio_tx_send(tx, num_active_streams, audio_frame);
 	if (ret) {
 		return ret;
 	}

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.h
@@ -224,12 +224,12 @@ int broadcast_source_id_get(uint8_t big_index, uint32_t *broadcast_id);
  *
  * @param[in]	big_index	Index of the Broadcast Isochronous Group (BIG) to broadcast.
  * @param[in]	subgroup_index	Index of the subgroup to broadcast.
- * @param[in]	enc_audio	Encoded audio struct.
+ * @param[in]	audio_frame	Pointer to the audio to send.
  *
  * @return	0 for success, error otherwise.
  */
 int broadcast_source_send(uint8_t big_index, uint8_t subgroup_index,
-			  struct le_audio_encoded_audio enc_audio);
+			  struct audio_data const *const audio_frame);
 
 /**
  * @brief	Disable the LE Audio broadcast (BIS) source.

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.h
@@ -27,12 +27,12 @@ struct le_audio_tx_info {
  *
  * @param[in]	tx		Pointer to an array of le_audio_tx_info elements.
  * @param[in]	num_tx		Number of elements in @p tx.
- * @param[in]	enc_audio	Encoded audio data.
+ * @param[in]	audio_frame	Pointer to the encoded audio data.
  *
  * @return	0 if successful, error otherwise.
  */
 int bt_le_audio_tx_send(struct le_audio_tx_info *tx, uint8_t num_tx,
-			struct le_audio_encoded_audio enc_audio);
+			struct audio_data const *const audio_frame);
 
 /**
  * @brief	Initializes a stream. Must be called when a TX stream is started.

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
@@ -12,6 +12,41 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(le_audio, CONFIG_BLE_LOG_LEVEL);
 
+int le_audio_frame_create(struct audio_data *audio_frame, const struct bt_bap_stream *stream,
+			  const struct bt_iso_recv_info *info, const struct net_buf *buf)
+{
+	int ret;
+
+	/* Populate the audio frame structure */
+	audio_frame->data = buf->data;
+	audio_frame->data_size = buf->len;
+	audio_frame->meta.bad_data = false;
+	audio_frame->meta.reference_ts_us = info->ts;
+	le_audio_freq_hz_get(stream->codec_cfg, &audio_frame->meta.sample_rate_hz);
+	le_audio_duration_us_get(stream->codec_cfg, &audio_frame->meta.data_len_us);
+
+	ret = bt_audio_codec_cfg_get_chan_allocation(stream->codec_cfg,
+						     &audio_frame->meta.locations, true);
+	if (ret < 0) {
+		LOG_ERR("Failed to get channel allocation: %d", ret);
+		return ret;
+	}
+
+	if (stream->codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
+		audio_frame->meta.data_coding = LC3;
+	} else {
+		LOG_ERR("Unsupported codec ID: %d", stream->codec_cfg->id);
+		return -EINVAL;
+	}
+
+	if (!(info->flags & BT_ISO_FLAGS_VALID) ||
+	    buf->len != bt_audio_codec_cfg_get_octets_per_frame(stream->codec_cfg)) {
+		audio_frame->meta.bad_data = true;
+	}
+
+	return 0;
+}
+
 int le_audio_ep_state_get(struct bt_bap_ep *ep, uint8_t *state)
 {
 	int ret;

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
@@ -44,33 +44,29 @@
 /**
  * @brief Callback for receiving Bluetooth LE Audio data.
  *
- * @param	data		Pointer to received data.
- * @param	size		Size of received data.
- * @param	bad_frame	Indicating if the frame is a bad frame or not.
- * @param	sdu_ref		ISO timestamp.
+ * @param	audio_frame	Pointer to audio data struct.
  * @param	channel_index	Audio channel index.
- * @param	desired_size	The expected data size.
  */
-typedef void (*le_audio_receive_cb)(const uint8_t *const data, size_t size, bool bad_frame,
-				    uint32_t sdu_ref, enum audio_channel channel_index,
-				    size_t desired_size);
-
-/**
- * @brief	Encoded audio data and information.
- *
- * @note	Container for SW codec (typically LC3) compressed audio data.
- */
-struct le_audio_encoded_audio {
-	uint8_t const *const data;
-	size_t size;
-	uint8_t num_ch;
-};
+typedef void (*le_audio_receive_cb)(struct audio_data *audio_frame, uint8_t channel_index);
 
 struct stream_index {
 	uint8_t lvl1; /* BIG / CIG */
 	uint8_t lvl2; /* Subgroups (only applicable to Broadcast) */
 	uint8_t lvl3; /* BIS / CIS */
 };
+
+/**
+ * @brief Function to handle the audio frame.
+ *
+ * @param[in] audio_frame	Pointer to the audio frame.
+ * @param[in] stream		Pointer to the stream.
+ * @param[in] info		Pointer to the ISO information.
+ * @param[in] buf		Pointer to the buffer.
+ *
+ * @return 0 if successful, error otherwise.
+ */
+int le_audio_frame_create(struct audio_data *audio_frame, const struct bt_bap_stream *stream,
+			  const struct bt_iso_recv_info *info, const struct net_buf *buf);
 
 /**
  * @brief	Get the current state of an endpoint.

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.h
@@ -114,11 +114,11 @@ int unicast_client_stop(uint8_t cig_index);
  * @brief	Send encoded audio using the Bluetooth LE Audio unicast.
  *
  * @param[in]	cig_index	Index of the Connected Isochronous Group (CIG) to send to.
- * @param[in]	enc_audio	Encoded audio struct.
+ * @param[in]	audio_frame	Pointer to the audio to send.
  *
  * @return	0 for success, error otherwise.
  */
-int unicast_client_send(uint8_t cig_index, struct le_audio_encoded_audio enc_audio);
+int unicast_client_send(uint8_t cig_index, struct audio_data const *const audio_frame);
 
 /**
  * @brief       Disable the Bluetooth LE Audio unicast (CIS) client.

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.c
@@ -337,19 +337,21 @@ static const struct bt_bap_unicast_server_cb unicast_server_cb = {
 static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
 			   struct net_buf *buf)
 {
-	bool bad_frame = false;
+	int ret;
+	struct audio_data audio_frame;
 
 	if (receive_cb == NULL) {
 		LOG_ERR("The RX callback has not been set");
 		return;
 	}
 
-	if (!(info->flags & BT_ISO_FLAGS_VALID)) {
-		bad_frame = true;
+	ret = le_audio_frame_create(&audio_frame, stream, info, buf);
+	if (ret) {
+		LOG_ERR("Failed to create RX frame: %d", ret);
+		return;
 	}
 
-	receive_cb(buf->data, buf->len, bad_frame, info->ts, 0,
-		   bt_audio_codec_cfg_get_octets_per_frame(stream->codec_cfg));
+	receive_cb(&audio_frame, 0);
 }
 #endif /* (CONFIG_BT_AUDIO_RX) */
 
@@ -601,7 +603,7 @@ int unicast_server_adv_populate(struct bt_data *adv_buf, uint8_t adv_buf_vacant)
 	return adv_buf_cnt;
 }
 
-int unicast_server_send(struct le_audio_encoded_audio enc_audio)
+int unicast_server_send(struct audio_data const *const audio_frame)
 {
 #if (CONFIG_BT_AUDIO_TX)
 	int ret;
@@ -629,7 +631,7 @@ int unicast_server_send(struct le_audio_encoded_audio enc_audio)
 		num_active_streams++;
 	}
 
-	ret = bt_le_audio_tx_send(tx, num_active_streams, enc_audio);
+	ret = bt_le_audio_tx_send(tx, num_active_streams, audio_frame);
 	if (ret) {
 		return ret;
 	}

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.h
@@ -54,11 +54,11 @@ int unicast_server_adv_populate(struct bt_data *adv_buf, uint8_t adv_buf_vacant)
 /**
  * @brief	Send data from the LE Audio unicast (CIS) server, if configured as a source.
  *
- * @param[in]	enc_audio	Encoded audio struct.
+ * @param[in]	audio_frame	Pointer to the audio data.
  *
  * @return	0 for success, error otherwise.
  */
-int unicast_server_send(struct le_audio_encoded_audio enc_audio);
+int unicast_server_send(struct audio_data const *const audio_frame);
 
 /**
  * @brief	Disable the Bluetooth LE Audio unicast (CIS) server.

--- a/applications/nrf5340_audio/unicast_client/main.c
+++ b/applications/nrf5340_audio/unicast_client/main.c
@@ -530,15 +530,13 @@ uint8_t stream_state_get(void)
 	return strm_state;
 }
 
-void streamctrl_send(void const *const data, size_t size, uint8_t num_ch)
+void streamctrl_send(struct audio_data const *const audio_frame)
 {
 	int ret;
 	static int prev_ret;
 
-	struct le_audio_encoded_audio enc_audio = {.data = data, .size = size, .num_ch = num_ch};
-
 	if (strm_state == STATE_STREAMING) {
-		ret = unicast_client_send(0, enc_audio);
+		ret = unicast_client_send(0, audio_frame);
 
 		if (ret != 0 && ret != prev_ret) {
 			if (ret == -ECANCELED) {

--- a/applications/nrf5340_audio/unicast_server/main.c
+++ b/applications/nrf5340_audio/unicast_server/main.c
@@ -506,15 +506,13 @@ uint8_t stream_state_get(void)
 	return strm_state;
 }
 
-void streamctrl_send(void const *const data, size_t size, uint8_t num_ch)
+void streamctrl_send(struct audio_data const *const audio_frame)
 {
 	int ret;
 	static int prev_ret;
 
-	struct le_audio_encoded_audio enc_audio = {.data = data, .size = size, .num_ch = num_ch};
-
 	if (strm_state == STATE_STREAMING) {
-		ret = unicast_server_send(enc_audio);
+		ret = unicast_server_send(audio_frame);
 
 		if (ret != 0 && ret != prev_ret) {
 			if (ret == -ECANCELED) {

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -208,6 +208,8 @@ nRF5340 Audio
 
   * The application to use the ``NFC.TAGHEADER0`` value from FICR as the broadcast ID instead of using a random ID.
   * The application to change from Newlib to Picolib to align with |NCS| and Zephyr.
+  * The application to use an audio struct that contains meta data about the audio stream.
+
 
 nRF Desktop
 -----------

--- a/include/audio_defines.h
+++ b/include/audio_defines.h
@@ -13,6 +13,7 @@
 
 #include <zephyr/types.h>
 #include <stdbool.h>
+#include <zephyr/bluetooth/audio/audio.h>
 
 /**
  * @brief Audio channel assignment values
@@ -101,5 +102,24 @@ struct audio_data {
 	 */
 	struct audio_metadata meta;
 };
+
+/**
+ * @brief Get the number of channels in the audio data.
+ *
+ * This function will count the number of bits set in the
+ * locations field of the audio metadata.
+ *
+ * @param audio_frame Pointer to the audio data structure.
+ *
+ * @return The number of channels.
+ */
+static inline uint8_t audio_data_num_ch_get(struct audio_data const *const audio_frame)
+{
+	if (audio_frame == NULL) {
+		return 0;
+	}
+
+	return bt_audio_get_chan_count(audio_frame->meta.locations);
+}
 
 #endif /* _AUDIO_DEFINES_H_ */

--- a/lib/data_fifo/data_fifo.c
+++ b/lib/data_fifo/data_fifo.c
@@ -59,7 +59,7 @@ int data_fifo_block_lock(struct data_fifo *data_fifo, void **data, size_t size)
 	int ret;
 
 	if (size > data_fifo->block_size_max) {
-		LOG_ERR("Size %zu too big", size);
+		LOG_ERR("Size %zu too big, max: %zu", size, data_fifo->block_size_max);
 		return -ENOMEM;
 	} else if (size == 0) {
 		LOG_ERR("Size is zero");


### PR DESCRIPTION
- Implement new struct in broadcast_sink from end-to-end
- Implement audio struct in usb RX
  - Added audio struct to USB RX all the way up to sw_encode
- Use audio struct in sw_encode
  - Replace PCM data with LC3 data and update meta data
  - Uses audio struct from USB all the way to le_audio_tx
- Added audio_struct to the decode function
- Implement audio_struct in unicast
  - Using the new audio struct in both unicast server and client
- Implement the new audio struct in nrf_auraconfig sample
- OCT-3285

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>