### PR TITLE
Minor changes to manifest and bluetooth: gatt_dm

### DIFF
--- a/include/bluetooth/gatt_dm.h
+++ b/include/bluetooth/gatt_dm.h
@@ -328,6 +328,7 @@ void bt_gatt_dm_data_print(const struct bt_gatt_dm *dm);
 #else
 static inline void bt_gatt_dm_data_print(const struct bt_gatt_dm *dm)
 {
+	ARG_UNUSED(dm);
 }
 #endif
 

--- a/west.yml
+++ b/west.yml
@@ -79,7 +79,6 @@ manifest:
         #
         # Please keep this list sorted alphabetically.
         name-allowlist:
-          - percepio
           - canopennode
           - chre
           - cmsis
@@ -105,10 +104,11 @@ manifest:
           - nrf_hw_models
           - nrf_wifi
           - open-amp
+          - percepio
           - picolibc
           - segger
-          - tinycrypt
           - tf-m-tests
+          - tinycrypt
           - uoscore-uedhoc
           - zcbor
           - zscilib


### PR DESCRIPTION
Two unrelated minor patches: 
1. manifest: alphabetically sort the name-allowlist
2. bluetooth: gatt_dm: silence a compiler warning for unused parameter
