### PR TITLE
samples: bluetooth: clean sample.yaml configurations

### DIFF
--- a/samples/bluetooth/central_bas/sample.yaml
+++ b/samples/bluetooth/central_bas/sample.yaml
@@ -4,18 +4,6 @@ sample:
 tests:
   sample.bluetooth.central_bas:
     sysbuild: true
-    harness: bluetooth
-    integration_platforms:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-    platform_allow:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-    tags:
-      - bluetooth
-      - sysbuild
-  sample.bluetooth.central_bas.build:
-    sysbuild: true
     build_only: true
     integration_platforms:
       - nrf52dk/nrf52832

--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -4,18 +4,6 @@ sample:
 tests:
   sample.bluetooth.central_hids:
     sysbuild: true
-    harness: bluetooth
-    integration_platforms:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-    platform_allow:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-    tags:
-      - bluetooth
-      - sysbuild
-  sample.bluetooth.central_hids.build:
-    sysbuild: true
     build_only: true
     integration_platforms:
       - nrf52dk/nrf52832

--- a/samples/bluetooth/central_smp_client/sample.yaml
+++ b/samples/bluetooth/central_smp_client/sample.yaml
@@ -4,33 +4,21 @@ sample:
 tests:
   sample.bluetooth.central_dfu_smp:
     sysbuild: true
-    harness: bluetooth
-    integration_platforms:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-      - nrf54l15dk/nrf54l05/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-      - nrf54l15dk/nrf54l05/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-    tags:
-      - bluetooth
-      - sysbuild
-  sample.bluetooth.central_dfu_smp.build:
-    sysbuild: true
     build_only: true
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
     tags:

--- a/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
@@ -4,18 +4,6 @@ sample:
 tests:
   sample.bluetooth.peripheral_hids_keyboard:
     sysbuild: true
-    harness: bluetooth
-    integration_platforms:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-    platform_allow:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-    tags:
-      - bluetooth
-      - sysbuild
-  sample.bluetooth.peripheral_hids_keyboard.build:
-    sysbuild: true
     build_only: true
     integration_platforms:
       - nrf52dk/nrf52832

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -4,18 +4,6 @@ sample:
 tests:
   sample.bluetooth.peripheral_hids_mouse:
     sysbuild: true
-    harness: bluetooth
-    integration_platforms:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-    platform_allow:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-    tags:
-      - bluetooth
-      - sysbuild
-  sample.bluetooth.peripheral_hids_mouse.build:
-    sysbuild: true
     build_only: true
     integration_platforms:
       - nrf52dk/nrf52832


### PR DESCRIPTION
Merge build only with harness: bluetooth.
There is no such harness, thus it is effectively build only.