### PR TITLE
doc: fix links to the Programmer app

### DIFF
--- a/doc/nrf/app_dev/device_guides/custom/programming_custom_board.rst
+++ b/doc/nrf/app_dev/device_guides/custom/programming_custom_board.rst
@@ -76,4 +76,4 @@ The following steps describe how to connect your custom board to a debug probe.
 Programming custom boards
 *************************
 
-After you connected the custom board, you can program your application to the board using either the :ref:`standard programming instructions <programming>` or the `Programmer app <nRF Connect Programmer>`_ from `nRF Connect for Desktop`_.
+After you connected the custom board, you can program your application to the board using either the :ref:`standard programming instructions <programming>` or the `Programmer app`_ from `nRF Connect for Desktop`_.

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_dk_updating_fw_programmer.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_dk_updating_fw_programmer.rst
@@ -49,7 +49,7 @@ Modem firmware
 
 The :file:`CONTENTS.txt` file in the extracted folder contains the location and names of the different firmware images.
 
-Complete the steps in the following sections to program applications using the `Programmer app <nRF Connect Programmer>`_ from `nRF Connect for Desktop`_.
+Complete the steps in the following sections to program applications using the `Programmer app`_ from `nRF Connect for Desktop`_.
 The nRF Connect for Desktop requires `SEGGER J-Link`_ |jlink_ver|.
 
 * On Windows, the driver comes bundled with nRF Connect for Desktop.

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_features.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_features.rst
@@ -117,7 +117,7 @@ There are two ways to update the modem firmware:
 Full update
   You can use either a wired or a wireless connection to do a full update of the modem firmware:
 
-  * When using a wired connection, you can use either the `Programmer app <nRF Connect Programmer>`_, which is part of `nRF Connect for Desktop`_, or `nRF Util's device command <Upgrading modem firmware using J-Link_>`_.
+  * When using a wired connection, you can use either the `Programmer app`_, which is part of `nRF Connect for Desktop`_, or `nRF Util's device command <Upgrading modem firmware using J-Link_>`_.
     Both methods use the :term:`Serial Wire Debug (SWD)` interface to update the firmware.
 
     You can use the Programmer app to perform the update, regardless of the images that are part of the existing firmware of the device.

--- a/doc/nrf/app_dev/device_guides/thingy53/building_thingy53.rst
+++ b/doc/nrf/app_dev/device_guides/thingy53/building_thingy53.rst
@@ -68,10 +68,10 @@ For the compatible Wi-Fi samples in the |NCS|, see the :ref:`wifi_samples` secti
 Programming methods for Thingy:53
 *********************************
 
-You can program the firmware on the Nordic Thingy:53 using an external debug probe and a 10-pin JTAG cable, using :ref:`Visual Studio Code <thingy53_build_pgm_vscode>`, :ref:`command line <thingy53_build_pgm_command_line>`, or the `programmer application <prog_thingy_53>`_ from nRF Connect for Desktop.
-You can also program applications running on both the network and application core using the built-in MCUboot serial recovery mode, using `nRF Connect Programmer`_ from nRF Connect for Desktop or `nRF Util <Programming application firmware using MCUboot serial recovery_>`_.
+You can program the firmware on the Nordic Thingy:53 using an external debug probe and a 10-pin JTAG cable, using :ref:`Visual Studio Code <thingy53_build_pgm_vscode>`, :ref:`command line <thingy53_build_pgm_command_line>`, or the `programmer application <Programming Nordic Thingy53_>`_ from nRF Connect for Desktop.
+You can also program applications running on both the network and application core using the built-in MCUboot serial recovery mode, using the `Programmer app`_ from nRF Connect for Desktop or `nRF Util <Programming application firmware using MCUboot serial recovery_>`_.
 
-Finally, you can use the `nRF Connect Programmer`_ app in nRF Connect for Desktop, the `nRF Programmer mobile app`_ for Android and iOS, or nRF Util to update the :ref:`preloaded application images <thingy53_precompiled>`.
+Finally, you can use the `Programmer app`_ in nRF Connect for Desktop, the `nRF Programmer mobile app`_ for Android and iOS, or nRF Util to update the :ref:`preloaded application images <thingy53_precompiled>`.
 
 .. _thingy53_app_update_debug:
 
@@ -84,7 +84,7 @@ In such cases, you can program the Thingy:53 the same way as the nRF5340 DK.
 The external debug probe must support Arm Cortex-M33 (such as the nRF5340 DK).
 You need a 10-pin 2x5 socket-to-socket 1.27 mm IDC (:term:`Serial Wire Debug (SWD)`) JTAG cable to connect to the external debug probe.
 
-This method is supported when programming with :ref:`Visual Studio Code <thingy53_build_pgm_vscode>`, :ref:`command line <thingy53_build_pgm_command_line>`, or the `Programmer app <prog_thingy_53>`_ from nRF Connect for Desktop.
+This method is supported when programming with :ref:`Visual Studio Code <thingy53_build_pgm_vscode>`, :ref:`command line <thingy53_build_pgm_command_line>`, or the `Programmer app <Programming Nordic Thingy53_>`_ from nRF Connect for Desktop.
 
 See also :ref:`ug_nrf5340` for additional information.
 
@@ -101,7 +101,7 @@ You can program the precompiled firmware image in one of the following ways:
   In this scenario, the Thingy is connected directly to your PC through USB.
   For details, refer to the :ref:`thingy53_app_mcuboot_bootloader` section.
 
-  See `Programming Nordic Thingy:53 <prog_thingy_53>`_ for details on how to program the Thingy:53 using nRF Connect for Desktop.
+  See `Programming Nordic Thingy:53 <Programming Nordic Thingy53_>`_ for details on how to program the Thingy:53 using nRF Connect for Desktop.
 
 * Update the firmware over-the-air (OTA) using Bluetooth LE and the nRF Programmer mobile application for Android or iOS.
   To use this method, the application that is currently programmed on Thingy:53 must support it.
@@ -193,14 +193,14 @@ To build and program the source code from the command line, complete the followi
 .. _thingy53_gs_updating_usb:
 .. _thingy53_gs_updating_external_probe:
 
-Programming using nRF Connect Programmer
-****************************************
+Programming using the Programmer app
+************************************
 
-You can program the Nordic Thingy:53 using `nRF Connect Programmer`_ from nRF Connect for Desktop and MCUboot's serial recovery feature.
+You can program the Nordic Thingy:53 using the `Programmer app`_ from nRF Connect for Desktop and MCUboot's serial recovery feature.
 You can use this application to also program precompiled firmware packages.
 
-You can program the Thingy:53 using nRF Connect Programmer with either USB-C or an external debug probe.
-See the `Programming Nordic Thingy:53 <prog_thingy_53>`_ in the tool documentation for detailed steps.
+You can program the Thingy:53 using the Programmer app with either USB-C or an external debug probe.
+See the `Programming Nordic Thingy:53 <Programming Nordic Thingy53_>`_ in the tool documentation for detailed steps.
 
 Programming using nRF Util
 **************************

--- a/doc/nrf/app_dev/device_guides/thingy53/thingy53_precompiled.rst
+++ b/doc/nrf/app_dev/device_guides/thingy53/thingy53_precompiled.rst
@@ -102,11 +102,11 @@ You can update the precompiled firmware using any of the following methods:
 
    .. tab:: Programmer app (USB)
 
-      See the `Programming Nordic Thingy:53 <prog_thingy_53>`_ in the tool documentation for detailed steps.
+      See the `Programming Nordic Thingy:53 <Programming Nordic Thingy53_>`_ in the tool documentation for detailed steps.
 
    .. tab:: Programmer app (external debug probe)
 
-      See the `Programming Nordic Thingy:53 <prog_thingy_53>`_ in the tool documentation for detailed steps.
+      See the `Programming Nordic Thingy:53 <Programming Nordic Thingy53_>`_ in the tool documentation for detailed steps.
 
    .. tab:: nRF Util
 

--- a/doc/nrf/app_dev/device_guides/thingy91/thingy91_building_programming.rst
+++ b/doc/nrf/app_dev/device_guides/thingy91/thingy91_building_programming.rst
@@ -31,16 +31,16 @@ You must use the build target ``thingy91/nrf9160/ns`` when building the applicat
 
 The following table shows the different types of build files that are generated and the different scenarios in which they are used:
 
-+--------------------------+----------------------------------------+-----------------------------------------------------------------------------------+
-| File                     | File format                            | Programming scenario                                                              |
-+==========================+========================================+===================================================================================+
-|:file:`merged.hex`        | Full image, HEX format                 | Using an external debug probe and the `Programmer app <nRF Connect Programmer>`_. |
-+--------------------------+----------------------------------------+-----------------------------------------------------------------------------------+
-|:file:`zephyr.signed.hex` | MCUboot compatible image, HEX format   | Using the built-in bootloader and the `Programmer app <nRF Connect Programmer>`_. |
-+--------------------------+----------------------------------------+-----------------------------------------------------------------------------------+
-|:file:`app_update.bin`    | MCUboot compatible image, binary format|* Using the built-in bootloader and mcumgr command line tool.                      |
-|                          |                                        |* For FOTA updates.                                                                |
-+--------------------------+----------------------------------------+-----------------------------------------------------------------------------------+
++---------------------------+-----------------------------------------+---------------------------------------------------------------+
+|           File            |               File format               |                     Programming scenario                      |
++===========================+=========================================+===============================================================+
+| :file:`merged.hex`        | Full image, HEX format                  | Using an external debug probe and the `Programmer app`_.      |
++---------------------------+-----------------------------------------+---------------------------------------------------------------+
+| :file:`zephyr.signed.hex` | MCUboot compatible image, HEX format    | Using the built-in bootloader and the `Programmer app`_.      |
++---------------------------+-----------------------------------------+---------------------------------------------------------------+
+| :file:`app_update.bin`    | MCUboot compatible image, binary format | * Using the built-in bootloader and mcumgr command line tool. |
+|                           |                                         | * For FOTA updates.                                           |
++---------------------------+-----------------------------------------+---------------------------------------------------------------+
 
 For an overview of different types of build files in the |NCS|, see :ref:`app_build_output_files`.
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -680,10 +680,10 @@
 
 .. _`Direct Test Mode app`: https://docs.nordicsemi.com/bundle/nrf-connect-direct-test-mode/page/index.html
 
-.. _`nRF Connect Programmer`: https://docs.nordicsemi.com/bundle/nrf-connect-programmer/page/index.html
+.. _`Programmer app`: https://docs.nordicsemi.com/bundle/nrf-connect-programmer/page/index.html
 .. _`Programming the nRF52840 Dongle`:
 .. _`Programming a Development Kit`: https://docs.nordicsemi.com/bundle/nrf-connect-programmer/page/programming_dk.html
-.. _`prog_thingy_53`: https://docs.nordicsemi.com/bundle/nrf-connect-programmer/page/programming_dk.html#programming-nordic-thingy53
+.. _`Programming Nordic Thingy53`: https://docs.nordicsemi.com/bundle/nrf-connect-programmer/page/programming_dk.html#programming-nordic-thingy53
 
 .. _`Serial Terminal app`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html
 .. _`Connecting using the Serial Terminal app`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/connecting.html

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_3.0.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_3.0.rst
@@ -351,7 +351,7 @@ Asset Tracker v2
    * The Asset Tracker v2 application has been removed.
      For development of asset tracking applications, refer to the `Asset Tracker Template <Asset Tracker Template_>`_.
 
-     The factory-programmed Asset Tracker v2 firmware is still available to program the nRF91xx DKs using the `Programmer app <nRF Connect Programmer>`_, the `Quick Start app`_, and the `Cellular Monitor app`_.
+     The factory-programmed Asset Tracker v2 firmware is still available to program the nRF91xx DKs using the `Programmer app`_, the `Quick Start app`_, and the `Cellular Monitor app`_.
 
 nRF Desktop
 -----------

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.9.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.9.0.rst
@@ -93,7 +93,7 @@ See the following documentation for an overview of which modem firmware versions
 * `Modem firmware compatibility matrix for the nRF9161 DK`_
 * `Modem firmware compatibility matrix for the nRF9160 DK`_
 
-Use the latest version of the `Programmer app <nRF Connect Programmer>`_ of `nRF Connect for Desktop`_ to update the modem firmware.
+Use the latest version of the `Programmer app`_ of `nRF Connect for Desktop`_ to update the modem firmware.
 See :ref:`nrf9160_gs_updating_fw_modem` for instructions.
 
 Modem-related libraries and versions

--- a/doc/nrf/releases_and_maturity/releases/release-notes-3.0.0-preview1.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-3.0.0-preview1.rst
@@ -901,4 +901,4 @@ Documentation
   * The :ref:`dm-revisions` section of the :ref:`dm_code_base` page with information about the preview release tag, which replaces the development tag.
 
 * Removed the standalone page for getting started with Nordic Thingy:53.
-  The contents of this page have been moved to the :ref:`thingy53_precompiled` page and to the `Programmer app <prog_thingy_53>`_ documentation.
+  The contents of this page have been moved to the :ref:`thingy53_precompiled` page and to the `Programming Nordic Thingy:53 <Programming Nordic Thingy53_>`_ section in the Programmer app documentation.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-3.0.0-preview2.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-3.0.0-preview2.rst
@@ -1137,7 +1137,7 @@ Documentation
   * The entire Zigbee protocol, application and samples documentation.
     It is now available as separate `Zigbee R22`_ and `Zigbee R23`_ add-on repositories.
   * The standalone page for getting started with Nordic Thingy:53.
-    The contents of this page have been moved to the :ref:`thingy53_precompiled` page and to the `Programmer app <prog_thingy_53>`_ documentation.
+    The contents of this page have been moved to the :ref:`thingy53_precompiled` page and to the `Programming Nordic Thingy:53 <Programming Nordic Thingy53_>`_ section in the Programmer app documentation.
   * The standalone page for getting started with Nordic Thingy:91.
     The contents of this page are covered by the `Cellular IoT Fundamentals course`_ in the `Nordic Developer Academy`_.
     The part about connecting the prototyping platform to nRF Cloud is now a standalone :ref:`thingy91_connect_to_cloud` page in the :ref:`thingy91_ug_intro` section.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-3.0.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-3.0.0.rst
@@ -1424,7 +1424,7 @@ Documentation
   * The entire Zigbee protocol, application, and samples documentation.
     It is now available as separate `Zigbee R22`_ and `Zigbee R23`_ add-on repositories.
   * The standalone page for getting started with Nordic Thingy:53.
-    The contents of this page have been moved to the :ref:`thingy53_precompiled` page and to the `Programmer app <prog_thingy_53>`_ documentation.
+    The contents of this page have been moved to the :ref:`thingy53_precompiled` page and to the `Programming Nordic Thingy:53 <Programming Nordic Thingy53_>`_ section in the Programmer app documentation.
   * The standalone page for getting started with Nordic Thingy:91.
     The contents of this page are covered by the `Cellular IoT Fundamentals course`_ in the `Nordic Developer Academy`_.
     The part about connecting the prototyping platform to nRF Cloud is now a standalone :ref:`thingy91_connect_to_cloud` page in the :ref:`thingy91_ug_intro` section.


### PR DESCRIPTION
Edited links to the Programmer app in nRF Connect for Desktop
not to use `nRF Connect`. Follow-up to https://github.com/nrfconnect/sdk-nrf/pull/18911 and partial revert
of https://github.com/nrfconnect/sdk-nrf/pull/22229.