### PR TITLE
applications: serial_lte_modem: Add pppd parameter "lcp-echo-interval 0"

### DIFF
--- a/applications/serial_lte_modem/scripts/slm_start_ppp.sh
+++ b/applications/serial_lte_modem/scripts/slm_start_ppp.sh
@@ -56,5 +56,5 @@ echo "Connect and wait for PPP link..."
 test -c $AT_CMUX
 chat $CHATOPT -t$TIMEOUT "" "AT+CFUN=1" "OK" "\c" "#XPPP: 1,0" >$AT_CMUX <$AT_CMUX
 
-pppd $PPP_CMUX noauth novj nodeflate nobsdcomp debug noipdefault passive +ipv6 \
-		noremoteip local linkname nrf91 defaultroute defaultroute-metric -1 persist
+pppd $PPP_CMUX noauth novj nodeflate nobsdcomp debug noipdefault passive +ipv6 noremoteip \
+	local linkname nrf91 defaultroute defaultroute-metric -1 persist lcp-echo-interval 0


### PR DESCRIPTION
Add "lcp-echo-interval 0" to Linux PPP start script for pppd. This is needed so that PPP connection is maintained after longer idle periods.