### PR TITLE
samples: matter: Switch to peripheral-only BLE role on nRF54L15

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -333,7 +333,7 @@ Keys samples
 Matter samples
 --------------
 
-|no_changes_yet_note|
+* Changed Bluetooth Low Energy variant of the Soft Device Controller (SDC) to use the Peripheral-only role in all Matter samples.
 
 Networking samples
 ------------------

--- a/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Multirole is the only currently supported role by SoftDevice.
-CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
-
 # ZMS cache optimization
 CONFIG_ZMS_LOOKUP_CACHE=y
 CONFIG_ZMS_LOOKUP_CACHE_SIZE=512

--- a/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/light_switch/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Multirole is the only currently supported role by SoftDevice.
-CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
-
 # ZMS cache optimization
 CONFIG_ZMS_LOOKUP_CACHE=y
 CONFIG_ZMS_LOOKUP_CACHE_SIZE=512

--- a/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/lock/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Multirole is the only currently supported role by SoftDevice.
-CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
-
 # ZMS cache optimization
 CONFIG_ZMS_LOOKUP_CACHE=y
 CONFIG_ZMS_LOOKUP_CACHE_SIZE=512

--- a/samples/matter/manufacturer_specific/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/manufacturer_specific/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Multirole is the only currently supported role by SoftDevice.
-CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 

--- a/samples/matter/manufacturer_specific/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/manufacturer_specific/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Multirole is the only currently supported role by SoftDevice.
-CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
-
 # Set the ZMS sector count to match the settings partition size that is 40 kB for this application.
 CONFIG_SETTINGS_ZMS_SECTOR_COUNT=10
 

--- a/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/smoke_co_alarm/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Multirole is the only currently supported role by SoftDevice.
-CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
-
 # ZMS cache optimization
 CONFIG_ZMS_LOOKUP_CACHE=y
 CONFIG_ZMS_LOOKUP_CACHE_SIZE=512

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Multirole is the only currently supported role by SoftDevice.
-CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
-
 # ZMS cache optimization
 CONFIG_ZMS_LOOKUP_CACHE=y
 CONFIG_ZMS_LOOKUP_CACHE_SIZE=512

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Multirole is the only currently supported role by SoftDevice.
-CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
-
 # ZMS cache optimization
 CONFIG_ZMS_LOOKUP_CACHE=y
 CONFIG_ZMS_LOOKUP_CACHE_SIZE=512

--- a/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
+++ b/samples/matter/template/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Multirole is the only currently supported role by SoftDevice.
-CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
-
 # ZMS cache optimization
 CONFIG_ZMS_LOOKUP_CACHE=y
 CONFIG_ZMS_LOOKUP_CACHE_SIZE=512

--- a/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/thermostat/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Multirole is the only currently supported role by SoftDevice.
-CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
-
 # ZMS cache optimization
 CONFIG_ZMS_LOOKUP_CACHE=y
 CONFIG_ZMS_LOOKUP_CACHE_SIZE=512

--- a/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/matter/window_covering/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Multirole is the only currently supported role by SoftDevice.
-CONFIG_BT_LL_SOFTDEVICE_MULTIROLE=y
-
 # ZMS cache optimization
 CONFIG_ZMS_LOOKUP_CACHE=y
 CONFIG_ZMS_LOOKUP_CACHE_SIZE=512


### PR DESCRIPTION
Once peripheral-only SDC library is available for nRF54L15, we can use it instead of multirole variant.