### PR TITLE
applications: nrf_desktop: Align config channel CMakeLists entry

### DIFF
--- a/applications/nrf_desktop/src/util/CMakeLists.txt
+++ b/applications/nrf_desktop/src/util/CMakeLists.txt
@@ -19,8 +19,8 @@ target_sources_ifdef(CONFIG_DESKTOP_ADV_PROV_UUID16_ALL
 target_sources_ifdef(CONFIG_DESKTOP_DFU_LOCK
 		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/dfu_lock.c)
 
-target_sources_ifdef(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE app
-			PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/config_channel_transport.c)
+target_sources_ifdef(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE
+		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/config_channel_transport.c)
 
 if(CONFIG_DESKTOP_BLE_QOS_ENABLE)
   if(CONFIG_FPU)


### PR DESCRIPTION
Change aligns format of config channel transport utility's CMakeLists entry with other nRF Desktop utilities.