### PR TITLE
mpsl: fem: nrf21540 gpio spi on nrf54l

### DIFF
--- a/subsys/mpsl/fem/common/include/mpsl_fem_utils.h
+++ b/subsys/mpsl/fem/common/include/mpsl_fem_utils.h
@@ -102,6 +102,7 @@ int mpsl_fem_utils_ppi_channel_alloc(uint8_t *ppi_channels, size_t size);
  */
 void mpsl_fem_extended_pin_to_mpsl_fem_pin(uint32_t pin_num, mpsl_fem_pin_t *p_fem_pin);
 
+#if !defined(_MPSL_FEM_CONFIG_API_NEXT)
 /** @brief Initializes the gpiote pin according to the configuration.
  *
  * @param[inout] gpiote_pin Configuration of gpiote pin.
@@ -109,6 +110,6 @@ void mpsl_fem_extended_pin_to_mpsl_fem_pin(uint32_t pin_num, mpsl_fem_pin_t *p_f
  * @return 0 in case of success, appropriate error code otherwise.
  */
 int mpsl_fem_utils_gpiote_pin_init(mpsl_fem_gpiote_pin_config_t *gpiote_pin);
-
+#endif /* !defined(_MPSL_FEM_CONFIG_API_NEXT) */
 
 #endif /* MPSL_FEM_UTILS_H__ */

--- a/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
+++ b/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
@@ -173,6 +173,7 @@ static int fem_nrf21540_gpio_configure(void)
 		return err;
 	}
 
+#if !defined(_MPSL_FEM_CONFIG_API_NEXT)
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), tx_en_gpios)
 	err = mpsl_fem_utils_gpiote_pin_init(&cfg.pa_pin_config);
 	if (err) {
@@ -193,6 +194,7 @@ static int fem_nrf21540_gpio_configure(void)
 		return err;
 	}
 #endif
+#endif /* !defined(_MPSL_FEM_CONFIG_API_NEXT) */
 
 	BUILD_ASSERT(
 	  (CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB == CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTA) ||

--- a/subsys/mpsl/fem/nrf21540_gpio_spi/mpsl_fem_nrf21540_gpio_spi.c
+++ b/subsys/mpsl/fem/nrf21540_gpio_spi/mpsl_fem_nrf21540_gpio_spi.c
@@ -63,7 +63,10 @@ static uint32_t fem_nrf21540_spi_configure(mpsl_fem_nrf21540_gpio_spi_interface_
 			},
 			.enable        = true,
 			.active_high   = true,
-			.gpiote_ch_id  = cs_gpiote_channel
+			.gpiote_ch_id  = cs_gpiote_channel,
+#if defined(NRF54L_SERIES)
+			.p_gpiote = cs_gpiote.p_reg,
+#endif
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif
@@ -172,7 +175,10 @@ static int fem_nrf21540_gpio_spi_configure(void)
 			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(tx_en_gpios),
-			.gpiote_ch_id  = txen_gpiote_channel
+			.gpiote_ch_id  = txen_gpiote_channel,
+#if defined(NRF54L_SERIES)
+			.p_gpiote = txen_gpiote.p_reg,
+#endif
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif
@@ -186,7 +192,10 @@ static int fem_nrf21540_gpio_spi_configure(void)
 			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(rx_en_gpios),
-			.gpiote_ch_id  = rxen_gpiote_channel
+			.gpiote_ch_id  = rxen_gpiote_channel,
+#if defined(NRF54L_SERIES)
+			.p_gpiote = rxen_gpiote.p_reg,
+#endif
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif
@@ -200,7 +209,10 @@ static int fem_nrf21540_gpio_spi_configure(void)
 			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(pdn_gpios),
-			.gpiote_ch_id  = pdn_gpiote_channel
+			.gpiote_ch_id  = pdn_gpiote_channel,
+#if defined(NRF54L_SERIES)
+			.p_gpiote = pdn_gpiote.p_reg,
+#endif
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif

--- a/subsys/mpsl/fem/nrf2220/mpsl_fem_nrf2220.c
+++ b/subsys/mpsl/fem/nrf2220/mpsl_fem_nrf2220.c
@@ -178,6 +178,7 @@ static int fem_nrf2220_configure(void)
 		return err;
 	}
 
+#if !defined(_MPSL_FEM_CONFIG_API_NEXT)
 	err = mpsl_fem_utils_gpiote_pin_init(&cfg.cs_pin_config);
 	if (err) {
 		return err;
@@ -187,6 +188,7 @@ static int fem_nrf2220_configure(void)
 	if (err) {
 		return err;
 	}
+#endif /* !defined(_MPSL_FEM_CONFIG_API_NEXT) */
 
 	err = mpsl_fem_nrf2220_interface_config_set(&cfg);
 

--- a/subsys/mpsl/fem/nrf2240/mpsl_fem_nrf2240.c
+++ b/subsys/mpsl/fem/nrf2240/mpsl_fem_nrf2240.c
@@ -190,6 +190,7 @@ static int fem_nrf2240_configure(void)
 		return err;
 	}
 
+#if !defined(_MPSL_FEM_CONFIG_API_NEXT)
 	err = mpsl_fem_utils_gpiote_pin_init(&cfg.cs_pin_config);
 	if (err) {
 		return err;
@@ -199,6 +200,7 @@ static int fem_nrf2240_configure(void)
 	if (err) {
 		return err;
 	}
+#endif /* !defined(_MPSL_FEM_CONFIG_API_NEXT) */
 
 	err = mpsl_fem_nrf2240_interface_config_set(&cfg);
 


### PR DESCRIPTION
This PR contains alignment of NCS code needed to migrate to the MPSL version containing support for nRF21540 in GPIO+SPI mode on nRF54L.