### PR TITLE
[Backport v3.0-branch] net: nrf_provisioning: Fix memory leak

### DIFF
--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
@@ -55,7 +55,6 @@ LOG_MODULE_REGISTER(nrf_provisioning_coap, CONFIG_NRF_PROVISIONING_LOG_LEVEL);
 static const char *resp_path = "p/rsp";
 static const char *dtls_suspend = "/.dtls/suspend";
 
-static struct zsock_addrinfo *address;
 static struct coap_client client;
 static bool socket_keep_open;
 
@@ -169,7 +168,8 @@ static int dtls_setup(int fd)
 
 static int socket_connect(int *const fd)
 {
-	static struct zsock_addrinfo hints;
+	struct zsock_addrinfo hints = {};
+	struct zsock_addrinfo *address = NULL;
 	int st;
 	int ret = 0;
 	struct sockaddr *sa;
@@ -225,6 +225,10 @@ static int socket_connect(int *const fd)
 	LOG_INF("Connected");
 
 clean_up:
+
+	if (address) {
+		zsock_freeaddrinfo(address);
+	}
 
 	if (ret) {
 		if (*fd > -1) {

--- a/tests/subsys/net/lib/nrf_provisioning/src/coap.c
+++ b/tests/subsys/net/lib/nrf_provisioning/src/coap.c
@@ -113,6 +113,10 @@ int zsock_getaddrinfo(const char *host, const char *service, const struct zsock_
 	return 0;
 }
 
+void zsock_freeaddrinfo(struct zsock_addrinfo *ai)
+{
+}
+
 int z_impl_zsock_connect(int sock, const struct sockaddr *addr, socklen_t addrlen)
 {
 	return 0;


### PR DESCRIPTION
Free results from zsock_getaddrinfo().

Signed-off-by: Juha Ylinen <juha.ylinen@nordicsemi.no>
(cherry picked from commit 7ec2d4788fb354e6271f243feaea2b0f7a109ba1)