### PR TITLE
manifest: Bring TF-M with split target_cfg.c

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: bf3105bd6f49a758dee722e124e0dc0db9119afe
+      revision: pull/198/head
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
Brings TF-M with the target_cfg.c file splitted for nrf53/91 and nrf54 series.