### PR TITLE
drivers: serial: uart_nrf_sw_lpuart: clear req pin at the end of req_pin_idle() function

### DIFF
--- a/drivers/serial/uart_nrf_sw_lpuart.c
+++ b/drivers/serial/uart_nrf_sw_lpuart.c
@@ -155,6 +155,7 @@ static void req_pin_idle(struct lpuart_data *data)
 		     NRF_GPIO_PIN_NOPULL,
 		     NRF_GPIO_PIN_S0S1,
 		     NRF_GPIO_PIN_NOSENSE);
+	nrf_gpio_pin_clear(data->req_pin);
 }
 
 static void pend_req_pin_idle(struct lpuart_data *data)


### PR DESCRIPTION
According to driver doc req pin should be configured as output and set low in idle mode. However inside the lpuart driver pin is only configured as output without clearing. This creates weakness of the driver which can be utlized by simply setting pin high prior to driver initialization. This commit is intended to fix it.