### PR TITLE
Bluetooth Peripheral HIDS keyboard: nfct node enabled at board level

### DIFF
--- a/boards/nordic/nrf54lm20pdk/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20a_cpuapp_common.dtsi
@@ -95,6 +95,10 @@
 	status = "okay";
 };
 
+&nfct {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };

--- a/samples/bluetooth/peripheral_hids_keyboard/app.overlay
+++ b/samples/bluetooth/peripheral_hids_keyboard/app.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2025 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
- */
-
-&nfct {
-	status = "okay";
-};

--- a/samples/bluetooth/peripheral_hids_keyboard/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_hids_keyboard/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2025 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
- */
-
-/ {
-	/delete-node/ nfct;
-};

--- a/west.yml
+++ b/west.yml
@@ -145,7 +145,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 9924a5f82206f0cd31905fd659d7a3621249db79
+      revision: 89a665471355b21cb2f3577025ee531a470a631f
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
TODO

- [x] Align the nrf/board definition for nRF54LM20 DK with the zephyr/board definition (the configuration to enable the nfct node is missing in the nrf/board directory)
      Upstream Zephyr PR: https://github.com/zephyrproject-rtos/zephyr/pull/88637
- [x] Fix the `CONFIG_HAS_HW_NRF_NFCT` Kconfig state for the nRF54H20 DK target: https://github.com/zephyrproject-rtos/zephyr/pull/86280#issuecomment-2949871540
      Suggested fix: https://github.com/nrfconnect/sdk-zephyr/pull/2942