### PR TITLE
doc: Added docs for available OT networking options in Matter

### DIFF
--- a/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
+++ b/doc/nrf/protocols/matter/getting_started/advanced_kconfigs.rst
@@ -359,3 +359,18 @@ For example, for the ``nrf52840dk/nrf52840`` board target and the :ref:`matter_l
 
   You can increase the UART speed using this snippet only for Nordic Development Kits.
   If you want to use the snippet for your custom board, you need to adjust the UART speed manually.
+
+.. _ug_matter_networking_selection:
+
+Networking layer selection
+==========================
+
+The |NCS| supports two networking architectures for the Matter protocol:
+
+* The Zephyr networking layer, which is enabled by default for Matter over Wi-Fi.
+  You can also enable this architecture for Matter over Thread by setting the :kconfig:option:`CONFIG_CHIP_USE_ZEPHYR_NETWORKING` Kconfig option to ``y``.
+* The APIs of the OpenThread stack and the IEEE 802.15.4 radio driver, which are enabled by default for Matter over Thread.
+  This architecture is not supported for Matter over Wi-Fi.
+  To enable it, set the :kconfig:option:`CONFIG_CHIP_USE_OPENTHREAD_ENDPOINT` Kconfig option to ``y``.
+
+To learn more about the available architectures and suitable use cases for the presented options, see the :ref:`openthread_stack_architecture` user guide.

--- a/doc/nrf/protocols/thread/configuring.rst
+++ b/doc/nrf/protocols/thread/configuring.rst
@@ -36,23 +36,21 @@ Thread requires the following Zephyr modules to properly operate in the |NCS|:
 Enable OpenThread in the |NCS|
 ==============================
 
-You can use the Thread protocol in the |NCS| in two ways: by utilizing the Zephyr networking layer, or by passing Thread frames directly to the nRF 802.15.4 radio driver.
+You can enable the Thread protocol in the |NCS| by using the Zephyr networking layer or by passing Thread frames directly to the nRF 802.15.4 radio driver.
 
 * To use the Thread protocol with Zephyr networking layer, enable the following Kconfig options:
 
   * :kconfig:option:`CONFIG_NETWORKING` - This option enables a generic link layer and the IP networking support.
   * :kconfig:option:`CONFIG_NET_L2_OPENTHREAD` - This option enables the OpenThread stack required for operating the Thread protocol effectively.
 
-* To use the Thread protocol and nRF 802.15.4 radio directly, disable the previous Kconfig options, and enable the following:
-
-  * :kconfig:option:`CONFIG_OPENTHREAD` - This option enables the OpenThread stack, allowing the direct use of the nRF 802.15.4 radio.
+* To use the Thread protocol and nRF 802.15.4 radio directly, disable the previous Kconfig options and enable the :kconfig:option:`CONFIG_OPENTHREAD` option.
+  This enables the OpenThread stack, allowing for direct use of the nRF 802.15.4 radio.
 
 To learn more about available architectures, see the :ref:`openthread_stack_architecture` user guide.
 
-Additionally, you can set the following Kconfig options:
-
-* :kconfig:option:`CONFIG_MPSL` - This option enables the :ref:`nrfxlib:mpsl` (MPSL) implementation, which provides services for both :ref:`single-protocol and multi-protocol implementations <ug_thread_architectures>`.
-  This is automatically set for all samples in the |NCS| that use the :ref:`zephyr:ieee802154_interface` radio driver.
+Additionally, you can set the :kconfig:option:`CONFIG_MPSL` Kconfig option.
+It enables the :ref:`nrfxlib:mpsl` (MPSL) implementation, which provides services for both :ref:`single-protocol and multi-protocol implementations <ug_thread_architectures>`.
+This is automatically set for all |NCS| samples that use the :ref:`zephyr:ieee802154_interface` radio driver.
 
 .. _ug_thread_select_libraries:
 .. _ug_thread_configuring_basic_building:
@@ -183,7 +181,7 @@ You can configure the EUI-64 for a device in the following ways depending on cho
 
         Replace the company ID
           You can enable the :kconfig:option:`CONFIG_IEEE802154_VENDOR_OUI_ENABLE` Kconfig option to replace Nordic Semiconductor's company ID with your own company ID.
-          Specify your company ID in :kconfig:option:`CONFIG_IEEE802154_VENDOR_OUI`.
+          Specify your company ID with the :kconfig:option:`CONFIG_IEEE802154_VENDOR_OUI` option.
 
           The extension identifier is set to the default, namely the DEVICEID from FICR.
 
@@ -220,7 +218,7 @@ You can configure the EUI-64 for a device in the following ways depending on cho
 
              If you used a different value for :kconfig:option:`CONFIG_IEEE802154_NRF5_UICR_EUI64_REG`, you must use different register addresses.
 
-             At the end of the configuration process, you can check the EUI-64 value using OpenThread CLI:
+             At the end of the configuration process, you can check the EUI-64 value using the OpenThread CLI as follows:
 
               .. code-block:: console
 
@@ -236,7 +234,7 @@ You can configure the EUI-64 for a device in the following ways depending on cho
 
         Replace the company ID
           You can enable the :kconfig:option:`CONFIG_IEEE802154_VENDOR_OUI_ENABLE` Kconfig option to replace Nordic Semiconductor's company ID with your own company ID.
-          Specify your company ID in :kconfig:option:`CONFIG_NRF5_VENDOR_OUI`.
+          Specify your company ID with the :kconfig:option:`CONFIG_NRF5_VENDOR_OUI` option.
 
           The extension identifier is set to the default, namely the DEVICEID from FICR.
 

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_3.1.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_3.1.rst
@@ -39,7 +39,7 @@ Matter
       * The :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH` Kconfig option has been introduced.
         Previously, the path to the ZAP file was deduced based on hardcoded locations.
         Now, the location is configured using the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH` Kconfig option.
-        This change requires you to update your application ``prj.conf`` file by setting the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH` option to point the location of you ZAP file.
+        This change requires you to update your application :file:`prj.conf` file by setting the :kconfig:option:`CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH` option to point to the location of you ZAP file.
 
    * For the :ref:`Matter light bulb <matter_light_bulb_sample>` sample:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -184,6 +184,9 @@ Matter
   * Matter-over-Thread apps can now use the OpenThread API directly, instead of using intermediate Zephyr L2 layer.
     This change significantly reduces memory usage in Matter applications.
     On the :zephyr:board:`nrf54l15dk`, it saves approximately 15 kB of RAM and 40 kB of flash.
+    To learn more about the new architecture option, see the :ref:`ug_matter_networking_selection` user guide.
+  * The :ref:`ug_matter_networking_selection` section on the :ref:`ug_matter_device_advanced_kconfigs` page.
+    The section describes how to select the networking layer for Matter applications.
 
 * Updated:
 


### PR DESCRIPTION
Added section about configuring Matter to work with and without Zephyr networking layer.