### PR TITLE
Update .overlays for NRF7120 (SPI/PWM ) loopback twister test

### DIFF
--- a/tests/drivers/pwm/gpio_loopback/boards/nrf7120pdk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/pwm/gpio_loopback/boards/nrf7120pdk_nrf7120_cpuapp.overlay
@@ -11,6 +11,21 @@
 	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
 		compatible = "test-pwm-to-gpio-loopback";
 		pwms = <&pwm20 0 0 PWM_POLARITY_NORMAL>;
-		gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	/omit-if-no-ref/ pwm20_default: pwm20_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 11)>;
+		};
+	};
+
+	/omit-if-no-ref/ pwm20_sleep: pwm20_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 11)>;
+			low-power-enable;
+		};
 	};
 };

--- a/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf7120pdk_nrf7120_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf7120pdk_nrf7120_cpuapp.overlay
@@ -7,17 +7,17 @@
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
-				<NRF_PSEL(SPIM_MISO, 1, 11)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 9)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 11)>,
+				<NRF_PSEL(SPIM_MISO, 1, 0)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 8)>;
 		};
 	};
 
 	spi22_sleep_alt: spi22_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
-				<NRF_PSEL(SPIM_MISO, 1, 11)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 9)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 11)>,
+				<NRF_PSEL(SPIM_MISO, 1, 0)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 8)>;
 			low-power-enable;
 		};
 	};
@@ -25,24 +25,24 @@
 	spi21_default_alt: spi21_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 12)>,
-				<NRF_PSEL(SPIS_MISO, 1, 10)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 8)>,
-				<NRF_PSEL(SPIS_CSN, 1, 14)>;
+				<NRF_PSEL(SPIS_MISO, 1, 14)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 9)>,
+				<NRF_PSEL(SPIS_CSN, 1, 5)>;
 		};
 	};
 
 	spi21_sleep_alt: spi21_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 12)>,
-				<NRF_PSEL(SPIS_MISO, 1, 10)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 8)>,
-				<NRF_PSEL(SPIS_CSN, 1, 14)>;
+				<NRF_PSEL(SPIS_MISO, 1, 14)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 9)>,
+				<NRF_PSEL(SPIS_CSN, 1, 5)>;
 			low-power-enable;
 		};
 	};
 };
 
-&gpio2 {
+&gpio1 {
 	status = "okay";
 };
 
@@ -52,7 +52,7 @@
 	pinctrl-1 = <&spi22_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
-	cs-gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
 	zephyr,pm-device-runtime-auto;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";

--- a/tests/zephyr/drivers/spi/spi_loopback/boards/nrf7120pdk_nrf7120_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_loopback/boards/nrf7120pdk_nrf7120_cpuapp.overlay
@@ -4,29 +4,37 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * Test requires following loopback:
+ * P1.4 - P1.5
+ */
+
 &pinctrl {
-	spi00_default: spi00_default {
+	spi20_default: spi20_default {
 		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 1, 4)>;
+		};
+		group2 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
-				<NRF_PSEL(SPIM_MISO, 2, 9)>,
-				<NRF_PSEL(SPIM_MOSI, 2, 8)>;
+				<NRF_PSEL(SPIM_MOSI, 1, 5)>;
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
 		};
 	};
 
-	spi00_sleep: spi00_sleep {
+	spi20_sleep: spi20_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
-				<NRF_PSEL(SPIM_MISO, 2, 9)>,
-				<NRF_PSEL(SPIM_MOSI, 2, 8)>;
+				<NRF_PSEL(SPIM_MISO, 1, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 5)>;
 			low-power-enable;
 		};
 	};
 };
 
-&spi00 {
+&spi20 {
 	status = "okay";
-	pinctrl-0 = <&spi00_default>;
-	pinctrl-1 = <&spi00_sleep>;
+	pinctrl-0 = <&spi20_default>;
+	pinctrl-1 = <&spi20_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
@@ -44,4 +52,10 @@
 
 &gpio2 {
 	status = "okay";
+};
+
+// UART20 disabled to avoid pin-conflicts with SPI20 + uses the same peripheral hardware block .
+
+&uart20 {
+	status = "disabled";
 };


### PR DESCRIPTION
This PR updates the pin-mappings for the twister tests that require loopbacks to pass .