### PR TITLE
ci: fix docbuild requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,6 +15,7 @@ pykwalify                       # |     |         |        |         |         |
 pytest                          # |     |         |        |         |         |      |   X    |
 recommonmark                    # |     |         |   X    |    X    |         |      |        |
 sphinx~=7.4                     # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
+snowballstemmer<3.0.0           # https://github.com/snowballstem/snowball/issues/229
 sphinx-autobuild                # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
 sphinx-copybutton               # |  X  |         |        |         |         |      |   X    |
 sphinx-ncs-theme<1.1            # |  X  |         |        |         |         |      |        |


### PR DESCRIPTION
Broken snowballstemmer was released. As a workaround fallback to older release.