### PR TITLE
bluetooth: rpc: fix enable, disable, enable scenario

### DIFF
--- a/subsys/bluetooth/rpc/client/bt_rpc_gap_client.c
+++ b/subsys/bluetooth/rpc/client/bt_rpc_gap_client.c
@@ -107,7 +107,6 @@ int bt_enable(bt_ready_cb_t cb)
 	struct nrf_rpc_cbor_ctx ctx;
 	int result = 0;
 	size_t buffer_size_max = 5;
-	static atomic_t init;
 
 	validate_config();
 
@@ -121,20 +120,15 @@ int bt_enable(bt_ready_cb_t cb)
 	}
 
 	NRF_RPC_CBOR_ALLOC(&bt_rpc_grp, ctx, buffer_size_max);
-
 	nrf_rpc_encode_callback(&ctx, cb);
-
 	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_ENABLE_RPC_CMD, &ctx, nrf_rpc_rsp_decode_i32,
 				&result);
 
-	/* In case if the Bluetooth was disabled, we don't need to init again
-	 * dependencies.
-	 */
-	if ((!atomic_cas(&init, 0, 1)) || result) {
+	if (result) {
 		return result;
 	}
 
-	if (IS_ENABLED(CONFIG_SETTINGS)) {
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		buffer_size_max = 0;
 		NRF_RPC_CBOR_ALLOC(&bt_rpc_grp, ctx, buffer_size_max);
 

--- a/subsys/bluetooth/rpc/host/bt_rpc_gap_host.c
+++ b/subsys/bluetooth/rpc/host/bt_rpc_gap_host.c
@@ -2114,7 +2114,7 @@ NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_le_per_adv_sync_cb_register_on_remote,
 			 bt_le_per_adv_sync_cb_register_on_remote_rpc_handler, NULL);
 #endif /* defined(CONFIG_BT_PER_ADV_SYNC) */
 
-#if defined(CONFIG_SETTINGS)
+#if defined(CONFIG_BT_SETTINGS)
 static void bt_rpc_settings_load_rpc_handler(const struct nrf_rpc_group *group,
 					     struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
 {
@@ -2126,4 +2126,4 @@ static void bt_rpc_settings_load_rpc_handler(const struct nrf_rpc_group *group,
 
 NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_rpc_settings_load, BT_SETTINGS_LOAD_RPC_CMD,
 			 bt_rpc_settings_load_rpc_handler, NULL);
-#endif /* defined(CONFIG_SETTINGS) */
+#endif /* defined(CONFIG_BT_SETTINGS) */


### PR DESCRIPTION
Fix the scenario in which a user calls bt_enable, followed by bt_disable and bt_enable again. In such a case, BT RPC client would not request loading Bluetooth settings for the second bt_enable call, which is necessary to either load or create Bluetooth identities and complete the initialization.

The faulty behavior was likely due to an attempt to optimize registering static callbacks and services but:
1. Registering static callbacks and services was moved some time ago and it is now done before invoking bt_enable on the remote device, so the optimization isn't effective anymore.
2. Loading settings must happen for each bt_enable call as bt_disable clears all the identities.

Btw, also change the code for invoking settings load to depend on BT_SETTINGS instead of more generic SETTINGS.