### PR TITLE
doc: Fixed matter watchdog documentation

### DIFF
--- a/doc/nrf/protocols/matter/end_product/watchdog.rst
+++ b/doc/nrf/protocols/matter/end_product/watchdog.rst
@@ -31,7 +31,7 @@ To enable the Matter watchdog feature in a Matter sample, set the :ref:`CONFIG_N
 The feature is enabled by default for the release build type in all Matter samples and applications.
 
 To set the timeout for the watchdog timer, configure the :ref:`CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_TIMEOUT<CONFIG_NCS_SAMPLE_MATTER_WATCHDOG_TIMEOUT>` with a value in milliseconds.
-By default, the timeout is set to 10 seconds.
+By default, the timeout is set to 10 minutes.
 
 .. note::
 


### PR DESCRIPTION
There is a mistake in the Matter docs that uses seconds unit instead of minutes.