### PR TITLE
dts: common: nordic: Add reg parameter for global_peripherals node

### DIFF
--- a/dts/common/nordic/nrf54lm20a.dtsi
+++ b/dts/common/nordic/nrf54lm20a.dtsi
@@ -119,6 +119,7 @@
 		};
 
 		global_peripherals: peripheral@50000000 {
+			reg = <0x50000000 0x10000000>;
 			ranges = <0x0 0x50000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/common/nordic/nrf54lv10a.dtsi
+++ b/dts/common/nordic/nrf54lv10a.dtsi
@@ -112,11 +112,13 @@
 
  #ifdef USE_NON_SECURE_ADDRESS_MAP
 		global_peripherals: peripheral@40000000 {
+			reg = <0x40000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x40000000 0x10000000>;
  #else
 		global_peripherals: peripheral@50000000 {
+			reg = <0x50000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x50000000 0x10000000>;

--- a/dts/common/nordic/nrf7120_enga.dtsi
+++ b/dts/common/nordic/nrf7120_enga.dtsi
@@ -159,11 +159,13 @@
 
 #ifdef USE_NON_SECURE_ADDRESS_MAP
 		global_peripherals: peripheral@40000000 {
+			reg = <0x40000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x40000000 0x10000000>;
 #else
 		global_peripherals: peripheral@50000000 {
+			reg = <0x50000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x50000000 0x10000000>;


### PR DESCRIPTION
Add missing reg parameters to DTS nodes for:

- nrf54lm20a
- nrf54lv10a
- nrf7120