### PR TITLE
applications: serial_lte_modem: Trigger indicate pin for PPP DL data

### DIFF
--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -56,11 +56,52 @@ tests:
     tags:
       - ci_build
       - sysbuild
+  applications.serial_lte_modem.ppp_without_cmux_power_indicate_pin:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-ppp.conf"
+      - EXTRA_DTC_OVERLAY_FILE="overlay-ppp-without-cmux.overlay"
+    extra_configs:
+      - CONFIG_SLM_POWER_PIN=31
+      - CONFIG_SLM_INDICATE_PIN=30
+    platform_allow:
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151/ns
+      - nrf9131ek/nrf9131/ns
+      - thingy91/nrf9160/ns
+      - thingy91x/nrf9151/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
   applications.serial_lte_modem.ppp_cmux_linux:
     sysbuild: true
     build_only: true
     extra_args:
       - EXTRA_CONF_FILE="overlay-ppp-cmux-linux.conf"
+    platform_allow:
+      - nrf9160dk/nrf9160/ns
+      - nrf9161dk/nrf9161/ns
+      - nrf9151dk/nrf9151/ns
+      - nrf9131ek/nrf9131/ns
+      - thingy91/nrf9160/ns
+      - thingy91x/nrf9151/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+  applications.serial_lte_modem.ppp_cmux_linux_power_indicate_pin:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-ppp-cmux-linux.conf"
+    extra_configs:
+      - CONFIG_SLM_POWER_PIN=31
+      - CONFIG_SLM_INDICATE_PIN=30
     platform_allow:
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns

--- a/applications/serial_lte_modem/src/slm_ppp.c
+++ b/applications/serial_lte_modem/src/slm_ppp.c
@@ -20,6 +20,7 @@
 #include <zephyr/posix/sys/eventfd.h>
 #include <zephyr/posix/sys/socket.h>
 #include <zephyr/random/random.h>
+#include <zephyr/pm/device.h>
 #include <assert.h>
 
 LOG_MODULE_REGISTER(slm_ppp, CONFIG_SLM_LOG_LEVEL);
@@ -33,6 +34,7 @@ bool slm_fwd_cgev_notifs;
 #if defined(CONFIG_SLM_CMUX)
 BUILD_ASSERT(!DT_NODE_EXISTS(DT_CHOSEN(ncs_slm_ppp_uart)),
 	"When CMUX is enabled PPP is usable only through it so it cannot have its own UART.");
+static const struct device *ppp_uart_dev = DEVICE_DT_GET(DT_CHOSEN(ncs_slm_uart));
 #else
 static const struct device *ppp_uart_dev = DEVICE_DT_GET(DT_CHOSEN(ncs_slm_ppp_uart));
 #endif
@@ -668,6 +670,7 @@ static void ppp_data_passing_thread(void*, void*, void*)
 {
 	const size_t mtu = net_if_get_mtu(ppp_iface);
 	struct zsock_pollfd fds[PPP_FDS_COUNT];
+	enum pm_device_state state = PM_DEVICE_STATE_OFF;
 
 	for (size_t i = 0; i != ARRAY_SIZE(fds); ++i) {
 		fds[i].fd = ppp_fds[i];
@@ -706,6 +709,14 @@ static void ppp_data_passing_thread(void*, void*, void*)
 				delegate_ppp_event(PPP_STOP, PPP_REASON_DEFAULT);
 				return;
 			}
+
+			/* Check if UART is suspended */
+			pm_device_state_get(ppp_uart_dev, &state);
+			if (state != PM_DEVICE_STATE_ACTIVE) {
+				LOG_DBG("UART not active");
+				slm_indicate();
+			}
+
 			const ssize_t len =
 				zsock_recv(fds[src].fd, ppp_data_buf, mtu, ZSOCK_MSG_DONTWAIT);
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -236,6 +236,7 @@ Serial LTE modem
   * The initialization of the application to ignore a failure in nRF Cloud module initialization.
     This occurs sometimes especially during development.
   * The initialization of the application to send "INIT ERROR" over to UART and show clear error log to indicate that the application is not operational in case of failing initialization.
+  * The PPP downlink data to trigger indicate pin when SLM is in idle.
 
 Thingy:53: Matter weather station
 ---------------------------------


### PR DESCRIPTION
When SLM is in idle (`AT#XSLEEP=2`), it didn't trigger indicate pin. This is now changed.

Jira: LRCS-193