### PR TITLE
applications: machine_learning: Correct nRF54H20 overlay

### DIFF
--- a/applications/machine_learning/sysbuild/ipc_radio/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/applications/machine_learning/sysbuild/ipc_radio/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -11,6 +11,21 @@
 	};
 };
 
+/delete-node/ &cpuapp_slot0_partition;
+/delete-node/ &cpurad_slot0_partition;
+
+&mram1x {
+	partitions {
+		cpuapp_slot0_partition: partition@30000 {
+			reg = <0x30000 0x82000>;
+		};
+
+		slot0_partition: cpurad_slot0_partition: partition@b2000 {
+			reg = <0xb2000 0x32000>;
+		};
+	};
+};
+
 &uart135 {
 	status = "disabled";
 };


### PR DESCRIPTION
Correct nRF54H20 overlay in machine learning application to align with ironside.

Jira: NCSDK-34532