### PR TITLE
Doc/ncsdk 33212

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54l/dfu_config.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/dfu_config.rst
@@ -130,6 +130,10 @@ Key invalidation occurs after reboot, and the confirmed application invalidates 
 A valid signature verification must precede any key invalidation.
 The last remaining key cannot be invalidated.
 
+.. note::
+   Once the application running in test mode confirms its stability, it will reboot the device to enable MCUboot to invalidate the keys.
+   Until this reboot occurs, the application should avoid collecting further firmware updates or performing any erase or write operations on the image storage partition.
+
 Images encryption
 *****************
 

--- a/doc/nrf/app_dev/device_guides/nrf54l/fota_update.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/fota_update.rst
@@ -125,6 +125,8 @@ To perform a FOTA update, complete the following steps:
          For samples using random HCI identities, the Test and Confirm mode should not be used.
 
    #. Wait for the DFU to finish and then verify that the new application works properly by observing the new device name visible in the Device Manager app.
+   #. After confirming if the advanced tool mode was used, reset the device again.
+      This ensures that the new application runs correctly and allows you to revoke old signature keys if desired.
 
 .. fota_upgrades_over_ble_nrfcdm_common_dfu_steps_end
 


### PR DESCRIPTION
Added node with explanation on the need for rebooting the device in
order to perform key revocation action.

ref.: NCSDK-33212