### PR TITLE
boards: nrf54lv10dk: switch UART consoles between cores

### DIFF
--- a/boards/nordic/nrf54lv10dk/nrf54lv10a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lv10dk/nrf54lv10a_cpuapp_common.dtsi
@@ -11,11 +11,11 @@
 
 / {
 	chosen {
-		zephyr,console = &uart20;
-		zephyr,shell-uart = &uart20;
-		zephyr,uart-mcumgr = &uart20;
-		zephyr,bt-mon-uart = &uart20;
-		zephyr,bt-c2h-uart = &uart20;
+		zephyr,console = &uart30;
+		zephyr,shell-uart = &uart30;
+		zephyr,uart-mcumgr = &uart30;
+		zephyr,bt-mon-uart = &uart30;
+		zephyr,bt-c2h-uart = &uart30;
 		zephyr,flash-controller = &rram_controller;
 		zephyr,flash = &cpuapp_rram;
 		zephyr,bt-hci = &bt_hci_sdc;
@@ -87,7 +87,7 @@
 	};
 };
 
-&uart20 {
+&uart30 {
 	status = "okay";
 };
 

--- a/boards/nordic/nrf54lv10dk/nrf54lv10dk_nrf54lv10a_cpuflpr.dts
+++ b/boards/nordic/nrf54lv10dk/nrf54lv10dk_nrf54lv10a_cpuflpr.dts
@@ -13,8 +13,8 @@
 	compatible = "nordic,nrf54lv10dk_nrf54lv10a-cpuflpr";
 
 	chosen {
-		zephyr,console = &uart30;
-		zephyr,shell-uart = &uart30;
+		zephyr,console = &uart20;
+		zephyr,shell-uart = &uart20;
 		zephyr,code-partition = &cpuflpr_code_partition;
 		zephyr,flash = &cpuflpr_rram;
 		zephyr,sram = &cpuflpr_sram;
@@ -43,7 +43,7 @@
 	status = "okay";
 };
 
-&uart30 {
+&uart20 {
 	status = "okay";
 };
 

--- a/snippets/nordic-flpr/soc/nrf54lv10a_cpuapp.overlay
+++ b/snippets/nordic-flpr/soc/nrf54lv10a_cpuapp.overlay
@@ -29,7 +29,7 @@
 	ranges = <0x0 0x20000000 DT_SIZE_K(127)>;
 };
 
-&uart30 {
+&uart20 {
 	status = "reserved";
 };
 


### PR DESCRIPTION
Due to pin layout on nRF54LV10DK, logging for app is moved to UART30, while logging for flpr is moved to UART20.