### PR TITLE
manifest: update sdk-zephyr to have MDK 8.68.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.7.99-ncs2-1
+      revision: 523f420a8ccc924751d1ed3d9616b39412de5ce5
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated MDK improves support for nRF54L05 and nRF54L10 erratas.