### PR TITLE
applications: nrf_desktop: Use warning log on HID report sent error

### DIFF
--- a/applications/nrf_desktop/src/modules/hid_provider_consumer_ctrl.c
+++ b/applications/nrf_desktop/src/modules/hid_provider_consumer_ctrl.c
@@ -184,7 +184,7 @@ static void consumer_ctrl_report_sent(uint8_t report_id, bool error)
 	__ASSERT_NO_MSG(active_sub);
 
 	if (error) {
-		LOG_ERR("HID report send error");
+		LOG_WRN("Error while sending report");
 		/* HID state will try to send next HID consumer control report to refresh state. */
 		report_data.update_needed = true;
 	}

--- a/applications/nrf_desktop/src/modules/hid_provider_keyboard.c
+++ b/applications/nrf_desktop/src/modules/hid_provider_keyboard.c
@@ -230,7 +230,7 @@ static void keyboard_report_sent(uint8_t report_id, bool error)
 			((report_id == REPORT_ID_BOOT_KEYBOARD) && boot_mode));
 
 	if (error) {
-		LOG_ERR("HID report send error");
+		LOG_WRN("Error while sending report");
 		/* HID state will try to send next HID keyboard report to refresh state. */
 		report_data.update_needed = true;
 	}

--- a/applications/nrf_desktop/src/modules/hid_provider_mouse.c
+++ b/applications/nrf_desktop/src/modules/hid_provider_mouse.c
@@ -263,7 +263,7 @@ static void mouse_report_sent(uint8_t report_id, bool error)
 	report_data.pipeline_cnt--;
 
 	if (error) {
-		LOG_ERR("HID report send error");
+		LOG_WRN("Error while sending report");
 		/* HID state will send subsequent HID mouse report to update state. No need to do
 		 * anything.
 		 */

--- a/applications/nrf_desktop/src/modules/hid_provider_system_ctrl.c
+++ b/applications/nrf_desktop/src/modules/hid_provider_system_ctrl.c
@@ -184,7 +184,7 @@ static void system_ctrl_report_sent(uint8_t report_id, bool error)
 	__ASSERT_NO_MSG(active_sub);
 
 	if (error) {
-		LOG_ERR("HID report send error");
+		LOG_WRN("Error while sending report");
 		/* HID state will try to send next HID system control report to refresh state. */
 		report_data.update_needed = true;
 	}


### PR DESCRIPTION
The HID report sent error may be reported while disconnecting HID transport (BLE/USB), it may not be related to actual error. Switch from error log level to warning log level.

Jira: NCSDK-33593