### PR TITLE
samples: Bluetooth: Rename sample direction finding

### DIFF
--- a/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: Direction Finding Connectionless Beacon
   description: Sample application showing connectionless Direction Finding transmission
 tests:
-  sample.bluetooth.direction_finding_connectionless_tx.aoa.sdc.nrf52_nrf53_54lx:
+  sample.bluetooth.direction_finding_connectionless_tx.aoa.sdc:
     sysbuild: true
     build_only: true
     platform_allow:


### PR DESCRIPTION
Length of the sample name spawns build failures for Windows. This commit customizes name of sample to building requirements.