### PR TITLE
samples: log_rpc_shell: fix history threshold cmd

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/client/src/log_rpc_shell.c
+++ b/samples/nrf_rpc/protocols_serialization/client/src/log_rpc_shell.c
@@ -122,7 +122,7 @@ static int cmd_log_rpc_history_threshold(const struct shell *sh, size_t argc, ch
 	uint32_t threshold;
 	int rc = 0;
 
-	if (argc == 0) {
+	if (argc == 1) {
 		shell_print(sh, "%u", log_rpc_get_history_usage_threshold());
 		return 0;
 	}


### PR DESCRIPTION
Change the argument check in cmd_log_rpc_history_threshold from 0 to 1 to correctly retrieve the log RPC history usage threshold.