### PR TITLE
samples: fast_pair: locator_tag: Enable LTO in MCUboot for nRF53 targets

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -443,6 +443,8 @@ Bluetooth Fast Pair samples
     * The configurations for nRF54L-based board targets that store the MCUboot verification key in the KMU peripheral to automatically generate the :file:`keyfile.json` file in the build directory (the ``SB_CONFIG_MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE`` Kconfig option) based on the input file provided by the ``SB_CONFIG_BOOT_SIGNATURE_KEY_FILE`` Kconfig option.
       This KMU provisioning step can now be performed automatically by the west runner, provided that a :file:`keyfile.json` file is present in the build directory.
       The provisioning is only performed if the ``west flash`` command is executed with the ``--erase``  or ``--recover`` flag.
+    * Link Time Optimization (:kconfig:option:`CONFIG_LTO`) to be enabled in MCUboot configurations of the nRF5340 DK and Thingy:53.
+      LTO no longer causes boot failures and it reduces the memory footprint.
 
 Cellular samples
 ----------------

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -19,9 +19,3 @@ CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE=16
 CONFIG_FLASH_SIMULATOR=y
 CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES=y
 CONFIG_FLASH_SIMULATOR_STATS=n
-
-# Dectivate LTO
-# On the */ns targets, when MCUboot tries to jump to the first image slot it
-# looks like it jumps to itself.
-CONFIG_LTO=n
-CONFIG_ISR_TABLES_LOCAL_DECLARATION=n

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/thingy53_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/thingy53_nrf5340_cpuapp.conf
@@ -22,9 +22,3 @@ CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE=16
 CONFIG_FLASH_SIMULATOR=y
 CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES=y
 CONFIG_FLASH_SIMULATOR_STATS=n
-
-# Dectivate LTO
-# On the */ns targets, when MCUboot tries to jump to the first image slot it
-# looks like it jumps to itself.
-CONFIG_LTO=n
-CONFIG_ISR_TABLES_LOCAL_DECLARATION=n


### PR DESCRIPTION
Enabled LTO in MCUboot configurations of the nrf5340dk/nrf5340/cpuapp(/ns) and thingy53/nrf5340/cpuapp(/ns).
LTO no longer causes boot failures.

Jira: NCSDK-28291