### PR TITLE
sample: cellular: modem_shell: cmng multiline support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -388,6 +388,7 @@ Cellular samples
 
     * ``ATE0`` and ``ATE1`` commands in AT command mode to handle echo off/on.
     * Support for RX only mode to the ``link funmode`` command.
+    * Support for ``AT%CMNG`` multi-line commands.
 
 * :ref:`nrf_cloud_multi_service` sample:
 

--- a/samples/cellular/modem_shell/README.rst
+++ b/samples/cellular/modem_shell/README.rst
@@ -122,6 +122,10 @@ in a separate plain AT command mode where also pipelining of AT commands is supp
    When using ``at`` command, any quotation marks (``"``), apostrophes (``'``) and backslashes (``\``) within the AT command syntax must be escaped with a backslash (``\``).
    The percentage sign (``%``) is often needed and can be written as is.
 
+.. note::
+   In order to support provisioning certificates using the ``AT%CMNG=0`` command, occurences of escaped newlines ``\\n`` are replaced by ``\r\n`` internally.
+   To use this feature, remove existing occurences of ``\r`` and replace ``\n`` with ``\\n`` in the AT command string.
+
 Examples
 --------
 


### PR DESCRIPTION
Align Modem Shell with the AT Shell library to support writing certificates with the AT%CMNG command which required multiline support. A substitution is needed to make this work in a shell.