### PR TITLE
samples: peripheral_power_profiling: Add support for nRF54LV10DK

### DIFF
--- a/samples/bluetooth/peripheral_power_profiling/Kconfig
+++ b/samples/bluetooth/peripheral_power_profiling/Kconfig
@@ -79,6 +79,7 @@ config BT_POWER_PROFILING_LED_DISABLED
 
 config BT_POWER_PROFILING_NFC_DISABLED
 	bool "Disable NFC"
+	default y if !HAS_HW_NRF_NFCT
 	help
 	  Disables the NFC to reduce power consumption.
 

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NFC_T2T_NRFXLIB=n
+
+CONFIG_NFC_NDEF=n
+CONFIG_NFC_NDEF_MSG=n
+CONFIG_NFC_NDEF_RECORD=n
+CONFIG_NFC_NDEF_LE_OOB_REC=n
+CONFIG_NFC_NDEF_CH_MSG=n
+
+CONFIG_PM_DEVICE=y
+CONFIG_PM_DEVICE_RUNTIME=y

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		/delete-property/ sw2;
+		/delete-property/ sw3;
+	};
+};
+
+/delete-node/ &button2;
+/delete-node/ &button3;
+
+&uart30 {
+	zephyr,pm-device-runtime-auto;
+};

--- a/samples/bluetooth/peripheral_power_profiling/sample.yaml
+++ b/samples/bluetooth/peripheral_power_profiling/sample.yaml
@@ -15,6 +15,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833
@@ -25,6 +26,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     tags:
       - bluetooth
       - ci_build


### PR DESCRIPTION
Add support for nRF54LV10DK in peripheral_power_profiling sample.