### PR TITLE
applications: serial_lte_modem: Add MSG_WAITACK support

### DIFF
--- a/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
@@ -995,11 +995,18 @@ Syntax
 
 ::
 
-   #XSEND[=<data>]
+   #XSEND=[<data>][,<flags>]
 
 * The ``<data>`` parameter is a string that contains the data to be sent.
   The maximum size of the data is 1024 bytes.
   When the parameter is not specified, SLM enters ``slm_data_mode``.
+
+* The ``<flags>`` parameter sets the sending behavior.
+  It can be set to the following value:
+
+  * ``512`` - Blocks send operation until the request is acknowledged.
+    The request will not return until the send operation is completed by lower layers, or until the timeout given by the AT_SO_SNDTIMEO socket option, is reached.
+    Valid timeout values are 1 to 600 seconds.
 
 Response syntax
 ~~~~~~~~~~~~~~~
@@ -1019,6 +1026,11 @@ Example
    AT#XSEND="Test TCP"
    #XSEND: 8
    OK
+
+   AT#XSEND=,512
+   OK
+   Test datamode with flags
+   +++
 
 Read command
 ------------
@@ -1103,7 +1115,7 @@ Syntax
 
 ::
 
-   #XSENDTO=<url>,<port>[,<data>]
+   #XSENDTO=<url>,<port>[,<data>][,<flags>]
 
 * The ``<url>`` parameter is a string.
   It indicates the hostname or the IP address of the remote peer.
@@ -1114,6 +1126,12 @@ Syntax
 * The ``<data>`` parameter is a string that contains the data to be sent.
   Its maximum size is 1024 bytes.
   When the parameter is not specified, SLM enters ``slm_data_mode``.
+* The ``<flags>`` parameter sets the sending behavior.
+  It can be set to the following value:
+
+  * ``512`` - Blocks send operation until the request is acknowledged.
+    The request will not return until the send operation is completed by lower layers, or until the timeout given by the AT_SO_SNDTIMEO socket option, is reached.
+    Valid timeout values are 1 to 600 seconds.
 
 Response syntax
 ~~~~~~~~~~~~~~~

--- a/applications/serial_lte_modem/doc/TCPUDP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPUDP_AT_commands.rst
@@ -307,11 +307,17 @@ Syntax
 
 ::
 
-   #XTCPSEND[=<data>]
+   #XTCPSEND=[<data>][,<flags>]
 
 * The ``<data>`` parameter is a string that contains the data to be sent.
   The maximum size of the data is 1024 bytes.
   When the parameter is not specified, SLM enters ``slm_data_mode``.
+* The ``<flags>`` parameter sets the sending behavior.
+  It can be set to the following value:
+
+  * ``512`` - Blocks send operation until the request is acknowledged.
+    The request will not return until the send operation is completed by lower layers, or until the timeout given by the AT_SO_SNDTIMEO socket option, is reached.
+    Valid timeout values are 1 to 600 seconds.
 
 Response syntax
 ~~~~~~~~~~~~~~~
@@ -684,11 +690,17 @@ Syntax
 
 ::
 
-   #XUDPSEND[=<data>]
+   #XUDPSEND=[<data>][,<flags>]
 
 * The ``<data>`` parameter is a string that contains the data to be sent.
   The maximum size of the data is 1024 bytes.
   When the parameter is not specified, SLM enters ``slm_data_mode``.
+* The ``<flags>`` parameter sets the sending behavior.
+  It can be set to the following value:
+
+  * ``512`` - Blocks send operation until the request is acknowledged.
+    The request will not return until the send operation is completed by lower layers, or until the timeout given by the AT_SO_SNDTIMEO socket option, is reached.
+    Valid timeout values are 1 to 600 seconds.
 
 Response syntax
 ~~~~~~~~~~~~~~~

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -275,7 +275,11 @@ nRF Machine Learning (Edge Impulse)
 Serial LTE modem
 ----------------
 
-* Added the ``AT#XAPOLL`` command to asynchronously poll sockets for data.
+* Added:
+
+  * The ``AT#XAPOLL`` command to asynchronously poll sockets for data.
+  * The send flags for ``#XSEND``, ``#XSENDTO``, ``#XTCPSEND`` and ``#XUDPSEND`` commands.
+  * The send flag value ``512`` for waiting for acknowledgment of the sent data.
 
 * Updated:
 


### PR DESCRIPTION
Adding support for `MSG_WAITACK` flag for sending data with `#XSEND`, `#XSENDTO`, `#XTCPSEND` and `#XUDPSEND`.
This flag means that modem waits for the LTE network to acknowledge the sending operation before returning.

Jira: SLM-83