### PR TITLE
quarantine_zephyr: Add quarantine for libraries.libc.* at NCS

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -328,6 +328,16 @@
     - nrf54l15dk/nrf54l05/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/NRFX-7879"
 
+- scenarios:
+    - libraries.libc.common.picolibc.module
+    - libraries.libc.common.picolibc.notls
+    - libraries.libc.strerror.picolibc.module
+    - libraries.libc.strerror.picolibc.notls
+    - libraries.libc.picolibc.sprintf_inexact
+  platforms:
+    - nrf54l15dk/nrf54l15/cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-34100"
+
 # ---------------------------------   Won't fix section -----------------------------------
 
 - scenarios:


### PR DESCRIPTION
Quarantined test configurations are investigated.
Until fix for that, these should be quarantined.