### PR TITLE
cmake: sysbuild: fix the string expansion for MCUboot signature key file

### DIFF
--- a/cmake/sysbuild/generate_default_keyfile.cmake
+++ b/cmake/sysbuild/generate_default_keyfile.cmake
@@ -41,14 +41,15 @@ endif()
 
 # Second command (conditional): Update keyfile for UROT_PUBKEY
 if(SB_CONFIG_MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE)
+  string(CONFIGURE "${SB_CONFIG_BOOT_SIGNATURE_KEY_FILE}" mcuboot_signature_key_file)
   list(APPEND kmu_json_commands
     COMMAND ${Python3_EXECUTABLE} -m west ncs-provision upload
       --keyname UROT_PUBKEY
-      --key ${SB_CONFIG_BOOT_SIGNATURE_KEY_FILE}
+      --key ${mcuboot_signature_key_file}
       --build-dir ${CMAKE_BINARY_DIR}
       --dry-run
   )
-  list(APPEND kmu_json_dependencies ${SB_CONFIG_BOOT_SIGNATURE_KEY_FILE})
+  list(APPEND kmu_json_dependencies ${mcuboot_signature_key_file})
 endif()
 
 # --- Add custom command to generate/update keyfile.json ---


### PR DESCRIPTION
Fixed the string expansion in the SB_CONFIG_BOOT_SIGNATURE_KEY_FILE Kconfig option when it is used to generate keyfile JSON for the KMU provisioning. The feature works properly now with a more complex definition of the SB_CONFIG_BOOT_SIGNATURE_KEY_FILE Kconfig option such as:

SB_CONFIG_BOOT_SIGNATURE_KEY_FILE="\${SB_APPLICATION_CONFIG_DIR}/..."