### PR TITLE
nrf_security: cracen: reorder includes to fix attribute redefinition

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <zephyr/kernel.h>
 #include <nrfx.h>
 #include <cracen/mem_helpers.h>
 #include <cracen/statuscodes.h>
@@ -12,8 +13,6 @@
 #include <psa/crypto.h>
 #include <stdint.h>
 #include <sxsymcrypt/internal.h>
-#include <zephyr/sys/util.h>
-#include <zephyr/sys/__assert.h>
 #include <hw_unique_key.h>
 #include <cracen_psa.h>
 #include "common.h"


### PR DESCRIPTION
Just as 3b785730cec207fb725dbfabaa839b4e440d4477/#22877 did, include zephyr/kernel.h as the first thing to avoid redefinitions of attributes (__noinline, __deprecated, __fallthrough) in picolibc.

ref: NCSDK-34100