### PR TITLE
Cracen kmu fixes

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
@@ -1354,7 +1354,8 @@ psa_status_t cracen_copy_key(psa_key_attributes_t *attributes, const uint8_t *so
 		return PSA_ERROR_DOES_NOT_EXIST;
 	}
 
-	if (PSA_KEY_TYPE_IS_ECC(psa_get_key_type(attributes))) {
+	if (PSA_KEY_TYPE_IS_ECC(psa_get_key_type(attributes)) ||
+	    (psa_get_key_type(attributes) == PSA_KEY_TYPE_HMAC)) {
 		size_t key_bits;
 
 		return cracen_import_key(attributes, source_key, source_key_length,

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -864,10 +864,10 @@ psa_status_t cracen_kmu_provision(const psa_key_attributes_t *key_attr, int slot
 	/* Provisioning data for encrypted keys:
 	 *     - Nonce
 	 *     - Key material (first 128 bits)
-	 *     - Key material (optional for keys > 128 bits.)
+	 *     - Key material (optional for keys > 128 bits. Up to 512 bits.)
 	 *     - Tag
 	 */
-	uint8_t encrypted_workmem[CRACEN_KMU_SLOT_KEY_SIZE * 4] = {};
+	uint8_t encrypted_workmem[CRACEN_KMU_SLOT_KEY_SIZE * 6] = {};
 #endif
 	psa_status_t status = clean_up_unfinished_provisioning();
 


### PR DESCRIPTION
Increase KMU encrypted workmem to handle 512 bits keys.
Fix for copy of HMAC keys.