### PR TITLE
samples: bluetooth: direct_test_mode: Fix hmpan 216 workaround

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -2696,6 +2696,15 @@ Bluetooth samples
 
 .. rst-class:: v3-0-2 v3-0-1 v3-0-0
 
+NCSDK-33915: The :ref:`direct_test_mode` asserts on nRF54H20 devices
+  The sample asserts during reception tests and sends too few packets during transmission tests.
+
+  **Affected platforms:** nRF54H20
+
+  **Workaround:** Move the ``errata216_on_wait()`` static function call from the ``radio_start()`` function to the test command handlers in :file:`dtm.c`, which enable radio: ``dtm_vendor_specific_pkt()``, ``dtm_test_receive()``, and ``dtm_test_transmit()``.
+
+.. rst-class:: v3-0-2 v3-0-1 v3-0-0
+
 NCSDK-33040: Output power tests running with the Anritsu tester fail
   This happens with the :ref:`direct_test_mode` sample.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -362,7 +362,10 @@ Bluetooth samples
   * Updated the buffer count (:kconfig:option:`CONFIG_BT_ISO_TX_BUF_COUNT`) to be in-line with SoftDevice Controller (SDC) defaults.
     This can be changed and optimized for specific use cases.
 
-|no_changes_yet_note|
+* :ref:`direct_test_mode` sample:
+
+  * Fixed a bug in the workaround for errata 216 on nRF54H20 devices.
+    The device asserted when a packet was received during reception tests and too few packets where transmitted during transmission tests.
 
 Bluetooth Mesh samples
 ----------------------


### PR DESCRIPTION
Fixing workaround behavior that caused assertion in RX and low packet rate in TX. Adding related doc entries