### PR TITLE
tests: benchmarks: nrf54h: Add test case for fast UART on slow domain…

### DIFF
--- a/tests/benchmarks/multicore/idle_uarte/boards/nrf54h20dk_nrf54h20_cpuapp_fast_slow_pins.overlay
+++ b/tests/benchmarks/multicore/idle_uarte/boards/nrf54h20dk_nrf54h20_cpuapp_fast_slow_pins.overlay
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * To execute this test case the following loopback
+ * is required: P2.04 <--> P2.06
+ * Note: Console UART is connected to P1 (if02)
+ */
+
+/ {
+	aliases {
+		led = &led0;
+		/delete-property/ led1;
+	};
+
+	chosen {
+		zephyr,console = &uart135;
+	};
+};
+
+/delete-node/ &led1;
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&cpuapp_dma_region {
+	status = "okay";
+};
+
+&pinctrl {
+	uart120_default_alt: uart120_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 2, 6)>,
+				<NRF_PSEL(UART_RX, 2, 4)>;
+		};
+	};
+
+	uart120_sleep_alt: uart120_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 2, 6)>,
+				<NRF_PSEL(UART_RX, 2, 4)>;
+			low-power-enable;
+		};
+	};
+};
+
+&uart136 {
+	status = "disabled";
+	/delete-property/ memory-regions;
+};
+
+&uart135 {
+	status = "okay";
+	memory-regions = <&cpuapp_dma_region>;
+	pinctrl-0 = <&uart135_default>;
+	pinctrl-1 = <&uart135_sleep>;
+	pinctrl-names = "default", "sleep";
+	current-speed = <115200>;
+	/delete-property/ hw-flow-control;
+};
+
+dut: &uart120 {
+	status = "okay";
+	memory-regions = <&dma_fast_region>;
+	pinctrl-0 = <&uart120_default_alt>;
+	pinctrl-1 = <&uart120_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	current-speed = <4000000>;
+	/delete-property/ hw-flow-control;
+};

--- a/tests/benchmarks/multicore/idle_uarte/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_uarte/testcase.yaml
@@ -43,6 +43,21 @@ tests:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_gated_uarte"
     timeout: 90
 
+
+  benchmarks.multicore.idle_uarte.fast.nrf54h20dk_cpuapp_cpurad.s2ram.slow_pins:
+    tags:
+      - ci_build
+      - ci_tests_benchmarks_multicore
+      - uarte
+    filter: not CONFIG_COVERAGE
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_slow_pins.overlay"
+    build_only: true
+
   benchmarks.multicore.idle_uarte.fast.nrf54h20dk_cpuapp_cpurad.s2ram.remote_gd_freq_switching:
     tags:
       - ci_build


### PR DESCRIPTION
… pins

Test fast UART on slow domain pins (P2) for nrf54h. This test will not execute in CI (requires specific conflicting setup), manual test only. Test case marked as 'build only'.