### PR TITLE
actions: manifest: Remove unnecessary west update command

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -27,8 +27,6 @@ jobs:
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
           west init -l . || true
-          # We only import the zephyr manifest
-          west update zephyr
 
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@ea38f222cddfbbb9debb5f0239f4139ae2677ebb # v1.8.0


### PR DESCRIPTION
In commit f7eb8c8, we introduced the use of the use-tree-checkout option. But at the same time we also restricted the parsed imports to self:, which means that the import statement for sdk-zephyr in the main west.yml file in sdk-nrf is ignored when running this action. Hence, there's no need to actually clone the zephyr tree as part of the action execution.