### PR TITLE
samples: ipc: ipc-service: Added NRF7002DK Support

### DIFF
--- a/samples/ipc/ipc_service/Kconfig.common
+++ b/samples/ipc/ipc_service/Kconfig.common
@@ -6,7 +6,7 @@
 
 config APP_IPC_SERVICE_SEND_INTERVAL
 	int "Ipc service sending interval [us]"
-	default 30 if BOARD_NRF5340DK_NRF5340_CPUNET
+	default 30 if BOARD_NRF5340DK_NRF5340_CPUNET || BOARD_NRF7002DK_NRF5340_CPUNET
 	default 70
 	help
 	  Time in micro seconds between sending subsequent data packages over

--- a/samples/ipc/ipc_service/Kconfig.sysbuild
+++ b/samples/ipc/ipc_service/Kconfig.sysbuild
@@ -8,8 +8,8 @@ source "share/sysbuild/Kconfig"
 
 config REMOTE_BOARD
 	string "The board used for remote target"
-	default "nrf5340dk/nrf5340/cpunet" if BOARD_NRF5340DK_NRF5340_CPUAPP
-	default "nrf5340dk/nrf5340/cpunet" if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+	default "nrf5340dk/nrf5340/cpunet" if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+	default "nrf7002dk/nrf5340/cpunet" if BOARD_NRF7002DK_NRF5340_CPUAPP || BOARD_NRF7002DK_NRF5340_CPUAPP_NS
 	default "nrf54h20dk/nrf54h20/cpurad" if BOARD_NRF54H20DK_NRF54H20_CPUAPP
 	default "nrf54l15dk/nrf54l15/cpuflpr" if BOARD_NRF54L15DK_NRF54L15_CPUAPP
 	default "nrf54lm20dk/nrf54lm20a/cpuflpr" if BOARD_NRF54LM20DK_NRF54LM20A_CPUAPP

--- a/samples/ipc/ipc_service/README.rst
+++ b/samples/ipc/ipc_service/README.rst
@@ -20,6 +20,11 @@ Currently, the sample supports the following backends:
   * `OpenAMP`_ library
   * :ref:`zephyr:ipc_service_backend_icmsg`
 
+* :zephyr:board:`nrf7002dk` board:
+
+  * `OpenAMP`_ library
+  * :ref:`zephyr:ipc_service_backend_icmsg`
+
 * :zephyr:board:`nrf54h20dk` board:
 
   * :ref:`zephyr:ipc_service_backend_icbmsg`
@@ -94,6 +99,38 @@ Use these overlays when building the IPC sample to test the following scenarios:
 
      west build -p -b nrf5340dk/nrf5340/cpuapp -T sample.ipc.ipc_service.nrf5340dk_icmsg_cpuapp_sending .
      west build -p -b nrf5340dk/nrf5340/cpuapp -T sample.ipc.ipc_service.nrf5340dk_icmsg_cpunet_sending .
+
+ **nRF7002 DK**
+
+ You can build the sample using either the RPMsg or ICMSG backend.
+ For the default RPMsg backend, use the following command:
+
+ .. code-block:: console
+
+    west build -p -b nrf7002dk/nrf5340/cpuapp
+
+ For the ICMSG backend, use the following command:
+
+ .. code-block:: console
+
+    west build -p -b nrf7002dk/nrf5340/cpuapp -T sample.ipc.ipc_service.nrf5340dk_icmsg_default .
+
+ A set of overlays is available for the sample to verify the throughput when only one core is sending the data.
+ Use these overlays when building the IPC sample to test the following scenarios:
+
+ * Either the network or application core is sending data through the IPC service using RPMsg:
+
+   .. code-block:: console
+
+      west build -p -b nrf7002dk/nrf5340/cpuapp -T sample.ipc.ipc_service.nrf5340dk_rpmsg_cpuapp_sending .
+      west build -p -b nrf7002dk/nrf5340/cpuapp -T sample.ipc.ipc_service.nrf5340dk_rpmsg_cpunet_sending .
+
+ * Either the network or application core is sending data through the IPC service using the :ref:`zephyr:ipc_service_backend_icmsg` backend:
+
+   .. code-block:: console
+
+      west build -p -b nrf7002dk/nrf5340/cpuapp -T sample.ipc.ipc_service.nrf5340dk_icmsg_cpuapp_sending .
+      west build -p -b nrf7002dk/nrf5340/cpuapp -T sample.ipc.ipc_service.nrf5340dk_icmsg_cpunet_sending .
 
 **nRF54H20 DK**
 

--- a/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SOC_NRF53_CPUNET_ENABLE=y
+CONFIG_OPENAMP=y
+CONFIG_OPENAMP_SLAVE=n

--- a/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_icbmsg.conf
+++ b/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_icbmsg.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SOC_NRF53_CPUNET_ENABLE=y
+CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=0

--- a/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_icbmsg.overlay
+++ b/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_icbmsg.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &ipc0;
+
+/ {
+	chosen {
+		/delete-property/ zephyr,ipc_shm;
+		/delete-property/ zephyr,bt-hci;
+	};
+
+	reserved-memory {
+		/delete-node/ memory@20070000;
+
+		sram_tx: memory@20070000 {
+			reg = <0x20070000 0x8000>;
+		};
+
+		sram_rx: memory@20078000 {
+			reg = <0x20078000 0x8000>;
+		};
+	};
+
+	ipc0: ipc0 {
+		compatible = "zephyr,ipc-icbmsg";
+		tx-region = <&sram_tx>;
+		rx-region = <&sram_rx>;
+		tx-blocks = <20>;
+		rx-blocks = <20>;
+		mboxes = <&mbox 0>, <&mbox 1>;
+		mbox-names = "tx", "rx";
+		status = "okay";
+	};
+};

--- a/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_icmsg.conf
+++ b/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_icmsg.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SOC_NRF53_CPUNET_ENABLE=y
+CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=60

--- a/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_icmsg.overlay
+++ b/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_icmsg.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &ipc0;
+
+/ {
+	chosen {
+		/delete-property/ zephyr,ipc_shm;
+		/delete-property/ zephyr,bt-hci;
+	};
+
+	reserved-memory {
+		/delete-node/ memory@20070000;
+
+		sram_tx: memory@20070000 {
+			reg = <0x20070000 0x8000>;
+		};
+
+		sram_rx: memory@20078000 {
+			reg = <0x20078000 0x8000>;
+		};
+	};
+
+	ipc0: ipc0 {
+		compatible = "zephyr,ipc-icmsg";
+		tx-region = <&sram_tx>;
+		rx-region = <&sram_rx>;
+		mboxes = <&mbox 0>, <&mbox 1>;
+		mbox-names = "tx", "rx";
+		status = "okay";
+	};
+};

--- a/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
+++ b/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SOC_NRF53_CPUNET_ENABLE=y
+CONFIG_OPENAMP=y
+CONFIG_OPENAMP_SLAVE=n

--- a/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet.conf
+++ b/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_OPENAMP=y
+CONFIG_OPENAMP_MASTER=n

--- a/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet_icbmsg.conf
+++ b/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet_icbmsg.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=0

--- a/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet_icbmsg.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet_icbmsg.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &ipc0;
+
+/ {
+	chosen {
+		/delete-property/ zephyr,ipc_shm;
+	};
+
+	reserved-memory {
+		/delete-node/ memory@20070000;
+
+		sram_rx: memory@20070000 {
+			reg = <0x20070000 0x8000>;
+		};
+
+		sram_tx: memory@20078000 {
+			reg = <0x20078000 0x8000>;
+		};
+	};
+
+	ipc0: ipc0 {
+		compatible = "zephyr,ipc-icbmsg";
+		tx-region = <&sram_tx>;
+		rx-region = <&sram_rx>;
+		tx-blocks = <20>;
+		rx-blocks = <20>;
+		mboxes = <&mbox 0>, <&mbox 1>;
+		mbox-names = "rx", "tx";
+		status = "okay";
+	};
+};

--- a/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet_icmsg.conf
+++ b/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet_icmsg.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=25

--- a/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet_icmsg.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet_icmsg.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &ipc0;
+
+/ {
+	chosen {
+		/delete-property/ zephyr,ipc_shm;
+	};
+
+	reserved-memory {
+		/delete-node/ memory@20070000;
+
+		sram_rx: memory@20070000 {
+			reg = <0x20070000 0x8000>;
+		};
+
+		sram_tx: memory@20078000 {
+			reg = <0x20078000 0x8000>;
+		};
+	};
+
+	ipc0: ipc0 {
+		compatible = "zephyr,ipc-icmsg";
+		tx-region = <&sram_tx>;
+		rx-region = <&sram_rx>;
+		mboxes = <&mbox 0>, <&mbox 1>;
+		mbox-names = "rx", "tx";
+		status = "okay";
+	};
+};

--- a/samples/ipc/ipc_service/sample.yaml
+++ b/samples/ipc/ipc_service/sample.yaml
@@ -93,6 +93,81 @@ tests:
         - "Δpkt: (?!0)\\d+ ((?!0)\\d+ B/pkt) | throughput: (?!0)\\d+ bit/s"
         - "Δpkt: \\d+ (\\d+ B/pkt) | throughput: \\d+ bit/s"
         - "Δpkt: \\d+ (\\d+ B/pkt) | throughput: \\d+ bit/s"
+  sample.ipc.ipc_service.nrf7002dk_rpmsg_default:
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf7002dk/nrf5340/cpuapp
+  sample.ipc.ipc_service.nrf7002dk_rpmsg_cpuapp_sending:
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf7002dk/nrf5340/cpuapp
+    extra_configs:
+      - CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=1
+    extra_args:
+      - remote_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=200000000
+  sample.ipc.ipc_service.nrf7002dk_rpmsg_cpunet_sending:
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf7002dk/nrf5340/cpuapp
+    extra_configs:
+      - CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=200000000
+    extra_args:
+      - remote_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=1
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "IPC-service .* demo started"
+        # there will be only single tranfser from this core
+        - "Δpkt: (?!0)\\d+ ((?!0)\\d+ B/pkt) | throughput: (?!0)\\d+ bit/s"
+        - "Δpkt: \\d+ (\\d+ B/pkt) | throughput: \\d+ bit/s"
+        - "Δpkt: \\d+ (\\d+ B/pkt) | throughput: \\d+ bit/s"
+  sample.ipc.ipc_service.nrf7002dk_icmsg_default:
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf7002dk/nrf5340/cpuapp
+    extra_args:
+      - FILE_SUFFIX=icmsg
+  sample.ipc.ipc_service.nrf7002dk_icbmsg_default:
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf7002dk/nrf5340/cpuapp
+    extra_args:
+      - FILE_SUFFIX=icbmsg
+  sample.ipc.ipc_service.nrf7002dk_icmsg_cpuapp_sending:
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf7002dk/nrf5340/cpuapp
+    extra_configs:
+      - CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=35
+    extra_args:
+      - FILE_SUFFIX=icmsg
+      - remote_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=200000000
+  sample.ipc.ipc_service.nrf7002dk_icmsg_cpunet_sending:
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf7002dk/nrf5340/cpuapp
+    extra_configs:
+      - CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=200000000
+    extra_args:
+      - FILE_SUFFIX=icmsg
+      - remote_CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=1
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "IPC-service .* demo started"
+        # there will be only single tranfser from this core
+        - "Δpkt: (?!0)\\d+ ((?!0)\\d+ B/pkt) | throughput: (?!0)\\d+ bit/s"
+        - "Δpkt: \\d+ (\\d+ B/pkt) | throughput: \\d+ bit/s"
+        - "Δpkt: \\d+ (\\d+ B/pkt) | throughput: \\d+ bit/s"
   sample.ipc.ipc_service.nrf54h20dk_cpuapp_cpurad_icbmsg:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Added board overlay files, updated the Kconfig to support the nRF7002DK, and revised the documentation accordingly.