### PR TITLE
applications: serial_lte_modem: Improve parameter parsing

### DIFF
--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -118,8 +118,8 @@ static int do_ftp_open(enum at_parser_cmd_type cmd_type, struct at_parser *parse
 	int sz_password = sizeof(password);
 	char hostname[SLM_MAX_URL];
 	int sz_hostname = sizeof(hostname);
-	uint16_t port = FTP_DEFAULT_PORT;
-	sec_tag_t sec_tag = INVALID_SEC_TAG;
+	uint16_t port;
+	sec_tag_t sec_tag;
 
 	/* Parse AT command */
 	ret = util_string_get(parser, 2, username, &sz_username);
@@ -136,17 +136,13 @@ static int do_ftp_open(enum at_parser_cmd_type cmd_type, struct at_parser *parse
 	if (ret) {
 		return ret;
 	}
-	if (param_count > 5) {
-		ret = at_parser_num_get(parser, 5, &port);
-		if (ret) {
-			return ret;
-		}
+	ret = util_get_num_with_default(parser, 5, param_count, FTP_DEFAULT_PORT, &port);
+	if (ret) {
+		return ret;
 	}
-	if (param_count > 6) {
-		ret = at_parser_num_get(parser, 6, &sec_tag);
-		if (ret) {
-			return ret;
-		}
+	ret = util_get_num_with_default(parser, 6, param_count, INVALID_SEC_TAG, &sec_tag);
+	if (ret) {
+		return ret;
 	}
 
 	/* FTP open */

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -490,8 +490,8 @@ static int handle_at_mqtt_config(enum at_parser_cmd_type cmd_type, struct at_par
 				 uint32_t param_count)
 {
 	int err = -EINVAL;
-	uint16_t keep_alive = CONFIG_MQTT_KEEPALIVE;
-	uint16_t clean_session = CONFIG_MQTT_CLEAN_SESSION;
+	uint16_t keep_alive;
+	uint16_t clean_session;
 
 	switch (cmd_type) {
 	case AT_PARSER_CMD_TYPE_SET:
@@ -501,17 +501,15 @@ static int handle_at_mqtt_config(enum at_parser_cmd_type cmd_type, struct at_par
 		if (err) {
 			return err;
 		}
-		if (param_count > 2) {
-			err = at_parser_num_get(parser, 2, &keep_alive);
-			if (err) {
-				return err;
-			}
+		err = util_get_num_with_default(parser, 2, param_count,
+					 CONFIG_MQTT_KEEPALIVE, &keep_alive);
+		if (err) {
+			return err;
 		}
-		if (param_count > 3) {
-			err = at_parser_num_get(parser, 3, &clean_session);
-			if (err) {
-				return err;
-			}
+		err = util_get_num_with_default(parser, 3, param_count,
+					 CONFIG_MQTT_CLEAN_SESSION, &clean_session);
+		if (err) {
+			return err;
 		}
 		err = do_mqtt_config(keep_alive, (uint8_t)clean_session);
 		break;
@@ -574,12 +572,10 @@ static int handle_at_mqtt_connect(enum at_parser_cmd_type cmd_type, struct at_pa
 			if (err) {
 				return err;
 			}
-			ctx.sec_tag = INVALID_SEC_TAG;
-			if (param_count > 6) {
-				err = at_parser_num_get(parser, 6, &ctx.sec_tag);
-				if (err) {
-					return err;
-				}
+			err = util_get_num_with_default(parser, 6, param_count, INVALID_SEC_TAG,
+							&ctx.sec_tag);
+			if (err) {
+				return err;
 			}
 			ctx.family = (op == MQTTC_CONNECT) ? AF_INET : AF_INET6;
 			err = do_mqtt_connect();
@@ -646,8 +642,8 @@ static int handle_at_mqtt_publish(enum at_parser_cmd_type cmd_type, struct at_pa
 {
 	int err = -EINVAL;
 
-	uint16_t qos = MQTT_QOS_0_AT_MOST_ONCE;
-	uint16_t retain = 0;
+	uint16_t qos;
+	uint16_t retain;
 	size_t topic_sz = MQTT_MAX_TOPIC_LEN;
 	uint8_t pub_msg[SLM_MAX_PAYLOAD_SIZE];
 	size_t msg_sz = sizeof(pub_msg);
@@ -669,19 +665,15 @@ static int handle_at_mqtt_publish(enum at_parser_cmd_type cmd_type, struct at_pa
 				return err;
 			}
 		}
-		if (param_count > 3) {
-			err = at_parser_num_get(parser, 3, &qos);
-			if (err) {
-				return err;
-			}
+		err = util_get_num_with_default(parser, 3, param_count, MQTT_QOS_0_AT_MOST_ONCE,
+						&qos);
+		if (err) {
+			return err;
 		}
-		if (param_count > 4) {
-			err = at_parser_num_get(parser, 4, &retain);
-			if (err) {
-				return err;
-			}
+		err = util_get_num_with_default(parser, 4, param_count, 0, &retain);
+		if (err) {
+			return err;
 		}
-
 		/* common publish parameters*/
 		if (qos <= MQTT_QOS_2_EXACTLY_ONCE) {
 			pub_param.message.topic.qos = (uint8_t)qos;

--- a/applications/serial_lte_modem/src/nrfcloud/slm_at_nrfcloud.c
+++ b/applications/serial_lte_modem/src/nrfcloud/slm_at_nrfcloud.c
@@ -551,7 +551,7 @@ static int handle_at_nrf_cloud(enum at_parser_cmd_type cmd_type, struct at_parse
 	};
 	int err = -EINVAL;
 	uint16_t op;
-	uint16_t send_location = 0;
+	bool send_location;
 
 	switch (cmd_type) {
 	case AT_PARSER_CMD_TYPE_SET:
@@ -560,14 +560,10 @@ static int handle_at_nrf_cloud(enum at_parser_cmd_type cmd_type, struct at_parse
 			return err;
 		}
 		if (op == SLM_NRF_CLOUD_CONNECT && !slm_nrf_cloud_ready) {
-			if (param_count > 2) {
-				err = at_parser_num_get(parser, 2, &send_location);
-				if (send_location != 0 && send_location != 1) {
-					err = -EINVAL;
-				}
-				if (err < 0) {
-					return err;
-				}
+			err = util_get_bool_with_default(parser, 2, param_count, false,
+							 &send_location);
+			if (err) {
+				return err;
 			}
 			/* Disconnect for the case where a connection previously
 			 * got initiated and failed to receive NRF_CLOUD_EVT_READY.

--- a/applications/serial_lte_modem/src/slm_at_icmp.c
+++ b/applications/serial_lte_modem/src/slm_at_icmp.c
@@ -539,26 +539,23 @@ static int handle_at_icmp_ping(enum at_parser_cmd_type cmd_type, struct at_parse
 		if (err < 0) {
 			return err;
 		}
-		ping_argv.count = 1; /* default 1 */
-		if (param_count > 4) {
-			err = at_parser_num_get(parser, 4, &ping_argv.count);
-			if (err < 0) {
-				return err;
-			};
+
+		/* Default 1 */
+		err = util_get_num_with_default(parser, 4, param_count, 1, &ping_argv.count);
+		if (err) {
+			return err;
 		}
-		ping_argv.interval = 1000; /* default 1s */
-		if (param_count > 5) {
-			err = at_parser_num_get(parser, 5, &ping_argv.interval);
-			if (err < 0) {
-				return err;
-			};
+
+		/* Default 1s */
+		err = util_get_num_with_default(parser, 5, param_count, 1000, &ping_argv.interval);
+		if (err) {
+			return err;
 		}
-		ping_argv.pdn = 0; /* default 0 primary PDN */
-		if (param_count > 6) {
-			err = at_parser_num_get(parser, 6, &ping_argv.pdn);
-			if (err < 0) {
-				return err;
-			};
+
+		/* Default 0 for primary PDN */
+		err = util_get_num_with_default(parser, 6, param_count, 0, &ping_argv.pdn);
+		if (err) {
+			return err;
 		}
 
 		err = ping_test_handler(target);

--- a/applications/serial_lte_modem/src/slm_util.h
+++ b/applications/serial_lte_modem/src/slm_util.h
@@ -189,8 +189,72 @@ int util_resolve_host(int cid, const char *host, uint16_t port, int family, stru
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-
 int util_get_peer_addr(struct sockaddr *peer, char addr[static INET6_ADDRSTRLEN], uint16_t *port);
+
+/**
+ * @brief Get a number from the AT parser with a default value.
+ *
+ * This macro is used to get a number from the AT parser, and it will
+ * call the appropriate function based on the type of the value pointer.
+ *
+ * @param[in] parser AT parser.
+ * @param[in] param_index Index of the parameter to get.
+ * @param[in] param_count Total number of parameters in the AT command.
+ * @param[in] default_value Default value to return if the parameter is not present.
+ * @param[out] value Pointer to store the retrieved value.
+ *
+ * @retval 0 If the operation was successful.
+ *          Otherwise, a (negative) error code is returned.
+ */
+#define util_get_num_with_default(parser, param_index, param_count, default_value, value)          \
+	_Generic((value),                                                                          \
+		uint16_t * : util_get_uint16_with_default,                                         \
+		int32_t * : util_get_int32_with_default)(parser, param_index, param_count,         \
+							default_value, value)
+
+/**
+ * @brief Get a 16-bit unsigned number from the AT parser with a default value.
+ * @param[in] parser AT parser.
+ * @param[in] param_index Index of the parameter to get.
+ * @param[in] param_count Total number of parameters in the AT command.
+ * @param[in] default_value Default value to return if the parameter is not present.
+ * @param[out] value Pointer to store the retrieved value.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int util_get_uint16_with_default(struct at_parser *parser, uint32_t param_index,
+				 uint32_t param_count, uint16_t default_value, uint16_t *value);
+
+/**
+ * @brief Get a 32-bit signed number from the AT parser with a default value.
+ *
+ * @param[in] parser AT parser.
+ * @param[in] param_index Index of the parameter to get.
+ * @param[in] param_count Total number of parameters in the AT command.
+ * @param[in] default_value Default value to return if the parameter is not present.
+ * @param[out] value Pointer to store the retrieved value.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int util_get_int32_with_default(struct at_parser *parser, uint32_t param_index,
+				uint32_t param_count, int32_t default_value, int32_t *value);
+
+/**
+ * @brief Get a boolean value from the AT parser with a default value.
+ * @param[in] parser AT parser.
+ * @param[in] param_index Index of the parameter to get.
+ * @param[in] param_count Total number of parameters in the AT command.
+ * @param[in] default_value Default value to return if the parameter is not present.
+ * @param[out] value Pointer to store the retrieved boolean value.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int util_get_bool_with_default(struct at_parser *parser, uint32_t param_index, uint32_t param_count,
+			       bool default_value, bool *value);
+
 /** @} */
 
 #endif /* SLM_UTIL_ */


### PR DESCRIPTION
Add wrappers for parsing the optional parameters with default values. Parameters which are not given or for which an empty value is given (,,) use the default value.