### PR TITLE
manifest: sdk-mcuboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: d24b28f652e2eeb6117b9c60fca0277db3d4e226
+      revision: pull/478/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Main failing to build for nrf54l15 with ed25519 and KMU enabled, when PSA lite is used.