### PR TITLE
mpsl: Increase the default of CONFIG_MPSL_HFCLK_LATENCY

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -63,7 +63,8 @@ Developing with nRF70 Series
 Developing with nRF54L Series
 =============================
 
-|no_changes_yet_note|
+* Increased the default value of the :kconfig:option:`CONFIG_MPSL_HFCLK_LATENCY` Kconfig option to support slower crystals.
+  See the Kconfig description for a detailed description on how to select the correct value for a given application.
 
 Developing with nRF54H Series
 =============================

--- a/subsys/mpsl/init/Kconfig
+++ b/subsys/mpsl/init/Kconfig
@@ -77,25 +77,26 @@ config MPSL_LOW_PRIO_IRQN
 
 config MPSL_HFCLK_LATENCY
 	int "HFCLK ramp-up latency in microsecond, assumed by MPSL to wait for the clock availability"
-	default 854 if SOC_SERIES_NRF54LX
+	default 1650 if SOC_SERIES_NRF54LX
 	default 1400
 	help
 	  This option configures the amount of time MPSL will assume it takes
 	  for the HFCLK to be available after it's requested.
 	  Lowering this value will improve power consumption.
 	  Making this value too small can degrade BLE performance.
-	  In order to configure this value effectively, there are several considerations.
-	  This value needs to include the startup time of the HFXO, which will depend on various
-	  factors including the crystal itself, load capacitors, ESR,
-	  operating conditions, variations in bias voltage, etc. For complete information
-	  about the startup time for the HFXO in use, consult the relevant datasheet
-	  or contact the crystal vendor. Recommended load capacitances are
-	  given in the nordic product specifications.
-	  Additionally, depending on the product, a debounce period may be implemented
-	  in the nordic chip before the HFXO is considered available.
-	  For the nRF52 Series this is configured by the HFXODEBOUNCE register in
-	  the CLOCK peripheral. For the nRF53 Series application core it's
-	  configured by the HFXOCNT register in the UICR.
+
+	  To obtain an appropriate value for MPSL_HFCLK_LATENCY,
+	  measure the startup time.
+	  Set MPSL_HFCLK_LATENCY as twice this number to account for
+	  temperature and supply variations.
+	  On nRF52 and nRF53 Series devices, the startup time corresponds
+	  to the time between TASKS_HFCLKSTART and EVENTS_HFCLKSTARTED.
+	  On nRF54L Series devices, this corresponds to the time between
+	  TASKS_XOSTART and EVENTS_XOTUNED.
+
+	  Note that HFXO will need more time than usual on the first power-up
+	  to set up the appropriate drive level for the crystal used.
+	  The first power-up should not be used to set MPSL_HFCLK_LATENCY.
 
 config MPSL_CALIBRATION_PERIOD
 	int "Calibration callback period in milliseconds"


### PR DESCRIPTION
The new default value will also work for some typical slower crystals.

Jira: DRGN-25262