### PR TITLE
Bring TF-M with split target_cfg.c

### DIFF
--- a/modules/trusted-firmware-m/tfm_boards/common/dummy_provisioning.c
+++ b/modules/trusted-firmware-m/tfm_boards/common/dummy_provisioning.c
@@ -6,9 +6,14 @@
 
 #include "tfm_plat_provisioning.h"
 
-int tfm_plat_provisioning_is_required(void)
+enum tfm_plat_err_t tfm_plat_provisioning_is_required(bool *provisioning_required)
 {
-	return 0;
+	if (provisioning_required == NULL) {
+		return TFM_PLAT_ERR_INVALID_INPUT;
+	}
+
+	*provisioning_required = false;
+	return TFM_PLAT_ERR_SUCCESS;
 }
 
 enum tfm_plat_err_t tfm_plat_provisioning_perform(void)

--- a/modules/trusted-firmware-m/tfm_boards/common/nrf_provisioning.c
+++ b/modules/trusted-firmware-m/tfm_boards/common/nrf_provisioning.c
@@ -73,13 +73,18 @@ static enum tfm_plat_err_t verify_debug_disabled(void)
 	return TFM_PLAT_ERR_SUCCESS;
 }
 
-int tfm_plat_provisioning_is_required(void)
+enum tfm_plat_err_t tfm_plat_provisioning_is_required(bool *provisioning_required)
 {
 	enum tfm_security_lifecycle_t lcs;
 
 	lcs = tfm_attest_hal_get_security_lifecycle();
 
-	return lcs == TFM_SLC_PSA_ROT_PROVISIONING;
+	if (provisioning_required == NULL) {
+		return TFM_PLAT_ERR_INVALID_INPUT;
+	}
+
+	*provisioning_required = (lcs == TFM_SLC_PSA_ROT_PROVISIONING);
+	return TFM_PLAT_ERR_SUCCESS;
 }
 
 enum tfm_plat_err_t tfm_plat_provisioning_perform(void)

--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: bf3105bd6f49a758dee722e124e0dc0db9119afe
+      revision: 44bbc980ed6bcc7583d5bf532991f804d8ef0ea6
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
    Brings TF-M where the target_cfg.c is split for
    different platforms.

    Ref: NCSDK-31914
