### PR TITLE
sysbuild: Fix including correct files for b0 with MCUboot

### DIFF
--- a/cmake/sysbuild/b0_mcuboot_signing.cmake
+++ b/cmake/sysbuild/b0_mcuboot_signing.cmake
@@ -101,6 +101,21 @@ function(ncs_secure_boot_mcuboot_sign application bin_files signed_targets prefi
       ${application_image_dir}/zephyr/.config
       ${CMAKE_BINARY_DIR}/signed_by_b0_${application}.hex
       )
+
+    if(SB_CONFIG_PARTITION_MANAGER AND NOT prefix)
+      # Set the partition manager hex file and target
+      set_property(
+        GLOBAL PROPERTY
+        ${application}_PM_HEX_FILE
+        ${output}.hex
+      )
+
+      set_property(
+        GLOBAL PROPERTY
+        ${application}_PM_TARGET
+        ${application}_signed_packaged_target
+      )
+    endif()
   endif()
 
   # Add the west sign calls and their byproducts to the post-processing

--- a/cmake/sysbuild/sign.cmake
+++ b/cmake/sysbuild/sign.cmake
@@ -303,17 +303,20 @@ function(b0_sign_image slot cpunet_target)
     signature_public_key_file_target
     )
 
-  # Set hex file and target for the ${slot) (s0/s1) container partition.
-  # This includes the hex file (and its corresponding target) to the build.
-  set_property(
-    GLOBAL PROPERTY
-    ${target_name}_PM_HEX_FILE
-    ${signed_hex}
+  if(NOT SB_CONFIG_BOOTLOADER_MCUBOOT OR cpunet_target)
+    # Set hex file and target for the ${slot) (s0/s1) container partition.
+    # This includes the hex file (and its corresponding target) to the build.
+    # Only do this if this is the network core target or MCUboot is not enabled
+    set_property(
+      GLOBAL PROPERTY
+      ${target_name}_PM_HEX_FILE
+      ${signed_hex}
     )
 
-  set_property(
-    GLOBAL PROPERTY
-    ${target_name}_PM_TARGET
-    ${slot}_signed_kernel_hex_target
+    set_property(
+      GLOBAL PROPERTY
+      ${target_name}_PM_TARGET
+      ${slot}_signed_kernel_hex_target
     )
+  endif()
 endfunction()


### PR DESCRIPTION
Fixes which files are included with partition manager when b0 is enabled and MCUboot is also enabled, which otherwise would have used the files without MCUboot signatures, which would fail to boot if image verification on boot is enabled

Fixes: NCSIDB-1549