### PR TITLE
tests: drivers: gpio: gpio_more_loops: Fix loopback on PCA10184

### DIFF
--- a/tests/drivers/gpio/gpio_more_loops/boards/nrf54lm20pdk_nrf54lm20a_common_0_2_0_csp.dtsi
+++ b/tests/drivers/gpio/gpio_more_loops/boards/nrf54lm20pdk_nrf54lm20a_common_0_2_0_csp.dtsi
@@ -14,11 +14,11 @@
 	test_gpios {
 		compatible = "gpio-leds";
 		out_gpios: out_gpios {
-			gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>, <&gpio1 3 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>, <&gpio1 3 GPIO_ACTIVE_HIGH>;
 		};
 
 		in_gpios: in_gpios {
-			gpios = <&gpio2 6 GPIO_ACTIVE_HIGH>, <&gpio1 4 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>, <&gpio1 4 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };
@@ -27,10 +27,10 @@
 	status = "okay";
 };
 
-&gpio1 {
+&gpio0 {
 	status = "okay";
 };
 
-&gpio2 {
+&gpio1 {
 	status = "okay";
 };


### PR DESCRIPTION
CI setup was reconfigured.
P1.07-P2.06 was removed.
P0.04-P0.05 was added.