### PR TITLE
samples/zephyr/smp_svr_mini_boot: disable by TRNG KMU provisioning

### DIFF
--- a/samples/zephyr/smp_svr_mini_boot/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/zephyr/smp_svr_mini_boot/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -8,3 +8,7 @@ CONFIG_NRF_GRTC_TIMER=n
 CONFIG_PSA_CORE_LITE=y
 CONFIG_PSA_CORE_LITE_NSIB_ED25519_OPTIMIZATIONS=y
 CONFIG_CRACEN_IKG=n
+
+# Disable run-time CRACEN provisioning of TRNG data.
+# KMU slots 248, 249 shall be pre-provisioned while programming with secret TRNG values instead.
+CONFIG_CRACEN_PROVISION_PROT_RAM_INV_DATA=n


### PR DESCRIPTION
Disable run-time CRACEN provisioning of TRNG data to KMU. KMU slots 248, 249 shall be pre-provisioned while programming with externally generate secret random values instead.

- [x] shall go after https://github.com/nrfconnect/sdk-nrf/pull/22783