### PR TITLE
Nrf7120 enga auxpll support

### DIFF
--- a/boards/nordic/nrf7120pdk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120pdk/nrf7120_cpuapp_common.dtsi
@@ -184,6 +184,11 @@
 	status = "okay";
 };
 
+&audio_auxpll {
+	nordic,frequency = <NRF_AUXPLL_FREQ_DIV_AUDIO_48K>;
+	status = "okay";
+};
+
 &cpuapp_bellboard {
 	status = "okay";
 };

--- a/dts/common/nordic/nrf7120_enga.dtsi
+++ b/dts/common/nordic/nrf7120_enga.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/clock/nrf-auxpll.h>
 
 /delete-node/ &sw_pwm;
 
@@ -112,7 +113,7 @@
 		ficr: ficr@ffc000 {
 			compatible = "nordic,nrf-ficr";
 			reg = <0xffc000 0x1000>;
-			status = "disabled";
+			#nordic,ficr-cells = <1>;
 		};
 
 #ifdef USE_NON_SECURE_ADDRESS_MAP
@@ -666,6 +667,13 @@
 				status = "disabled";
 			};
 
+			tdm: tdm@e8000 {
+				compatible = "nordic,nrf-tdm";
+				reg = <0xe8000 0x1000>;
+				interrupts = <232 NRF_DEFAULT_IRQ_PRIORITY>;
+				status = "disabled";
+			};
+
 			spi23: spi@ed000 {
 				compatible = "nordic,nrf-spim";
 				reg = <0xed000 0x1000>;
@@ -814,6 +822,25 @@
 				compatible = "nordic,nrf-clock";
 				reg = <0x10e000 0x1000>;
 				interrupts = <270 NRF_DEFAULT_IRQ_PRIORITY>;
+				status = "disabled";
+			};
+
+			audio_auxpll: auxpll@130000 {
+				compatible = "nordic,nrf-auxpll";
+				reg = <0x130000 0x1000>;
+				interrupts = <304 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hfxo32m>;
+				#clock-cells = <0>;
+				/*
+				 * Temporarily reading FICR addr 0 as FICR offsets
+				 * not defined yet
+				 */
+				nordic,ficrs = <&ficr 0>;
+				nordic,out-div = <2>;
+				nordic,out-drive = <0>;
+				nordic,current-tune = <6>;
+				nordic,sdm-disable;
+				nordic,range = "high";
 				status = "disabled";
 			};
 


### PR DESCRIPTION
Adding support for AUDIOPLL in nrf7120 which uses the AUXPLL IP. FICR definitions not finalised yet so will need further changes when they are.


(NOW merged) Waiting for https://github.com/zephyrproject-rtos/zephyr/pull/91065 to be cherry picked to sdk-zephyr