### PR TITLE
bootloader: bl_storage: Replace s0/s1 address in provision with defines

### DIFF
--- a/include/bl_storage.h
+++ b/include/bl_storage.h
@@ -143,8 +143,6 @@ struct bl_storage_data {
 	/* NB: When placed in OTP, reads must be 4 bytes and 4 byte aligned */
 	struct life_cycle_state_data lcs;
 	uint8_t implementation_id[32];
-	uint32_t s0_address;
-	uint32_t s1_address;
 	uint32_t num_public_keys; /* Number of entries in 'key_data' list. */
 	struct {
 		uint32_t valid;

--- a/subsys/bootloader/bl_storage/bl_storage.c
+++ b/subsys/bootloader/bl_storage/bl_storage.c
@@ -104,12 +104,20 @@ static uint16_t bl_storage_otp_halfword_read(uint32_t address)
  */
 uint32_t s0_address_read(void)
 {
-	return bl_storage_word_read((uint32_t)&BL_STORAGE->s0_address);
+#ifdef CONFIG_PARTITION_MANAGER_ENABLED
+	return PM_S0_ADDRESS;
+#else
+#error "Not currently supported"
+#endif
 }
 
 uint32_t s1_address_read(void)
 {
-	return bl_storage_word_read((uint32_t)&BL_STORAGE->s1_address);
+#ifdef CONFIG_PARTITION_MANAGER_ENABLED
+	return PM_S1_ADDRESS;
+#else
+#error "Not currently supported"
+#endif
 }
 
 uint32_t num_public_keys_read(void)


### PR DESCRIPTION
Replaces storing s0/s1 addresses in provision data when these values are already known and can be directly compiled into the code