### PR TITLE
west.yml: Fix boot failures when MCUboot is used with LTO

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: e92888b3388147c0010017fcb78c5775ffebb9e5
+      revision: pull/437/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Change fixes placement of pointer to arm vector in MCUboot to prevent boot failures if MCUboot is used with LTO.

Jira: NCSDK-33099