### PR TITLE
lib: at_parser: return -ENODATA on empty subparameter

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -495,6 +495,19 @@ Modem libraries
 
   * Added support for parsing DECT NR+ modem firmware names.
 
+  * Updated the following macros and functions to return ``-ENODATA`` when the target subparameter to parse is empty:
+
+    * :c:macro:`at_parser_num_get` macro
+    * Functions:
+
+      * :c:func:`at_parser_int16_get`
+      * :c:func:`at_parser_uint16_get`
+      * :c:func:`at_parser_int32_get`
+      * :c:func:`at_parser_uint32_get`
+      * :c:func:`at_parser_int64_get`
+      * :c:func:`at_parser_uint64_get`
+      * :c:func:`at_parser_string_get`
+
 * :ref:`lte_lc_readme` library:
 
   * Added the :kconfig:option:`CONFIG_LTE_LC_DNS_FALLBACK_MODULE` and :kconfig:option:`CONFIG_LTE_LC_DNS_FALLBACK_ADDRESS` Kconfig options to enable setting a fallback DNS address.

--- a/include/modem/at_parser.h
+++ b/include/modem/at_parser.h
@@ -67,6 +67,7 @@ struct at_parser {
  * @retval -EINVAL     One or more of the supplied parameters are invalid.
  * @retval -EPERM      @p parser has not been initialized.
  * @retval -EOPNOTSUPP Operation not supported for the type of value at the given index.
+ * @retval -ENODATA    The value at the given index is empty.
  * @retval -ERANGE     Parsed integer value is out of range for the expected type.
  * @retval -EBADMSG    The AT command string is malformed.
  * @retval -EAGAIN     Parsing of the current AT command line is terminated and a subsequent line is
@@ -157,6 +158,7 @@ int at_parser_cmd_count_get(struct at_parser *parser, size_t *count);
  * @retval -EINVAL     One or more of the supplied parameters are invalid.
  * @retval -EPERM      @p parser has not been initialized.
  * @retval -EOPNOTSUPP Operation not supported for the type of value at the given index.
+ * @retval -ENODATA    The value at the given index is empty.
  * @retval -ERANGE     Parsed integer value is out of range for the expected type.
  * @retval -EBADMSG    The AT command string is malformed.
  * @retval -EAGAIN     Parsing of the current AT command line is terminated and a subsequent line is
@@ -180,6 +182,7 @@ int at_parser_int16_get(struct at_parser *parser, size_t index, int16_t *value);
  * @retval -EINVAL     One or more of the supplied parameters are invalid.
  * @retval -EPERM      @p parser has not been initialized.
  * @retval -EOPNOTSUPP Operation not supported for the type of value at the given index.
+ * @retval -ENODATA    The value at the given index is empty.
  * @retval -ERANGE     Parsed integer value is out of range for the expected type.
  * @retval -EBADMSG    The AT command string is malformed.
  * @retval -EAGAIN     Parsing of the current AT command line is terminated and a subsequent line is
@@ -203,6 +206,7 @@ int at_parser_uint16_get(struct at_parser *parser, size_t index, uint16_t *value
  * @retval -EINVAL     One or more of the supplied parameters are invalid.
  * @retval -EPERM      @p parser has not been initialized.
  * @retval -EOPNOTSUPP Operation not supported for the type of value at the given index.
+ * @retval -ENODATA    The value at the given index is empty.
  * @retval -ERANGE     Parsed integer value is out of range for the expected type.
  * @retval -EBADMSG    The AT command string is malformed.
  * @retval -EAGAIN     Parsing of the current AT command line is terminated and a subsequent line is
@@ -226,6 +230,7 @@ int at_parser_int32_get(struct at_parser *parser, size_t index, int32_t *value);
  * @retval -EINVAL     One or more of the supplied parameters are invalid.
  * @retval -EPERM      @p parser has not been initialized.
  * @retval -EOPNOTSUPP Operation not supported for the type of value at the given index.
+ * @retval -ENODATA    The value at the given index is empty.
  * @retval -ERANGE     Parsed integer value is out of range for the expected type.
  * @retval -EBADMSG    The AT command string is malformed.
  * @retval -EAGAIN     Parsing of the current AT command line is terminated and a subsequent line is
@@ -249,6 +254,7 @@ int at_parser_uint32_get(struct at_parser *parser, size_t index, uint32_t *value
  * @retval -EINVAL     One or more of the supplied parameters are invalid.
  * @retval -EPERM      @p parser has not been initialized.
  * @retval -EOPNOTSUPP Operation not supported for the type of value at the given index.
+ * @retval -ENODATA    The value at the given index is empty.
  * @retval -ERANGE     Parsed integer value is out of range for the expected type.
  * @retval -EBADMSG    The AT command string is malformed.
  * @retval -EAGAIN     Parsing of the current AT command line is terminated and a subsequent line is
@@ -272,6 +278,7 @@ int at_parser_int64_get(struct at_parser *parser, size_t index, int64_t *value);
  * @retval -EINVAL     One or more of the supplied parameters are invalid.
  * @retval -EPERM      @p parser has not been initialized.
  * @retval -EOPNOTSUPP Operation not supported for the type of value at the given index.
+ * @retval -ENODATA    The value at the given index is empty.
  * @retval -ERANGE     Parsed integer value is out of range for the expected type.
  * @retval -EBADMSG    The AT command string is malformed.
  * @retval -EAGAIN     Parsing of the current AT command line is terminated and a subsequent line is
@@ -301,6 +308,7 @@ int at_parser_uint64_get(struct at_parser *parser, size_t index, uint64_t *value
  * @retval -EINVAL     One or more of the supplied parameters are invalid.
  * @retval -EPERM      @p parser has not been initialized.
  * @retval -EOPNOTSUPP Operation not supported for the type of value at the given index.
+ * @retval -ENODATA    The value at the given index is empty.
  * @retval -ENOMEM     @p str is smaller than the null-terminated string to be copied.
  * @retval -EBADMSG    The AT command string is malformed.
  * @retval -EAGAIN     Parsing of the current AT command line is terminated and a subsequent line is

--- a/lib/at_parser/at_parser.c
+++ b/lib/at_parser/at_parser.c
@@ -370,7 +370,13 @@ static int at_parser_num_get_impl(struct at_parser *parser, size_t index, void *
 		return err;
 	}
 
-	if (token.type != AT_TOKEN_TYPE_INT) {
+	switch (token.type) {
+	/* Acceptable types. */
+	case AT_TOKEN_TYPE_INT:
+		break;
+	case AT_TOKEN_TYPE_EMPTY:
+		return -ENODATA;
+	default:
 		return -EOPNOTSUPP;
 	}
 
@@ -493,6 +499,8 @@ static int at_parser_string_common_get_impl(struct at_parser *parser, size_t ind
 	case AT_TOKEN_TYPE_STRING:
 	case AT_TOKEN_TYPE_ARRAY:
 		break;
+	case AT_TOKEN_TYPE_EMPTY:
+		return -ENODATA;
 	default:
 		return -EOPNOTSUPP;
 	}

--- a/tests/lib/at_parser/src/main.c
+++ b/tests/lib/at_parser/src/main.c
@@ -810,15 +810,22 @@ ZTEST(at_parser, test_at_parser_uint16_get_eopnotsupp)
 	/* Trying to parse notification string as integer. */
 	ret = at_parser_uint16_get(&parser, 0, &val);
 	zassert_equal(ret, -EOPNOTSUPP);
+}
 
-	const char *str2 = "+NOTIF: 1,,3";
+ZTEST(at_parser, test_at_parser_uint16_get_enodata)
+{
+	int ret;
+	uint16_t val;
+	struct at_parser parser;
 
-	ret = at_parser_init(&parser, str2);
+	const char *str1 = "+NOTIF: 1,,3";
+
+	ret = at_parser_init(&parser, str1);
 	zassert_ok(ret);
 
 	/* Trying to parse an empty subparameter as integer. */
 	ret = at_parser_uint16_get(&parser, 2, &val);
-	zassert_equal(ret, -EOPNOTSUPP);
+	zassert_equal(ret, -ENODATA);
 }
 
 ZTEST(at_parser, test_at_parser_uint16_get_ebadmsg)
@@ -951,15 +958,22 @@ ZTEST(at_parser, test_at_parser_int16_get_eopnotsupp)
 	/* Trying to parse notification string as integer. */
 	ret = at_parser_int16_get(&parser, 0, &val);
 	zassert_equal(ret, -EOPNOTSUPP);
+}
 
-	const char *str2 = "+NOTIF: 1,,3";
+ZTEST(at_parser, test_at_parser_int16_get_enodata)
+{
+	int ret;
+	int16_t val;
+	struct at_parser parser;
 
-	ret = at_parser_init(&parser, str2);
+	const char *str1 = "+NOTIF: 1,,3";
+
+	ret = at_parser_init(&parser, str1);
 	zassert_ok(ret);
 
 	/* Trying to parse an empty subparameter as integer. */
 	ret = at_parser_int16_get(&parser, 2, &val);
-	zassert_equal(ret, -EOPNOTSUPP);
+	zassert_equal(ret, -ENODATA);
 }
 
 ZTEST(at_parser, test_at_parser_int16_get_ebadmsg)
@@ -1099,15 +1113,22 @@ ZTEST(at_parser, test_at_parser_uint32_get_eopnotsupp)
 	/* Trying to parse notification string as integer. */
 	ret = at_parser_uint32_get(&parser, 0, &val);
 	zassert_equal(ret, -EOPNOTSUPP);
+}
 
-	const char *str2 = "+NOTIF: 1,,3";
+ZTEST(at_parser, test_at_parser_uint32_get_enodata)
+{
+	int ret;
+	uint32_t val;
+	struct at_parser parser;
 
-	ret = at_parser_init(&parser, str2);
+	const char *str1 = "+NOTIF: 1,,3";
+
+	ret = at_parser_init(&parser, str1);
 	zassert_ok(ret);
 
 	/* Trying to parse an empty subparameter as integer. */
 	ret = at_parser_uint32_get(&parser, 2, &val);
-	zassert_equal(ret, -EOPNOTSUPP);
+	zassert_equal(ret, -ENODATA);
 }
 
 ZTEST(at_parser, test_at_parser_uint32_get_ebadmsg)
@@ -1242,15 +1263,22 @@ ZTEST(at_parser, test_at_parser_int32_get_eopnotsupp)
 	/* Trying to parse notification string as integer. */
 	ret = at_parser_int32_get(&parser, 0, &val);
 	zassert_equal(ret, -EOPNOTSUPP);
+}
 
-	const char *str2 = "+NOTIF: 1,,3";
+ZTEST(at_parser, test_at_parser_int32_get_enodata)
+{
+	int ret;
+	int32_t val;
+	struct at_parser parser;
 
-	ret = at_parser_init(&parser, str2);
+	const char *str1 = "+NOTIF: 1,,3";
+
+	ret = at_parser_init(&parser, str1);
 	zassert_ok(ret);
 
 	/* Trying to parse an empty subparameter as integer. */
 	ret = at_parser_int32_get(&parser, 2, &val);
-	zassert_equal(ret, -EOPNOTSUPP);
+	zassert_equal(ret, -ENODATA);
 }
 
 ZTEST(at_parser, test_at_parser_int32_get_ebadmsg)
@@ -1389,15 +1417,22 @@ ZTEST(at_parser, test_at_parser_uint64_get_eopnotsupp)
 	/* Trying to parse notification string as integer. */
 	ret = at_parser_uint64_get(&parser, 0, &val);
 	zassert_equal(ret, -EOPNOTSUPP);
+}
 
-	const char *str2 = "+NOTIF: 1,,3";
+ZTEST(at_parser, test_at_parser_uint64_get_enodata)
+{
+	int ret;
+	uint64_t val;
+	struct at_parser parser;
 
-	ret = at_parser_init(&parser, str2);
+	const char *str1 = "+NOTIF: 1,,3";
+
+	ret = at_parser_init(&parser, str1);
 	zassert_ok(ret);
 
 	/* Trying to parse an empty subparameter as integer. */
 	ret = at_parser_uint64_get(&parser, 2, &val);
-	zassert_equal(ret, -EOPNOTSUPP);
+	zassert_equal(ret, -ENODATA);
 }
 
 ZTEST(at_parser, test_at_parser_uint64_get_ebadmsg)
@@ -1540,15 +1575,22 @@ ZTEST(at_parser, test_at_parser_int64_get_eopnotsupp)
 	/* Trying to parse notification string as integer. */
 	ret = at_parser_int64_get(&parser, 0, &val);
 	zassert_equal(ret, -EOPNOTSUPP);
+}
 
-	const char *str2 = "+NOTIF: 1,,3";
+ZTEST(at_parser, test_at_parser_int64_get_enodata)
+{
+	int ret;
+	int64_t val;
+	struct at_parser parser;
 
-	ret = at_parser_init(&parser, str2);
+	const char *str1 = "+NOTIF: 1,,3";
+
+	ret = at_parser_init(&parser, str1);
 	zassert_ok(ret);
 
 	/* Trying to parse an empty subparameter as integer. */
 	ret = at_parser_int64_get(&parser, 2, &val);
-	zassert_equal(ret, -EOPNOTSUPP);
+	zassert_equal(ret, -ENODATA);
 }
 
 ZTEST(at_parser, test_at_parser_int64_get_ebadmsg)


### PR DESCRIPTION
Return `-ENODATA` instead of `-EOPNOTSUPP` when parsing empty subparameters.

Context: https://github.com/nrfconnect/sdk-nrf/pull/22331#discussion_r2090382280

Will update changelog and migration guide later. First running CI on this.