### PR TITLE
doc: fast_pair: add documentation for the Fast Pair advertising manager

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -113,6 +113,7 @@
 /doc/nrf/drivers/uart_nrf_sw_lpuart.rst   @nrfconnect/ncs-doc-leads
 /doc/nrf/external_comp/avsystem.rst       @nrfconnect/ncs-iot-oulu-tampere-doc
 /doc/nrf/external_comp/bt_fast_pair.rst   @nrfconnect/ncs-si-bluebagel-doc
+/doc/nrf/external_comp/bt_fast_pair/      @nrfconnect/ncs-si-bluebagel-doc
 /doc/nrf/external_comp/coremark.rst       @nrfconnect/ncs-si-bluebagel-doc
 /doc/nrf/external_comp/dult.rst           @nrfconnect/ncs-si-bluebagel-doc
 /doc/nrf/external_comp/edge_impulse.rst   @nrfconnect/ncs-si-muffin-doc
@@ -128,6 +129,7 @@
 /doc/nrf/libraries/bluetooth/mesh/        @nrfconnect/ncs-paladin-doc
 /doc/nrf/libraries/bluetooth/adv_prov.rst @nrfconnect/ncs-si-bluebagel-doc
 /doc/nrf/libraries/bluetooth/mesh.rst     @nrfconnect/ncs-paladin-doc
+/doc/nrf/libraries/bluetooth/services/fast_pair/ @nrfconnect/ncs-si-bluebagel-doc
 /doc/nrf/libraries/bluetooth/services/fast_pair.rst @nrfconnect/ncs-si-bluebagel-doc
 /doc/nrf/libraries/bluetooth/services/wifi_prov.rst @nrfconnect/ncs-wifi-doc
 /doc/nrf/libraries/caf/                   @nrfconnect/ncs-si-muffin-doc @nrfconnect/ncs-si-bluebagel-doc

--- a/doc/nrf/external_comp/bt_fast_pair.rst
+++ b/doc/nrf/external_comp/bt_fast_pair.rst
@@ -104,6 +104,20 @@ The FMDN Accessory specification integrates the Detecting Unwanted Location Trac
 Relevant FMDN sections of this guide describe the DULT integration with the FMDN extension.
 For more details on the DULT integration guidelines, see the `Fast Pair Unwanted Tracking Prevention Guidelines`_ documentation.
 
+Integration guides for helper modules
+*************************************
+
+This integration guide includes additional pages that discuss the Fast Pair helper modules.
+While these helper modules can provide additional functionality in your application, they are not strictly required for the Fast Pair integration.
+Each helper module is described on a dedicated page.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Integration guides for helper modules:
+   :glob:
+
+   bt_fast_pair/*
+
 .. _ug_integrating_fast_pair:
 
 Integration steps
@@ -423,6 +437,11 @@ Setting up Bluetooth LE advertising
 
 The Fast Pair Provider must include Fast Pair service advertising data in the advertising payload.
 The Fast Pair Seeker must also know the Provider's transmit power to determine proximity.
+
+.. note::
+   The :ref:`bt_fast_pair_adv_manager_readme` helper module can be used to simplify the Fast Pair advertising management that is described in this integration step.
+   This module is also compatible with the requirements of the FMDN extension and its FMDN advertising set that are also covered by this integration step.
+   See :ref:`ug_bt_fast_pair_adv_manager` for more details on how to integrate it in your application.
 
 Advertising data and parameters
 ===============================
@@ -1138,11 +1157,22 @@ You must implement the guidelines at application level as they cannot be automat
 Implement these guidelines in your application if your product is targeting the locator tag use case.
 To see how to implement `Fast Pair Locator Tag Specific Guidelines`_ , see the :ref:`fast_pair_locator_tag` sample.
 
+.. note::
+   You can configure the :ref:`bt_fast_pair_adv_manager_readme` helper module to automatically handle locator tag guidelines related to the Fast Pair advertising.
+   Read through this section to learn more about this module.
+
 You must declare support for the locator tag use case when registering your device in the Google Nearby Device console.
 To enable the support, populate the **Fast Pair** protocol configuration panel in the following order:
 
 #. Select the :guilabel:`Locator Tag` option from the **Device Type** list.
 #. Set the **Find My Device** feature to **true**.
+
+It is recommended to use the :ref:`bt_fast_pair_adv_manager_readme` helper module for Fast Pair advertising management in the locator tag use case.
+This module follows the requirements of the FMDN extension and is compatible with the FMDN advertising set.
+It also provides additional layer for the locator tag use case.
+You can configure it using the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER_USE_CASE_LOCATOR_TAG` Kconfig option, that implements Fast Pair advertising requirements specified in the `Fast Pair Locator Tag Specific Guidelines`_ section of the FMDN Accessory specification.
+The :ref:`fast_pair_locator_tag` sample demonstrates how you can integrate the :ref:`bt_fast_pair_adv_manager_readme` in your application.
+See also :ref:`ug_bt_fast_pair_adv_manager` page that provides a comprehensive guide on how to integrate it in your application.
 
 .. note::
    It is recommended to use the special mode of the ``Fast Pair Procedure`` for the locator tag use case (see :ref:`ug_bt_fast_pair_gatt_service_no_ble_pairing` for more details).
@@ -1181,6 +1211,7 @@ Library support
 The following |NCS| libraries support the Fast Pair integration:
 
 * :ref:`bt_fast_pair_readme` library implements the Fast Pair GATT Service and provides the APIs required for :ref:`ug_bt_fast_pair` with the |NCS|.
+* :ref:`bt_fast_pair_adv_manager_readme` library implements the helper module that simplifies the Fast Pair advertising management.
 * :ref:`bt_le_adv_prov_readme` library - Google Fast Pair advertising data provider (:kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR`) can be used to integrate Fast Pair advertising payload to this library.
   The Bluetooth LE advertising provider subsystem can be used to manage advertising and scan response data.
 

--- a/doc/nrf/external_comp/bt_fast_pair/adv_manager.rst
+++ b/doc/nrf/external_comp/bt_fast_pair/adv_manager.rst
@@ -1,0 +1,387 @@
+.. _ug_bt_fast_pair_adv_manager:
+
+Google Fast Pair Advertising Manager integration
+################################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The :ref:`bt_fast_pair_adv_manager_readme` is a helper module for the :ref:`bt_fast_pair_readme` that manages the Fast Pair advertising set.
+This page provides guidelines on how to integrate this module in your application.
+
+.. note::
+   This page complements the main Fast Pair integration guide and covers only integration steps for the :ref:`bt_fast_pair_adv_manager_readme` module.
+   For the complete Fast Pair integration guide, see :ref:`ug_bt_fast_pair`.
+
+Prerequisites
+*************
+
+Before using the :ref:`bt_fast_pair_adv_manager_readme`, ensure to fulfill the following prerequisites:
+
+* Read through the main :ref:`ug_bt_fast_pair` guide to understand the overall Fast Pair integration requirements and ensure you meet all the prerequisites listed in this document.
+* Accept the usage of the Bluetooth® LE Extended Advertising feature (:kconfig:option:`CONFIG_BT_EXT_ADV`), which is a dependency for the :ref:`bt_fast_pair_adv_manager_readme` module.
+
+  .. note::
+     The Bluetooth LE Extended Advertising feature (:kconfig:option:`CONFIG_BT_EXT_ADV` Kconfig option) enforces the SoftDevice Controller library in the multirole variant (:file:`libsoftdevice_controller_multirole.a`) for most supported platforms.
+     The multirole SoftDevice Controller library has higher memory footprint than the peripheral and central variants.
+
+* Accept the usage of the :ref:`bt_le_adv_prov_readme` library (:kconfig:option:`CONFIG_BT_ADV_PROV`) as a way of encoding the advertising payload for the Fast Pair advertising set.
+  Additionally, the advertising provider for the Fast Pair payload (:kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR` Kconfig option) must be enabled when using this module.
+
+Extension compatibility
+***********************
+
+The Fast Pair Advertising Manager module is compatible with all Fast Pair extensions that are supported by the :ref:`bt_fast_pair_readme` module.
+
+Integration steps
+*****************
+
+The process of Fast Pair Advertising Manager integration has the following steps:
+
+1. :ref:`ug_bt_fast_pair_adv_manager_setup`
+#. :ref:`ug_bt_fast_pair_adv_manager_triggers`
+#. :ref:`ug_bt_fast_pair_adv_manager_payload`
+#. :ref:`ug_bt_fast_pair_adv_manager_use_case`
+
+For an integration example, see the :ref:`fast_pair_locator_tag` sample.
+
+.. rst-class:: numbered-step
+
+.. _ug_bt_fast_pair_adv_manager_setup:
+
+Setting up the module
+*********************
+
+To start integrating the Fast Pair Advertising Manager in your project, complete the following steps:
+
+* :ref:`ug_bt_fast_pair_adv_manager_setup_kconfig`
+* :ref:`ug_bt_fast_pair_adv_manager_setup_lifecycle`
+
+.. _ug_bt_fast_pair_adv_manager_setup_kconfig:
+
+Adding module Kconfig configuration
+===================================
+
+To support the Fast Pair Advertising Manager in your project, enable the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER` Kconfig option in the configuration file of your application image.
+You must also set the :kconfig:option:`CONFIG_BT_FAST_PAIR` Kconfig option that enables the general support for the Fast Pair solution.
+Additionally, enable all dependencies of the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER` Kconfig option.
+They are listed in the :ref:`bt_fast_pair_adv_manager_config` section.
+
+.. _ug_bt_fast_pair_adv_manager_setup_lifecycle:
+
+Managing module lifecycle
+=========================
+
+Before you can start using the Fast Pair Advertising Manager, you must first enable the Fast Pair subsystem using the :c:func:`bt_fast_pair_enable` function and then enable the Advertising Manager using the :c:func:`bt_fast_pair_adv_manager_enable` function.
+
+During the enable operation, the module allocates the Fast Pair advertising set from the Bluetooth stack memory pool and may start advertising if any client module requests the advertising to be active before the :c:func:`bt_fast_pair_adv_manager_enable` function call.
+
+.. note::
+   If you use more than one advertising set simultaneously in your application, make sure that the :kconfig:option:`CONFIG_BT_EXT_ADV_MAX_ADV_SET` Kconfig option is set to a correct value.
+   The additional advertising sets must also rotate their Resolvable Private Addresses (RPA) in synchronization with the Fast Pair advertising set to maintain the privacy properties of the overall solution.
+
+You can disable the module using the :c:func:`bt_fast_pair_adv_manager_disable` function.
+During the disable operation, all module's activities are stopped:
+
+* The Fast Pair advertising is stopped and the associated advertising set is deallocated from the Bluetooth stack memory pool.
+* The Fast Pair connection derived from the Fast Pair advertising set is terminated.
+
+.. note::
+   The :c:func:`bt_fast_pair_adv_manager_enable` and :c:func:`bt_fast_pair_adv_manager_disable` functions are not thread-safe and must be called in the cooperative thread context.
+
+You can check the module readiness using the :c:func:`bt_fast_pair_adv_manager_is_ready` function.
+The extension is marked as *ready* when it is in the enabled state and *unready* when it is in the disabled state.
+
+Some optional API functions must only be used in the *unready* state.
+The following subsections describe them in more details.
+
+Bluetooth identity configuration
+--------------------------------
+
+You can configure the Bluetooth identity, but by default, the module uses the :c:macro:`BT_ID_DEFAULT` identity.
+
+To set the Bluetooth identity for Fast Pair advertising and connections, use the :c:func:`bt_fast_pair_adv_manager_id_set` function.
+Make sure that the Bluetooth identity has been created in the Bluetooth stack before you enable the module with the :c:func:`bt_fast_pair_adv_manager_enable` function.
+The Bluetooth identity cannot be updated if the Fast Pair module is in the *ready* state (see the :c:func:`bt_fast_pair_adv_manager_is_ready` function).
+
+You can also use the :c:func:`bt_fast_pair_adv_manager_id_get` function to get the Bluetooth identity that is currently set in the module.
+
+Information callback registration
+---------------------------------
+
+The Fast Pair Advertising Manager uses the information callbacks to notify the application about events related to the module.
+
+The callback registration is optional.
+However, if you want to subscribe to information callbacks, you must register them using the :c:func:`bt_fast_pair_adv_manager_info_cb_register` function before the module is enabled with the :c:func:`bt_fast_pair_adv_manager_enable` function.
+Make sure that the registered :c:struct:`bt_fast_pair_adv_manager_info_cb` structure persists in the application memory (static declaration), as during the registration, the module stores only the memory pointer to it.
+You can register multiple callback sets using the :c:func:`bt_fast_pair_adv_manager_info_cb_register` function.
+
+The :c:struct:`bt_fast_pair_adv_manager_info_cb` structure supports only one callback type.
+
+The :c:member:`bt_fast_pair_adv_manager_info_cb.adv_state_changed` callback provides notifications about changes in the advertising state.
+See the :ref:`ug_bt_fast_pair_adv_manager_setup_callbacks_adv_state_changed` section for more details.
+
+.. _ug_bt_fast_pair_adv_manager_setup_callbacks_adv_state_changed:
+
+Advertising state change callback
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :c:member:`bt_fast_pair_adv_manager_info_cb.adv_state_changed` callback is triggered when the advertising state changes.
+When the advertising starts, the callback's *active* parameter is set to ``true``.
+When the advertising stops, the *active* parameter is set to ``false``.
+
+This callback can also be triggered in the context of the :c:func:`bt_fast_pair_adv_manager_enable` function provided that the module starts advertising during the enable operation.
+Similarly, the callback can be triggered in the context of the :c:func:`bt_fast_pair_adv_manager_disable` function provided that the module stops advertising during the disable operation.
+
+You can also use the :c:func:`bt_fast_pair_adv_manager_is_adv_active` function that is associated with this asynchronous callback to synchronously check the current state of the Fast Pair advertising.
+
+.. rst-class:: numbered-step
+
+.. _ug_bt_fast_pair_adv_manager_triggers:
+
+Defining and using triggers
+***************************
+
+Triggers are the core mechanism for controlling Fast Pair advertising.
+Each trigger represents a reason for advertising and can be configured with specific parameters.
+
+Trigger definition
+==================
+
+To start using the advertising trigger, you must first define it with the :c:macro:`BT_FAST_PAIR_ADV_MANAGER_TRIGGER_REGISTER` macro.
+This macro creates a :c:struct:`bt_fast_pair_adv_manager_trigger` structure in the dedicated memory section that is managed by the Fast Pair Advertising Manager module.
+This structure is used to represent the advertising trigger.
+
+The :c:macro:`BT_FAST_PAIR_ADV_MANAGER_TRIGGER_REGISTER` macro requires the following two mandatory parameters:
+
+* The variable name of the :c:struct:`bt_fast_pair_adv_manager_trigger` structure.
+* The trigger identifier in string format.
+
+The :c:macro:`BT_FAST_PAIR_ADV_MANAGER_TRIGGER_REGISTER` macro also accepts a third optional parameter, namely a pointer to the :c:struct:`bt_fast_pair_adv_manager_trigger_config` structure that describes the trigger configuration.
+The trigger configuration is a constant field of the :c:struct:`bt_fast_pair_adv_manager_trigger` structure and it cannot be changed at runtime.
+If you do not need to configure the trigger, you can pass ``NULL`` as the third parameter.
+
+An example of how to define a trigger for the user-initiated pairing mode that uses a dedicated configuration:
+
+.. code-block:: c
+
+   /* Trigger for user-initiated pairing mode */
+   BT_FAST_PAIR_ADV_MANAGER_TRIGGER_REGISTER(
+       fp_adv_trigger_pairing_mode,
+       "pairing_mode",
+       (&(const struct bt_fast_pair_adv_manager_trigger_config) {
+           .pairing_mode = true,
+           .suspend_rpa = true,
+       }));
+
+Trigger configuration options
+=============================
+
+You can attach a configuration to the trigger using the :c:macro:`BT_FAST_PAIR_ADV_MANAGER_TRIGGER_REGISTER` macro.
+The trigger configuration is represented by the :c:struct:`bt_fast_pair_adv_manager_trigger_config` structure that is a part of the :c:struct:`bt_fast_pair_adv_manager_trigger` structure and cannot be changed at runtime once it is defined.
+
+You can customize the advertising properties of each trigger by populating the fields of the :c:struct:`bt_fast_pair_adv_manager_trigger_config` structure.
+The available configuration options include:
+
+* :ref:`ug_bt_fast_pair_adv_manager_triggers_pairing_mode`
+* :ref:`ug_bt_fast_pair_adv_manager_triggers_suspend_rpa`
+
+.. _ug_bt_fast_pair_adv_manager_triggers_pairing_mode:
+
+Pairing mode
+------------
+
+The :c:member:`bt_fast_pair_adv_manager_trigger_config.pairing_mode` option is used to create a trigger that enables advertising in the pairing mode.
+
+When the pairing mode is active, the Fast Pair advertising set uses the discoverable advertising payload.
+When inactive, the non-discoverable payload is used.
+
+The pairing mode is active if at least one Fast Pair Advertising Manager trigger is active and is configured for the pairing mode.
+The change of the pairing mode state always triggers an advertising payload update.
+
+To check if the Fast Pair Advertising Manager is in the pairing mode, use the :c:func:`bt_fast_pair_adv_manager_is_pairing_mode` function.
+
+.. _ug_bt_fast_pair_adv_manager_triggers_suspend_rpa:
+
+Suspension of Resolvable Private Address (RPA) rotations
+--------------------------------------------------------
+
+The :c:member:`bt_fast_pair_adv_manager_trigger_config.suspend_rpa` option creates a trigger that suspends RPA rotations for the Fast Pair advertising set.
+
+The RPA rotation is suspended if at least one Fast Pair Advertising Manager trigger is active and configured to suspend RPA rotations.
+
+Use this option with caution, as it decreases the privacy of the advertiser by freezing its RPA rotations.
+It is typically used for triggers that are only active for a short period of time.
+
+Trigger activation
+==================
+
+To activate and deactivate a specific trigger, use the :c:func:`bt_fast_pair_adv_manager_request` function.
+The function requires a pointer to the :c:struct:`bt_fast_pair_adv_manager_trigger` structure to identify the trigger instance and a boolean parameter that indicates whether the trigger should be activated or deactivated.
+Initially, the trigger is in inactive state.
+
+Once the new trigger is activated, the Fast Pair Advertising Manager module parses its configuration and adjusts the advertising process accordingly.
+After its deactivation, this particular trigger configuration is no longer taken into account by the module during the advertising.
+
+This Fast Pair Advertising Manager module starts advertising when at least one trigger is active.
+Similarly, it stops advertising when all triggers are inactive.
+
+If Fast Pair advertising is active as a result of other active triggers, the activation of a new trigger does not cause the advertising payload update unless the new trigger changes the pairing mode.
+If necessary, you can force the advertising payload update using the :c:func:`bt_fast_pair_adv_manager_payload_refresh` function.
+
+You can also call the :c:func:`bt_fast_pair_adv_manager_request` function to set the trigger state when the Fast Pair Advertising Manager module is in the *unready* state and has not been enabled yet with the :c:func:`bt_fast_pair_adv_manager_enable` function.
+However, in this case, changes in the trigger state do not have an effect on the Fast Pair advertising.
+When the module is in the *unready* state, advertising is disabled regardless of the trigger state.
+The advertising is started in the context of the :c:func:`bt_fast_pair_adv_manager_enable` function if at least one trigger is activated before the enable operation.
+
+.. rst-class:: numbered-step
+
+.. _ug_bt_fast_pair_adv_manager_payload:
+
+Managing advertising payload
+****************************
+
+The Fast Pair Advertising Manager uses the :ref:`bt_le_adv_prov_readme` library (:kconfig:option:`CONFIG_BT_ADV_PROV`) to construct the advertising payload.
+This module acts as middleware between the :ref:`bt_le_adv_prov_readme` library and the application part responsible for controlling Fast Pair advertising with triggers.
+This design allows for flexible composition of advertising data.
+
+Understanding advertising providers
+===================================
+
+The advertising payload is constructed from multiple providers, each responsible for a specific advertising data element.
+To use the Fast Pair Advertising Manager, you must enable the Fast Pair advertising data provider (:kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR`) in the project's configuration file.
+This particular provider is used to encode the Fast Pair advertising data either in the discoverable mode if the pairing mode is active or in the not discoverable mode otherwise.
+
+The Fast Pair Advertising Manager module does not include any other providers by default.
+You can either implement additional providers manually or use the ones available in the :ref:`bt_le_adv_prov_readme` library (such as the TX Power provider - :kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER`).
+To understand how to implement custom providers, see the :ref:`ug_bt_fast_pair_adv_manager_payload_custom` section.
+
+Each provider can decide whether to include its data based on the current advertising state.
+The pairing mode state of the Fast Pair Advertising Manager is directly passed to the provider in the :c:struct:`bt_le_adv_prov_adv_state` structure.
+
+For more details on the advertising providers, see the :ref:`bt_le_adv_prov_readme` page.
+
+Managing advertising space
+==========================
+
+Bluetooth LE advertising packets have limited space (31 bytes for legacy advertising).
+When combining multiple advertising providers, ensure that the encoded advertising payload does not exceed the advertising packet size.
+The Fast Pair Advertising Manager module does not perform any payload size validation and you must verify if the advertising payload is within the limits.
+Note that providers can include their data conditionally based on the current advertising state.
+Ensure that data length is within the limits in all cases.
+
+Data privacy considerations
+===========================
+
+When designing custom advertising data providers, pay special attention to data privacy to maintain the privacy properties of the Fast Pair solution:
+
+* Avoid constant device identifiers - Do not include static device identifiers, such as serial numbers, MAC addresses, or other persistent device-specific information in the advertising payload.
+  These identifiers can be used to track the device across different advertising sessions and compromise user privacy.
+  If strictly necessary, you can encode the device identifier in the advertising payload provided that it is broadcasted for a limited time.
+
+* Handle random data properly - If your custom provider includes random numbers or other dynamic data, ensure that this data is regenerated on each Resolvable Private Address (RPA) rotation.
+  This prevents correlation of advertising data across different RPA periods, which could be used to track the device.
+  The Fast Pair Advertising Manager automatically rotates the RPA if it is not blocked by any advertising trigger (with the suspend RPA rotation option).
+  Your custom providers should respond to these rotations by updating any random data they include in the advertising payload.
+
+.. _ug_bt_fast_pair_adv_manager_payload_custom:
+
+Adding custom advertising data
+==============================
+
+To extend the advertising payload you can implement custom advertising data providers.
+This allows you to include application-specific data alongside the Fast Pair payload.
+
+To create a custom provider, implement the :c:func:`bt_le_adv_prov_data_get` callback and register it using the :c:macro:`BT_LE_ADV_PROV_AD_PROVIDER_REGISTER` macro to include its data in the advertising payload.
+
+Similarly, you can use the :c:macro:`BT_LE_ADV_PROV_SD_PROVIDER_REGISTER` macro to register the scan response data provider.
+
+Here is an example that conditionally includes the Bluetooth Advertising Data (AD) with the 16-bit UUID type and the payload corresponding to the Human Interface Device Service (HIDS) and Battery Service (BAS):
+
+.. code-block:: c
+
+   #include <zephyr/bluetooth/uuid.h>
+   #include <bluetooth/adv_prov.h>
+
+   static int get_data(struct bt_data *ad, const struct bt_le_adv_prov_adv_state *state,
+                       struct bt_le_adv_prov_feedback *fb)
+   {
+      ARG_UNUSED(fb);
+
+      /* Only include this advertising data when the pairing mode is active. */
+      if (!state->pairing_mode) {
+         return -ENOENT;
+      }
+
+      /* Define the list of Bluetooth service UUIDs that should be included in the payload. */
+      static const uint8_t data[] = {
+         BT_UUID_16_ENCODE(BT_UUID_HIDS_VAL),
+         BT_UUID_16_ENCODE(BT_UUID_BAS_VAL),
+      };
+
+      /* Populate the AD structure with the list of Bluetooth service UUIDs. */
+      ad->type = BT_DATA_UUID16_ALL;
+      ad->data_len = sizeof(data);
+      ad->data = data;
+
+      return 0;
+   }
+
+   BT_LE_ADV_PROV_AD_PROVIDER_REGISTER(uuid16_all, get_data);
+
+.. rst-class:: numbered-step
+
+.. _ug_bt_fast_pair_adv_manager_use_case:
+
+Use case integration
+********************
+
+The module supports extensions that handle common advertising scenarios automatically.
+Each extension is intended for a specific use case, which means that you can only enable one extension at a time.
+By default, the use case layer is disabled and the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER_USE_CASE` Kconfig choice is set to the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER_USE_CASE_UNSPECIFIED` value.
+If you want to support a specific use case, you must enable the corresponding Kconfig choice manually.
+Currently, this layer supports only the locator tag use case.
+
+Locator tag
+===========
+
+To enable the module extension for the locator tag use case, use the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER_USE_CASE_LOCATOR_TAG` Kconfig option.
+
+.. note::
+   If the locator tag extension of this module does not fit your application requirements, you can choose not to enable the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER_USE_CASE_LOCATOR_TAG` Kconfig option and replace it with your custom implementation.
+
+The Fast Pair Advertising Manager module is compatible with the Find My Device Network (FMDN) extension and handles the complex advertising state transitions automatically.
+The advertising policy of the Fast Pair advertising set respects the requirements of the FMDN advertising set.
+
+.. include:: /includes/fast_pair_fmdn_rename.txt
+
+This extension provides automatic handling of FMDN-related advertising requirements that are specified in the `Fast Pair Locator Tag Specific Guidelines`_ section of the FMDN Accessory specification.
+This is achieved by using the advertising triggers in the module's use case layer for locator tags.
+This extension manages the following triggers:
+
+* The FMDN provisioning trigger used to maintain Fast Pair non-discoverable advertising after the Account Key write operation.
+  The FMDN provisioning trigger is active until the FMDN provisioning is completed or when the timeout period expires.
+* The FMDN clock synchronization trigger used to maintain Fast Pair non-discoverable advertising after a power loss to synchronize time between the locator tag and the phone.
+  The FMDN clock synchronization trigger is active until the clock synchronization operation is completed.
+  You can disable this trigger with the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER_USE_CASE_LOCATOR_TAG_CLOCK_SYNC_TRIGGER` Kconfig option and replace it with your custom implementation.
+
+See the :ref:`fast_pair_locator_tag` sample to understand how to use the locator tag extension of the Fast Pair Advertising Manager module in the example application.
+
+For the overall integration details on the locator tag use case, see the :ref:`ug_bt_fast_pair_use_case_locator_tag` section in the general Fast Pair integration guide.
+
+Applications and samples
+************************
+
+See the :ref:`fast_pair_locator_tag` sample for a complete implementation example using the Fast Pair Advertising Manager.
+
+Dependencies
+************
+
+The following are the required dependencies for the Fast Pair integration:
+
+* :ref:`zephyr:random_api`
+* :ref:`zephyr:kernel_api`
+* :ref:`zephyr:bluetooth`
+* :ref:`bt_fast_pair_readme`
+* :ref:`bt_le_adv_prov_readme`

--- a/doc/nrf/libraries/bluetooth/services/fast_pair.rst
+++ b/doc/nrf/libraries/bluetooth/services/fast_pair.rst
@@ -9,6 +9,19 @@ Google Fast Pair Service (GFPS)
 
 The Google Fast Pair Service (Fast Pair for short) implements a Bluetooth® Low Energy (LE) GATT Service required for :ref:`ug_bt_fast_pair` with the |NCS|.
 
+Helper modules
+**************
+
+The Fast Pair service includes helper modules that may provide additional functionality during the implementation of the Fast Pair application.
+Each helper module is described in a dedicated subpage.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Helper modules:
+   :glob:
+
+   fast_pair/*
+
 Service UUID
 ************
 
@@ -98,6 +111,8 @@ With the :kconfig:option:`CONFIG_BT_FAST_PAIR` Kconfig option enabled, the follo
     * :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_CLOCK_NVM_UPDATE_RETRY_TIME` - The option configures the retry time (in seconds) when the beacon clock write to the non-volatile memory fails.
 * :kconfig:option:`CONFIG_BT_FAST_PAIR_USE_CASE_UNKNOWN`, :kconfig:option:`CONFIG_BT_FAST_PAIR_USE_CASE_INPUT_DEVICE`, :kconfig:option:`CONFIG_BT_FAST_PAIR_USE_CASE_LOCATOR_TAG`and :kconfig:option:`CONFIG_BT_FAST_PAIR_USE_CASE_MOUSE` - These options are used to select the Fast Pair use case and configure the Fast Pair library according to the `Fast Pair Device Feature Requirements`_ for the chosen use case.
   The :kconfig:option:`CONFIG_BT_FAST_PAIR_USE_CASE_UNKNOWN` Kconfig option is used by default.
+* :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER` - The option enables the :ref:`bt_fast_pair_adv_manager_readme` module.
+  See the :ref:`bt_fast_pair_adv_manager_config` section to learn more about the remaining Kconfig options of this module.
 
 See the Kconfig help for details.
 

--- a/doc/nrf/libraries/bluetooth/services/fast_pair/adv_manager.rst
+++ b/doc/nrf/libraries/bluetooth/services/fast_pair/adv_manager.rst
@@ -1,0 +1,253 @@
+.. _bt_fast_pair_adv_manager_readme:
+
+Fast Pair Advertising Manager
+#############################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The Fast Pair Advertising Manager is a helper module for the :ref:`bt_fast_pair_readme` that provides management of the Fast Pair advertising set.
+The module implements a trigger-based system for controlling Fast Pair advertising state that allows client modules to request advertising with their preferred configuration.
+It also defines the use case layer that provides an implementation of specific advertising requirements for supported use cases.
+
+Overview
+********
+
+The Fast Pair Advertising Manager module provides the following key features:
+
+* Trigger-based advertising control - Allows multiple components to request the start of advertising using registered triggers.
+* Trigger-based advertising configuration - Provides flexible configuration of the advertising parameters, such as pairing mode and RPA rotation behavior based on trigger requirements.
+* Payload synchronization - Ensures advertising payload updates are synchronized with RPA rotations.
+* Extension compatibility - Is compatible with the Fast Pair extensions that are supported by the :ref:`bt_fast_pair_readme` module (for example, the Find My Device Network extension).
+
+  .. include:: /includes/fast_pair_fmdn_rename.txt
+
+* Use case support - Provides tailored behavior for specific Fast Pair device types (for example, locator tags).
+
+.. note::
+   The module is designed to work in a cooperative thread context.
+
+.. _bt_fast_pair_adv_manager_config:
+
+Configuration
+*************
+
+To enable the Fast Pair Advertising Manager, use the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER` Kconfig option.
+As this is a helper module, the Kconfig option is only configurable if the :kconfig:option:`CONFIG_BT_FAST_PAIR` Kconfig option is enabled (see the :ref:`bt_fast_pair_readme` documentation for more details).
+
+With the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER` Kconfig option enabled, you can use the following Kconfig options with this module:
+
+* :kconfig:option:`BT_FAST_PAIR_ADV_MANAGER_USE_CASE` - This Kconfig option allows to select the Fast Pair use case (device type) and to enable additional advertising behaviors that are specific to your use case.
+
+  * :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER_USE_CASE_UNSPECIFIED` - The option provides a neutral configuration without behaviors specific to any use case.
+    By default, the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER_USE_CASE_UNSPECIFIED` option is selected.
+  * :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER_USE_CASE_LOCATOR_TAG` - The option provides a tailored configuration for Fast Pair locator tags that use the FMDN extension.
+    It depends on the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN` Kconfig option.
+
+    * :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER_USE_CASE_LOCATOR_TAG_CLOCK_SYNC_TRIGGER` - The option enables the clock synchronization trigger for locator tag devices.
+      The option is enabled by default.
+
+Dependencies
+============
+
+The :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER` Kconfig option depends on the following Bluetooth LE features:
+
+* :kconfig:option:`CONFIG_BT_PERIPHERAL` - Peripheral role support
+* :kconfig:option:`CONFIG_BT_EXT_ADV` - Extended advertising support
+* :kconfig:option:`CONFIG_BT_PRIVACY` - Bluetooth privacy support
+* :kconfig:option:`CONFIG_BT_SMP` - Security Manager Protocol support
+* :kconfig:option:`CONFIG_BT_ADV_PROV` - Advertising data provider support
+* :kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR` - Fast Pair advertising data provider support
+
+Implementation details
+**********************
+
+This module uses Zephyr Bluetooth subsystem APIs to manage the Fast Pair advertising set and the connections that are derived from it.
+
+Module lifecycle
+================
+
+The module follows a specific lifecycle:
+
+1. Initialization - The module is initialized during system startup by the ``SYS_INIT`` macro.
+#. Configuration - The majority of the configuration (such as information callbacks or Bluetooth identity) is performed before enabling the module.
+#. Enabling - The module is enabled with the :c:func:`bt_fast_pair_adv_manager_enable` function, which requires that the Fast Pair subsystem is ready (:c:func:`bt_fast_pair_enable`).
+#. Operation - Triggers can request advertising activation or deactivation.
+#. Disabling - The module is disabled with the :c:func:`bt_fast_pair_adv_manager_disable` function before the Fast Pair subsystem is disabled.
+
+Advertising triggers
+====================
+
+The module uses a trigger-based system where different components can request advertising activation.
+
+All advertising triggers are registered in the module section with the :c:macro:`BT_FAST_PAIR_ADV_MANAGER_TRIGGER_REGISTER` macro that uses the :c:macro:`STRUCT_SECTION_ITERABLE` macro to place the :c:struct:`bt_fast_pair_adv_manager_trigger` descriptor in the module section.
+See the :ref:`zephyr:iterable_sections_api` section for more details.
+The number of registered triggers is limited to ``32``.
+
+Each trigger can have a dedicated configuration that is described by the :c:struct:`bt_fast_pair_adv_manager_trigger_config` structure.
+The trigger configuration is a constant field of the :c:struct:`bt_fast_pair_adv_manager_trigger` structure and cannot be changed at runtime.
+
+Advertising process
+===================
+
+The module uses the Bluetooth Extended Advertising API (:file:`include/zephyr/bluetooth/bluetooth.h`) to manage the Fast Pair advertising set.
+
+.. note::
+   Even though the Bluetooth Extended Advertising API is used to manage the Fast Pair advertising set, the module still broadcasts advertising frames in the legacy format over-the-air.
+
+Advertising set initialization
+------------------------------
+
+The Fast Pair advertising set is allocated with the :c:func:`bt_le_ext_adv_create` function in the :c:func:`bt_fast_pair_adv_manager_enable` context.
+During the advertising set creation, the module registers the following callbacks:
+
+* :c:member:`bt_le_ext_adv_cb.connected` - The callback is used to track the connection state.
+* :c:member:`bt_le_ext_adv_cb.rpa_expired` - The callback is used to manage the RPA rotations.
+
+Additionally, during the advertising set creation, the advertising parameters are set as follows:
+
+* Advertising interval ``100 ms``
+
+  .. note::
+     Currently, the advertising interval is fixed and cannot be changed with a Kconfig option or API functions.
+
+* Bluetooth identity according to the module configuration (:c:func:`bt_fast_pair_adv_manager_id_set`).
+
+Since this module is typically responsible for setting the RPA timeout that affects all advertising sets, it triggers the initial RPA rotation with the :c:func:`bt_le_oob_get_local` function to configure the timeout according to the Fast Pair advertising requirements.
+This operation takes place right after the advertising set creation and before the advertising process is started.
+
+The module starts advertising in the :c:func:`bt_fast_pair_adv_manager_enable` context if the appropriate conditions are met.
+
+RPA rotations
+-------------
+
+The module is typically responsible for setting the RPA timeout.
+The module sets the RPA timeout with the :c:func:`bt_le_set_rpa_timeout` function in the context of the :c:member:`bt_le_ext_adv_cb.rpa_expired` callback that is registered during the advertising set creation.
+
+.. note::
+   If the FMDN extension is used, the FMDN advertising configures the RPA timeout in the FMDN provisioned state.
+   This module is tightly integrated with the FMDN extension and respects this requirement.
+
+The timeout value is recalculated for every RPA rotation and randomized to increase privacy.
+The typical timeout ranges between ``11`` and ``15`` minutes.
+The :c:func:`sys_csrand_get` function from the :ref:`zephyr:random_api` subsystem is used to generate random value for the timeout.
+
+The RPA rotation is suspended if any active advertising trigger has the :c:member:`bt_fast_pair_adv_manager_trigger_config.suspend_rpa` flag set to ``true``.
+This is achieved by returning ``false`` from the :c:member:`bt_le_ext_adv_cb.rpa_expired` callback.
+
+Advertising payload
+-------------------
+
+The module uses the :ref:`bt_le_adv_prov_readme` library (:kconfig:option:`CONFIG_BT_ADV_PROV`) to construct the advertising payload.
+
+During the payload update procedure, the module populates the :c:struct:`bt_le_adv_prov_adv_state` structure to indicate the current advertising state.
+Information about the pairing mode, RPA rotation, and other parameters is passed to the :ref:`bt_le_adv_prov_readme` library with the help of this structure and the API functions that are mentioned in subsequent sentences.
+Then, it calls the :c:func:`bt_le_adv_prov_get_ad` function to encode the advertising payload in the array of :c:struct:`bt_data` elements.
+The array size is properly allocated with the :c:func:`bt_le_adv_prov_get_ad_prov_cnt` function before the encode operation.
+Similarly, the :c:func:`bt_le_adv_prov_get_sd` function is used to encode the scanning data.
+As the final step, the collected payload is set in the Fast Pair advertising set with the :c:func:`bt_le_ext_adv_set_data` function.
+
+The advertising payload is updated in the following cases:
+
+* Advertising process is started.
+* The :c:func:`bt_fast_pair_adv_manager_payload_refresh` function is called and the advertising is ongoing.
+* The :c:member:`bt_le_ext_adv_cb.rpa_expired` callback is triggered due to the RPA rotation and the advertising is ongoing.
+* The pairing mode state of the module changes as a result of the :c:func:`bt_fast_pair_adv_manager_request` function call and the advertising is ongoing.
+
+Advertising conditions
+----------------------
+
+The advertising is started with the :c:func:`bt_le_ext_adv_start` function and the process is maintained if the following conditions are met:
+
+* The module is enabled (:c:func:`bt_fast_pair_adv_manager_enable`).
+* At least one advertising trigger gets activated with the :c:func:`bt_fast_pair_adv_manager_request` function.
+* The module does not maintain any connection.
+
+  .. note::
+     The module currently supports only one connection at a time.
+     A connection stops the Fast Pair advertising even if the advertising triggers are active.
+     The advertising is restarted when the connection is terminated.
+
+Otherwise, the advertising is inactive.
+
+The module tracks the advertising activity and can report each change with the :c:member:`bt_fast_pair_adv_manager_info_cb.adv_state_changed` callback to the application.
+
+Trigger state changes
+---------------------
+
+The trigger configuration (:c:struct:`bt_fast_pair_adv_manager_trigger_config`) may update the module's advertising state once the given trigger is activated with the :c:func:`bt_fast_pair_adv_manager_request` function.
+The advertising state is also updated when the previously activated trigger gets deactivated as its configuration is no longer applied.
+
+Advertising set deinitialization
+--------------------------------
+
+During the disable operation, in the :c:func:`bt_fast_pair_adv_manager_disable` function context, the module stops the ongoing Bluetooth activities:
+
+* Advertising process with the :c:func:`bt_le_ext_adv_stop` function.
+* Active connections with the :c:func:`bt_conn_disconnect` function.
+  This disconnect operation is only limited to the connections that are derived from the Fast Pair advertising set.
+
+The advertising set is also deleted with the :c:func:`bt_le_ext_adv_delete` function.
+
+Coexistence with other advertising sets
+=======================================
+
+The Fast Pair advertising set, that is managed by this module, can operate in parallel with other advertising sets without interfering with them.
+
+The module only manages the advertising process for the Fast Pair advertising set and the connections that are derived from it.
+It uses one connection slot from the connection pool of the Bluetooth stack (:kconfig:option:`CONFIG_BT_MAX_CONN`).
+
+Other advertising sets that also use RPA as its MAC address are affected by the RPA timeout setting of the Fast Pair advertising set.
+The RPA timeout is set globally with the :c:func:`bt_le_set_rpa_timeout` function in the Bluetooth stack and affects all advertising sets.
+
+FMDN integration
+================
+
+The module is compatible with the Find My Device Network (FMDN) extension and handles the complex advertising state transitions automatically.
+The advertising policy of the Fast Pair advertising set respects the requirements of the FMDN advertising set.
+The module rotates the RPA and the payload of the Fast Pair advertising set synchronously with the FMDN advertising set.
+
+The module yields control over the RPA timeout configuration to the FMDN advertising set once the FMDN provisioning is completed.
+Conversely, right after the unprovisioning, the module takes back control over the RPA timeout configuration.
+To achieve this, the module uses the :c:func:`bt_le_oob_get_local` function to trigger the premature RPA rotation and set the RPA according to the Fast Pair advertising requirements.
+
+Use case extensions
+===================
+
+The module supports use case layer that provides an implementation of specific advertising requirements for supported use cases.
+Currently, the use case extension is only available for the locator tags.
+
+By default, the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER_USE_CASE_UNSPECIFIED` Kconfig option is enabled, which means that this layer is disabled.
+
+If you change this default configuration and select a specific use case, the core library uses the enable callback to activate the use case extension in the :c:func:`bt_fast_pair_adv_manager_enable` function.
+
+Similarly, the disable callback is used in the context of the :c:func:`bt_fast_pair_adv_manager_disable` function to deactivate the use case extension.
+
+For this process to work, the use case layer must register the mandatory callback structure with the enable and disable callbacks.
+
+Locator tag
+-----------
+
+The locator tag extension registers the :c:struct:`bt_fast_pair_info_cb` and the :c:struct:`bt_fast_pair_fmdn_info_cb` callback structures to manage the advertising triggers that are specific to the locator tag use case.
+
+This extension defines the FMDN provisioning trigger that is used to maintain the Fast Pair advertising between the Owner Account Key write (:c:member:`bt_fast_pair_info_cb.account_key_written`) and the successful FMDN provisioning (:c:member:`bt_fast_pair_fmdn_info_cb.provisioning_state_changed`).
+This advertising trigger is also configured to suspend the RPA rotation during the FMDN provisioning.
+If the FMDN provisioning is not completed within the allowed time, the extension deactivates the FMDN provisioning with the :c:func:`bt_fast_pair_adv_manager_request` function.
+The trigger behavior is aligned with the requirements of the `Fast Pair Locator Tag Specific Guidelines`_ section of the FMDN Accessory specification.
+
+.. note::
+   If the FMDN provisioning trigger is deactivated prematurely with the :c:func:`bt_fast_pair_adv_manager_disable` function, it will not be restored during the :c:func:`bt_fast_pair_adv_manager_enable` function call.
+   The device should typically advertise continuously for the predefined period until it is factory reset or successfully provisioned.
+
+The extension also defines the FMDN clock synchronization trigger that is used to maintain the Fast Pair advertising after a power loss until the clock synchronization (:c:member:`bt_fast_pair_fmdn_info_cb.clock_synced`) is completed.
+This trigger is enabled by default and can be controlled with the :kconfig:option:`CONFIG_BT_FAST_PAIR_ADV_MANAGER_USE_CASE_LOCATOR_TAG_CLOCK_SYNC_TRIGGER` Kconfig option.
+This advertising trigger does not use a dedicated configuration structure and passes ``NULL`` as the configuration pointer.
+
+API documentation
+*****************
+
+| Header file: :file:`include/bluetooth/services/fast_pair/adv_manager.h`
+| Source files: :file:`subsys/bluetooth/services/fast_pair/adv_manager`
+
+.. doxygengroup:: bt_fast_pair_adv_manager

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -676,6 +676,10 @@ Bluetooth libraries and services
 
 * :ref:`bt_fast_pair_readme` library:
 
+  * Added the new :ref:`bt_fast_pair_adv_manager_readme` helper module that can be used to manage the Fast Pair advertising set.
+    The module implements a trigger-based system for controlling Fast Pair advertising state that allows client modules to request advertising with their preferred configuration.
+    It also defines the use case layer that provides implementation of specific advertising requirements for supported use cases.
+
   * Updated the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_RING_REQ_TIMEOUT_DULT_MOTION_DETECTOR` Kconfig option dependency.
     The dependency has been updated from the :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_DULT` Kconfig option to :kconfig:option:`CONFIG_BT_FAST_PAIR_FMDN_DULT_MOTION_DETECTOR`.
 
@@ -901,7 +905,10 @@ This section provides detailed lists of changes by :ref:`integration <integratio
 Google Fast Pair integration
 ----------------------------
 
-|no_changes_yet_note|
+* Added the :ref:`ug_bt_fast_pair_adv_manager` page that describes how to integrate the :ref:`bt_fast_pair_adv_manager_readme` module in your application.
+
+* Updated the :ref:`ug_bt_fast_pair` page to mention the availability of the guide for :ref:`ug_bt_fast_pair_adv_manager` that covers the associated helper module.
+  Mentioned applicability of the :ref:`bt_fast_pair_adv_manager_readme` module in the :ref:`ug_bt_fast_pair_advertising` and the :ref:`ug_bt_fast_pair_use_case_locator_tag` sections.
 
 Edge Impulse integration
 ------------------------
@@ -999,6 +1006,9 @@ Documentation
   * The :ref:`mcuboot_serial_recovery` documentation page, based on the official Zephyr documentation, which discusses the implementation and usage of the serial recovery.
   * The :ref:`data_storage` page, which covers storage alternatives for general data, including NVMC, NVS, file systems, Settings, and PSA Protected Storage, with feature comparisons and configuration examples.
   * The :ref:`key_storage` page, which covers storage alternatives for cryptographic keys, including PSA Crypto API, Hardware Unique Keys (HUK), modem certificate storage, and other security-focused storage mechanisms.
+  * The :ref:`bt_fast_pair_adv_manager_readme` page that describes the new helper module for the :ref:`bt_fast_pair_readme` library.
+
+* Updated the :ref:`bt_fast_pair_readme` page to mention the availability of the :ref:`bt_fast_pair_adv_manager_readme` helper module.
 
 * Moved the Wi-Fi credentials library page to the upstream :ref:`Zephyr repository <zephyr:lib_wifi_credentials>`.
 * Removed the Getting started with nRF7002 DK and Getting started with other DKs pages from the :ref:`gsg_guides` section.


### PR DESCRIPTION
Added the library documentation page and the user guide page for the new Fast Pair Advertising Manager module, which is the helper module for the Google Fast Pair library.

Ref: NCSDK-34134

Additional notes:

- The PR covers the documentation for the new module that has been added in the following PR: https://github.com/nrfconnect/sdk-nrf/pull/22638
- The documentation update for the FP Locator Tag sample will be covered in a separate PR 
