### PR TITLE
applications: nrf_desktop: Update button_event subscription priority

### DIFF
--- a/applications/nrf_desktop/doc/fn_keys.rst
+++ b/applications/nrf_desktop/doc/fn_keys.rst
@@ -22,8 +22,8 @@ Module events
 Configuration
 *************
 
-The module uses ``button_event`` sent by :ref:`caf_buttons`.
-Make sure mentioned hardware interface is defined.
+The module uses :c:struct:`button_event` sent by :ref:`caf_buttons`.
+Make sure mentioned CAF module is enabled.
 
 The module is enabled with :ref:`CONFIG_DESKTOP_FN_KEYS_ENABLE <config_desktop_app_options>` option.
 
@@ -37,6 +37,9 @@ You must configure the following options:
 
 In the file :file:`fn_keys_def.h`, define all the dual-purpose keys.
 The ``fn_keys`` array must be sorted by key ID (the module uses binary search).
+
+By default, the module subscribes for :c:struct:`button_event` as the first subscriber (:c:macro:`APP_EVENT_SUBSCRIBE_FIRST`).
+You can disable the :ref:`CONFIG_DESKTOP_FN_KEYS_BUTTON_EVENT_SUBSCRIBE_FIRST <config_desktop_app_options>` Kconfig option to use early subscription (:c:macro:`APP_EVENT_SUBSCRIBE_EARLY`).
 
 Implementation details
 **********************

--- a/applications/nrf_desktop/src/hw_interface/buttons_sim.c
+++ b/applications/nrf_desktop/src/hw_interface/buttons_sim.c
@@ -181,6 +181,6 @@ static bool app_event_handler(const struct app_event_header *aeh)
 
 APP_EVENT_LISTENER(MODULE, app_event_handler);
 APP_EVENT_SUBSCRIBE(MODULE, module_state_event);
-APP_EVENT_SUBSCRIBE(MODULE, button_event);
+APP_EVENT_SUBSCRIBE_EARLY(MODULE, button_event);
 APP_EVENT_SUBSCRIBE(MODULE, power_down_event);
 APP_EVENT_SUBSCRIBE(MODULE, wake_up_event);

--- a/applications/nrf_desktop/src/hw_interface/passkey_buttons.c
+++ b/applications/nrf_desktop/src/hw_interface/passkey_buttons.c
@@ -227,5 +227,5 @@ static bool app_event_handler(const struct app_event_header *aeh)
 }
 APP_EVENT_LISTENER(MODULE, app_event_handler);
 APP_EVENT_SUBSCRIBE(MODULE, module_state_event);
-APP_EVENT_SUBSCRIBE(MODULE, button_event);
+APP_EVENT_SUBSCRIBE_EARLY(MODULE, button_event);
 APP_EVENT_SUBSCRIBE(MODULE, passkey_req_event);

--- a/applications/nrf_desktop/src/modules/Kconfig.fn_keys
+++ b/applications/nrf_desktop/src/modules/Kconfig.fn_keys
@@ -38,6 +38,17 @@ config DESKTOP_FN_KEYS_MAX_ACTIVE
 	help
 	  Maximum number of function keys pressed at the same time.
 
+config DESKTOP_FN_KEYS_BUTTON_EVENT_SUBSCRIBE_FIRST
+	bool "Subscribe for button_event as the first subscriber"
+	default y
+	help
+	  Subscribe for button_event as the first subscriber to handle the event
+	  before early subscribers. If the option is disabled, the module uses
+	  early subscription.
+
+	  Make sure to keep the option enabled if other early button_event
+	  subscribers use function keys.
+
 module = DESKTOP_FN_KEYS
 module-str = Fn keys
 source "subsys/logging/Kconfig.template.log_config"

--- a/applications/nrf_desktop/src/modules/fn_keys.c
+++ b/applications/nrf_desktop/src/modules/fn_keys.c
@@ -214,5 +214,9 @@ static bool app_event_handler(const struct app_event_header *aeh)
 }
 
 APP_EVENT_LISTENER(MODULE, app_event_handler);
+#if CONFIG_DESKTOP_FN_KEYS_BUTTON_EVENT_SUBSCRIBE_FIRST
+APP_EVENT_SUBSCRIBE_FIRST(MODULE, button_event);
+#else
 APP_EVENT_SUBSCRIBE_EARLY(MODULE, button_event);
+#endif
 APP_EVENT_SUBSCRIBE(MODULE, module_state_event);

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -312,6 +312,8 @@ nRF Desktop
   * Improved HID subscription handling in the HID transports (:ref:`nrf_desktop_hids` and :ref:`nrf_desktop_usb_state`).
     Both HID transports now unsubscribe from HID input reports related to the previously used HID protocol mode before subscribing to HID input reports related to the new HID protocol mode.
     This change ensures that subscriptions to both HID boot and HID report protocol mode are not enabled at the same time.
+  * The :ref:`nrf_desktop_fn_keys` to subscribe for :c:struct:`button_event` as the first subscriber (:c:macro:`APP_EVENT_SUBSCRIBE_FIRST`) by default.
+    You can disable the :ref:`CONFIG_DESKTOP_FN_KEYS_BUTTON_EVENT_SUBSCRIBE_FIRST <config_desktop_app_options>` Kconfig option to use early subscription (:c:macro:`APP_EVENT_SUBSCRIBE_EARLY`).
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -314,6 +314,8 @@ nRF Desktop
     This change ensures that subscriptions to both HID boot and HID report protocol mode are not enabled at the same time.
   * The :ref:`nrf_desktop_fn_keys` to subscribe for :c:struct:`button_event` as the first subscriber (:c:macro:`APP_EVENT_SUBSCRIBE_FIRST`) by default.
     You can disable the :ref:`CONFIG_DESKTOP_FN_KEYS_BUTTON_EVENT_SUBSCRIBE_FIRST <config_desktop_app_options>` Kconfig option to use early subscription (:c:macro:`APP_EVENT_SUBSCRIBE_EARLY`).
+  * The :ref:`nrf_desktop_passkey` and :ref:`nrf_desktop_buttons_sim` to subscribe for :c:struct:`button_event` as an early subscriber (:c:macro:`APP_EVENT_SUBSCRIBE_EARLY`).
+    This allows the modules to process the event before other application modules.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
PR updates button_event subscription priority in the Fn keys, passkey buttons and button simulator modules to let the modules process the event before other application modules.

Jira: NCSDK-34374
