### PR TITLE
bluetooth: rpc: reclaim GATT buffer on bt_disable

### DIFF
--- a/subsys/bluetooth/rpc/client/bt_rpc_gap_client.c
+++ b/subsys/bluetooth/rpc/client/bt_rpc_gap_client.c
@@ -150,6 +150,10 @@ int bt_disable(void)
 	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_DISABLE_RPC_CMD, &ctx, nrf_rpc_rsp_decode_i32,
 				&result);
 
+	if (IS_ENABLED(CONFIG_BT_CONN) && (result == 0)) {
+		result = bt_rpc_gatt_uninit();
+	}
+
 	return result;
 }
 

--- a/subsys/bluetooth/rpc/client/bt_rpc_gatt_client.h
+++ b/subsys/bluetooth/rpc/client/bt_rpc_gatt_client.h
@@ -20,13 +20,24 @@ extern "C" {
 
 /** @brief Initialize GATT functionality over RPC.
  *
- * This function registers all GATT static services and its attribute on a host.
- * Serives are registered as dynamic services on a host.
+ * This function registers all GATT static services and its attributes on the host.
+ *
+ * @note On the host, the client's static services are represented as dynamic services.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
 int bt_rpc_gatt_init(void);
+
+/** @brief Uninitialize GATT functionality over RPC.
+ *
+ * This function reverses the operations performed by :c:func:`bt_rpc_gatt_init`.
+ * Specifically, it unregisters all GATT static services on the host.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int bt_rpc_gatt_uninit(void);
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/rpc/host/bt_rpc_gatt_host.c
+++ b/subsys/bluetooth/rpc/host/bt_rpc_gatt_host.c
@@ -740,6 +740,16 @@ static void bt_rpc_gatt_service_unregister_rpc_handler(const struct nrf_rpc_grou
 		result = bt_rpc_gatt_remove_service(svc);
 	}
 
+	if (!result && (bt_rpc_gatt_get_service_by_index(0) == NULL)) {
+		/*
+		 * The last service has been unregistered, so we can reclaim the entire GATT buffer.
+		 * Ideally, each dynamic service would use a separate buffer so that unregistering
+		 * a single service releases all its resources right away, but this requires
+		 * rewriting the GATT attribute memory management.
+		 */
+		net_buf_simple_reset(&gatt_buffer);
+	}
+
 	nrf_rpc_rsp_send_int(group, result);
 	return;
 decoding_error:


### PR DESCRIPTION
bt_enable() fails after a few bt_enable() -> bt_disable() cycles because:
1. bt_enable() registers static services on the host device
2. on the host, the service data is allocated from shared GATT memory buffer and the memory used by a service is never released.
3. eventually, the GATT memory buffer is exhausted and 1 fails.

Fix the most common scenario where only static services are used, or all dynamic services are registered at once by implementing the following changes:
1. in bt_disable(), unregister all static services
2. on the host, reset the GATT memory buffer if the last registered service has just been unregistered.