### PR TITLE
nrf_security: cracen: Fix hanging samples and tests with CRACEN lite

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -217,7 +217,9 @@ struct sx_pk_acq_req sx_pk_acquire_req(const struct sx_pk_cmd_def *cmd)
 
 	/* Wait until initialized. */
 	while (ba414ep_is_busy(req.req) || ik_is_busy(req.req)) {
+#ifndef CONFIG_CRACEN_HW_VERSION_LITE
 		cracen_wait_for_pke_interrupt();
+#endif
 	}
 
 	return req;


### PR DESCRIPTION
On CRACEN  lite the PKE-IKG interrupt can not be cleared from outside ik mode Therefore this interrupt was disabled in a previous commit. Unfortunately when power to CRACEN is turned fully off this also affects this registert meaning cracen_wait_for_interrupt can also not be used. This is therefore disabled for CRACEN lite

Fixing this exposed an issue where the IKG would sometimes hang due to a entropy error that was not handled. This is now worked around by having a error code be returned and then rerunning the function.