### PR TITLE
tests: subsys: debug: cpu_load: Change duplicated test name

### DIFF
--- a/tests/subsys/debug/cpu_load/testcase.yaml
+++ b/tests/subsys/debug/cpu_load/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  debug.cpu_load:
+  debug.cpu_load.nrf:
     sysbuild: true
     platform_allow:
       - nrf52840dk/nrf52840


### PR DESCRIPTION
Fix Twister runtime error.
twisterlib.error.TwisterRuntimeError: Duplicated test scenarios found:
- debug.cpu_load found in:
[./ncs/zephyr/tests/subsys/debug/cpu_load](https://github.com/nrfconnect/sdk-zephyr/blob/main/tests/subsys/debug/cpu_load/testcase.yaml#L8)
[./ncs/nrf/tests/subsys/debug/cpu_load](https://github.com/nrfconnect/sdk-nrf/blob/main/tests/subsys/debug/cpu_load/testcase.yaml#L2)