### PR TITLE
tests: kmu: Added no_reset fixture in provisioning tests

### DIFF
--- a/tests/subsys/kmu/pytest/conftest.py
+++ b/tests/subsys/kmu/pytest/conftest.py
@@ -4,9 +4,20 @@
 import pytest
 import logging
 
+from twister_harness.device.device_adapter import DeviceAdapter
+from twister_harness.fixtures import determine_scope
+
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function', autouse=True)
 def test_log(request: pytest.FixtureRequest):
     logging.info("========= Test '{}' STARTED".format(request.node.nodeid))
+
+
+@pytest.fixture(scope=determine_scope)
+def no_reset(device_object: DeviceAdapter):
+    """Do not reset after flashing."""
+    device_object.device_config.west_flash_extra_args.append("--no-reset")
+    yield
+    device_object.device_config.west_flash_extra_args.remove("--no-reset")

--- a/tests/subsys/kmu/pytest/test_kmu_provision.py
+++ b/tests/subsys/kmu/pytest/test_kmu_provision.py
@@ -19,6 +19,7 @@ from common import (
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.usefixtures("no_reset")
 @pytest.mark.parametrize(
     'test_option', ['one_key', 'three_keys_second_used', 'three_keys_last_used']
 )
@@ -62,6 +63,7 @@ def test_kmu_use_key_from_config(dut: DeviceAdapter, test_option):
     logger.info("Passed: Booted successfully after provisioning the same key that was used during building")
 
 
+@pytest.mark.usefixtures("no_reset")
 def test_kmu_use_wrong_key(dut: DeviceAdapter):
     """
     Upload keys using west ncs-provision command,

--- a/tests/subsys/kmu/pytest/test_kmu_revoke_in_app.py
+++ b/tests/subsys/kmu/pytest/test_kmu_revoke_in_app.py
@@ -15,6 +15,7 @@ from common import provision_keys_for_kmu, reset_board, APP_KEYS_FOR_KMU
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.usefixtures("no_reset")
 def test_kmu_policy_revokable(dut: DeviceAdapter):
     """
     Upload keys using 'revokable' policy,
@@ -50,6 +51,7 @@ def test_kmu_policy_revokable(dut: DeviceAdapter):
     logger.info("Passed: not booted with revoked keys")
 
 
+@pytest.mark.usefixtures("no_reset")
 def test_kmu_policy_lock(dut: DeviceAdapter):
     """
     Upload keys using 'lock' policy,

--- a/tests/subsys/kmu/pytest/test_kmu_verify_keys_in_app.py
+++ b/tests/subsys/kmu/pytest/test_kmu_verify_keys_in_app.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import pytest
 
 from pathlib import Path
 from twister_harness import DeviceAdapter
@@ -17,6 +18,7 @@ from common import (
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.usefixtures("no_reset")
 def test_kmu_correct_keys_uploaded(dut: DeviceAdapter):
     """
     Upload valid keys to DUT using west ncs-provission command
@@ -46,6 +48,7 @@ def test_kmu_correct_keys_uploaded(dut: DeviceAdapter):
     ])
 
 
+@pytest.mark.usefixtures("no_reset")
 def test_kmu_wrong_keys_uploaded(dut: DeviceAdapter):
     """
     Upload two wrong keys to DUT using west ncs-provission command


### PR DESCRIPTION
Updated tests/subsys/kmu tests with `no_reset` fixture. This fixtures adds `--no-reset` argument to west flash, to not reset device after flashing. Works only with pytest-harness.

To test is locally, one can run:
`$ZEPHYR_BASE/scripts/twister -T tests/subsys/kmu --device-testing --hardware-map ~/tmp/hardware_map.yml --west-flash="--recover" -vv -c -ll debug`

