### PR TITLE
doc: install: fix VSC walkthrough link

### DIFF
--- a/doc/nrf/app_dev/create_application.rst
+++ b/doc/nrf/app_dev/create_application.rst
@@ -150,7 +150,7 @@ Creating application in the |nRFVSC|
 ====================================
 
 .. note::
-   If you prefer, you can `start VS Code walkthrough`_ and create applications and build configurations from there.
+   If you prefer, you can `start VS Code extension walkthrough`_ and create applications and build configurations from there.
 
 Use the following steps depending on the application placement:
 

--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -50,7 +50,7 @@ Depending on your preferred development environment, install the following softw
 
       Additionally, install |VSC|:
 
-      * The latest version of |VSC| for your operating system from the `Visual Studio Code download page`_ or `using this direct link <start VS Code walkthrough_>`_.
+      * The latest version of |VSC| for your operating system from the `Visual Studio Code download page`_ or `using this direct link <start VS Code extension walkthrough_>`_.
       * In |VSC|, the latest version of the `nRF Connect for VS Code Extension Pack`_.
         The |nRFVSC| comes with its own bundled version of some of the nRF Util commands.
 
@@ -83,7 +83,7 @@ Depending on your preferred development environment, complete the following step
    .. group-tab:: nRF Connect for Visual Studio Code
 
       .. note::
-         If you prefer, you can now `start VS Code walkthrough`_ and install the toolchain and the SDK from there.
+         If you prefer, you can now `start VS Code extension walkthrough`_ and install the toolchain and the SDK from there.
 
       1. Open the nRF Connect extension in |VSC| by clicking its icon in the :guilabel:`Activity Bar`.
       #. In the extension's :guilabel:`Welcome View`, click on :guilabel:`Manage toolchains`.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1616,7 +1616,7 @@
 .. _`VSMQTT`: https://marketplace.visualstudio.com/items?itemName=rpdswtk.vsmqtt
 .. _`Visual Studio Code download page`: https://code.visualstudio.com/download
 
-.. _`start VS Code walkthrough`: vscode://nordic-semiconductor.nrf-connect-extension-pack/quickstart
+.. _`start VS Code extension walkthrough`: vscode://nordic-semiconductor.nrf-connect-extension-pack/quickstart
 
 .. ### Source: python.org
 


### PR DESCRIPTION
Fixed link that opens VS Code on the extension walkthrough page. TECHDOC-3868 and VSC-3031.