### PR TITLE
scripts: hid_configurator: Fix discovering dongle peers

### DIFF
--- a/scripts/hid_configurator/NrfHidDevice.py
+++ b/scripts/hid_configurator/NrfHidDevice.py
@@ -246,7 +246,8 @@ class NrfHidDevice():
             else:
                 dev_active = NrfHidDevice._add_nrf_hid_device(discovered_dev, dir_devs)
                 for dp in discovered_peers:
-                    dev_active = dev_active or NrfHidDevice._add_nrf_hid_device(dp, non_dir_devs)
+                    added = NrfHidDevice._add_nrf_hid_device(dp, non_dir_devs)
+                    dev_active = dev_active or added
 
             if dev and not dev_active:
                 dev.close()


### PR DESCRIPTION
Change fixes discovery of HID peripherals connected through a dongle.

Jira: NCSDK-33604