### PR TITLE
Generate default key file with west ncs-provision, enable automatic KMU provisioning

### DIFF
--- a/cmake/sysbuild/generate_default_keyfile.cmake
+++ b/cmake/sysbuild/generate_default_keyfile.cmake
@@ -1,0 +1,69 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# This script defines a CMake target 'generate_kmu_keyfile_json' to create keyfile.json
+# using 'west ncs-provision upload --dry-run'.
+
+# --- Construct the list of commands and dependencies ---
+set(kmu_json_commands "")
+set(kmu_json_dependencies "")
+
+# First command: Generate keyfile for BL_PUBKEY
+if(SB_CONFIG_SECURE_BOOT_GENERATE_DEFAULT_KMU_KEYFILE)
+  # --- Determine the signing key file to use ---
+  set(signature_private_key_file "") # Initialize
+
+  if(SB_CONFIG_SECURE_BOOT_SIGNING_KEY_FILE)
+    string(CONFIGURE "${SB_CONFIG_SECURE_BOOT_SIGNING_KEY_FILE}" keyfile)
+    if(IS_ABSOLUTE ${keyfile})
+      set(signature_private_key_file ${keyfile})
+    else()
+      set(signature_private_key_file ${APPLICATION_CONFIG_DIR}/${keyfile})
+    endif()
+    set(keyfile)
+
+    if(NOT EXISTS ${signature_private_key_file})
+      message(FATAL_ERROR "Config points to non-existing PEM file '${signature_private_key_file}'")
+    endif()
+  else()
+    set(signature_private_key_file "${CMAKE_BINARY_DIR}/GENERATED_NON_SECURE_SIGN_KEY_PRIVATE.pem")
+  endif()
+
+  list(APPEND kmu_json_commands
+    COMMAND ${Python3_EXECUTABLE} -m west ncs-provision upload
+      --keyname BL_PUBKEY
+      --key ${signature_private_key_file}
+      --build-dir ${CMAKE_BINARY_DIR}
+      --dry-run
+  )
+  list(APPEND kmu_json_dependencies ${signature_private_key_file})
+endif()
+
+# Second command (conditional): Update keyfile for UROT_PUBKEY
+if(SB_CONFIG_MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE)
+  list(APPEND kmu_json_commands
+    COMMAND ${Python3_EXECUTABLE} -m west ncs-provision upload
+      --keyname UROT_PUBKEY
+      --key ${SB_CONFIG_BOOT_SIGNATURE_KEY_FILE}
+      --build-dir ${CMAKE_BINARY_DIR}
+      --dry-run
+  )
+  list(APPEND kmu_json_dependencies ${SB_CONFIG_BOOT_SIGNATURE_KEY_FILE})
+endif()
+
+# --- Add custom command to generate/update keyfile.json ---
+if(NOT kmu_json_commands STREQUAL "")
+  add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/keyfile.json
+    ${kmu_json_commands} # Expands to one or more COMMAND clauses
+    DEPENDS ${kmu_json_dependencies}
+    COMMENT "Generating/Updating KMU keyfile JSON (${CMAKE_BINARY_DIR}/keyfile.json)"
+    VERBATIM
+  )
+
+  # --- Add custom target to trigger the generation ---
+  add_custom_target(
+    generate_kmu_keyfile_json ALL
+    DEPENDS ${CMAKE_BINARY_DIR}/keyfile.json
+  )
+endif()

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -737,6 +737,10 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
     include_provision_hex()
   endif()
 
+  if(SB_CONFIG_SECURE_BOOT_GENERATE_DEFAULT_KMU_KEYFILE OR SB_CONFIG_MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE)
+    include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/generate_default_keyfile.cmake)
+  endif()
+
   if(SB_CONFIG_MATTER_OTA)
     include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/zephyr/ota-image_sysbuild.cmake)
     if(SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_BUILD OR SB_CONFIG_SUIT_MULTI_IMAGE_PACKAGE_BUILD)

--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -176,6 +176,13 @@ config BOOT_SHARED_CRYPTO_ECDSA_P256
 	depends on BOOT_SIGNATURE_TYPE_ECDSA_P256 && !SOC_SERIES_NRF54LX
 	default y
 
+config MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE
+	bool "Generate default keyfile for provisioning during build"
+	depends on SOC_SERIES_NRF54LX
+	depends on MCUBOOT_SIGNATURE_USING_KMU
+	help
+	  If enabled, the build system will generate keyfile.json file in the build directory.
+
 endif
 
 config MCUBOOT_USE_ALL_AVAILABLE_RAM

--- a/sysbuild/Kconfig.secureboot
+++ b/sysbuild/Kconfig.secureboot
@@ -361,6 +361,13 @@ config SECURE_BOOT_DEBUG_NO_VERIFY_HASHES
 	help
 	  [DEBUG] Don't check public key hashes for applicability. Only Use this in (negative) tests!
 
+config SECURE_BOOT_GENERATE_DEFAULT_KMU_KEYFILE
+	bool "Generate default keyfile for provisioning during build"
+	depends on SOC_SERIES_NRF54LX
+	depends on SECURE_BOOT_APPCORE
+	help
+	  If enabled, the build system will generate keyfile.json file in the build directory.
+
 endif
 
 endmenu

--- a/tests/subsys/bootloader/boot_chains/Kconfig.sysbuild
+++ b/tests/subsys/bootloader/boot_chains/Kconfig.sysbuild
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if SOC_SERIES_NRF54LX
+
+config MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE
+	default y if BOOTLOADER_MCUBOOT && MCUBOOT_SIGNATURE_USING_KMU
+
+config SECURE_BOOT_GENERATE_DEFAULT_KMU_KEYFILE
+	default y if SECURE_BOOT_APPCORE
+
+endif
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"

--- a/tests/subsys/bootloader/boot_chains/testcase.yaml
+++ b/tests/subsys/bootloader/boot_chains/testcase.yaml
@@ -4,6 +4,7 @@ common:
     # MCUBoot enabled as well
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
+    - nrf54l15dk/nrf54l15/cpuapp
   harness: console
   harness_config:
     type: one_line

--- a/tests/subsys/kmu/hello_for_kmu/testcase.yaml
+++ b/tests/subsys/kmu/hello_for_kmu/testcase.yaml
@@ -1,18 +1,40 @@
 common:
   sysbuild: true
-  timeout: 180
   tags:
-    - pytest
     - mcuboot
     - kmu
     - ci_tests_subsys_kmu
   platform_allow:
     - nrf54l15dk/nrf54l15/cpuapp
-    - nrf54lm20pdk/nrf54lm20a/cpuapp
-    - nrf54lv10dk/nrf54lv10a/cpuapp
-  harness: pytest
-  harness_config:
-    pytest_root:
-      - "../pytest/test_kmu_provision.py"
 tests:
-  mcuboot.kmu.west.provision.basic: {}
+  mcuboot.kmu.west.provision.basic:
+    timeout: 180
+    platform_allow:
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+    tags:
+      - pytest
+    harness: pytest
+    harness_config:
+      pytest_root:
+        - "../pytest/test_kmu_provision.py"
+  mcuboot.kmu.west_flash_default_provision:
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "Hello World! (.*)"
+    extra_args:
+      - SB_CONFIG_MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE=y
+  mcuboot.kmu.west_flash_default_provision_with_b0:
+    tags:
+      - nsib
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "Hello World! (.*)"
+    extra_args:
+      - SB_CONFIG_SECURE_BOOT_APPCORE=y
+      - SB_CONFIG_SECURE_BOOT_GENERATE_DEFAULT_KMU_KEYFILE=y
+      - SB_CONFIG_MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE=y


### PR DESCRIPTION
Updated manifest to sdk-zephyr.
Changes in zephyr allows to provision KMU keys with `west flash` command, if keyfile.json (generated by west ncs-provision) is in build directory.

Changes in sdk-nrf:
Introduced the capability to automatically generate
the keyfile.json during the build process for nRF54L series devices.
Added new Kconfigs:
* SB_CONFIG_SECURE_BOOT_GENERATE_DEFAULT_KMU_KEYFILE
* SB_CONFIG_MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE
to control creating keyfile.json during the build process.
Creating keyfile.json is implemented in generate_default_keyfile.cmake.

Additionally updated tests on nrf54l15dk:
* tests/subsys/bootloader/boot_chains
* tests/subsys/kmu/hello_for_kmu

To test is manually on nrf54l15dk:
hello world + NSIB
```
west build -p -b nrf54l15dk/nrf54l15/cpuapp $ZEPHYR_BASE/samples/hello_world  -d build-54l-nsib -- \
-DSB_CONFIG_SECURE_BOOT_APPCORE=y \
-DSB_CONFIG_SECURE_BOOT_GENERATE_DEFAULT_KMU_KEYFILE=y

west flash --skip-rebuild --erase -d build-54l-nsib
```

MCUboot (with KMU enabled)
```
west build -p -b nrf54l15dk/nrf54l15/cpuapp $ZEPHYR_BASE/samples/hello_world -d build-54l-mcuboot_kmu -- \
-DSB_CONFIG_BOOTLOADER_MCUBOOT=y \
-DSB_CONFIG_MCUBOOT_SIGNATURE_USING_KMU=y \
-DSB_CONFIG_MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE=y

west flash --skip-rebuild --erase -d build-54l-mcuboot_kmu 
```

hello world + NSIB + MCUboot
```
west build -p -b nrf54l15dk/nrf54l15/cpuapp $ZEPHYR_BASE/samples/hello_world  -d build-54l-nsib_mcuboot -- \
-DSB_CONFIG_SECURE_BOOT_APPCORE=y \
-DSB_CONFIG_BOOTLOADER_MCUBOOT=y \
-DSB_CONFIG_MCUBOOT_SIGNATURE_USING_KMU=y \
-DSB_CONFIG_SECURE_BOOT_GENERATE_DEFAULT_KMU_KEYFILE=y \
-DSB_CONFIG_MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE=y

west flash --skip-rebuild --erase -d build-54l-nsib_mcuboot
```

To run Twister tests:
```
$ZEPHYR_BASE/scripts/twister \
-c -vv -ll debug \
--device-testing -p nrf54l15dk/nrf54l15/cpuapp --device-serial /dev/ttyACM1 --west-flash="--recover" \
-T tests/subsys/bootloader/boot_chains

$ZEPHYR_BASE/scripts/twister \
-c -vv -ll debug \
--device-testing -p nrf54l15dk/nrf54l15/cpuapp --device-serial /dev/ttyACM1 --west-flash="--recover" \
-T tests/subsys/kmu/hello_for_kmu \
-s mcuboot.kmu.west_flash_default_provision \
-s mcuboot.kmu.west_flash_default_provision_with_b0
```
 


