### PR TITLE
boards: wifi: Add Wi-Fi support to nrf54lm20 PDK

### DIFF
--- a/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp.dts
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20pdk_nrf54lm20a_cpuapp.dts
@@ -25,3 +25,6 @@
 &bt_hci_controller {
 	status = "disabled";
 };
+
+/* Get a node label for wi-fi spi to use in shield files */
+wifi_spi: &spi22 {};

--- a/boards/shields/nrf7002eb2/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.overlay
+++ b/boards/shields/nrf7002eb2/boards/nrf54lm20pdk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../nrf7002eb2_gpio_pins_1.dtsi"
+
+/ {
+	chosen {
+		zephyr,wifi = &wlan0;
+		zephyr,console = &uart30;
+		zephyr,shell-uart = &uart30;
+		zephyr,uart-mcumgr = &uart30;
+		zephyr,bt-mon-uart = &uart30;
+		zephyr,bt-c2h-uart = &uart30;
+	};
+};
+
+&pinctrl {
+	spi22_default: spi22_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+			bias-pull-down;
+		};
+	};
+
+	spi22_sleep: spi22_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+			bias-pull-down;
+			low-power-enable;
+		};
+	};
+
+	uart30_default: uart30_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 0, 7)>;
+			bias-pull-up;
+		};
+	};
+
+	uart30_sleep: uart30_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>,
+				<NRF_PSEL(UART_RX, 0, 7)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi22 {
+	status = "okay";
+	cs-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&spi22_default>;
+	pinctrl-1 = <&spi22_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+/* uart20 has pin conflicts with EB-II shield hence disabling that
+ * and enabling uart30 as console port.
+ */
+&uart20 {
+	status = "disabled";
+};
+
+&uart30 {
+	status = "okay";
+};


### PR DESCRIPTION
Add Wi-Fi support to nRF54lm20 PDK via EB-II shield