### PR TITLE
tests: drivers: i2s: i2s_mclk: scale expectation at coverage

### DIFF
--- a/tests/drivers/i2s/i2s_mclk/src/test_i2s_mclk.c
+++ b/tests/drivers/i2s/i2s_mclk/src/test_i2s_mclk.c
@@ -60,7 +60,7 @@ static const struct gpio_dt_spec gpio_lrck_spec =
 static const struct device *dev_i2s;
 
 #if defined(CONFIG_COVERAGE)
-#define EXPECTED_MCLK_SCALE 0.8
+#define EXPECTED_MCLK_SCALE 0.5
 #else
 #define EXPECTED_MCLK_SCALE 1.0
 #endif


### PR DESCRIPTION
Scale down expectation when coverage mode is used.