### PR TITLE
tests: zephyr: drivers: i2s: Fix ACLK settings for TDM

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -69,10 +69,3 @@
   platforms:
     - qemu_cortex_m3/ti_lm3s6965
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-33747"
-
-- scenarios:
-    - nrf.extended.drivers.i2s.i2s_api.gpio_loopback.54h.audiopll
-    - nrf.extended.drivers.i2s.i2s_speed.gpio_loopback.54h.audiopll
-  platforms:
-    - nrf54h20dk@0.9.0/nrf54h20/cpuapp
-  comment: "https://nordicsemi.atlassian.net/browse/NRFX-7789"

--- a/tests/zephyr/drivers/i2s/i2s_api/boards/tdm_audiopll.overlay
+++ b/tests/zephyr/drivers/i2s/i2s_api/boards/tdm_audiopll.overlay
@@ -5,7 +5,7 @@
  */
 
 &tdm130 {
-	clock-source = "ACLK";
+	sck-clock-source = "ACLK";
 };
 
 &audiopll {

--- a/tests/zephyr/drivers/i2s/i2s_speed/boards/tdm_audiopll.overlay
+++ b/tests/zephyr/drivers/i2s/i2s_speed/boards/tdm_audiopll.overlay
@@ -5,7 +5,7 @@
  */
 
 &tdm130 {
-	clock-source = "ACLK";
+	sck-clock-source = "ACLK";
 };
 
 &audiopll {


### PR DESCRIPTION
ACLK can be independently connected to MCK and SCK, thus two different properies are to be used (`sck-clock-source` and `mck-clock-source`) instead of common `clock-source`.