### PR TITLE
Remove SoC argument from west ncs-provision command

### DIFF
--- a/applications/nrf_desktop/pytest/test_mcuboot_kmu.py
+++ b/applications/nrf_desktop/pytest/test_mcuboot_kmu.py
@@ -39,9 +39,8 @@ def _mcuboot_key_path(dut: DeviceAdapter):
 
 
 def mcuboot_provision(dut: DeviceAdapter):
-    soc = dut.device_config.platform.split("/")[1]
     key_path = _mcuboot_key_path(dut)
-    command = ["west", "ncs-provision", "upload", "-s", soc, "-k", key_path]
+    command = ["west", "ncs-provision", "upload", "-k", key_path]
     if dut.device_config.id:
         command.extend(["--dev-id", dut.device_config.id])
 

--- a/doc/nrf/app_dev/device_guides/nrf54l/kmu_provision.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/kmu_provision.rst
@@ -58,9 +58,7 @@ Once you have an unprovisioned SoC, upload keys to the board by running one of t
       .. parsed-literal::
         :class: highlight
 
-          west ncs-provision upload -s nrf54l15 -k ed25519.pem -k ed25519-1.pem -k ed25519-2.pem --keyname UROT_PUBKEY
-
-      * Parameter ``-s (-–soc)`` specifies the target device.
+          west ncs-provision upload -k ed25519.pem -k ed25519-1.pem -k ed25519-2.pem --keyname UROT_PUBKEY
 
       * Parameter ``-k (-–key)`` specifies the private key PEM files to be provisioned to the SoC.
         You can specify up to three keys.
@@ -123,7 +121,7 @@ Once you have an unprovisioned SoC, upload keys to the board by running one of t
       .. parsed-literal::
         :class: highlight
 
-          west ncs-provision upload -s nrf54l15 -k ed25519.pem --keyname UROT_PUBKEY
+          west ncs-provision upload -k ed25519.pem --keyname UROT_PUBKEY
 
    .. tab:: nRF Util
 

--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -640,9 +640,8 @@ Assuming that your current working directory points to this sample directory, yo
 .. parsed-literal::
    :class: highlight
 
-   west ncs-provision upload -s <soc> -k sysbuild/configuration/<board_target>/boot_signature_key_file_<algorithm>.pem --keyname UROT_PUBKEY
+   west ncs-provision upload -k sysbuild/configuration/<board_target>/boot_signature_key_file_<algorithm>.pem --keyname UROT_PUBKEY
 
-* The ``<soc>`` placeholder is the SoC name used in your board target (for example, ``nrf54l15``).
 * The ``<board_target>`` placeholder is your board target name (for example, ``nrf54l15dk/nrf54l15/cpuapp``).
 * The ``<algorithm>`` placeholder is the algorithm used to generate the key pair for the application image signature generation and verification (for example, ``ed25519``).
 
@@ -651,7 +650,7 @@ The examplary command for the ``nrf54l15dk/nrf54l15/cpuapp`` board target and th
 .. parsed-literal::
    :class: highlight
 
-   west ncs-provision upload -s nrf54l15 -k sysbuild/configuration/nrf54l15dk_nrf54l15_cpuapp/boot_signature_key_file_ed25519.pem --keyname UROT_PUBKEY
+   west ncs-provision upload -k sysbuild/configuration/nrf54l15dk_nrf54l15_cpuapp/boot_signature_key_file_ed25519.pem --keyname UROT_PUBKEY
 
 See :ref:`ug_nrf54l_developing_provision_kmu` for further details regarding the KMU provisioning process.
 

--- a/scripts/west_commands/ncs_provision.py
+++ b/scripts/west_commands/ncs_provision.py
@@ -164,10 +164,7 @@ class NcsProvision(WestCommand):
         upload_parser.add_argument(
             "-s",
             "--soc",
-            type=str,
-            help="SoC",
-            choices=["nrf54l05", "nrf54l10", "nrf54l15", "nrf54lm20a"],
-            required=True,
+            help="Deprecated, is not used anymore."
         )
         upload_parser.add_argument("--dev-id", help="Device serial number")
         upload_parser.add_argument(
@@ -187,8 +184,7 @@ class NcsProvision(WestCommand):
 
     def do_run(self, args, unknown_args):
         if args.command == "upload":
-            if args.soc in ["nrf54l05", "nrf54l10", "nrf54l15", "nrf54lm20a"]:
-                self._upload_keys(args)
+            self._upload_keys(args)
 
     def _upload_keys(self, args: argparse.Namespace) -> None:
         slots: list[SlotParams] = []

--- a/tests/subsys/kmu/pytest/common.py
+++ b/tests/subsys/kmu/pytest/common.py
@@ -76,15 +76,13 @@ def flash_board(build_dir: Path | str, dev_id: str | None, erase: bool = False):
 def provision_keys_for_kmu(
         keys: list[str] | str,
         keyname: str = "UROT_PUBKEY",  # UROT_PUBKEY, BL_PUBKEY, APP_PUBKEY
-        soc: str = "nrf54l15",  # nrf54l15, nrf54l10, nrf54l05
         policy: str | None = None,  # revokable, lock, lock-last (default)
         dev_id: str | None = None
 ):
     logger.info("Provision keys using west command.")
     command = [
         'west', 'ncs-provision', 'upload',
-        '--keyname', keyname,
-        '--soc', soc
+        '--keyname', keyname
     ]
     if policy:
         command += ['--policy', policy]


### PR DESCRIPTION
Removed SoC argument from west ncs-provision command.
SoC was required in previous version of ncs-provision script, where nrfutil was not used.

Updated docs and tests.