### PR TITLE
boards: nordic: nrf54lv10dk: Enable DCDC converter

### DIFF
--- a/boards/nordic/nrf54lv10dk/nrf54lv10a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lv10dk/nrf54lv10a_cpuapp_common.dtsi
@@ -42,6 +42,11 @@
 	load-capacitance-femtofarad = <15000>;
 };
 
+&vregmain {
+	status = "okay";
+	regulator-initial-mode = <NRF5X_REG_MODE_DCDC>;
+};
+
 &grtc {
 	owned-channels = <0 1 2 3 4 5 6 7 8 9 10 11>;
 	/* Channels 7-11 reserved for Zero Latency IRQs, 3-4 for FLPR */


### PR DESCRIPTION
Set the vregmain node to use the DCDC converter by default.