### PR TITLE
move mramc dtsi to secure dtsi

### DIFF
--- a/dts/common/nordic/nrf7120_enga.dtsi
+++ b/dts/common/nordic/nrf7120_enga.dtsi
@@ -812,28 +812,6 @@
 				status = "disabled";
 			};
 
-			mram_controller: mram-controller@0x5004e000 {
-				compatible = "nordic,mram-controller";
-				reg = <0x5004e000 0x1000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
-				interrupts = <78 NRF_DEFAULT_IRQ_PRIORITY>;
-
-				cpuapp_mram: mram@0 {
-					compatible = "nordic,mram";
-					reg = <0 DT_SIZE_K(3972)>;
-					erase-block-size = <4096>;
-					write-block-size = <4>;
-				};
-
-				cpuflpr_mram: mram@3e1000 {
-					compatible = "nordic,mram";
-					reg = <0x3e1000 DT_SIZE_K(116)>;
-					erase-block-size = <4096>;
-					write-block-size = <4>;
-				};
-			};
-
 			cpuapp_ppb: cpuapp-ppb-bus {
 				#address-cells = <1>;
 				#size-cells = <1>;

--- a/dts/common/nordic/nrf7120_enga_secure_peripherals.dtsi
+++ b/dts/common/nordic/nrf7120_enga_secure_peripherals.dtsi
@@ -21,6 +21,28 @@ kmu: kmu@49000 {
 	status = "disabled";
 };
 
+mram_controller: mram-controller@4e000 {
+	compatible = "nordic,mram-controller";
+	reg = <0x4e000 0x1000>;
+	#address-cells = <1>;
+	#size-cells = <1>;
+	interrupts = <78 NRF_DEFAULT_IRQ_PRIORITY>;
+
+	cpuapp_mram: mram@0 {
+		compatible = "soc-nv-flash";
+		reg = <0 DT_SIZE_K(3972)>;
+		erase-block-size = <4096>;
+		write-block-size = <4>;
+	};
+
+	cpuflpr_mram: mram@3e1000 {
+		compatible = "soc-nv-flash";
+		reg = <0x3e1000 DT_SIZE_K(116)>;
+		erase-block-size = <4096>;
+		write-block-size = <4>;
+	};
+};
+
 spu10: spu@80000 {
 	compatible = "nordic,nrf-spu";
 	reg = <0x80000 0x1000>;


### PR DESCRIPTION
move mram-controller dtsi to secure_peripherals.dtsi as it is secure, bind compatible of mram node to soc-nv-flash as to differentiate driver from nrf54h20.