### PR TITLE
zigbee: fix application versioning in Zigbee project

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -159,6 +159,7 @@ Zigbee
 ------
 
 * Fixed compilation errors that previously occurred when the :kconfig:option:`CONFIG_ZIGBEE_FACTORY_RESET` Kconfig option was disabled.
+* Fixed the :file:`zb_add_ota_header.py` script to allow a patch version higher than 9 in an ``APPLICATION_VERSION_STRING``.
 
 Wi-Fi
 -----

--- a/scripts/bootloader/zb_add_ota_header.py
+++ b/scripts/bootloader/zb_add_ota_header.py
@@ -141,7 +141,7 @@ class OTA_header:
 
 def convert_version_string_to_int(s):
     """Convert from semver string "1.2.3", to integer 1020003"""
-    match = re.match(r'^([0-9]+)\.([0-9]+)\.([0-9])(?:\+[0-9]+)?$', s)
+    match = re.match(r'^([0-9]+)\.([0-9]+)\.([0-9]+)(?:\+[0-9]+)?$', s)
     if match is None:
         raise ValueError('application-version-string parameter must be on the format x.y.z or x.y.z+t')
     js = [0x100*0x10000, 0x10000, 1]


### PR DESCRIPTION
Allow a patch version higher than 9 in an APPLICATION_VERSION_STRING.

Backport of https://github.com/nrfconnect/sdk-nrf/pull/20039