### PR TITLE
application: serial_lte_modem: sms: Fix receiving concatenated SMS

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_sms.c
+++ b/applications/serial_lte_modem/src/slm_at_sms.c
@@ -30,7 +30,7 @@ static void sms_callback(struct sms_data *const data, void *context)
 	static uint8_t total_msgs;
 	static uint8_t count;
 	static char messages[MAX_CONCATENATED_MESSAGE - 1][SMS_MAX_PAYLOAD_LEN_CHARS + 1];
-	char rsp_buf[MAX_CONCATENATED_MESSAGE * SMS_MAX_PAYLOAD_LEN_CHARS + 64] = {0};
+	static char rsp_buf[MAX_CONCATENATED_MESSAGE * SMS_MAX_PAYLOAD_LEN_CHARS + 64] = {0};
 
 	ARG_UNUSED(context);
 


### PR DESCRIPTION
Collected rsp_buf for received concatenated SMS was from the stack. When 2nd and following parts were received, the first part was lost. So we always sent everything except the first part and not the #XSMS notification name and parameters other than the data. Moved rsp_buf to static RAM so it's preserved over multiple SMS parts.

Jira: LRCS-169