### PR TITLE
zigbee: subsys: Fix compilation when FACTORY_RESET is disabled

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -158,7 +158,7 @@ Thread
 Zigbee
 ------
 
-|no_changes_yet_note|
+* Fixed compilation errors that previously occurred when the :kconfig:option:`CONFIG_ZIGBEE_FACTORY_RESET` Kconfig option was disabled.
 
 Wi-Fi
 -----

--- a/include/zigbee/zigbee_app_utils.h
+++ b/include/zigbee/zigbee_app_utils.h
@@ -263,6 +263,23 @@ void check_factory_reset_button(uint32_t button_state, uint32_t has_changed);
  */
 bool was_factory_reset_done(void);
 
+#else /* CONFIG_ZIGBEE_FACTORY_RESET */
+
+static inline void register_factory_reset_button(uint32_t)
+{
+	/* No action. Functionality is disabled. */
+}
+
+static inline void check_factory_reset_button(uint32_t, uint32_t)
+{
+	/* No action. Functionality is disabled. */
+}
+
+static inline bool was_factory_reset_done(void)
+{
+	return false; /* Functionality is disabled. */
+}
+
 #endif /* CONFIG_ZIGBEE_FACTORY_RESET */
 
 #ifdef __cplusplus

--- a/subsys/zigbee/lib/zigbee_app_utils/zigbee_app_utils.c
+++ b/subsys/zigbee/lib/zigbee_app_utils/zigbee_app_utils.c
@@ -448,10 +448,12 @@ zb_ret_t zigbee_default_signal_handler(zb_bufid_t bufid)
 
 			if (zb_get_network_role() ==
 			    ZB_NWK_DEVICE_TYPE_COORDINATOR) {
+#if defined CONFIG_ZIGBEE_FACTORY_RESET
 				if (factory_reset_context.pibcache_pan_id_needs_reset) {
 					zigbee_pibcache_pan_id_clear();
 					factory_reset_context.pibcache_pan_id_needs_reset = false;
 				}
+#endif
 				/* For coordinator node,
 				 * start network formation.
 				 */


### PR DESCRIPTION
Without this change building the application with CONFIG_ZIGBEE_FACTORY_RESET=n results in a compilation error.