### PR TITLE
samples: cellular: multi_service: Remove delay after L4 up

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/src/cloud_connection.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/cloud_connection.c
@@ -316,8 +316,6 @@ static void l4_event_handler(struct net_mgmt_event_callback *cb,
 	if (event == NET_EVENT_L4_CONNECTED) {
 		LOG_INF("Network connectivity gained!");
 
-		k_sleep(K_MSEC(1000));
-
 		/* Set the network ready flag */
 		k_event_post(&cloud_events, NETWORK_READY);
 


### PR DESCRIPTION
The L4 up delay appears to be removable now, Wi-Fi is more stable.

IRIS-9476