### PR TITLE
net: nrf_provisioning: Add new query parameter

### DIFF
--- a/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_cbor
+++ b/subsys/net/lib/nrf_provisioning/Kconfig.nrf_provisioning_cbor
@@ -11,6 +11,7 @@ if NRF_PROVISIONING_CBOR
 
 config NRF_PROVISIONING_CBOR_RECORDS
 	int "Maximum number of CBOR records that can be encoded or decoded at a time"
+	range 5 20
 	default 10
 
 endif

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
@@ -49,7 +49,9 @@ LOG_MODULE_REGISTER(nrf_provisioning_coap, CONFIG_NRF_PROVISIONING_LOG_LEVEL);
 #define CMDS_AFTER "after=%s"
 #define CMDS_MAX_RX_SZ "rxMaxSize=%s"
 #define CMDS_MAX_TX_SZ "txMaxSize=%s"
-#define CMDS_API_TEMPLATE (CMDS_PATH "?" CMDS_AFTER "&" CMDS_MAX_RX_SZ "&" CMDS_MAX_TX_SZ)
+#define CMDS_LIMIT "limit=%s"
+#define CMDS_API_TEMPLATE (CMDS_PATH "?" \
+	CMDS_AFTER "&" CMDS_MAX_RX_SZ "&" CMDS_MAX_TX_SZ "&" CMDS_LIMIT)
 
 #define RETRY_AMOUNT 10
 static const char *resp_path = "p/rsp";
@@ -482,17 +484,18 @@ static int request_commands(struct coap_client *client,
 {
 	int ret;
 	char after[NRF_PROVISIONING_CORRELATION_ID_SIZE];
-	char *rx_buf_sz = STRINGIFY(CONFIG_NRF_PROVISIONING_RX_BUF_SZ);
-	char *tx_buf_sz = STRINGIFY(CONFIG_NRF_PROVISIONING_TX_BUF_SZ);
+	const char *rx_buf_sz = STRINGIFY(CONFIG_NRF_PROVISIONING_RX_BUF_SZ);
+	const char *tx_buf_sz = STRINGIFY(CONFIG_NRF_PROVISIONING_TX_BUF_SZ);
+	const char *limit = STRINGIFY(CONFIG_NRF_PROVISIONING_CBOR_RECORDS);
 	char cmd[sizeof(CMDS_API_TEMPLATE) + NRF_PROVISIONING_CORRELATION_ID_SIZE +
-		 strlen(rx_buf_sz) + strlen(tx_buf_sz)];
+		 strlen(rx_buf_sz) + strlen(tx_buf_sz) + strlen(limit)];
 
 	LOG_DBG("Get commands");
 
 	memcpy(after, nrf_provisioning_codec_get_latest_cmd_id(),
 	       NRF_PROVISIONING_CORRELATION_ID_SIZE);
 
-	ret = snprintk(cmd, sizeof(cmd), CMDS_API_TEMPLATE, after, rx_buf_sz, tx_buf_sz);
+	ret = snprintk(cmd, sizeof(cmd), CMDS_API_TEMPLATE, after, rx_buf_sz, tx_buf_sz, limit);
 
 	if ((ret < 0) || (ret >= sizeof(cmd))) {
 		LOG_ERR("Could not format URL");

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
@@ -53,8 +53,9 @@ LOG_MODULE_REGISTER(nrf_provisioning_http, CONFIG_NRF_PROVISIONING_LOG_LEVEL);
 #define CMDS_MAX_RX_SZ "rxMaxSize=%s"
 #define CMDS_MAX_TX_SZ "txMaxSize=%s"
 #define CMDS_MVER "mver=%s"
+#define CMDS_LIMIT "limit=%s"
 #define API_CMDS_TEMPLATE (API_GET_CMDS "?" \
-	CMDS_AFTER "&" CMDS_MAX_RX_SZ "&" CMDS_MAX_TX_SZ "&" CMDS_MVER "&" CMDS_CVER)
+	CMDS_AFTER "&" CMDS_MAX_RX_SZ "&" CMDS_MAX_TX_SZ "&" CMDS_MVER "&" CMDS_CVER "&" CMDS_LIMIT)
 
 #define API_POST_RSLT API_VER API_PRV "/response"
 
@@ -257,10 +258,11 @@ static int gen_provisioning_url(struct rest_client_req_context *const req)
 {
 	char *url;
 	size_t buff_sz;
-	char *rx_buf_sz = STRINGIFY(CONFIG_NRF_PROVISIONING_RX_BUF_SZ);
-	char *tx_buf_sz = STRINGIFY(CONFIG_NRF_PROVISIONING_TX_BUF_SZ);
+	const char *rx_buf_sz = STRINGIFY(CONFIG_NRF_PROVISIONING_RX_BUF_SZ);
+	const char *tx_buf_sz = STRINGIFY(CONFIG_NRF_PROVISIONING_TX_BUF_SZ);
+	const char *limit = STRINGIFY(CONFIG_NRF_PROVISIONING_CBOR_RECORDS);
+	const char *cver = STRINGIFY(1);
 	char mver[128];
-	char *cver = STRINGIFY(1);
 	int ret;
 	char *mvernmb, *save_mvernmb;
 	int cnt;
@@ -286,7 +288,7 @@ static int gen_provisioning_url(struct rest_client_req_context *const req)
 
 	buff_sz = sizeof(API_CMDS_TEMPLATE) +
 		strlen(after) + strlen(rx_buf_sz) + strlen(tx_buf_sz) +
-		strlen(mvernmb) + strlen(cver);
+		strlen(mvernmb) + strlen(cver) + strlen(limit);
 	url = k_malloc(buff_sz);
 	if (!url) {
 		ret = -ENOMEM;
@@ -296,7 +298,7 @@ static int gen_provisioning_url(struct rest_client_req_context *const req)
 	req->url = url;
 
 	ret = snprintk(url, buff_sz,
-		API_CMDS_TEMPLATE, after, rx_buf_sz, tx_buf_sz, mvernmb, cver);
+		API_CMDS_TEMPLATE, after, rx_buf_sz, tx_buf_sz, mvernmb, cver, limit);
 
 	if ((ret < 0) || (ret >= buff_sz)) {
 		LOG_ERR("Could not format URL");

--- a/tests/subsys/net/lib/nrf_provisioning/src/coap.c
+++ b/tests/subsys/net/lib/nrf_provisioning/src/coap.c
@@ -275,7 +275,8 @@ static int coap_client_cmds_valid_path_cb(struct coap_client *client, int sock,
 					  int cmock_num_calls)
 {
 	char path[] = "p/cmd?after=&rxMaxSize=" STRINGIFY(CONFIG_NRF_PROVISIONING_RX_BUF_SZ)
-		"&txMaxSize=" STRINGIFY(CONFIG_NRF_PROVISIONING_TX_BUF_SZ);
+		"&txMaxSize=" STRINGIFY(CONFIG_NRF_PROVISIONING_TX_BUF_SZ)
+		"&limit=" STRINGIFY(CONFIG_NRF_PROVISIONING_CBOR_RECORDS);
 
 	if (strncmp(req->path, auth_path, strlen(auth_path)) == 0) {
 		req->cb(COAP_RESPONSE_CODE_CREATED, 0, NULL, 0, true, req->user_data);

--- a/tests/subsys/net/lib/nrf_provisioning/src/main.c
+++ b/tests/subsys/net/lib/nrf_provisioning/src/main.c
@@ -42,7 +42,7 @@
 
 #define CRLF "\r\n"
 
-#define QUERY_ITEMS_MAX 5
+#define QUERY_ITEMS_MAX 6
 
 char tok_jwt_plain[] = AUTH_HDR_BEARER_JWT_DUMMY;
 char http_auth_hdr[] = AUTH_HDR_BEARER AUTH_HDR_BEARER_JWT_DUMMY CRLF;
@@ -328,17 +328,19 @@ static int rest_client_request_url_valid(struct rest_client_req_context *req_ctx
 		char *command;
 		char *txMaxSize;
 		char *rxMaxSize;
+		char *limit;
 	};
 
-	/* 'txMaxSize', 'rxMaxSize', 'mver', 'cver' and 'after' */
-	char *query_items[QUERY_ITEMS_MAX] = { NULL, NULL, NULL, NULL };
+	/* 'txMaxSize', 'rxMaxSize', 'mver', 'cver', limit and 'after' */
+	char *query_items[QUERY_ITEMS_MAX] = {};
 
 	struct url_info info = { .apiver = 0,
 				 .mversion = NULL,
 				 .endpoint = NULL,
 				 .command = NULL,
 				 .txMaxSize = NULL,
-				 .rxMaxSize = NULL };
+				 .rxMaxSize = NULL,
+				 .limit = NULL };
 
 	tokens = (char *)malloc(strlen(req_ctx->url) + 1);
 
@@ -405,6 +407,10 @@ static int rest_client_request_url_valid(struct rest_client_req_context *req_ctx
 			info.rxMaxSize = &(query_items[idx][strlen("rxMaxSize=")]);
 			TEST_ASSERT_EQUAL_INT(
 				CONFIG_NRF_PROVISIONING_RX_BUF_SZ, atoi(info.rxMaxSize));
+		} else if (strncmp(query_items[idx], "limit=", strlen("limit=")) == 0) {
+			info.limit = &(query_items[idx][strlen("limit=")]);
+			TEST_ASSERT_EQUAL_INT(
+				CONFIG_NRF_PROVISIONING_CBOR_RECORDS, atoi(info.limit));
 		} else if (strncmp(query_items[idx], "after=", strlen("after=")) == 0) {
 			;
 		} else {


### PR DESCRIPTION
Introduce a new query parameter that allows users to specify the maximum number of provisioning commands that can be received from the server.