### PR TITLE
nrf_security: Fix 54lm20 alignment issue in Cracen

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/silexpk/src/montgomery.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/src/montgomery.c
@@ -34,11 +34,11 @@ struct sx_pk_acq_req sx_async_x25519_ptmult_go(const struct sx_x25519_op *k,
 	sx_wrpkmem(inputs.p.addr, pt->bytes, SX_X25519_OP_SZ);
 	sx_wrpkmem(inputs.k.addr, k->bytes, SX_X25519_OP_SZ);
 	/* clamp the scalar */
-	inputs.k.addr[31] |= 1 << 6;
-	inputs.k.addr[31] &= 0x7f;
-	inputs.k.addr[0] &= 0xF8;
+	sx_wrpkmem_byte(&inputs.k.addr[31], (inputs.k.addr[31] | 1 << 6) & 0x7f);
+	sx_wrpkmem_byte(&inputs.k.addr[0], inputs.k.addr[0] & 0xF8);
+
 	/* clamp the pt */
-	inputs.p.addr[31] &= 0x7f;
+	sx_wrpkmem_byte(&inputs.p.addr[31], inputs.p.addr[31] & 0x7f);
 
 	sx_pk_run(pkreq.req);
 
@@ -90,8 +90,8 @@ struct sx_pk_acq_req sx_async_x448_ptmult_go(const struct sx_x448_op *k,
 	sx_wrpkmem(inputs.p.addr, pt->bytes, SX_X448_OP_SZ);
 	sx_wrpkmem(inputs.k.addr, k->bytes, SX_X448_OP_SZ);
 	/* clamp the scalar */
-	inputs.k.addr[55] |= 0x80;
-	inputs.k.addr[0] &= 0xFC;
+	sx_wrpkmem_byte(&inputs.k.addr[55], inputs.k.addr[55] | 0x80);
+	sx_wrpkmem_byte(&inputs.k.addr[0], inputs.k.addr[0] & 0xFC);
 
 	sx_pk_run(pkreq.req);
 


### PR DESCRIPTION
The Cracen in 54lm20 does not allow single byte writes in the PK memory. There was some single byte writes in Montgomery. This makes sure that the single byte writes are done using the relevant sx_ functions which implement workarounds for this issue when needed.

Ref: NCSDK-33957