### PR TITLE
esb: align 4 mbit radio data rate setting for nRF54H20 and nRF54L

### DIFF
--- a/include/esb.h
+++ b/include/esb.h
@@ -122,15 +122,10 @@ enum esb_bitrate {
 	ESB_BITRATE_2MBPS_BLE = NRF_RADIO_MODE_BLE_2MBIT,
 #endif /* defined(RADIO_MODE_MODE_Ble_2Mbit) || defined(__DOXYGEN__) */
 
-#if defined(RADIO_MODE_MODE_Nrf_4Mbit0_5) || defined(__DOXYGEN__)
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) || defined(__DOXYGEN__)
 	/** 4 Mb radio mode. */
-	ESB_BITRATE_4MBPS = NRF_RADIO_MODE_NRF_4MBIT_H_0_5,
-#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit0_5) || defined(__DOXYGEN__) */
-
-#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6)
-	/** 4 Mb radio mode. */
-	ESB_BITRATE_4MBPS = RADIO_MODE_MODE_Nrf_4Mbit_0BT6,
-#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) */
+	ESB_BITRATE_4MBPS = NRF_RADIO_MODE_NRF_4MBIT_BT_0_6,
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) || defined(__DOXYGEN__) */
 };
 
 /** @brief Enhanced ShockBurst CRC modes. */

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -646,11 +646,11 @@ static void update_rf_payload_format_esb_dpl(uint32_t payload_length)
 	}
 #endif /* defined(RADIO_MODE_MODE_Ble_2Mbit) */
 
-#if defined(RADIO_MODE_MODE_Nrf_4Mbit0_5) || defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6)
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6)
 	if (esb_cfg.bitrate == ESB_BITRATE_4MBPS) {
 		packet_config.plen = NRF_RADIO_PREAMBLE_LENGTH_16BIT;
 	}
-#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit0_5) || defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) */
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) */
 
 #endif /* defined(RADIO_PCNF0_PLEN_Msk) */
 
@@ -896,11 +896,11 @@ static bool update_radio_bitrate(void)
 
 	switch (esb_cfg.bitrate) {
 
-#if defined(RADIO_MODE_MODE_Nrf_4Mbit0_5) || defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6)
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6)
 	case ESB_BITRATE_4MBPS:
 		wait_for_ack_timeout_us = RX_ACK_TIMEOUT_US_4MBPS;
 		break;
-#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit0_5) || define(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) */
+#endif /* defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6) */
 
 	case ESB_BITRATE_2MBPS:
 


### PR DESCRIPTION
The 4 Mb radio modes with BT=0.5 have been removed from nRF54H20 register definitions. The recommended mode for the 4 Mb data rate is BT=0.6/h=0.5 - use it as the only 4 Mb option for ESB.