### PR TITLE
samples: peripheral: lpuart: align to uart console change at LV10

### DIFF
--- a/samples/peripheral/lpuart/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/samples/peripheral/lpuart/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -35,17 +35,17 @@
 	status = "okay";
 };
 
-&uart20_default {
+&uart30_default {
 	/* Disconnect CTS and RTS lines from pins.
 	 * This is a workaround for increased current consumption
 	 * (~250 uA more).
 	 */
 	group1 {
-		psels = <NRF_PSEL(UART_TX, 1, 4)>,
+		psels = <NRF_PSEL(UART_TX, 0, 0)>,
 			<NRF_PSEL_DISCONNECTED(UART_RTS)>;
 	};
 	group2 {
-		psels = <NRF_PSEL(UART_RX, 1, 5)>,
+		psels = <NRF_PSEL(UART_RX, 0, 1)>,
 			<NRF_PSEL_DISCONNECTED(UART_CTS)>;
 		bias-pull-up;
 	};


### PR DESCRIPTION
Align that uart console was changed uart20->uart30.