### PR TITLE
mpsl: continue calibrating LFRC after mpsl_lib_uninit()

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -803,6 +803,11 @@ Multiprotocol Service Layer libraries
 
 * Added an implementation of the API required by the MPSL (defined by :file:`mpsl_hwres.h`) for the nRF53 and nRF54L Series devices.
 
+* Fixed an issue where calling the :c:func:`mpsl_lib_uninit` function would prevent calibration of the RC oscillator when MPSL was subsequently re-initialized using the :c:func:`mpsl_lib_init()` function.
+
+  This could happen, for instance, when using bluetooth with the :kconfig:option:`CONFIG_BT_UNINIT_MPSL_ON_DISABLE` Kconfig option enabled.
+  The low-frequency clock had poor accuracy in this case.
+
 * Updated the implementation of the following interrupt service routine wrappers:
 
   * :c:func:`mpsl_timer0_isr_wrapper`

--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -529,6 +529,12 @@ int32_t mpsl_lib_init(void)
 
 	mpsl_lib_irq_connect();
 
+#if defined(CONFIG_MPSL_CALIBRATION_PERIOD)
+	atomic_set(&do_calibration, 1);
+	mpsl_work_schedule(&calibration_work,
+			   K_MSEC(CONFIG_MPSL_CALIBRATION_PERIOD));
+#endif /* CONFIG_MPSL_CALIBRATION_PERIOD */
+
 	return 0;
 #else /* !IS_ENABLED(CONFIG_MPSL_DYNAMIC_INTERRUPTS) */
 	return -NRF_EPERM;


### PR DESCRIPTION
Calling mpsl_lib_uninit() would clear the atomic do_calibration, so if the calibration work handler was entered, the work item was never rescheduled, even if mpsl_lib_init() was called later.