### PR TITLE
boards: nrf7120pdk: Add Wi-Fi IPC support

### DIFF
--- a/boards/nordic/nrf7120pdk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120pdk/nrf7120_cpuapp_common.dtsi
@@ -20,6 +20,54 @@
 		zephyr,ieee802154 = &ieee802154;
 		zephyr,wifi = &wlan0;
 	};
+
+	/* TODO: Fine tune the sizes */
+	ipc_shm_area_cpuapp_cpuuma: memory@200C0000 {
+		compatible = "mmio-sram";
+		reg = <0x200C0000 0x2000>;
+		ranges = <0x0 0x200C0000 0x2000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		status = "okay";
+
+		ipc_shm_cpuapp_cpuuma_0: memory@0 {
+			reg = <0x0 DT_SIZE_K(2)>;
+		};
+
+		ipc_shm_cpuuma_cpuapp_0: memory@800 {
+			reg = <0x800 DT_SIZE_K(2)>;
+		};
+
+		ipc_shm_cpuapp_cpuuma_1: memory@1000 {
+			reg = <0x1000 DT_SIZE_K(2)>;
+		};
+
+		ipc_shm_cpuuma_cpuapp_1: memory@1800 {
+			reg = <0x1800 DT_SIZE_K(2)>;
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			tx-region = <&ipc_shm_cpuapp_cpuuma_0>;
+			rx-region = <&ipc_shm_cpuuma_cpuapp_0>;
+			mboxes = <&wifi_bellboard 2>,
+					 <&cpuapp_bellboard 0>;
+			mbox-names = "tx", "rx";
+			status = "okay";
+		};
+
+		ipc1: ipc1 {
+			compatible = "zephyr,ipc-icmsg";
+			tx-region = <&ipc_shm_cpuapp_cpuuma_1>;
+			rx-region = <&ipc_shm_cpuuma_cpuapp_1>;
+			mboxes = <&wifi_bellboard 3>,
+					 <&cpuapp_bellboard 1>;
+			mbox-names = "tx", "rx";
+			status = "okay";
+		};
+	};
 };
 
 &cpuapp_sram {
@@ -133,5 +181,13 @@
 };
 
 &wifi {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};
+
+&wifi_bellboard {
 	status = "okay";
 };


### PR DESCRIPTION
Add support for IPC between APP and UMA, this is essential for Wi-Fi operation. This is still using RAM_01, will be migrated to RAM_02 in the future.