### PR TITLE
applications: serial_lte_modem: #XSMS error response handling fixed

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -547,7 +547,9 @@ static void cmd_send(uint8_t *buf, size_t cmd_length, size_t buf_size)
 		return;
 	}
 
-	/* Send to modem, reserve space for CRLF in response buffer */
+	/* Send to modem. Same buffer used for sending and for the response.
+	 * Reserve space for CRLF in response buffer.
+	 */
 	err = nrf_modem_at_cmd(buf + strlen(CRLF_STR), buf_size - strlen(CRLF_STR), "%s", at_cmd);
 	if (err == -SILENT_AT_COMMAND_RET) {
 		return;
@@ -556,7 +558,8 @@ static void cmd_send(uint8_t *buf, size_t cmd_length, size_t buf_size)
 		rsp_send_error();
 		return;
 	} else if (err > 0) {
-		LOG_ERR("AT command error, type: %d", nrf_modem_at_err_type(err));
+		LOG_ERR("AT command error (%d), type: %d: value: %d",
+			err, nrf_modem_at_err_type(err), nrf_modem_at_err(err));
 	}
 
 	/** Format as TS 27.007 command V1 with verbose response format,
@@ -893,6 +896,33 @@ int slm_at_cb_wrapper(char *buf, size_t len, char *at_cmd, slm_at_callback *cb)
 		err = at_cmd_custom_respond(buf, len, "OK\r\n");
 		if (err) {
 			LOG_ERR("Failed to set OK response: %d", err);
+		}
+	} else if (err > 0) {
+		int at_cmd_err = err;
+
+		/* Reconstruct 'ERROR', 'CME ERROR' and 'CMS ERROR' response from
+		 * nrf_modem_at_cmd() return value, which is returned by some SLM specific
+		 * AT commands, such as AT#XSMS
+		 */
+		switch (nrf_modem_at_err_type(err)) {
+		case NRF_MODEM_AT_CME_ERROR:
+			err = at_cmd_custom_respond(buf, len, "+CME ERROR: %d\r\n",
+				nrf_modem_at_err(err));
+			break;
+		case NRF_MODEM_AT_CMS_ERROR:
+			err = at_cmd_custom_respond(buf, len, "+CMS ERROR: %d\r\n",
+				nrf_modem_at_err(err));
+			break;
+		case NRF_MODEM_AT_ERROR:
+		default:
+			err = at_cmd_custom_respond(buf, len, "ERROR\r\n");
+			break;
+		}
+		if (err) {
+			LOG_ERR("Failed to set error response: %d", err);
+		} else {
+			/* Return the original error code from 'cb()' */
+			err = at_cmd_err;
 		}
 	}
 

--- a/applications/serial_lte_modem/src/slm_at_sms.c
+++ b/applications/serial_lte_modem/src/slm_at_sms.c
@@ -128,7 +128,7 @@ static int do_sms_start(void)
 
 	if (sms_handle >= 0) {
 		/* already registered */
-		return -EINVAL;
+		return -EBUSY;
 	}
 
 	sms_handle = sms_register_listener(sms_callback, NULL);
@@ -143,11 +143,6 @@ static int do_sms_start(void)
 
 static int do_sms_stop(void)
 {
-	if (sms_handle < 0) {
-		/* not registered yet */
-		return -EINVAL;
-	}
-
 	sms_unregister_listener(sms_handle);
 	sms_handle = -1;
 
@@ -159,8 +154,8 @@ static int do_sms_send(const char *number, const char *message)
 	int err;
 
 	if (sms_handle < 0) {
-		/* not registered yet */
-		return -EINVAL;
+		LOG_ERR("SMS not registered");
+		return -EPERM;
 	}
 
 	err = sms_send_text(number, message);
@@ -205,6 +200,7 @@ static int handle_at_sms(enum at_parser_cmd_type cmd_type, struct at_parser *par
 			err = do_sms_send(number, message);
 		} else {
 			LOG_WRN("Unknown SMS operation: %d", op);
+			err = -EINVAL;
 		}
 		break;
 


### PR DESCRIPTION
When sending SMS with `#XSMS=2`, positive error codes from `sms_send_text()` are not handled properly.
`ERROR`, `CME ERROR` and `CMS ERROR` doesn't write this to return buffer and SLM got stuck. This is now fixed.

In addition, some return codes within SLM for starting SMS service and stopping it has been fine-tuned.

Jira: LRCS-89