### PR TITLE
samples: matter: Fixed configuration for nrf7001

### DIFF
--- a/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp_nrf7001.conf
+++ b/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp_nrf7001.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable LTO to decrease the flash usage.
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp_nrf7001_release.conf
+++ b/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp_nrf7001_release.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable LTO to decrease the flash usage.
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -40,13 +40,6 @@
   comment: "Variant does not fit in FLASH area - it should be probably removed in the future"
 
 - scenarios:
-    - sample.matter.lock.debug
-    - sample.matter.lock.smp_dfu
-  platforms:
-    - nrf7002dk/nrf5340/cpuapp/nrf7001
-  comment: "https://nordicsemi.atlassian.net/browse/KRKNWK-20529"
-
-- scenarios:
     - nrf.extended.drivers.uart.uart_elementary_dual_l09
     - nrf.extended.drivers.uart.uart_elementary_dual_setup_mismatch_l09
   platforms:


### PR DESCRIPTION
nRF7001 configuration misses LTO=y, what results in flash region overflow. Enabled LTO for this target and removed it from quarantine.