### PR TITLE
manifest: update zephyr to include link line duplication fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 42124163b77314d47091f99de2dd2e36c5ddf65c
+      revision: aa34a5632971262ce4002e73ed0fb09e9bd14808
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr to include fix which remove link flag duplication.