### PR TITLE
applications: nrf_desktop: Update first HID report delay for keyboards

### DIFF
--- a/applications/nrf_desktop/doc/hids.rst
+++ b/applications/nrf_desktop/doc/hids.rst
@@ -76,7 +76,7 @@ Sending the first HID report to the connected Bluetooth peer is delayed by this 
 .. note::
    The nRF Desktop centrals perform the GATT service discovery and reenable the HID notifications on every reconnection.
    A HID report that is received before the subscription is reenabled will be dropped before it reaches the application.
-   The :ref:`CONFIG_DESKTOP_HIDS_FIRST_REPORT_DELAY <config_desktop_app_options>` option is set to 500 ms for nRF Desktop keyboards (:ref:`CONFIG_DESKTOP_PERIPHERAL_TYPE_KEYBOARD <config_desktop_app_options>`) to make sure that the input is not lost on reconnection with the nRF Desktop dongle.
+   The :ref:`CONFIG_DESKTOP_HIDS_FIRST_REPORT_DELAY <config_desktop_app_options>` option is set to 1000 ms for nRF Desktop keyboards (:ref:`CONFIG_DESKTOP_PERIPHERAL_TYPE_KEYBOARD <config_desktop_app_options>`) to make sure that the input is not lost on reconnection with the nRF Desktop dongle.
 
 Implementation details
 **********************

--- a/applications/nrf_desktop/src/modules/Kconfig.hids
+++ b/applications/nrf_desktop/src/modules/Kconfig.hids
@@ -18,7 +18,7 @@ if DESKTOP_HIDS_ENABLE
 
 config DESKTOP_HIDS_FIRST_REPORT_DELAY
 	int "First HID report delay [ms]"
-	default 500 if DESKTOP_PERIPHERAL_TYPE_KEYBOARD
+	default 1000 if DESKTOP_PERIPHERAL_TYPE_KEYBOARD
 	default 0
 	range 0 2000
 	help
@@ -28,7 +28,7 @@ config DESKTOP_HIDS_FIRST_REPORT_DELAY
 	  centrals reenable the subscriptions on every reconnection. HID report
 	  is dropped if received before the subscription was reenabled.
 
-	  By default, nRF Desktop keyboard uses a delay of 500 ms to prevent
+	  By default, nRF Desktop keyboard uses a delay of 1000 ms to prevent
 	  dropping HID reports right after reconnection.
 
 config DESKTOP_HIDS_SUBSCRIBER_PRIORITY

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -307,6 +307,8 @@ nRF Desktop
     Extra ATT buffers are no longer needed for keyboards as :ref:`nrf_desktop_hids` limits the maximum number of simultaneously processed HID input reports (:ref:`CONFIG_DESKTOP_HIDS_SUBSCRIBER_REPORT_MAX <config_desktop_app_options>`) to ``2`` by default.
   * The nRF Desktop application aligns the defaults of :kconfig:option:`CONFIG_BT_ATT_TX_COUNT` and :kconfig:option:`CONFIG_BT_CONN_TX_MAX` Kconfig options to application needs.
     The options are no longer explicitly set in application configurations.
+  * Increased the default first HID report delay (:ref:`CONFIG_DESKTOP_HIDS_FIRST_REPORT_DELAY <config_desktop_app_options>`) for keyboard (:ref:`CONFIG_DESKTOP_PERIPHERAL_TYPE_KEYBOARD <config_desktop_app_options>`) in :ref:`nrf_desktop_hids` from ``500 ms`` to ``1000 ms``.
+    This is done to ensure that queued keypresses are not lost on reconnection with the nRF Desktop dongle.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
Change updates first HID report delay for keyboards to make sure that the input is not lost on reconnection with the nRF Desktop dongle.

Jira: NCSDK-34348