### PR TITLE
tests: nrf_compress: Add nrf54h20 test support

### DIFF
--- a/tests/subsys/nrf_compress/decompression/arm_thumb/testcase.yaml
+++ b/tests/subsys/nrf_compress/decompression/arm_thumb/testcase.yaml
@@ -11,10 +11,12 @@ common:
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf54h20dk/nrf54h20/cpuapp
   integration_platforms:
     - native_sim
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf54h20dk/nrf54h20/cpuapp
 tests:
   nrf_compress.decompression.arm_thumb.static: {}

--- a/tests/subsys/nrf_compress/decompression/lzma/testcase.yaml
+++ b/tests/subsys/nrf_compress/decompression/lzma/testcase.yaml
@@ -11,11 +11,13 @@ common:
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf54h20dk/nrf54h20/cpuapp
   integration_platforms:
     - native_sim
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf54h20dk/nrf54h20/cpuapp
 tests:
   nrf_compress.decompression.lzma.static: {}
   nrf_compress.decompression.lzma.dynamic:

--- a/tests/subsys/nrf_compress/decompression/mcuboot_update/Kconfig
+++ b/tests/subsys/nrf_compress/decompression/mcuboot_update/Kconfig
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-config UPDATE_SLOT_NUMBER
+config UPDATE_IMAGE_NUMBER
 	int "Image update number"
-	range 0 3
+	range 0 1
 	default 0
 	help
 	  Should be set to the image containing the firmware to mark for upgrade

--- a/tests/subsys/nrf_compress/decompression/mcuboot_update/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/subsys/nrf_compress/decompression/mcuboot_update/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,code-partition = &cpuapp_slot0_partition;
+	};
+};
+
+/delete-node/ &cpuapp_slot0_partition;
+/delete-node/ &cpuapp_slot1_partition;
+
+&mram1x {
+	partitions {
+		cpuapp_slot0_partition: partition@40000 {
+			reg = <0x40000 DT_SIZE_K(580)>;
+		};
+
+		cpuapp_slot1_partition: partition@D1000 {
+			reg = <0xD1000 DT_SIZE_K(580)>;
+		};
+	};
+};
+
+slot0_partition: &cpuapp_slot0_partition {
+	label = "image-0";
+};
+
+slot1_partition: &cpuapp_slot1_partition {
+	label = "image-1";
+};

--- a/tests/subsys/nrf_compress/decompression/mcuboot_update/modified_signing.cmake
+++ b/tests/subsys/nrf_compress/decompression/mcuboot_update/modified_signing.cmake
@@ -15,3 +15,7 @@ set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
              ${CMAKE_OBJCOPY} -I ihex -O ihex --change-addresses 0x91000
              ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.signed.hex ${output})
 set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts ${output})
+
+if(NOT SB_CONFIG_PARTITION_MANAGER)
+  zephyr_runner_file(hex ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.moved.signed.hex)
+endif()

--- a/tests/subsys/nrf_compress/decompression/mcuboot_update/src/main.c
+++ b/tests/subsys/nrf_compress/decompression/mcuboot_update/src/main.c
@@ -13,15 +13,22 @@
 #include <zephyr/sys/byteorder.h>
 
 #include <bootutil/image.h>
+#include <zephyr/devicetree.h>
 
 LOG_MODULE_REGISTER(mcuboot_update, LOG_LEVEL_DBG);
 
-#define UPDATE_SLOT_NUMBER CONFIG_UPDATE_SLOT_NUMBER
-
-#if CONFIG_UPDATE_SLOT_NUMBER == 0
+#if defined(CONFIG_PARTITION_MANAGER_ENABLED)
+#if CONFIG_UPDATE_IMAGE_NUMBER == 0
 #define UPDATE_SLOT_ID PM_MCUBOOT_SECONDARY_ID
 #else
-#define UPDATE_SLOT_ID PM_MCUBOOT_SECONDARY_ ## CONFIG_UPDATE_SLOT_NUMBER ## _ID
+#define UPDATE_SLOT_ID PM_MCUBOOT_SECONDARY_ ## CONFIG_UPDATE_IMAGE_NUMBER ## _ID
+#endif
+#else
+#if CONFIG_UPDATE_IMAGE_NUMBER == 0
+#define UPDATE_SLOT_ID DT_FIXED_PARTITION_ID(DT_NODELABEL(slot1_partition))
+#else
+#define UPDATE_SLOT_ID DT_FIXED_PARTITION_ID(DT_NODELABEL(slot3_partition))
+#endif
 #endif
 
 int main(void)
@@ -64,10 +71,10 @@ int main(void)
 		return 0;
 	}
 
-	rc = boot_request_upgrade_multi(UPDATE_SLOT_NUMBER, true);
+	rc = boot_request_upgrade_multi(CONFIG_UPDATE_IMAGE_NUMBER, true);
 
 	if (rc) {
-		LOG_ERR("Update of image %d failed: %d", UPDATE_SLOT_NUMBER, rc);
+		LOG_ERR("Update of image %d failed: %d", CONFIG_UPDATE_IMAGE_NUMBER, rc);
 		k_sleep(K_SECONDS(1));
 
 		return 0;

--- a/tests/subsys/nrf_compress/decompression/mcuboot_update/sysbuild/mcuboot/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/tests/subsys/nrf_compress/decompression/mcuboot_update/sysbuild/mcuboot/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SPI_NOR=n
+
+CONFIG_FPROTECT=n
+
+CONFIG_BOOT_WATCHDOG_FEED=n

--- a/tests/subsys/nrf_compress/decompression/mcuboot_update/sysbuild/mcuboot/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/subsys/nrf_compress/decompression/mcuboot_update/sysbuild/mcuboot/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf54h20dk_nrf54h20_cpuapp.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/tests/subsys/nrf_compress/decompression/mcuboot_update/testcase.yaml
+++ b/tests/subsys/nrf_compress/decompression/mcuboot_update/testcase.yaml
@@ -9,10 +9,12 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     harness: console
     harness_config:
       type: multi_line


### PR DESCRIPTION
This PR provides support for the nrf54h20dk board in the nrf_compress decompression tests.

Additional changes:
- 'main.c' - support no Partition Manager builds
- 'Kconfig' - clarify the meaning of the 'CONFIG_UPDATE_IMAGE_NUMBER' option, which is used to select the image to be updated in the mcuboot_update test. Also, no more than two images are needed.

Related: NCSDK-33627