### PR TITLE
applications: hpf: move common Kconfig to gpio and mspi Kconfigs

### DIFF
--- a/applications/hpf/Kconfig
+++ b/applications/hpf/Kconfig
@@ -1,7 +1,0 @@
-config HPF_DEVELOPER_MODE
-	bool "HPF developer mode"
-	help
-	  High Performance Framework developer mode.
-	  If enabled, changes in HRT files will be included in build.
-	  Otherwise, if there is a change in HRT that produces a different ASM file than
-	  the provided one, build error is reported.

--- a/applications/hpf/gpio/Kconfig
+++ b/applications/hpf/gpio/Kconfig
@@ -15,5 +15,12 @@ config HPF_GPIO_BACKEND_ICBMSG
 
 endchoice
 
-rsource "../Kconfig"
+config HPF_DEVELOPER_MODE
+	bool "HPF developer mode"
+	help
+	  High Performance Framework developer mode.
+	  If enabled, changes in HRT files will be included in build.
+	  Otherwise, if there is a change in HRT that produces a different ASM file than
+	  the provided one, build error is reported.
+
 source "Kconfig.zephyr"

--- a/applications/hpf/mspi/Kconfig
+++ b/applications/hpf/mspi/Kconfig
@@ -18,5 +18,12 @@ config HPF_MSPI_FAULT_TIMER
 	  Timer is used to detect application faults. If the timer expires,
 	  the application is considered to be in a fault state.
 
-rsource "../Kconfig"
+config HPF_DEVELOPER_MODE
+	bool "HPF developer mode"
+	help
+	  High Performance Framework developer mode.
+	  If enabled, changes in HRT files will be included in build.
+	  Otherwise, if there is a change in HRT that produces a different ASM file than
+	  the provided one, build error is reported.
+
 source "Kconfig.zephyr"


### PR DESCRIPTION
Move options from common HPF Kconfig file to GPIO and MSPI applications' specific Kconfig files to fix building these applications out-of-tree with VS Code.
When VS Code creates an out-of-tree application, it copies only the application directory (`nrf/applications/hpf/mspi` for MSPI sample), so when built, it fails on `rsource "../Kconfig"`, because it is not visible.