### PR TITLE
samples: wifi: provisioning: softap: Add nrf7002ek support

### DIFF
--- a/samples/wifi/provisioning/softap/sample.yaml
+++ b/samples/wifi/provisioning/softap/sample.yaml
@@ -11,6 +11,19 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_wifi
+  sample.nrf7002_eks.softap.wifi.provision:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - softap_SHIELD=nrf7002ek
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpuapp/ns
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_wifi
   sample.nrf54l15.softap.wifi.provision:
     sysbuild: true
     build_only: true


### PR DESCRIPTION
Add an entry to support nrf7002EK.

Fixes SHEL-3727.