### PR TITLE
manifest: update sdk-zephyr to bring fix for Bluetooth host CS

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 21e025ebfa11bb30bd5574a1538ef76c77562a68
+      revision: pull/2972/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update manifest to point to a temporary fix for Bluetooth host channel sounding bt_le_cs_start_test.