### PR TITLE
manifest: Updated Matter repository to v1.4.2 version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 3ccd6078b9b33af0fa6ddb71e51bb9860f9198a0
+      revision: pull/623/head
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Pulled the most recent v1.4.2 of Matter.