### PR TITLE
bluetooth: improving linking for channel sounding

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -994,6 +994,13 @@ static int configure_supported_features(void)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_CTLR_SDC_CS_STEP_MODE3)) {
+		err = sdc_support_channel_sounding_mode3();
+		if (err) {
+			return -ENOTSUP;
+		}
+	}
+
 	if (IS_ENABLED(CONFIG_BT_CTLR_SDC_LE_POWER_CLASS_1)) {
 		err = sdc_support_le_power_class_1();
 		if (err) {


### PR DESCRIPTION
Allowing users to link-out the channel sounding mode 3 to improve flash usage.