### PR TITLE
lib: nrf_modem_lib: Add missing parameter initialization

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os_rpc.c
+++ b/lib/nrf_modem_lib/nrf_modem_os_rpc.c
@@ -130,6 +130,7 @@ int nrf_modem_os_rpc_open(struct nrf_modem_os_rpc *instance,
 	instance->conf.mbox_rx.dev = (struct device *)config->rx.sigdev;
 	instance->conf.mbox_tx.channel_id = config->tx.ch;
 	instance->conf.mbox_rx.channel_id = config->rx.ch;
+	instance->conf.unbound_mode = ICMSG_UNBOUND_MODE_DISABLE;
 
 	instance->cb.bound = config->cb.bound;
 	instance->cb.received = config->cb.received;


### PR DESCRIPTION
Added missing icmsg instance parameter initialization. Because the parameter was not properly initialized, the icmsg handshake failed.