### PR TITLE
mpsl: adjust for mpsl_fem_tx_power_split additional phy parameter

### DIFF
--- a/include/fem_al/fem_al.h
+++ b/include/fem_al/fem_al.h
@@ -163,12 +163,14 @@ uint32_t fem_radio_rx_ramp_up_delay_get(bool fast, nrf_radio_mode_t mode);
  *
  * @param[in] power TX power requested for transmission on air.
  * @param[out] radio_tx_power Tx power value to be set on the radio peripheral.
+ * @param[in] radio_mode The mode of the RADIO.
  * @param[in] freq_mhz Frequency in MHz. The output power is valid only for this frequency.
  *
  * @return The power in dBm that is achieved as device output power. It can be different from
  *         the value requested by @p power.
  */
-int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power, uint16_t freq_mhz);
+int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power,
+				   nrf_radio_mode_t radio_mode, uint16_t freq_mhz);
 
 /**@brief Check a real Tx output power, for the SoC with the front-end module for given parameters.
  *
@@ -177,6 +179,7 @@ int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power, uint16_
  * requested output power.
  *
  * @param[in] power Tx power level to check.
+ * @param[in] radio_mode The mode of the RADIO.
  * @param[in] freq_mhz Frequency in MHz. The output power check is valid only for this frequency.
  * @param[in] tx_power_ceiling Flag to get the ceiling or floor of the requested transmit power
  *                             level.
@@ -185,30 +188,33 @@ int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power, uint16_
  *         be different than @p power and depending on @p tx_power_ceiling it can be greater or
  *         lower than the requested one.
  */
-int8_t fem_tx_output_power_check(int8_t power, uint16_t freq_mhz, bool tx_power_ceiling);
+int8_t fem_tx_output_power_check(int8_t power, nrf_radio_mode_t radio_mode, uint16_t freq_mhz,
+				 bool tx_power_ceiling);
 
 /**@brief Get the minimum Tx output power for the SoC with the front-end module.
  *
+ * @param[in] radio_mode The mode of the RADIO.
  * @param[in] freq_mhz Frequency in MHz. The minimum output power is valid only for this frequency.
  *
  * @return The minimum output power in dBm.
  */
-static inline int8_t fem_tx_output_power_min_get(uint16_t freq_mhz)
+static inline int8_t fem_tx_output_power_min_get(nrf_radio_mode_t radio_mode, uint16_t freq_mhz)
 {
 	/* Using INT8_MIN returns the minimum supported Tx output power value. */
-	return fem_tx_output_power_check(INT8_MIN, freq_mhz, false);
+	return fem_tx_output_power_check(INT8_MIN, radio_mode, freq_mhz, false);
 }
 
 /**@brief Get the maximum Tx output power for the SoC with the front-end module.
  *
+ * @param[in] radio_mode The mode of the RADIO.
  * @param[in] freq_mhz Frequency in MHz. The maximum output power is valid only for this frequency.
  *
  * @return The maximum output power in dBm.
  */
-static inline int8_t fem_tx_output_power_max_get(uint16_t freq_mhz)
+static inline int8_t fem_tx_output_power_max_get(nrf_radio_mode_t radio_mode, uint16_t freq_mhz)
 {
 	/* Using INT8_MAX returns the maximum supported Tx output power value. */
-	return fem_tx_output_power_check(INT8_MAX, freq_mhz, true);
+	return fem_tx_output_power_check(INT8_MAX, radio_mode, freq_mhz, true);
 }
 
 /**@brief Get the front-end module default Tx output power.

--- a/samples/bluetooth/direct_test_mode/src/dtm.c
+++ b/samples/bluetooth/direct_test_mode/src/dtm.c
@@ -1035,20 +1035,21 @@ static nrf_radio_txpower_t dbm_to_nrf_radio_txpower(int8_t tx_power)
 }
 
 #if CONFIG_DTM_POWER_CONTROL_AUTOMATIC
-static int8_t dtm_radio_min_power_get(uint16_t frequency)
+static int8_t dtm_radio_min_power_get(nrf_radio_mode_t radio_mode, uint16_t frequency)
 {
-	return fem_tx_output_power_min_get(frequency);
+	return fem_tx_output_power_min_get(radio_mode, frequency);
 }
 
-static int8_t dtm_radio_max_power_get(uint16_t frequency)
+static int8_t dtm_radio_max_power_get(nrf_radio_mode_t radio_mode, uint16_t frequency)
 {
-	return fem_tx_output_power_max_get(frequency);
+	return fem_tx_output_power_max_get(radio_mode, frequency);
 }
 
-static int8_t dtm_radio_nearest_power_get(int8_t tx_power, uint16_t frequency)
+static int8_t dtm_radio_nearest_power_get(int8_t tx_power, nrf_radio_mode_t radio_mode,
+					  uint16_t frequency)
 {
-	int8_t tx_power_floor = fem_tx_output_power_check(tx_power, frequency, false);
-	int8_t tx_power_ceiling = fem_tx_output_power_check(tx_power, frequency, true);
+	int8_t tx_power_floor = fem_tx_output_power_check(tx_power, radio_mode, frequency, false);
+	int8_t tx_power_ceiling = fem_tx_output_power_check(tx_power, radio_mode, frequency, true);
 	int8_t output_power;
 
 	output_power = (abs(tx_power_floor - tx_power) > abs(tx_power_ceiling - tx_power)) ?
@@ -1058,26 +1059,30 @@ static int8_t dtm_radio_nearest_power_get(int8_t tx_power, uint16_t frequency)
 }
 
 #else
-static int8_t dtm_radio_min_power_get(uint16_t frequency)
+static int8_t dtm_radio_min_power_get(nrf_radio_mode_t radio_mode, uint16_t frequency)
 {
+	ARG_UNUSED(radio_mode);
 	ARG_UNUSED(frequency);
 
 	return dtm_hw_radio_min_power_get();
 }
 
-static int8_t dtm_radio_max_power_get(uint16_t frequency)
+static int8_t dtm_radio_max_power_get(nrf_radio_mode_t radio_mode, uint16_t frequency)
 {
+	ARG_UNUSED(radio_mode);
 	ARG_UNUSED(frequency);
 
 	return dtm_hw_radio_max_power_get();
 }
 
-static int8_t dtm_radio_nearest_power_get(int8_t tx_power, uint16_t frequency)
+static int8_t dtm_radio_nearest_power_get(int8_t tx_power, nrf_radio_mode_t radio_mode,
+					  uint16_t frequency)
 {
 	int8_t output_power = INT8_MAX;
 	const size_t size = dtm_hw_radio_power_array_size_get();
 	const int8_t *power = dtm_hw_radio_power_array_get();
 
+	ARG_UNUSED(radio_mode);
 	ARG_UNUSED(frequency);
 
 	for (size_t i = 1; i < size; i++) {
@@ -1110,7 +1115,7 @@ static uint16_t radio_frequency_get(uint8_t channel)
 	return (channel << 1) + base_frequency;
 }
 
-static void radio_tx_power_set(uint8_t channel, int8_t tx_power)
+static void radio_tx_power_set(uint8_t channel, int8_t tx_power, nrf_radio_mode_t radio_mode)
 {
 	int8_t radio_power = tx_power;
 
@@ -1125,11 +1130,12 @@ static void radio_tx_power_set(uint8_t channel, int8_t tx_power)
 		 * Tx output power level for channel 0. That is why output Tx power needs to be
 		 * aligned for final transmission channel.
 		 */
-		tx_power = dtm_radio_nearest_power_get(tx_power, frequency);
-		(void)fem_tx_output_power_prepare(tx_power, &radio_power, frequency);
+		tx_power = dtm_radio_nearest_power_get(tx_power, radio_mode, frequency);
+		(void)fem_tx_output_power_prepare(tx_power, &radio_power, radio_mode, frequency);
 	}
 #else
 	ARG_UNUSED(channel);
+	ARG_UNUSED(radio_mode);
 #endif /* CONFIG_FEM */
 
 #ifdef NRF53_SERIES
@@ -1183,7 +1189,7 @@ static int radio_init(void)
 	/* Turn off radio before configuring it */
 	radio_reset();
 
-	radio_tx_power_set(dtm_inst.phys_ch, dtm_inst.txpower);
+	radio_tx_power_set(dtm_inst.phys_ch, dtm_inst.txpower, dtm_inst.radio_mode);
 	nrf_radio_mode_set(NRF_RADIO, dtm_inst.radio_mode);
 	nrf_radio_fast_ramp_up_enable_set(NRF_RADIO, IS_ENABLED(CONFIG_DTM_FAST_RAMP_UP));
 
@@ -1814,7 +1820,7 @@ static void radio_prepare(bool rx)
 
 		radio_start(rx, false);
 	} else { /* tx */
-		radio_tx_power_set(dtm_inst.phys_ch, dtm_inst.txpower);
+		radio_tx_power_set(dtm_inst.phys_ch, dtm_inst.txpower, dtm_inst.radio_mode);
 
 #if NRF52_ERRATA_172_PRESENT
 		/* Stop the timer used by anomaly 172 */
@@ -2294,8 +2300,8 @@ struct dtm_tx_power dtm_setup_set_transmit_power(enum dtm_tx_power_request power
 						 uint8_t channel)
 {
 	uint16_t frequency = radio_frequency_get(channel);
-	const int8_t tx_power_min = dtm_radio_min_power_get(frequency);
-	const int8_t tx_power_max = dtm_radio_max_power_get(frequency);
+	const int8_t tx_power_min = dtm_radio_min_power_get(dtm_inst.radio_mode, frequency);
+	const int8_t tx_power_max = dtm_radio_max_power_get(dtm_inst.radio_mode, frequency);
 	struct dtm_tx_power tmp = {
 		.power = 0,
 		.min = false,
@@ -2317,7 +2323,8 @@ struct dtm_tx_power dtm_setup_set_transmit_power(enum dtm_tx_power_request power
 		} else if (val >= tx_power_max) {
 			dtm_inst.txpower = tx_power_max;
 		} else {
-			dtm_inst.txpower = dtm_radio_nearest_power_get(val, frequency);
+			dtm_inst.txpower = dtm_radio_nearest_power_get(val, dtm_inst.radio_mode,
+								       frequency);
 		}
 
 		break;

--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -400,7 +400,7 @@ static void radio_power_set(nrf_radio_mode_t mode, uint8_t channel, int8_t power
 
 	if (IS_ENABLED(CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC)) {
 		frequency = channel_to_frequency(mode, channel);
-		output_power = fem_tx_output_power_prepare(power, &radio_power, frequency);
+		output_power = fem_tx_output_power_prepare(power, &radio_power, mode, frequency);
 	}
 #else
 	ARG_UNUSED(mode);

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -858,6 +858,27 @@ static nrf_radio_txpower_t dbm_to_nrf_radio_txpower(int8_t tx_power)
 }
 #endif /* defined(CONFIG_SOC_SERIES_NRF54HX) || defined(CONFIG_SOC_SERIES_NRF54LX) */
 
+#if defined(_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY)
+static mpsl_phy_t convert_bitrate_to_mpsl_phy(enum esb_bitrate bitrate)
+{
+	switch (bitrate) {
+	case ESB_BITRATE_1MBPS: return MPSL_PHY_NRF_1Mbit;
+	case ESB_BITRATE_2MBPS: return MPSL_PHY_NRF_2Mbit;
+#if defined(RADIO_MODE_MODE_Nrf_250Kbit)
+	case ESB_BITRATE_250KBPS: return MPSL_PHY_NRF_250Kbit;
+#endif
+	case ESB_BITRATE_1MBPS_BLE: return MPSL_PHY_BLE_1M;
+#if defined(RADIO_MODE_MODE_Ble_2Mbit)
+	case ESB_BITRATE_2MBPS_BLE: return MPSL_PHY_BLE_2M;
+#endif
+#if defined(RADIO_MODE_MODE_Nrf_4Mbit_0BT6)
+	case ESB_BITRATE_4MBPS: return MPSL_PHY_NRF_4Mbit_0BT6;
+#endif
+	default: return MPSL_PHY_NRF_1Mbit;
+	}
+}
+#endif
+
 static void update_radio_tx_power(void)
 {
 #if !(defined(CONFIG_SOC_SERIES_NRF54HX) || defined(CONFIG_SOC_SERIES_NRF54LX))
@@ -865,6 +886,9 @@ static void update_radio_tx_power(void)
 	mpsl_tx_power_split_t tx_power;
 
 	(void)mpsl_fem_tx_power_split(esb_cfg.tx_output_power, &tx_power,
+#if defined(_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY)
+				      convert_bitrate_to_mpsl_phy(esb_cfg.bitrate),
+#endif
 				      (RADIO_BASE_FREQUENCY + esb_addr.rf_channel), false);
 
 	err = mpsl_fem_pa_power_control_set(tx_power.fem_pa_power_control);


### PR DESCRIPTION
In the MPSL the `mpsl_fem_tx_power_split` function will change soon (dragoon repo PR # 13369). It will have an additional  `phy` parameter and the the `mpsl_phy_t` type is extended with additional enumerators. To smoothly transition through the change in public API for FEM the new MPSL version will define a macro `_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY`.

This PR adjusts NCS code to this change. For short period NCS will support both MPSL APIs, distinguished by `_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY` macro.

After MPSL containing the new version is deployed the code for `!defined(_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY)` will be removed.

Ref: KRKNWK-20453
