### PR TITLE
manifest: update zephyr to bring in nrf21540 timing fix

### DIFF
--- a/doc/nrf/app_dev/device_guides/fem/fem_nrf21540_gpio.rst
+++ b/doc/nrf/app_dev/device_guides/fem/fem_nrf21540_gpio.rst
@@ -84,7 +84,11 @@ To use nRF21540 in GPIO mode, complete the following steps:
    The nRF54L devices contain only four PPIB channels between PERI Power Domain and Low Power Domain.
    Due to this limitation, only two out of three pins from group ``tx-en-gpios``, ``rx-en-gpios`` and ``pdn-gpios`` (for example, ``tx-en-gpios`` and ``rx-en-gpios``) can be controlled by GPIO P0.
    Select other GPIO port for the one remaining pin of the pin group (for example ``pdn-gpios``).
-   To ensure proper timing, set the ``tx-en-settle-time-us`` and ``rx-en-settle-time-us`` devicetree properties of the ``nrf_radio_fem`` node to the value ``12``.
+   To ensure proper timing, set the following devicetree properties of the ``nrf_radio_fem`` node:
+
+   * ``tx-en-settle-time-us`` to the value ``27``.
+   * ``rx-en-settle-time-us`` to the value ``12``.
+
    Enable appropriate instances of the ``DPPIC`` and ``PPIB`` peripherals in the devicetree file:
 
    .. code-block:: devicetree

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 464150f23f1f19d427145cb8e3d2a47f4d15de11
+      revision: 893c3332454a29c1611fa90aa8ceaf87a6bdf848
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit brings in zephyr containing the fix of tx-en-settle-time-us default value for the nrf21540 Front-End Module.

The doc commit is cherry picked from NCS 3.0 branch 61bd2af2997a3f0b507c848c2173d924861ac5b2

Ref: KRKNWK-20212