### PR TITLE
dts: common: nordic: nrf54lm20a: Use 32 bit bus width for VPR

### DIFF
--- a/dts/common/nordic/nrf54lm20a.dtsi
+++ b/dts/common/nordic/nrf54lm20a.dtsi
@@ -43,7 +43,7 @@
 			reg = <1>;
 			device_type = "cpu";
 			riscv,isa = "rv32emc";
-			nordic,bus-width = <64>;
+			nordic,bus-width = <32>;
 		};
 	};
 


### PR DESCRIPTION
Align with other VPRs where 32 bit is used.