### PR TITLE
net: openthread: rpc: call client with mutex unlocked

### DIFF
--- a/subsys/net/openthread/rpc/server/ot_rpc_cli.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_cli.c
@@ -36,7 +36,9 @@ static int ot_cli_output_callback(void *aContext, const char *aFormat, va_list a
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
 	nrf_rpc_encode_str(&ctx, output_line_buffer, num_written);
 
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_CLI_OUTPUT, &ctx, ot_rpc_decode_void, NULL);
+	ot_rpc_mutex_lock();
 
 	return num_written;
 }

--- a/subsys/net/openthread/rpc/server/ot_rpc_coap.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_coap.c
@@ -463,8 +463,11 @@ static void ot_rpc_coap_resource_handler(void *aContext, otMessage *aMessage,
 	nrf_rpc_encode_str(&ctx, uri, -1);
 	nrf_rpc_encode_uint(&ctx, message_rep);
 	ot_rpc_encode_message_info(&ctx, aMessageInfo);
+
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_RESOURCE_HANDLER, &ctx,
 				nrf_rpc_rsp_decode_void, NULL);
+	ot_rpc_mutex_lock();
 
 	ot_res_tab_msg_free(message_rep);
 }
@@ -567,8 +570,11 @@ static void ot_rpc_coap_default_handler(void *aContext, otMessage *aMessage,
 	NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
 	nrf_rpc_encode_uint(&ctx, message_rep);
 	ot_rpc_encode_message_info(&ctx, aMessageInfo);
+
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_DEFAULT_HANDLER, &ctx,
 				nrf_rpc_rsp_decode_void, NULL);
+	ot_rpc_mutex_lock();
 
 	ot_res_tab_msg_free(message_rep);
 }
@@ -621,8 +627,11 @@ static void ot_rpc_coap_response_handler(void *context, otMessage *message,
 	nrf_rpc_encode_uint(&ctx, message_rep);
 	ot_rpc_encode_message_info(&ctx, message_info);
 	nrf_rpc_encode_uint(&ctx, error);
+
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_COAP_RESPONSE_HANDLER, &ctx,
 				nrf_rpc_rsp_decode_void, NULL);
+	ot_rpc_mutex_lock();
 
 	ot_res_tab_msg_free(message_rep);
 }

--- a/subsys/net/openthread/rpc/server/ot_rpc_dns_client.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_dns_client.c
@@ -71,8 +71,10 @@ static void address_response_callback(otError error, const otDnsAddressResponse 
 	nrf_rpc_encode_uint(&ctx, (uintptr_t)context);
 	nrf_rpc_encode_uint(&ctx, callback_slot);
 
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_DNS_ADDRESS_RESPONSE_CB, &ctx,
 				ot_rpc_decode_void, NULL);
+	ot_rpc_mutex_lock();
 }
 
 
@@ -93,8 +95,10 @@ static void browse_response_callback(otError error, const otDnsBrowseResponse *r
 	nrf_rpc_encode_uint(&ctx, (uintptr_t)context);
 	nrf_rpc_encode_uint(&ctx, callback_slot);
 
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_DNS_BROWSE_RESPONSE_CB, &ctx,
 				ot_rpc_decode_void, NULL);
+	ot_rpc_mutex_lock();
 }
 
 NRF_RPC_CBKPROXY_HANDLER(browse_response_callback_encoder, browse_response_callback,
@@ -114,8 +118,10 @@ static void service_response_callback(otError error, const otDnsServiceResponse 
 	nrf_rpc_encode_uint(&ctx, (uintptr_t)context);
 	nrf_rpc_encode_uint(&ctx, callback_slot);
 
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_DNS_SERVICE_RESPONSE_CB, &ctx,
 				ot_rpc_decode_void, NULL);
+	ot_rpc_mutex_lock();
 }
 
 NRF_RPC_CBKPROXY_HANDLER(service_response_callback_encoder, service_response_callback,

--- a/subsys/net/openthread/rpc/server/ot_rpc_meshdiag.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_meshdiag.c
@@ -120,8 +120,11 @@ static void handle_mesh_diag_discover(otError aError, otMeshDiagRouterInfo *aRou
 		NRF_RPC_CBOR_ALLOC(&ot_group, ctx, cbor_buffer_size);
 
 		nrf_rpc_encode_uint(&ctx, aError);
+
+		ot_rpc_mutex_unlock();
 		nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_MESH_DIAG_DISCOVER_TOPOLOGY_CB, &ctx,
 					nrf_rpc_rsp_decode_void, NULL);
+		ot_rpc_mutex_lock();
 		return;
 	}
 
@@ -161,8 +164,10 @@ static void handle_mesh_diag_discover(otError aError, otMeshDiagRouterInfo *aRou
 	nrf_rpc_encode_uint(&ctx, ip6_iterator_key);
 	nrf_rpc_encode_uint(&ctx, child_iterator_key);
 
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_MESH_DIAG_DISCOVER_TOPOLOGY_CB, &ctx,
 				nrf_rpc_rsp_decode_void, NULL);
+	ot_rpc_mutex_lock();
 
 	ot_res_tab_meshdiag_ip6_it_free(ip6_iterator_key);
 	ot_res_tab_meshdiag_child_it_free(child_iterator_key);

--- a/subsys/net/openthread/rpc/server/ot_rpc_netdiag.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_netdiag.c
@@ -301,8 +301,10 @@ void handle_receive_diagnostic_get(otError aError, otMessage *aMessage,
 	nrf_rpc_encode_uint(&ctx, message_rep);
 	ot_rpc_encode_message_info(&ctx, aMessageInfo);
 
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_THREAD_SEND_DIAGNOSTIC_GET_CB, &ctx,
 				nrf_rpc_rsp_decode_void, NULL);
+	ot_rpc_mutex_lock();
 
 	ot_res_tab_msg_free(message_rep);
 }

--- a/subsys/net/openthread/rpc/server/ot_rpc_srp_client.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_srp_client.c
@@ -419,8 +419,10 @@ static void ot_rpc_srp_client_auto_start_cb(const otSockAddr *server_sock_addr, 
 
 	ot_rpc_encode_sockaddr(&ctx, server_sock_addr);
 
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_SRP_CLIENT_AUTO_START_CB, &ctx,
 				nrf_rpc_rsp_decode_void, NULL);
+	ot_rpc_mutex_lock();
 }
 
 static void ot_rpc_cmd_srp_client_enable_auto_start_mode(const struct nrf_rpc_group *group,
@@ -537,8 +539,10 @@ static void ot_rpc_srp_client_callback(otError error, const otSrpClientHostInfo 
 		service_data_free(sd, prev);
 	}
 
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_SRP_CLIENT_CB, &ctx, nrf_rpc_rsp_decode_void,
 				NULL);
+	ot_rpc_mutex_lock();
 }
 
 static void ot_rpc_cmd_srp_client_set_callback(const struct nrf_rpc_group *group,

--- a/subsys/net/openthread/rpc/server/ot_rpc_thread.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_thread.c
@@ -56,8 +56,10 @@ static void ot_thread_discover_cb(otActiveScanResult *result, void *context, uin
 	nrf_rpc_encode_uint(&ctx, (uintptr_t)context);
 	nrf_rpc_encode_uint(&ctx, callback_slot);
 
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_no_err(&ot_group, OT_RPC_CMD_THREAD_DISCOVER_CB, &ctx, ot_rpc_decode_void,
 				NULL);
+	ot_rpc_mutex_lock();
 }
 
 NRF_RPC_CBKPROXY_HANDLER(ot_thread_discover_cb_encoder, ot_thread_discover_cb,

--- a/subsys/net/openthread/rpc/server/ot_rpc_udp.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_udp.c
@@ -81,7 +81,10 @@ static void handle_udp_receive(void *context, otMessage *message, const otMessag
 	nrf_rpc_encode_uint(&ctx, soc_key);
 	nrf_rpc_encode_uint(&ctx, msg_key);
 	ot_rpc_encode_message_info(&ctx, message_info);
+
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_cmd_rsp_no_err(&ot_group, OT_RPC_CMD_UDP_RECEIVE_CB, &ctx);
+	ot_rpc_mutex_lock();
 
 	if (!nrf_rpc_decoding_done_and_check(&ot_group, &ctx)) {
 		ot_rpc_report_rsp_decoding_error(OT_RPC_CMD_UDP_RECEIVE_CB);

--- a/tests/subsys/net/openthread/rpc/server/src/coap_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/coap_suite.c
@@ -6,6 +6,7 @@
 
 #include <mock_nrf_rpc_transport.h>
 #include <ot_rpc_ids.h>
+#include <ot_rpc_lock.h>
 #include <ot_rpc_resource.h>
 #include <test_rpc_env.h>
 
@@ -391,8 +392,10 @@ ZTEST(ot_rpc_coap, test_otCoapAddResource_otCoapRemoveResource)
 	mock_nrf_rpc_tr_expect_add(
 		RPC_CMD(OT_RPC_CMD_COAP_RESOURCE_HANDLER, CBOR_URI, message_rep, CBOR_MSG_INFO),
 		RPC_RSP());
+	ot_rpc_mutex_lock();
 	otCoapAddResource_fake.arg1_val->mHandler(otCoapAddResource_fake.arg1_val->mContext,
 						  (otMessage *)MSG_ADDR, &message_info);
+	ot_rpc_mutex_unlock();
 	mock_nrf_rpc_tr_expect_done();
 	zassert_is_null(ot_res_tab_msg_get(message_rep));
 
@@ -439,8 +442,10 @@ ZTEST(ot_rpc_coap, test_otCoapSetDefaultHandler)
 	/* Test serialization of the default handler call */
 	mock_nrf_rpc_tr_expect_add(
 		RPC_CMD(OT_RPC_CMD_COAP_DEFAULT_HANDLER, message_rep, CBOR_MSG_INFO), RPC_RSP());
+	ot_rpc_mutex_lock();
 	otCoapSetDefaultHandler_fake.arg1_val(otCoapSetDefaultHandler_fake.arg2_val,
 					      (otMessage *)MSG_ADDR, &message_info);
+	ot_rpc_mutex_unlock();
 	mock_nrf_rpc_tr_expect_done();
 	zassert_is_null(ot_res_tab_msg_get(message_rep));
 
@@ -497,9 +502,11 @@ ZTEST(ot_rpc_coap, test_otCoapSendRequest)
 	mock_nrf_rpc_tr_expect_add(RPC_CMD(OT_RPC_CMD_COAP_RESPONSE_HANDLER, request_rep,
 					   response_rep, CBOR_MSG_INFO, OT_ERROR_PARSE),
 				   RPC_RSP());
+	ot_rpc_mutex_lock();
 	otCoapSendRequestWithParameters_fake.arg3_val(otCoapSendRequestWithParameters_fake.arg4_val,
 						      (otMessage *)MSG_ADDR, &message_info,
 						      OT_ERROR_PARSE);
+	ot_rpc_mutex_unlock();
 	mock_nrf_rpc_tr_expect_done();
 }
 

--- a/tests/subsys/net/openthread/rpc/server/src/dns_client_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/dns_client_suite.c
@@ -8,6 +8,7 @@
 
 #include <mock_nrf_rpc_transport.h>
 #include <ot_rpc_ids.h>
+#include <ot_rpc_lock.h>
 #include <test_rpc_env.h>
 
 #include <zephyr/fff.h>
@@ -138,11 +139,13 @@ ZTEST(ot_rpc_dns_client, test_response_callbacks)
 	mock_nrf_rpc_tr_expect_add(RPC_CMD(OT_RPC_CMD_DNS_SERVICE_RESPONSE_CB, 0,
 				   CBOR_UINT32(0xcccccccc), 0, 0), RPC_RSP());
 
+	ot_rpc_mutex_lock();
 	(void)address_response_callback_encoder(0, 0, 0, 0, OT_ERROR_NONE, (void *)0xaaaaaaaa,
 						NULL);
 	(void)browse_response_callback_encoder(0, 0, 0, 0, OT_ERROR_NONE, (void *)0xbbbbbbbb, NULL);
 	(void)service_response_callback_encoder(0, 0, 0, 0, OT_ERROR_NONE, (void *)0xcccccccc,
 						NULL);
+	ot_rpc_mutex_unlock();
 
 	mock_nrf_rpc_tr_expect_done();
 }

--- a/tests/subsys/net/openthread/rpc/server/src/meshdiag_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/meshdiag_suite.c
@@ -6,6 +6,7 @@
 
 #include <mock_nrf_rpc_transport.h>
 #include <ot_rpc_ids.h>
+#include <ot_rpc_lock.h>
 #include <ot_rpc_resource.h>
 #include <test_rpc_env.h>
 
@@ -105,7 +106,9 @@ ZTEST(ot_rpc_meshdiag, test_otMeshDiagDiscoverTopology)
 			CBOR_UINT16(RLOC16), MESHDIAG_ROUTER_ID, THREAD_VERSION,
 			MESHDIAG_ROUTER_INFO_FLAGS, MESHDIAG_LINK_QUALITIES, RESOURCE_TABLE_KEY,
 			RESOURCE_TABLE_KEY), RPC_RSP());
+	ot_rpc_mutex_lock();
 	otMeshDiagDiscoverTopology_fake.arg2_val(OT_ERROR_NONE, &router_info, NULL);
+	ot_rpc_mutex_unlock();
 	mock_nrf_rpc_tr_expect_done();
 }
 

--- a/tests/subsys/net/openthread/rpc/server/src/mocks.c
+++ b/tests/subsys/net/openthread/rpc/server/src/mocks.c
@@ -12,8 +12,10 @@
 #include <ot_rpc_lock.h>
 
 #include <zephyr/net/openthread.h>
+#include <zephyr/ztest.h>
 
 static struct openthread_context ot_context;
+static bool locked;
 
 struct otInstance *openthread_get_default_instance(void)
 {
@@ -22,10 +24,17 @@ struct otInstance *openthread_get_default_instance(void)
 
 void ot_rpc_mutex_lock(void)
 {
-	(void)k_mutex_lock(&ot_context.api_lock, K_FOREVER);
+	/*
+	 * The unit tests are executed in a single thread but implement these mocks to
+	 * validate that each command decoder unlocks the stack after processing command,
+	 * and each callback encoder locks the stack after invoking the callback.
+	 */
+	zassert_false(locked);
+	locked = true;
 }
 
 void ot_rpc_mutex_unlock(void)
 {
-	(void)k_mutex_unlock(&ot_context.api_lock);
+	zassert_true(locked);
+	locked = false;
 }

--- a/tests/subsys/net/openthread/rpc/server/src/netdiag_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/netdiag_suite.c
@@ -6,6 +6,7 @@
 
 #include <mock_nrf_rpc_transport.h>
 #include <ot_rpc_ids.h>
+#include <ot_rpc_lock.h>
 #include <ot_rpc_resource.h>
 #include <test_rpc_env.h>
 
@@ -287,8 +288,10 @@ ZTEST(ot_rpc_netdiag, test_otThreadSendDiagnosticGet)
 	mock_nrf_rpc_tr_expect_add(
 		RPC_CMD(OT_RPC_CMD_THREAD_SEND_DIAGNOSTIC_GET_CB, OT_ERROR_NONE, RESOURCE_TABLE_KEY,
 			CBOR_MSG_INFO), RPC_RSP());
+	ot_rpc_mutex_lock();
 	otThreadSendDiagnosticGet_fake.arg4_val(OT_ERROR_NONE, (otMessage *)MSG_ADDR,
 						&message_info, NULL);
+	ot_rpc_mutex_unlock();
 	mock_nrf_rpc_tr_expect_done();
 }
 

--- a/tests/subsys/net/openthread/rpc/server/src/thread_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/thread_suite.c
@@ -8,6 +8,7 @@
 
 #include <mock_nrf_rpc_transport.h>
 #include <ot_rpc_ids.h>
+#include <ot_rpc_lock.h>
 #include <test_rpc_env.h>
 
 #include <zephyr/ztest.h>
@@ -112,7 +113,9 @@ ZTEST(ot_rpc_thread, test_tx_discover_cb)
 					   CBOR_UINT8(0x44), 0x0f, CBOR_FALSE, CBOR_TRUE,
 					   CBOR_FALSE, CBOR_UINT32(0xdeadbeef), 0),
 				   RPC_RSP());
+	ot_rpc_mutex_lock();
 	(void)ot_thread_discover_cb_encoder(0, 0, 0, 0, &result, (void *)0xdeadbeef);
+	ot_rpc_mutex_unlock();
 	mock_nrf_rpc_tr_expect_done();
 }
 
@@ -124,7 +127,9 @@ ZTEST(ot_rpc_thread, test_tx_discover_cb_null)
 	mock_nrf_rpc_tr_expect_add(
 		RPC_CMD(OT_RPC_CMD_THREAD_DISCOVER_CB, CBOR_NULL, CBOR_UINT32(0xdeadbeef), 0),
 		RPC_RSP());
+	ot_rpc_mutex_lock();
 	(void)ot_thread_discover_cb_encoder(0, 0, 0, 0, NULL, (void *)0xdeadbeef);
+	ot_rpc_mutex_unlock();
 	mock_nrf_rpc_tr_expect_done();
 }
 


### PR DESCRIPTION
OpenThread over RPC server invoked OpenThread callbacks on the RPC client with the OpenThread stack mutex locked. This may have lead to a deadlock when the client called the server while the server was calling the client.

Therefore, unlock the OpenThread stack mutex before calling the client, and lock it again when the response arrives.