### PR TITLE
doc: Fix doc failure of Wi-Fi cred library

### DIFF
--- a/doc/nrf/includes/wifi_credentials_shell.txt
+++ b/doc/nrf/includes/wifi_credentials_shell.txt
@@ -1,7 +1,7 @@
 Configuring Wi-Fi access point credentials
 ==========================================
 
-This sample uses the :ref:`lib_wifi_credentials` library to manage Wi-Fi credentials.
+This sample uses the :ref:`Wi-Fi credentials <zephyr:lib_wifi_credentials>` library to manage Wi-Fi credentials.
 Before the sample can connect to a Wi-Fi network, you must configure at least one credential set.
 
 Once you have flashed your device with this sample, connect to your device's UART interface and add credentials using the following command:

--- a/doc/nrf/libraries/bluetooth/services/wifi_prov.rst
+++ b/doc/nrf/libraries/bluetooth/services/wifi_prov.rst
@@ -238,7 +238,7 @@ Configuration management
 ************************
 
 The configuration management component manages Wi-Fi configurations.
-It uses the :ref:`lib_wifi_credentials` library to handle the configurations in flash.
+It uses the :ref:`Wi-Fi credentials <zephyr:lib_wifi_credentials>` library to handle the configurations in flash.
 The component has one slot in RAM to save the configurations.
 
 You can save the configuration in flash or RAM during provisioning.

--- a/doc/nrf/libraries/networking/wifi_mgmt_ext.rst
+++ b/doc/nrf/libraries/networking/wifi_mgmt_ext.rst
@@ -13,7 +13,7 @@ Overview
 ********
 
 The automatic connection feature is implemented by adding a ``NET_REQUEST_WIFI_CONNECT_STORED`` command to Zephyr's Wi-Fi L2 Layer.
-Credentials are pulled from the :ref:`lib_wifi_credentials` library.
+Credentials are pulled from the :ref:`Wi-Fi credentials <zephyr:lib_wifi_credentials>` library.
 
 Configuration
 *************

--- a/doc/nrf/releases_and_maturity/migration/2.4.99-cs3_to_2.6.99-cs2/migration_guide_2.4.99-cs3_to_2.6.99-cs2_application.rst
+++ b/doc/nrf/releases_and_maturity/migration/2.4.99-cs3_to_2.6.99-cs2/migration_guide_2.4.99-cs3_to_2.6.99-cs2_application.rst
@@ -98,7 +98,7 @@ Security
        It is not backward compatible with the previous PSA ITS implementation.
        Migrating from the PSA ITS implementation, enabled by the ``CONFIG_PSA_NATIVE_ITS`` option, to the new :ref:`trusted_storage_readme` library requires manual data migration.
 
-   * For :ref:`lib_wifi_credentials` library and Wi-Fi® samples:
+   * For Wi-Fi credentials library and Wi-Fi® samples:
 
      * ``CONFIG_WIFI_CREDENTIALS_BACKEND_PSA_UID_OFFSET`` has been removed because it was specific to the previous solution that used PSA Protected Storage instead of PSA Internal Trusted Storage (ITS).
        Use :kconfig:option:`CONFIG_WIFI_CREDENTIALS_BACKEND_PSA_OFFSET` to specify the key offset for PSA ITS.

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.6.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.6.rst
@@ -190,7 +190,7 @@ Security
        It is not backward compatible with the previous PSA ITS implementation.
        Migrating from the PSA ITS implementation, enabled by the ``CONFIG_PSA_NATIVE_ITS`` option, to the new :ref:`trusted_storage_readme` library requires manual data migration.
 
-   * For :ref:`lib_wifi_credentials` library and Wi-Fi samples:
+   * For Wi-Fi credentials library and Wi-Fi samples:
 
      * ``CONFIG_WIFI_CREDENTIALS_BACKEND_PSA_UID_OFFSET`` has been removed because it was specific to the previous solution that used PSA Protected Storage instead of PSA Internal Trusted Storage (ITS).
        Use :kconfig:option:`CONFIG_WIFI_CREDENTIALS_BACKEND_PSA_OFFSET` to specify the key offset for PSA ITS.

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
@@ -440,7 +440,7 @@ Wi-Fi®
 
 .. toggle::
 
-   * For :ref:`lib_wifi_credentials` library:
+   * For Wi-Fi credentials library:
 
      * Syntax for ``add`` command has been modified to support ``getopt`` model.
        For example, the following command with old syntax:

--- a/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/migration_guide_2.4.99-cs3_to_2.7_application.rst
+++ b/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/migration_guide_2.4.99-cs3_to_2.7_application.rst
@@ -562,7 +562,7 @@ Security
        It is not backward compatible with the previous PSA ITS implementation.
        Migrating from the PSA ITS implementation, enabled by the ``CONFIG_PSA_NATIVE_ITS`` option, to the new :ref:`trusted_storage_readme` library requires manual data migration.
 
-   * For :ref:`lib_wifi_credentials` library and Wi-Fi® samples:
+   * For Wi-Fi credentials library and Wi-Fi® samples:
 
      * ``CONFIG_WIFI_CREDENTIALS_BACKEND_PSA_UID_OFFSET`` has been removed because it was specific to the previous solution that used PSA Protected Storage instead of PSA Internal Trusted Storage (ITS).
        Use :kconfig:option:`CONFIG_WIFI_CREDENTIALS_BACKEND_PSA_OFFSET` to specify the key offset for PSA ITS.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.3.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.3.0.rst
@@ -277,7 +277,7 @@ Wi-Fi
 
   * New sample :ref:`wifi_sr_coex_sample` demonstrating Wi-Fi Bluetooth LE coexistence.
   * :ref:`ug_wifi` document.
-  * :ref:`lib_wifi_credentials` library to store credentials.
+  * Wi-Fi credentials library to store credentials.
   * :ref:`wifi_mgmt_ext` library to provide an ``autoconnect`` command based on Wi-Fi credentials.
 
 * Updated:
@@ -628,8 +628,8 @@ Wi-Fi samples
 
 * Updated:
 
-  * The :ref:`wifi_shell_sample` sample now uses the :ref:`lib_wifi_credentials` and :ref:`wifi_mgmt_ext` libraries.
-  * The :ref:`wifi_provisioning` sample now uses the :ref:`lib_wifi_credentials` and :ref:`wifi_prov_readme` libraries.
+  * The :ref:`wifi_shell_sample` sample now uses the Wi-Fi credentials and :ref:`wifi_mgmt_ext` libraries.
+  * The :ref:`wifi_provisioning` sample now uses the Wi-Fi credentials and :ref:`wifi_prov_readme` libraries.
 
 * Removed nRF7002 revision A support.
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.6.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.6.0.rst
@@ -1325,7 +1325,7 @@ Libraries for networking
 
   * Updated the :c:struct:`nrf_cloud_rest_location_request` structure to accept a pointer to a :c:struct:`nrf_cloud_location_config` structure in place of the single ``disable_response`` flag.
 
-* :ref:`lib_wifi_credentials` library:
+* Wi-Fi credentials library:
 
   * Updated the PSA backend to use the PSA Internal Trusted Storage (ITS) for storing Wi-Fi credentials instead of the Protected Storage.
     This has been changed because the PSA ITS is a better fit for storing assets like credentials.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-2.7.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-2.7.0.rst
@@ -1107,7 +1107,7 @@ Libraries for networking
    * The :ref:`lib_softap_wifi_provision` library.
    * The :ref:`lib_wifi_ready` library.
 
-* :ref:`lib_wifi_credentials` library:
+* Wi-Fi credentials library:
 
   * Added:
 

--- a/samples/cellular/nrf_cloud_multi_service/README.rst
+++ b/samples/cellular/nrf_cloud_multi_service/README.rst
@@ -991,7 +991,7 @@ If you are certain you understand the inherent security risks, you can use this 
 Setting up Wi-Fi access point credentials
 =========================================
 
-This sample uses the :ref:`lib_wifi_credentials` library to manage Wi-Fi credentials.
+This sample uses the :ref:`Wi-Fi credentials <zephyr:lib_wifi_credentials>` library to manage Wi-Fi credentials.
 Before the sample can connect to a Wi-Fi network, you must add at least one credential set.
 
 Once your device has been flashed with this sample, you can add a credential by connecting to your device's UART interface and then entering the following command:

--- a/samples/net/azure_iot_hub/README.rst
+++ b/samples/net/azure_iot_hub/README.rst
@@ -260,4 +260,4 @@ It uses the following libraries and secure firmware component for nRF91 Series b
 It uses the following libraries for nRF7 Series builds:
 
 * :ref:`nrf_security`
-* :ref:`lib_wifi_credentials`
+* :ref:`Wi-Fi credentials <zephyr:lib_wifi_credentials>`

--- a/samples/wifi/provisioning/ble/README.rst
+++ b/samples/wifi/provisioning/ble/README.rst
@@ -150,7 +150,7 @@ Dependencies
 This sample uses the following |NCS| libraries:
 
 * :ref:`wifi_prov_readme`
-* :ref:`lib_wifi_credentials`
+* :ref:`Wi-Fi credentials <zephyr:lib_wifi_credentials>`
 
 This sample also uses a module that can be found in the following location in the |NCS| folder structure:
 

--- a/samples/wifi/shell/README.rst
+++ b/samples/wifi/shell/README.rst
@@ -269,7 +269,7 @@ Supported CLI commands
        | wifi -i1 -c5
 
 ``wifi cred`` is an extension to the Wi-Fi command line.
-It adds the following subcommands to interact with the :ref:`lib_wifi_credentials` library:
+It adds the following subcommands to interact with the :ref:`Wi-Fi credentials <zephyr:lib_wifi_credentials>` library:
 
 .. list-table:: Wi-Fi credentials shell subcommands
    :header-rows: 1

--- a/samples/wifi/sta/README.rst
+++ b/samples/wifi/sta/README.rst
@@ -240,4 +240,4 @@ This sample uses the following |NCS| libraries:
 
 * :ref:`nrf_security`
 * :ref:`lib_wifi_ready`
-* :ref:`lib_wifi_credentials`
+* :ref:`Wi-Fi credentials <zephyr:lib_wifi_credentials>`


### PR DESCRIPTION
Wi-Fi credentials library document has been moved upstream zephyr. Need to update page references for doc failure.