### PR TITLE
samples: wifi: raw_tx_packet: Fix OOM errors

### DIFF
--- a/samples/wifi/raw_tx_packet/src/main.c
+++ b/samples/wifi/raw_tx_packet/src/main.c
@@ -172,7 +172,8 @@ static int setup_raw_pkt_socket(int *sockfd, struct sockaddr_ll *sa)
 	struct net_if *iface = NULL;
 	int ret;
 
-	*sockfd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+	/* proto=0 implies a TX only socket */
+	*sockfd = socket(AF_PACKET, SOCK_RAW, 0);
 	if (*sockfd < 0) {
 		LOG_ERR("Unable to create a socket %d", errno);
 		return -1;


### PR DESCRIPTION
In connected mode, all the packets are delivered to raw socket also causing OOM issue esp. with the low networking packet config.

Fix by using a TX only socket (protocol=0), SHEL-2473.