### PR TITLE
samples: matter: Fix internal build configuration.

### DIFF
--- a/samples/matter/light_bulb/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
+++ b/samples/matter/light_bulb/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
@@ -1,55 +1,52 @@
 mcuboot:
   address: 0x0
   region: flash_primary
-  size: 0xD000
+  size: 0xA000
 mcuboot_pad:
-  address: 0xD000
+  address: 0xA000
   region: flash_primary
   size: 0x800
 app:
-  address: 0xD800
+  address: 0xA800
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
 mcuboot_primary:
-  address: 0xD000
+  address: 0xA000
   orig_span: &id001
   - app
   - mcuboot_pad
   region: flash_primary
-  size: 0xF1000
+  size: 0x126000
   span: *id001
 mcuboot_primary_app:
-  address: 0xD800
+  address: 0xA800
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
   span: *id002
 mcuboot_secondary:
-  address: 0xFE000
+  address: 0x130000
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: flash_primary
-  size: 0xF1000
+  size: 0xC0000
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0xFE000
+  address: 0x130000
   size: 0x800
+# Compression rate 34.75%
 mcuboot_secondary_app:
   region: flash_primary
-  address: 0xFE800
-  size: 0xF0800
+  address: 0x130800
+  size: 0xBF800
 factory_data:
-  address: 0x1EF000
+  address: 0x1F0000
   region: flash_primary
   size: 0x1000
 settings_storage:
-  address: 0x1F0000
+  address: 0x1F1000
   region: flash_primary
   size: 0xC000
-reserved:
-  address: 0x1FC000
-  region: flash_primary
-  size: 0x1000

--- a/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
+++ b/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
@@ -16,7 +16,7 @@ CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
-# Adjust the maximum sectors to the maximum app image size of ~2MB
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
 CONFIG_BOOT_MAX_IMG_SECTORS=512
 
 # Currently, without tickless kernel, the SYSCOUNTER value after the software

--- a/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
@@ -32,6 +32,9 @@ CONFIG_SPI_NOR=n
 CONFIG_SPI=n
 CONFIG_MULTITHREADING=n
 
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
+CONFIG_BOOT_MAX_IMG_SECTORS=512
+
 # Currently, without tickless kernel, the SYSCOUNTER value after the software
 # reset is not set properly and due to that the first system interrupt is not called
 # in the proper time - the SYSCOUNTER value is set to the value from before

--- a/samples/matter/light_switch/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
+++ b/samples/matter/light_switch/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
@@ -1,55 +1,52 @@
 mcuboot:
   address: 0x0
   region: flash_primary
-  size: 0xD000
+  size: 0xA000
 mcuboot_pad:
-  address: 0xD000
+  address: 0xA000
   region: flash_primary
   size: 0x800
 app:
-  address: 0xD800
+  address: 0xA800
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
 mcuboot_primary:
-  address: 0xD000
+  address: 0xA000
   orig_span: &id001
   - app
   - mcuboot_pad
   region: flash_primary
-  size: 0xF1000
+  size: 0x126000
   span: *id001
 mcuboot_primary_app:
-  address: 0xD800
+  address: 0xA800
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
   span: *id002
 mcuboot_secondary:
-  address: 0xFE000
+  address: 0x130000
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: flash_primary
-  size: 0xF1000
+  size: 0xC0000
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0xFE000
+  address: 0x130000
   size: 0x800
+# Compression rate 34.75%
 mcuboot_secondary_app:
   region: flash_primary
-  address: 0xFE800
-  size: 0xF0800
+  address: 0x130800
+  size: 0xBF800
 factory_data:
-  address: 0x1EF000
+  address: 0x1F0000
   region: flash_primary
   size: 0x1000
 settings_storage:
-  address: 0x1F0000
+  address: 0x1F1000
   region: flash_primary
   size: 0xC000
-reserved:
-  address: 0x1FC000
-  region: flash_primary
-  size: 0x1000

--- a/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
+++ b/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
@@ -16,7 +16,7 @@ CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
-# Adjust the maximum sectors to the maximum app image size of ~2MB
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
 CONFIG_BOOT_MAX_IMG_SECTORS=512
 
 # Currently, without tickless kernel, the SYSCOUNTER value after the software

--- a/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
@@ -32,6 +32,9 @@ CONFIG_SPI_NOR=n
 CONFIG_SPI=n
 CONFIG_MULTITHREADING=n
 
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
+CONFIG_BOOT_MAX_IMG_SECTORS=512
+
 # Currently, without tickless kernel, the SYSCOUNTER value after the software
 # reset is not set properly and due to that the first system interrupt is not called
 # in the proper time - the SYSCOUNTER value is set to the value from before

--- a/samples/matter/lock/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
+++ b/samples/matter/lock/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
@@ -1,55 +1,52 @@
 mcuboot:
   address: 0x0
   region: flash_primary
-  size: 0xD000
+  size: 0xA000
 mcuboot_pad:
-  address: 0xD000
+  address: 0xA000
   region: flash_primary
   size: 0x800
 app:
-  address: 0xD800
+  address: 0xA800
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
 mcuboot_primary:
-  address: 0xD000
+  address: 0xA000
   orig_span: &id001
   - app
   - mcuboot_pad
   region: flash_primary
-  size: 0xF1000
+  size: 0x126000
   span: *id001
 mcuboot_primary_app:
-  address: 0xD800
+  address: 0xA800
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
   span: *id002
 mcuboot_secondary:
-  address: 0xFE000
+  address: 0x130000
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: flash_primary
-  size: 0xF1000
+  size: 0xC0000
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0xFE000
+  address: 0x130000
   size: 0x800
+# Compression rate 34.75%
 mcuboot_secondary_app:
   region: flash_primary
-  address: 0xFE800
-  size: 0xF0800
+  address: 0x130800
+  size: 0xBF800
 factory_data:
-  address: 0x1EF000
+  address: 0x1F0000
   region: flash_primary
   size: 0x1000
 settings_storage:
-  address: 0x1F0000
+  address: 0x1F1000
   region: flash_primary
   size: 0xC000
-reserved:
-  address: 0x1FC000
-  region: flash_primary
-  size: 0x1000

--- a/samples/matter/lock/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
+++ b/samples/matter/lock/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
@@ -16,7 +16,7 @@ CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
-# Adjust the maximum sectors to the maximum app image size of ~2MB
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
 CONFIG_BOOT_MAX_IMG_SECTORS=512
 
 # Currently, without tickless kernel, the SYSCOUNTER value after the software

--- a/samples/matter/lock/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/lock/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
@@ -32,6 +32,9 @@ CONFIG_SPI_NOR=n
 CONFIG_SPI=n
 CONFIG_MULTITHREADING=n
 
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
+CONFIG_BOOT_MAX_IMG_SECTORS=512
+
 # Currently, without tickless kernel, the SYSCOUNTER value after the software
 # reset is not set properly and due to that the first system interrupt is not called
 # in the proper time - the SYSCOUNTER value is set to the value from before

--- a/samples/matter/manufacturer_specific/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
+++ b/samples/matter/manufacturer_specific/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
@@ -1,55 +1,52 @@
 mcuboot:
   address: 0x0
   region: flash_primary
-  size: 0xD000
+  size: 0xA000
 mcuboot_pad:
-  address: 0xD000
+  address: 0xA000
   region: flash_primary
   size: 0x800
 app:
-  address: 0xD800
+  address: 0xA800
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
 mcuboot_primary:
-  address: 0xD000
+  address: 0xA000
   orig_span: &id001
   - app
   - mcuboot_pad
   region: flash_primary
-  size: 0xF1000
+  size: 0x126000
   span: *id001
 mcuboot_primary_app:
-  address: 0xD800
+  address: 0xA800
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
   span: *id002
 mcuboot_secondary:
-  address: 0xFE000
+  address: 0x130000
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: flash_primary
-  size: 0xF1000
+  size: 0xC0000
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0xFE000
+  address: 0x130000
   size: 0x800
+# Compression rate 34.75%
 mcuboot_secondary_app:
   region: flash_primary
-  address: 0xFE800
-  size: 0xF0800
+  address: 0x130800
+  size: 0xBF800
 factory_data:
-  address: 0x1EF000
+  address: 0x1F0000
   region: flash_primary
   size: 0x1000
 settings_storage:
-  address: 0x1F0000
+  address: 0x1F1000
   region: flash_primary
   size: 0xC000
-reserved:
-  address: 0x1FC000
-  region: flash_primary
-  size: 0x1000

--- a/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
+++ b/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
@@ -16,7 +16,7 @@ CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
-# Adjust the maximum sectors to the maximum app image size of ~2MB
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
 CONFIG_BOOT_MAX_IMG_SECTORS=512
 
 # Currently, without tickless kernel, the SYSCOUNTER value after the software

--- a/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
@@ -32,6 +32,9 @@ CONFIG_SPI_NOR=n
 CONFIG_SPI=n
 CONFIG_MULTITHREADING=n
 
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
+CONFIG_BOOT_MAX_IMG_SECTORS=512
+
 # Currently, without tickless kernel, the SYSCOUNTER value after the software
 # reset is not set properly and due to that the first system interrupt is not called
 # in the proper time - the SYSCOUNTER value is set to the value from before

--- a/samples/matter/smoke_co_alarm/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
+++ b/samples/matter/smoke_co_alarm/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
@@ -1,55 +1,52 @@
 mcuboot:
   address: 0x0
   region: flash_primary
-  size: 0xD000
+  size: 0xA000
 mcuboot_pad:
-  address: 0xD000
+  address: 0xA000
   region: flash_primary
   size: 0x800
 app:
-  address: 0xD800
+  address: 0xA800
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
 mcuboot_primary:
-  address: 0xD000
+  address: 0xA000
   orig_span: &id001
   - app
   - mcuboot_pad
   region: flash_primary
-  size: 0xF1000
+  size: 0x126000
   span: *id001
 mcuboot_primary_app:
-  address: 0xD800
+  address: 0xA800
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
   span: *id002
 mcuboot_secondary:
-  address: 0xFE000
+  address: 0x130000
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: flash_primary
-  size: 0xF1000
+  size: 0xC0000
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0xFE000
+  address: 0x130000
   size: 0x800
+# Compression rate 34.75%
 mcuboot_secondary_app:
   region: flash_primary
-  address: 0xFE800
-  size: 0xF0800
+  address: 0x130800
+  size: 0xBF800
 factory_data:
-  address: 0x1EF000
+  address: 0x1F0000
   region: flash_primary
   size: 0x1000
 settings_storage:
-  address: 0x1F0000
+  address: 0x1F1000
   region: flash_primary
   size: 0xC000
-reserved:
-  address: 0x1FC000
-  region: flash_primary
-  size: 0x1000

--- a/samples/matter/smoke_co_alarm/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
+++ b/samples/matter/smoke_co_alarm/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
@@ -16,7 +16,7 @@ CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
-# Adjust the maximum sectors to the maximum app image size of ~2MB
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
 CONFIG_BOOT_MAX_IMG_SECTORS=512
 
 # Currently, without tickless kernel, the SYSCOUNTER value after the software

--- a/samples/matter/smoke_co_alarm/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/smoke_co_alarm/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
@@ -32,6 +32,9 @@ CONFIG_SPI_NOR=n
 CONFIG_SPI=n
 CONFIG_MULTITHREADING=n
 
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
+CONFIG_BOOT_MAX_IMG_SECTORS=512
+
 # Currently, without tickless kernel, the SYSCOUNTER value after the software
 # reset is not set properly and due to that the first system interrupt is not called
 # in the proper time - the SYSCOUNTER value is set to the value from before

--- a/samples/matter/template/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
+++ b/samples/matter/template/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
@@ -1,55 +1,52 @@
 mcuboot:
   address: 0x0
   region: flash_primary
-  size: 0xD000
+  size: 0xA000
 mcuboot_pad:
-  address: 0xD000
+  address: 0xA000
   region: flash_primary
   size: 0x800
 app:
-  address: 0xD800
+  address: 0xA800
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
 mcuboot_primary:
-  address: 0xD000
+  address: 0xA000
   orig_span: &id001
   - app
   - mcuboot_pad
   region: flash_primary
-  size: 0xF1000
+  size: 0x126000
   span: *id001
 mcuboot_primary_app:
-  address: 0xD800
+  address: 0xA800
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
   span: *id002
 mcuboot_secondary:
-  address: 0xFE000
+  address: 0x130000
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: flash_primary
-  size: 0xF1000
+  size: 0xC0000
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0xFE000
+  address: 0x130000
   size: 0x800
+# Compression rate 34.75%
 mcuboot_secondary_app:
   region: flash_primary
-  address: 0xFE800
-  size: 0xF0800
+  address: 0x130800
+  size: 0xBF800
 factory_data:
-  address: 0x1EF000
+  address: 0x1F0000
   region: flash_primary
   size: 0x1000
 settings_storage:
-  address: 0x1F0000
+  address: 0x1F1000
   region: flash_primary
   size: 0xC000
-reserved:
-  address: 0x1FC000
-  region: flash_primary
-  size: 0x1000

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_internal.conf
@@ -34,8 +34,6 @@ CONFIG_SPI_NOR=n
 CONFIG_SPI=n
 CONFIG_MULTITHREADING=n
 
-CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
-
 # Currently, without tickless kernel, the SYSCOUNTER value after the software
 # reset is not set properly and due to that the first system interrupt is not called
 # in the proper time - the SYSCOUNTER value is set to the value from before

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
@@ -16,7 +16,7 @@ CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
-# Adjust the maximum sectors to the maximum app image size of ~2MB
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
 CONFIG_BOOT_MAX_IMG_SECTORS=512
 
 # Currently, without tickless kernel, the SYSCOUNTER value after the software

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
@@ -32,6 +32,9 @@ CONFIG_SPI_NOR=n
 CONFIG_SPI=n
 CONFIG_MULTITHREADING=n
 
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
+CONFIG_BOOT_MAX_IMG_SECTORS=512
+
 # Currently, without tickless kernel, the SYSCOUNTER value after the software
 # reset is not set properly and due to that the first system interrupt is not called
 # in the proper time - the SYSCOUNTER value is set to the value from before

--- a/samples/matter/thermostat/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
+++ b/samples/matter/thermostat/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
@@ -1,55 +1,52 @@
 mcuboot:
   address: 0x0
   region: flash_primary
-  size: 0xD000
+  size: 0xA000
 mcuboot_pad:
-  address: 0xD000
+  address: 0xA000
   region: flash_primary
   size: 0x800
 app:
-  address: 0xD800
+  address: 0xA800
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
 mcuboot_primary:
-  address: 0xD000
+  address: 0xA000
   orig_span: &id001
   - app
   - mcuboot_pad
   region: flash_primary
-  size: 0xF1000
+  size: 0x126000
   span: *id001
 mcuboot_primary_app:
-  address: 0xD800
+  address: 0xA800
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
   span: *id002
 mcuboot_secondary:
-  address: 0xFE000
+  address: 0x130000
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: flash_primary
-  size: 0xF1000
+  size: 0xC0000
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0xFE000
+  address: 0x130000
   size: 0x800
+# Compression rate 34.75%
 mcuboot_secondary_app:
   region: flash_primary
-  address: 0xFE800
-  size: 0xF0800
+  address: 0x130800
+  size: 0xBF800
 factory_data:
-  address: 0x1EF000
+  address: 0x1F0000
   region: flash_primary
   size: 0x1000
 settings_storage:
-  address: 0x1F0000
+  address: 0x1F1000
   region: flash_primary
   size: 0xC000
-reserved:
-  address: 0x1FC000
-  region: flash_primary
-  size: 0x1000

--- a/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
+++ b/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
@@ -16,7 +16,7 @@ CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
-# Adjust the maximum sectors to the maximum app image size of ~2MB
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
 CONFIG_BOOT_MAX_IMG_SECTORS=512
 
 # Currently, without tickless kernel, the SYSCOUNTER value after the software

--- a/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
@@ -32,6 +32,9 @@ CONFIG_SPI_NOR=n
 CONFIG_SPI=n
 CONFIG_MULTITHREADING=n
 
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
+CONFIG_BOOT_MAX_IMG_SECTORS=512
+
 # Currently, without tickless kernel, the SYSCOUNTER value after the software
 # reset is not set properly and due to that the first system interrupt is not called
 # in the proper time - the SYSCOUNTER value is set to the value from before

--- a/samples/matter/window_covering/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
+++ b/samples/matter/window_covering/pm_static_nrf54lm20pdk_nrf54lm20a_cpuapp_internal.yml
@@ -1,55 +1,52 @@
 mcuboot:
   address: 0x0
   region: flash_primary
-  size: 0xD000
+  size: 0xA000
 mcuboot_pad:
-  address: 0xD000
+  address: 0xA000
   region: flash_primary
   size: 0x800
 app:
-  address: 0xD800
+  address: 0xA800
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
 mcuboot_primary:
-  address: 0xD000
+  address: 0xA000
   orig_span: &id001
   - app
   - mcuboot_pad
   region: flash_primary
-  size: 0xF1000
+  size: 0x126000
   span: *id001
 mcuboot_primary_app:
-  address: 0xD800
+  address: 0xA800
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0xF0800
+  size: 0x125800
   span: *id002
 mcuboot_secondary:
-  address: 0xFE000
+  address: 0x130000
   orig_span: &id003
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: flash_primary
-  size: 0xF1000
+  size: 0xC0000
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0xFE000
+  address: 0x130000
   size: 0x800
+# Compression rate 34.75%
 mcuboot_secondary_app:
   region: flash_primary
-  address: 0xFE800
-  size: 0xF0800
+  address: 0x130800
+  size: 0xBF800
 factory_data:
-  address: 0x1EF000
+  address: 0x1F0000
   region: flash_primary
   size: 0x1000
 settings_storage:
-  address: 0x1F0000
+  address: 0x1F1000
   region: flash_primary
   size: 0xC000
-reserved:
-  address: 0x1FC000
-  region: flash_primary
-  size: 0x1000

--- a/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
+++ b/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.conf
@@ -16,7 +16,7 @@ CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
-# Adjust the maximum sectors to the maximum app image size of ~2MB
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
 CONFIG_BOOT_MAX_IMG_SECTORS=512
 
 # Currently, without tickless kernel, the SYSCOUNTER value after the software

--- a/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_internal.conf
@@ -32,6 +32,9 @@ CONFIG_SPI_NOR=n
 CONFIG_SPI=n
 CONFIG_MULTITHREADING=n
 
+# Increase the maximum number of sectors to 512 to fit the big image size (> 1024 kB).
+CONFIG_BOOT_MAX_IMG_SECTORS=512
+
 # Currently, without tickless kernel, the SYSCOUNTER value after the software
 # reset is not set properly and due to that the first system interrupt is not called
 # in the proper time - the SYSCOUNTER value is set to the value from before


### PR DESCRIPTION
For nRF54LM20 DKs we must CONFIG_BOOT_MAX_IMG_SECTORS=512 in Mcuboot configuration, because the primary image size is bigger than 1024 kB (256 sectors per 4kB). Even for the internal DFU configuration.