### PR TITLE
applications: nrf_desktop: nrf54lm20a: add workaround for mpsl asserts

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/prj.conf
@@ -125,6 +125,10 @@ CONFIG_BT_ID_MAX=3
 CONFIG_BT_CTLR_SDC_LLPM=y
 CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 
+# Workaround for the MPSL assert issue.
+# This assert occurs when the HFCLK is not ready within the timeframe expected by MPSL.
+CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL=y
+
 # External FLASH is not used by the application. Disable the driver.
 CONFIG_SPI_NOR=n
 

--- a/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/prj_llvm.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/prj_llvm.conf
@@ -129,6 +129,10 @@ CONFIG_BT_ID_MAX=3
 CONFIG_BT_CTLR_SDC_LLPM=y
 CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 
+# Workaround for the MPSL assert issue.
+# This assert occurs when the HFCLK is not ready within the timeframe expected by MPSL.
+CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL=y
+
 # External FLASH is not used by the application. Disable the driver.
 CONFIG_SPI_NOR=n
 

--- a/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/prj_release.conf
@@ -121,6 +121,10 @@ CONFIG_BT_ID_MAX=3
 CONFIG_BT_CTLR_SDC_LLPM=y
 CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 
+# Workaround for the MPSL assert issue.
+# This assert occurs when the HFCLK is not ready within the timeframe expected by MPSL.
+CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL=y
+
 # External FLASH is not used by the application. Disable the driver.
 CONFIG_SPI_NOR=n
 


### PR DESCRIPTION
Enabled the workaround for the MPSL assert issue that occured for the nRF54LM20 PDK in the nRF Desktop application.

Ref: NCSDK-34000