### PR TITLE
soc: nrf54l: Add the linker script for the KMU push area

### DIFF
--- a/soc/nordic/nrf54l/CMakeLists.txt
+++ b/soc/nordic/nrf54l/CMakeLists.txt
@@ -4,6 +4,16 @@
 zephyr_library_sources(
   ${ZEPHYR_BASE}/soc/nordic/nrf54l/soc.c
   )
+
+# We need a buffer in memory in a static location which can be used by
+# the KMU peripheral. The KMU has a static destination address, we chose
+# this address to be 0x20000000, which is the first address in the SRAM.
+if(NOT CONFIG_BUILD_WITH_TFM AND CONFIG_PSA_NEED_CRACEN_KMU_DRIVER AND CONFIG_XIP)
+  # Exclamation mark is printable character with the lowest number in ASCII table.
+  # We are sure that this file will be included first.
+  zephyr_linker_sources(RAM_SECTIONS SORT_KEY ! ${ZEPHYR_BASE}/soc/nordic/nrf54l/kmu_push_area_section.ld)
+endif()
+
 zephyr_include_directories(${ZEPHYR_BASE}/soc/nordic/nrf54l)
 add_subdirectory(${ZEPHYR_BASE}/soc/nordic/common ${CMAKE_BINARY_DIR}/common)
 


### PR DESCRIPTION
The nRF54L devices have a reserved RAM area which is used by the KMU as a target for the push operation.

This is done by including a linker script which defines this area. For nRF54L10/L15 this linker script is directly included by the CMake logic in the soc folder in upstream Zephyr.

Since the nRF54LM20A doesn't use the upstream Zephyr CMake logic from the soc directory we need to copy the logic here.

When the nRF54LM20A uses the upstream Zephyr CMake logic this can be removed.