### PR TITLE
nrf_security: Add protected RAM invalidation logic

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54l/cryptography.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/cryptography.rst
@@ -108,7 +108,10 @@ The following table gives an overview of the KMU slots and their usage:
      - BL_PUBKEY_2
      - | Revokable firmware image key for immutable bootloader, generation 2.
        | ED25519 public key.
-   * - 248-255
+   * - 248-249
+     - Reserved
+     - Random bytes which invalidate the protected RAM content after an operation.
+   * - 250-255
      - Reserved
      - --
 

--- a/subsys/nrf_security/src/drivers/cracen/Kconfig
+++ b/subsys/nrf_security/src/drivers/cracen/Kconfig
@@ -40,6 +40,17 @@ config CRACEN_LIB_KMU
 	help
 	  The CRACEN KMU library.
 
+config CRACEN_PROVISION_PROT_RAM_INV_DATA
+	bool "Provision protected RAM invalidation data"
+	depends on CRACEN_LIB_KMU
+	default y
+	help
+	  Provision the protected RAM invalidation data in the KMU. This will generate random
+	  data and provision the reserved KMU slots with the data that will be used to invalidate
+	  the protected RAM after a key is used.
+	  When disabled the application is expected to provision the reserved KMU slots 248 and 249
+	  manually, otherwise the protected RAM keys will not be usable.
+
 config CRACEN_IKG
 	bool "Enable CRACEN IKG"
 	default y

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cipher.c
@@ -807,7 +807,13 @@ psa_status_t cracen_cipher_finish(cracen_cipher_operation_t *operation, uint8_t 
 
 psa_status_t cracen_cipher_abort(cracen_cipher_operation_t *operation)
 {
-	sx_blkcipher_free(&operation->cipher);
+	int sx_status;
+
+	sx_status = sx_blkcipher_free(&operation->cipher);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
 	safe_memzero(operation, sizeof(cracen_cipher_operation_t));
 	return PSA_SUCCESS;
 }

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen.c
@@ -144,6 +144,10 @@ int cracen_init(void)
 		goto exit;
 	}
 
+#if defined(CONFIG_CRACEN_PROVISION_PROT_RAM_INV_DATA)
+	status = cracen_provision_prot_ram_inv_data();
+#endif /* CONFIG_CRACEN_PROVISION_PROT_RAM_INV_DATA */
+
 exit:
 	cracen_release();
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ctr_drbg.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ctr_drbg.c
@@ -20,6 +20,7 @@
 #include <sxsymcrypt/keyref.h>
 #include <zephyr/kernel.h>
 #include <nrf_security_mutexes.h>
+#include <string.h>
 
 #ifdef CONFIG_CRACEN_HW_VERSION_LITE
 #define MAX_BITS_PER_REQUEST (1 << 16) /* Cracen Lite only supports 2^16 ctr size */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -110,7 +110,7 @@ static const psa_key_usage_t metadata_usage_flags_mapping[] = {
  */
 static psa_status_t get_encryption_key(const uint8_t *context, uint8_t *key)
 {
-	psa_status_t status;
+	psa_status_t psa_status;
 	psa_key_attributes_t mkek_attr = PSA_KEY_ATTRIBUTES_INIT;
 
 	psa_set_key_type(&mkek_attr, PSA_KEY_TYPE_AES);
@@ -121,26 +121,27 @@ static psa_status_t get_encryption_key(const uint8_t *context, uint8_t *key)
 
 	cracen_key_derivation_operation_t op = {};
 
-	status = cracen_key_derivation_setup(&op, PSA_ALG_SP800_108_COUNTER_CMAC);
-	if (status != PSA_SUCCESS) {
-		return status;
+	psa_status = cracen_key_derivation_setup(&op, PSA_ALG_SP800_108_COUNTER_CMAC);
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
-	status = cracen_key_derivation_input_key(&op, PSA_KEY_DERIVATION_INPUT_SECRET, &mkek_attr,
-						 NULL, 0);
-	if (status != PSA_SUCCESS) {
-		return status;
+	psa_status = cracen_key_derivation_input_key(&op, PSA_KEY_DERIVATION_INPUT_SECRET,
+						     &mkek_attr, NULL, 0);
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
-	status = cracen_key_derivation_input_bytes(&op, PSA_KEY_DERIVATION_INPUT_LABEL, "KMU", 3);
-	if (status != PSA_SUCCESS) {
-		return status;
+	psa_status =
+		cracen_key_derivation_input_bytes(&op, PSA_KEY_DERIVATION_INPUT_LABEL, "KMU", 3);
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
-	status = cracen_key_derivation_input_bytes(&op, PSA_KEY_DERIVATION_INPUT_CONTEXT, context,
-						   CRACEN_KMU_SLOT_KEY_SIZE);
-	if (status != PSA_SUCCESS) {
-		return status;
+	psa_status = cracen_key_derivation_input_bytes(&op, PSA_KEY_DERIVATION_INPUT_CONTEXT,
+						       context, CRACEN_KMU_SLOT_KEY_SIZE);
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
-	status = cracen_key_derivation_output_bytes(&op, key, 32);
-	return status;
+	psa_status = cracen_key_derivation_output_bytes(&op, key, 32);
+	return psa_status;
 }
 
 static psa_status_t cracen_kmu_encrypt(const uint8_t *key, size_t key_length,
@@ -149,7 +150,7 @@ static psa_status_t cracen_kmu_encrypt(const uint8_t *key, size_t key_length,
 				       size_t *encrypted_buffer_length)
 {
 	uint8_t key_buffer[32] = {};
-	psa_status_t status;
+	psa_status_t psa_status;
 	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
 
 	psa_set_key_algorithm(&attr, PSA_ALG_GCM);
@@ -158,7 +159,7 @@ static psa_status_t cracen_kmu_encrypt(const uint8_t *key, size_t key_length,
 	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_ENCRYPT);
 
 	if (encrypted_buffer_size > CRACEN_KMU_SLOT_KEY_SIZE) {
-		status = psa_generate_random(encrypted_buffer, CRACEN_KMU_SLOT_KEY_SIZE);
+		psa_status = psa_generate_random(encrypted_buffer, CRACEN_KMU_SLOT_KEY_SIZE);
 	} else {
 		return PSA_ERROR_GENERIC_ERROR;
 	}
@@ -168,20 +169,20 @@ static psa_status_t cracen_kmu_encrypt(const uint8_t *key, size_t key_length,
 	encrypted_buffer += CRACEN_KMU_SLOT_KEY_SIZE;
 	encrypted_buffer_size -= CRACEN_KMU_SLOT_KEY_SIZE;
 
-	status = get_encryption_key(nonce, key_buffer);
-	if (status != PSA_SUCCESS) {
-		return status;
+	psa_status = get_encryption_key(nonce, key_buffer);
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
 
-	status = cracen_aead_encrypt(&attr, key_buffer, sizeof(key_buffer), PSA_ALG_GCM, nonce, 12,
-				     (uint8_t *)metadata, sizeof(*metadata), key, key_length,
-				     encrypted_buffer, encrypted_buffer_size,
-				     encrypted_buffer_length);
+	psa_status = cracen_aead_encrypt(&attr, key_buffer, sizeof(key_buffer), PSA_ALG_GCM, nonce,
+					 12, (uint8_t *)metadata, sizeof(*metadata), key,
+					 key_length, encrypted_buffer, encrypted_buffer_size,
+					 encrypted_buffer_length);
 
-	if (status == PSA_SUCCESS) {
+	if (psa_status == PSA_SUCCESS) {
 		*encrypted_buffer_length += CRACEN_KMU_SLOT_KEY_SIZE;
 	}
-	return status;
+	return psa_status;
 }
 
 static psa_status_t cracen_kmu_decrypt(kmu_metadata *metadata, size_t number_of_slots)
@@ -194,10 +195,10 @@ static psa_status_t cracen_kmu_decrypt(kmu_metadata *metadata, size_t number_of_
 	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_DECRYPT);
 
 	uint8_t key_buffer[32] = {50};
-	psa_status_t status = get_encryption_key(kmu_push_area, key_buffer);
+	psa_status_t psa_status = get_encryption_key(kmu_push_area, key_buffer);
 
-	if (status != PSA_SUCCESS) {
-		return status;
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
 
 	size_t outlen = 0;
@@ -217,7 +218,7 @@ psa_status_t cracen_provision_prot_ram_inv_data(void)
 	uint8_t rng_buffer[2 * CRACEN_KMU_SLOT_KEY_SIZE];
 	bool needs_provisioning;
 	psa_key_attributes_t key_attributes = PSA_KEY_ATTRIBUTES_INIT;
-	psa_status_t status;
+	psa_status_t psa_status;
 	int kmu_slot;
 
 	needs_provisioning = lib_kmu_is_slot_empty(PROTECTED_RAM_INVALIDATION_DATA_SLOT1) ||
@@ -227,9 +228,9 @@ psa_status_t cracen_provision_prot_ram_inv_data(void)
 		return PSA_SUCCESS;
 	}
 
-	status = cracen_get_random(NULL, rng_buffer, sizeof(rng_buffer));
-	if (status != PSA_SUCCESS) {
-		return status;
+	psa_status = cracen_get_random(NULL, rng_buffer, sizeof(rng_buffer));
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
 
 	/* Just use attributes which are suitable for a normal protected RAM
@@ -254,9 +255,10 @@ psa_status_t cracen_provision_prot_ram_inv_data(void)
 	kmu_slot = CRACEN_PSA_GET_KMU_SLOT(
 		MBEDTLS_SVC_KEY_ID_GET_KEY_ID(psa_get_key_id(&key_attributes)));
 
-	status = cracen_kmu_provision(&key_attributes, kmu_slot, rng_buffer, sizeof(rng_buffer));
+	psa_status =
+		cracen_kmu_provision(&key_attributes, kmu_slot, rng_buffer, sizeof(rng_buffer));
 	safe_memzero(rng_buffer, sizeof(rng_buffer));
-	return status;
+	return psa_status;
 }
 #endif /* CONFIG_CRACEN_PROVISION_PROT_RAM_INV_DATA */
 
@@ -288,9 +290,9 @@ int cracen_kmu_prepare_key(const uint8_t *user_data)
 			}
 		}
 
-		psa_status_t status = cracen_kmu_decrypt(&metadata, key->number_of_slots);
+		psa_status_t psa_status = cracen_kmu_decrypt(&metadata, key->number_of_slots);
 
-		if (status != PSA_SUCCESS) {
+		if (psa_status != PSA_SUCCESS) {
 			return SX_ERR_PLATFORM_ERROR;
 		}
 
@@ -482,11 +484,11 @@ static psa_status_t get_kmu_slot_id_and_count(const psa_key_attributes_t *key_at
 					      unsigned int *slot_id, unsigned int *slot_count)
 {
 	kmu_metadata metadata;
-	psa_status_t status;
+	psa_status_t psa_status;
 
-	status = get_kmu_slot_id_and_metadata(psa_get_key_id(key_attr), slot_id, &metadata);
-	if (status != PSA_SUCCESS) {
-		return status;
+	psa_status = get_kmu_slot_id_and_metadata(psa_get_key_id(key_attr), slot_id, &metadata);
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
 
 	return get_kmu_slot_count(metadata, key_attr, slot_count);
@@ -500,21 +502,21 @@ psa_status_t cracen_kmu_destroy_key(const psa_key_attributes_t *attributes)
 	psa_key_persistence_t persistence = PSA_KEY_LIFETIME_GET_PERSISTENCE(lifetime);
 
 	if (location == PSA_KEY_LOCATION_CRACEN_KMU) {
-		psa_status_t status;
+		psa_status_t psa_status;
 		unsigned int slot_id, slot_count;
 
 		if (persistence == CRACEN_KEY_PERSISTENCE_READ_ONLY) {
 			return PSA_ERROR_NOT_PERMITTED;
 		}
 
-		status = get_kmu_slot_id_and_count(attributes, &slot_id, &slot_count);
-		if (status != PSA_SUCCESS) {
-			return status;
+		psa_status = get_kmu_slot_id_and_count(attributes, &slot_id, &slot_count);
+		if (psa_status != PSA_SUCCESS) {
+			return psa_status;
 		}
 
-		status = set_provisioning_in_progress(slot_id, slot_count);
-		if (status != PSA_SUCCESS) {
-			return status;
+		psa_status = set_provisioning_in_progress(slot_id, slot_count);
+		if (psa_status != PSA_SUCCESS) {
+			return psa_status;
 		}
 		/* This will revoke the related key slots. */
 		return clean_up_unfinished_provisioning();
@@ -950,15 +952,15 @@ psa_status_t cracen_kmu_provision(const psa_key_attributes_t *key_attr, int slot
 	 */
 	uint8_t encrypted_workmem[CRACEN_KMU_SLOT_KEY_SIZE * 6] = {};
 #endif
-	psa_status_t status = clean_up_unfinished_provisioning();
+	psa_status_t psa_status = clean_up_unfinished_provisioning();
 
-	if (status != PSA_SUCCESS) {
-		return status;
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
-	status = convert_from_psa_attributes(key_attr, &metadata);
+	psa_status = convert_from_psa_attributes(key_attr, &metadata);
 
-	if (status) {
-		return status;
+	if (psa_status) {
+		return psa_status;
 	}
 
 	switch (metadata.key_usage_scheme) {
@@ -1004,13 +1006,13 @@ psa_status_t cracen_kmu_provision(const psa_key_attributes_t *key_attr, int slot
 	if (metadata.key_usage_scheme == CRACEN_KMU_KEY_USAGE_SCHEME_ENCRYPTED) {
 		/* Copy key material to workbuffer, zero-pad key and align to key slot size. */
 		memcpy(encrypted_workmem + CRACEN_KMU_SLOT_KEY_SIZE, key_buffer, key_buffer_size);
-		status = cracen_kmu_encrypt(encrypted_workmem + CRACEN_KMU_SLOT_KEY_SIZE,
-					    ROUND_UP(key_buffer_size, CRACEN_KMU_SLOT_KEY_SIZE),
-					    &metadata, encrypted_workmem, sizeof(encrypted_workmem),
-					    &key_buffer_size);
+		psa_status = cracen_kmu_encrypt(encrypted_workmem + CRACEN_KMU_SLOT_KEY_SIZE,
+						ROUND_UP(key_buffer_size, CRACEN_KMU_SLOT_KEY_SIZE),
+						&metadata, encrypted_workmem,
+						sizeof(encrypted_workmem), &key_buffer_size);
 
-		if (status != PSA_SUCCESS) {
-			return status;
+		if (psa_status != PSA_SUCCESS) {
+			return psa_status;
 		}
 		key_buffer = encrypted_workmem;
 	}
@@ -1021,15 +1023,15 @@ psa_status_t cracen_kmu_provision(const psa_key_attributes_t *key_attr, int slot
 
 	for (size_t i = 0; i < num_slots; i++) {
 		if (!lib_kmu_is_slot_empty(slot_id + i)) {
-			status = PSA_ERROR_ALREADY_EXISTS;
+			psa_status = PSA_ERROR_ALREADY_EXISTS;
 			goto exit;
 		}
 	}
 
 	if (num_slots > 1) {
-		status = set_provisioning_in_progress(slot_id, num_slots);
-		if (status != PSA_SUCCESS) {
-			return status;
+		psa_status = set_provisioning_in_progress(slot_id, num_slots);
+		if (psa_status != PSA_SUCCESS) {
+			return psa_status;
 		}
 	}
 
@@ -1050,7 +1052,7 @@ psa_status_t cracen_kmu_provision(const psa_key_attributes_t *key_attr, int slot
 
 		if (st) {
 			/* We've already verified that this slot empty, so it should not fail. */
-			status = PSA_ERROR_HARDWARE_FAILURE;
+			psa_status = PSA_ERROR_HARDWARE_FAILURE;
 
 			clean_up_unfinished_provisioning();
 			break;
@@ -1059,25 +1061,25 @@ psa_status_t cracen_kmu_provision(const psa_key_attributes_t *key_attr, int slot
 		safe_memzero(&kmu_desc, sizeof(kmu_desc));
 	}
 
-	if (num_slots > 1 && status == PSA_SUCCESS) {
-		status = end_provisioning(slot_id, num_slots);
+	if (num_slots > 1 && psa_status == PSA_SUCCESS) {
+		psa_status = end_provisioning(slot_id, num_slots);
 	}
 
 exit:
-	return status;
+	return psa_status;
 }
 
 psa_status_t cracen_kmu_get_key_slot(mbedtls_svc_key_id_t key_id, psa_key_lifetime_t *lifetime,
 				     psa_drv_slot_number_t *slot_number)
 {
-	psa_status_t status;
+	psa_status_t psa_status;
 	unsigned int slot_id;
 	kmu_metadata metadata;
 	psa_key_persistence_t persistence;
 
-	status = get_kmu_slot_id_and_metadata(key_id, &slot_id, &metadata);
-	if (status != PSA_SUCCESS) {
-		return status;
+	psa_status = get_kmu_slot_id_and_metadata(key_id, &slot_id, &metadata);
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
 
 	switch (metadata.rpolicy) {
@@ -1103,12 +1105,12 @@ psa_status_t cracen_kmu_get_key_slot(mbedtls_svc_key_id_t key_id, psa_key_lifeti
 
 psa_status_t cracen_kmu_block(const psa_key_attributes_t *key_attr)
 {
-	psa_status_t status;
+	psa_status_t psa_status;
 	unsigned int slot_id, slot_count;
 
-	status = get_kmu_slot_id_and_count(key_attr, &slot_id, &slot_count);
-	if (status != PSA_SUCCESS) {
-		return status;
+	psa_status = get_kmu_slot_id_and_count(key_attr, &slot_id, &slot_count);
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
 
 	if (lib_kmu_block_slot_range(slot_id, slot_count) != LIB_KMU_SUCCESS) {
@@ -1123,21 +1125,21 @@ static psa_status_t push_kmu_key_to_ram(uint8_t *key_buffer, size_t key_buffer_s
 		return PSA_ERROR_BUFFER_TOO_SMALL;
 	}
 
-	psa_status_t status;
+	psa_status_t psa_status;
 
 	/* The kmu_push_area is guarded by the symmetric mutex since it is the most common use case.
 	 * Here the decision was to avoid defining another mutex to handle the push buffer for the
 	 * rest of the use cases.
 	 */
 	nrf_security_mutex_lock(cracen_mutex_symmetric);
-	status = silex_statuscodes_to_psa(cracen_kmu_prepare_key(key_buffer));
-	if (status == PSA_SUCCESS) {
+	psa_status = silex_statuscodes_to_psa(cracen_kmu_prepare_key(key_buffer));
+	if (psa_status == PSA_SUCCESS) {
 		memcpy(key_buffer, kmu_push_area, key_buffer_size);
 		safe_memzero(kmu_push_area, sizeof(kmu_push_area));
 	}
 	nrf_security_mutex_unlock(cracen_mutex_symmetric);
 
-	return status;
+	return psa_status;
 }
 
 psa_status_t cracen_kmu_get_builtin_key(psa_drv_slot_number_t slot_number,
@@ -1145,11 +1147,11 @@ psa_status_t cracen_kmu_get_builtin_key(psa_drv_slot_number_t slot_number,
 					size_t key_buffer_size, size_t *key_buffer_length)
 {
 	kmu_metadata metadata;
-	psa_status_t status = read_primary_slot_metadata(slot_number, &metadata);
+	psa_status_t psa_status = read_primary_slot_metadata(slot_number, &metadata);
 	size_t opaque_key_size;
 
-	if (status != PSA_SUCCESS) {
-		return status;
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
 
 	if (slot_number == PROTECTED_RAM_INVALIDATION_DATA_SLOT1 ||
@@ -1158,25 +1160,25 @@ psa_status_t cracen_kmu_get_builtin_key(psa_drv_slot_number_t slot_number,
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 
-	status = clean_up_unfinished_provisioning();
-	if (status != PSA_SUCCESS) {
-		return status;
+	psa_status = clean_up_unfinished_provisioning();
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
 
 	if (!attributes) {
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 
-	status = convert_to_psa_attributes(&metadata, attributes);
+	psa_status = convert_to_psa_attributes(&metadata, attributes);
 
-	if (status != PSA_SUCCESS) {
-		return status;
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
 
 
-	status = cracen_get_opaque_size(attributes, &opaque_key_size);
-	if (status != PSA_SUCCESS) {
-		return status;
+	psa_status = cracen_get_opaque_size(attributes, &opaque_key_size);
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
 
 	if (key_buffer_size >= opaque_key_size) {
@@ -1192,9 +1194,9 @@ psa_status_t cracen_kmu_get_builtin_key(psa_drv_slot_number_t slot_number,
 
 		key->key_usage_scheme = metadata.key_usage_scheme;
 
-		status = get_kmu_slot_count(metadata, attributes, &slot_count);
-		if (status != PSA_SUCCESS) {
-			return status;
+		psa_status = get_kmu_slot_count(metadata, attributes, &slot_count);
+		if (psa_status != PSA_SUCCESS) {
+			return psa_status;
 		}
 		key->number_of_slots = slot_count;
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.h
@@ -27,6 +27,14 @@ typedef struct {
 	uint8_t slot_id;	     /* KMU slot number. */
 } kmu_opaque_key_buffer;
 
+/* Two KMU slots are reserved for storing the invalidation data for the protected RAM.
+ * These are meant to have random data that can pushed to the protected RAM after
+ * an actual key is being used so that the key material does not reside in the protected
+ * RAM for more than the required time.
+ */
+#define PROTECTED_RAM_INVALIDATION_DATA_SLOT1 248
+#define PROTECTED_RAM_INVALIDATION_DATA_SLOT2 249
+
 extern uint8_t kmu_push_area[64];
 
 /**
@@ -65,3 +73,13 @@ psa_status_t cracen_kmu_provision(const psa_key_attributes_t *key_attr, int slot
  * @brief Destroy a key stored in the KMU.
  */
 psa_status_t cracen_kmu_destroy_key(const psa_key_attributes_t *attributes);
+
+/**
+ * @brief Provision the protected RAM invalidation data.
+ *
+ * This function provisions two KMU slots with random data that can be used to invalidate
+ * the protected RAM after a key is used.
+ *
+ * @return PSA status code.
+ */
+psa_status_t cracen_provision_prot_ram_inv_data(void);

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/aes.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/aes.h
@@ -388,8 +388,10 @@ static inline bool sx_aead_aesccm_nonce_size_is_valid(size_t noncesz)
  * @brief Free resources related to blkcipher operation.
  *
  * @param[out] c block cipher operation context
+ *
+ * @return sxsymcrypt status code.
  */
-void sx_blkcipher_free(struct sxblkcipher *c);
+int sx_blkcipher_free(struct sxblkcipher *c);
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/internal.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/internal.h
@@ -13,6 +13,7 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include <cracen/statuscodes.h>
 
 #ifndef SX_EXTRA_IN_DESCS
 #define SX_EXTRA_IN_DESCS 0
@@ -167,6 +168,20 @@ struct sxchannel {
 struct sxcmmask {
 	struct sxchannel channel;
 };
+
+/**
+ * @brief Function to handle CRACEN nested errors in the sxsymcrypt
+ *
+ * @param[in] nested_err	Nested error occurred while handling an error.
+ * @param[in] err		Original error code.
+ *
+ * @return Return the nested error if it is not SX_OK, otherwise return
+ *         the original error code.
+ */
+inline int sx_handle_nested_error(int nested_err, int err)
+{
+	return nested_err ? nested_err != SX_OK : err;
+}
 
 #ifdef __cplusplus
 }

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/mac.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/mac.h
@@ -164,8 +164,9 @@ int sx_mac_status(struct sxmac *c);
  *
  * @param[in,out] c MAC operation context
  *
+ * @return sxsymcrypt status code.
  */
-void sx_mac_free(struct sxmac *c);
+int sx_mac_free(struct sxmac *c);
 
 /** Find an available MAC engine for the operation.
  *


### PR DESCRIPTION
    nrf_security: Add protected RAM invalidation logic

    Reserve two KMU slots two store random data which are used
    to invalidate the protected RAM content after an operation
    is finished.

    Add a Kconfig so that that it is possible for size constrained
    images to provision the KMU slots before usage.

    Ref: NCSDK-33885

    Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>



test_crypto: PR-820
