### PR TITLE
doc: known_issues: Add missing empty line in workaround

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -4677,6 +4677,7 @@ KRKNWK-19974: CCA ED threshold is not optimal
   **Affected platforms:** nRF5340, nRF52840, nRF52833, nRF52820, nRF54L15
 
   **Workaround:** Depending on the SoC, the value should be set to the following:
+
     * nRF5340 and nRF52833 - Set :kconfig:option:`CONFIG_NRF_802154_CCA_ED_THRESHOLD` to ``18``
     * Other devices -  Set :kconfig:option:`CONFIG_NRF_802154_CCA_ED_THRESHOLD` to ``17``
 


### PR DESCRIPTION
The workaround part was not rendered properly in the documentation due to missing newline.