### PR TITLE
lib: modem_slm: Remove EXPERIMENTAL status

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -543,7 +543,10 @@ Modem libraries
       * The :kconfig:option:`CONFIG_MODEM_SLM_UART_TX_BUF_SIZE` Kconfig option for configuring TX buffer size.
       * The :kconfig:option:`CONFIG_MODEM_SLM_AT_CMD_RESP_MAX_SIZE` Kconfig option for buffering AT command responses.
 
-  * Updated the UART implementation between the host device, using the :ref:`lib_modem_slm` library, and the device running the :ref:`Serial LTE Modem <slm_description>` application.
+  * Updated:
+
+      * The software maturity of the library to supported instead of experimental.
+      * The UART implementation between the host device, using the :ref:`lib_modem_slm` library, and the device running the :ref:`Serial LTE Modem <slm_description>` application.
 
   * Removed:
 

--- a/lib/modem_slm/Kconfig
+++ b/lib/modem_slm/Kconfig
@@ -5,12 +5,11 @@
 #
 
 menuconfig MODEM_SLM
+	bool "Modem SLM Library for host MCU"
 	depends on SERIAL
 	depends on UART_ASYNC_API
 	depends on RING_BUFFER
-	select EXPERIMENTAL
 	select UART_USE_RUNTIME_CONFIGURE
-	bool "Modem SLM Library for MCU [EXPERIMENTAL]"
 
 if MODEM_SLM
 


### PR DESCRIPTION
Remove EXPERIMENTAL status as the library has been stabilized and test coverage has been extended significantly.

Jira: SLM-16