### PR TITLE
applications: zigbee_weather_station: Fix negative values logging

### DIFF
--- a/applications/zigbee_weather_station/src/sensor.c
+++ b/applications/zigbee_weather_station/src/sensor.c
@@ -91,9 +91,8 @@ int sensor_get_temperature(float *temperature)
 			if (err) {
 				LOG_ERR("Failed to get sensor channel: %d", err);
 			} else {
-				LOG_INF("Sensor    T:%3d.%06d [*C]",
-					sensor_temperature.val1, sensor_temperature.val2);
 				*temperature = convert_sensor_value(sensor_temperature);
+				LOG_INF("Sensor    T:%9.3f [*C]", (double)(*temperature));
 			}
 		} else {
 			LOG_ERR("Sensor not initialized");
@@ -121,9 +120,8 @@ int sensor_get_pressure(float *pressure)
 			if (err) {
 				LOG_ERR("Failed to get sensor channel: %d", err);
 			} else {
-				LOG_INF("Sensor    P:%3d.%06d [kPa]",
-					sensor_pressure.val1, sensor_pressure.val2);
 				*pressure = convert_sensor_value(sensor_pressure);
+				LOG_INF("Sensor    P:%9.3f [kPa]", (double)(*pressure));
 			}
 		} else {
 			LOG_ERR("Sensor not initialized");
@@ -151,9 +149,8 @@ int sensor_get_humidity(float *humidity)
 			if (err) {
 				LOG_ERR("Failed to get sensor channel: %d", err);
 			} else {
-				LOG_INF("Sensor    H:%3d.%06d [%%]",
-					sensor_humidity.val1, sensor_humidity.val2);
 				*humidity = convert_sensor_value(sensor_humidity);
+				LOG_INF("Sensor    H:%9.3f [%%]", (double)(*humidity));
 			}
 		} else {
 			LOG_ERR("Sensor not initialized");

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -220,6 +220,14 @@ Thingy:53: Matter weather station
 
 |no_changes_yet_note|
 
+Thingy:53: Zigbee weather station
+---------------------------------
+
+* Added:
+
+  * A fix for logging negative temperature values.
+  * Logging unification.
+
 Samples
 =======
 


### PR DESCRIPTION
Withaout fix, negative temperatures values are wrongly logged on the console. Unification of logging added.
 
Signed-off-by: Michal Leksinski <michal.leksinski@nordicsemi.no>