### PR TITLE
bootloader: mcuboot: Added BOOT_SIGNATURE_USING_ITS configuration

### DIFF
--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -293,6 +293,14 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
       endif()
     endif()
 
+    if(SB_CONFIG_SOC_SERIES_NRF54HX)
+      if(SB_CONFIG_MCUBOOT_SIGNATURE_USING_ITS)
+        set_config_bool(mcuboot CONFIG_NRF_BOOT_SIGNATURE_USING_ITS y)
+      else()
+        set_config_bool(mcuboot CONFIG_NRF_BOOT_SIGNATURE_USING_ITS n)
+      endif()
+    endif()
+
     # A v1 board doesn't define board qualifiers, thus below test will just test the pure board
     # name for a v1 board. A v2 board will match against the board qualifier.
     if("${BOARD}${BOARD_QUALIFIERS}" MATCHES "(_|/)ns$")

--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -171,6 +171,13 @@ config MCUBOOT_SIGNATURE_USING_KMU
 	help
 	  The device needs to be provisioned with proper set of keys.
 
+config MCUBOOT_SIGNATURE_USING_ITS
+	bool "Use ITS stored keys for signature verification [EXPERIMENTAL]"
+	depends on SOC_SERIES_NRF54HX
+	select EXPERIMENTAL
+	help
+	  The device needs to be provisioned with proper set of keys.
+
 config BOOT_SHARED_CRYPTO_ECDSA_P256
 	bool "Use external crypto from NSIB for ECDSA P256 signature"
 	depends on SECURE_BOOT_APPCORE && SECURE_BOOT_SIGNATURE_TYPE_ECDSA

--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: e6ab32b862d6b529fcb16d85f91b5355a24e114d
+      revision: 68379845127b83191fd3d06591e084f6a532a9a5
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
This configuration has the purpose of using keys provisioned to the internal trusted storage (ITS).