### PR TITLE
nrf_security: cracen: Update workaround for lm20

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ikg_signature.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/ikg_signature.c
@@ -63,19 +63,24 @@ static int exit_ikg(struct sx_pk_acq_req *pkreq)
 {
 
 	int status;
-
+	int i = 0;
 	sx_pk_release_req(pkreq->req);
-	*pkreq = sx_pk_acquire_req(SX_PK_CMD_IK_EXIT);
-	pkreq->status = sx_pk_list_ik_inslots(pkreq->req, 0, NULL);
-	if (pkreq->status) {
-		return pkreq->status;
+	while (pkreq->status != SX_OK && i <= MAX_ATTEMPTS) {
+		*pkreq = sx_pk_acquire_req(SX_PK_CMD_IK_EXIT);
 	}
-	sx_pk_run(pkreq->req);
-	status = sx_pk_wait(pkreq->req);
-	if (status != SX_OK) {
-		return status;
-	}
-	sx_pk_release_req(pkreq->req);
+		if (pkreq->status) {
+			return pkreq->status;
+		}
+		status = sx_pk_list_ik_inslots(pkreq->req, 0, NULL);
+		if (status) {
+			return pkreq->status;
+		}
+		sx_pk_run(pkreq->req);
+		status = sx_pk_wait(pkreq->req);
+		if (status != SX_OK) {
+			return status;
+		}
+		sx_pk_release_req(pkreq->req);
 	return SX_OK;
 }
 

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -244,6 +244,10 @@ struct sx_pk_acq_req sx_pk_acquire_req(const struct sx_pk_cmd_def *cmd)
 
 			cracen_wait_for_pke_interrupt();
 		}
+		if (sx_pk_rdreg(&req.req->regs, IK_REG_STATUS) == IK_ENTROPY_ERROR) {
+			req.status = SX_ERR_RETRY;
+			return req;
+		}
 	}
 
 	return req;


### PR DESCRIPTION
Update workaround to support new failing test cases