### PR TITLE
samples: wifi: provisioning: ble: Fix stack overflow

### DIFF
--- a/samples/wifi/provisioning/ble/prj.conf
+++ b/samples/wifi/provisioning/ble/prj.conf
@@ -80,7 +80,9 @@ CONFIG_BT_BUF_ACL_RX_SIZE=151
 CONFIG_BT_L2CAP_TX_MTU=147
 CONFIG_BT_BUF_ACL_TX_SIZE=151
 
-CONFIG_BT_RX_STACK_SIZE=5120
+# Increased BT RX stack size because BLE and Wi-Fi operations
+# run in the same BT RX workqueue thread during provisioning.
+CONFIG_BT_RX_STACK_SIZE=5400
 CONFIG_BT_BONDABLE=n
 CONFIG_BT_DEVICE_NAME_DYNAMIC=y
 


### PR DESCRIPTION
Increase bluetooth RX stack size to prevent stack overflow.

Fixes SHEL-3623.