### PR TITLE
lib: nrf_cloud: rest: Fix A-GNSS data download error handling

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
@@ -680,7 +680,7 @@ int nrf_cloud_rest_agnss_data_get(struct nrf_cloud_rest_context *const rest_ctx,
 
 	int ret;
 	int type_count = 0;
-	size_t total_bytes = 0;
+	int total_bytes = 0;
 	size_t rcvd_bytes = 0;
 	size_t remain = 0;
 	size_t pos = 0;


### PR DESCRIPTION
The `total_bytes` variable in the `nrf_cloud_rest_agnss_data_get()` function was of type `size_t`, which is unsigned. The variable was used to store negative error codes, which caused the code execution to take unexpected paths.