### PR TITLE
docs: Add changelog for bt_mesh_adv_unref fix

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -395,7 +395,9 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
-|no_changes_yet_note|
+* :ref:`bt_mesh` library:
+
+  * Fixed an issue where the ``bt_mesh_adv_unref()`` function could assert when messaging to a proxy node.
 
 Common Application Framework
 ----------------------------


### PR DESCRIPTION
Adds a change log for bt_mesh_adv_unref fix.

PR with the fix: https://github.com/nrfconnect/sdk-nrf/pull/22221