### PR TITLE
applications: serial_lte_modem: Use persist option on Linux PPP

### DIFF
--- a/applications/serial_lte_modem/scripts/slm_start_ppp.sh
+++ b/applications/serial_lte_modem/scripts/slm_start_ppp.sh
@@ -57,4 +57,4 @@ test -c $AT_CMUX
 chat $CHATOPT -t$TIMEOUT "" "AT+CFUN=1" "OK" "\c" "#XPPP: 1,0" >$AT_CMUX <$AT_CMUX
 
 pppd $PPP_CMUX noauth novj nodeflate nobsdcomp debug noipdefault passive +ipv6 \
-		noremoteip local linkname nrf91 defaultroute defaultroute-metric -1
+		noremoteip local linkname nrf91 defaultroute defaultroute-metric -1 persist


### PR DESCRIPTION
When using Linux PPPD on a host device, use "persist" option so the PPP daemon keep the ppp link waiting for LCP configuration requrests in case SLM is not yet responding.

This makes PPPD to tolerate network lost events, at least "AT+CFUN=4" followed by "AT+CFUN=1" works OK.