### PR TITLE
ci: fix docbuild requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -14,6 +14,7 @@ PyYAML                          # |  X  |         |        |         |         |
 pykwalify                       # |     |         |        |         |         |      |   X    |
 pytest                          # |     |         |        |         |         |      |   X    |
 recommonmark                    # |     |         |   X    |    X    |         |      |        |
+snowballstemmer<3.0.0           # https://github.com/snowballstem/snowball/issues/229
 sphinx~=8.1                     # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
 sphinx-autobuild                # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
 sphinx-copybutton               # |  X  |         |        |         |         |      |   X    |


### PR DESCRIPTION
Broken snowballstemmer was released. As a workaround fallback to older release.