### PR TITLE
samples: cellular: modem_shell: Add ATE0/ATE1

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -281,6 +281,10 @@ Cellular samples
 
   * The sample is no longer maintained and is now deprecated.
 
+* :ref:`modem_shell_application` sample:
+
+  * Added ``ATE0`` and ``ATE1`` in AT command mode to handle echo off/on.
+
 * :ref:`nrf_cloud_multi_service` sample:
 
   * Added support for native simulator platform and updated the documentation accordingly.

--- a/samples/cellular/modem_shell/README.rst
+++ b/samples/cellular/modem_shell/README.rst
@@ -168,6 +168,7 @@ Examples
      at at_cmd_mode start
      MoSh AT command mode started, press ctrl-x ctrl-q to escape
      MoSh specific AT commands:
+       Echo off/on: ATE0 and ATE1
        ICMP Ping: AT+NPING=<addr>[,<payload_length>,<timeout_msecs>,<count>[,<interval_msecs>[,<cid>]]]
      Other custom functionalities:
        AT command pipelining, for example:

--- a/samples/cellular/modem_shell/src/at/at_cmd_mode_sett.c
+++ b/samples/cellular/modem_shell/src/at/at_cmd_mode_sett.c
@@ -17,8 +17,11 @@
 #define AT_CMD_MODE_SETT_KEY "at_cmd_mode_settings"
 
 #define AT_CMD_MODE_SETT_AUTOSTART "autostart_enabled"
+#define AT_CMD_MODE_SETT_ECHO_ON "echo_on"
 
 static bool sett_autostart_enabled;
+
+extern bool at_cmd_mode_echo_on;
 
 /******************************************************************************/
 
@@ -32,6 +35,12 @@ static int at_cmd_mode_sett_handler(const char *key, size_t len, settings_read_c
 		ret = read_cb(cb_arg, &sett_autostart_enabled, sizeof(sett_autostart_enabled));
 		if (ret < 0) {
 			mosh_error("Failed to read sett_autostart_enabled, error: %d", ret);
+			return ret;
+		}
+	} else if (strcmp(key, AT_CMD_MODE_SETT_ECHO_ON) == 0) {
+		ret = read_cb(cb_arg, &at_cmd_mode_echo_on, sizeof(at_cmd_mode_echo_on));
+		if (ret < 0) {
+			mosh_error("Failed to read at_cmd_mode_echo_on, error: %d", ret);
 			return ret;
 		}
 	}
@@ -62,6 +71,28 @@ int at_cmd_mode_sett_autostart_enabled(bool enabled)
 bool at_cmd_mode_sett_is_autostart_enabled(void)
 {
 	return sett_autostart_enabled;
+}
+
+int at_cmd_mode_sett_echo_on(bool enabled, bool print_status)
+{
+	const char *key_enabled = AT_CMD_MODE_SETT_KEY "/" AT_CMD_MODE_SETT_ECHO_ON;
+	int err;
+
+	at_cmd_mode_echo_on = enabled;
+
+	if (print_status) {
+		mosh_print("at_cmd_mode echo_%s", (enabled ? "on" : "off"));
+	}
+
+	err = settings_save_one(key_enabled, &at_cmd_mode_echo_on, sizeof(at_cmd_mode_echo_on));
+	if (err) {
+		if (print_status) {
+			mosh_error("sett_echo_on: err %d from settings_save_one()", err);
+		}
+		return err;
+	}
+
+	return 0;
 }
 
 /******************************************************************************/

--- a/samples/cellular/modem_shell/src/at/at_cmd_mode_sett.h
+++ b/samples/cellular/modem_shell/src/at/at_cmd_mode_sett.h
@@ -10,5 +10,6 @@
 int at_cmd_mode_sett_init(void);
 int at_cmd_mode_sett_autostart_enabled(bool enabled);
 bool at_cmd_mode_sett_is_autostart_enabled(void);
+int at_cmd_mode_sett_echo_on(bool enabled, bool print_status);
 
 #endif /* MOSH_AT_CMD_MODE_SETT_H */

--- a/samples/cellular/modem_shell/src/at/at_shell.c
+++ b/samples/cellular/modem_shell/src/at/at_shell.c
@@ -41,6 +41,16 @@ static int at_shell_cmd_mode_disable_autostart(const struct shell *shell, size_t
 	at_cmd_mode_sett_autostart_enabled(false);
 	return 0;
 }
+static int at_shell_cmd_mode_enable_echo(const struct shell *shell, size_t argc, char **argv)
+{
+	at_cmd_mode_sett_echo_on(true, true);
+	return 0;
+}
+static int at_shell_cmd_mode_disable_echo(const struct shell *shell, size_t argc, char **argv)
+{
+	at_cmd_mode_sett_echo_on(false, true);
+	return 0;
+}
 static int at_shell_cmd_mode_term_cr_lf(const struct shell *shell, size_t argc, char **argv)
 {
 	at_cmd_mode_line_termination_set(CR_LF_TERM);
@@ -115,6 +125,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(disable_autostart, NULL,
 		  "Disable AT command mode autostart on bootup.",
 		  at_shell_cmd_mode_disable_autostart),
+	SHELL_CMD(echo_on, NULL,
+		  "Enable echo in AT command mode.",
+		  at_shell_cmd_mode_enable_echo),
+	SHELL_CMD(echo_off, NULL,
+		  "Disable echo in AT command mode.",
+		  at_shell_cmd_mode_disable_echo),
 	SHELL_CMD(term_cr_lf, NULL,
 		  "Receive CR+LF as command line termination.",
 		  at_shell_cmd_mode_term_cr_lf),


### PR DESCRIPTION
Add ATE0 and ATE1 in AT command mode to handle echo on/off. Store last used mode in settings.