### PR TITLE
west: adding sdk-find-my internal overwrite

### DIFF
--- a/test-manifests/90-sdk-find-my.yml
+++ b/test-manifests/90-sdk-find-my.yml
@@ -1,0 +1,17 @@
+manifest:
+
+  version: "0.13"
+  remotes:
+    - name: ncs
+      url-base: https://github.com/nrfconnect
+
+  defaults:
+    remote: ncs
+
+  projects:
+    - name: find-my
+      repo-path: sdk-find-my-internal
+      path: find-my
+      revision: 58ffc984b57f301458590c07aa61bc0b025c12e0
+      groups:
+        - find-my


### PR DESCRIPTION
Adding sdk-find my overwrite file to point to the new
'sdk-find-my-inernal' repo if west-test.yml is used

To use this, west needs to be initialised with the west-test.yml
```
west init -l nrf --mf=west-test.yml
```

Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>
