### PR TITLE
tests: zephyr: boards: nrf: hwinfo: enable for LV10 DK

### DIFF
--- a/tests/zephyr/boards/nrf/hwinfo/reset_cause/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
+++ b/tests/zephyr/boards/nrf/hwinfo/reset_cause/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
@@ -1,3 +1,0 @@
-&wdt31 {
-	status = "okay";
-};

--- a/tests/zephyr/boards/nrf/hwinfo/reset_cause/testcase.yaml
+++ b/tests/zephyr/boards/nrf/hwinfo/reset_cause/testcase.yaml
@@ -4,6 +4,7 @@ common:
     - hwinfo
     - ci_tests_zephyr_boards_nrf_hwinfo
   harness: console
+  timeout: 30
 
 tests:
   nrf.extended.drivers.hwinfo.reset_cause:
@@ -36,16 +37,15 @@ tests:
         - "PASS: reset causes were cleared"
         - "All tests done"
     platform_allow:
-      - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54lm20pdk@0.0.0/nrf54lm20a/cpuapp
-      - nrf54lm20pdk@0.2.0/nrf54lm20a/cpuapp
       - nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuapp
+      - nrf54lm20pdk@0.2.0/nrf54lm20a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk@0.0.0/nrf54lv10a/cpuapp
+      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp
     integration_platforms:
-      - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp


### PR DESCRIPTION
LV10 DK.