### PR TITLE
doc: fast_pair: fmdn: add a note about the extension rename

### DIFF
--- a/doc/nrf/external_comp/bt_fast_pair.rst
+++ b/doc/nrf/external_comp/bt_fast_pair.rst
@@ -74,6 +74,8 @@ The FMDN extension leverages the Find My Device network, which is a crowdsourced
 The entire process is end-to-end encrypted and anonymous, so no one else (including Google) can view device's location or information.
 The Find My Device network also includes features protecting the user against unwanted tracking.
 
+.. include:: /includes/fast_pair_fmdn_rename.txt
+
 You can add your accessory to the Find My Device network through provisioning that happens during the Bluetooth LE connection.
 Once provisioned, the accessory starts to advertise FMDN frames that contain its unique identifier.
 This advertising payload is used by nearby Android devices to report the accessory location to its owner.

--- a/doc/nrf/external_comp/dult.rst
+++ b/doc/nrf/external_comp/dult.rst
@@ -55,6 +55,8 @@ The DULT standard implementation in the |NCS| integrates the location-tracking a
 For an integration example, see the Find My Device Network (FMDN) extension of the :ref:`bt_fast_pair_readme`.
 Also see the :ref:`fast_pair_locator_tag` sample that integrates the Fast Pair with the FMDN extension, which integrates the :ref:`dult_readme` module.
 
+.. include:: /includes/fast_pair_fmdn_rename.txt
+
 .. rst-class:: numbered-step
 
 .. _ug_dult_registering:

--- a/doc/nrf/includes/fast_pair_fmdn_rename.txt
+++ b/doc/nrf/includes/fast_pair_fmdn_rename.txt
@@ -1,0 +1,4 @@
+.. note::
+   The `Fast Pair Find My Device Network extension`_ has been renamed to the Find Hub Network (FHN) extension, and the `Find My Device app`_ is now called the Find Hub app.
+   However, this documentation page still uses the previous terminology.
+   The naming will be updated in the future releases.

--- a/doc/nrf/libraries/bluetooth/services/fast_pair.rst
+++ b/doc/nrf/libraries/bluetooth/services/fast_pair.rst
@@ -27,6 +27,8 @@ The Fast Pair service also contains additional GATT characteristics under the fo
 * The Beacon Actions GATT characteristic when the Find My Device Network (FMDN) extension is enabled (:kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN`).
   The characteristic is described in the `Fast Pair Find My Device Network extension`_ documentation.
 
+  .. include:: /includes/fast_pair_fmdn_rename.txt
+
 Configuration
 *************
 

--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -14,6 +14,8 @@ Google Fast Pair Service (GFPS) is a standard for pairing Bluetooth® and Blueto
 Google Fast Pair standard also supports the Find My Device Network (FMDN) extension that is the main focus of this sample demonstration.
 For detailed information, see the official `Fast Pair Find My Device Network extension`_ documentation.
 
+.. include:: /includes/fast_pair_fmdn_rename.txt
+
 This sample follows the `Fast Pair Device Feature Requirements for Locator Tags`_ documentation and uses the Fast Pair configuration for the locator tag use case.
 The software maturity level for the locator tag use case is outlined in the :ref:`Google Fast Pair use case support <software_maturity_fast_pair_use_case>` table.
 


### PR DESCRIPTION
Created a linkable note that notifies the user about the Fast Pair extension rename. The Fast Pair Find My Device Network (FMDN) extension has been renamed to the Find Hub Network (FHN) extension, and the Find My Device app is now called the Find Hub app.

Ref: NCSDK-33576