### PR TITLE
samples: bluetooth: event_trigger: Fix EGU interrupt run kernel sched

### DIFF
--- a/samples/bluetooth/event_trigger/src/main.c
+++ b/samples/bluetooth/event_trigger/src/main.c
@@ -82,7 +82,7 @@ static int setup_connection_event_trigger(struct bt_conn *conn, bool enable)
 		cmd_params.task_address =
 			nrf_egu_task_address_get(NRF_EGU, NRF_EGU_TASK_TRIGGER0);
 
-		IRQ_DIRECT_CONNECT(DT_IRQN(EGU_NODE), 5, egu_handler, 0);
+		IRQ_CONNECT(DT_IRQN(EGU_NODE), 5, egu_handler, 0, 0);
 		nrf_egu_int_enable(NRF_EGU, NRF_EGU_INT_TRIGGERED0);
 		NVIC_EnableIRQ(DT_IRQN(EGU_NODE));
 	} else {


### PR DESCRIPTION
Recently MPSL ISRs were fixe to do not trigger kenrel scheduler because they are zero latency interrupts. The event_trigger sample uses EGU to be triggered when a connection event happens. The EGU ISR is connected with IRQ_DIRECT_CONNECT macro but it is defined as regular ISR (withouth use of macro ISR_DIRECT_DECLARE).

Since there is no return value from the egu_handler() the kenrel scheduler is not triggered. There is no other event that kicks the scheduler so sample is hanging in the while loop in the main() waiting for a NUM_TRIGGERS number of connection events to happen.

Use IRQ_CONNECT macro to connect the egu_handler() as a regular ISR. That makes sure the kenrel is triggered at end of the ISR.