### PR TITLE
samples: radio_test:  Fixing mismatching description

### DIFF
--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -1365,7 +1365,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_transmit_pattern,
 		  "Set the transmission pattern to 11110000.",
 		  cmd_pattern_11110000),
 	SHELL_CMD(pattern_11001100, NULL,
-		  "Set the transmission pattern to 10101010.",
+		  "Set the transmission pattern to 11001100.",
 		  cmd_pattern_11001100),
 	SHELL_SUBCMD_SET_END
 );


### PR DESCRIPTION
Fixing mismatching description of radio pattern, non-functional change. User in devzone case 342657 reports this as something he was confused by.
This PR reintroduces https://github.com/nrfconnect/sdk-nrf/pull/22502 with commit details fixed.