### PR TITLE
applications: serial_lte_modem: Kconfig for PPP auto enable

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -161,17 +161,22 @@ config SLM_NRF_CLOUD
 
 config SLM_FULL_FOTA
 	bool "Full modem FOTA support in SLM"
-	default n
 	depends on !BOARD_THINGY91_NRF9160_NS
 
 config SLM_PPP
 	bool "PPP support in SLM"
-	help
-	  When enabled, SLM automatically brings up/down the PPP link
-	  when the LTE link (default PDN) is connected/disconnected,
-	  regardless of what is done with AT#XPPP.
 
 if SLM_PPP
+
+config SLM_PPP_AUTO_ENABLE
+	bool "Bring up PPP link automatically when PDN is connected"
+	default y
+	help
+	  When enabled, SLM automatically brings up/down the PPP link
+	  when the PDN assigned for PPP (the default PDN by default) is connected/disconnected,
+	  regardless of what is done with AT#XPPP.
+	  When disabled, PPP link is brought up when AT#XPPP=1 is issued after
+	  the PDN assigned for PPP (the default PDN by default) is connected.
 
 config SLM_PPP_FALLBACK_MTU
 	int "Fallback MTU to be used by PPP"

--- a/applications/serial_lte_modem/src/slm_ppp.c
+++ b/applications/serial_lte_modem/src/slm_ppp.c
@@ -452,6 +452,8 @@ static void subscribe_cgev_notifications(void)
 	}
 }
 
+#if defined(CONFIG_SLM_PPP_AUTO_ENABLE)
+
 AT_MONITOR(slm_ppp_on_cgev, "CGEV", at_notif_on_cgev);
 
 static void at_notif_on_cgev(const char *notify)
@@ -484,6 +486,7 @@ static void at_notif_on_cgev(const char *notify)
 		}
 	}
 }
+#endif
 
 /* Notification subscriptions are reset on CFUN=0.
  * We intercept CFUN set commands to automatically subscribe.
@@ -502,7 +505,10 @@ static int at_cfun_set_callback(char *buf, size_t len, char *at_cmd)
 	}
 
 	if (mode == LTE_LC_FUNC_MODE_NORMAL || mode == LTE_LC_FUNC_MODE_ACTIVATE_LTE) {
-		subscribe_cgev_notifications();
+		/* +CGEV notifications only needed when PPP link is brought up automatically */
+		if (IS_ENABLED(CONFIG_SLM_PPP_AUTO_ENABLE)) {
+			subscribe_cgev_notifications();
+		}
 	} else if (mode == LTE_LC_FUNC_MODE_POWER_OFF) {
 		/* Unsubscribe the user as would normally happen. */
 		slm_fwd_cgev_notifs = false;


### PR DESCRIPTION
Added Kconfig for enabling PPP automatically when PDN connection is activated. This has been the behavior so far so the Kconfig is to be able to disable it. The option is ON by default.

Jira: SLM-85