### PR TITLE
applications: nrf_desktop: doc: usb_state: generalize dwc2 udc support

### DIFF
--- a/applications/nrf_desktop/doc/usb_state.rst
+++ b/applications/nrf_desktop/doc/usb_state.rst
@@ -37,7 +37,7 @@ To select the USB stack, enable one of the following Kconfig choice options:
   The USB legacy stack is used by default.
 * :ref:`CONFIG_DESKTOP_USB_STACK_NEXT <config_desktop_app_options>`
   The option enables USB next stack (:kconfig:option:`CONFIG_USB_DEVICE_STACK_NEXT`).
-  This is the only USB stack that supports USB High-Speed and the nRF54H20 devices.
+  This is the only USB stack that supports SoCs with USB High-Speed (such as the nRF54H20 SoC).
 
 .. note::
    The USB next stack integration is :ref:`experimental <software_maturity>`.
@@ -85,7 +85,7 @@ The module informs that the HID report was sent using :c:struct:`hid_report_sent
   In the case of :ref:`nrf_desktop_hid_mouse_report_handling`, enabling the USB SOF synchronization also synchronizes motion sensor sampling with the USB SOF instead of USB polls (motion sensor sampling is synchronized to :c:struct:`hid_report_sent_event`).
   This synchronization ensures that the sensor is sampled more evenly.
 
-The :ref:`CONFIG_DESKTOP_USB_HID_REPORT_SENT_ON_SOF <config_desktop_app_options>` Kconfig option is enabled by default on the nRF54H Series SoC (:kconfig:option:`CONFIG_SOC_SERIES_NRF54HX`) to mitigate a negative impact of jitter related to USB polls.
+The :ref:`CONFIG_DESKTOP_USB_HID_REPORT_SENT_ON_SOF <config_desktop_app_options>` Kconfig option is enabled by default on devices (such as the nRF54H20 SoC) that use an UDC driver with High-Speed support (:kconfig:option:`CONFIG_UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT`) to mitigate a negative impact of jitter related to USB polls.
 The negative impact of the jitter is more visible for USB High-Speed.
 
 .. _nrf_desktop_usb_state_hid_class_instance:
@@ -236,15 +236,12 @@ The |usb_state| is a transport for :ref:`nrf_desktop_config_channel` when the ch
 The module also handles a HID keyboard LED output report received through USB from the connected host.
 The module sends the report using :c:struct:`hid_report_event`, that is handled either by :ref:`nrf_desktop_hid_state` (for peripheral) or by the :ref:`nrf_desktop_hid_forward` (for dongle).
 
-nRF54H20 support
-================
+DWC2 USB device controller support
+==================================
 
-Due to the characteristics of the nRF54H20 USB Device Controller (UDC), following change has been made in the USB state module to support the nRF54H20 devices:
-
-* The module disables the USB stack when the USB cable is disconnected and enables the stack when the cable is connected.
-
-This change is applicable to the nRF54H20 devices only.
-It is necessary to ensure proper USB stack operation on the nRF54H20 devices.
+Due to the characteristics of the DWC2 USB Device Controller (UDC), the USB state module disables the USB stack when the USB cable is disconnected and enables the stack when the cable is connected.
+These actions are necessary to ensure proper USB stack operation.
+This change is applicable to the devices that use the DWC2 USB driver (such as the nRF54H20 SoC).
 
 The :kconfig:option:`CONFIG_UDC_DWC2_USBHS_VBUS_READY_TIMEOUT` Kconfig option is set to a non-zero value to prevent the :c:func:`usbd_enable` function from blocking the application forever when the USB cable is not connected.
 Instead, the function returns an error on timeout.


### PR DESCRIPTION
Refactor the documentation of the USB State module from the nRF Desktop application to generalize the support for the DWC2 USB Device Controller driver.