### PR TITLE
nrf_security: CRACEN: Add workaround for trng on CRACEN lite

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/ba431regs.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/ba431regs.h
@@ -29,6 +29,10 @@
 #define BA431_REG_Key3_OFST			(0x1Cu)
 /** TestData: Test data register. */
 #define  BA431_REG_TestData_OFST                (0x20u)
+/** RepeatThreshold: Repetition test cut-off register. */
+#define  BA431_REG_REPEATTHRESHOLD              (0x24u)
+/** PropThreshold: Proportion test cut-off. */
+#define  BA431_REG_PROPTHRESHOLD                (0x28u)
 /** Status: Status register. */
 #define BA431_REG_Status_OFST			(0x30u)
 /** InitWaitVal: Initial wait counter value. */

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/trng.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/trng.c
@@ -27,6 +27,11 @@
 			  BA431_FLD_Control_HealthTestBypass_MASK | \
 			  BA431_FLD_Control_Conditioning_Bypass_MASK)
 
+#if defined(CONFIG_CRACEN_HW_VERSION_LITE)
+#define RNG_REPEATTHRESHOLD_VAL (21)
+#define RNG_PROPTESTCUTOFF_VAL	(311)
+#endif
+
 static int ba431_check_state(void)
 {
 	uint32_t state = sx_rd_trng(BA431_REG_Status_OFST);
@@ -114,6 +119,13 @@ int sx_trng_open(struct sx_trng *ctx, const struct sx_trng_config *config)
 	sx_wr_trng(BA431_REG_SwOffTmrVal_OFST, rng_off_timer_val);
 	sx_wr_trng(BA431_REG_ClkDiv_OFST, rng_clkdiv);
 	sx_wr_trng(BA431_REG_InitWaitVal_OFST, rng_init_wait_val);
+
+	/* CRACEN Lite has incorrect values for the TRNG tests. We update these here as a workaround
+	 */
+#if defined(CONFIG_CRACEN_HW_VERSION_LITE)
+	sx_wr_trng(BA431_REG_REPEATTHRESHOLD, RNG_REPEATTHRESHOLD_VAL);
+	sx_wr_trng(BA431_REG_PROPTHRESHOLD, RNG_PROPTESTCUTOFF_VAL);
+#endif /* CONFIG_CRACEN_HW_VERSION_LITE */
 
 	/* Configure the control register and set the enable bit */
 	control = (RNG_NB_128BIT_BLOCKS << BA431_FLD_Control_Nb128BitBlocks_LSB);


### PR DESCRIPTION
CRACEN lite has the wrong configuration for TRNG.
Add workaround to set these directly during startup of TRNG This might be possible to remove in the future