### PR TITLE
nrf_security: Make the Cracen IKG configurable

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/Kconfig
+++ b/subsys/nrf_security/src/drivers/cracen/Kconfig
@@ -37,6 +37,12 @@ config CRACEN_LIB_KMU
 	help
 	  The CRACEN KMU library.
 
+config CRACEN_IKG
+	bool "Enable CRACEN IKG"
+	default y
+	help
+	  Enable the Cracen Isolated Key Generator.
+
 config CRACEN_IKG_SEED_LOAD
 	bool "Load the CRACEN IKG seed"
 	depends on CRACEN_LIB_KMU

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/cracenpsa.cmake
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/cracenpsa.cmake
@@ -17,7 +17,6 @@ list(APPEND cracen_driver_sources
   ${CMAKE_CURRENT_LIST_DIR}/src/ec_helpers.c
   ${CMAKE_CURRENT_LIST_DIR}/src/ecc.c
   ${CMAKE_CURRENT_LIST_DIR}/src/rndinrange.c
-  ${CMAKE_CURRENT_LIST_DIR}/src/ikg_signature.c
 
   # Note: We always need to have cipher.c and ctr_drbg.c since it
   # is used directly by many Cracen drivers.
@@ -25,6 +24,12 @@ list(APPEND cracen_driver_sources
   ${CMAKE_CURRENT_LIST_DIR}/src/ctr_drbg.c
   ${CMAKE_CURRENT_LIST_DIR}/src/prng_pool.c
 )
+
+if(CONFIG_CRACEN_IKG)
+  list(APPEND cracen_driver_sources
+    ${CMAKE_CURRENT_LIST_DIR}/src/ikg_signature.c
+  )
+endif()
 
 if(CONFIG_CRACEN_LIB_KMU)
   list(APPEND cracen_driver_sources

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
@@ -673,7 +673,7 @@ int cracen_prepare_ik_key(const uint8_t *user_data)
 	}
 #endif
 
-	struct sx_pk_config_ik cfg = {};
+	__attribute__((unused)) struct sx_pk_config_ik cfg = {};
 
 #ifdef CONFIG_PSA_NEED_CRACEN_PLATFORM_KEYS
 	cfg.device_secret = DEVICE_SECRET_ADDRESS;
@@ -720,7 +720,12 @@ int cracen_prepare_ik_key(const uint8_t *user_data)
 	}
 #endif
 
+
+#if defined(CONFIG_CRACEN_IKG)
 	return sx_pk_ik_derive_keys(&cfg);
+#else
+	return PSA_ERROR_NOT_SUPPORTED;
+#endif
 }
 
 static int cracen_clean_ik_key(const uint8_t *user_data)
@@ -817,7 +822,12 @@ psa_status_t cracen_load_keyref(const psa_key_attributes_t *attributes, const ui
 	    PSA_KEY_LOCATION_CRACEN) {
 
 		if (cracen_is_ikg_key(attributes)) {
-			return cracen_load_ikg_keyref(attributes, key_buffer, key_buffer_size, k);
+			if (IS_ENABLED(CONFIG_CRACEN_IKG)) {
+				return cracen_load_ikg_keyref(attributes, key_buffer,
+							      key_buffer_size, k);
+			} else {
+				return PSA_ERROR_NOT_SUPPORTED;
+			}
 		}
 
 		k->owner_id = MBEDTLS_SVC_KEY_ID_GET_OWNER_ID(psa_get_key_id(attributes));

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/include/silexpk/ik.h
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/include/silexpk/ik.h
@@ -139,15 +139,6 @@ struct sx_pk_config_ik {
  */
 int sx_pk_ik_derive_keys(struct sx_pk_config_ik *cfg);
 
-/** Exit IK mode.
- *
- * @param[in,out] cnx Connection structure obtained through sx_pk_open() at
- * startup
- *
- * @return Any \ref SX_PK_STATUS "status code"
- */
-int sx_pk_ik_mode_exit(struct sx_pk_cnx *cnx);
-
 struct sx_pk_config_rng {
 	/** Personalization string */
 	uint32_t *personalization;

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/silexpk.cmake
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/silexpk.cmake
@@ -17,9 +17,6 @@ list(APPEND cracen_driver_sources
 
   ${CMAKE_CURRENT_LIST_DIR}/target/baremetal_ba414e_with_ik/pk_baremetal.c
 
-  ${CMAKE_CURRENT_LIST_DIR}/target/hw/ik/ikhardware.c
-  ${CMAKE_CURRENT_LIST_DIR}/target/hw/ik/cmddefs_ik.c
-
   ${CMAKE_CURRENT_LIST_DIR}/target/hw/ba414/pkhardware_ba414e.c
   ${CMAKE_CURRENT_LIST_DIR}/target/hw/ba414/ba414_status.c
   ${CMAKE_CURRENT_LIST_DIR}/target/hw/ba414/ec_curves.c
@@ -34,3 +31,10 @@ list(APPEND cracen_driver_include_dirs
   ${CMAKE_CURRENT_LIST_DIR}/target/baremetal_ba414e_with_ik
   ${CMAKE_CURRENT_LIST_DIR}/include
 )
+
+if(CONFIG_CRACEN_IKG)
+  list(APPEND cracen_driver_sources
+    ${CMAKE_CURRENT_LIST_DIR}/target/hw/ik/ikhardware.c
+    ${CMAKE_CURRENT_LIST_DIR}/target/hw/ik/cmddefs_ik.c
+  )
+endif()

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ik/ikhardware.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ik/ikhardware.c
@@ -219,26 +219,6 @@ int sx_pk_ik_derive_keys(struct sx_pk_config_ik *cfg)
 	return r;
 }
 
-int sx_pk_ik_mode_exit(struct sx_pk_cnx *cnx)
-{
-	int sx_status;
-	struct sx_pk_acq_req pkreq = sx_pk_acquire_req(SX_PK_CMD_IK_EXIT);
-
-	if (pkreq.status) {
-		return pkreq.status;
-	}
-
-	pkreq.status = sx_pk_list_ik_inslots(pkreq.req, 0, NULL);
-	if (pkreq.status) {
-		return pkreq.status;
-	}
-
-	sx_pk_run(pkreq.req);
-	sx_status = sx_pk_wait(pkreq.req);
-	sx_pk_release_req(pkreq.req);
-	return sx_status;
-}
-
 int sx_pk_ik_rng_reconfig(struct sx_pk_cnx *cnx, struct sx_pk_config_rng *cfg)
 {
 	if (cfg->personalization && cfg->personalization_sz) {


### PR DESCRIPTION
    Add the configuration option CRACEN_IKG
    which allows to disable the IKG funcionality
    if it is not needed.
    
    This will decrease the flash usage for applications
    which don't use the IKG.
    
    Ref: NCSDK-30246
    
    Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>
