### PR TITLE
samples: matter: template: add missing ci_tag

### DIFF
--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -1,6 +1,10 @@
 sample:
   description: Matter Template sample
   name: Matter Template
+common:
+  tags:
+    - sysbuild
+    - ci_samples_matter
 tests:
   sample.matter.template.debug:
     sysbuild: true
@@ -23,9 +27,6 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
-    tags:
-      - sysbuild
-      - ci_samples_matter
   sample.matter.template.release:
     sysbuild: true
     build_only: true
@@ -48,9 +49,6 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
-    tags:
-      - sysbuild
-      - ci_samples_matter
   sample.matter.template.smp_dfu:
     sysbuild: true
     build_only: true
@@ -73,9 +71,6 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
-    tags:
-      - sysbuild
-      - ci_samples_matter
   sample.matter.template.release.internal:
     sysbuild: true
     build_only: true
@@ -88,9 +83,6 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
-    tags:
-      - sysbuild
-      - ci_samples_matter
   sample.matter.template.release.internal.smp_dfu:
     sysbuild: true
     build_only: true
@@ -104,9 +96,6 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
-    tags:
-      - sysbuild
-      - ci_samples_matter
   sample.matter.template.cc3xx_backend:
     sysbuild: true
     build_only: true
@@ -118,9 +107,6 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    tags:
-      - sysbuild
-      - ci_samples_matter
   sample.matter.template.smp_dfu.old_ec:
     sysbuild: true
     build_only: true
@@ -149,6 +135,3 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
-    tags:
-      - sysbuild
-      - ci_samples_matter


### PR DESCRIPTION
Make tags common so they will be used for all configurations.