### PR TITLE
net: lib: mqtt_helper && aws_iot: Allow to bind with specific network interface

### DIFF
--- a/include/net/aws_iot.h
+++ b/include/net/aws_iot.h
@@ -272,6 +272,11 @@ struct aws_iot_config {
 	 *  If not set (NULL), CONFIG_AWS_IOT_BROKER_HOST_NAME will be used.
 	 */
 	char *host_name;
+
+	/** Name of the interface that the AWS library should be bound to.
+	 *  Leave as NULL if not specified.
+	 */
+	const char *if_name;
 };
 
 /** @brief Initialize the library.

--- a/include/net/mqtt_helper.h
+++ b/include/net/mqtt_helper.h
@@ -88,6 +88,11 @@ struct mqtt_helper_conn_params {
 	struct mqtt_helper_buf device_id;
 	struct mqtt_helper_buf user_name;
 	struct mqtt_helper_buf password;
+
+	/** Name of the interface that the MQTT helper should be bound to.
+	 *  Leave as NULL if not specified.
+	 */
+	const char *if_name;
 };
 
 /** @brief Initialize the MQTT helper.

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -656,6 +656,7 @@ int aws_iot_connect(const struct aws_iot_config *const config)
 		.hostname.size = (config && config->host_name) ? strlen(config->host_name) : 0,
 		.device_id.ptr = (config && config->client_id) ? config->client_id : NULL,
 		.device_id.size = (config && config->client_id) ? strlen(config->client_id) : 0,
+		.if_name = (config && config->if_name) ? config->if_name : NULL,
 	};
 
 	/* Set the hostname to CONFIG_AWS_IOT_BROKER_HOST_NAME if it was not provided

--- a/subsys/net/lib/mqtt_helper/mqtt_helper.c
+++ b/subsys/net/lib/mqtt_helper/mqtt_helper.c
@@ -483,6 +483,7 @@ static int client_connect(struct mqtt_helper_conn_params *conn_params)
 	mqtt_client.will_message = &last_will_message;
 #endif
 
+	mqtt_client.transport.if_name = conn_params->if_name;
 #if defined(CONFIG_MQTT_LIB_TLS)
 	mqtt_client.transport.type      = MQTT_TRANSPORT_SECURE;
 #else


### PR DESCRIPTION
It's now possible to bind the mqtt client with a specific network interface, which is useful in projects with multiple network interfaces (which can even be a mix of offloaded and native ones - in this case socket dispatcher is involved). In order to be able to use this feature, we need to forward the configuration from the application down to the mqtt client library through the mqtt_helper and aws_iot libs.