### PR TITLE
test-spec: extend the scope for lwm2m

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -126,6 +126,7 @@
   - "include/modem/pdn.h"
   - "include/modem/at_params.h"
   - "include/modem/modem_key_mgmt.h"
+  - "subsys/dfu/dfu_target/**/*"
 
 "CI-dfu-test":
   - "include/bl*"


### PR DESCRIPTION
The LwM2M Carrier library has a dependency on the DFU Target subsystem.