### PR TITLE
crypto: PSA core lite: Adding incremental hash

### DIFF
--- a/subsys/nrf_security/src/core/lite/psa_core_lite.c
+++ b/subsys/nrf_security/src/core/lite/psa_core_lite.c
@@ -142,6 +142,49 @@ psa_status_t psa_verify_message(
 
 #if defined(PSA_WANT_ALG_SHA_256) || defined(PSA_WANT_ALG_SHA_512)
 
+psa_status_t psa_hash_setup(psa_hash_operation_t *operation, psa_algorithm_t alg)
+{
+	if (operation == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	if (!UTIL_CONCAT_OR(VERIFY_ALG_SHA_256(alg),
+			    VERIFY_ALG_SHA_512(alg))) {
+		return PSA_ERROR_NOT_SUPPORTED;
+	}
+
+	return psa_driver_wrapper_hash_setup(operation, alg);
+}
+
+psa_status_t psa_hash_update(
+	psa_hash_operation_t *operation, const uint8_t *input, size_t input_length)
+{
+	if (operation == NULL || input == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	return psa_driver_wrapper_hash_update(operation, input, input_length);
+}
+
+psa_status_t psa_hash_finish(
+	psa_hash_operation_t *operation, uint8_t *hash, size_t hash_size, size_t *hash_length)
+{
+	if (operation == NULL || hash == NULL || hash_length == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	return psa_driver_wrapper_hash_finish(operation, hash, hash_size, hash_length);
+}
+
+psa_status_t psa_hash_abort(psa_hash_operation_t *operation)
+{
+	if (operation == NULL) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	return psa_driver_wrapper_hash_abort(operation);
+}
+
 psa_status_t psa_hash_compute(
 	psa_algorithm_t alg, const uint8_t *input, size_t input_length,
 	uint8_t *hash, size_t hash_size, size_t *hash_length)


### PR DESCRIPTION
-Added support for incremental hash for SHA-256 and SHA-512 by
 adding psa_hash_setup, psa_hash_update, psa_hash_finish and
 psa_hash_abort
-Testing is reusing secp256r1 test vectors for SHA-256 and
 Ed25519ph test vectors for SHA-512
-Fixed copy-paste error in test case for test_hash_compute
 (wrong statement for failure condition)

Note that psa_hash_verify and psa_hash_clone is not added as it is assumed to not be used in bootloader context

Note that there is no additional test-target added in test_case.yaml -Testing SHA-256: Use psa_core_lite.ecdsa test target -Testing SHA-512: Use psa_core_lite.ed25519 test target

ref: NCSDK-33725