### PR TITLE
tests: drivers: i2c: Add i2c test entry to 'test-spec.yml'

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -624,6 +624,7 @@
   - "tests/drivers/sensor/**/*"
   - "tests/drivers/spi/**/*"
   - "tests/drivers/uart/**/*"
+  - "tests/drivers/i2c/**/*"
   - "tests/subsys/event_manager_proxy/**/*"
   - "tests/zephyr/boards/nrf/**/*"
   - "tests/zephyr/drivers/adc/**/*"


### PR DESCRIPTION
The downstream i2c tests are executed in the test-low-level job.