### PR TITLE
tests: idle_spim_loopback: Use high-drive for fast SPIM on P2

### DIFF
--- a/tests/benchmarks/multicore/idle_spim_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_slow_pins.overlay
+++ b/tests/benchmarks/multicore/idle_spim_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_slow_pins.overlay
@@ -31,9 +31,13 @@
 &pinctrl {
 	spi121_default: spi121_default {
 		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 2, 10)>;
+		};
+
+		group2 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 2)>,
-				<NRF_PSEL(SPIM_MISO, 2, 10)>,
 				<NRF_PSEL(SPIM_MOSI, 2, 11)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
 		};
 	};
 


### PR DESCRIPTION
SPIM121 requires high-drive on P2 pins for proper transfer.