### PR TITLE
net: nrf_provisioning: Update Http connection

### DIFF
--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
@@ -430,7 +430,6 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 					(char *const)auth_hdr,
 					PRV_CONTENT_TYPE_HDR,
 					USER_AGENT_HDR,
-					PRV_CONNECTION_HDR,
 					NULL };
 
 		req.header_fields = (const char **)headers;


### PR DESCRIPTION
The rest_client uses now small intermediate buffer for response data. Keep the connection open until all data is received and let the rest_client close the socket.