### PR TITLE
tests: zephyr: drivers: timer: enable for LV10 DK

### DIFF
--- a/tests/zephyr/drivers/timer/nrf_grtc_timer/testcase.yaml
+++ b/tests/zephyr/drivers/timer/nrf_grtc_timer/testcase.yaml
@@ -4,7 +4,6 @@ tests:
       - drivers
       - ci_tests_zephyr_drivers_timer
     platform_allow:
-      - nrf54l09pdk/nrf54l09/cpuflpr
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuflpr
       - nrf54lm20pdk@0.0.0/nrf54lm20a/cpuapp
@@ -15,7 +14,11 @@ tests:
       - nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuflpr
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk@0.0.0/nrf54lv10a/cpuapp
+      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuflpr
+      - nrf54lv10dk@0.0.0/nrf54lv10a/cpuflpr
+      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuflpr
     integration_platforms:
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+    timeout: 30

--- a/tests/zephyr/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/zephyr/kernel/timer/timer_behavior/testcase.yaml
@@ -11,6 +11,8 @@ tests:
       - nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk@0.0.0/nrf54lv10a/cpuapp
+      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
     integration_platforms:
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+    timeout: 30


### PR DESCRIPTION
LV10 DK.