### PR TITLE
boards: thingy91x: Add bias-pull-up to UART pins

### DIFF
--- a/boards/nordic/thingy91x/thingy91x_nrf9151_common-pinctrl.dtsi
+++ b/boards/nordic/thingy91x/thingy91x_nrf9151_common-pinctrl.dtsi
@@ -55,8 +55,11 @@
 
 	uart0_default: uart0_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 1)>,
-				<NRF_PSEL(UART_RX, 0, 0)>;
+			psels = <NRF_PSEL(UART_TX, 0, 1)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 0, 0)>;
+			bias-pull-up;
 		};
 	};
 
@@ -70,8 +73,11 @@
 
 	uart1_default: uart1_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 5)>,
-				<NRF_PSEL(UART_RX, 0, 4)>;
+			psels = <NRF_PSEL(UART_TX, 0, 5)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 0, 4)>;
+			bias-pull-up;
 		};
 	};
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -38,7 +38,7 @@ IDE, OS, and tool support
 Board support
 =============
 
-|no_changes_yet_note|
+* Added bias-pull-up for Thingy:91 X nRF9151 UART RX pins.
 
 Build and configuration system
 ==============================


### PR DESCRIPTION
Add bias-pull-up for nRF9151 UART RX pins. This fixes an issue with framing error detected when device connect or disconnect serial.