### PR TITLE
samples: zephyr: system_off: Add support for nRF7120pdk

### DIFF
--- a/samples/zephyr/boards/nordic/system_off/boards/nrf7120pdk_nrf7120_cpuapp.conf
+++ b/samples/zephyr/boards/nordic/system_off/boards/nrf7120pdk_nrf7120_cpuapp.conf
@@ -1,0 +1,5 @@
+# Disable RC Oscillator so that LFXO will be used
+CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=n
+
+# Output log immediately
+CONFIG_LOG_MODE_IMMEDIATE=y

--- a/samples/zephyr/boards/nordic/system_off/boards/nrf7120pdk_nrf7120_cpuapp.overlay
+++ b/samples/zephyr/boards/nordic/system_off/boards/nrf7120pdk_nrf7120_cpuapp.overlay
@@ -1,0 +1,25 @@
+/ {
+	cpuapp_sram@2007ec00 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x2007ec00 DT_SIZE_K(4)>;
+		zephyr,memory-region = "RetainedMem";
+		status = "okay";
+
+		retainedmem0: retainedmem {
+			compatible = "zephyr,retained-ram";
+			status = "okay";
+		};
+	};
+
+	aliases {
+		retainedmemdevice = &retainedmem0;
+	};
+};
+
+&cpuapp_sram {
+	/* Shrink SRAM size to avoid overlap with retained memory region:
+	 * 511 - 4 = 507KB = 0x7ec00
+	 */
+	reg = <0x20000000 DT_SIZE_K(507)>;
+	ranges = <0x0 0x20000000 0x7ec00>;
+};

--- a/samples/zephyr/boards/nordic/system_off/sample.yaml
+++ b/samples/zephyr/boards/nordic/system_off/sample.yaml
@@ -1,5 +1,5 @@
 sample:
-  name: Low Power State Sample for nRF5x
+  name: Low Power State Sample for nRF5x and nRF71
 common:
   tags:
     - ci_samples_zephyr_boards_nordic_system_off
@@ -45,6 +45,7 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk@0.0.0/nrf54lv10a/cpuapp
       - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp
     extra_configs:
       - CONFIG_GRTC_WAKEUP_ENABLE=y
       - CONFIG_GPIO_WAKEUP_ENABLE=n
@@ -68,6 +69,7 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk@0.0.0/nrf54lv10a/cpuapp
       - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
+      - nrf7120pdk/nrf7120/cpuapp
     extra_configs:
       - CONFIG_APP_USE_RETAINED_MEM=y
       - CONFIG_GRTC_WAKEUP_ENABLE=y


### PR DESCRIPTION
Add support for the nRF7120pdk for the systemoff samples:

- grtc_wakeup
- grtc_wakeup (memory retained)