### PR TITLE
tests: drivers: i2s: i2s_mclk: Extend test with ACLK configuration

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -1540,7 +1540,9 @@ ci_tests_zephyr_drivers_i2s:
     - nrf/tests/zephyr/drivers/i2s/
     - zephyr/drivers/i2s/
     - zephyr/dts/bindings/i2s/
+    - zephyr/include/zephyr/drivers/i2s.h
     - zephyr/tests/drivers/i2s/
+    - nrf/tests/drivers/i2s/
 
 ci_tests_zephyr_drivers_retained_mem:
   files:

--- a/tests/drivers/i2s/i2s_mclk/boards/tdm_mck_audiopll.overlay
+++ b/tests/drivers/i2s/i2s_mclk/boards/tdm_mck_audiopll.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&tdm130 {
+	mck-clock-source = "ACLK";
+};
+
+&audiopll {
+	status = "okay";
+};

--- a/tests/drivers/i2s/i2s_mclk/boards/tdm_sck_audiopll.overlay
+++ b/tests/drivers/i2s/i2s_mclk/boards/tdm_sck_audiopll.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&tdm130 {
+	sck-clock-source = "ACLK";
+};
+
+&audiopll {
+	status = "okay";
+};

--- a/tests/drivers/i2s/i2s_mclk/testcase.yaml
+++ b/tests/drivers/i2s/i2s_mclk/testcase.yaml
@@ -28,3 +28,33 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
+
+  drivers.i2s.i2s_mclk.gpio_loopback.54h.aclk_sck:
+    harness_config:
+      fixture: i2s_loopback
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="boards/tdm_sck_audiopll.overlay"
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+
+  drivers.i2s.i2s_mclk.gpio_loopback.54h.aclk_mck:
+    harness_config:
+      fixture: i2s_loopback
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="boards/tdm_mck_audiopll.overlay"
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+
+  drivers.i2s.i2s_mclk.gpio_loopback.54h.aclk_mck_sck:
+    harness_config:
+      fixture: i2s_loopback
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="boards/tdm_mck_audiopll.overlay boards/tdm_sck_audiopll.overlay"
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Add nRF54H20 overlays that select Audio PLL as a source of clock signal for bit-clock and/or master-clock signals.