### PR TITLE
modem: nrf_modem_lib: Simulate PS detach and attach

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -196,6 +196,31 @@ static int handle_at_shutdown(enum at_parser_cmd_type cmd_type, struct at_parser
 	return 0;
 }
 
+SLM_AT_CMD_CUSTOM(xnetif, "AT#XPS", handle_at_ps);
+static int handle_at_ps(enum at_parser_cmd_type cmd_type, struct at_parser *parser, uint32_t)
+{
+	int ret = -EINVAL;
+
+	if (cmd_type == AT_PARSER_CMD_TYPE_SET) {
+		int enable_ps;
+
+		ret = at_parser_num_get(parser, 1, &enable_ps);
+		if (ret) {
+			return ret;
+		}
+		if (enable_ps != 0 && enable_ps != 1) {
+			return -EINVAL;
+		}
+
+		return nrf_modem_lib_ps_set(enable_ps);
+	} else if (cmd_type == AT_PARSER_CMD_TYPE_READ) {
+		rsp_send("\r\n#XPS: %d\r\n", nrf_modem_lib_ps_get());
+		ret = 0;
+	}
+
+	return ret;
+}
+
 FUNC_NORETURN void slm_reset(void)
 {
 	slm_at_host_uninit();

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -560,6 +560,7 @@ client_events:
 	tcpsvr_terminate_connection(ret);
 	zsock_close(proxy.sock);
 	proxy.sock = INVALID_SOCKET;
+	proxy.efd = INVALID_SOCKET;
 
 	if (in_datamode()) {
 		exit_datamode_handler(ret);
@@ -648,6 +649,7 @@ static void tcpcli_thread_func(void *p1, void *p2, void *p3)
 
 	zsock_close(proxy.sock);
 	proxy.sock = INVALID_SOCKET;
+	proxy.efd = INVALID_SOCKET;
 
 	if (in_datamode()) {
 		exit_datamode_handler(ret);

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -89,6 +89,9 @@ int nrf_modem_lib_bootloader_init(void);
  */
 int nrf_modem_lib_shutdown(void);
 
+int nrf_modem_lib_ps_set(bool enable_socket);
+int nrf_modem_lib_ps_get(void);
+
 /**
  * @brief Modem library dfu callback struct.
  */

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -247,3 +247,17 @@ int nrf_modem_lib_shutdown(void)
 
 	return 0;
 }
+
+int nrf_modem_lib_ps_set(bool enabled)
+{
+	extern int nrf9x_socket_enable(bool);
+
+	return nrf9x_socket_enable(enabled);
+}
+
+int nrf_modem_lib_ps_get(void)
+{
+	extern int nrf9x_socket_enabled(void);
+
+	return nrf9x_socket_enabled();
+}


### PR DESCRIPTION
Use a flag to control access to socket service to simulate traditional PS detach and attach in 2G/3G.

Also include test logic in SLM.