### PR TITLE
samples: persistent_key_usage: fix execution on devices w/ CC310

### DIFF
--- a/samples/crypto/persistent_key_usage/boards/nrf52840dk_nrf52840.conf
+++ b/samples/crypto/persistent_key_usage/boards/nrf52840dk_nrf52840.conf
@@ -9,6 +9,8 @@ CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
 
 # When TF-M is not in use, the Secure storage subsystem provides the PSA Secure Storage API.
 CONFIG_SECURE_STORAGE=y
+# Use ChaCha20-Poly1305 instead of AES-GCM because the latter is not supported by CC310.
+CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_SCHEME_CHACHA20_POLY1305=y
 
 CONFIG_FLASH=y
 CONFIG_FLASH_PAGE_LAYOUT=y

--- a/samples/crypto/persistent_key_usage/boards/nrf9160dk_nrf9160.conf
+++ b/samples/crypto/persistent_key_usage/boards/nrf9160dk_nrf9160.conf
@@ -9,6 +9,8 @@ CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
 
 # When TF-M is not in use, the Secure storage subsystem provides the PSA Secure Storage API.
 CONFIG_SECURE_STORAGE=y
+# Use ChaCha20-Poly1305 instead of AES-GCM because the latter is not supported by CC310.
+CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_SCHEME_CHACHA20_POLY1305=y
 
 CONFIG_FLASH=y
 CONFIG_FLASH_PAGE_LAYOUT=y

--- a/samples/crypto/persistent_key_usage/boards/nrf9161dk_nrf9161.conf
+++ b/samples/crypto/persistent_key_usage/boards/nrf9161dk_nrf9161.conf
@@ -9,6 +9,8 @@ CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
 
 # When TF-M is not in use, the Secure storage subsystem provides the PSA Secure Storage API.
 CONFIG_SECURE_STORAGE=y
+# Use ChaCha20-Poly1305 instead of AES-GCM because the latter is not supported by CC310.
+CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_SCHEME_CHACHA20_POLY1305=y
 
 CONFIG_FLASH=y
 CONFIG_FLASH_PAGE_LAYOUT=y


### PR DESCRIPTION
The CC310 HW does not support AES-GCM, so use ChaCha20-Poly1305 instead.