### PR TITLE
docker: Use nrfutil device from toolchain bundle

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get install -y wget ca-certificates qemu-system-arm gi
     && rm -rf /var/lib/apt/lists/*
 RUN wget https://developer.nordicsemi.com/.pc-tools/nrfutil/x64-linux/nrfutil -q -O /usr/local/bin/nrfutil  \
     && chmod +x /usr/local/bin/nrfutil \
-    && nrfutil install device=2.8.8 \
     && nrfutil install toolchain-manager=0.15.0
 RUN nrfutil toolchain-manager install --toolchain-bundle-id $VERSION \
     && nrfutil toolchain-manager env --as-script > /opt/toolchain-env.sh \


### PR DESCRIPTION
Nrfutil device command is included in toolchain bundle.