### PR TITLE
sysbuild: cmake: set iron board cluster for iron variant

### DIFF
--- a/sysbuild/Kconfig.netcore
+++ b/sysbuild/Kconfig.netcore
@@ -18,6 +18,7 @@ config SUPPORT_NETCORE
 config NETCORE_REMOTE_BOARD_TARGET_CPUCLUSTER
 	string
 	default "cpunet" if SOC_NRF5340_CPUAPP
+	default "cpurad/iron" if SOC_NRF54H20_IRON
 	default "cpurad" if SOC_NRF54H20_CPUAPP
 
 config NETCORE_REMOTE_DOMAIN


### PR DESCRIPTION
Ref: NCSDK-NONE