### PR TITLE
applications: nrf_desktop: Fix nrf52840gmouse's port_state_def.h

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/port_state_def.h
@@ -20,7 +20,7 @@ const struct {} port_state_def_include_once;
 
 static const struct pin_state port0_on[] = {
 
-#if !defined(CONFIG_DESKTOP_BATTERY_DISCRETE)
+#if defined(CONFIG_DESKTOP_BATTERY_MEAS_NONE)
 	{6,  0}, /* battery monitor enable */
 #endif
 


### PR DESCRIPTION
Change fixes invalid Kconfig option reference in the header file. The GPIO pin should be set only if battery measurement is disabled.

Jira: NCSDK-34354