### PR TITLE
samples: mcuboot: firmware_loader_entrance: Update PM static files

### DIFF
--- a/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_adding_sysbuild.rst
+++ b/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_adding_sysbuild.rst
@@ -373,64 +373,17 @@ To use this mode, you must create a static partition file for the application th
 Ensure the firmware loader partition is named ``firmware_loader``.
 This partition must be located identically as ``mcuboot_secondary_app`` partition, starting after the image's header offset within ``mcuboot_secondary`` partition.
 
-The following is an example static Partition Manager file for the nRF53 devices:
+The following are example static Partition Manager files:
 
-.. code-block:: yaml
+.. tabs::
 
-    app:
-      address: 0x10200
-      region: flash_primary
-      size: 0xdfe00
-    mcuboot:
-      address: 0x0
-      region: flash_primary
-      size: 0x10000
-    mcuboot_pad:
-      address: 0x10000
-      region: flash_primary
-      size: 0x200
-    mcuboot_primary:
-      address: 0x10000
-      orig_span: &id001
-      - mcuboot_pad
-      - app
-      region: flash_primary
-      size: 0xc0000
-      span: *id001
-    mcuboot_primary_app:
-      address: 0x10200
-      orig_span: &id002
-      - app
-      region: flash_primary
-      size: 0xbfe00
-      span: *id002
-    firmware_loader:
-      address: 0xd0200
-      region: flash_primary
-      size: 0x1fe00
-    mcuboot_secondary:
-      address: 0xd0000
-      orig_span: &id003
-      - mcuboot_pad
-      - firmware_loader
-      region: flash_primary
-      size: 0x20000
-      span: *id003
-    mcuboot_secondary_app:
-      address: 0xd0200
-      orig_span: &id004
-      - firmware_loader
-      region: flash_primary
-      size: 0x1fe00
-      span: *id004
-    settings_storage:
-      address: 0xf0000
-      region: flash_primary
-      size: 0x10000
-    pcd_sram:
-      address: 0x20000000
-      size: 0x2000
-      region: sram_primary
+    .. group-tab:: nRF52840
+        .. literalinclude:: ../../../../../samples/mcuboot/firmware_loader_entrance/pm_static_nrf52840dk_nrf52840.yml
+           :language: yaml
+
+    .. group-tab:: nRF54L15
+        .. literalinclude:: ../../../../../samples/mcuboot/firmware_loader_entrance/pm_static_nrf54l15dk_nrf54l15_cpuapp.yml
+           :language: yaml
 
 The project must also configure MCUboot to operate in firmware loader mode and specify a firmware loader image in the :file:`sysbuild.conf` file.
 For example to select ``smp_svr``, set the following options:

--- a/samples/mcuboot/firmware_loader_entrance/pm_static_nrf52840dk_nrf52840.yml
+++ b/samples/mcuboot/firmware_loader_entrance/pm_static_nrf52840dk_nrf52840.yml
@@ -5,7 +5,7 @@ mcuboot:
 app:
   address: 0x8200
   region: flash_primary
-  size: 0x5fe00
+  size: 0xb7e00
 mcuboot_pad:
   address: 0x8000
   region: flash_primary
@@ -16,36 +16,32 @@ mcuboot_primary:
   - app
   - mcuboot_pad
   region: flash_primary
-  size: 0x60000
+  size: 0xb8000
   span: *id001
 mcuboot_primary_app:
   address: 0x8200
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0x5fe00
+  size: 0xb7e00
   span: *id002
 mcuboot_secondary:
-  address: 0x68000
+  address: 0xc0000
   orig_span: &id003
   - mcuboot_secondary_pad
   - firmware_loader
   region: flash_primary
-  size: 0x60000
+  size: 0x3c000
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0x68000
+  address: 0xc0000
   size: 0x200
 firmware_loader:
   region: flash_primary
-  address: 0x68200
-  size: 0x5fe00
+  address: 0xc0200
+  size: 0x3be00
 settings_storage:
-  address: 0xc8000
+  address: 0xfc000
   region: flash_primary
   size: 0x4000
-unallocated:
-  address: 0xcc000
-  region: flash_primary
-  size: 0x34000

--- a/samples/mcuboot/firmware_loader_entrance/pm_static_nrf54l15dk_nrf54l15_cpuapp.yml
+++ b/samples/mcuboot/firmware_loader_entrance/pm_static_nrf54l15dk_nrf54l15_cpuapp.yml
@@ -5,7 +5,7 @@ mcuboot:
 app:
   address: 0xa800
   region: flash_primary
-  size: 0x60000
+  size: 0x117800
 mcuboot_pad:
   address: 0xa000
   region: flash_primary
@@ -16,36 +16,32 @@ mcuboot_primary:
   - app
   - mcuboot_pad
   region: flash_primary
-  size: 0x60800
+  size: 0x118000
   span: *id001
 mcuboot_primary_app:
   address: 0xa800
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0x60000
+  size: 0x117800
   span: *id002
 mcuboot_secondary:
-  address: 0x6a800
+  address: 0x122000
   orig_span: &id003
   - mcuboot_secondary_pad
   - firmware_loader
   region: flash_primary
-  size: 0x60800
+  size: 0x3f000
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
-  address: 0x6a800
+  address: 0x122000
   size: 0x800
 firmware_loader:
   region: flash_primary
-  address: 0x6b000
-  size: 0x60000
+  address: 0x122800
+  size: 0x3e800
 settings_storage:
-  address: 0xcb000
+  address: 0x161000
   region: flash_primary
   size: 0x4000
-unallocated:
-  address: 0xcf000
-  region: flash_primary
-  size: 0x96000


### PR DESCRIPTION
    Updates PM static files to have smaller firmware loader partitions
    and to remove unused space at the end of NVM


also

    doc: nrf: app_dev: bootloaders_dfu: mcuboot_nsib: Update PM usage
    
    Updates partition manager example to reference files from a sample


NCSDK-34548