### PR TITLE
applications: serial_lte_modem: Fix xapoll exit

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -77,7 +77,7 @@ static struct slm_socket *sock = &socks[0]; /* Current socket in use */
 
 enum EFD_COMMAND {
 	EFD_POLL = 0x1,
-	EFD_CLOSE = 0x2
+	EFD_CLOSE = 0x8000
 };
 
 struct async_poll_ctx {
@@ -1834,7 +1834,7 @@ static void apoll_thread(void*, void*, void*)
 			}
 
 			if (afds[i].fd == poll_ctx.efd) {
-				if (get_efd_event(&afds[i]) == EFD_CLOSE) {
+				if (get_efd_event(&afds[i]) & EFD_CLOSE) {
 					/* Exit thread. */
 					poll_ctx.poll_running = false;
 				}


### PR DESCRIPTION
Multiple eventfd_write's all increase the same value. This caused EFD_CLOSE to take place if two EFD_POLL's were done before the xapoll thread could run.