### PR TITLE
emds: fix writing buffer size usage

### DIFF
--- a/subsys/emds/Kconfig
+++ b/subsys/emds/Kconfig
@@ -75,6 +75,18 @@ config EMDS_FLASH_TIME_BASE_OVERHEAD_US
 	   datasheet.
 	   For RRAM-based persistent memory driver, use ERASEPROTECT and disregard the SOC_FLASH_NRF_PARTIAL_ERASE_MS parameter.
 
+if SOC_FLASH_NRF_RRAM
+
+config EMDS_RRAM_WRITE_BUFFER_SIZE
+	int "Internal write-buffer size"
+	default 1
+	range 1 32
+	help
+	  Number of 128-bit words.
+	  Maximum buffer size can be configured to the value of 32 (128-bit words).
+
+endif # SOC_FLASH_NRF_RRAM
+
 module = EMDS
 module-str = emergency data storage
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/subsys/emds/emds_flash.c
+++ b/subsys/emds/emds_flash.c
@@ -20,7 +20,9 @@
 #define RRAM_START            DT_REG_ADDR(RRAM)
 #define RRAM_SIZE             DT_REG_SIZE(RRAM)
 #define EMDS_FLASH_BLOCK_SIZE DT_PROP(RRAM, write_block_size)
-#define WRITE_BUFFER_SIZE     NRF_RRAMC_CONFIG_WRITE_BUFF_SIZE_MAX
+#define WRITE_BUFFER_SIZE     CONFIG_EMDS_RRAM_WRITE_BUFFER_SIZE /* in 128-bits words */
+#define WRITE_LINE_SIZE       16 /* In bytes, one line is 128 bits. */
+#define WRITE_BUFFER_SIZE_IN_BYTES (WRITE_BUFFER_SIZE * WRITE_LINE_SIZE)
 #else
 #include <nrfx_nvmc.h>
 #define FLASH                 DT_INST(0, soc_nv_flash)
@@ -145,7 +147,7 @@ static void commit_changes(size_t len)
 		return;
 	}
 
-	if ((len % WRITE_BUFFER_SIZE) == 0) {
+	if ((len % WRITE_BUFFER_SIZE_IN_BYTES) == 0) {
 		/* Our last operation was buffer size-aligned, so we're done. */
 		return;
 	}

--- a/tests/subsys/emds/emds_flash/src/main.c
+++ b/tests/subsys/emds/emds_flash/src/main.c
@@ -22,7 +22,7 @@
 #define RRAM DT_INST(0, soc_nv_flash)
 #define EMDS_FLASH_BLOCK_SIZE DT_PROP(RRAM, write_block_size)
 #define EXPECTED_STORE_TIME_BLOCK_SIZE (400)
-#define EXPECTED_STORE_TIME_1024 (3000)
+#define EXPECTED_STORE_TIME_1024 (6200)
 #else
 #define FLASH DT_INST(0, soc_nv_flash)
 #define EMDS_FLASH_BLOCK_SIZE DT_PROP(FLASH, write_block_size)


### PR DESCRIPTION
Commit:
 * adds option to configure rram writing buffer size;
 * fixes writing buffer length usage;
 * fixes emds test measured writing performance (it uses now value close to datasheet)