### PR TITLE
samples: matter: Fixed mcuboot pad warning

### DIFF
--- a/samples/matter/manufacturer_specific/Kconfig.sysbuild
+++ b/samples/matter/manufacturer_specific/Kconfig.sysbuild
@@ -70,6 +70,14 @@ config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
 
 endif # BOARD_NRF54L15DK
 
+# Mcuboot padding size is modified to 0x1000 in pm_static file.
+if SOC_NRF54L10
+
+config PM_MCUBOOT_PAD
+	default 0x1000
+
+endif # SOC_NRF54L10
+
 endif # BOOTLOADER_MCUBOOT
 
 #### Enable generating factory data

--- a/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -27,6 +27,3 @@ CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
-
-# Mcuboot padding size is modified to 0x1000 in pm_static file.
-CONFIG_PM_PARTITION_SIZE_MCUBOOT_PAD=0x1000

--- a/samples/matter/smoke_co_alarm/Kconfig.sysbuild
+++ b/samples/matter/smoke_co_alarm/Kconfig.sysbuild
@@ -67,6 +67,15 @@ config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
 	default y
 
 endif # BOARD_NRF54L15DK
+
+# Mcuboot padding size is modified to 0x1000 in pm_static file.
+if SOC_NRF54L10
+
+config PM_MCUBOOT_PAD
+	default 0x1000
+
+endif # SOC_NRF54L10
+
 endif # BOOTLOADER_MCUBOOT
 
 #### Enable generating factory data

--- a/samples/matter/smoke_co_alarm/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/smoke_co_alarm/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -30,6 +30,3 @@ CONFIG_TICKLESS_KERNEL=y
 
 # Low Power mode
 CONFIG_POWEROFF=y
-
-# Mcuboot padding size is modified to 0x1000 in pm_static file.
-CONFIG_PM_PARTITION_SIZE_MCUBOOT_PAD=0x1000

--- a/samples/matter/template/Kconfig.sysbuild
+++ b/samples/matter/template/Kconfig.sysbuild
@@ -70,6 +70,14 @@ config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
 
 endif # (BOARD_NRF54L15DK || BOARD_NRF54LM20PDK)
 
+# Mcuboot padding size is modified to 0x1000 in pm_static file.
+if SOC_NRF54L10
+
+config PM_MCUBOOT_PAD
+	default 0x1000
+
+endif # SOC_NRF54L10
+
 endif # BOOTLOADER_MCUBOOT
 
 #### Enable generating factory data

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -27,6 +27,3 @@ CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
-
-# Mcuboot padding size is modified to 0x1000 in pm_static file.
-CONFIG_PM_PARTITION_SIZE_MCUBOOT_PAD=0x1000


### PR DESCRIPTION
Fixed the following warning:
MCUboot padding partition size is 0x1000 but signing uses 0x800, please adjust PM_MCUBOOT_PAD value in sysbuild Kconfig to 0x1000.

Moved changing mcuboot pad from the mcuboot related .conf file, to sysbuild Kconfig, as sysbuild is responsible for passing this value to the partition manager.