### PR TITLE
samples: matter: enable additional 54lm20 configuration for CI

### DIFF
--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -56,11 +56,13 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     tags:
       - sysbuild
       - ci_samples_matter
@@ -100,11 +102,13 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf7002dk/nrf5340/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf7002dk/nrf5340/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     tags:
       - sysbuild
       - ci_samples_matter

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -133,10 +133,12 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     tags:
       - sysbuild
       - ci_samples_matter

--- a/samples/matter/smoke_co_alarm/sample.yaml
+++ b/samples/matter/smoke_co_alarm/sample.yaml
@@ -52,10 +52,12 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
     tags:
       - sysbuild
       - ci_samples_matter


### PR DESCRIPTION
Enable additional 54lm20 configuration for Matter CI.