### PR TITLE
lib: nrf_modem_lib: lte_net_if: offload modem fault to system workq  and correct fault recovery in download sample

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -549,6 +549,10 @@ Security libraries
 Modem libraries
 ---------------
 
+* :ref:`nrf_modem_lib_readme`:
+
+  * Fixed an issue with modem fault handling in the :ref:`nrf_modem_lib_lte_net_if`, where the event must be deferred from interrupt context before it can be forwarded to the Zephyr's :ref:`net_mgmt_interface` module.
+
 * :ref:`at_parser_readme` library:
 
   * Added support for parsing DECT NR+ modem firmware names.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -395,6 +395,7 @@ Networking samples
 
   * Added the :ref:`CONFIG_SAMPLE_PROVISION_CERT <CONFIG_SAMPLE_PROVISION_CERT>` Kconfig option to provision the root CA certificate to the modem.
     The certificate is provisioned only if the :ref:`CONFIG_SAMPLE_SECURE_SOCKET <CONFIG_SAMPLE_SECURE_SOCKET>` Kconfig option is set to ``y``.
+  * Fixed an issue where the network interface was not re-initialized after a fault.
 
 NFC samples
 -----------


### PR DESCRIPTION
* The net_mgmt module in zephyr cannot handle the modem fault event in interrupt context. The event is therefore deferred to the system workq.
* The application is responsible for restarting the network interface when a fault occur.