### PR TITLE
samples: peripheral: radio_test: Add experimental LLVM support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -351,7 +351,9 @@ nRF5340 samples
 Peripheral samples
 ------------------
 
-|no_changes_yet_note|
+* :ref:`radio_test` sample:
+
+  * Added experimental ``llvm`` toolchain support for the ``nrf54l15dk/nrf54l15/cpuapp`` board target.
 
 PMIC samples
 ------------

--- a/samples/peripheral/radio_test/sample.yaml
+++ b/samples/peripheral/radio_test/sample.yaml
@@ -104,3 +104,17 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_peripheral_radio_test
+  sample.peripheral.radio_test.llvm:
+    toolchain_allow: llvm
+    sysbuild: true
+    build_only: true
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_peripheral_radio_test


### PR DESCRIPTION
Introduced experimental LLVM support in the radio_test sample.

Ref: NCSDK-33299