### PR TITLE
tests: zephyr: drivers: uart: elementary: Fix nrf54lv10 DK

### DIFF
--- a/tests/zephyr/drivers/uart/uart_elementary/boards/nrf54lv10dk_nrf54lv10a_dual_uart.overlay
+++ b/tests/zephyr/drivers/uart/uart_elementary/boards/nrf54lv10dk_nrf54lv10a_dual_uart.overlay
@@ -1,5 +1,5 @@
 &pinctrl {
-	uart20_default: uart20_default {
+	uart20_alt_default: uart20_alt_default {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 10)>,
 				<NRF_PSEL(UART_RX, 1, 8)>;
@@ -7,7 +7,7 @@
 		};
 	};
 
-	uart20_sleep: uart20_sleep {
+	uart20_alt_sleep: uart20_alt_sleep {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 10)>,
 				<NRF_PSEL(UART_RX, 1, 8)>;
@@ -15,7 +15,7 @@
 		};
 	};
 
-	uart21_default: uart21_default {
+	uart21_alt_default: uart21_alt_default {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 9)>,
 				<NRF_PSEL(UART_RX, 1, 11)>;
@@ -23,7 +23,7 @@
 		};
 	};
 
-	uart21_sleep: uart21_sleep {
+	uart21_alt_sleep: uart21_alt_sleep {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 9)>,
 				<NRF_PSEL(UART_RX, 1, 11)>;
@@ -35,15 +35,15 @@
 dut: &uart20 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart20_default>;
-	pinctrl-1 = <&uart20_sleep>;
+	pinctrl-0 = <&uart20_alt_default>;
+	pinctrl-1 = <&uart20_alt_sleep>;
 	pinctrl-names = "default", "sleep";
 };
 
 dut_aux: &uart21 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart21_default>;
-	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-0 = <&uart21_alt_default>;
+	pinctrl-1 = <&uart21_alt_sleep>;
 	pinctrl-names = "default", "sleep";
 };


### PR DESCRIPTION
Fix configuration for nrf54lv10 DK. Default pinctrl configuration for uart20 already existed and after merging with test configuration it was resulting in wrong pin being used.