### PR TITLE
lib: at_parser: parse DECT NR+ mfw names

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -431,6 +431,10 @@ Security libraries
 Modem libraries
 ---------------
 
+* :ref:`at_parser_readme` library:
+
+  * Added support for parsing DECT NR+ modem firmware names.
+
 * :ref:`lte_lc_readme` library:
 
   * Added the :kconfig:option:`CONFIG_LTE_LC_DNS_FALLBACK_MODULE` and :kconfig:option:`CONFIG_LTE_LC_DNS_FALLBACK_ADDRESS` Kconfig options to enable setting a fallback DNS address.

--- a/lib/at_parser/at_match.re
+++ b/lib/at_parser/at_match.re
@@ -177,7 +177,7 @@ struct at_token at_match_str(const char *at, const char **remainder)
 
 	SPACE = " ";
 	CRLF = "\r\n";
-	STR = [A-Za-z0-9][A-Za-z_\-.0-9 ]*;
+	STR = [A-Za-z0-9][A-Za-z_\-+.0-9 ]*;
 
 	str         = SPACE? @t1 STR @t2 CRLF?;
 

--- a/lib/at_parser/generated/at_match.c
+++ b/lib/at_parser/generated/at_match.c
@@ -805,6 +805,7 @@ yy45:
 			yyt2 = cursor;
 			goto yy47;
 		case ' ':
+		case '+':
 		case '-':
 		case '.':
 		case '0':

--- a/tests/lib/at_parser/src/main.c
+++ b/tests/lib/at_parser/src/main.c
@@ -1741,7 +1741,7 @@ ZTEST(at_parser, test_at_parser_string_get)
 {
 	int ret;
 	struct at_parser parser;
-	char buffer[32] = { 0 };
+	char buffer[64] = { 0 };
 	size_t len = sizeof(buffer);
 
 	const char *str1 = "+CGEV: ME PDN ACT 0";
@@ -1753,6 +1753,8 @@ ZTEST(at_parser, test_at_parser_string_get)
 	zassert_ok(ret);
 	zassert_mem_equal("ME PDN ACT 0", buffer, len);
 
+	len = sizeof(buffer);
+
 	const char *str2 = "+NOTIF: \"\"";
 
 	ret = at_parser_init(&parser, str2);
@@ -1761,6 +1763,17 @@ ZTEST(at_parser, test_at_parser_string_get)
 	ret = at_parser_string_get(&parser, 1, buffer, &len);
 	zassert_ok(ret);
 	zassert_mem_equal("", buffer, len);
+
+	len = sizeof(buffer);
+
+	const char *str3 = "mfw-nr+_nrf91x1_0.0.0-110.nr+-test\r\nOK\r\n";
+
+	ret = at_parser_init(&parser, str3);
+	zassert_ok(ret);
+
+	ret = at_parser_string_get(&parser, 0, buffer, &len);
+	zassert_ok(ret);
+	zassert_mem_equal("mfw-nr+_nrf91x1_0.0.0-110.nr+-test", buffer, len);
 }
 
 ZTEST(at_parser, test_at_parser_string_get_array)


### PR DESCRIPTION
Adds support for parsing DECT NR+ modem firmware
names.