### PR TITLE
nrf_security: Drop support for embedded keys

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/cracenpsa.cmake
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/cracenpsa.cmake
@@ -118,5 +118,4 @@ if(CONFIG_PSA_NEED_CRACEN_PLATFORM_KEYS)
   list(APPEND cracen_driver_sources
     ${CMAKE_CURRENT_LIST_DIR}/src/platform_keys/platform_keys.c
   )
-  zephyr_linker_sources(ROM_START SORT_KEY 0x1keys ${CMAKE_CURRENT_LIST_DIR}/src/platform_keys/platform_keys.ld)
 endif()

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/platform_keys/platform_keys.ld
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/platform_keys/platform_keys.ld
@@ -1,1 +1,0 @@
-KEEP(*(_embedded_keys))


### PR DESCRIPTION
Embedded keys were introduced to support a SUIT use-case. But there will not be any more releases of SUIT based on NCS master so we do not need this support any more.