### PR TITLE
scripts: memory-threshold: find_my: locator_tag: Add nRF54LM20 DK

### DIFF
--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -44,6 +44,7 @@
     - nrf5340dk/nrf5340/cpuapp/ns
     - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54lm20dk/nrf54lm20a/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
   rom_increase: 1024
   ram_increase: 1024


### PR DESCRIPTION
Added nrf54lm20dk/nrf54lm20a/cpuapp board target to the Find My Locator Tag sample targets in the memory threshold configuration.

Jira: NCSDK-34285