### PR TITLE
dts: nordic: 54lm20a: enable psa-rng by default

### DIFF
--- a/dts/arm/nordic/nrf54lm20a_enga_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54lm20a_enga_cpuapp.dtsi
@@ -17,7 +17,7 @@ nvic: &cpuapp_nvic {};
 
 / {
 	chosen {
-		zephyr,entropy = &prng;
+		zephyr,entropy = &psa_rng;
 	};
 
 	soc {
@@ -28,12 +28,12 @@ nvic: &cpuapp_nvic {};
 
 	psa_rng: psa-rng {
 		compatible = "zephyr,psa-crypto-rng";
-		status = "disabled";
+		status = "okay";
 	};
 
 	prng: prng {
 		compatible = "nordic,entropy-prng";
-		status = "okay";
+		status = "disabled";
 	};
 };
 


### PR DESCRIPTION
Make possible to use true RNG on nRF54lm20a. Enable the PSA RNG and setup it as the entropy source.