### PR TITLE
samples: nfc: Add support for nRF54LM20PDK

### DIFF
--- a/samples/nfc/record_launch_app/sample.yaml
+++ b/samples/nfc/record_launch_app/sample.yaml
@@ -14,6 +14,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -23,6 +24,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     tags:
       - ci_build
       - sysbuild

--- a/samples/nfc/record_text/sample.yaml
+++ b/samples/nfc/record_text/sample.yaml
@@ -15,6 +15,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -25,6 +26,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     tags:
       - ci_build
       - sysbuild

--- a/samples/nfc/shell/sample.yaml
+++ b/samples/nfc/shell/sample.yaml
@@ -14,6 +14,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -23,6 +24,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     tags:
       - ci_build
       - sysbuild

--- a/samples/nfc/system_off/sample.yaml
+++ b/samples/nfc/system_off/sample.yaml
@@ -13,6 +13,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -21,6 +22,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     tags:
       - ci_build
       - sysbuild

--- a/samples/nfc/tnep_tag/sample.yaml
+++ b/samples/nfc/tnep_tag/sample.yaml
@@ -14,6 +14,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -23,6 +24,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     tags:
       - ci_build
       - sysbuild

--- a/samples/nfc/writable_ndef_msg/sample.yaml
+++ b/samples/nfc/writable_ndef_msg/sample.yaml
@@ -14,6 +14,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -23,6 +24,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     tags:
       - ci_build
       - sysbuild


### PR DESCRIPTION
Added support for nRF54LM20PDK in NFC samples:
- record_launch_app
- record_text
- shell
- system_off
- tnep_tag
- writable_ndef_msg

Ref: NCSDK-33608