### PR TITLE
mpsl: fem: enable simple_gpio for nRF54L series

### DIFF
--- a/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
+++ b/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
@@ -73,7 +73,10 @@ static int fem_simple_gpio_configure(void)
 			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(ctx_gpios),
-			.gpiote_ch_id  = ctx_gpiote_channel
+			.gpiote_ch_id  = ctx_gpiote_channel,
+#if defined(NRF54L_SERIES)
+			.p_gpiote = ctx_gpiote.p_reg,
+#endif
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif
@@ -87,7 +90,10 @@ static int fem_simple_gpio_configure(void)
 			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(crx_gpios),
-			.gpiote_ch_id  = crx_gpiote_channel
+			.gpiote_ch_id  = crx_gpiote_channel,
+#if defined(NRF54L_SERIES)
+			.p_gpiote = crx_gpiote.p_reg,
+#endif
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif


### PR DESCRIPTION
The `simple_gpio` Front-End Module is enabled for nRF54L Series devices.

Note: The simple_gpio FEM for nRF54L requires an MPSL that supports the simple_gpio. This PR changes only necessary parts in the sdk-nrf.