### PR TITLE
bluetooth: hci: Replace bt_hci_cmd_create() with bt_hci_cmd_alloc()

### DIFF
--- a/subsys/bluetooth/adv_prov/providers/tx_power.c
+++ b/subsys/bluetooth/adv_prov/providers/tx_power.c
@@ -26,7 +26,7 @@ static int get_data(struct bt_data *ad, const struct bt_le_adv_prov_adv_state *s
 	struct bt_hci_cp_vs_read_tx_power_level *cp;
 	struct bt_hci_rp_vs_read_tx_power_level *rp;
 	struct net_buf *rsp = NULL;
-	struct net_buf *cmd_buf = bt_hci_cmd_create(BT_HCI_OP_VS_READ_TX_POWER_LEVEL, sizeof(*cp));
+	struct net_buf *cmd_buf = bt_hci_cmd_alloc(K_FOREVER);
 
 	if (!cmd_buf) {
 		return -ENOBUFS;

--- a/subsys/bluetooth/hci_vs_sdc.c
+++ b/subsys/bluetooth/hci_vs_sdc.c
@@ -28,7 +28,7 @@ static int hci_vs_cmd_no_rsp(uint16_t opcode, const void *params, size_t params_
 {
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(opcode, params_size);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOMEM;
 	}
@@ -45,7 +45,7 @@ static int hci_vs_cmd_with_rsp(
 	struct net_buf *buf;
 	struct net_buf *rsp_buf;
 
-	buf = bt_hci_cmd_create(opcode, params_size);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOMEM;
 	}

--- a/subsys/bluetooth/host_extensions/host_extensions.c
+++ b/subsys/bluetooth/host_extensions/host_extensions.c
@@ -46,7 +46,7 @@ int bt_conn_set_remote_tx_power_level(struct bt_conn *conn,
 		return err;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_SET_REMOTE_TX_POWER, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -69,7 +69,7 @@ int bt_conn_set_power_control_request_params(struct bt_conn_set_pcr_params *para
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_SET_POWER_CONTROL_REQUEST_PARAMS, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/subsys/bluetooth/rpc/host/bt_rpc_internal_host.c
+++ b/subsys/bluetooth/rpc/host/bt_rpc_internal_host.c
@@ -104,7 +104,7 @@ static void bt_hci_cmd_send_sync_rpc_handler(const struct nrf_rpc_group *group,
 	} else {
 		NRF_RPC_SCRATCHPAD_DECLARE(&scratchpad, ctx);
 		len = nrf_rpc_decode_uint(ctx);
-		buf = bt_hci_cmd_create(opcode, len);
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			ret = -ENOBUFS;
 		} else {

--- a/subsys/bluetooth/services/fast_pair/fmdn/state.c
+++ b/subsys/bluetooth/services/fast_pair/fmdn/state.c
@@ -580,7 +580,7 @@ static int fmdn_tx_power_set(uint16_t handle, int8_t *tx_power)
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_VS_WRITE_TX_POWER_LEVEL, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		LOG_ERR("FMDN State: cannot allocate buffer to set TX power");
 		return -ENOMEM;


### PR DESCRIPTION
Adapt to upstream zephyr host hci changes.