### PR TITLE
dts: bindings: Fix nRF7120 binding

### DIFF
--- a/dts/bindings/wifi/nordic,nrf7120.yaml
+++ b/dts/bindings/wifi/nordic,nrf7120.yaml
@@ -5,7 +5,7 @@ description: >
   This is a representation of the Wi-Fi parts of the nRF71 Series Wi-Fi and
   Bluetooth chip SoC.
 
-compatible: nordic,wifi71
+compatible: nordic,nrf7120
 
 include:
   - "wifi-tx-power-2g.yaml"

--- a/dts/common/nordic/nrf7120_enga.dtsi
+++ b/dts/common/nordic/nrf7120_enga.dtsi
@@ -852,7 +852,7 @@
 	};
 
 	wifi: wifi {
-		compatible = "nordic,wifi71";
+		compatible = "nordic,nrf7120";
 		status = "disabled";
 
 		wifi-max-tx-pwr-2g-dsss = <21>;


### PR DESCRIPTION
Fix below issues:

1. Binding file name should be same as compat
2. Use specific version for the compat instead of generic Series name.