### PR TITLE
doc: tf-m: add mention of /ns being recommended

### DIFF
--- a/doc/nrf/app_dev/board_names.rst
+++ b/doc/nrf/app_dev/board_names.rst
@@ -43,14 +43,15 @@ While the board name is always present, other elements, such as the board revisi
   Check the Product Specification of the given SoC for more information about the available CPU clusters.
 
 * :ref:`Variant <zephyr:glossary>` - You can use this board qualifier to build for a particular type or configuration of a build for a combination of SoC and CPU cluster.
-  In the |NCS|, variants are used for indicating the usage of Cortex-M Security Extensions (CMSE):
+  In the |NCS|, variants are used for indicating the usage of Cortex-M Security Extensions (CMSE) (security by separation):
 
-  * Entries without ``*/ns`` - When you choose this target, you build the application core firmware as a single execution environment that does not use CMSE (:ref:`Trusted Firmware-M (TF-M) <ug_tfm>`).
-  * Entries with ``*/ns`` (for example, ``cpuapp/ns``) - When you choose this target, you build the application with CMSE.
+  * Entries without ``*/ns`` (for example, ``cpuapp``) - When you choose this target, you build the application core firmware as a single execution environment that does not use CMSE (:ref:`Trusted Firmware-M (TF-M) <ug_tfm>`).
+  * Entries with ``*/ns`` (for example, ``cpuapp/ns``) - Recommended for more security.
+    When you choose this target, you build the application with CMSE using security by separation.
     The application core firmware is placed in Non-Secure Processing Environment (NSPE) and uses Secure Processing Environment (SPE) for security features.
     By default, the build system automatically includes :ref:`Trusted Firmware-M (TF-M) <ug_tfm>` in SPE and merges it with NSPE.
 
-  Read more about separation of processing environments on the :ref:`app_boards_spe_nspe` page.
+  Read more about separation of processing environments on the :ref:`ug_tfm_security_by_separation` page.
 
 .. note::
     This board name scheme was introduced in the |NCS| before the v2.7.0 release following changes in Zephyr v3.6.0.

--- a/doc/nrf/app_dev/device_guides/nrf53/features_nrf53.rst
+++ b/doc/nrf/app_dev/device_guides/nrf53/features_nrf53.rst
@@ -51,26 +51,14 @@ Application core
 The application core is a full-featured Arm Cortex-M33 processor including DSP instructions and FPU.
 Use this core for tasks that require high performance and for application-level logic.
 
-The M33 TrustZone, one of Cortex-M Security Extensions (CMSE), divides the application MCU into Secure Processing Environment (SPE) and Non-Secure Processing Environment (NSPE).
-When the MCU boots, it always starts executing from the secure area.
+You can use :ref:`security by separation <ug_tfm_security_by_separation>` with the M33 TrustZone for the application core.
+When security by separation is used, the MCU always starts executing from the secure area at boot.
+When enabled, the secure bootloader chain starts the :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`, which configures a part of memory and peripherals to be non-secure, and then jumps to the user application located in the non-secure area.
 
-In Zephyr, the firmware of the application core is built using one of the following board targets:
+The firmware of the application core is built using one of the following board targets:
 
-* ``nrf5340dk/nrf5340/cpuapp`` for board targets with CMSE disabled.
-* ``nrf5340dk/nrf5340/cpuapp/ns`` for board targets that have CMSE enabled and have the SPE firmware alongside the NSPE firmware.
-
-For information about CMSE and the difference between the two environments, see :ref:`app_boards_spe_nspe`.
-
-Trusted Firmware-M (TF-M)
--------------------------
-
-Trusted Firmware-M provides a configurable set of software components to create a Trusted Execution Environment.
-It has replaced Secure Partition Manager as the solution used by |NCS| applications and samples.
-This means that when you build your application with CMSE enabled, the :ref:`TF-M <ug_tfm>` is automatically included in the build.
-It is a framework for functions and use cases beyond the scope of Secure Partition Manager.
-
-For more information about the TF-M, see :ref:`ug_tfm`.
-See also :ref:`tfm_hello_world` for a sample that demonstrates how to add TF-M to an application.
+* ``nrf5340dk/nrf5340/cpuapp`` for board targets with security by separation disabled.
+* ``nrf5340dk/nrf5340/cpuapp/ns`` for board targets with security by separation enabled.
 
 .. _ug_nrf5340_intro_inter_core:
 

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_features.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_features.rst
@@ -41,17 +41,14 @@ Application MCU
 The application core is a full-featured Arm Cortex-M33 processor including DSP instructions and FPU.
 Use this core for tasks that require high performance and for application-level logic.
 
-The M33 TrustZone, one of Cortex-M Security Extensions (CMSE), divides the application MCU into Secure Processing Environment (SPE) and Non-Secure Processing Environment (NSPE).
-When the MCU boots, it always starts executing from the secure area.
-The secure bootloader chain starts the :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`, which configures a part of memory and peripherals to be non-secure, and then jumps to the user application located in the non-secure area.
-
-For information about CMSE and the difference between the two environments, see :ref:`app_boards_spe_nspe`.
+You can use :ref:`security by separation <ug_tfm_security_by_separation>` with the M33 TrustZone for the application MCU.
+When security by separation is used, the MCU always starts executing from the secure area at boot.
+When enabled, the :ref:`ug_bootloader` starts the :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`, which configures a part of memory and peripherals to be non-secure, and then jumps to the user application located in the non-secure area.
 
 Secure bootloader chain
 =======================
 
-A secure bootloader chain protects your application against running unauthorized code, and it enables you to do device firmware updates (DFU).
-See :ref:`ug_bootloader` for more information.
+A :ref:`ug_bootloader` protects your application against running unauthorized code, and it enables you to do device firmware updates (DFU).
 
 A bootloader chain is optional.
 Not all of the nRF91 Series samples include a secure bootloader chain, but the ones that do use the :ref:`bootloader` sample and :doc:`MCUboot <mcuboot:index-ncs>`.

--- a/doc/nrf/app_dev/device_guides/thingy91x/thingy91x_building_programming.rst
+++ b/doc/nrf/app_dev/device_guides/thingy91x/thingy91x_building_programming.rst
@@ -25,7 +25,7 @@ The build targets of interest for Thingy:91 X in the |NCS| are as follows:
 +----------------------------------+---------------------------------+
 
 .. note::
-   LTE/GNSS features can only be used with :ref:`Cortex-M Security Extensions enabled <app_boards_spe_nspe_cpuapp_ns>` (nRF9151 ``ns`` build target).
+   LTE/GNSS features can only be used with :ref:`Cortex-M Security Extensions enabled <app_boards_spe_nspe_cpuapp_ns>` (``thingy91x/nrf9151/ns`` build target).
 
 The following table shows the different types of build files that are generated and the different scenarios in which they are used:
 

--- a/doc/nrf/gsg_guides/nrf7002_gs.rst
+++ b/doc/nrf/gsg_guides/nrf7002_gs.rst
@@ -286,28 +286,20 @@ This allows to build and run secure-only applications on the nRF5340 SoC.
 Building |NCS| applications with Arm TrustZone
 ==============================================
 
-Applications on nRF5340 can use Cortex-M Security Extensions (CMSE) and separate firmware for the application core between Secure Processing Environment (SPE) and Non-Secure Processing Environment (NSPE).
-You can build SPE using either |NCS| or `Trusted Firmware M`_ (TF-M).
-You must always build NSPE using |NCS|.
+Applications on nRF5340 can use the M33 TrustZone for :ref:`security by separation <ug_tfm_security_by_separation>`.
+When security by separation is used, the MCU always starts executing from the secure area at boot.
+When enabled, the :ref:`ug_bootloader` starts the :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`, which configures a part of memory and peripherals to be non-secure, and then jumps to the user application located in the non-secure area.
 
-For information about Cortex-M Security Extensions (CMSE) and the difference between the two environments, see :ref:`app_boards_spe_nspe`.
-
-.. note::
-   By default, SPE for the nRF5340 application core is built using TF-M.
-
-Building the firmware with TF-M
--------------------------------
-
-If you want to use |NCS| to build the firmware image separated in SPE with TF-M and NSPE, complete the following steps:
+If you want to use |NCS| to build the firmware image with security by separation, complete the following steps:
 
 1. Build the |NCS| application for the application core using the ``nrf7002dk/nrf5340/cpuapp/ns`` board target.
 
-   To invoke the building of TF-M, the |NCS| build system requires the Kconfig option :kconfig:option:`CONFIG_BUILD_WITH_TFM` to be enabled, which is set by default when building |NCS| as an application that supports both NSPE and SPE.
+   To invoke the building of TF-M, the |NCS| build system requires the Kconfig option :kconfig:option:`CONFIG_BUILD_WITH_TFM` to be enabled, which is set by default when building |NCS| as an application that supports security by separation.
 
    The |NCS| build system performs the following steps automatically:
 
-      a. Build the NSPE firmware image as a regular |NCS| application.
-      #. Build an SPE firmware image (with TF-M).
+      a. Build the Non-Secure Processing Environment (NSPE) firmware image as a regular |NCS| application.
+      #. Build a Secure Processing Environment (SPE) firmware image (with TF-M).
       #. Merge the output image binaries.
       #. Optionally, build a bootloader image (MCUboot).
 
@@ -316,8 +308,8 @@ If you want to use |NCS| to build the firmware image separated in SPE with TF-M 
 
 #. Build the application firmware for the network core using the ``nrf7002dk/nrf5340/cpunet`` board target.
 
-Building application without CMSE
-=================================
+Building application without security by separation
+===================================================
 
 Build the |NCS| application as described in :ref:`building`, using the ``nrf7002dk/nrf5340/cpuapp`` board target for the firmware running on the nRF5340 application core and the ``nrf7002dk/nrf5340/cpunet`` board target for the firmware running on the nRF5340 network core.
 

--- a/doc/nrf/includes/application_build_and_run_ns.txt
+++ b/doc/nrf/includes/application_build_and_run_ns.txt
@@ -1,9 +1,8 @@
 This application can be found under |application path| in the |NCS| folder structure.
 
-You can build this application as firmware image for a board target with the ``*/ns`` :ref:`variant <app_boards_names>` (see the Requirements section above).
-In such cases, the sample has Cortex-M Security Extensions (CMSE) enabled and separates the firmware between Non-Secure Processing Environment (NSPE) and Secure Processing Environment (SPE).
-Because of this, it automatically includes the :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`.
-To read more about CMSE, see :ref:`app_boards_spe_nspe`.
+For more security, it is recommended to use the ``*/ns`` :ref:`variant <app_boards_names>` of the board target (see the Requirements section above.)
+When built for this variant, the sample is configured to compile and run as a non-secure application using :ref:`security by separation <ug_tfm_security_by_separation>`.
+Therefore, it automatically includes :ref:`Trusted Firmware-M <ug_tfm>` that prepares the required peripherals and secure services to be available for the application.
 
 To build the application, follow the instructions in :ref:`building` for your preferred building environment.
 See also :ref:`programming` for programming steps and :ref:`testing` for general information about testing and debugging in the |NCS|.

--- a/doc/nrf/includes/build_and_run_ns.txt
+++ b/doc/nrf/includes/build_and_run_ns.txt
@@ -1,9 +1,8 @@
 This sample can be found under |sample path| in the |NCS| folder structure.
 
-You can build this sample as firmware image for a board target with the ``*/ns`` :ref:`variant <app_boards_names>` (see the Requirements section above).
-In such cases, the sample has Cortex-M Security Extensions (CMSE) enabled and separates the firmware between Non-Secure Processing Environment (NSPE) and Secure Processing Environment (SPE).
-Because of this, it automatically includes the :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`.
-To read more about CMSE, see :ref:`app_boards_spe_nspe`.
+For more security, it is recommended to use the ``*/ns`` :ref:`variant <app_boards_names>` of the board target (see the Requirements section above.)
+When built for this variant, the sample is configured to compile and run as a non-secure application using :ref:`security by separation <ug_tfm_security_by_separation>`.
+Therefore, it automatically includes :ref:`Trusted Firmware-M <ug_tfm>` that prepares the required peripherals and secure services to be available for the application.
 
 To build the sample, follow the instructions in :ref:`building` for your preferred building environment.
 See also :ref:`programming` for programming steps and :ref:`testing` for general information about testing and debugging in the |NCS|.

--- a/doc/nrf/includes/tfm.txt
+++ b/doc/nrf/includes/tfm.txt
@@ -1,2 +1,3 @@
-When built for a board target with the ``*/ns`` :ref:`variant <app_boards_names>`, the sample is configured to compile and run as a non-secure application with :ref:`Cortex-M Security Extensions enabled <app_boards_spe_nspe_cpuapp_ns>`.
+For more security, it is recommended to use the ``*/ns`` :ref:`variant <app_boards_names>` of the board target.
+When built for this variant, the sample is configured to compile and run as a non-secure application using :ref:`security by separation <ug_tfm_security_by_separation>`.
 Therefore, it automatically includes :ref:`Trusted Firmware-M <ug_tfm>` that prepares the required peripherals and secure services to be available for the application.

--- a/doc/nrf/libraries/security/trusted_storage.rst
+++ b/doc/nrf/libraries/security/trusted_storage.rst
@@ -165,8 +165,10 @@ The following options are used to configure the AEAD backend and its behavior:
 Usage
 *****
 
-The trusted storage library can only be used on a build using a board target with :ref:`CMSE disabled <app_boards_spe_nspe_cpuapp>` (``/cpuapp``).
-When you build for ``/cpuapp``, you build the firmware for the application core without CMSE and thus no TF-M.
+The trusted storage library can only be used on a build without Trusted Firmware-M.
+
+This means that you must use a board target without :ref:`security by separation <ug_tfm_security_by_separation>` (``/cpuapp``).
+When you build for ``/cpuapp``, you build the firmware for the application core without Cortex-M Security Extensions (CMSE) and so without TF-M.
 The library can be used directly on such a build to store important assets.
 However, for cryptographic keys we suggest to use the `PSA functions for key management`_.
 These APIs will internally use this library to store persistent keys.

--- a/doc/nrf/protocols/lte/overview.rst
+++ b/doc/nrf/protocols/lte/overview.rst
@@ -153,7 +153,7 @@ Security
 ========
 
 The nRF91 Series devices include a range of security features, such as Arm TrustZone and Arm CryptoCell for secure application and data handling.
-For more information, refer to the :ref:`app_boards_spe_nspe` documentation.
+For more information, refer to the :ref:`security` documentation.
 
 Security best practices are also implemented to protect data transmitted over the cellular network.
 This includes using Transport Layer Security (TLS) for Transmission Control Protocol (TCP) and Datagram Transport Layer Security (DTLS) for User Datagram Protocol (UDP).

--- a/doc/nrf/protocols/matter/end_product/security.rst
+++ b/doc/nrf/protocols/matter/end_product/security.rst
@@ -24,7 +24,7 @@ Depending on the board, Matter samples can use a secure processing environment.
 nRF54L with Trusted Firmware-M (TF-M)
 =====================================
 
-On the nRF54L SoC, Matter samples support :ref:`app_boards_spe_nspe` with Trusted Firmware-M (TF-M).
+On the nRF54L SoC, Matter samples support :ref:`security by separation <ug_tfm_security_by_separation>` with Trusted Firmware-M (TF-M).
 All cryptographic operations within the Matter stack are performed by utilizing the `Platform Security Architecture (PSA)`_ API and executed in the secure TF-M environment.
 The secure materials like Matter Session keys and other keys, except for the DAC private key, are stored in the TF-M secure storage using the :ref:`tfm_encrypted_its` module.
 Matter samples use the full TF-M library, so you cannot use the :ref:`tfm_minimal_build` version of TF-M.

--- a/doc/nrf/protocols/thread/overview/security.rst
+++ b/doc/nrf/protocols/thread/overview/security.rst
@@ -27,7 +27,7 @@ Depending on the board, Thread samples can use a secure processing environment.
 nRF54L with Trusted Firmware-M (TF-M)
 =====================================
 
-On the nRF54L15 SoC, Thread samples support :ref:`app_boards_spe_nspe` with Trusted Firmware-M (TF-M).
+On the nRF54L15 SoC, Thread samples support :ref:`security by separation <ug_tfm_security_by_separation>` with Trusted Firmware-M (TF-M).
 All cryptographic operations within the Thread stack are performed by utilizing the `Platform Security Architecture (PSA)`_ API and executed in the secure TF-M environment.
 The secure materials like Thread network key are stored in the TF-M secure storage using the :ref:`tfm_encrypted_its` module.
 

--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -24,6 +24,7 @@ However, Zephyr samples and applications are not tested and verified to work wit
 General information about samples in the |NCS|
    * |ncs_unchanged_samples_note|
    * |ncs_oot_sample_note|
+   * |samples_tfm_info|
    * All samples in the |NCS| use :ref:`lib_fatal_error` library and are configured to perform a system reset if a fatal error occurs.
      This behavior is different from how fatal errors are handled in the Zephyr samples.
      You can change the default behavior by updating the configuration option :kconfig:option:`CONFIG_RESET_ON_FATAL_ERROR`.

--- a/doc/nrf/samples/tfm.rst
+++ b/doc/nrf/samples/tfm.rst
@@ -5,6 +5,8 @@ Trusted Firmware-M (TF-M) samples
 
 This section lists the available |NCS| samples and tests for :ref:`ug_tfm`, one of the :ref:`security` features of the |NCS|.
 
+You can start by checking the :ref:`tfm_hello_world` sample, which demonstrates how to add TF-M to an application.
+
 .. include:: ../samples.rst
     :start-after: samples_general_info_start
     :end-before: samples_general_info_end

--- a/doc/nrf/security/tfm/index.rst
+++ b/doc/nrf/security/tfm/index.rst
@@ -26,8 +26,7 @@ The TF-M implementation in the |NCS| is demonstrated in the following samples:
 * All :ref:`cryptography samples <crypto_samples>` in this SDK
 * A series of :zephyr:code-sample-category:`tfm_integration` samples available in Zephyr (these include :ref:`ug_tfm_supported_services_tfm_services` from the |NCS| when they are built from the |NCS| context)
 
-Starting from the |NCS| v2.0.0, TF-M is enabled by default for applications and samples that support hardware-enforced separation of the SPE and the NSPE.
-In addition, the TF-M implementation is used in all samples and applications in this SDK that support the ``*/ns`` :ref:`variant <app_boards_names>` of the boards, due to :ref:`Cortex-M Security Extensions (CMSE) <app_boards_spe_nspe>` support.
+|samples_tfm_info|
 
 The pages in this section describe the architecture and configuration of TF-M in the |NCS|.
 For more information about TF-M, see the `Trusted Firmware-M documentation <TF-M documentation_>`_, which is oriented towards TF-M implementation developers.

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -200,6 +200,9 @@
 
 .. |trusted_execution| replace:: nRF5340 and nRF9160
 
+.. |samples_tfm_info| replace:: Starting from the |NCS| v2.0.0, TF-M is the only way to use :ref:`security by separation <ug_tfm_security_by_separation>` with ARM TrustZone.
+   In addition, the TF-M implementation is enabled by default for all samples and applications in the |NCS| when you build for the ``*/ns`` :ref:`variant <app_boards_names>` of the boards.
+
 .. |plusminus| unicode:: U+000B1 .. PLUS-MINUS SIGN
    :rtrim:
 


### PR DESCRIPTION
Edited notes to mention that the /ns board target is recommended for more security. Edited some of the links to the security by separation page. More thorough pass will be done in the future. NCSDK-16510.