### PR TITLE
tests: drivers: mspi: add ranges property to softperiph_ram

### DIFF
--- a/doc/nrf/drivers/mspi_sqspi.rst
+++ b/doc/nrf/drivers/mspi_sqspi.rst
@@ -149,7 +149,7 @@ The following example configuration for the nRF54H20 SoC sets up the necessary p
 
 			softperiph_ram: memory@2f890000 {
 				reg = <0x2f890000 0x4000>;
-				ranges;
+				ranges = <0x0 0x2f890000 0x4000>;
 				#address-cells = <1>;
 				#size-cells = <1>;
 

--- a/tests/drivers/mspi/mspi_with_spis/boards/nrf54h20dk_nrf54h20_cpuapp_sqspi.overlay
+++ b/tests/drivers/mspi/mspi_with_spis/boards/nrf54h20dk_nrf54h20_cpuapp_sqspi.overlay
@@ -132,7 +132,7 @@
 	reserved-memory {
 		softperiph_ram: memory@2f890000 {
 			reg = <0x2f890000 0x4000>;
-			ranges;
+			ranges = <0x0 0x2f890000 0x4000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 


### PR DESCRIPTION
Fix an issue introduced by c960096b0a6929b9c7f2fb77101141c8d1738cca where the driver code would access the soft peripheral at the incorrect address, causing a crash.

Also update the documentation with the fix.