### PR TITLE
cracen: Reorder includes to fix include order issue

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/common/include/cracen/membarriers.h
+++ b/subsys/nrf_security/src/drivers/cracen/common/include/cracen/membarriers.h
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <zephyr/kernel.h>
 #include <nrfx.h>
 
 /** Compiler memory barrier.

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <stdint.h>
-
 #include <zephyr/kernel.h>
+
+#include <stdint.h>
 
 #include "../hw/ba414/ba414_status.h"
 #include "../hw/ba414/pkhardware_ba414e.h"

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/pkhardware_ba414e.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/pkhardware_ba414e.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <zephyr/kernel.h>
+
 #include <cracen/membarriers.h>
 
 #include <stdint.h>
 #include <assert.h>
-
-#include <zephyr/sys/util.h>
 
 #include <silexpk/core.h>
 #include "regs_addr.h"

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/platform/baremetal/cmdma_hw.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/platform/baremetal/cmdma_hw.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <zephyr/kernel.h>
+
 #include "../../hw.h"
 #include <stddef.h>
 #include <stdint.h>
@@ -14,7 +16,6 @@
 
 #include <nrf_security_mutexes.h>
 
-#include <zephyr/kernel.h>
 /* Enable interrupts showing that an operation finished or aborted.
  * For that, we're interested in :
  *     - Fetcher DMA error (bit: 2)


### PR DESCRIPTION
We are observing that

__noinline for instance, is being defined both by gcc.h from Zephyr and by a picolib header in the build dir.

Reordering the includes like this is observed to fix the issue.

I suspect that we are including internal zephyr headers that are not designed to be included directly.

See https://nordicsemi.atlassian.net/browse/NCSDK-34100 for more details