### PR TITLE
samples: net: download: add CONFIG_SAMPLE_PROVISION_CERT kconfig option

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -334,7 +334,10 @@ Matter samples
 Networking samples
 ------------------
 
-|no_changes_yet_note|
+* :ref:`download_sample` sample:
+
+  * Added the :ref:`CONFIG_SAMPLE_PROVISION_CERT <CONFIG_SAMPLE_PROVISION_CERT>` Kconfig option to provision the root CA certificate to the modem.
+    The certificate is provisioned only if the :ref:`CONFIG_SAMPLE_SECURE_SOCKET <CONFIG_SAMPLE_SECURE_SOCKET>` Kconfig option is set to ``y``.
 
 NFC samples
 -----------

--- a/samples/net/download/CMakeLists.txt
+++ b/samples/net/download/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(download)
 
 # Generate hex file from pem file
-if(CONFIG_SAMPLE_SECURE_SOCKET)
+if(CONFIG_SAMPLE_PROVISION_CERT)
   get_filename_component(FILE_NAME ${CONFIG_SAMPLE_CERT_FILE} NAME)
   set(OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/certs/${FILE_NAME}.inc")
   add_definitions(-DSAMPLE_CERT_FILE_INC="${OUTPUT_FILE}")

--- a/samples/net/download/Kconfig
+++ b/samples/net/download/Kconfig
@@ -10,9 +10,20 @@ config SAMPLE_SEC_TAG
 	int "Security tag"
 	default 42
 
+config SAMPLE_PROVISION_CERT
+	bool "Provision root CA certificate"
+	default y
+	help
+	  Provision the root CA certificate for the server to the modem. This is needed for secure
+	  connections.
+	  Disable this option to avoid overwriting an existing root CA certificate already stored in
+	  the modem.
+
 config SAMPLE_CERT_FILE
 	string "Certificate file name"
 	default "cert/file-example.pem"
+	depends on SAMPLE_PROVISION_CERT
+
 endif
 
 choice SAMPLE_FILE

--- a/samples/net/download/README.rst
+++ b/samples/net/download/README.rst
@@ -27,7 +27,7 @@ Overview
 ********
 
 The sample first initializes the :ref:`nrfxlib:nrf_modem` and AT communications.
-Next, it provisions a certificate to the modem using the :ref:`modem_key_mgmt` library if the :ref:`CONFIG_SAMPLE_SECURE_SOCKET <CONFIG_SAMPLE_SECURE_SOCKET>` option is set.
+Next, if the :ref:`CONFIG_SAMPLE_PROVISION_CERT <CONFIG_SAMPLE_PROVISION_CERT>` is set, it provisions a certificate to the modem using the :ref:`modem_key_mgmt` library if the :ref:`CONFIG_SAMPLE_SECURE_SOCKET <CONFIG_SAMPLE_SECURE_SOCKET>` option is set.
 When using an nRF91 Series device, the provisioning of the certificates must be done before connecting to the LTE network since the certificates can only be provisioned when the device is not connected.
 The certificate file name and security tag can be configured using the :ref:`CONFIG_SAMPLE_SEC_TAG <CONFIG_SAMPLE_SEC_TAG>` and the :ref:`CONFIG_SAMPLE_CERT_FILE <CONFIG_SAMPLE_CERT_FILE>` options, respectively.
 
@@ -46,7 +46,7 @@ To enable CoAP block-wise transfer, it is necessary to enable :ref:`Zephyr's CoA
 Using TLS and DTLS
 ==================
 
-By default, the :ref:`CONFIG_SAMPLE_SECURE_SOCKET <CONFIG_SAMPLE_SECURE_SOCKET>` option is set, which means that the sample provisions the certificate found in the :file:`samples/net/download/cert` folder.
+By default, the :ref:`CONFIG_SAMPLE_PROVISION_CERT <CONFIG_SAMPLE_PROVISION_CERT>` option is set, which means that the sample provisions the certificate found in the :file:`samples/net/download/cert` folder.
 The certificate file name is indicated by the :ref:`CONFIG_SAMPLE_CERT_FILE <CONFIG_SAMPLE_CERT_FILE>` option.
 This certificate will work for the default test files.
 If you are using a custom download test file, you must provision the correct certificate for the servers from which the certificates will be downloaded.
@@ -68,12 +68,17 @@ Check and configure the following configuration options for the sample:
 .. _CONFIG_SAMPLE_SECURE_SOCKET:
 
 CONFIG_SAMPLE_SECURE_SOCKET - Secure socket configuration
-   If enabled, this option provisions the certificate to the modem.
+   If enabled, downloading is done using a secure socket over TLS or DTLS.
 
 .. _CONFIG_SAMPLE_SEC_TAG:
 
 CONFIG_SAMPLE_SEC_TAG - Security tag configuration
    This option configures the security tag.
+
+.. _CONFIG_SAMPLE_PROVISION_CERT:
+
+CONFIG_SAMPLE_PROVISION_CERT - Root CA Certificate provision
+   If enabled, this option provisions the certificate to the modem.
 
 .. _CONFIG_SAMPLE_CERT_FILE:
 

--- a/samples/net/download/src/main.c
+++ b/samples/net/download/src/main.c
@@ -41,6 +41,8 @@ static struct net_if *net_if;
 static K_SEM_DEFINE(network_connected_sem, 0, 1);
 
 #if CONFIG_SAMPLE_SECURE_SOCKET
+static int sec_tag_list[] = { SEC_TAG };
+#if CONFIG_SAMPLE_PROVISION_CERT
 static const char cert[] = {
 	#include SAMPLE_CERT_FILE_INC
 
@@ -49,9 +51,9 @@ static const char cert[] = {
 	 */
 	IF_ENABLED(CONFIG_TLS_CREDENTIALS, (0x00))
 };
-static int sec_tag_list[] = { SEC_TAG };
 BUILD_ASSERT(sizeof(cert) < KB(4), "Certificate too large");
-#endif
+#endif /* CONFIG_SAMPLE_PROVISION_CERT */
+#endif /* CONFIG_SAMPLE_SECURE_SOCKET */
 
 static char dl_buf[2048];
 
@@ -78,7 +80,7 @@ static mbedtls_sha256_context sha256_ctx;
 
 static int64_t ref_time;
 
-#if CONFIG_SAMPLE_SECURE_SOCKET
+#if CONFIG_SAMPLE_PROVISION_CERT
 static int cert_provision(void)
 {
 	int err;
@@ -286,7 +288,7 @@ int main(void)
 		return err;
 	}
 
-#if CONFIG_SAMPLE_SECURE_SOCKET
+#if CONFIG_SAMPLE_PROVISION_CERT
 	/* Provision certificates before connecting to the network */
 	err = cert_provision();
 	if (err) {


### PR DESCRIPTION
The default is to provision a root CA certificate from a file. Disable this option to avoid overwriting an existing certificate already stored in the modem.

Added this kconfig option because I did not want to overwrite the nrf cloud certificate I already had stored in the modem. I thought it would be nice to have a kconfig option for this instead of having to comment out several sections in different files to disable the provisioning.