### PR TITLE
CODEOWNERS: Extend owners for lpuart sample

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -542,7 +542,7 @@
 /samples/openthread/                      @nrfconnect/ncs-co-networking @nrfconnect/ncs-thread
 /samples/peripheral/802154_phy_test/      @nrfconnect/ncs-radio-sw
 /samples/peripheral/802154_sniffer/       @e-rk
-/samples/peripheral/lpuart/               @nordic-krch
+/samples/peripheral/lpuart/               @nordic-krch @nrfconnect/ncs-low-level-test
 /samples/peripheral/radio_test/           @nrfconnect/ncs-si-muffin
 /samples/pmic/native/                     @nordic-auko
 /samples/sensor/bh1749/                   @nrfconnect/ncs-co-drivers @nrfconnect/ncs-cia


### PR DESCRIPTION
Add ll testers.