### PR TITLE
tests: Extend boot_chains, added monotonic counters

### DIFF
--- a/tests/subsys/bootloader/boot_chains/testcase.yaml
+++ b/tests/subsys/bootloader/boot_chains/testcase.yaml
@@ -5,6 +5,8 @@ common:
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
+  tags:
+    - ci_tests_subsys_bootloader
   harness: console
   harness_config:
     type: one_line
@@ -13,18 +15,16 @@ common:
 
 tests:
   boot_chains.secure_boot:
-    extra_args: SB_CONFIG_SECURE_BOOT_APPCORE=y
-    tags:
-      - ci_tests_subsys_bootloader
+    extra_args:
+      - SB_CONFIG_SECURE_BOOT_APPCORE=y
   boot_chains.bootloader_mcuboot:
-    extra_args: SB_CONFIG_BOOTLOADER_MCUBOOT=y
+    extra_args:
+      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags:
-      - ci_tests_subsys_bootloader
   boot_chains.secure_boot_and_bootloader_mcuboot:
     extra_args:
       - SB_CONFIG_SECURE_BOOT_APPCORE=y
@@ -34,19 +34,28 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-    tags:
-      - ci_tests_subsys_bootloader
   boot_chains.bootloader_mcuboot_and_nv_counters:
     extra_args:
       - SB_CONFIG_BOOTLOADER_MCUBOOT=y
       - SB_CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION=y
-    tags:
-      - ci_tests_subsys_bootloader
+      - SB_CONFIG_MCUBOOT_HW_DOWNGRADE_PREVENTION_COUNTER_SLOTS=64
+    platform_exclude:
+      - nrf52840dk/nrf52840
+  boot_chains.secure_boot_and_nv_counters:
+    extra_args:
+      - SB_CONFIG_SECURE_BOOT_APPCORE=y
+      - CONFIG_SB_MONOTONIC_COUNTER=y
+      - CONFIG_SB_NUM_VER_COUNTER_SLOTS=64
+  boot_chains.secure_boot_and_mcuboot_and_nv_counters:
+    extra_args:
+      - SB_CONFIG_SECURE_BOOT_APPCORE=y
+      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
+      - mcuboot_CONFIG_SB_MONOTONIC_COUNTER=y
+      - mcuboot_CONFIG_SB_NUM_VER_COUNTER_SLOTS=64
   boot_chains.secure_boot_and_optimizations_speed:
     extra_args:
       - SB_CONFIG_SECURE_BOOT_APPCORE=y
       - CONFIG_SPEED_OPTIMIZATIONS=y
-    tags: ci_tests_subsys_bootloader
   boot_chains.secure_boot_and_optimizations_size:
     extra_args:
       - SB_CONFIG_SECURE_BOOT_APPCORE=y
@@ -56,7 +65,6 @@ tests:
     extra_args:
       - SB_CONFIG_SECURE_BOOT_APPCORE=y
       - CONFIG_DEBUG_OPTIMIZATIONS=y
-    tags: ci_tests_subsys_bootloader
   boot_chains.secure_boot_and_hw_crypto_backends:
     extra_args:
       - SB_CONFIG_SECURE_BOOT_APPCORE=y
@@ -64,4 +72,3 @@ tests:
       - SB_CONFIG_SECURE_BOOT_APPCORE_HASH_TYPE_HARDWARE=y
     platform_exclude:
       - nrf5340dk/nrf5340/cpuapp
-    tags: ci_tests_subsys_bootloader


### PR DESCRIPTION
Extend boot_chains test configurations to verify
hardware downgrade prevention and monotonic counters configured in MCUboot and in NSIB. Limit number of slots to 64 to check requirements:
R50_PSBG_ROLLBACK: Each rollback counter used
to validate SPE software must support at least 64 values