### PR TITLE
samples: zephyr: drivers: jesd216: run on LM20 DK

### DIFF
--- a/samples/zephyr/drivers/jesd216/sample.yaml
+++ b/samples/zephyr/drivers/jesd216/sample.yaml
@@ -21,3 +21,18 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay"
+  nrf.extended.sample.drivers.spi.jesd216:
+    filter: dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("jedec,mspi-nor")
+    platform_allow:
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+      - nrf54lm20pdk@0.2.0/nrf54lm20a/cpuapp
+      - nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuapp
+    integration_platforms:
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+    harness_config:
+      fixture: external_flash
+      type: multi_line
+      ordered: true
+      regex:
+        - "sfdp-bfp ="
+        - "jedec-id ="

--- a/samples/zephyr/drivers/spi_flash/sample.yaml
+++ b/samples/zephyr/drivers/spi_flash/sample.yaml
@@ -24,3 +24,22 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay"
+  nrf.extended.sample.drivers.spi.flash:
+    filter: dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("nordic,qspi-nor")
+      or dt_compat_enabled("jedec,mspi-nor")
+    platform_allow:
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+      - nrf54lm20pdk@0.2.0/nrf54lm20a/cpuapp
+      - nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuapp
+    integration_platforms:
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+    harness_config:
+      fixture: external_flash
+      type: multi_line
+      ordered: true
+      regex:
+        - "Test 1: Flash erase"
+        - "Flash erase succeeded!"
+        - "Test 2: Flash write"
+        - "Attempting to write 4 bytes"
+        - "Data read matches data written. Good!!"


### PR DESCRIPTION
With specific fixture.