### PR TITLE
doc: wifi: Improve radio test combo build instruction

### DIFF
--- a/doc/nrf/includes/wifi_radio_test_subcommands.txt
+++ b/doc/nrf/includes/wifi_radio_test_subcommands.txt
@@ -265,3 +265,9 @@ Wi-Fi radio test subcommands
      - N/A
      - Action
      - Get battery voltage.
+   * - sr_ant_switch_ctrl
+     - | 0: Use SR antenna
+       | 1: Use shared Wi-Fi antenna
+     - 0
+     - Configuration
+     - Allows configuration of the Short Range (SR) side switch to connect to either SR antenna or Wi-Fi antenna.

--- a/doc/nrf/protocols/wifi/regulatory_certification/wifi_radio_test_sample/wifi_build_instructions.rst
+++ b/doc/nrf/protocols/wifi/regulatory_certification/wifi_radio_test_sample/wifi_build_instructions.rst
@@ -18,11 +18,15 @@ Combined build for Radio test and Wi-Fi Radio test
 **************************************************
 
 The combined build configuration builds the binary files for the Wi-Fi Radio test that resides in the application core and the Radio test (short-range) that resides in the network core.
-In the :file:`<ncs_repo>/nrf/samples/wifi/radio_test/multi_domain/prj.conf` file, set :kconfig:option:`CONFIG_SUPPORT_NETCORE_PERIPHERAL_RADIO_TEST` = ``y``.
+In the :file:`<ncs_repo>/nrf/samples/wifi/radio_test/multi_domain/prj.conf` file, set :kconfig:option:`CONFIG_NRF70_SR_COEX` = ``y``, :kconfig:option:`CONFIG_NRF70_SR_COEX_RF_SWITCH` = ``y``, and :kconfig:option:`CONFIG_SUPPORT_NETCORE_PERIPHERAL_RADIO_TEST` = ``y`` Kconfig options.
 
 .. code-block:: shell
 
    $ west build -p -b nrf7002dk/nrf5340/cpuapp (DK build)
+
+.. note::
+
+   Set ``sr_ant_switch_ctrl`` subcommand to ``1`` on the Wi-Fi Radio test UART port to switch the BLE RF signal to the BLE U.FL socket.
 
 The following HEX files are generated:
 

--- a/samples/wifi/radio_test/multi_domain/sample.yaml
+++ b/samples/wifi/radio_test/multi_domain/sample.yaml
@@ -26,7 +26,10 @@ tests:
   sample.nrf7002.radio_test_combo:
     sysbuild: true
     build_only: true
-    extra_args: SB_CONFIG_SUPPORT_NETCORE_PERIPHERAL_RADIO_TEST=y
+    extra_args:
+      - CONFIG_NRF70_SR_COEX=y
+      - CONFIG_NRF70_SR_COEX_RF_SWITCH=y
+      - SB_CONFIG_SUPPORT_NETCORE_PERIPHERAL_RADIO_TEST=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp


### PR DESCRIPTION
[SHEL-3458]: Introduce kconfig options for radio test combo build command, add instructions and description for sr antenna switch control.

[SHEL-3458]: https://nordicsemi.atlassian.net/browse/SHEL-3458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ