### PR TITLE
Partition Manager: support for FIXED_PARTITION macros and update of sdk-zephyr with fixed flash-map tests

### DIFF
--- a/include/flash_map_pm.h
+++ b/include/flash_map_pm.h
@@ -71,4 +71,15 @@
 #define FIXED_PARTITION_EXISTS(label) IS_ENABLED(PM_IS_ENABLED(label))
 #define FLASH_AREA_LABEL_EXISTS(label) FIXED_PARTITION_EXISTS(label)
 
+#define FIXED_PARTITION(label)							\
+	((const struct flash_area *)&UTIL_CAT(global_pm_partition_, label))
+
+#define DECLARE_PARTITION(label)						\
+	extern const struct flash_area UTIL_CAT(global_pm_partition_, label)
+
+/* For each partition found in PM config generate the extern declaration */
+#define MAKE_LABEL(id, _) UTIL_CAT(PM_, UTIL_CAT(PM_##id##_LABEL))
+FOR_EACH(DECLARE_PARTITION, (;), LISTIFY(PM_NUM, MAKE_LABEL, (,)));
+#undef MAKE_LABEL
+
 #endif /* FLASH_MAP_PM_H_*/

--- a/subsys/partition_manager/flash_map_partition_manager.c
+++ b/subsys/partition_manager/flash_map_partition_manager.c
@@ -44,13 +44,15 @@
 	COND_CODE_1(FLASH_MAP_PM_DEV_HAS_ALL(x),	\
 		(FLASH_AREA_FOO(x)), ())
 
-#define FLASH_AREA_FOO(i) \
+#define FLASH_AREA_FOOO(i) \
 	{						\
 		.fa_id       = FLASH_MAP_ID(i),		\
 		.fa_off      = FLASH_MAP_OFFSET(i),	\
 		.fa_dev	     = FLASH_MAP_DEV(i),	\
 		.fa_size     = FLASH_MAP_SIZE(i)	\
-	},
+	}
+
+#define FLASH_AREA_FOO(i) FLASH_AREA_FOOO(i),
 
 #define MAKE_SINGLE(x) UTIL_CAT(PM_, UTIL_CAT(PM_##x##_LABEL))
 #define FLASH_MAP_PM_SINGLE(x, _) FLASH_MAP_PM_ENTRY(UTIL_CAT(PM_, UTIL_CAT(PM_##x##_LABEL)))
@@ -62,6 +64,14 @@ static const struct flash_area pm_flash_map[] = {
 
 const int flash_map_entries = ARRAY_SIZE(pm_flash_map);
 const struct flash_area *flash_map = pm_flash_map;
+
+#define DEFINE_PARTITION(part)								\
+	COND_CODE_1(FLASH_MAP_PM_DEV_HAS_ALL(part), (DEFINE_PARTITION_0(part)), ())
+#define DEFINE_PARTITION_0(part)							\
+	const struct flash_area UTIL_CAT(global_pm_partition_, part) = FLASH_AREA_FOOO(part)
+
+#define MAKE_LABEL(x, _) UTIL_CAT(PM_, UTIL_CAT(PM_##x##_LABEL))
+FOR_EACH(DEFINE_PARTITION, (;), LISTIFY(PM_NUM, MAKE_LABEL, (,)));
 
 #else
 


### PR DESCRIPTION
Two commits:
 - support for FIXED_PARTITION macro that allows to obtain direct pointer to flash_area object representing partition, instead of using flash_area_open with id;
 - Zephyr manifest update with sdk-zephyr changes to flash_map tests, that conditionally disable parts of tests that are not possible to run on Partition Manager enabled build.

You can build the Zephyr flash map test using:
```
west build --sysbuild -d builds/pm-flash -b nrf52840dk/nrf52840 zephyr/tests/subsys/storage/flash_map/ -DSB_CONFIG_PARTITION_MANAGER=y -DSB_CONFIG_BOOTLOADER_MCUBOOT=y
```
to get free PM definitions that allow you to run the test on nrf52840.

Depends on:
https://github.com/nrfconnect/sdk-nrf/pull/22473