### PR TITLE
net: lib: mqtt_client: Don't initialize MQTT client struct on connect

### DIFF
--- a/subsys/net/lib/mqtt_helper/mqtt_helper.c
+++ b/subsys/net/lib/mqtt_helper/mqtt_helper.c
@@ -452,8 +452,6 @@ static int client_connect(struct mqtt_helper_conn_params *conn_params)
 		.size = conn_params->password.size,
 	};
 
-	mqtt_client_init(&mqtt_client);
-
 	err = broker_init(&broker, conn_params);
 	if (err) {
 		return err;
@@ -575,6 +573,8 @@ int mqtt_helper_init(struct mqtt_helper_cfg *cfg)
 	}
 
 	current_cfg = *cfg;
+
+	mqtt_client_init(&mqtt_client);
 
 	mqtt_state_set(MQTT_STATE_DISCONNECTED);
 

--- a/tests/subsys/net/lib/mqtt_helper/src/mqtt_helper_test.c
+++ b/tests/subsys/net/lib/mqtt_helper/src/mqtt_helper_test.c
@@ -242,6 +242,8 @@ void test_mqtt_helper_init_when_unitialized(void)
 		},
 	};
 
+	__cmock_mqtt_client_init_Expect(&mqtt_client);
+
 	TEST_ASSERT_EQUAL(0, mqtt_helper_init(&cfg));
 	TEST_ASSERT_EQUAL(mqtt_state_get(), MQTT_STATE_DISCONNECTED);
 }
@@ -272,8 +274,6 @@ void test_mqtt_helper_connect_when_disconnected(void)
 		},
 	};
 
-	__cmock_mqtt_client_init_Expect(&mqtt_client);
-
 	/* Make getddrinfo return a pointer that points to NULL. Otherwise the unit under test
 	 * would be dereferencing uninitialized memory location. The behavior of the unit
 	 * under test for when non-NULL values are returned is out of scope of this test.
@@ -298,8 +298,6 @@ void test_mqtt_helper_connect_when_disconnected(void)
 void test_mqtt_helper_connect_when_disconnected_mqtt_api_error(void)
 {
 	struct mqtt_helper_conn_params conn_params_dummy;
-
-	__cmock_mqtt_client_init_Expect(&mqtt_client);
 
 	__cmock_zsock_freeaddrinfo_ExpectAnyArgs();
 	__cmock_mqtt_connect_ExpectAndReturn(&mqtt_client, -2);


### PR DESCRIPTION
Part of the MQTT client struct initialization is memset() on the structure and mutex initialization. Having this as a part of the client connect doesn't work well in multi-threaded environment (as in MQTT sample), where client reconnect can be triggered from a different thread than regular client processing. In such case, the mutex structure could be reinitialized while already being in use by the MQTT helper thread, leading to asserts.

Fix this by initializing the MQTT client structure once, on MQTT helper library init.

Jira: NCSIDB-1569