### PR TITLE
doc: requirements: Refine Sphinx version required

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,7 +15,7 @@ pykwalify                       # |     |         |        |         |         |
 pytest                          # |     |         |        |         |         |      |   X    |
 recommonmark                    # |     |         |   X    |    X    |         |      |        |
 snowballstemmer<3.0.0           # https://github.com/snowballstem/snowball/issues/229
-sphinx<8.2.0                    # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
+sphinx>=8.1,<8.2                # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
 sphinx-autobuild                # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
 sphinx-copybutton               # |  X  |         |        |         |         |      |   X    |
 sphinx-ncs-theme<1.1            # |  X  |         |        |         |         |      |        |


### PR DESCRIPTION
Commit 85eb35fb4736e001b42eab68e6a7c233f842895d changed the version string for pip, with only a `<8.2.0` requirement. This however is not enough, since an arbitrary old version of sphinx would not be updated, and 8.1.0 is actually required.

Switch to manually specifying `==8.1.*`, which is equivalent to `>=8.1.0,<8.2.0`.