### PR TITLE
doc: Ensure that that sphinx version is ~=8.1.0

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,7 +15,7 @@ pykwalify                       # |     |         |        |         |         |
 pytest                          # |     |         |        |         |         |      |   X    |
 recommonmark                    # |     |         |   X    |    X    |         |      |        |
 snowballstemmer<3.0.0           # https://github.com/snowballstem/snowball/issues/229
-sphinx<8.2.0                    # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
+sphinx>=8.1,<8.2                # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
 sphinx-autobuild                # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
 sphinx-copybutton               # |  X  |         |        |         |         |      |   X    |
 sphinx-ncs-theme<1.1            # |  X  |         |        |         |         |      |        |


### PR DESCRIPTION
The commit 85eb35fb4736e001b42eab68e6a7c233f842895d limited the sphinx version to < 8.2.0
But required version is at least 8.1.0, due to `:cve:` tags.