### PR TITLE
ci: tags: ci_samples_cellular: Remove dependency to bluetooth

### DIFF
--- a/samples/cellular/lte_ble_gateway/sample.yaml
+++ b/samples/cellular/lte_ble_gateway/sample.yaml
@@ -11,3 +11,4 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_cellular
+      - bluetooth

--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -384,6 +384,7 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_cellular
+      - bluetooth
   sample.cellular.modem_shell.rtt:
     sysbuild: true
     build_only: true

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -434,7 +434,6 @@ ci_samples_cellular:
     - nrf/modules/cjson/
     - nrf/samples/cellular/
     - nrf/subsys/app_event_manager/
-    - nrf/subsys/bluetooth/
     - nrf/subsys/bootloader/
     - nrf/subsys/caf/
     - nrf/subsys/debug/


### PR DESCRIPTION
This change speeds up CI when changing Bluetooth only. After this commit the number of cellular samples being built upon a Bluetooth change is reduced from 93 to 2.
The tag `bluetooth` has been added to the cellular samples containing `CONFIG_BT=y`.