### PR TITLE
mpsl: Add support for HFCLK24M to MPSL clock driver

### DIFF
--- a/drivers/mpsl/clock_control/nrfx_clock_mpsl.c
+++ b/drivers/mpsl/clock_control/nrfx_clock_mpsl.c
@@ -3,28 +3,52 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-
 #include <nrfx_clock.h>
+
 #include <mpsl.h>
 #include <mpsl_clock.h>
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(nrfx_clock_mpsl, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
+
 static nrfx_clock_event_handler_t event_handler;
 
-static void mpsl_hfclk_callback(void)
+static void mpsl_hfclk_src_callback(mpsl_clock_evt_type_t evt_type)
 {
-#if IS_ENABLED(CONFIG_SOC_SERIES_NRF54LX)
-	event_handler(NRFX_CLOCK_EVT_XO_TUNED);
-#else
-	event_handler(NRFX_CLOCK_EVT_HFCLK_STARTED);
-#endif
+	switch (evt_type) {
+#if NRF_CLOCK_HAS_XO_TUNE
+	/* nRF clock driver doesn't do anything with NRFX_CLOCK_EVT_XO_TUNE_ERROR and
+	 * NRFX_CLOCK_EVT_XO_TUNE_FAILED events. There is no need to report them.
+	 */
+	case MPSL_CLOCK_EVT_XO_TUNED:
+		event_handler(NRFX_CLOCK_EVT_XO_TUNED);
+		break;
+#endif /* NRF_CLOCK_HAS_XO_TUNE */
+	case MPSL_CLOCK_EVT_HFCLK_STARTED:
+		event_handler(NRFX_CLOCK_EVT_HFCLK_STARTED);
+		break;
+#if NRF_CLOCK_HAS_HFCLK24M
+	case MPSL_CLOCK_EVT_HFCLK24M_STARTED:
+		event_handler(NRFX_CLOCK_EVT_HFCLK24M_STARTED);
+		break;
+#endif /* NRF_CLOCK_HAS_HFCLK24M */
+	default:
+		/* We do not send notification about any other clock event to higher level driver */
+		LOG_WRN("Unsupported HFCLK event: %d", evt_type);
+	}
 }
 
 void nrfx_clock_start(nrf_clock_domain_t domain)
 {
 	switch (domain) {
 	case NRF_CLOCK_DOMAIN_HFCLK:
-		mpsl_clock_hfclk_request(mpsl_hfclk_callback);
+		mpsl_clock_hfclk_src_request(MPSL_CLOCK_HF_SRC_XO, mpsl_hfclk_src_callback);
 		break;
+#if NRF_CLOCK_HAS_HFCLK24M
+	case NRF_CLOCK_DOMAIN_HFCLK24M:
+		mpsl_clock_hfclk_src_request(MPSL_CLOCK_HF_SRC_HFCLK24M, mpsl_hfclk_src_callback);
+		break;
+#endif /* NRF_CLOCK_HAS_HFCLK24M */
 	case NRF_CLOCK_DOMAIN_LFCLK:
 		event_handler(NRFX_CLOCK_EVT_LFCLK_STARTED);
 		break;
@@ -37,8 +61,13 @@ void nrfx_clock_stop(nrf_clock_domain_t domain)
 {
 	switch (domain) {
 	case NRF_CLOCK_DOMAIN_HFCLK:
-		mpsl_clock_hfclk_release();
+		mpsl_clock_hfclk_src_release(MPSL_CLOCK_HF_SRC_XO);
 		break;
+#if NRF_CLOCK_HAS_HFCLK24M
+	case NRF_CLOCK_DOMAIN_HFCLK24M:
+		mpsl_clock_hfclk_src_release(MPSL_CLOCK_HF_SRC_HFCLK24M);
+		break;
+#endif /* NRF_CLOCK_HAS_HFCLK24M */
 	case NRF_CLOCK_DOMAIN_LFCLK:
 		/* empty */
 		break;

--- a/west.yml
+++ b/west.yml
@@ -145,7 +145,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: f81e6e5f17ea6e1bd785620b8b90f5d55b4e1e36
+      revision: aa1b002f7a11237e6086faa6da9eba2a85296f52
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
@@ -183,7 +183,7 @@ manifest:
       # Only for internal Nordic development
       repo-path: dragoon.git
       remote: dragoon
-      revision: cc098c3d2659ed5368686d41056e760d2195f0c9
+      revision: 995f1f6feeb0f881c77085660c42f58a581acc2b
       groups:
         - dragoon
     - name: cjson


### PR DESCRIPTION
There is a new HFCLK source HFCLK24M that might be used when
MPSL internal clok driver is enabled. That clock is used for
example by USB. The MPSL didn't support any other HFCLK except
HFXO.

The commit adds changes in MPSL clock driver that are based
on new clock API provided by the MPSL library.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>