### PR TITLE
boards: Update lfxo node on nRF54LV10-DK and nRF54LM20-PDK

### DIFF
--- a/boards/nordic/nrf54lm20pdk/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20a_cpuapp_common.dtsi
@@ -33,7 +33,7 @@
 
 &lfxo {
 	load-capacitors = "internal";
-	load-capacitance-femtofarad = <15500>;
+	load-capacitance-femtofarad = <17000>;
 };
 
 &hfxo {

--- a/boards/nordic/nrf54lv10dk/nrf54lv10a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lv10dk/nrf54lv10a_cpuapp_common.dtsi
@@ -34,7 +34,7 @@
 
 &lfxo {
 	load-capacitors = "internal";
-	load-capacitance-femtofarad = <15500>;
+	load-capacitance-femtofarad = <17000>;
 };
 
 &hfxo {


### PR DESCRIPTION
Update the lfxo node load-capacitance-femtofarad to match the chosen external lfxo on the following DK designs:
* nRF54LM20-PDK
* nRF54LV10-DK

Previous stray capacitance value was calculated incorrectly, which resulted in a too low load capacitance.