### PR TITLE
mcuboot: Support for DIRECT XIP on nRF54H (App core only)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -792,6 +792,7 @@
 /subsys/fw_info/                          @nrfconnect/ncs-pluto
 /subsys/gazell/                           @leewkb4567
 /subsys/logging/                          @nrfconnect/ncs-protocols-serialization
+/subsys/mcuboot/                          @nrfconnect/ncs-charon
 /subsys/mgmt/                             @nrfconnect/ncs-pluto
 /subsys/mgmt/suitfu/                      @nrfconnect/ncs-charon
 /subsys/mpsl/                             @nrfconnect/ncs-dragoon

--- a/subsys/mcuboot/mcuboot_secondary_app.overlay
+++ b/subsys/mcuboot/mcuboot_secondary_app.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,code-partition = &slot1_partition;
+	};
+};

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -287,8 +287,8 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
       set_config_bool(mcuboot CONFIG_BOOT_FIH_PROFILE_DEFAULT_LOW y)
     endif()
 
-    if(SB_CONFIG_PARTITION_MANAGER)
-      # Use NCS signing script with support for PM
+    if(SB_CONFIG_PARTITION_MANAGER OR SB_CONFIG_MCUBOOT_MODE_DIRECT_XIP OR SB_CONFIG_MCUBOOT_MODE_DIRECT_XIP_WITH_REVERT)
+      # Use NCS signing script with support for PM or direct XIP (NCS specific features)
       if(SB_CONFIG_QSPI_XIP_SPLIT_IMAGE)
         set(${DEFAULT_IMAGE}_SIGNING_SCRIPT "${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/image_signing_split.cmake" CACHE INTERNAL "MCUboot signing script" FORCE)
 

--- a/sysbuild/mcuboot.cmake
+++ b/sysbuild/mcuboot.cmake
@@ -5,10 +5,24 @@
 
 if(SB_CONFIG_MCUBOOT_BUILD_DIRECT_XIP_VARIANT)
   set(image mcuboot_secondary_app)
-  ExternalNcsVariantProject_Add(APPLICATION ${DEFAULT_IMAGE} VARIANT ${image})
+  if(SB_CONFIG_PARTITION_MANAGER)
+    ExternalNcsVariantProject_Add(APPLICATION ${DEFAULT_IMAGE} VARIANT ${image})
 
-  set_property(GLOBAL APPEND PROPERTY
-      PM_APP_IMAGES
-      "${image}"
-  )
+    set_property(GLOBAL APPEND PROPERTY
+        PM_APP_IMAGES
+        "${image}"
+    )
+  else()
+    # TODO: NCSDK-33774 add a general way to pass configuration options to the variant
+    # image
+    zephyr_get(extra_conf_file SYSBUILD LOCAL VAR EXTRA_CONF_FILE)
+
+    ExternalNcsVariantProject_Add(APPLICATION ${DEFAULT_IMAGE} VARIANT ${image} SPLIT_KCONFIG true)
+    set(${image}_EXTRA_CONF_FILE "${extra_conf_file}" CACHE INTERNAL "")
+    set_target_properties(${image} PROPERTIES
+      IMAGE_CONF_SCRIPT ${ZEPHYR_BASE}/share/sysbuild/image_configurations/MAIN_image_default.cmake
+    )
+    set(secondary_overlay "${ZEPHYR_NRF_MODULE_DIR}/subsys/mcuboot/mcuboot_secondary_app.overlay")
+    add_overlay_dts(${image} "${secondary_overlay}")
+  endif()
 endif()


### PR DESCRIPTION
This commit adds support for the DIRECT_XIP modes
on nRF54H20