### PR TITLE
nrf_security: Fix HMAC update for Cracen PSA driver

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_mac_hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_mac_hmac.c
@@ -72,6 +72,13 @@ psa_status_t cracen_hmac_update(cracen_mac_operation_t *operation, const uint8_t
 		return PSA_SUCCESS;
 	}
 
+	if (!operation->is_first_block) {
+		sx_status = sx_hash_resume_state(&operation->hmac.hashctx);
+		if (sx_status != SX_OK) {
+			return silex_statuscodes_to_psa(sx_status);
+		}
+	}
+
 	operation->is_first_block = false;
 
 	/* Feed the data that are currently in the input buffer to the driver */


### PR DESCRIPTION
The cracen_hmac_update needs to resume the hash operation for any call apart from the first block.
This was missing before which could make the cracen_hmac_update to fail in cases where the input was not a multiple of the block size.