### PR TITLE
samples: matter: do not override PM_MCUBOOT_PAD sysbuild config

### DIFF
--- a/samples/matter/light_bulb/Kconfig.sysbuild
+++ b/samples/matter/light_bulb/Kconfig.sysbuild
@@ -63,17 +63,12 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 
 endif # SOC_SERIES_NRF53X
 
-if BOARD_NRF54L15DK_NRF54L15_CPUAPP_NS
+if BOARD_NRF54L15DK
 
-# Disable checking the external drivers for NS build.
 config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
 	default y
 
-# override the mcuboot pad size, because it is not set globally for NS build.
-config PM_MCUBOOT_PAD
-	default 0x800
-
-endif # BOARD_NRF54L15DK_NRF54L15_CPUAPP_NS
+endif # BOARD_NRF54L15DK
 
 endif # BOOTLOADER_MCUBOOT
 

--- a/samples/matter/light_switch/Kconfig.sysbuild
+++ b/samples/matter/light_switch/Kconfig.sysbuild
@@ -63,17 +63,12 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 
 endif # SOC_SERIES_NRF53X
 
-if BOARD_NRF54L15DK_NRF54L15_CPUAPP_NS
+if BOARD_NRF54L15DK
 
-# Disable checking the external drivers for NS build.
 config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
 	default y
 
-# override the mcuboot pad size, because it is not set globally for NS build.
-config PM_MCUBOOT_PAD
-	default 0x800
-
-endif # BOARD_NRF54L15DK_NRF54L15_CPUAPP_NS
+endif # BOARD_NRF54L15DK
 
 endif # BOOTLOADER_MCUBOOT
 

--- a/samples/matter/lock/Kconfig.sysbuild
+++ b/samples/matter/lock/Kconfig.sysbuild
@@ -63,17 +63,12 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 
 endif # SOC_SERIES_NRF53X
 
-if BOARD_NRF54L15DK_NRF54L15_CPUAPP_NS
+if BOARD_NRF54L15DK
 
-# Disable checking the external drivers for NS build.
 config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
 	default y
 
-# override the mcuboot pad size, because it is not set globally for NS build.
-config PM_MCUBOOT_PAD
-	default 0x800
-
-endif # BOARD_NRF54L15DK_NRF54L15_CPUAPP_NS
+endif # BOARD_NRF54L15DK
 
 endif # BOOTLOADER_MCUBOOT
 

--- a/samples/matter/manufacturer_specific/Kconfig.sysbuild
+++ b/samples/matter/manufacturer_specific/Kconfig.sysbuild
@@ -65,13 +65,8 @@ endif # SOC_SERIES_NRF53X
 
 if BOARD_NRF54L15DK
 
-# Disable checking the external drivers for nRF54L15 DKs.
 config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
 	default y
-
-# override the mcuboot pad size, because it is not set globally for NS build.
-config PM_MCUBOOT_PAD
-	default 0x800
 
 endif # BOARD_NRF54L15DK
 

--- a/samples/matter/template/Kconfig.sysbuild
+++ b/samples/matter/template/Kconfig.sysbuild
@@ -65,13 +65,8 @@ endif # SOC_SERIES_NRF53X
 
 if BOARD_NRF54L15DK
 
-# Disable checking the external drivers for nRF54L15 DKs.
 config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
 	default y
-
-# override the mcuboot pad size, because it is not set globally for NS build.
-config PM_MCUBOOT_PAD
-	default 0x800
 
 endif # BOARD_NRF54L15DK
 

--- a/samples/matter/thermostat/Kconfig.sysbuild
+++ b/samples/matter/thermostat/Kconfig.sysbuild
@@ -63,17 +63,12 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 
 endif # SOC_SERIES_NRF53X
 
-if BOARD_NRF54L15DK_NRF54L15_CPUAPP_NS
+if BOARD_NRF54L15DK
 
-# Disable checking the external drivers for NS build.
 config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
 	default y
 
-# override the mcuboot pad size, because it is not set globally for NS build.
-config PM_MCUBOOT_PAD
-	default 0x800
-
-endif # BOARD_NRF54L15DK_NRF54L15_CPUAPP_NS
+endif # BOARD_NRF54L15DK
 
 endif # BOOTLOADER_MCUBOOT
 

--- a/samples/matter/window_covering/Kconfig.sysbuild
+++ b/samples/matter/window_covering/Kconfig.sysbuild
@@ -63,17 +63,12 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 
 endif # SOC_SERIES_NRF53X
 
-if BOARD_NRF54L15DK_NRF54L15_CPUAPP_NS
+if BOARD_NRF54L15DK
 
-# Disable checking the external drivers for NS build.
 config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
 	default y
 
-# override the mcuboot pad size, because it is not set globally for NS build.
-config PM_MCUBOOT_PAD
-	default 0x800
-
-endif # BOARD_NRF54L15DK_NRF54L15_CPUAPP_NS
+endif # BOARD_NRF54L15DK
 
 endif # BOOTLOADER_MCUBOOT
 


### PR DESCRIPTION
This commit removes redundant configuration of sysbuild config PM_MCUBOOT_PAD.

This is no longer needed after #17334 
