### PR TITLE
net: nrf_cloud_coap: kconfig for max_retries

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -855,6 +855,7 @@ Libraries for networking
 
   * Added
 
+    * The :kconfig:option:`CONFIG_NRF_CLOUD_COAP_MAX_RETRIES` Kconfig option to configure the maximum number of retries for CoAP requests.
     * The :kconfig:option:`CONFIG_NRF_PROVISIONING_INITIAL_BACKOFF` Kconfig option to configure the initial backoff time for provisioning retries.
     * The :kconfig:option:`CONFIG_NRF_PROVISIONING_STACK_SIZE` Kconfig option to configure the stack size of the provisioning thread.
     * A new query parameter to limit the number of provisioning commands included in a single provisioning request.

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
@@ -51,6 +51,13 @@ config NRF_CLOUD_COAP_KEEPOPEN
 	  Improve benefit from using DTLS Connection ID by keeping the socket
 	  open when temporary LTE PDN connection loss occurs.
 
+config NRF_CLOUD_COAP_MAX_RETRIES
+	int "Maximum number of CoAP request retries"
+	default 10
+	help
+	  The maximum number of times a CoAP request will be retried before it is considered failed.
+	  A value of 0 means that no retries will be attempted.
+
 if WIFI
 
 config NRF_CLOUD_COAP_SEND_SSIDS

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
@@ -45,7 +45,6 @@ LOG_MODULE_REGISTER(nrf_cloud_coap_transport, CONFIG_NRF_CLOUD_COAP_LOG_LEVEL);
 /** @TODO: figure out whether to make this a Kconfig value or place in a header */
 #define CDDL_VERSION "1"
 #define MAX_COAP_PATH 256
-#define MAX_RETRIES 10
 #define JWT_BUF_SZ 700
 #define VER_STRING_FMT "mver=%s&cver=%s&dver=%s"
 #define VER_STRING_FMT2 "cver=" CDDL_VERSION "&dver=" BUILD_VERSION_STR
@@ -482,7 +481,7 @@ static int client_transfer(enum coap_method method,
 		/* -EAGAIN means the CoAP client is currently waiting for a response
 		 * to a previous request (likely started in a separate thread).
 		 */
-		if (retry++ > MAX_RETRIES) {
+		if (retry++ > CONFIG_NRF_CLOUD_COAP_MAX_RETRIES) {
 			LOG_ERR("Timeout waiting for CoAP client to be available");
 			err = -ETIMEDOUT;
 			goto transfer_end;


### PR DESCRIPTION
Add a Kconfig option to set the maximum number of CoAP request retries.