### PR TITLE
net: lib: downloader: Increase default stack size with P-GPS

### DIFF
--- a/subsys/net/lib/downloader/Kconfig
+++ b/subsys/net/lib/downloader/Kconfig
@@ -14,6 +14,7 @@ comment "Thread and stack buffers"
 config DOWNLOADER_STACK_SIZE
 	int "Thread stack size"
 	range 768 8192
+	default 1408 if NRF_CLOUD_PGPS
 	default 1280
 
 config DOWNLOADER_MAX_HOSTNAME_SIZE


### PR DESCRIPTION
Increased the default stack size when `CONFIG_NRF_CLOUD_PGPS` is enabled. Otherwise the stack sometimes overflows, causing the application to crash.

Jira: MOSH-648