### PR TITLE
Out of tree nrfutil runner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -733,6 +733,8 @@
 /scripts/partition_manager/*.rst          @nrfconnect/ncs-aurora-doc
 /scripts/shell/ble_console/**/*.rst       @nrfconnect/ncs-doc-leads
 /scripts/west_commands/sbom/*.rst         @nrfconnect/ncs-co-doc @nrfconnect/ncs-doc-leads
+/scripts/runners/nrf_common_next.py       @nrfconnect/ncs-ci
+/scripts/runners/nrfutil_next.py          @nrfconnect/ncs-ci
 
 # Share
 /share/                                   @nrfconnect/ncs-co-build-system

--- a/boards/nordic/common/nrfutil_next.board.cmake
+++ b/boards/nordic/common/nrfutil_next.board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+board_set_flasher_ifnset(nrfutil_next)
+board_finalize_runner_args(nrfutil_next) # No default arguments to provide.

--- a/boards/nordic/nrf7120pdk/board.cmake
+++ b/boards/nordic/nrf7120pdk/board.cmake
@@ -15,6 +15,6 @@ if(CONFIG_TFM_FLASH_MERGED_BINARY)
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 endif()
 
+include(${CMAKE_CURRENT_LIST_DIR}/../common/nrfutil_next.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/scripts/runners/nrf_common_next.py
+++ b/scripts/runners/nrf_common_next.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+'''
+Import nrf_common.py and override/include additional
+functionality required for nRF7120
+'''
+
+import os
+import sys
+
+ZEPHYR_BASE = os.environ.get('ZEPHYR_BASE')
+sys.path.append(f"{ZEPHYR_BASE}/scripts/west_commands/runners")
+import nrf_common
+
+nrf_common.UICR_RANGES['nrf71'] = {'Application': (0x00FFD000, 0x00FFDA00)}
+
+class NrfBinaryRunnerNext(nrf_common.NrfBinaryRunner):
+
+    def __init__(self, cfg, family, softreset, pinreset, dev_id, erase=False,
+                 erase_mode=None, ext_erase_mode=None, reset=True,
+                 tool_opt=None, force=False, recover=False):
+
+        self.family = family # Required to silence git complience checks
+
+        super().__init__(cfg, family, softreset, pinreset, dev_id, erase=False,
+                 erase_mode=None, ext_erase_mode=None, reset=True,
+                 tool_opt=None, force=False, recover=False)
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument('--nrf-family',
+                            choices=['NRF71'],
+                            help='''MCU family; still accepted for
+                            compatibility only''')
+        # Not using a mutual exclusive group for softreset and pinreset due to
+        # the way dump_runner_option_help() works in run_common.py
+        parser.add_argument('--softreset', required=False,
+                            action='store_true',
+                            help='use softreset instead of pinreset')
+        parser.add_argument('--pinreset', required=False,
+                            action='store_true',
+                            help='use pinreset instead of softreset')
+        parser.add_argument('--snr', required=False, dest='dev_id',
+                            help='obsolete synonym for -i/--dev-id')
+        parser.add_argument('--force', required=False,
+                            action='store_true',
+                            help='Flash even if the result cannot be guaranteed.')
+        parser.add_argument('--recover', required=False,
+                            action='store_true',
+                            help='''erase all user available non-volatile
+                            memory and disable read back protection before
+                            flashing (erases flash for both cores on nRF53)''')
+        parser.add_argument('--erase-mode', required=False,
+                            choices=['none', 'ranges', 'all'],
+                            help='Select the type of erase operation for the '
+                                 'internal non-volatile memory')
+        parser.add_argument('--ext-erase-mode', required=False,
+                            choices=['none', 'ranges', 'all'],
+                            help='Select the type of erase operation for the '
+                                 'external non-volatile memory')
+
+        parser.set_defaults(reset=True)
+
+
+    def ensure_family(self):
+        # Ensure self.family is set.
+
+        if self.family is not None:
+            return
+
+        if self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF71X'):
+            self.family = 'nrf71'
+        else:
+            raise RuntimeError(f'unknown nRF; update {__file__}')
+
+
+    def _get_core(self):
+        if self.family in ('nrf54h', 'nrf71', 'nrf92'):
+            if self.build_conf.getboolean('CONFIG_SOC_NRF7120_ENGA_CPUAPP'):
+                return 'Application'
+            raise RuntimeError(f'Core not found for family: {self.family}')
+        return None

--- a/scripts/runners/nrfutil_next.py
+++ b/scripts/runners/nrfutil_next.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+'''Runner for flashing with nrfutil.'''
+
+import os
+import sys
+
+FILE_PATH = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(f"{FILE_PATH}")
+
+import json
+import subprocess
+from pathlib import Path
+
+from runners.core import _DRY_RUN
+from nrf_common_next import NrfBinaryRunnerNext
+
+
+class NrfUtilBinaryRunner(NrfBinaryRunnerNext):
+    '''Runner front-end for nrfutil.'''
+
+    def __init__(self, cfg, family, softreset, pinreset, dev_id, erase=False,
+                 erase_mode=None, ext_erase_mode=None, reset=True, tool_opt=None,
+                 force=False, recover=False, suit_starter=False,
+                 ext_mem_config_file=None):
+
+        super().__init__(cfg, family, softreset, pinreset, dev_id, erase,
+                         erase_mode, ext_erase_mode, reset, tool_opt, force,
+                         recover)
+
+        self.suit_starter = suit_starter
+        self.ext_mem_config_file = ext_mem_config_file
+
+        self._ops = []
+        self._op_id = 1
+
+    @classmethod
+    def name(cls):
+        return 'nrfutil_next'
+
+    @classmethod
+    def capabilities(cls):
+        return NrfBinaryRunnerNext._capabilities(mult_dev_ids=True)
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        return NrfBinaryRunnerNext._dev_id_help() + \
+               '''.\n This option can be specified multiple times'''
+
+    @classmethod
+    def tool_opt_help(cls) -> str:
+        return 'Additional options for nrfutil, e.g. "--log-level"'
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        return NrfUtilBinaryRunner(cfg, args.nrf_family, args.softreset,
+                                   args.pinreset, args.dev_id, erase=args.erase,
+                                   erase_mode=args.erase_mode,
+                                   ext_erase_mode=args.ext_erase_mode,
+                                   reset=args.reset, tool_opt=args.tool_opt,
+                                   force=args.force, recover=args.recover,
+                                   suit_starter=args.suit_manifest_starter,
+                                   ext_mem_config_file=args.ext_mem_config_file)
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        super().do_add_parser(parser)
+        parser.add_argument('--suit-manifest-starter', required=False,
+                            action='store_true',
+                            help='Use the SUIT manifest starter file')
+        parser.add_argument('--ext-mem-config-file', required=False,
+                            dest='ext_mem_config_file',
+                            help='path to an JSON file with external memory configuration')
+
+    def _exec(self, args):
+        jout_all = []
+
+        cmd = ['nrfutil', '--json', 'device'] + args
+        self._log_cmd(cmd)
+
+        if _DRY_RUN:
+            return {}
+
+        with subprocess.Popen(cmd, stdout=subprocess.PIPE) as p:
+            for line in iter(p.stdout.readline, b''):
+                # https://github.com/ndjson/ndjson-spec
+                jout = json.loads(line.decode(sys.getdefaultencoding()))
+                jout_all.append(jout)
+
+                if 'x-execute-batch' in args:
+                    if jout['type'] == 'batch_update':
+                        pld = jout['data']['data']
+                        if (
+                            pld['type'] == 'task_progress' and
+                            pld['data']['progress']['progressPercentage'] == 0
+                        ):
+                            self.logger.info(pld['data']['progress']['description'])
+                    elif jout['type'] == 'batch_end' and jout['data']['error']:
+                        raise subprocess.CalledProcessError(
+                            jout['data']['error']['code'], cmd
+                        )
+        if p.returncode != 0:
+            raise subprocess.CalledProcessError(p.returncode, cmd)
+
+        return jout_all
+
+    def do_get_boards(self):
+        out = self._exec(['list'])
+        devs = []
+        for o in out:
+            if o['type'] == 'task_end':
+                devs = o['data']['data']['devices']
+        snrs = [dev['serialNumber'] for dev in devs if dev['traits']['jlink']]
+
+        self.logger.debug(f'Found boards: {snrs}')
+        return snrs
+
+    def do_require(self):
+        self.require('nrfutil')
+
+    def _insert_op(self, op):
+        op['operationId'] = f'{self._op_id}'
+        self._op_id += 1
+        self._ops.append(op)
+
+    def _format_dev_ids(self):
+        if isinstance(self.dev_id, list):
+            return ','.join(self.dev_id)
+        else:
+            return self.dev_id
+
+    def _append_batch(self, op, json_file):
+        _op = op['operation']
+        op_type = _op['type']
+
+        cmd = [f'{op_type}']
+
+        if op_type == 'program':
+            cmd += ['--firmware', _op['firmware']['file']]
+            opts = _op['options']
+            # populate the options
+            cmd.append('--options')
+            cli_opts = f"chip_erase_mode={opts['chip_erase_mode']}"
+            if opts.get('ext_mem_erase_mode'):
+                cli_opts += f",ext_mem_erase_mode={opts['ext_mem_erase_mode']}"
+            if opts.get('verify'):
+                cli_opts += f",verify={opts['verify']}"
+            cmd.append(cli_opts)
+        elif op_type == 'reset':
+            cmd += ['--reset-kind', _op['kind']]
+        elif op_type == 'erase':
+            cmd.append(f'--{_op["kind"]}')
+        elif op_type == 'x-provision-keys':
+            cmd += ['--key-file', _op['keyfile']]
+
+        cmd += ['--core', op['core']] if op.get('core') else []
+        cmd += ['--x-family', f'{self.family}']
+        cmd += ['--x-append-batch', f'{json_file}']
+        self._exec(cmd)
+
+    def _exec_batch(self):
+        # Use x-append-batch to get the JSON from nrfutil itself
+        json_file = Path(self.hex_).parent / 'generated_nrfutil_batch.json'
+        json_file.unlink(missing_ok=True)
+        for op in self._ops:
+            self._append_batch(op, json_file)
+
+        # reset first in case an exception is thrown
+        self._ops = []
+        self._op_id = 1
+        self.logger.debug(f'Executing batch in: {json_file}')
+        precmd = []
+        if self.ext_mem_config_file:
+            # This needs to be prepended, as it's a global option
+            precmd = ['--x-ext-mem-config-file', self.ext_mem_config_file]
+
+        self._exec(precmd + ['x-execute-batch', '--batch-path', f'{json_file}',
+                             '--serial-number', self._format_dev_ids()])
+
+    def do_exec_op(self, op, force=False):
+        self.logger.debug(f'Executing op: {op}')
+        if force:
+            if len(self._ops) != 0:
+                raise RuntimeError(f'Forced exec with {len(self._ops)} ops')
+            self._insert_op(op)
+            self._exec_batch()
+            return True
+        # Defer by default
+        return False
+
+    def flush_ops(self, force=True):
+        if not force:
+            return
+        while self.ops:
+            self._insert_op(self.ops.popleft())
+        self._exec_batch()

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -9,3 +9,8 @@ build:
     dts_root: .
     module_ext_root: .
     snippet_root: .
+
+runners:
+  # Additional runners, Zephyr will import these when discovering
+  # subclasses of the `ZephyrBinaryRunner` class.
+  - file: scripts/runners/nrfutil_next.py


### PR DESCRIPTION
An out of tree runner for boards supported by `nrfutil device` but not yet supported in upstream zephyr. 

Inherits from nrfutil / nrf_common and then modifies to support new devices (nRF7120).

