### PR TITLE
samples: matter: enabled measuring factory reset time

### DIFF
--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -96,6 +96,7 @@ tests:
     extra_args:
       - CONFIG_CHIP_MEMORY_PROFILING=y
       - CONFIG_SHELL_MINIMAL=y
+      - CONFIG_CHIP_FACTORY_RESET_TIME_MEASUREMENT=y
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: c5cfa39480801673c06fd0c58107844eb384d2f2
+      revision: 5f4785ec4cbb645d8fff071735d12de3c12107c8
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Enabled Kconfig that allows to measure factory reset time in the memory profiling configuration.