### PR TITLE
subsys/bootloader: removed hidden CONFIG_SB_NRF54L15_STYLE_IMPL

### DIFF
--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -55,19 +55,14 @@ config SB_NUM_VER_COUNTER_SLOTS
 
 endif # SECURE_BOOT
 
-#hidden option for mark secure-boot as nRF54L15 style
-config SB_NRF54L15_STYLE_IMPL
-	bool
-	default y if SOC_NRF54L15_CPUAPP || SOC_NRF54L05_CPUAPP || SOC_NRF54L10_CPUAPP
-
 config PM_PARTITION_SIZE_PROVISION
 	hex
 	default 0x280 if SOC_SERIES_NRF91X || SOC_NRF5340_CPUAPP # Stored in OTP region
 	# Monotonic counter slot takes 4 bytes on nRF54L Series
-	default 0x460 if SB_NRF54L15_STYLE_IMPL
+	default 0x460 if SOC_NRF54L15_CPUAPP || SOC_NRF54L05_CPUAPP || SOC_NRF54L10_CPUAPP
 	default 0x280 if SOC_NRF5340_CPUNET # Second instance stored in internal flash of NET
 	default FPROTECT_BLOCK_SIZE
-	prompt "Flash space reserved for PROVISION" if !(SOC_NRF9160 || SOC_NRF5340_CPUAPP || SB_NRF54L15_STYLE_IMPL)
+	prompt "Flash space reserved for PROVISION" if !(SOC_NRF9160 || SOC_NRF5340_CPUAPP || SOC_NRF54L15_CPUAPP || SOC_NRF54L05_CPUAPP || SOC_NRF54L10_CPUAPP)
 	help
 	  Flash space set aside for the PROVISION partition.
 
@@ -80,7 +75,7 @@ config PM_PARTITION_SIZE_B0_IMAGE
 	default 0x7800 if !B0_MIN_PARTITION_SIZE && (SOC_NRF5340_CPUNET)
 	default FPROTECT_BLOCK_SIZE if SOC_SERIES_NRF91X || SOC_NRF5340_CPUAPP
 	default 0x3800 if SOC_NRF5340_CPUNET
-	default 0x7800 if SB_NRF54L15_STYLE_IMPL
+	default 0x7800 if SOC_NRF54L15_CPUAPP || SOC_NRF54L05_CPUAPP || SOC_NRF54L10_CPUAPP
 	default 0x7000 if !B0_MIN_PARTITION_SIZE
 	default 0x4000
 	help
@@ -112,7 +107,7 @@ config SB_CLEANUP_RAM
 
 config SB_DISABLE_SELF_RWX
 	bool "Disable read and execution on self NVM"
-	depends on SB_NRF54L15_STYLE_IMPL && !FPROTECT_ALLOW_COMBINED_REGIONS
+	depends on (SOC_NRF54L15_CPUAPP || SOC_NRF54L05_CPUAPP || SOC_NRF54L10_CPUAPP) && !FPROTECT_ALLOW_COMBINED_REGIONS
 	help
 	  Sets RRAMC's BOOTCONF region protection before jumping to application.
 	  It disables reads writes and execution memory area which holds NSIB.


### PR DESCRIPTION
Removed hidden CONFIG_SB_NRF54L15_STYLE_IMPL kconfig property and use dependency on nRF54l15/05/10 directly for NSIB.

Ref.: https://github.com/nrfconnect/sdk-nrf/pull/22470#discussion_r2125729434