### PR TITLE
mpsl: fem: cleanup after transition to mpsl_fem_tx_power_split with phy

### DIFF
--- a/lib/fem_al/fem_al.c
+++ b/lib/fem_al/fem_al.c
@@ -279,7 +279,6 @@ void fem_txrx_stop(void)
 	mpsl_fem_deactivate_now(MPSL_FEM_ALL);
 }
 
-#if defined(_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY)
 static mpsl_phy_t convert_radio_mode_to_mpsl_phy(nrf_radio_mode_t radio_mode)
 {
 	switch (radio_mode) {
@@ -316,7 +315,6 @@ static mpsl_phy_t convert_radio_mode_to_mpsl_phy(nrf_radio_mode_t radio_mode)
 	default: return MPSL_PHY_BLE_1M;
 	}
 }
-#endif
 
 int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power,
 				   nrf_radio_mode_t radio_mode, uint16_t freq_mhz)
@@ -324,17 +322,9 @@ int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power,
 	int8_t output_power;
 	int32_t err;
 	mpsl_tx_power_split_t power_split = { 0 };
-#if defined(_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY)
 	mpsl_phy_t mpsl_phy = convert_radio_mode_to_mpsl_phy(radio_mode);
-#else
-	(void)radio_mode;
-#endif
 
-	output_power = mpsl_fem_tx_power_split(power, &power_split,
-#if defined(_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY)
-					       mpsl_phy,
-#endif
-					       freq_mhz, false);
+	output_power = mpsl_fem_tx_power_split(power, &power_split, mpsl_phy, freq_mhz, false);
 
 	*radio_tx_power = power_split.radio_tx_power;
 
@@ -351,18 +341,10 @@ int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power,
 int8_t fem_tx_output_power_check(int8_t power, nrf_radio_mode_t radio_mode, uint16_t freq_mhz,
 				 bool tx_power_ceiling)
 {
-#if defined(_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY)
 	mpsl_phy_t mpsl_phy = convert_radio_mode_to_mpsl_phy(radio_mode);
-#else
-	(void)radio_mode;
-#endif
 	mpsl_tx_power_split_t power_split = { 0 };
 
-	return mpsl_fem_tx_power_split(power, &power_split,
-#if defined(_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY)
-				       mpsl_phy,
-#endif
-				       freq_mhz, tx_power_ceiling);
+	return mpsl_fem_tx_power_split(power, &power_split, mpsl_phy, freq_mhz, tx_power_ceiling);
 }
 
 int8_t fem_default_tx_output_power_get(void)

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -858,7 +858,7 @@ static nrf_radio_txpower_t dbm_to_nrf_radio_txpower(int8_t tx_power)
 }
 #endif /* defined(CONFIG_SOC_SERIES_NRF54HX) || defined(CONFIG_SOC_SERIES_NRF54LX) */
 
-#if defined(_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY)
+#if !(defined(CONFIG_SOC_SERIES_NRF54HX) || defined(CONFIG_SOC_SERIES_NRF54LX))
 static mpsl_phy_t convert_bitrate_to_mpsl_phy(enum esb_bitrate bitrate)
 {
 	switch (bitrate) {
@@ -877,7 +877,7 @@ static mpsl_phy_t convert_bitrate_to_mpsl_phy(enum esb_bitrate bitrate)
 	default: return MPSL_PHY_NRF_1Mbit;
 	}
 }
-#endif
+#endif /* !(defined(CONFIG_SOC_SERIES_NRF54HX) || defined(CONFIG_SOC_SERIES_NRF54LX)) */
 
 static void update_radio_tx_power(void)
 {
@@ -886,9 +886,7 @@ static void update_radio_tx_power(void)
 	mpsl_tx_power_split_t tx_power;
 
 	(void)mpsl_fem_tx_power_split(esb_cfg.tx_output_power, &tx_power,
-#if defined(_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY)
 				      convert_bitrate_to_mpsl_phy(esb_cfg.bitrate),
-#endif
 				      (RADIO_BASE_FREQUENCY + esb_addr.rf_channel), false);
 
 	err = mpsl_fem_pa_power_control_set(tx_power.fem_pa_power_control);


### PR DESCRIPTION
The PR #22987 prepared modules for migration of MPSL FEM API to the new version signalled by the presence of the macro `_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY`.

The PR #23120 brought in the MPSL containing the new API version which defined the `_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY` macro.

Now the code variant for not defined `_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY` is no more necessary. This commit removes it, what ends a transition in FEM mpsl_fem_tx_power_split API change. The `_MPSL_FEM_TX_POWER_SPLIT_HAS_PHY` will be removed from MPSL in the near future.

Ref: KRKNWK-20453