### PR TITLE
bootloader: mcuboot: Changes needed to support AES256

### DIFF
--- a/cmake/sysbuild/image_signing.cmake
+++ b/cmake/sysbuild/image_signing.cmake
@@ -158,6 +158,12 @@ function(zephyr_mcuboot_tasks)
   set(confirmed_args)
   set(encrypted_args)
 
+  if(NOT "${keyfile_enc}" STREQUAL "")
+    if(CONFIG_MCUBOOT_ENCRYPTION_ALG_AES_256)
+      set(imgtool_args ${imgtool_args} --encrypt-keylen 256)
+    endif()
+  endif()
+
   # Set up .bin outputs.
   if(CONFIG_BUILD_OUTPUT_BIN)
     if(CONFIG_BUILD_WITH_TFM)

--- a/cmake/sysbuild/image_signing_firmware_loader.cmake
+++ b/cmake/sysbuild/image_signing_firmware_loader.cmake
@@ -110,6 +110,12 @@ function(zephyr_mcuboot_tasks)
   set(confirmed_args)
   set(encrypted_args)
 
+  if(NOT "${keyfile_enc}" STREQUAL "")
+    if(CONFIG_MCUBOOT_ENCRYPTION_ALG_AES_256)
+      set(imgtool_args ${imgtool_args} --encrypt-keylen 256)
+    endif()
+  endif()
+
   # Set up .bin outputs.
   if(CONFIG_BUILD_OUTPUT_BIN)
     if(CONFIG_BUILD_WITH_TFM)

--- a/cmake/sysbuild/image_signing_split.cmake
+++ b/cmake/sysbuild/image_signing_split.cmake
@@ -157,6 +157,12 @@ function(zephyr_mcuboot_tasks)
   set(confirmed_args)
   set(encrypted_args)
 
+  if(NOT "${keyfile_enc}" STREQUAL "")
+    if(CONFIG_MCUBOOT_ENCRYPTION_ALG_AES_256)
+      set(imgtool_args ${imgtool_args} --encrypt-keylen 256)
+    endif()
+  endif()
+
   # Split files apart
   split(
     ELF_FILE_IN ${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}

--- a/cmake/sysbuild/sign_nrf54h20.cmake
+++ b/cmake/sysbuild/sign_nrf54h20.cmake
@@ -200,6 +200,12 @@ function(mcuboot_sign_merged_nrf54h20 merged_hex main_image)
     set(imgtool_args --sha 512 ${imgtool_args})
   endif()
 
+  if(NOT "${keyfile_enc}" STREQUAL "")
+    if(SB_CONFIG_BOOT_ENCRYPTION_ALG_AES_256)
+      set(imgtool_args ${imgtool_args} --encrypt-keylen 256)
+    endif()
+  endif()
+
   # Set up .hex outputs.
   if(SB_CONFIG_BUILD_OUTPUT_HEX)
     list(APPEND byproducts ${output}.signed.hex)

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2cc69ef97a5ce7871628b29a2eaf2a7b4a628388
+      revision: 51f0b2c5c449b08826faef7cea0df23e9856ceed
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 0fadab126d9ba51365b3db1cdb6d55ed892c62b4
+      revision: 3b20ec38019dc0841062ba0622b4d7b6792193e5
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
This commit adds changes which are necessary to support the AES256 encryption algorithm in mcuboot.