### PR TITLE
doc: crypto: fix undefined Kconfig references

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -647,8 +647,8 @@
 .. _`CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED`: https://docs.nordicsemi.com/bundle/ncs-latest/page/kconfig/index.html#!CONFIG_SSF_PSA_CRYPTO_SERVICE_ENABLED
 .. _`Matter factory data Kconfig options`: https://docs.nordicsemi.com/bundle/ncs-latest/page/kconfig/index.html#!CHIP_FACTORY_DATA
 .. _`Kconfig search results`: https://docs.nordicsemi.com/bundle/ncs-latest/page/kconfig/index.html#!CONFIG_PM_PARTITION_SIZE
-.. _`CONFIG_PSA_WANT_*`: https://docs.nordicsemi.com/bundle/ncs-latest/page/kconfig/index.html#!CONFIG_PSA_WANT_
-.. _`CONFIG_PSA_USE_*`: https://docs.nordicsemi.com/bundle/ncs-latest/page/kconfig/index.html#!CONFIG_PSA_USE_
+.. _`CONFIG_PSA_WANT_*`: https://docs.nordicsemi.com/bundle/ncs-latest/page/kconfig/index.html#!CONFIG_PSA_WANT_*
+.. _`CONFIG_PSA_USE_*`: https://docs.nordicsemi.com/bundle/ncs-latest/page/kconfig/index.html#!CONFIG_PSA_USE_*
 
 .. _`Threads`: https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/kernel/services/threads/index.html
 

--- a/doc/nrf/security/crypto/crypto_supported_features.rst
+++ b/doc/nrf/security/crypto/crypto_supported_features.rst
@@ -34,7 +34,7 @@ Cryptographic feature support
 The following sections list the supported cryptographic features and algorithms for each of the drivers: :ref:`nrf_cc3xx <crypto_drivers_cc3xx>`, :ref:`CRACEN <crypto_drivers_cracen>`, and :ref:`nrf_oberon <crypto_drivers_oberon>`.
 The listed Kconfig options enable the features and algorithms for the drivers that support them.
 
-The Kconfig options follow the ``CONFIG_PSA_WANT_`` + ``CONFIG_PSA_USE_`` configuration scheme, which is described in detail on the :ref:`crypto_drivers` page.
+The Kconfig options follow the ``CONFIG_PSA_WANT_*`` + ``CONFIG_PSA_USE_*`` configuration scheme, which is described in detail on the :ref:`crypto_drivers` page.
 
 Key types and key management
 ============================
@@ -1059,7 +1059,7 @@ Key pair operations
 ===================
 
 The following sections list the supported key pair operation Kconfig options for different key types.
-The Kconfig options follow the ``CONFIG_PSA_WANT_`` configuration scheme, which is described in detail on the :ref:`crypto_drivers` page.
+The Kconfig options follow the ``CONFIG_PSA_WANT_*`` configuration scheme, which is described in detail on the :ref:`crypto_drivers` page.
 
 RSA key pair operations
 -----------------------
@@ -1207,7 +1207,7 @@ Key size configurations
 =======================
 
 The following sections list the supported AES and RSA key size Kconfig options.
-The Kconfig options follow the ``CONFIG_PSA_WANT_`` configuration scheme, which is described in detail on the :ref:`crypto_drivers` page.
+The Kconfig options follow the ``CONFIG_PSA_WANT_*`` configuration scheme, which is described in detail on the :ref:`crypto_drivers` page.
 
 AES key size configuration
 --------------------------

--- a/doc/nrf/security/crypto/driver_config.rst
+++ b/doc/nrf/security/crypto/driver_config.rst
@@ -112,9 +112,7 @@ When multiple enabled drivers support the same cryptographic feature, the config
 Configuring cryptographic features
 **********************************
 
-You can enable a cryptographic feature or algorithm using `CONFIG_PSA_WANT_*`_ Kconfig options, which are specific for PSA Crypto API configurations.
-For example, to enable the AES algorithm, set the :kconfig:option:`CONFIG_PSA_WANT_ALG_AES` Kconfig option.
-
+You can enable a cryptographic feature or algorithm using `CONFIG_PSA_WANT_*`_ and `CONFIG_PSA_USE_*`_ Kconfig options, which are specific to the :ref:`feature selection mechanism <crypto_drivers_feature_selection>` of the PSA Crypto API.
 For a list of supported cryptographic features and algorithms and the Kconfig options to enable them, see :ref:`ug_crypto_supported_features`.
 
 Building PSA Crypto API

--- a/doc/nrfxlib/nrfxlib.doxyfile.in
+++ b/doc/nrfxlib/nrfxlib.doxyfile.in
@@ -2403,7 +2403,6 @@ INCLUDE_FILE_PATTERNS  =
 
 PREDEFINED             = __DOXYGEN__ \
                          "MBEDTLS_CONFIG_FILE=\"@OUTPUT_DIRECTORY@/mbedtls_doxygen_config.h\"" \
-                         "CONFIG_MBEDTLS_VANILLA_BACKEND=y" \
                          "CONFIG_CC3XX_BACKEND=y" \
                          "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "CONFIG_THREAD_MONITOR=y" \


### PR DESCRIPTION
Fixed undefined Kconfig option references in crypto docs in sdk-nrf. NCSDK-34361.