### PR TITLE
applications: nrf5340_audio: nRF5340DK LED and button support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -204,9 +204,12 @@ Matter bridge
 
 nRF5340 Audio
 -------------
+
 * Updated:
 
   * The application to use the ``NFC.TAGHEADER0`` value from FICR as the broadcast ID instead of using a random ID.
+  * The application now supports the nRF5340 DK for the LED state indications and button controls.
+
 
 nRF Desktop
 -----------


### PR DESCRIPTION
The application now supports a vanilla nRF5340DK for the fewer LEDs and buttons.
NOTE: For headsets there is still no audio output hardware codec