### PR TITLE
nrf_security: ssf_secdom: add missing include path

### DIFF
--- a/subsys/nrf_security/src/ssf_secdom/CMakeLists.txt
+++ b/subsys/nrf_security/src/ssf_secdom/CMakeLists.txt
@@ -17,6 +17,7 @@ if(CONFIG_NRF_IRONSIDE_CALL)
 
   zephyr_library_include_directories(
     ${NRF_DIR}/include/tfm
+    ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/interface/include
     .
     )
 


### PR DESCRIPTION
The ironside PSA crypto client failed to build due to missing a
TFM include path.