### PR TITLE
boards: nordic: nrf54lm20pdk: Enable nfct

### DIFF
--- a/boards/nordic/nrf54lm20pdk/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20a_cpuapp_common.dtsi
@@ -139,6 +139,10 @@ zephyr_udc0: &usbhs {
 	status = "okay";
 };
 
+&nfct {
+	status = "okay";
+};
+
 &spi00 {
 	status = "okay";
 	cs-gpios = <&gpio2 5 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
Added NFCT support for the nRF54LM20PDK board.