### PR TITLE
net: nrf_provisioning: Remove undefined Kconfig options

### DIFF
--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_http.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_http.h
@@ -64,15 +64,6 @@ struct nrf_provisioning_http_context {
 	 * CONFIG_REST_CLIENT_SCKT_RECV_TIMEOUT instead.
 	 */
 	int32_t timeout_ms;
-	/** Authentication string: Bearer Token
-	 * If no JWT is provided, and CONFIG_NRF_PROVISIONING_AUTOGEN_JWT
-	 * is enabled, then one will be generated automatically with
-	 * CONFIG_NRF_PROVISIONING_AUTOGEN_JWT_VALID_TIME_S as its lifetime in
-	 * seconds.
-	 * If Attestation Token based authentication is enabled leaving this empty is mandatory,
-	 * unless a static token is used for testing purposes.
-	 */
-	char *auth;
 	/** User allocated buffer for receiving API response, which
 	 * includes the HTTPS headers, any response data and a terminating
 	 * NULL.

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
@@ -50,10 +50,6 @@ static bool reschedule;
 /* nRF Provisioning context */
 static struct nrf_provisioning_http_context rest_ctx = {
 	.connect_socket = REST_CLIENT_SCKT_CONNECT,
-	.keep_alive = false,
-	.rx_buf = NULL,
-	.rx_buf_len = 0,
-	.auth = NULL,
 };
 
 /* nRF Provisioning context */


### PR DESCRIPTION
Remove references to undefined Kconfig options
CONFIG_NRF_PROVISIONING_AUTOGEN_JWT and
all structure members that were used to support it.

This is a follow up of https://github.com/nrfconnect/sdk-nrf/pull/23234
