### PR TITLE
samples: nfc: Add experimental llvm support in selected samples

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -333,6 +333,11 @@ Networking samples
 NFC samples
 -----------
 
+* Added experimental ``llvm`` toolchain support for the ``nrf54l15dk/nrf54l15/cpuapp`` board target to the following samples:
+
+  * :ref:`writable_ndef_msg`
+  * :ref:`nfc_shell`
+
 * :ref:`record_text` sample:
 
   * Added support for the ``nrf54l15dk/nrf54l15/cpuapp/ns`` board target.

--- a/samples/nfc/shell/sample.yaml
+++ b/samples/nfc/shell/sample.yaml
@@ -27,3 +27,15 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_nfc
+  sample.nfc.shell.llvm:
+    toolchain_allow: llvm
+    sysbuild: true
+    build_only: true
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_nfc

--- a/samples/nfc/writable_ndef_msg/sample.yaml
+++ b/samples/nfc/writable_ndef_msg/sample.yaml
@@ -27,3 +27,15 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_nfc
+  sample.nfc.writable_ndef_msg.llvm:
+    toolchain_allow: llvm
+    sysbuild: true
+    build_only: true
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_nfc


### PR DESCRIPTION
Add experimental llvm support in NFC samples:
- writable_ndef_msg
- shell

Jira: NCSDK-33298