### PR TITLE
tests: drivers: audio: dmic_dump_buffer: Add stereo configuration

### DIFF
--- a/tests/drivers/audio/dmic_dump_buffer/Kconfig
+++ b/tests/drivers/audio/dmic_dump_buffer/Kconfig
@@ -12,3 +12,10 @@ config TEST_USE_DMM
 	  The test will use it to determine whether to prealocate DMM
 	  buffer or use regular mem slab and allocate dmm buffer inside
 	  PDM driver.
+
+config TEST_STEREO_CONFIGURATION
+	bool "Select mono / stereo operation"
+	help
+	  When set to 'y' PDM driver will be configured in stereo mode.
+	  In such case, import RAW audio data using following configuration:
+	  Signed 16-bit PCM; little-endian; stereo; 16000Hz.

--- a/tests/drivers/audio/dmic_dump_buffer/src/main.c
+++ b/tests/drivers/audio/dmic_dump_buffer/src/main.c
@@ -67,9 +67,16 @@ int main(void)
 		},
 		.streams = &stream,
 		.channel = {
-			.req_num_chan = 1,
 			.req_num_streams = 1,
+#if defined(CONFIG_TEST_STEREO_CONFIGURATION)
+			.req_num_chan = 2,
+			.req_chan_map_lo =
+				dmic_build_channel_map(0, 0, PDM_CHAN_LEFT) |
+				dmic_build_channel_map(1, 0, PDM_CHAN_RIGHT),
+#else
+			.req_num_chan = 1,
 			.req_chan_map_lo = dmic_build_channel_map(0, 0, PDM_CHAN_LEFT),
+#endif
 		},
 	};
 

--- a/tests/drivers/audio/dmic_dump_buffer/testcase.yaml
+++ b/tests/drivers/audio/dmic_dump_buffer/testcase.yaml
@@ -16,9 +16,25 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+  drivers.audio.dmic_dump_buffer.stereo:
+    filter: dt_nodelabel_enabled("dmic_dev")
+    extra_args:
+      - CONFIG_TEST_STEREO_CONFIGURATION=y
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
   drivers.audio.dmic_dump_buffer.dmm:
     filter: dt_nodelabel_enabled("dmic_dev")
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
       - CONFIG_TEST_USE_DMM=y
+  drivers.audio.dmic_dump_buffer.dmm.stereo:
+    filter: dt_nodelabel_enabled("dmic_dev")
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      - CONFIG_TEST_USE_DMM=y
+      - CONFIG_TEST_STEREO_CONFIGURATION=y


### PR DESCRIPTION
Extend test with possibility to add two microphones and check if stereo operation works correctly.