### PR TITLE
ci: docbuild: adjust Zoomin Sphinx<>Doxygen patching

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -135,7 +135,7 @@ jobs:
 
             # Patch links from Sphinx to Doxygen APIs
             find doc/_build/html/$docset -type f -name "*.html" -exec \
-              sed -ri "/href=\"([^\"]+)\/doxygen\/html\/([^\"]+)\"/{s//href=\"\1\/..\/..\/..\/$docset-apis-$VERSION\/page\/\2\"/g; :a s/__/_/g;ta; }" {} \;
+              sed -ri "/href=\"([^\"]+)\/([a-z]+)\/doxygen\/html\/([^\"]+)\"/{s//href=\"..\/..\/\1\/\2-apis-$VERSION\/page\/\3\"/g; :a s/__/_/g;ta; }" {} \;
 
             pushd "$OUTDIR"
             ARCHIVE="$docset-apis-$VERSION.zip"


### PR DESCRIPTION
It is nowadays possible to have references to N different Doxygen docsets, e.g. ncs, zephyr, nrfxlib... The current patching regex assumed all links did target the same matching Doxygen docset.