### PR TITLE
applications: serial_lte_modem: Cellular modem driver nw loss

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -204,8 +204,16 @@ config SLM_CMUX_NOTIFICATION_TX_BUFFER_SIZE
 
 if SLM_CMUX && SLM_PPP
 
+config SLM_MODEM_CELLULAR
+	bool "Compatibility with cellular modem driver"
+	help
+	  Enables compatibility with a host that uses the cellular modem driver. Compared to clients,
+	  such as pppd, the cellular modem driver retains more control on how the PPP link
+	  is brought up and down.
+
 config SLM_CMUX_AUTOMATIC_FALLBACK_ON_PPP_STOPPAGE
 	bool "AT channel automatic fallback to DLCI 1 when PPP stops."
+	default y if SLM_MODEM_CELLULAR
 	help
 	  This is mainly intended for compatibility with Zephyr's cellular modem driver.
 	  If enabled, when PPP stops (which happens automatically when the LTE link goes down)

--- a/applications/serial_lte_modem/overlay-zephyr-modem.conf
+++ b/applications/serial_lte_modem/overlay-zephyr-modem.conf
@@ -7,4 +7,5 @@
 # The nRF91 is power-managed by Zephyr's modem_cellular driver running on the other chip.
 CONFIG_SLM_START_SLEEP=y
 
-CONFIG_SLM_CMUX_AUTOMATIC_FALLBACK_ON_PPP_STOPPAGE=y
+# Compatibility with cellular modem driver.
+CONFIG_SLM_MODEM_CELLULAR=y

--- a/applications/serial_lte_modem/src/slm_ppp.c
+++ b/applications/serial_lte_modem/src/slm_ppp.c
@@ -565,12 +565,22 @@ static void ppp_net_mgmt_event_handler(struct net_mgmt_event_callback *cb,
 			break;
 		}
 		send_status_notification();
-		/* For the peer to be able to successfully reconnect
-		 * (handshake issues observed with pppd and Windows dial-up),
-		 * for some reason the Zephyr PPP link needs to be restarted.
-		 */
-		LOG_INF("Peer disconnected.");
-		delegate_ppp_event(PPP_RESTART, PPP_REASON_PEER_DISCONNECTED);
+
+		if (IS_ENABLED(CONFIG_SLM_MODEM_CELLULAR)) {
+			/* With cellular modem driver, the restoration of connection
+			 * is handled by the driver.
+			 */
+			LOG_INF("Peer disconnected. %s PPP...", "Stopping");
+			delegate_ppp_event(PPP_STOP, PPP_REASON_PEER_DISCONNECTED);
+
+		} else {
+			/* For the peer to be able to successfully reconnect
+			 * (handshake issues observed with pppd and Windows dial-up),
+			 * for some reason the Zephyr PPP link needs to be restarted.
+			 */
+			LOG_INF("Peer disconnected. %s PPP...", "Restarting");
+			delegate_ppp_event(PPP_RESTART, PPP_REASON_PEER_DISCONNECTED);
+		}
 		break;
 	}
 }


### PR DESCRIPTION
Added Kconfig CONFIG_SLM_CELLULAR_MODEM, which configures different operability between cellular modem driver other use cases, such as pppd.

In this case, we do not want to restart PPP immediately when terminated, as that is controlled by the cellular modem driver.