### PR TITLE
samples: cellular: modem_shell: Fix handling of quotes with backspace

### DIFF
--- a/samples/cellular/modem_shell/src/at/at_cmd_mode.c
+++ b/samples/cellular/modem_shell/src/at/at_cmd_mode.c
@@ -127,17 +127,23 @@ static void at_cmd_mode_cmd_rx_handler(uint8_t character)
 	case 0x08: /* Backspace. */
 		/* Fall through. */
 	case 0x7F: /* DEL character */
-		if (at_cmd_len > 0) {
-			/* Reprint with DEL/Backspace  */
-			k_mutex_lock(&at_buf_mutex, K_FOREVER);
-			at_buf[at_cmd_len] = '\0';
-			at_cmd_len--;
-			at_buf[at_cmd_len] = ' ';
-			printk("\r%s", at_buf);
-			at_buf[at_cmd_len] = '\0';
-			printk("\r%s", at_buf);
-			k_mutex_unlock(&at_buf_mutex);
+		if (at_cmd_len == 0) {
+			return;
 		}
+
+		/* Reprint with DEL/Backspace  */
+		k_mutex_lock(&at_buf_mutex, K_FOREVER);
+		at_buf[at_cmd_len] = '\0';
+		at_cmd_len--;
+		/* If the removed character was a quote, need to toggle the flag. */
+		if (at_buf[at_cmd_len] == '"') {
+			inside_quotes = !inside_quotes;
+		}
+		at_buf[at_cmd_len] = ' ';
+		printk("\r%s", at_buf);
+		at_buf[at_cmd_len] = '\0';
+		printk("\r%s", at_buf);
+		k_mutex_unlock(&at_buf_mutex);
 		return;
 	}
 


### PR DESCRIPTION
If the character removed using backspace was a quote, the internal state of the RX handler was not updated correctly. This caused incorrect behavior when handling the following characters.