### PR TITLE
samples: benchmarks: coremark: Enable sample on nrf54lm20dk

### DIFF
--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -261,3 +261,7 @@
 .. nrf54lm20pdk_nrf54lm20a_cpuapp
 
 | nRF54LM20 PDK |   | nrf54lm20pdk | ``nrf54lm20pdk/nrf54lm20a/cpuapp`` |
+
+.. nrf54lm20dk_nrf54lm20a_cpuapp
+
+| nRF54LM20 DK |   | nrf54lm20dk | ``nrf54lm20dk/nrf54lm20a/cpuapp`` |

--- a/samples/benchmarks/coremark/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
+++ b/samples/benchmarks/coremark/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_COREMARK_ITERATIONS=4000
+
+CONFIG_LOG_MODE_IMMEDIATE=y

--- a/samples/benchmarks/coremark/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/benchmarks/coremark/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+ #include "app_aliases_common.overlay"
+
+/* The following configuration is required to run the CPUFLPR core.
+ * It is imported from the nordic-flpr snippet in the sdk-nrf repository.
+ */
+/ {
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			cpuflpr_code_partition: image@1e5000 {
+				/* FLPR core code partition */
+				reg = <0x1e5000 DT_SIZE_K(96)>;
+			};
+		};
+
+		cpuflpr_sram_code_data: memory@20067c00 {
+			compatible = "mmio-sram";
+			reg = <0x20067c00 DT_SIZE_K(96)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x20067c00 DT_SIZE_K(96)>;
+		};
+	};
+};
+
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(415)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(415)>;
+};
+
+&uart30 {
+	status = "reserved";
+};
+
+&cpuflpr_vpr {
+	status = "okay";
+	execution-memory = <&cpuflpr_sram_code_data>;
+	source-memory = <&cpuflpr_code_partition>;
+};
+
+&cpuapp_vevif_tx {
+	status = "okay";
+};
+
+/* The same set of GPIO and GPIOTE DTS nodes are enabled in the cpuapp and the cpuflpr targets.
+ * This is done to allow control over one Button and one LED in each core. The benchmark code is
+ * responsible for ensuring that each core exclusively uses the individual GPIO pin and the GPIOTE
+ * instance that may be used with the GPIO pin (Button).
+ */

--- a/samples/benchmarks/coremark/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.conf
+++ b/samples/benchmarks/coremark/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_COREMARK_ITERATIONS=4000
+
+CONFIG_LOG_MODE_IMMEDIATE=y

--- a/samples/benchmarks/coremark/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
+++ b/samples/benchmarks/coremark/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		button = &button3;
+		led = &led3;
+	};
+};
+
+/* The same set of GPIO and GPIOTE DTS nodes are enabled in the cpuapp and the cpuflpr targets.
+ * This is done to allow control over one Button and one LED in each core. The benchmark code is
+ * responsible for ensuring that each core exclusively uses the individual GPIO pin and the GPIOTE
+ * instance that may be used with the GPIO pin (Button).
+ */

--- a/samples/benchmarks/coremark/sample.yaml
+++ b/samples/benchmarks/coremark/sample.yaml
@@ -16,6 +16,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -26,6 +27,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags:
@@ -43,6 +45,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -53,6 +56,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags:
@@ -78,6 +82,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -88,6 +93,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags:
@@ -106,6 +112,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -116,6 +123,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags:
@@ -134,6 +142,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -144,6 +153,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     tags:


### PR DESCRIPTION
Add overlays required to run the sample on nrf54lm20dk target.