### PR TITLE
scripts: west: create_board: Fix issues in some board templates

### DIFF
--- a/scripts/west_commands/create_board/config.yml
+++ b/scripts/west_commands/create_board/config.yml
@@ -70,7 +70,7 @@ products:
               - name: cpuapp
                 arch: arm
                 ram: 188
-                flash: 324
+                flash: 1428
   - series: nrf91
     socs:
       - name: nrf9131

--- a/scripts/west_commands/create_board/templates/nrf53/Kconfig.defconfig.jinja2
+++ b/scripts/west_commands/create_board/templates/nrf53/Kconfig.defconfig.jinja2
@@ -23,28 +23,20 @@ if  BOARD_{{ board | upper }}_NRF5340_CPUAPP || BOARD_{{ board | upper }}_NRF534
 #
 # For the non-secure version of the board, the firmware image SRAM is
 # always restricted to the allocated non-secure SRAM partition.
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
+#
 
 if BOARD_{{ board | upper }}_NRF5340_CPUAPP && TRUSTED_EXECUTION_SECURE
 
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
 
 config SRAM_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_SRAM_PARTITION),0,K)
 
 endif # BOARD_{{ board | upper }}_NRF5340_CPUAPP && TRUSTED_EXECUTION_SECURE
 
-if BOARD_{{ board | upper }}_NRF5340_CPUAPP_NS
-
-config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-endif # BOARD_{{ board | upper }}_NRF5340_CPUAPP_NS
+config BOARD_{{ board | upper }}
+	select USE_DT_CODE_PARTITION if BOARD_{{ board | upper }}_NRF5340_CPUAPP_NS
 
 config BT_HCI_IPC
 	default y if BT

--- a/scripts/west_commands/create_board/templates/nrf54l/board.dts.jinja2
+++ b/scripts/west_commands/create_board/templates/nrf54l/board.dts.jinja2
@@ -30,27 +30,22 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
+
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x10000 DT_SIZE_K(324)>;
+			reg = <0x10000 DT_SIZE_K(664)>;
 		};
-		slot0_ns_partition: partition@61000 {
-			label = "image-0-nonsecure";
-			reg = <0x61000 DT_SIZE_K(324)>;
-		};
-		slot1_partition: partition@b2000 {
+
+		slot1_partition: partition@b6000 {
 			label = "image-1";
-			reg = <0xb2000 DT_SIZE_K(324)>;
+			reg = <0xb6000 DT_SIZE_K(664)>;
 		};
-		slot1_ns_partition: partition@103000 {
-			label = "image-1-nonsecure";
-			reg = <0x103000 DT_SIZE_K(324)>;
-		};
-		/* 32k from 0x154000 to 0x15bfff reserved for TF-M partitions */
+
 		storage_partition: partition@15c000 {
 			label = "storage";
 			reg = <0x15c000 DT_SIZE_K(36)>;

--- a/scripts/west_commands/create_board/templates/nrf91/Kconfig.defconfig.jinja2
+++ b/scripts/west_commands/create_board/templates/nrf91/Kconfig.defconfig.jinja2
@@ -1,29 +1,6 @@
-if  BOARD_{{ board | upper }}_{{ soc | upper }} || BOARD_{{ board | upper }}_{{ soc | upper }}_NS
+if BOARD_{{ board | upper }}_{{ soc | upper }} || BOARD_{{ board | upper }}_{{ soc | upper }}_NS
 
-# For the secure version of the board the firmware is linked at the beginning of
-# the flash, or into the code-partition defined in DT if it is intended to be
-# loaded by MCUboot. If the secure firmware is to be combined with a non-secure
-# image (TRUSTED_EXECUTION_SECURE=y), the secure FW image shall always be
-# restricted to the size of its code partition. For the non-secure version of
-# the board, the firmware must be linked into the code-partition (non-secure)
-# defined in DT, regardless. Apply this configuration below by setting the
-# Kconfig symbols used by the linker according to the information extracted from
-# DT partitions.
-
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-	depends on BOARD_{{ board | upper }}_{{ soc | upper }} && TRUSTED_EXECUTION_SECURE
-
-if BOARD_{{ board | upper }}_{{ soc | upper }}_NS
-
-config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-endif # BOARD_{{ board | upper }}_{{ soc | upper }}_NS
+config BOARD_{{ board | upper }}
+	select USE_DT_CODE_PARTITION if BOARD_{{ board | upper }}_{{ soc | upper }}_NS
 
 endif # BOARD_{{ board | upper }}_{{ soc | upper }} || BOARD_{{ board | upper }}_{{ soc | upper }}_NS


### PR DESCRIPTION
Fixes some issues in board templates including not using the USE_DT_CODE_PARTITION Kconfig being used or having TF-M partitions where there should not be any

Test command:
```
west ncs-create-board -r '{"root":"<OUTPUT_FOLDER>","board":"boardname","description":"description","vendor":"company","soc":"nRF54L15-QFAA"}'
```
where soc can be:
```
nRF52805-CAAA
nRF52810-QFAA
nRF52811-QFAA
nRF52820-QDAA
nRF52832-CIAA
nRF52832-QFAA
nRF52832-QFAB
nRF52833-QDAA
nRF52833-QIAA
nRF52840-QFAA
nRF52840-QIAA
nRF5340-QKAA
nRF54L15-QFAA
nRF9131-LACA
nRF9151-LACA
nRF9160-SICA
nRF9161-LACA
```