### PR TITLE
bluetooth: mesh: fix usage of unknown KConfig options

### DIFF
--- a/doc/nrf/libraries/bluetooth/mesh/vnd/dm_srv.rst
+++ b/doc/nrf/libraries/bluetooth/mesh/vnd/dm_srv.rst
@@ -74,7 +74,7 @@ The Distance Measurement Server has following runtime configuration options:
 * Default reflector start delay.
 
 If the :kconfig:option:`CONFIG_BT_SETTINGS` option is enabled, the Distance Measurement Server stores its configuration states persistently using a configurable storage delay.
-See option :kconfig:option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+See option :kconfig:option:`CONFIG_BT_MESH_STORE_TIMEOUT`.
 
 API documentation
 =================

--- a/include/bluetooth/mesh/sensor_types.h
+++ b/include/bluetooth/mesh/sensor_types.h
@@ -24,7 +24,7 @@ extern "C" {
  *
  *  @brief Force the given sensor type to be included in the build.
  *
- *  If @em CONFIG_BT_MESH_SENSOR_FORCE_ALL is disabled, only referenced sensor
+ *  If @em CONFIG_BT_MESH_SENSOR_ALL_TYPES is disabled, only referenced sensor
  *  types will be included in the build, and the node will be unable to
  *  interpret the rest. Use this macro inside a function to force the type to be
  *  included in the build:

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -128,7 +128,7 @@ The descriptor also specifies the temperature sensor's sampling type, which is :
 
 The :ref:`dk_buttons_and_leds_readme` library is used to detect button presses.
 
-The :ref:`Zephyr settings API <zephyr:settings_api>` is used to persistently store the following settings given that :kconfig:option:`CONFIG_BT_SETTING` is enabled:
+The :ref:`Zephyr settings API <zephyr:settings_api>` is used to persistently store the following settings given that :kconfig:option:`CONFIG_BT_SETTINGS` is enabled:
 
 * The temperature range used in the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor
 * The presence motion threshold used in the :c:var:`bt_mesh_sensor_presence_detected` sensor


### PR DESCRIPTION
Commit fixes usage of the unknown KConfig options in the mesh related files.