### PR TITLE
samples: nsib: Add 54l to the sample.yaml

### DIFF
--- a/samples/bootloader/sample.yaml
+++ b/samples/bootloader/sample.yaml
@@ -9,6 +9,7 @@ tests:
       - nrf9160dk/nrf9160
       - nrf9161dk/nrf9161
       - nrf9151dk/nrf9151
+      - nrf54l15dk/nrf54l15/cpuapp
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -18,6 +19,7 @@ tests:
       - nrf9160dk/nrf9160
       - nrf9161dk/nrf9161
       - nrf9151dk/nrf9151
+      - nrf54l15dk/nrf54l15/cpuapp
       - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
       - nrf52dk/nrf52832


### PR DESCRIPTION
NSIB has been ported to 54L so add it to the sample.yaml.

Ref: NCSDK-NONE