### PR TITLE
samples: radio_test: Fix clearing of `test_is_running` flag

### DIFF
--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -800,6 +800,8 @@ static void radio_disable(void)
 		(void)fem_power_down();
 	}
 #endif /* CONFIG_FEM */
+
+	test_is_running = false;
 }
 
 static void mltpan_6(nrf_radio_mode_t mode)
@@ -1124,8 +1126,6 @@ void radio_test_cancel(enum radio_test_mode type)
 		} else {
 			cancel();
 		}
-
-		test_is_running = false;
 	}
 }
 


### PR DESCRIPTION
The test may end either due to a `cancel` command
or after sending predefined number of packets.
The `test_is_running` flag is now cleared in both cases.
