### PR TITLE
iar: cmake: remove hardcoded flags

### DIFF
--- a/subsys/nrf_security/src/CMakeLists.txt
+++ b/subsys/nrf_security/src/CMakeLists.txt
@@ -189,16 +189,6 @@ target_link_libraries(${mbedcrypto_target}
     mbedcrypto_base
 )
 
-# Disable compile warnings for Mbed TLS sources for files that are
-# added to the build for legacy APIs but are not enabled due to
-# configurations not being set.
-#
-# These can be removed when NCSDK-28901 is addressed.
-target_compile_options(${mbedcrypto_target}
-  PRIVATE
-    -Wno-unused-function
-    -Wno-unused-variable
-)
 
 # Add PSA core
 if(CONFIG_MBEDTLS_PSA_CRYPTO_C)

--- a/subsys/nrf_security/src/drivers/cracen/CMakeLists.txt
+++ b/subsys/nrf_security/src/drivers/cracen/CMakeLists.txt
@@ -24,13 +24,6 @@ add_library(cracen_psa_driver STATIC
   ${cracen_driver_sources}
 )
 
-# The CRACEN sources have not been written to comply with this gcc
-# warning
-target_compile_options(cracen_psa_driver
-  PRIVATE
-    -Wno-pointer-sign
-    -Wno-unused-function
-)
 
 target_link_libraries(cracen_psa_driver
   PRIVATE

--- a/subsys/nrf_security/src/drivers/nrf_oberon/CMakeLists.txt
+++ b/subsys/nrf_security/src/drivers/nrf_oberon/CMakeLists.txt
@@ -42,16 +42,6 @@ add_library(oberon_psa_driver STATIC
   ${src_crypto_oberon}
 )
 
-# Turn off warnings that Oberon are systematically
-# triggering. Oberon is testing this deliverable before we get it so
-# we don't need to re-test it with gcc warnings.
-target_compile_options(oberon_psa_driver
-  PRIVATE
-    -Wno-uninitialized
-    -Wno-unused-variable
-    -Wno-unused-function
-)
-
 # Clang does not support -Wno-maybe-uninitialized so the following
 # warning option is only used for GNU (GCC)
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
These seem to not be needed anymore.

If they turn out to be we should guard them checking for NOT IAR with if or generator expression.
Maybe they should be added as compiler property flags in zephyr, but that is a larger project.
I thought since comments looked like this was temporary that we try to remove them.
