### PR TITLE
applications: nrf_desktop: Enable LTO in MCUboot

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_mcuboot_qspi.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_mcuboot_qspi.conf
@@ -46,9 +46,9 @@ CONFIG_NCS_BOOT_BANNER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Disable Link Time Optimization (LTO). LTO causes application boot failures.
-CONFIG_LTO=n
-CONFIG_ISR_TABLES_LOCAL_DECLARATION=n
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
 
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_mcuboot_smp.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/prj_mcuboot_smp.conf
@@ -38,9 +38,9 @@ CONFIG_NCS_BOOT_BANNER=n
 # Use minimal C library instead of the Picolib
 CONFIG_MINIMAL_LIBC=y
 
-# Disable Link Time Optimization (LTO). LTO causes application boot failures.
-CONFIG_LTO=n
-CONFIG_ISR_TABLES_LOCAL_DECLARATION=n
+# Activate Link Time Optimization (LTO)
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
 
 # Improve debugging experience by disabling reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=n

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -211,8 +211,12 @@ nRF5340 Audio
 nRF Desktop
 -----------
 
-* Updated the application configurations for dongles on memory-limited SoCs (nRF52820) to reuse the system workqueue for GATT Discovery Manager (:kconfig:option:`CONFIG_BT_GATT_DM_WORKQ_SYS`).
-  This helps to reduce RAM usage.
+* Updated:
+
+  * Application configurations for dongles on memory-limited SoCs (nRF52820) to reuse the system workqueue for GATT Discovery Manager (:kconfig:option:`CONFIG_BT_GATT_DM_WORKQ_SYS`).
+    This helps to reduce RAM usage.
+  * Link Time Optimization (:kconfig:option:`CONFIG_LTO`) to be enabled in MCUboot configurations of the nRF52840 DK (``mcuboot_smp``, ``mcuboot_qspi``).
+    LTO no longer causes boot failures and it reduces the memory footprint.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
LTO no longer causes boot failures, enable it to reduce the memory footprint.

Jira: NCSDK-31751
Jira: NCSDK-33013