### PR TITLE
tests: zephyr: drivers: spi: change pins for nRF54LM20 0.2.0

### DIFF
--- a/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.overlay
@@ -6,7 +6,7 @@
 
 /* Test requires following loopbacks:
  * SCK:  P1.18 - P1.24
- * MISO: P1.30 - P1.31
+ * MISO: P1.19 - P1.29
  * MOSI: P1.15 - P1.16
  * CS:   P0.03 - P1.03
  */
@@ -15,7 +15,7 @@
 	spi22_default_alt: spi22_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 18)>,
-				<NRF_PSEL(SPIM_MISO, 1, 30)>,
+				<NRF_PSEL(SPIM_MISO, 1, 19)>,
 				<NRF_PSEL(SPIM_MOSI, 1, 15)>;
 		};
 	};
@@ -23,7 +23,7 @@
 	spi22_sleep_alt: spi22_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 18)>,
-				<NRF_PSEL(SPIM_MISO, 1, 30)>,
+				<NRF_PSEL(SPIM_MISO, 1, 19)>,
 				<NRF_PSEL(SPIM_MOSI, 1, 15)>;
 			low-power-enable;
 		};
@@ -32,7 +32,7 @@
 	spi21_default_alt: spi21_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 24)>,
-				<NRF_PSEL(SPIS_MISO, 1, 31)>,
+				<NRF_PSEL(SPIS_MISO, 1, 29)>,
 				<NRF_PSEL(SPIS_MOSI, 1, 16)>,
 				<NRF_PSEL(SPIS_CSN, 1, 3)>;
 		};
@@ -41,7 +41,7 @@
 	spi21_sleep_alt: spi21_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 24)>,
-				<NRF_PSEL(SPIS_MISO, 1, 31)>,
+				<NRF_PSEL(SPIS_MISO, 1, 29)>,
 				<NRF_PSEL(SPIS_MOSI, 1, 16)>,
 				<NRF_PSEL(SPIS_CSN, 1, 3)>;
 			low-power-enable;


### PR DESCRIPTION
Pins P1.30 and P1.31 are connected to leds, thus do not work properly in high-frequency signals, causing 8MHZ SPI testcases to fail. Moved to other loopback