### PR TITLE
net: mqtt: Add support to MQTT Helper for runtime configuration of TLS security tagL…

### DIFF
--- a/include/net/mqtt_helper.h
+++ b/include/net/mqtt_helper.h
@@ -80,6 +80,11 @@ struct mqtt_helper_cfg {
 		mqtt_helper_on_pingresp_t on_pingresp;
 		mqtt_helper_on_error_t on_error;
 	} cb;
+
+#if defined(CONFIG_MQTT_LIB_TLS)
+	const sec_tag_t *sec_tag_list;
+	size_t sec_tag_count;
+#endif
 };
 
 struct mqtt_helper_conn_params {

--- a/subsys/net/lib/mqtt_helper/mqtt_helper.c
+++ b/subsys/net/lib/mqtt_helper/mqtt_helper.c
@@ -493,22 +493,30 @@ static int client_connect(struct mqtt_helper_conn_params *conn_params)
 
 #if defined(CONFIG_MQTT_LIB_TLS)
 	struct mqtt_sec_config *tls_cfg = &(mqtt_client.transport).tls.config;
-
-	sec_tag_t sec_tag_list[] = {
-		CONFIG_MQTT_HELPER_SEC_TAG,
+    // Static array with proper lifetime
+    sec_tag_t kconfig_sec_tag_list[] = {
+        CONFIG_MQTT_HELPER_SEC_TAG,
 #if CONFIG_MQTT_HELPER_SECONDARY_SEC_TAG > -1
-		CONFIG_MQTT_HELPER_SECONDARY_SEC_TAG,
+        CONFIG_MQTT_HELPER_SECONDARY_SEC_TAG,
 #endif
-	};
+    };
 
-	tls_cfg->peer_verify	        = TLS_PEER_VERIFY_REQUIRED;
-	tls_cfg->cipher_count	        = 0;
-	tls_cfg->cipher_list	        = NULL; /* Use default */
-	tls_cfg->sec_tag_count	        = ARRAY_SIZE(sec_tag_list);
-	tls_cfg->sec_tag_list	        = sec_tag_list;
-	tls_cfg->session_cache	        = TLS_SESSION_CACHE_DISABLED;
-	tls_cfg->hostname	        = conn_params->hostname.ptr;
-	tls_cfg->set_native_tls		= IS_ENABLED(CONFIG_MQTT_HELPER_NATIVE_TLS);
+    if (current_cfg.sec_tag_list != NULL && current_cfg.sec_tag_count > 0) {
+        LOG_DBG("Using runtime provided security tag value");
+        tls_cfg->sec_tag_count = current_cfg.sec_tag_count;
+        tls_cfg->sec_tag_list = current_cfg.sec_tag_list;
+    } else {
+        LOG_DBG("Using build-time provided security tag value from Kconfig");
+        tls_cfg->sec_tag_count = ARRAY_SIZE(kconfig_sec_tag_list);
+        tls_cfg->sec_tag_list = kconfig_sec_tag_list;
+    }
+
+	tls_cfg->peer_verify = TLS_PEER_VERIFY_REQUIRED;
+	tls_cfg->cipher_count = 0;
+	tls_cfg->cipher_list = NULL; /* Use default */
+	tls_cfg->session_cache = TLS_SESSION_CACHE_DISABLED;
+	tls_cfg->hostname = conn_params->hostname.ptr;
+	tls_cfg->set_native_tls = IS_ENABLED(CONFIG_MQTT_HELPER_NATIVE_TLS);
 
 #if defined(CONFIG_MQTT_HELPER_PROVISION_CERTIFICATES)
 	err = certificates_provision();


### PR DESCRIPTION
The MQTT helper previously did not allow for users to define a TLS security tag at runtime, and could only use a buildtime value assigned to either the CONFIG_MQTT_HELPER_SEC_TAG or CONFIG_MQTT_HELPER_SECONDARY_SEC_TAG Kconfig symbols.

These changes provide users the ability to define a security tag value at runtime, while supporting backwards compatibility and having the mqtt helper using the Kconfig defined symbols in the case that the security tag values are not provided by the user.

I decided to leave the code to automatically use the Kconfig defined security tag value in the case the user does not provide one. This decision was made so that I could leave an existing BUILD ASSERT that requires the user to include a CONFIG_MQTT_HELPER_SEC_TAG symbol.

I have verified operation of the mqtt helper with these changes in an application using the nrf9151dk, with cellular LTE network connection to an AWS IoT server. Both situations where there are no user provided security tag values, and where the user provides a security tag, were verified.