### PR TITLE
sysbuild: Migrate from sysbuild_dt_*

### DIFF
--- a/cmake/sysbuild/fast_pair/hex.cmake
+++ b/cmake/sysbuild/fast_pair/hex.cmake
@@ -86,9 +86,9 @@ function(fast_pair_hex_dts)
 
   set(fp_partition_name bt_fast_pair_partition)
 
-  sysbuild_dt_nodelabel(
+  dt_nodelabel(
     bt_fast_pair_partition_node_full_path
-    IMAGE
+    TARGET
     ${DEFAULT_IMAGE}
     NODELABEL
     "${fp_partition_name}"
@@ -101,9 +101,9 @@ function(fast_pair_hex_dts)
             "data generation with the SB_CONFIG_BT_FAST_PAIR_PROV_DATA Kconfig.")
   endif()
 
-  sysbuild_dt_reg_addr(
+  dt_reg_addr(
     bt_fast_pair_partition_relative_address
-    IMAGE
+    TARGET
     ${DEFAULT_IMAGE}
     PATH
     "${bt_fast_pair_partition_node_full_path}"
@@ -120,9 +120,9 @@ function(fast_pair_hex_dts)
     nvm_node_full_path
     "${bt_fast_pair_partition_node_parent_full_path}"
     )
-  sysbuild_dt_reg_addr(
+  dt_reg_addr(
     nvm_base_address
-    IMAGE
+    TARGET
     ${DEFAULT_IMAGE}
     PATH
     "${nvm_node_full_path}"

--- a/cmake/sysbuild/image_signing_nrf700x.cmake
+++ b/cmake/sysbuild/image_signing_nrf700x.cmake
@@ -26,10 +26,10 @@ function(nrf7x_signing_tasks input output_hex output_bin dependencies)
   endif()
 
   # Fetch devicetree details for flash and slot information
-  sysbuild_dt_chosen(flash_node IMAGE ${DEFAULT_IMAGE} PROPERTY "zephyr,flash")
-  sysbuild_dt_nodelabel(slot0_flash IMAGE ${DEFAULT_IMAGE} NODELABEL "slot0_partition" REQUIRED)
-  sysbuild_dt_prop(slot_size IMAGE ${DEFAULT_IMAGE} PATH "${slot0_flash}" PROPERTY "reg" INDEX 1 REQUIRED)
-  sysbuild_dt_prop(write_block_size IMAGE ${DEFAULT_IMAGE} PATH "${flash_node}" PROPERTY "write-block-size")
+  dt_chosen(flash_node TARGET ${DEFAULT_IMAGE} PROPERTY "zephyr,flash")
+  dt_nodelabel(slot0_flash TARGET ${DEFAULT_IMAGE} NODELABEL "slot0_partition" REQUIRED)
+  dt_prop(slot_size TARGET ${DEFAULT_IMAGE} PATH "${slot0_flash}" PROPERTY "reg" INDEX 1 REQUIRED)
+  dt_prop(write_block_size TARGET ${DEFAULT_IMAGE} PATH "${flash_node}" PROPERTY "write-block-size")
 
   if(NOT write_block_size)
     set(write_block_size 4)

--- a/cmake/sysbuild/nrf700x.cmake
+++ b/cmake/sysbuild/nrf700x.cmake
@@ -5,8 +5,8 @@
 #
 
 function(setup_nrf700x_xip_data)
-  sysbuild_dt_nodelabel(qspi_nodelabel IMAGE ${DEFAULT_IMAGE} NODELABEL "qspi")
-  sysbuild_dt_reg_addr(qspi_xip_address IMAGE ${DEFAULT_IMAGE} PATH "${qspi_nodelabel}" NAME "qspi_mm")
+  dt_nodelabel(qspi_nodelabel TARGET ${DEFAULT_IMAGE} NODELABEL "qspi")
+  dt_reg_addr(qspi_xip_address TARGET ${DEFAULT_IMAGE} PATH "${qspi_nodelabel}" NAME "qspi_mm")
 
   set(NRF70_FW_BINS ${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_wifi/bin/ncs)
 

--- a/cmake/sysbuild/suit_provisioning.cmake
+++ b/cmake/sysbuild/suit_provisioning.cmake
@@ -14,9 +14,9 @@ set(MPI_BINARY_DIR ${DEFAULT_BINARY_DIR}/zephyr)
 # Store the absolute address of the SUIT storage inside CMake cache.
 #
 function(configure_storage_address_cache)
-  sysbuild_dt_nodelabel(
+  dt_nodelabel(
     suit_storage_dev
-    IMAGE
+    TARGET
     ${DEFAULT_IMAGE}
     NODELABEL
     "suit_storage_partition"
@@ -28,9 +28,9 @@ function(configure_storage_address_cache)
   endif()
 
   # Calculate SUIT storage address, based on the DTS
-  sysbuild_dt_reg_addr(
+  dt_reg_addr(
     suit_storage_address
-    IMAGE
+    TARGET
     ${DEFAULT_IMAGE}
     PATH
     "${suit_storage_dev}"

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_3.1.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_3.1.rst
@@ -40,6 +40,48 @@ This section describes the changes related to libraries.
 
 .. _migration_3.1_recommended:
 
+Build system
+============
+
+.. toggle::
+
+   * In sysbuild, the following CMake extensions have been removed:
+
+     * ``sysbuild_dt_nodelabel``
+     * ``sysbuild_dt_alias``
+     * ``sysbuild_dt_node_exists``
+     * ``sysbuild_dt_node_has_status``
+     * ``sysbuild_dt_prop``
+     * ``sysbuild_dt_comp_path``
+     * ``sysbuild_dt_num_regs``
+     * ``sysbuild_dt_reg_addr``
+     * ``sysbuild_dt_reg_size``
+     * ``sysbuild_dt_has_chosen``
+     * ``sysbuild_dt_chosen``
+
+     You must now use pre-existing devicetree extensions, such as ``dt_nodelabel``, without the ``sysbuild_`` prefix.
+     To specify the sysbuild image, use the ``TARGET`` argument in place of ``IMAGE``.
+
+     The following example shows one of the removed functions:
+
+     .. code-block:: none
+
+        sysbuild_dt_chosen(
+          flash_node
+          IMAGE ${DEFAULT_IMAGE}
+          PROPERTY "zephyr,flash"
+        )
+
+     It should now be modified as follows:
+
+     .. code-block:: none
+
+        dt_chosen(
+          flash_node
+          TARGET ${DEFAULT_IMAGE}
+          PROPERTY "zephyr,flash"
+        )
+
 Recommended changes
 *******************
 

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ad267ac6302f390e3387d5e7d79974f36214c6a5
+      revision: f1626faca7b6ff5a2a7f45ee2b085599999c08ed
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -156,7 +156,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 4ec4f3bcbcabd69969a628f9bb328501566a8cd7
+      revision: ab711a4c10ce17f498c9f804444e12546855cb37
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
The `sysbuild_dt_*` CMake API came from upstream Zephyr PR #: 73903. This had been in review for almost a year, and in the end, the proposed API ended up being replaced.

This merits an entry in the migration guide. Note that since the API was cherry-picked from PR, there's no deprecation process.