### PR TITLE
nrf_security: drivers: cracen: avoid empty unions

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
@@ -379,6 +379,7 @@ struct cracen_pake_operation {
 #ifdef CONFIG_PSA_NEED_CRACEN_SPAKE2P
 		cracen_spake2p_operation_t cracen_spake2p_ctx;
 #endif /* CONFIG_PSA_NEED_CRACEN_SPAKE2P */
+		uint8_t _unused;
 	};
 };
 typedef struct cracen_pake_operation cracen_pake_operation_t;


### PR DESCRIPTION
Empty unions are interpreted differently in C and C++:
- in C, they have size 0
- in C++, they have size 1.

This raises a warning when building with clang.