### PR TITLE
samples: cellular: deprecate lte_ble_gateway sample

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -511,6 +511,7 @@
 /samples/cellular/slm_shell/              @nrfconnect/ncs-iot-oulu
 /samples/cellular/sms/                    @nrfconnect/ncs-modem-tre
 /samples/cellular/uicc_lwm2m/             @stig-bjorlykke
+/samples/cellular/lte_ble_gateway/        @nrfconnect/ncs-cia
 /samples/common/                          @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-bluebagel
 /samples/crypto/                          @nrfconnect/ncs-aegir
 /samples/debug/memfault/                  @nrfconnect/ncs-cia

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -258,7 +258,10 @@ Bluetooth Fast Pair samples
 Cellular samples
 ----------------
 
-|no_changes_yet_note|
+* :ref:`lte_sensor_gateway` sample:
+
+  * The sample is no longer maintained and is now deprecated.
+
 
 Cryptography samples
 --------------------

--- a/samples/cellular/lte_ble_gateway/README.rst
+++ b/samples/cellular/lte_ble_gateway/README.rst
@@ -12,6 +12,11 @@ The LTE Sensor Gateway sample demonstrates how to transmit sensor data from an n
 The sensor data is collected using Bluetooth® Low Energy.
 Therefore, this sample acts as a gateway between the Bluetooth LE and the LTE connections to nRF Cloud.
 
+.. note::
+
+   This sample is deprecated and no longer maintained.
+   It will be removed from the |NCS| in a future release.
+
 Requirements
 ************
 

--- a/samples/cellular/modem_shell/README.rst
+++ b/samples/cellular/modem_shell/README.rst
@@ -1279,19 +1279,46 @@ BT shell support
 To build the MoSh sample with Zephyr BT shell command support, use the :file:`-DDTC_OVERLAY_FILE=bt.overlay` and :file:`-DEXTRA_CONF_FILE=overlay-bt.conf` options.
 When running this configuration, you can perform BT scanning and advertising using the ``bt`` command.
 
-Compile as follows:
+You must program the *board controller* with the :ref:`bluetooth-hci-lpuart-sample` sample first, before programming the main controller with the :ref:`modem_shell_application` sample.
+Program the board controller as follows:
 
-.. code-block:: console
+1. Set the **SW10** switch, marked as *debug/prog*, in the **NRF52** position.
+   On nRF9160 DK board version 0.9.0 and earlier versions, the switch was called **SW5**.
+#. Build the :ref:`bluetooth-hci-lpuart-sample` sample for the ``nrf9160dk/nrf52840`` board target and program the board controller with it.
 
-   west build -p -b nrf9160dk/nrf9160/ns -- -DDTC_OVERLAY_FILE="bt.overlay" -DEXTRA_CONF_FILE="overlay-bt.conf"
+   .. note::
+      To build the sample successfully, you must specify the board version along with the board target.
+      The board version is printed on the label of your DK, just below the PCA number.
+      For example, for board version 1.1.0, build the sample as follows:
 
-Additionally, you need to program the nRF52840 side of the nRF9160 DK as instructed in :ref:`lte_sensor_gateway`.
+      .. parsed-literal::
+         :class: highlight
 
-Compile the :ref:`bluetooth-hci-lpuart-sample` sample as follows:
+         west build --board nrf9160dk@1.1.0/nrf52840
 
-.. code-block:: console
+#. Verify that the programming was successful.
+   Use a terminal emulator, like the `Serial Terminal app`_, to connect to the second serial port and check the output.
+   See :ref:`test_and_optimize` for the required settings and steps.
 
-   west build -p -b nrf9160dk/nrf52840
+After programming the board controller, you must program the main controller with the :ref:`modem_shell_application` sample.
+Program the main controller as follows:
+
+1. Set the **SW10** switch, marked as *debug/prog*, in the **NRF91** position.
+   On nRF9160 DK board version 0.9.0 and earlier versions, the switch was called **SW5**.
+#. Build the sample for the ``nrf9160dk/nrf9160/ns`` board target and program the main controller with it.
+
+   .. note::
+      To build the sample successfully, you must specify the board version along with the board target.
+      For example, for board version 1.1.0, build the sample as follows:
+
+      .. parsed-literal::
+         :class: highlight
+
+         west build -p -b nrf9160dk@1.1.0/nrf9160/ns -- -DDTC_OVERLAY_FILE="bt.overlay" -DEXTRA_CONF_FILE="overlay-bt.conf"
+
+#. Verify that the programming was successful.
+   Use a terminal emulator, like the `Serial Terminal app`_, to connect to the first serial port and check the output.
+   See :ref:`test_and_optimize` for the required settings and steps.
 
 The following example demonstrates how to use MoSh with two development kits, where one acts as a broadcaster and the other one as an observer.
 


### PR DESCRIPTION
The lte_ble_gateway sample is deprecated and shall be removed in the next release. The sample is not maintained and has not been updated in a while.