### PR TITLE
dfu_target: Do not erase last page in dfu_target_mcuboot_done

### DIFF
--- a/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
@@ -78,10 +78,6 @@ static const char *const secondary_name[] = {
 	LIST_DROP_EMPTY(LISTIFY(TARGET_IMAGE_COUNT, _MB_SEC_PAT_STRING, (,), NAME))
 };
 
-static const off_t secondary_last_address[] = {
-	LIST_DROP_EMPTY(LISTIFY(TARGET_IMAGE_COUNT, _MB_SEC_LA, (,)))
-};
-
 static const char *const target_id_name[] = {
 	LIST_DROP_EMPTY(LISTIFY(TARGET_IMAGE_COUNT, _STR_TARGET_NAME, (,)))
 };
@@ -187,13 +183,6 @@ int dfu_target_mcuboot_done(bool successful)
 
 	if (successful) {
 		stream_buf_bytes = 0;
-		err = stream_flash_flatten_page(dfu_target_stream_get_stream(),
-					secondary_last_address[curr_sec_img]);
-
-		if (err != 0) {
-			LOG_ERR("Unable to delete last page: %d", err);
-			return err;
-		}
 	} else {
 		LOG_INF("MCUBoot image upgrade aborted.");
 	}


### PR DESCRIPTION
Erasing the last page is already done before writing the trailer in dfu_target_mcuboot_schedule_update.

It seems the erasing comes from a time a couple of years ago when the page was not erased inside mcuboot. Currently the code was not necessary and it caused flash wear out.