### PR TITLE
samples: cellular: slm_shell: Switch RTS and CTS pins in doc

### DIFF
--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -574,9 +574,9 @@ The following table shows how to connect selected development kit to an nRF91 Se
            - UART RX P0.11
          * - UART RX P1.01
            - UART TX P0.10
-         * - UART CTS P1.06
+         * - UART CTS P1.07
            - UART RTS P0.12
-         * - UART RTS P1.07
+         * - UART RTS P1.06
            - UART CTS P0.13
          * - GPIO OUT P0.11
            - GPIO IN P0.31
@@ -596,9 +596,9 @@ The following table shows how to connect selected development kit to an nRF91 Se
            - UART RX P0.11
          * - UART RX P1.05
            - UART TX P0.10
-         * - UART CTS P1.06
+         * - UART CTS P1.07
            - UART RTS P0.12
-         * - UART RTS P1.07
+         * - UART RTS P1.06
            - UART CTS P0.13
          * - GPIO OUT P0.23
            - GPIO IN P0.31

--- a/samples/cellular/slm_shell/README.rst
+++ b/samples/cellular/slm_shell/README.rst
@@ -37,9 +37,9 @@ The following table shows how to connect UART1 of the DK to the nRF91 Series DK'
            - UART RX P0.11
          * - UART RX P1.01
            - UART TX P0.10
-         * - UART CTS P1.06
+         * - UART CTS P1.07
            - UART RTS P0.12
-         * - UART RTS P1.07
+         * - UART RTS P1.06
            - UART CTS P0.13
          * - GPIO OUT P0.11 (Button1)
            - GPIO IN P0.31
@@ -66,9 +66,9 @@ The following table shows how to connect UART1 of the DK to the nRF91 Series DK'
            - UART RX P0.11
          * - UART RX P1.05
            - UART TX P0.10
-         * - UART CTS P1.06
+         * - UART CTS P1.07
            - UART RTS P0.12
-         * - UART RTS P1.07
+         * - UART RTS P1.06
            - UART CTS P0.13
          * - GPIO OUT P0.23 (Button1)
            - GPIO IN P0.31
@@ -95,9 +95,9 @@ The following table shows how to connect UART1 of the DK to the nRF91 Series DK'
            - UART RX P0.11
          * - UART RX P1.05
            - UART TX P0.10
-         * - UART CTS P1.06
+         * - UART CTS P1.07
            - UART RTS P0.12
-         * - UART RTS P1.07
+         * - UART RTS P1.06
            - UART CTS P0.13
          * - GPIO OUT P0.31
            - GPIO IN P0.31


### PR DESCRIPTION
Change SLM Shell pins, RTS and CTS, to correspond to SLM Shell overlays.