### PR TITLE
toolchain: provide the index-url to build requirements

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -1,3 +1,5 @@
+--index-url https://files.nordicsemi.com/artifactory/api/pypi/nordic-pypi/simple
+
 cbor2>=5.4.2.post1
 clang-format
 click==8.1.3


### PR DESCRIPTION
Due to installing matter-idl the nordic index need to be provided.