### PR TITLE
applications: nrf5340_audio: Stop using OPT_USE_NAME in adv

### DIFF
--- a/applications/nrf5340_audio/broadcast_sink/main.c
+++ b/applications/nrf5340_audio/broadcast_sink/main.c
@@ -537,6 +537,11 @@ static int ext_adv_populate(struct bt_data *ext_adv_buf, size_t ext_adv_buf_size
 		return ret;
 	}
 
+	ext_adv_buf[ext_adv_buf_cnt].type = BT_DATA_NAME_COMPLETE;
+	ext_adv_buf[ext_adv_buf_cnt].data = CONFIG_BT_DEVICE_NAME;
+	ext_adv_buf[ext_adv_buf_cnt].data_len = sizeof(CONFIG_BT_DEVICE_NAME) - 1;
+	ext_adv_buf_cnt++;
+
 	ret = broadcast_sink_adv_populate(&ext_adv_buf[ext_adv_buf_cnt],
 					  ext_adv_buf_size - ext_adv_buf_cnt);
 

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/bt_mgmt_adv.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/advertising/bt_mgmt_adv.c
@@ -44,7 +44,7 @@ static struct bt_le_adv_param ext_adv_param = {
 	.id = BT_ID_DEFAULT,
 	.sid = CONFIG_BLE_ACL_ADV_SID,
 	.secondary_max_skip = 0,
-	.options = BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_USE_NAME,
+	.options = BT_LE_ADV_OPT_EXT_ADV,
 	.interval_min = CONFIG_BLE_ACL_EXT_ADV_INT_MIN,
 	.interval_max = CONFIG_BLE_ACL_EXT_ADV_INT_MAX,
 	.peer = NULL,
@@ -320,10 +320,10 @@ void bt_mgmt_dir_adv_timed_out(uint8_t ext_adv_index)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_FILTER_ACCEPT_LIST)) {
-		ret = bt_le_ext_adv_create(LE_AUDIO_EXTENDED_ADV_CONN_NAME_FILTER, &adv_cb,
+		ret = bt_le_ext_adv_create(LE_AUDIO_EXTENDED_ADV_CONN_FILTER, &adv_cb,
 					   &ext_adv[ext_adv_index]);
 	} else {
-		ret = bt_le_ext_adv_create(LE_AUDIO_EXTENDED_ADV_CONN_NAME, &adv_cb,
+		ret = bt_le_ext_adv_create(LE_AUDIO_EXTENDED_ADV_CONN, &adv_cb,
 					   &ext_adv[ext_adv_index]);
 	}
 
@@ -449,7 +449,7 @@ int bt_mgmt_adv_start(uint8_t ext_adv_index, const struct bt_data *adv, size_t a
 	}
 
 	if (connectable) {
-		ret = bt_le_ext_adv_create(LE_AUDIO_EXTENDED_ADV_CONN_NAME, &adv_cb,
+		ret = bt_le_ext_adv_create(LE_AUDIO_EXTENDED_ADV_CONN, &adv_cb,
 					   &ext_adv[ext_adv_index]);
 		if (ret) {
 			LOG_ERR("Unable to create a connectable extended advertising set: %d", ret);

--- a/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/bt_mgmt.h
@@ -11,17 +11,16 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/audio.h>
 
-#define LE_AUDIO_EXTENDED_ADV_NAME                                                                 \
-	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_USE_NAME,                            \
+#define LE_AUDIO_EXTENDED_ADV                                                                      \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, CONFIG_BLE_ACL_EXT_ADV_INT_MIN,                     \
+			CONFIG_BLE_ACL_EXT_ADV_INT_MAX, NULL)
+
+#define LE_AUDIO_EXTENDED_ADV_CONN                                                                 \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONN,                                \
 			CONFIG_BLE_ACL_EXT_ADV_INT_MIN, CONFIG_BLE_ACL_EXT_ADV_INT_MAX, NULL)
 
-#define LE_AUDIO_EXTENDED_ADV_CONN_NAME                                                            \
-	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_USE_NAME,       \
-			CONFIG_BLE_ACL_EXT_ADV_INT_MIN, CONFIG_BLE_ACL_EXT_ADV_INT_MAX, NULL)
-
-#define LE_AUDIO_EXTENDED_ADV_CONN_NAME_FILTER                                                     \
-	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_USE_NAME |      \
-				BT_LE_ADV_OPT_FILTER_CONN,                                         \
+#define LE_AUDIO_EXTENDED_ADV_CONN_FILTER                                                          \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_FILTER_CONN,    \
 			CONFIG_BLE_ACL_EXT_ADV_INT_MIN, CONFIG_BLE_ACL_EXT_ADV_INT_MAX, NULL)
 
 #define LE_AUDIO_PERIODIC_ADV                                                                      \

--- a/applications/nrf5340_audio/unicast_server/main.c
+++ b/applications/nrf5340_audio/unicast_server/main.c
@@ -480,6 +480,11 @@ static int ext_adv_populate(struct bt_data *ext_adv_buf, size_t ext_adv_buf_size
 		return ret;
 	}
 
+	ext_adv_buf[ext_adv_buf_cnt].type = BT_DATA_NAME_COMPLETE;
+	ext_adv_buf[ext_adv_buf_cnt].data = CONFIG_BT_DEVICE_NAME;
+	ext_adv_buf[ext_adv_buf_cnt].data_len = sizeof(CONFIG_BT_DEVICE_NAME) - 1;
+	ext_adv_buf_cnt++;
+
 	ret = unicast_server_adv_populate(&ext_adv_buf[ext_adv_buf_cnt],
 					  ext_adv_buf_size - ext_adv_buf_cnt);
 


### PR DESCRIPTION
- Put device name in ext_adv data directly instead of using the deprecated BT_LE_ADV_OPT_USE_NAME.
- OCT-3364