### PR TITLE
lib: at_host: Improve terminal handling

### DIFF
--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -114,8 +114,14 @@ static void uart_rx_handler(uint8_t character)
 	/* Backspace and DEL character */
 	case 0x08:
 	case 0x7F:
-		if (at_cmd_len > 0) {
-			at_cmd_len--;
+		if (at_cmd_len == 0) {
+			return;
+		}
+
+		at_cmd_len--;
+		/* If the removed character was a quote, need to toggle the flag. */
+		if (at_buf[at_cmd_len] == '"') {
+			inside_quotes = !inside_quotes;
 		}
 		return;
 	}


### PR DESCRIPTION
If the character removed using backspace was a quote, the internal state of the RX handler was not updated correctly. This caused incorrect behavior when handling the following characters.

Make sure there are both CR and LF between the command and the output (response or notification). Otherwise the output will be printed on top of the command or the output will have offset.