### PR TITLE
tests: benchmarks: multicore: idle_clock_control: enable radio core

### DIFF
--- a/tests/benchmarks/multicore/idle_clock_control/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_clock_control/testcase.yaml
@@ -40,6 +40,7 @@ tests:
       - remote_CONFIG_PM_DEVICE_RUNTIME=y
       - remote_CONFIG_BOOT_BANNER=n
       - remote_CONFIG_CLOCK_CONTROL=n
+      - remote_CONFIG_SOC_NRF54H20_CPURAD_ENABLE=y
     harness_config:
       fixture: lfclk_at_lfxo
       pytest_root:
@@ -87,6 +88,7 @@ tests:
       - remote_CONFIG_PM_DEVICE_RUNTIME=y
       - remote_CONFIG_BOOT_BANNER=n
       - remote_CONFIG_CLOCK_CONTROL=n
+      - remote_CONFIG_SOC_NRF54H20_CPURAD_ENABLE=y
     harness_config:
       fixture: lfclk_at_lfrc
       pytest_root:


### PR DESCRIPTION
Make sure app is starting radio core.