### PR TITLE
tests: zephyr: drivers: uart: uart_elementary: default is csp

### DIFF
--- a/tests/drivers/uart/uart_baudrate_test/testcase.yaml
+++ b/tests/drivers/uart/uart_baudrate_test/testcase.yaml
@@ -68,10 +68,8 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/nrf54lm20pdk_nrf54lm20a_cpuapp_0_0_0_uart22.overlay"
   drivers.uart.baudrate_test.lm20_qfn_uart00:
     platform_allow:
-      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54lm20pdk@0.2.0/nrf54lm20a/cpuapp
     integration_platforms:
-      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54lm20pdk@0.2.0/nrf54lm20a/cpuapp
     extra_args: DTC_OVERLAY_FILE="boards/nrf54lm20pdk_nrf54lm20a_cpuapp_uart00.overlay"
     harness: ztest
@@ -91,8 +89,10 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/nrf54lm20pdk_nrf54lm20a_cpuapp_uart22.overlay"
   drivers.uart.baudrate_test.lm20_uart00:
     platform_allow:
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuapp
     integration_platforms:
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuapp
     extra_args: DTC_OVERLAY_FILE="boards/nrf54lm20pdk_nrf54lm20a_cpuapp_0_2_0_csp_uart00.overlay"
     harness: ztest

--- a/tests/zephyr/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/zephyr/drivers/uart/uart_elementary/testcase.yaml
@@ -69,8 +69,6 @@ tests:
   nrf.extended.drivers.uart.uart_elementary_dual_lm20_qfn:
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
     platform_allow:
-      - nrf54lm20pdk/nrf54lm20a/cpuapp
-      - nrf54lm20pdk/nrf54lm20a/cpuflpr
       - nrf54lm20pdk@0.2.0/nrf54lm20a/cpuapp
       - nrf54lm20pdk@0.2.0/nrf54lm20a/cpuflpr
     extra_args:
@@ -80,6 +78,8 @@ tests:
   nrf.extended.drivers.uart.uart_elementary_dual_lm20_csp:
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
     platform_allow:
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuflpr
       - nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuapp
       - nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuflpr
     extra_args:
@@ -140,8 +140,6 @@ tests:
   nrf.extended.drivers.uart.uart_elementary_dual_setup_mismatch_lm20_qfn:
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
     platform_allow:
-      - nrf54lm20pdk/nrf54lm20a/cpuapp
-      - nrf54lm20pdk/nrf54lm20a/cpuflpr
       - nrf54lm20pdk@0.2.0/nrf54lm20a/cpuapp
       - nrf54lm20pdk@0.2.0/nrf54lm20a/cpuflpr
     extra_args:
@@ -152,6 +150,8 @@ tests:
   nrf.extended.drivers.uart.uart_elementary_dual_setup_mismatch_lm20_csp:
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
     platform_allow:
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuflpr
       - nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuapp
       - nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuflpr
     extra_args:


### PR DESCRIPTION

Follow default revision change.