### PR TITLE
doc: Ensure that the sphinx version used is lower than 8.2.0

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,7 +15,7 @@ pykwalify                       # |     |         |        |         |         |
 pytest                          # |     |         |        |         |         |      |   X    |
 recommonmark                    # |     |         |   X    |    X    |         |      |        |
 snowballstemmer<3.0.0           # https://github.com/snowballstem/snowball/issues/229
-sphinx~=8.1                     # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
+sphinx<8.2.0                    # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
 sphinx-autobuild                # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
 sphinx-copybutton               # |  X  |         |        |         |         |      |   X    |
 sphinx-ncs-theme<1.1            # |  X  |         |        |         |         |      |        |


### PR DESCRIPTION
There are two issues with sphinx in NCS that this patch tries to resolve.

First, and for an unknown reason, having `sphinx~=8.1.0` as we did before does not prevent pip from installing sphinx 8.2.x. Second, sphinx 8.2.x seems to work fine when building the NCS doc all in one go (i.e. run `ninja` with no arguments). But when building independent docsets separately, the following errors appear:

 `WARNING: zephyr:board reference target not found: <board> [ref.board]`

Which corresponds to an entry similar to:
```
:zephyr:board:`<board>`
```
So, in summary:

Sphinx 8.2.x seems to have an issue with intersphinx and zephyr board names. This only seems to show when one builds docsets separately, but not if you build them together:

works: `cmake -GNinja -S. -B_build && cd _build && ninja` 
fails: `cmake -GNinja -Bdoc/_build -Sdoc -DSPHINXOPTS_EXTRA="-q" -DDTS_BINDINGS=ON -DHW_FEATURES=ON && ninja -C doc/_build zephyr-all && ninja -C doc/_build nrfx && ninja -C doc/_build tfm-all && ninja -C doc/_build matter-all && ninja -C doc/_build internal-all && ninja -C doc/_build copy-extra-content && ninja -C doc/_build`

test-sdk-nrf: doc-internal-qara