### PR TITLE
fix: prohibited term in create board schema

### DIFF
--- a/scripts/west_commands/create_board/schema.json
+++ b/scripts/west_commands/create_board/schema.json
@@ -1,5 +1,5 @@
 {
-  "title": "NCS board",
+  "title": "nRF Connect SDK Board",
   "type": "object",
   "required": [
     "board",


### PR DESCRIPTION
Fixed the prohibited "NCS" term in the schema for the create board west command.