### PR TITLE
nfc: add support for non-secure build targets for nRF54L15

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -318,7 +318,9 @@ Networking samples
 NFC samples
 -----------
 
-|no_changes_yet_note|
+* :ref:`record_text` sample:
+
+  * Added support for the ``nrf54l15dk/nrf54l15/cpuapp/ns`` board target.
 
 nRF5340 samples
 ---------------

--- a/samples/nfc/record_text/sample.yaml
+++ b/samples/nfc/record_text/sample.yaml
@@ -14,6 +14,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -23,6 +24,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
     tags:
       - ci_build
       - sysbuild

--- a/subsys/nfc/lib/platform.c
+++ b/subsys/nfc/lib/platform.c
@@ -142,7 +142,11 @@ nrfx_err_t nfc_platform_setup(nfc_lib_cb_resolve_t nfc_lib_cb_resolve, uint8_t *
 
 static nrfx_err_t nfc_platform_tagheaders_get(uint32_t tag_header[3])
 {
-#ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) && defined(NRF_FICR_S)
+/* If the NFC Platform code is built for the non-secure target and FICR
+ * registers belong to the secure address space on the SoC, the NFC tag UID
+ * needs to be read through secure services.
+ */
 #if defined(CONFIG_BUILD_WITH_TFM)
 	uint32_t err = 0;
 	enum tfm_platform_err_t plt_err;
@@ -163,14 +167,14 @@ static nrfx_err_t nfc_platform_tagheaders_get(uint32_t tag_header[3])
 
 #else
 #error "Cannot read FICR NFC Tag Header in current configuration"
-#endif
+#endif /* defined(CONFIG_BUILD_WITH_TFM) */
 #else
 
 	tag_header[0] = nrf_ficr_nfc_tagheader_get(NRF_FICR, 0);
 	tag_header[1] = nrf_ficr_nfc_tagheader_get(NRF_FICR, 1);
 	tag_header[2] = nrf_ficr_nfc_tagheader_get(NRF_FICR, 2);
 
-#endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE */
+#endif /* defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) && defined(NRF_FICR_S) */
 
 	return NRFX_SUCCESS;
 }


### PR DESCRIPTION
This PR is a general fix for platforms where FICR belongs to the non-secure address space.
Additionally: labelling explicit support for the build target `nrf54l15dk/nrf54l15/cpuapp/ns` in the _record_text_ sample.