### PR TITLE
samples: wifi: thread_coex: Replace incorrect reference to Bluetooth

### DIFF
--- a/samples/wifi/thread_coex/README.rst
+++ b/samples/wifi/thread_coex/README.rst
@@ -237,7 +237,7 @@ Complete the following steps to program the nRF7002 DK:
 Test procedure
 ==============
 
-The following tables provide the procedure to run Wi-Fi only, Bluetooth LE-only, and combined throughput for different Thread roles.
+The following tables provide the procedure to run Wi-Fi only, Thread-only, and combined throughput for different Thread roles.
 
 #. Complete the following steps to run the Wi-Fi client and Thread client:
 


### PR DESCRIPTION
Replace incorrect reference to Bluetooth with Thread.