### PR TITLE
net: nrf_provisioning: Improve storing string values

### DIFF
--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
@@ -204,6 +204,7 @@ static int nrf_provisioning_set(const char *key, size_t len_rd,
 			LOG_DBG("Stored interval: \"%jd\"", interval);
 			if (nxt_provisioning != interval) {
 				nxt_provisioning = interval;
+				reschedule = true;
 			}
 		}
 
@@ -493,7 +494,8 @@ int nrf_provisioning_schedule(void)
 		goto out;
 	}
 
-	if (now_s > deadline_s) {
+	if (now_s > deadline_s || reschedule) {
+
 		/* Provision now */
 		if (!nxt_provisioning && !deadline_s) {
 			deadline_s = now_s + CONFIG_NRF_PROVISIONING_INTERVAL_S;

--- a/tests/subsys/net/lib/nrf_provisioning/src/main.c
+++ b/tests/subsys/net/lib/nrf_provisioning/src/main.c
@@ -876,6 +876,7 @@ void test_codec_endorsement_keygen_invalid(void)
  * - To see that a configuration is decoded, written and responded to successfully
  * - Encoded output corresponds to the encoded input
  */
+
 void test_codec_config_store1_valid(void)
 {
 	struct cdc_context cdc_ctx;
@@ -900,8 +901,10 @@ void test_codec_config_store1_valid(void)
 
 	nrf_provisioning_codec_setup(&cdc_ctx, at_buff, sizeof(at_buff));
 
+	/* CBOR data is not null terminated */
+	char interval[] = {'9', '9'};
 	__cmock_settings_save_one_ExpectAndReturn(
-		"provisioning/interval-sec", "99", sizeof("99"), 0);
+		"provisioning/interval-sec", interval, sizeof(interval), 0);
 
 	int ret = nrf_provisioning_codec_process_commands();
 
@@ -911,7 +914,6 @@ void test_codec_config_store1_valid(void)
 
 	nrf_provisioning_codec_teardown();
 }
-
 /*
  * - Detect invalid CBOR payload
  * - To see that an invalid encoding is detected


### PR DESCRIPTION
The settings subsystem uses metadata for encoding the value length, so there no need to store the null-terminator in flash.