### PR TITLE
scripts: west_commands: create_board: use .yaml extension for generated Twister board files

### DIFF
--- a/scripts/west_commands/create_board/ncs_create_board.py
+++ b/scripts/west_commands/create_board/ncs_create_board.py
@@ -217,7 +217,7 @@ class NcsCreateBoard(WestCommand):
                 f.write(tmpl.render(target=target))
 
             tmpl = env.get_template("board_twister.yml.jinja2")
-            with open(out_dir / f"{name}.yml", "w") as f:
+            with open(out_dir / f"{name}.yaml", "w") as f:
                 f.write(tmpl.render(target=target))
 
         # return post-commands


### PR DESCRIPTION
Twister failed to recognize board files with the .yml extension. This fix changes the output extension to .yaml, ensuring compatibility with Twister's expected input format.