### PR TITLE
samples: radio_test: Modify radio transmission termination handling

### DIFF
--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -189,7 +189,7 @@ static int cmd_time_set(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_cancel(const struct shell *shell, size_t argc, char **argv)
 {
-	radio_test_cancel();
+	radio_test_cancel(test_config.type);
 	test_in_progress = false;
 	return 0;
 }
@@ -219,7 +219,7 @@ static int cmd_tx_carrier_start(const struct shell *shell, size_t argc,
 				char **argv)
 {
 	if (test_in_progress) {
-		radio_test_cancel();
+		radio_test_cancel(test_config.type);
 		test_in_progress = false;
 	}
 
@@ -282,7 +282,7 @@ static int cmd_tx_modulated_carrier_start(const struct shell *shell,
 					  char **argv)
 {
 	if (test_in_progress) {
-		radio_test_cancel();
+		radio_test_cancel(test_config.type);
 		test_in_progress = false;
 	}
 
@@ -633,7 +633,7 @@ static int cmd_tx_sweep_start(const struct shell *shell, size_t argc,
 static int cmd_rx_start(const struct shell *shell, size_t argc, char **argv)
 {
 	if (test_in_progress) {
-		radio_test_cancel();
+		radio_test_cancel(test_config.type);
 		test_in_progress = false;
 	}
 

--- a/samples/peripheral/radio_test/src/radio_test.h
+++ b/samples/peripheral/radio_test/src/radio_test.h
@@ -215,8 +215,10 @@ void radio_test_start(const struct radio_test_config *config);
 
 /**
  * @brief Function for stopping ongoing test (Radio and Timer operations).
+ *
+ * @param[in] type  Radio test mode.
  */
-void radio_test_cancel(void);
+void radio_test_cancel(enum radio_test_mode type);
 
 /**
  * @brief Function for get RX statistics.


### PR DESCRIPTION
Radio transmission is stopped on the END event,
ensuring it terminates immediately after the packet is sent.

Ref: NCSDK-33487