### PR TITLE
net: lib: nrf_cloud: Fix return values in FOTA poll

### DIFF
--- a/include/net/nrf_cloud_fota_poll.h
+++ b/include/net/nrf_cloud_fota_poll.h
@@ -134,6 +134,7 @@ int nrf_cloud_fota_poll_process_pending(struct nrf_cloud_fota_poll_ctx *ctx);
  * @retval -EFAULT          A FOTA job was not successful.
  * @retval -ENOENT          A FOTA job has finished and its status has been reported to the cloud.
  * @retval -EAGAIN          No FOTA job exists.
+ * @retval -ETIMEDOUT       The FOTA job check timed out. Retry later.
  */
 int nrf_cloud_fota_poll_process(struct nrf_cloud_fota_poll_ctx *ctx);
 

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
@@ -588,8 +588,10 @@ int nrf_cloud_coap_fota_job_get(struct nrf_cloud_fota_job_info *const job)
 		LOG_DBG("No pending FOTA job");
 	} else if (fota_err > 0) {
 		LOG_RESULT_CODE_ERR("Error getting FOTA job info; result code:", fota_err);
+	} else if (fota_err == -ETIMEDOUT) {
+		LOG_ERR("FOTA job request timed out: %d", fota_err);
 	} else if (fota_err < 0) {
-		LOG_ERR("FOTA response decoding error: %d", fota_err);
+		LOG_ERR("FOTA request failed: %d", fota_err);
 	} else {
 		/* No callback error: success */
 		LOG_DBG("FOTA job received; type:%d, id:%s, host:%s, path:%s, size:%d",


### PR DESCRIPTION
When fetching a job, propagate the error code -ETIMEDOUT to the application instead of -ENOTRECOVERABLE which is reserved for errors.

Document -ETIMEDOUT in the API documentation.