### PR TITLE
samples: matter: Enabled use of OT without Zephyr L2

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -170,7 +170,12 @@ Gazell
 Matter
 ------
 
-* Added FastTrack Recertification and Portfolio Certification programs.
+* Added:
+
+  * FastTrack Recertification and Portfolio Certification programs.
+  * Matter-over-Thread apps can now use the OpenThread API directly, instead of using intermediate Zephyr L2 layer.
+    This change significantly reduces memory usage in Matter applications.
+    On the :zephyr:board:`nrf54l15dk`, it saves approximately 15 kB of RAM and 40 kB of flash.
 
 * Updated:
 
@@ -508,6 +513,7 @@ Matter samples
 * Added:
 
   * Support for the NFC onboarding for the ``nrf54l15dk/nrf54l15/cpuapp/ns`` board target.
+  * Disabled usage of Zephyr L2 networking layer in favor of using the OpenThread API directly in the Matter over Thread applications.
 
 * Updated:
 

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -40,6 +40,13 @@
   comment: "Variant does not fit in FLASH area - it should be probably removed in the future"
 
 - scenarios:
+    - sample.matter.lock.debug
+    - sample.matter.lock.smp_dfu
+  platforms:
+    - nrf7002dk/nrf5340/cpuapp/nrf7001
+  comment: "https://nordicsemi.atlassian.net/browse/KRKNWK-20529"
+
+- scenarios:
     - nrf.extended.drivers.uart.uart_elementary_dual_l09
     - nrf.extended.drivers.uart.uart_elementary_dual_setup_mismatch_l09
   platforms:

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: b1a600e3613187046a9a3cfa61886ad3e73c9885
+      revision: pull/621/head
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: pull/621/head
+      revision: ee1f9441e70a1b103dd736201905d0a7d27de841
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Pulled Matter change that enabled by default usage of openthread without Zephyr L2 networking.

