### PR TITLE
ci: adding the sonarcloud autoscan config file

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,36 @@
+# This file is used by the SonarCloud GitHub App to configure the SonarCloud Automatic Analysis.
+# https://sonarcloud.io/project/overview?id=nrfconnect_sdk-nrf
+
+# SonarCloud project details
+sonar.projectKey=nrfconnect_sdk-nrf
+sonar.organization=nrfconnect
+sonar.projectName=sdk-nrf
+sonar.projectVersion=1.0
+
+# Path to sources
+sonar.sources = .
+sonar.exclusions=**/samples/matter/manufacturer_specific/src/default_zap/zap-generated/*
+sonar.inclusions=src,include,query_modules
+
+# Path to tests
+sonar.tests = tests/
+# sonar.test.exclusions=
+# sonar.test.inclusions=
+
+# Exclusions for copy-paste detection
+sonar.cpd.exclusions=**/tests/**/*, **/doc/_utils/redi*
+
+# Python version (for python projects only)
+sonar.python.version=3.12
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Pull Request Options
+sonar.pullrequest.github.summary_comment=false
+
+# Language.C
+sonar.cfamily.customTargetArch=arm
+sonar.cfamily.customTargetVendor=unknown
+sonar.cfamily.customTargetSystem=linux
+sonar.cfamily.customTargetEnv=gnueabi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,7 @@
 
 # Root folder
 /.*					  @nrfconnect/ncs-code-owners
+/.sonarcloud.properties                   @nrfconnect/ncs-ci
 /CMakeLists.txt                           @nrfconnect/ncs-co-build-system
 /CODEOWNERS                               @nrfconnect/ncs-code-owners
 /Jenkinsfile                              @nrfconnect/ncs-ci


### PR DESCRIPTION
adding .sonarcloud.properties to control file exclusions from the autoscan in sonarcloud