### PR TITLE
nrf_cloud_agnss: Increase maximum A-GNSS data size

### DIFF
--- a/include/net/nrf_cloud_agnss.h
+++ b/include/net/nrf_cloud_agnss.h
@@ -23,7 +23,7 @@ extern "C" {
  * Maximum size of assistance data in bytes when all assistance data types are received.
  * Can be used to set the buffer size for REST and CoAP.
  */
-#define NRF_CLOUD_AGNSS_MAX_DATA_SIZE 3600
+#define NRF_CLOUD_AGNSS_MAX_DATA_SIZE 4096
 
 /** Exclude the mask angle from the A-GNSS request */
 #define NRF_CLOUD_AGNSS_MASK_ANGLE_NONE	0xFF


### PR DESCRIPTION
The maximum A-GNSS data size was too small, if ephemerides and almanacs were received for all GPS satellites and more than four QZSS satellites. The planned QZSS constellation size is seven satellites. The updated size leaves some margin on top of 32 GPS and 7 QZSS satellites to avoid similar problems in the future.