### PR TITLE
modules: mcuboot: Remove deprecated security warning from Kconfig

### DIFF
--- a/modules/mcuboot/Kconfig
+++ b/modules/mcuboot/Kconfig
@@ -65,12 +65,10 @@ config USE_NRF53_MULTI_IMAGE_WITHOUT_UPGRADE_ONLY
 	  of bricking the network core upon reverts.
 
 config MCUBOOT_USE_ALL_AVAILABLE_RAM
-	bool "Allow MCUBoot to use all available RAM (security implications)"
+	bool "Allow MCUBoot to use all available RAM"
 	depends on ARM_TRUSTZONE_M
 	default y if BOARD_THINGY53_NRF5340_CPUAPP_NS || BOARD_THINGY53_NRF5340_CPUAPP
 	help
-	  By default MCUBoot uses only the secure RAM partition. Enabling this
-	  may allow secrets to be leaked to non-secure through the non-secure
-	  RAM partition.
+	  By default MCUBoot uses only the secure RAM partition.
 
 endmenu

--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -178,12 +178,10 @@ config BOOT_SHARED_CRYPTO_ECDSA_P256
 endif
 
 config MCUBOOT_USE_ALL_AVAILABLE_RAM
-	bool "Allow MCUboot to use all available RAM (security implications)"
+	bool "Allow MCUboot to use all available RAM"
 	depends on BOARD_IS_NON_SECURE
 	help
-	  By default MCUboot uses only the secure RAM partition. Enabling this
-	  may allow secrets to be leaked to non-secure through the non-secure
-	  RAM partition.
+	  By default MCUboot uses only the secure RAM partition.
 
 config MCUBOOT_NRF53_MULTI_IMAGE_UPDATE
 	bool "Network core multi-image update (in single operation)"


### PR DESCRIPTION
The warning is no longer true, since RAM is cleared by MCUboot before starting the application.

Ref: NCSDK-28492