### PR TITLE
Enable llpm sample for nrf7120

### DIFF
--- a/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120_cpuapp.dts
+++ b/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120_cpuapp.dts
@@ -14,5 +14,11 @@
 
 	chosen {
 		zephyr,sram = &cpuapp_sram;
+		zephyr,entropy = &prng;
+	};
+
+	prng: prng {
+		compatible = "nordic,entropy-prng";
+		status = "okay";
 	};
 };

--- a/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120_cpuapp_emu.dts
+++ b/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120_cpuapp_emu.dts
@@ -17,6 +17,12 @@
 		zephyr,sram = &cpuapp_sram;
 		zephyr,console = &uart00;
 		zephyr,shell-uart = &uart00;
+		zephyr,entropy = &prng;
+	};
+
+	prng: prng {
+		compatible = "nordic,entropy-prng";
+		status = "okay";
 	};
 };
 

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
+rsource "Kconfig.nrf_prng"
+
 config ENTROPY_CC3XX
 	bool "Arm CC3XX RNG driver for Nordic devices"
 	depends on HAS_HW_NRF_CC3XX && !BUILD_WITH_TFM

--- a/drivers/entropy/Kconfig.nrf_prng
+++ b/drivers/entropy/Kconfig.nrf_prng
@@ -1,0 +1,20 @@
+# nRF fake entropy prng generator driver configuration
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+if ENTROPY_GENERATOR
+
+config FAKE_ENTROPY_NRF_PRNG
+	bool "A fake nRF entropy driver"
+	default y
+	depends on DT_HAS_NORDIC_ENTROPY_PRNG_ENABLED
+	depends on (SOC_SERIES_NRF54HX || SOC_SERIES_NRF92X || SOC_SERIES_NRF54LX || SOC_SERIES_NRF71X)
+	select ENTROPY_HAS_DRIVER
+	help
+	  This is a super simple PRNG driver that can be used on nRF platforms that
+	  do not have an entropy source.
+	  This is NOT SAFE to use for cryptographic operations!
+
+endif

--- a/samples/bluetooth/llpm/boards/nrf7120pdk_nrf7120_cpuapp.conf
+++ b/samples/bluetooth/llpm/boards/nrf7120pdk_nrf7120_cpuapp.conf
@@ -1,0 +1,2 @@
+# Disabled Bluetooth Security Manager while crypto is not supported
+CONFIG_BT_SMP=n

--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -200,6 +200,13 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		if (err) {
 			printk("Failed to set security: %d\n", err);
 		}
+#else
+		/*Start service discovery*/
+		err = bt_gatt_dm_start(default_conn, BT_UUID_LATENCY, &discovery_cb,
+					&latency_client);
+		if (err) {
+			printk("Discover failed (err %d)\n", err);
+		}
 #endif /* CONFIG_BT_SMP */
 	}
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -108,7 +108,7 @@ config BT_CTLR_SDC_LLPM
 	bool "Enable Low Latency Packet Mode support"
 	select BT_CONN_PARAM_ANY if !BT_HCI_RAW
 	depends on (SOC_SERIES_NRF52X || SOC_SERIES_NRF54LX || SOC_SERIES_NRF54HX || \
-		    SOC_SERIES_BSIM_NRF52X || SOC_SERIES_BSIM_NRF54LX)
+		    SOC_SERIES_NRF71X || SOC_SERIES_BSIM_NRF52X || SOC_SERIES_BSIM_NRF54LX)
 	help
 	  Low Latency Packet Mode (LLPM) is a Nordic proprietary addition
 	  which lets the application use connection intervals down to 1 ms.


### PR DESCRIPTION
Changes required to run llpm sample on nrf7120.


