### PR TITLE
quarantine_windows: Add Matter samples to quarantine

### DIFF
--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -27,3 +27,10 @@
     - thingy53/nrf5340/cpuapp/ns
     - thingy53/nrf5340/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/SHEL-3161"
+
+- scenarios:
+    - sample.matter.*
+    - applications.matter.*
+  platforms:
+    - all
+  comment: "https://nordicsemi.atlassian.net/browse/KRKNWK-20461"


### PR DESCRIPTION
Build failures relate to Windows environments.
Until fix them, these test configurations will be quarantined.

Jira: KRKNWM-20461