### PR TITLE
subsys: dfu: dfu_target: adjust for erased_up_to

### DIFF
--- a/subsys/dfu/dfu_target/src/dfu_target_stream.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_stream.c
@@ -68,7 +68,7 @@ static int settings_set(const char *key, size_t len_rd,
 
 		/* Zero bytes written - set last erased page to its default. */
 		if (stream.bytes_written == 0) {
-			stream.last_erased_page_start_offset = -1;
+			stream.erased_up_to = 0;
 			return 0;
 		}
 
@@ -85,7 +85,7 @@ static int settings_set(const char *key, size_t len_rd,
 		/* Update the last erased page to avoid deleting already
 		 * written data.
 		 */
-		stream.last_erased_page_start_offset = page.start_offset;
+		stream.erased_up_to = page.start_offset + page.size - stream.offset;
 	}
 
 	return 0;

--- a/tests/subsys/dfu/dfu_target_stream/src/main.c
+++ b/tests/subsys/dfu/dfu_target_stream/src/main.c
@@ -216,7 +216,7 @@ ZTEST(dfu_target_stream_test, test_dfu_target_stream_save_progress)
 	/* Check that last erased page offset was set correctly when loading */
 	ctx = dfu_target_stream_get_stream();
 	zassert_not_null(ctx, "Expected non-null ctx.");
-	zassert_equal(erased_page_offset, ctx->last_erased_page_start_offset,
+	zassert_equal(0, ctx->erased_up_to,
 		      "Expected last erased page offset to be unchanged.");
 
 	/* Next, check that writes that end up right after a page boundary


### PR DESCRIPTION
stream is now using erased_up_to instead page start_offset.