### PR TITLE
scripts: ci: test_plan: early check if path is in testsuite roots

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -312,7 +312,7 @@ class Filters:
                         scope_found = True
                     else:
                         d = os.path.dirname(d)
-                elif tail == "common":
+                elif tail == "common" and self.is_in_testsuite_root(head):
                     # Look for yamls in directories collocated with common
 
                     yamls_found = [yaml for yaml in glob.iglob(head + '/**/testcase.yaml', recursive=True)]


### PR DESCRIPTION
For tree with common folder.
Performance improvment - prevent globbing outside of testsuite roots.