### PR TITLE
samples: peripheral: lpuart: Enable sample on PCA10197

### DIFF
--- a/samples/peripheral/lpuart/boards/nrf54lm20apdk_nrf54lm20a_cpuapp_0_0_0.overlay
+++ b/samples/peripheral/lpuart/boards/nrf54lm20apdk_nrf54lm20a_cpuapp_0_0_0.overlay
@@ -1,22 +1,17 @@
 /* SPDX-License-Identifier: LicenseRef-Nordic-5-Clause */
 
-/* Two GPIO loopbacks are required:
- * Request-Response Pins: P1.15 - P1.16,
- * UART RX-TX Pins: P1.18 - P1.24
- */
-
 &pinctrl {
 	uart21_default_alt: uart21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 1, 18)>,
-				<NRF_PSEL(UART_TX, 1, 24)>;
+			psels = <NRF_PSEL(UART_RX, 1, 10)>,
+				<NRF_PSEL(UART_TX, 1, 11)>;
 		};
 	};
 
 	uart21_sleep_alt: uart21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 1, 18)>,
-				<NRF_PSEL(UART_TX, 1, 24)>;
+			psels = <NRF_PSEL(UART_RX, 1, 10)>,
+				<NRF_PSEL(UART_TX, 1, 11)>;
 			low-power-enable;
 		};
 	};
@@ -31,8 +26,8 @@
 	lpuart: nrf-sw-lpuart {
 		compatible = "nordic,nrf-sw-lpuart";
 		status = "okay";
-		req-pin = <47>;
-		rdy-pin = <48>;
+		req-pin = <40>;
+		rdy-pin = <41>;
 	};
 };
 

--- a/samples/peripheral/lpuart/sample.yaml
+++ b/samples/peripheral/lpuart/sample.yaml
@@ -26,6 +26,7 @@ tests:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833
@@ -59,6 +60,7 @@ tests:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_configs:
@@ -109,6 +111,7 @@ tests:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     tags: ppk_power_measure
     harness: pytest
     harness_config:
@@ -149,6 +152,7 @@ tests:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lv10apdk/nrf54lv10a/cpuapp
       - nrf54lm20apdk/nrf54lm20a/cpuapp
+      - nrf54lm20apdk@0.2.0/nrf54lm20a/cpuapp
     harness: console
     harness_config:
       fixture: gpio_loopback


### PR DESCRIPTION
Add overlay required to run the sample on nrf54lm20apdk@0.2.0 available on PCA10197.