### PR TITLE
nrf_rpc: select NET_BUF

### DIFF
--- a/subsys/nrf_rpc/Kconfig
+++ b/subsys/nrf_rpc/Kconfig
@@ -131,6 +131,7 @@ config NRF_RPC_THREAD_PRIORITY
 config NRF_RPC_SERIALIZE_API
 	bool "API for serialization"
 	default y
+	depends on NET_BUF
 	help
 	  API for serialization and deserialization of several major CBOR types.
 


### PR DESCRIPTION
nrf_rpc depends on NET_BUF. Explicitly enable it if the NRF_RPC_SERIALIZE_API option is selected, instead of relying on some other part of the system enabling it.