### PR TITLE
tests: benchmarks: multicore: Fix use of undefined Kconfigs

### DIFF
--- a/tests/benchmarks/multicore/idle_flpr/remote/CMakeLists.txt
+++ b/tests/benchmarks/multicore/idle_flpr/remote/CMakeLists.txt
@@ -11,7 +11,7 @@ project(remote)
 
 target_sources(app PRIVATE src/main.c)
 
-if((DEFINED CONFIG_SOC_NRF54H20_CPUFLPR) OR (DEFINED CONFIG_SOC_NRF54H20_ENGB_CPUFLPR))
+if(DEFINED CONFIG_SOC_NRF54H20_CPUFLPR)
 	message(STATUS "Power Mode handler for RISC V is included.")
 	target_sources(app PRIVATE ../../common/power_off.c)
 endif()

--- a/tests/benchmarks/multicore/idle_grtc/CMakeLists.txt
+++ b/tests/benchmarks/multicore/idle_grtc/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 project(idle_grtc)
 
-if((DEFINED CONFIG_SOC_NRF54H20_CPUPPR) OR (DEFINED CONFIG_SOC_NRF54H20_ENGB_CPUPPR))
+if(DEFINED CONFIG_SOC_NRF54H20_CPUPPR)
 	message(STATUS "Power Mode handler for RISC V is included.")
 	target_sources(app PRIVATE ${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/common/power_off.c)
 endif()

--- a/tests/benchmarks/multicore/idle_ppr/remote/CMakeLists.txt
+++ b/tests/benchmarks/multicore/idle_ppr/remote/CMakeLists.txt
@@ -11,7 +11,7 @@ project(remote)
 
 target_sources(app PRIVATE ../src/main.c)
 
-if((DEFINED CONFIG_SOC_NRF54H20_CPUPPR) OR (DEFINED CONFIG_SOC_NRF54H20_ENGB_CPUPPR))
+if(DEFINED CONFIG_SOC_NRF54H20_CPUPPR)
 	message(STATUS "Power Mode handler for RISC V is included.")
 	target_sources(app PRIVATE ../../common/power_off.c)
 endif()

--- a/tests/benchmarks/multicore/idle_stm/remote/CMakeLists.txt
+++ b/tests/benchmarks/multicore/idle_stm/remote/CMakeLists.txt
@@ -11,7 +11,7 @@ project(remote)
 
 target_sources(app PRIVATE ../src/main.c)
 
-if((DEFINED CONFIG_SOC_NRF54H20_CPUPPR) OR (DEFINED CONFIG_SOC_NRF54H20_ENGB_CPUPPR))
+if(DEFINED CONFIG_SOC_NRF54H20_CPUPPR)
 	message(STATUS "Power Mode handler for RISC V is included.")
 	target_sources(app PRIVATE ../../common/power_off.c)
 endif()


### PR DESCRIPTION
Stop using
- CONFIG_SOC_NRF54H20_ENGB_CPUPPR
- CONFIG_SOC_NRF54H20_ENGB_CPUFLPR
as they were removed in meantime.