### PR TITLE
doc: Define App and sample-specific Kconfig options

### DIFF
--- a/applications/nrf5340_audio/doc/configuration.rst
+++ b/applications/nrf5340_audio/doc/configuration.rst
@@ -41,6 +41,13 @@ CONFIG_BT_AUDIO_USE_BROADCAST_NAME_ALT
 CONFIG_BT_AUDIO_BROADCAST_NAME_ALT
    Provides an alternative name for the second gateway in BIS mode.
 
+.. _CONFIG_BT_AUDIO_SCAN_DELEGATOR:
+
+CONFIG_BT_AUDIO_SCAN_DELEGATOR
+   Enables scan delegator.
+   When the scan delegator feature is enabled, the broadcast sink will not search for a predefined broadcast source.
+   Instead, it will wait for a broadcast assistant to connect and control it.
+
 .. _CONFIG_AUDIO_SOURCE_I2S:
 
 CONFIG_AUDIO_SOURCE_I2S

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -264,6 +264,15 @@ CONFIG_SLM_UART_TX_BUF_SIZE - Send buffer size for UART.
    This option defines the size of the buffer for sending (TX) UART traffic.
    The default value is 256.
 
+.. _CONFIG_SLM_PPP_FALLBACK_MTU:
+
+CONFIG_SLM_PPP_FALLBACK_MTU - Control the MTU used by PPP.
+   This option controls the MTU used by PPP.
+   PPP tries to retrieve the cellular link MTU from the modem (using ``AT+CGCONTRDP=0``).
+   If MTU is not returned by the modem, this value will be used as a fallback.
+   The MTU will be used for sending and receiving data on both the PPP and cellular links.
+   The default value is 1280.
+
 .. _slm_additional_config:
 
 Additional configuration

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.8.0-preview1.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.8.0-preview1.rst
@@ -392,7 +392,7 @@ Serial LTE modem
 * Added:
 
   * DTLS support for the ``#XUDPSVR`` and ``#XSSOCKET`` (UDP server sockets) AT commands when the :file:`overlay-native_tls.conf` configuration file is used.
-  * The :kconfig:option:`CONFIG_SLM_PPP_FALLBACK_MTU` Kconfig option that is used to control the MTU used by PPP when the cellular link MTU is not returned by the modem in response to the ``AT+CGCONTRDP=0`` AT command.
+  * The :ref:`CONFIG_SLM_PPP_FALLBACK_MTU <CONFIG_SLM_PPP_FALLBACK_MTU>` Kconfig option that is used to control the MTU used by PPP when the cellular link MTU is not returned by the modem in response to the ``AT+CGCONTRDP=0`` AT command.
   * Handler for new nRF Cloud event type ``NRF_CLOUD_EVT_RX_DATA_DISCON``.
   * Support for socket option ``AT_SO_IPV6_DELAYED_ADDR_REFRESH``.
 
@@ -539,12 +539,12 @@ Cellular samples
 
   * Added:
 
-    * The :kconfig:option:`CONFIG_TEST_COUNTER_MULTIPLIER` Kconfig option to multiply the number of test counter messages sent, for testing purposes.
+    * The :ref:`CONFIG_TEST_COUNTER_MULTIPLIER <CONFIG_TEST_COUNTER_MULTIPLIER>` Kconfig option to multiply the number of test counter messages sent, for testing purposes.
     * A handler for new nRF Cloud event type ``NRF_CLOUD_EVT_RX_DATA_DISCON`` to stop sensors and location services.
     * Board support files to enable Wi-Fi scanning for the Thingy:91 X.
-    * The :kconfig:option:`CONFIG_SEND_ONLINE_ALERT` Kconfig option to enable calling the :c:func:`nrf_cloud_alert` function on startup.
+    * The :ref:`CONFIG_SEND_ONLINE_ALERT <CONFIG_SEND_ONLINE_ALERT>` Kconfig option to enable calling the :c:func:`nrf_cloud_alert` function on startup.
     * Logging of the `reset reason code <nRF9160 RESETREAS_>`_.
-    * The :kconfig:option:`CONFIG_POST_PROVISIONING_INTERVAL_M` Kconfig option to reduce the provisioning connection interval once the device successfully connects.
+    * The :ref:`CONFIG_POST_PROVISIONING_INTERVAL_M <CONFIG_POST_PROVISIONING_INTERVAL_M>` Kconfig option to reduce the provisioning connection interval once the device successfully connects.
 
   * Updated:
 
@@ -564,7 +564,7 @@ Cellular samples
   * Added:
 
     * Support for dictionary logs using REST.
-    * The :kconfig:option:`CONFIG_SEND_ONLINE_ALERT` Kconfig option to enable calling the :c:func:`nrf_cloud_alert` function on startup.
+    * The :ref:`CONFIG_SEND_ONLINE_ALERT <CONFIG_SEND_ONLINE_ALERT>` Kconfig option to enable calling the :c:func:`nrf_cloud_alert` function on startup.
     * Logging of the `reset reason code <nRF9160 RESETREAS_>`_.
 
   * Updated:

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.8.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.8.0.rst
@@ -530,11 +530,11 @@ nRF5340 Audio
 
   * The functions ``bt_hci_err_to_str()`` and ``bt_security_err_to_str()`` that are used to allow printing error codes as strings.
     Each function returns string representations of the error codes when the corresponding Kconfig option, :kconfig:option:`CONFIG_BT_HCI_ERR_TO_STR` or :kconfig:option:`CONFIG_BT_SECURITY_ERR_TO_STR`, is enabled.
-  * CSIS to the BIS sink if the scan delegator feature, ``CONFIG_BT_AUDIO_SCAN_DELEGATOR``, is enabled.
+  * CSIS to the BIS sink if the scan delegator feature, :ref:`CONFIG_BT_AUDIO_SCAN_DELEGATOR <CONFIG_BT_AUDIO_SCAN_DELEGATOR>`, is enabled.
     Once a phone is connected to a BIS sink, the phone will find and connect to the second headset.
     Also, the phone can control the BIS headset in a group and deliver the PAST to both headsets at the same time.
   * Create CIG after reading the PACS from the first connected unicast server.
-  * A minimal scan delegator to the unicast server if the feature, ``CONFIG_BT_AUDIO_SCAN_DELEGATOR``, is enabled.
+  * A minimal scan delegator to the unicast server if the feature, :ref:`CONFIG_BT_AUDIO_SCAN_DELEGATOR <CONFIG_BT_AUDIO_SCAN_DELEGATOR>`, is enabled.
   * Available or support context type to PACS in broadcast sink and unicast client if the feature, :kconfig:option:`CONFIG_BT_PAC_SRC_NOTIFIABLE` is enabled.
   * The :ref:`nrf_auraconfig` sample.
 
@@ -619,7 +619,7 @@ Serial LTE modem
 * Added:
 
   * DTLS support for the ``#XUDPSVR`` and ``#XSSOCKET`` (UDP server sockets) AT commands when the :file:`overlay-native_tls.conf` configuration file is used.
-  * The :kconfig:option:`CONFIG_SLM_PPP_FALLBACK_MTU` Kconfig option that is used to control the MTU used by PPP when the cellular link MTU is not returned by the modem in response to the ``AT+CGCONTRDP=0`` AT command.
+  * The :ref:`CONFIG_SLM_PPP_FALLBACK_MTU <CONFIG_SLM_PPP_FALLBACK_MTU>` Kconfig option that is used to control the MTU used by PPP when the cellular link MTU is not returned by the modem in response to the ``AT+CGCONTRDP=0`` AT command.
   * Handler for new nRF Cloud event type :c:enumerator:`NRF_CLOUD_EVT_RX_DATA_DISCON`.
   * Support for socket option ``AT_SO_IPV6_DELAYED_ADDR_REFRESH``.
 
@@ -777,12 +777,12 @@ Cellular samples
 
   * Added:
 
-    * The :kconfig:option:`CONFIG_TEST_COUNTER_MULTIPLIER` Kconfig option to multiply the number of test counter messages sent, for testing purposes.
+    * The :ref:`CONFIG_TEST_COUNTER_MULTIPLIER <CONFIG_TEST_COUNTER_MULTIPLIER>` Kconfig option to multiply the number of test counter messages sent, for testing purposes.
     * A handler for new nRF Cloud event type :c:enumerator:`NRF_CLOUD_EVT_RX_DATA_DISCON` to stop sensors and location services.
     * Board support files to enable Wi-Fi scanning for the Thingy:91 X.
-    * The :kconfig:option:`CONFIG_SEND_ONLINE_ALERT` Kconfig option to enable calling the :c:func:`nrf_cloud_alert` function on startup.
+    * The :ref:`CONFIG_SEND_ONLINE_ALERT <CONFIG_SEND_ONLINE_ALERT>` Kconfig option to enable calling the :c:func:`nrf_cloud_alert` function on startup.
     * Logging of the `reset reason code <nRF9160 RESETREAS_>`_.
-    * The :kconfig:option:`CONFIG_POST_PROVISIONING_INTERVAL_M` Kconfig option to reduce the provisioning connection interval once the device successfully connects.
+    * The :ref:`CONFIG_POST_PROVISIONING_INTERVAL_M <CONFIG_POST_PROVISIONING_INTERVAL_M>` Kconfig option to reduce the provisioning connection interval once the device successfully connects.
 
   * Updated:
 
@@ -802,7 +802,7 @@ Cellular samples
   * Added:
 
     * Support for dictionary logs using REST.
-    * The :kconfig:option:`CONFIG_SEND_ONLINE_ALERT` Kconfig option to enable calling the :c:func:`nrf_cloud_alert` function on startup.
+    * The :ref:`CONFIG_SEND_ONLINE_ALERT <CONFIG_SEND_ONLINE_ALERT>` Kconfig option to enable calling the :c:func:`nrf_cloud_alert` function on startup.
     * Logging of the `reset reason code <nRF9160 RESETREAS_>`_.
 
   * Updated:

--- a/samples/cellular/nrf_cloud_multi_service/README.rst
+++ b/samples/cellular/nrf_cloud_multi_service/README.rst
@@ -124,7 +124,7 @@ Application thread and main application loop
 The application thread is implemented in the :file:`src/application.c` file, and is responsible for the high-level behavior of this sample.
 
 When it starts, it logs the `reset reason code <nRF9160 RESETREAS_>`_.
-If the :kconfig:option:`CONFIG_SEND_ONLINE_ALERT` Kconfig option is enabled, it sends an alert to nRF Cloud containing the reset reason as the value field.
+If the :ref:`CONFIG_SEND_ONLINE_ALERT <CONFIG_SEND_ONLINE_ALERT>` Kconfig option is enabled, it sends an alert to nRF Cloud containing the reset reason as the value field.
 
 It performs the following major tasks:
 
@@ -634,6 +634,14 @@ CONFIG_TEST_COUNTER - Enable test counter
    Enable the test counter.
    When enabled, the test counter configuration setting in the shadow is ignored.
 
+.. _CONFIG_TEST_COUNTER_MULTIPLIER:
+
+CONFIG_TEST_COUNTER_MULTIPLIER - Set the number of test counter messages sent on each update
+   Sets the number of test counter messages sent on each update.
+   This is a way to increase the number of device messages sent by the sample.
+   It is useful for load testing.
+   The value ranges from ``1`` to ``1000`` and the default value is ``1``.
+
 .. _CONFIG_AT_CMD_REQUESTS:
 
 CONFIG_AT_CMD_REQUESTS - Enable AT command requests
@@ -703,6 +711,19 @@ CONFIG_COAP_FOTA_JOB_CHECK_RATE_MINUTES - FOTA job check interval (minutes)
 
 CONFIG_COAP_FOTA_THREAD_STACK_SIZE - CoAP FOTA Thread Stack Size (bytes)
    Sets the stack size (in bytes) for the FOTA job checking thread of the sample.
+
+.. _CONFIG_SEND_ONLINE_ALERT:
+
+CONFIG_SEND_ONLINE_ALERT - Send a routine ``ALERT_TYPE_DEVICE_NOW_ONLINE`` on startup
+   This option, on enabling, demonstrates the alert feature of nRF Cloud.
+   Reception of this alert indicates that the device has rebooted.
+
+.. _CONFIG_POST_PROVISIONING_INTERVAL_M:
+
+CONFIG_POST_PROVISIONING_INTERVAL_M - Sets a delay (in minutes) between provisioning checks once connected
+   This option uses a slower rate to check for provisioning after you have successfully connected.
+   Until then you can use :kconfig:option:`CONFIG_NRF_PROVISIONING_INTERVAL_S`.
+   The default value is 30 minutes.
 
 .. include:: /libraries/modem/nrf_modem_lib/nrf_modem_lib_trace.rst
    :start-after: modem_lib_sending_traces_UART_start


### PR DESCRIPTION
Define App and sample-specific Kconfig options
that are mentioned in the 2.8 release notes.

NCSDK-30408