### PR TITLE
scripts: memory-threshold: find_my: switchable networks: fix dfu pattern

### DIFF
--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -60,7 +60,7 @@
     - nrfconnect/ncs-si-bluebagel
 
 - scenarios:
-    - sample.find_my.switchable_networks.release.dfu_switch*
+    - sample.find_my.switchable_networks.release.dfu_switch.*
   platforms:
     - all
   rom_increase: 512


### PR DESCRIPTION
Fixed the scenario matching pattern in the configuration of the Apple Find My Switchable Networks sample for the DFU switch variant.

Ref: NCSDK-31920

special thanks to @katgiadla for help :)