### PR TITLE
applications: serial_lte_modem: Increase CMUX notification buffer

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -197,10 +197,13 @@ config SLM_CMUX_UART_BUFFER_SIZE
 config SLM_CMUX_NOTIFICATION_TX_BUFFER_SIZE
 	int "TX buffer size for unsolicited notifications in CMUX"
 	depends on SLM_CMUX
-	default 256
+	default 4096
 	help
 	  Unsolicited notifications need to be buffered with CMUX.
 	  Notifications longer than this size will get truncated.
+	  This can be reduced if your use cases do not require lengthy notifications.
+	  Note: %NCELLMEAS notifications can be nearly 4kB in size,
+	  which explains the default value.
 
 if SLM_CMUX && SLM_PPP
 


### PR DESCRIPTION
Long AT notifications are truncated with CMUX based on CONFIG_SLM_CMUX_NOTIFICATION_TX_BUFFER_SIZE which was 256 by default. This is now increased to match the CONFIG_AT_MONITOR_HEAP_SIZE which reserves 4kB for the notifications.
We may need to revisit this when doing memory optimizations.

Jira: SLM-98