### PR TITLE
samples: Add nRF54H20-specific smp_svr configs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -693,6 +693,7 @@
 /samples/zephyr/smp_svr_mini_boot/        @nrfconnect/ncs-pluto
 /samples/zephyr/subsys/settings/          @nrfconnect/ncs-low-level-test
 /samples/zephyr/subsys/usb/               @nrfconnect/ncs-low-level-test
+/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/ @nrfconnect/ncs-charon
 
 /samples/**/*.svg                         @nrfconnect/ncs-doc-leads
 /samples/**/*.png                         @nrfconnect/ncs-doc-leads

--- a/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/CMakeLists.txt
+++ b/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(smp_svr)
+
+target_sources(app PRIVATE ${ZEPHYR_BASE}/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c)
+target_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_BT app PRIVATE ${ZEPHYR_BASE}/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c)

--- a/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/README.txt
+++ b/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/README.txt
@@ -1,0 +1,4 @@
+This sample extends the same-named Zephyr sample to verify it
+with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/subsys/mgmt/mcumgr/smp_svr.

--- a/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/boards/nrf54h20dk_nrf54h20_cpuapp_merged_slot.overlay
+++ b/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/boards/nrf54h20dk_nrf54h20_cpuapp_merged_slot.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../sysbuild/nrf54h20dk_nrf54h20_memory_map_merged_slot.dtsi"

--- a/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/overlay-bt.conf
+++ b/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/overlay-bt.conf
@@ -1,0 +1,47 @@
+CONFIG_BT=y
+CONFIG_BT_PERIPHERAL=y
+
+# Allow for large Bluetooth data packets.
+CONFIG_BT_L2CAP_TX_MTU=498
+CONFIG_BT_BUF_ACL_RX_SIZE=502
+CONFIG_BT_BUF_ACL_TX_SIZE=502
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
+
+# Enable the Bluetooth mcumgr transport (unauthenticated).
+CONFIG_MCUMGR_TRANSPORT_BT=y
+CONFIG_MCUMGR_TRANSPORT_BT_CONN_PARAM_CONTROL=y
+
+# Enable the Shell mcumgr transport.
+CONFIG_BASE64=y
+CONFIG_CRC=y
+CONFIG_SHELL=y
+CONFIG_SHELL_BACKEND_SERIAL=y
+CONFIG_MCUMGR_TRANSPORT_SHELL=y
+
+# Enable the mcumgr Packet Reassembly feature over Bluetooth and its configuration dependencies.
+# MCUmgr buffer size is optimized to fit one SMP packet divided into five Bluetooth Write Commands,
+# transmitted with the maximum possible MTU value: 498 bytes.
+CONFIG_MCUMGR_TRANSPORT_BT_REASSEMBLY=y
+CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE=2475
+CONFIG_MCUMGR_GRP_OS_MCUMGR_PARAMS=y
+CONFIG_MCUMGR_TRANSPORT_WORKQUEUE_STACK_SIZE=4608
+
+# Enable the LittleFS file system.
+CONFIG_FILE_SYSTEM=y
+CONFIG_FILE_SYSTEM_LITTLEFS=y
+
+# Enable file system commands
+CONFIG_MCUMGR_GRP_FS=y
+
+# Enable the storage erase command.
+CONFIG_MCUMGR_GRP_ZBASIC=y
+CONFIG_MCUMGR_GRP_ZBASIC_STORAGE_ERASE=y
+
+# Disable Bluetooth ping support
+CONFIG_BT_CTLR_LE_PING=n
+
+# Disable shell commands that are not needed
+CONFIG_CLOCK_CONTROL_NRF_SHELL=n
+CONFIG_DEVICE_SHELL=n
+CONFIG_DEVMEM_SHELL=n
+CONFIG_FLASH_SHELL=n

--- a/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/prj.conf
+++ b/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/prj.conf
@@ -1,0 +1,41 @@
+# Enable MCUmgr and dependencies.
+CONFIG_NET_BUF=y
+CONFIG_ZCBOR=y
+CONFIG_CRC=y
+CONFIG_MCUMGR=y
+CONFIG_STREAM_FLASH=y
+CONFIG_FLASH_MAP=y
+
+# Some command handlers require a large stack.
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
+CONFIG_MAIN_STACK_SIZE=2176
+
+# Ensure an MCUboot-compatible binary is generated.
+CONFIG_BOOTLOADER_MCUBOOT=y
+
+# Enable flash operations.
+CONFIG_FLASH=y
+
+# Required by the `taskstat` command.
+CONFIG_THREAD_MONITOR=y
+
+# Support for taskstat command
+CONFIG_MCUMGR_GRP_OS_TASKSTAT=y
+
+# Enable statistics and statistic names.
+CONFIG_STATS=y
+CONFIG_STATS_NAMES=y
+
+# Enable most core commands.
+CONFIG_FLASH=y
+CONFIG_IMG_MANAGER=y
+CONFIG_MCUMGR_GRP_IMG=y
+CONFIG_MCUMGR_GRP_OS=y
+CONFIG_MCUMGR_GRP_STAT=y
+
+# Enable logging
+CONFIG_LOG=y
+CONFIG_MCUBOOT_UTIL_LOG_LEVEL_WRN=y
+
+# Disable debug logging
+CONFIG_LOG_MAX_LEVEL=3

--- a/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -1,0 +1,33 @@
+sample:
+  description: Simple Management Protocol sample
+  name: smp svr
+common:
+  sysbuild: true
+  build_only: true
+tests:
+  sample.mcumgr.smp_svr.bt.nrf54h20dk:
+    sysbuild: true
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-bt.conf"
+      - SB_CONFIG_NETCORE_IPC_RADIO=y
+      - SB_CONFIG_NETCORE_IPC_RADIO_BT_HCI_IPC=y
+      - mcuboot_CONFIG_NRF_SECURITY=y
+      - mcuboot_CONFIG_MULTITHREADING=y
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+  sample.mcumgr.smp_svr.bt.nrf54h20dk.direct_xip_withrevert:
+    sysbuild: true
+    extra_args:
+      - FILE_SUFFIX="merged_slot"
+      - EXTRA_CONF_FILE="overlay-bt.conf"
+      - SB_CONFIG_NETCORE_IPC_RADIO=y
+      - SB_CONFIG_NETCORE_IPC_RADIO_BT_HCI_IPC=y
+      - SB_CONFIG_MCUBOOT_MODE_DIRECT_XIP_WITH_REVERT=y
+      - mcuboot_CONFIG_NRF_SECURITY=y
+      - mcuboot_CONFIG_MULTITHREADING=y
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sysbuild.conf
+++ b/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sysbuild.conf
@@ -1,0 +1,2 @@
+# Enable MCUboot bootloader support
+SB_CONFIG_BOOTLOADER_MCUBOOT=y

--- a/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sysbuild/mcuboot_merged_slot.overlay
+++ b/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sysbuild/mcuboot_merged_slot.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54h20dk_nrf54h20_memory_map_merged_slot.dtsi"
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sysbuild/nrf54h20dk_nrf54h20_memory_map_merged_slot.dtsi
+++ b/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sysbuild/nrf54h20dk_nrf54h20_memory_map_merged_slot.dtsi
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* On nRF54H20 the Direct XIP mode is supported in the merged slot configuration
+ * Merge application and radio slots by extending the application parition.
+ */
+&cpuapp_slot0_partition {
+	reg = <0x40000 DT_SIZE_K(656)>;
+};
+
+&cpuapp_slot1_partition {
+	reg = <0x100000 DT_SIZE_K(656)>;
+};

--- a/scripts/ci/license_allow_list.yaml
+++ b/scripts/ci/license_allow_list.yaml
@@ -51,6 +51,7 @@ Apache-2.0: |
   ^nrf/tests/subsys/suit/common/tls_config/user-tls-conf.h
   ^nrf/subsys/settings/
   ^nrf/tests/zephyr/subsys/settings/
+  ^nrf/samples/zephyr/
 curl: "^nrf/ext/"
 MIT: "^nrf/ext/"
 BSD-3-CLAUSE: |

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3849be3604ec69e6bc06b6596ed39a215aa49b58
+      revision: b48277124014f0394e8f2566ba4eb5fa0b0edd08
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add additional sample variants for the nRF54H20 SoC inside smp_svr zephyr sample.

Ref: NCSDK-34305