### PR TITLE
samples: peripheral: lpuart: fix memory slab usage

### DIFF
--- a/samples/peripheral/lpuart/src/main.c
+++ b/samples/peripheral/lpuart/src/main.c
@@ -15,7 +15,7 @@
 LOG_MODULE_REGISTER(app);
 
 #define BUF_SIZE 64
-static K_MEM_SLAB_DEFINE(uart_slab, BUF_SIZE, 3, 4);
+K_MEM_SLAB_DEFINE_STATIC(uart_slab, BUF_SIZE, 3, 4);
 
 #define TX_DATA_SIZE 5
 static const uint8_t tx_buf[TX_DATA_SIZE] = {1, 2, 3, 4, 5};


### PR DESCRIPTION
K_MEM_SLAB_DEFINE() cannot be used after static keyword. Proper Zephyr API to define static memory slabs is K_MEM_SLAB_DEFINE_STATIC().

The misuse of static keyword did not cause build failure until upstream commit 3c47f91be4f8 ("include: kernel: add macros to enable allocation from specific sections") introduced build time asserts.