### PR TITLE
tests: benchmarks: add missing conf to start radio at h20

### DIFF
--- a/tests/benchmarks/current_consumption/twim_suspend/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/tests/benchmarks/current_consumption/twim_suspend/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SOC_NRF54H20_CPURAD_ENABLE=y

--- a/tests/benchmarks/multicore/idle_clock_control/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/tests/benchmarks/multicore/idle_clock_control/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SOC_NRF54H20_CPURAD_ENABLE=y

--- a/tests/benchmarks/multicore/idle_spim/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/tests/benchmarks/multicore/idle_spim/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SOC_NRF54H20_CPURAD_ENABLE=y


### PR DESCRIPTION
Needed to achive lowest power consumption.