### PR TITLE
Resolved: Nrfx 7694 nrf extended drivers spi fails at nrf 7120 pdk nrf 7120 cpuapp

### DIFF
--- a/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120-common.dtsi
+++ b/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120-common.dtsi
@@ -87,6 +87,13 @@
 	};
 };
 
+&uart00 {
+	current-speed = <115200>;
+	pinctrl-0 = <&uart00_default>;
+	pinctrl-1 = <&uart00_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
 &uart20 {
 	current-speed = <115200>;
 	pinctrl-0 = <&uart20_default>;

--- a/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120-emu-pinctrl.dtsi
+++ b/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120-emu-pinctrl.dtsi
@@ -4,7 +4,7 @@
  */
 
 &pinctrl {
-	uart00_default: uart00_default {
+	/omit-if-no-ref/ uart00_default: uart00_default {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 2, 2)>,
 					<NRF_PSEL(UART_RTS, 2, 5)>;
@@ -17,7 +17,7 @@
 		};
 	};
 
-	uart00_sleep: uart00_sleep {
+	/omit-if-no-ref/ uart00_sleep: uart00_sleep {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 2, 2)>,
 					<NRF_PSEL(UART_RX, 2, 0)>,

--- a/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120_cpuapp.dts
+++ b/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120_cpuapp.dts
@@ -14,15 +14,5 @@
 
 	chosen {
 		zephyr,sram = &cpuapp_sram;
-		zephyr,console = &uart00;
-		zephyr,shell-uart = &uart00;
 	};
-};
-
-&uart00 {
-	status = "okay";
-	current-speed = <115200>;
-	pinctrl-0 = <&uart00_default>;
-	pinctrl-1 = <&uart00_sleep>;
-	pinctrl-names = "default", "sleep";
 };

--- a/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120_cpuapp_emu.dts
+++ b/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120_cpuapp_emu.dts
@@ -22,10 +22,6 @@
 
 &uart00 {
 	status = "okay";
-	current-speed = <115200>;
-	pinctrl-0 = <&uart00_default>;
-	pinctrl-1 = <&uart00_sleep>;
-	pinctrl-names = "default", "sleep";
 };
 
 &grtc {

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -63,21 +63,6 @@
   comment: "SUIT is planned to be removed from NCS soon"
 
 - scenarios:
-    - nrf.extended.drivers.spi.loopback
-    - nrf.extended.drivers.spi.nrf_pm_runtime
-    - nrf.extended.drivers.spi.pm_runtime
-    - nrf.extended.drivers.spi.spi_4MHz
-    - nrf.extended.drivers.spi.spi_8MHz
-    - nrf.extended.drivers.spi.spi_error_cases
-    - nrf.extended.drivers.spi.spi_mode0
-    - nrf.extended.drivers.spi.spi_mode1
-    - nrf.extended.drivers.spi.spi_mode2
-    - nrf.extended.drivers.spi.spi_mode3
-  platforms:
-    - nrf7120pdk/nrf7120/cpuapp
-  comment: "https://nordicsemi.atlassian.net/browse/NRFX-7694"
-
-- scenarios:
     - sample.qspi.ext_flash_xip
   platforms:
     - nrf52840dk/nrf52840


### PR DESCRIPTION
Resolved: https://nordicsemi.atlassian.net/browse/NRFX-7694

SPI00 and UART00 cannot be enabled at the same time, set default uart for console / shell to be 20. 