### PR TITLE
Applications: nrf5340_audio: Buildprog tooling update

### DIFF
--- a/applications/nrf5340_audio/tools/buildprog/buildprog.py
+++ b/applications/nrf5340_audio/tools/buildprog/buildprog.py
@@ -175,10 +175,8 @@ def __build_module(build_config, options):
 def __find_snr():
     """Rebooting or programming requires connected programmer/debugger"""
 
-    # Use nrfjprog executable for WSL compatibility
-    stdout = subprocess.check_output(
-        "nrfjprog --ids", shell=True).decode("utf-8")
-    snrs = re.findall(r"([\d]+)", stdout)
+    stdout = subprocess.check_output("nrfutil device list", shell=True).decode("utf-8")
+    snrs = re.findall(r"^\d+$", stdout, re.MULTILINE)
 
     if not snrs:
         print("No programmer/debugger connected to PC")
@@ -270,7 +268,7 @@ def __main():
         action="store_true",
         dest="sequential_prog",
         default=False,
-        help="Run nrfjprog sequentially instead of in parallel",
+        help="Run nrfutil sequentially instead of in parallel. This may be required in virtual machines",
     )
     parser.add_argument(
         "-f",

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -209,6 +209,7 @@ nRF5340 Audio
   * The application to use the ``NFC.TAGHEADER0`` value from FICR as the broadcast ID instead of using a random ID.
   * The application to change from Newlib to Picolib to align with |NCS| and Zephyr.
   * The application to use an audio struct that contains meta data about the audio stream.
+  * The optional buildprog tool to use `nRF Util`_ instead of nrfjprog that has been deprecated.
 
 
 nRF Desktop


### PR DESCRIPTION
OCT-3386
Updated Buildprog to use nrfutil instead of nrfjprog