### PR TITLE
scripts: bluetooth: mesh: fix vendor model id extraction

### DIFF
--- a/scripts/bluetooth/mesh/mesh_dfu_metadata.py
+++ b/scripts/bluetooth/mesh/mesh_dfu_metadata.py
@@ -358,7 +358,7 @@ def read_comp_data(elf_path, addr, kconfigs):
                         if not vnd:
                             elem_item.sig_model_add(id1)
                         else:
-                            elem_item.vnd_model_add(id1, id2)
+                            elem_item.vnd_model_add(id2, id1)
 
                 if sig_count > 0:
                     models_unpack(sig_ptr, elem_item, False)

--- a/tests/subsys/bluetooth/mesh/metadata_extraction/src/main.c
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/src/main.c
@@ -12,31 +12,38 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <bluetooth/mesh/models.h>
 
+#define TEST_VND_COMPANY_ID 0x1234
+#define TEST_VND_MOD_ID   0x5678
 
 static struct bt_mesh_health_srv health_srv;
 
 BT_MESH_HEALTH_PUB_DEFINE(health_pub, 0);
 
-static struct bt_mesh_model models[] = {
+static const struct bt_mesh_model models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
 };
 
-static struct bt_mesh_elem elements[] = {
-	BT_MESH_ELEM(1, models, BT_MESH_MODEL_NONE),
+static const struct bt_mesh_model vnd_models[] = {
+	BT_MESH_MODEL_VND_CB(TEST_VND_COMPANY_ID, TEST_VND_MOD_ID, BT_MESH_MODEL_NO_OPS, NULL, NULL,
+			     NULL),
+};
+
+static const struct bt_mesh_elem elements[] = {
+	BT_MESH_ELEM(1, models, vnd_models),
 };
 
 #ifndef CONFIG_COMP_DATA_LAYOUT_SINGLE
 static struct bt_mesh_onoff_cli onoff_cli;
 static struct bt_mesh_lvl_cli lvl_cli;
 
-static struct bt_mesh_model extra_models[] = {
+static const struct bt_mesh_model extra_models[] = {
 	BT_MESH_MODEL_ONOFF_CLI(&onoff_cli),
 	BT_MESH_MODEL_LVL_CLI(&lvl_cli),
 };
 
-static struct bt_mesh_elem elements_alt[] = {
-	BT_MESH_ELEM(1, models, BT_MESH_MODEL_NONE),
+static const struct bt_mesh_elem elements_alt[] = {
+	BT_MESH_ELEM(1, models, vnd_models),
 	BT_MESH_ELEM(2, extra_models, BT_MESH_MODEL_NONE),
 };
 #endif

--- a/tests/subsys/bluetooth/mesh/metadata_extraction/verify_metadata.py
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/verify_metadata.py
@@ -59,11 +59,11 @@ def expected_metadata(size):
                 'crpl': 64,
                 'features': 5,
                 'elements': [
-                    {'location': 1, 'sig_models': [0, 2], 'vendor_models': []}
+                    {'location': 1, 'sig_models': [0, 2], 'vendor_models': [0x56781234]}
                 ]
             },
-            'composition_hash': 92775163,
-            'encoded_metadata': f'0102030004000000{encoded_size}01fba287050100'
+            'composition_hash': 1829016033,
+            'encoded_metadata': f'0102030004000000{encoded_size}01e191046d0100'
         },
         {
             'sign_version': {'major': 1, 'minor': 2, 'revision': 3, 'build_number': 4},
@@ -76,12 +76,12 @@ def expected_metadata(size):
                 'crpl': 64,
                 'features': 5,
                 'elements': [
-                    {'location': 1, 'sig_models': [0, 2], 'vendor_models': []},
+                    {'location': 1, 'sig_models': [0, 2], 'vendor_models': [0x56781234]},
                     {'location': 2, 'sig_models': [4097, 4099], 'vendor_models': []}
                 ]
             },
-            'composition_hash': 334602563,
-            'encoded_metadata': f'0102030004000000{encoded_size}0143a1f1130200'
+            'composition_hash': 214185805,
+            'encoded_metadata': f'0102030004000000{encoded_size}014d37c40c0200'
         }
     ]
 


### PR DESCRIPTION
Commit:
* Fixes vendor model id extraction from elf file. Company id and model id positions were swapped.
* Extends the composition data of the metadata test by dummy vendor model.