### PR TITLE
lib: st25r3911b: Correct irq_clear to prevent spurious IRQs

### DIFF
--- a/lib/st25r3911b/st25r3911b_interrupt.c
+++ b/lib/st25r3911b/st25r3911b_interrupt.c
@@ -161,6 +161,8 @@ int st25r39_irq_clear(void)
 {
 	uint8_t val[IRQ_REG_CNT] = {0};
 
+	k_sem_take(sem, K_NO_WAIT);
+
 	return st25r3911b_multiple_reg_read(ST25R3911B_REG_MAIN_INT,
 					    val, ARRAY_SIZE(val));
 }


### PR DESCRIPTION
For example: suppose the code had previously initialized the ST25R3911 and set it to wake-up mode. Later, for some reason, the application on the nRF device was rebooted.

During re-initialization, after calling st25r3911b_irq_init(), there is a short delay between enabling IRQs and starting the oscillator via osc_start(). In this interval, an IRQ may already be triggered by the chip. Since wake-up-related IRQs can occur every 10–800 ms, it’s likely that an interrupt happens before the oscillator is started.

After calling osc_start(), the code expects an interrupt signaling that the oscillator is ready. However, if the IRQ already occurred earlier, code may immediately read the IRQ registers and not find the expected oscillator-ready bit. This causes the code to misinterpret the state and return an error.

By adding k_sem_take() in st25r39_irq_clear(), we avoid handling such stale interrupts that happened before initialization was properly complete.
