### PR TITLE
sysbuild: suit: Disable SUIT_ENVELOPE for SOC_NRF54H20_IRON

### DIFF
--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -730,10 +730,8 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
   endif()
 
   include_packaging()
-  if(NOT SB_CONFIG_SOC_NRF54H20_IRON)
-    include_suit_provisioning()
-    include_suit()
-  endif()
+  include_suit_provisioning()
+  include_suit()
 
   if(SB_CONFIG_SECURE_BOOT OR SB_CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION)
     include_provision_hex()

--- a/sysbuild/Kconfig.suit
+++ b/sysbuild/Kconfig.suit
@@ -9,6 +9,7 @@ menu "SUIT"
 menuconfig SUIT_ENVELOPE
 	bool "Create SUIT envelope"
 	default y if SOC_SERIES_NRF54HX
+	depends on !SOC_NRF54H20_IRON
 	help
 	  Enable DFU SUIT envelope creation
 


### PR DESCRIPTION
This was missing to properly disable SUIT without messing with CMake.