### PR TITLE
kconfig: Change default main stack size for softdevice

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -60,6 +60,7 @@ config NET_SOCKETS_OFFLOAD_TLS
 #  - For running tests.
 #  - For CC3XX RNG
 #  - For Cracen RNG
+#  - For bt_enable() when using the SoftDevice Controller
 config MAIN_STACK_SIZE
 	default 4096 if PSA_NEED_CRACEN_CTR_DRBG_DRIVER && !BUILD_WITH_TFM && TRUSTED_STORAGE
 	default 3584 if PSA_NEED_CRACEN_CTR_DRBG_DRIVER && !BUILD_WITH_TFM
@@ -67,6 +68,7 @@ config MAIN_STACK_SIZE
 	default 2048 if PSA_NEED_OBERON_CTR_DRBG_DRIVER && !BUILD_WITH_TFM
 	default 2048 if ZTEST
 	default 2048 if ENTROPY_CC3XX && !BUILD_WITH_TFM
+	default 1128 if BT_LL_SOFTDEVICE
 
 config ZTEST_STACK_SIZE
 	default 2048 if ZTEST


### PR DESCRIPTION
NCS Applications often initialise Bluetooth and the SoftDevice Controller in the main thread.
Ensure the NCS main stack size is sufficient to cover the minimum stack usage requirements for enabling SDC. Many platforms implicitly end up with a larger default stack size via either ENTROPY_CC3XX or PSA_NEED_CRACEN_CTR_DRBG_DRIVER, but the stack size is now insufficient for others such as nRF52832 or nRF5340 cpunet.
The stack usage has not increased by a large amount, but it had been very close to 1024 and susceptible to overflowing from a marginal increase. The estimated stack size via thread analyzer is 1040 bytes, and an additional 10% margin has been added.