### PR TITLE
doc: Update and list asset tracker template techdoc link

### DIFF
--- a/doc/nrf/applications.rst
+++ b/doc/nrf/applications.rst
@@ -14,7 +14,10 @@ If you want to list applications available for one or more specific boards, `use
 
 Applications are also available through the `nRF Connect SDK Add-ons`_, a curated collection of supplementary |NCS| components designed to extend the functionality of the |NCS| and provide specific application use cases.
 
-`Asset Tracker Template <Asset Tracker Template_>`_, a reference template recommended for nRF91 Series asset tracking applications, is an example of an add-on.
+.. toctree::
+   :maxdepth: 1
+
+   Asset Tracker Template Add-on <https://docs.nordicsemi.com/bundle/asset-tracker-template-latest/page/index.html>
 
 The following lists the |NCS| applications:
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -51,7 +51,7 @@
 .. _`Zephyr issue #69546`: https://github.com/zephyrproject-rtos/zephyr/issues/69546
 .. _`TF-M sample incompatibility issue`: https://github.com/zephyrproject-rtos/zephyr/issues/34658
 
-.. _`Asset Tracker Template`: https://github.com/nrfconnect/Asset-Tracker-Template
+.. _`Asset Tracker Template`: https://docs.nordicsemi.com/bundle/asset-tracker-template-latest/page/index.html
 
 .. _`generate_psa_key_attributes.py`: https://github.com/nrfconnect/sdk-nrf/blob/main/scripts/generate_psa_key_attributes.py
 .. _`print_toolchain_checksum.sh`: https://github.com/nrfconnect/sdk-nrf/blob/main/scripts/print_toolchain_checksum.sh


### PR DESCRIPTION
* Updated asset tracker Techdoc link
in the link.txt file.
* Add Asset Tracker Template into the NCS
application list.