### PR TITLE
samples: add nrf54lm20pdk

### DIFF
--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -25,6 +25,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
@@ -34,6 +35,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags:
       - bluetooth

--- a/samples/bluetooth/central_uart/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
+++ b/samples/bluetooth/central_uart/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unspupported UART0 driver
+CONFIG_NRFX_UARTE0=n

--- a/samples/bluetooth/central_uart/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.overlay
+++ b/samples/bluetooth/central_uart/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,nus-uart = &uart20;
+	};
+};

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -14,6 +14,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
@@ -24,6 +25,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags:
       - bluetooth

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -25,6 +25,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
@@ -34,6 +35,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags:
       - bluetooth

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -15,6 +15,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
@@ -26,6 +27,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags:
       - bluetooth

--- a/samples/bluetooth/peripheral_uart/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable the unspupported UART0 driver
+CONFIG_NRFX_UARTE0=n

--- a/samples/bluetooth/peripheral_uart/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,nus-uart = &uart20;
+	};
+};

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -17,6 +17,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
     integration_platforms:
@@ -31,6 +32,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
     tags:


### PR DESCRIPTION
Add to sample yaml
Add board overlay with uart configuration

In nrf ble samples:
- peripheral_lbs
- central_uart
- peripheral_uart
- bluetooth_peripheral_hids_mouse
- bluetooth_central_hids