### PR TITLE
tests: zephyr: drivers: adc: adc_accuracy_test: fix reference-mv

### DIFF
--- a/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
+++ b/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
@@ -1,8 +1,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc 0>;
-		reference_mv = <1800>;
-		expected_accuracy = <64>;
+		reference-mv = <1800>;
+		expected-accuracy = <64>;
 	};
 };
 

--- a/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.overlay
+++ b/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.overlay
@@ -11,8 +11,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc 0>;
-		reference_mv = <1800>;
-		expected_accuracy = <64>;
+		reference-mv = <1800>;
+		expected-accuracy = <64>;
 	};
 };
 

--- a/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_0_0_0.overlay
+++ b/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf54lm20pdk_nrf54lm20a_cpuapp_0_0_0.overlay
@@ -1,8 +1,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc 0>;
-		reference_mv = <1800>;
-		expected_accuracy = <64>;
+		reference-mv = <1800>;
+		expected-accuracy = <64>;
 	};
 };
 

--- a/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc 0>;
-		reference_mv = <1800>;
-		expected_accuracy = <64>;
+		reference-mv = <1800>;
+		expected-accuracy = <64>;
 	};
 };
 


### PR DESCRIPTION
"_" -> "-" as this makes difference in this test.