### PR TITLE
samples: bluetooth: Fix errata 117 check

### DIFF
--- a/samples/bluetooth/direct_test_mode/src/dtm.c
+++ b/samples/bluetooth/direct_test_mode/src/dtm.c
@@ -1592,7 +1592,7 @@ static void errata_172_handle(bool enable)
 
 static void errata_117_handle(bool enable)
 {
-	if (!nrf52_errata_117()) {
+	if (!nrf53_errata_117()) {
 		return;
 	}
 


### PR DESCRIPTION
There is a typo in the nrf5340 errata 117 logic, where it checked for a nRF52-series device instead of a nRF53-series device. This caused a hard-fault if the function ran successfully on a nRF52-series device.

Fix is to use the same implementation as done in sample ../peripheral/radio_test
https://github.com/nrfconnect/sdk-nrf/blob/v2.9-branch/samples/peripheral/radio_test/src/radio_test.c#L721-L735