### PR TITLE
bluetooth: samples: Save and restore local steps in RAS server callback

### DIFF
--- a/subsys/bluetooth/services/ras/rrsp/ras_rd_buffer.c
+++ b/subsys/bluetooth/services/ras/rrsp/ras_rd_buffer.c
@@ -272,7 +272,11 @@ static void subevent_data_available(struct bt_conn *conn,
 		hdr->num_steps_reported = result->header.num_steps_reported;
 
 		if (result->step_data_buf) {
+			struct net_buf_simple_state buf_state;
+
+			net_buf_simple_save(result->step_data_buf, &buf_state);
 			bt_le_cs_step_data_parse(result->step_data_buf, process_step_data, buf);
+			net_buf_simple_restore(result->step_data_buf, &buf_state);
 		}
 	}
 


### PR DESCRIPTION
Because of the way connection callbacks work, and because bt_le_cs_step_data_parse() consumes the data in the buffer, any user callbacks called after this module's would end up losing access to the step data.

To avoid this problem, we can do a simple save and restore when parsing.