### PR TITLE
bluetooth: controller: Set default ACL spacing when CS is used

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -174,7 +174,9 @@ config BT_CTLR_SDC_CONN_EVENT_EXTEND_DEFAULT
 config BT_CTLR_SDC_CENTRAL_ACL_EVENT_SPACING_DEFAULT
 	int "Default central ACL event spacing [us]"
 	depends on BT_CENTRAL
+	default 110000 if BT_ISO && BT_CTLR_CHANNEL_SOUNDING
 	default 30000 if BT_ISO
+	default 90000 if BT_CTLR_CHANNEL_SOUNDING
 	default BT_CTLR_SDC_MAX_CONN_EVENT_LEN_DEFAULT
 	help
 	  On the central, sets the time ACL connections are spaced apart assuming that


### PR DESCRIPTION
Set large default values for ACL spacing when CS is used. This will help provide better support for running CS on multiple links.

The default value of 80ms space reserved for non-ACL activity assumes a single subevent per event and 160 mode-3 steps with 128-bit payloads on 1M PHY, which takes about 79ms with the currently supported optional interlude timings on nordic devices.