### PR TITLE
ci/docbuild: fix Zoomin patching for the same docset Doxygen case

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -133,9 +133,13 @@ jobs:
             cp doc/_zoomin/$docset.apis.tags.yml "$OUTDIR/tags.yml"
             sed -i 's/__VERSION__/'"$VERSION"'/g' "$OUTDIR/tags.yml"
 
-            # Patch links from Sphinx to Doxygen APIs
+            # Patch links from Sphinx to other docset Doxygen APIs
             find doc/_build/html/$docset -type f -name "*.html" -exec \
               sed -ri "/href=\"([^\"]+)\/([a-z]+)\/doxygen\/html\/([^\"]+)\"/{s//href=\"..\/..\/\1\/\2-apis-$VERSION\/page\/\3\"/g; :a s/__/_/g;ta; }" {} \;
+
+            # Patch links from Sphinx to same docset Doxygen APIs
+            find doc/_build/html/$docset -type f -name "*.html" -exec \
+              sed -ri "/href=\"([^\"]+)\/doxygen\/html\/([^\"]+)\"/{s//href=\"\1\/..\/..\/..\/$docset-apis-$VERSION\/page\/\2\"/g; :a s/__/_/g;ta; }" {} \;
 
             pushd "$OUTDIR"
             ARCHIVE="$docset-apis-$VERSION.zip"


### PR DESCRIPTION
Links to the Doxygen APIs from the same docset were broken as they need some special treatment (they do not follow the same pattern). I have added a 2nd patching step to cover such case after the other docset links are patched first. There may be a better solution, but this is fast enough for now.