### PR TITLE
samples: bluetooth: Add support for LLVM in selected samples

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -263,6 +263,12 @@ Amazon Sidewalk samples
 Bluetooth samples
 -----------------
 
+* Added experimental ``llvm`` toolchain support for the nRF54L Series board targets to the following samples:
+
+  * :ref:`peripheral_lbs`
+  * :ref:`central_uart`
+  * :ref:`power_profiling`
+
 * :ref:`bluetooth_isochronous_time_synchronization` sample:
 
   * Fixed an issue where the sample would assert with the :kconfig:option:`CONFIG_ASSERT` Kconfig option enabled.

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -54,3 +54,18 @@ tests:
       - bluetooth
       - ci_build
       - sysbuild
+  sample.bluetooth.central_uart.llvm:
+    toolchain_allow: llvm
+    sysbuild: true
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -142,3 +142,18 @@ tests:
       - CONFIG_BOOTLOADER_MCUBOOT=y
       - CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
       - CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT=y
+  sample.bluetooth.peripheral_lbs.llvm:
+    toolchain_allow: llvm
+    sysbuild: true
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild

--- a/samples/bluetooth/peripheral_power_profiling/sample.yaml
+++ b/samples/bluetooth/peripheral_power_profiling/sample.yaml
@@ -148,3 +148,17 @@ tests:
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_54L_ble_power_profiling"
     timeout: 150
+
+  sample.bluetooth.peripheral_power_profiling.llvm:
+    toolchain_allow: llvm
+    sysbuild: true
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20pdk/nrf54lm20a/cpuapp
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild


### PR DESCRIPTION
Add experimental support for LLVM in:
-peripheral_lbs
-central_uart
-peripheral_power profiling

for nRF54L15, nRF54LM20 and nRF54LV10 boards.

Jira: NCSDK-33297