### PR TITLE
boards: nordic: nrf54lm20pdk: do not enable ext flash by default

### DIFF
--- a/boards/nordic/nrf54lm20pdk/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lm20pdk/nrf54lm20a_cpuapp_common.dtsi
@@ -152,7 +152,7 @@ zephyr_udc0: &usbhs {
 
 	mx25r64: mx25r6435f@0 {
 		compatible = "jedec,spi-nor";
-		status = "okay";
+		status = "disabled";
 		reg = <0>;
 		spi-max-frequency = <8000000>;
 		jedec-id = [c2 28 17];


### PR DESCRIPTION
Samples/tests which need it should enable it explicitly.