### PR TITLE
samples: matter: Fix identify on EP1 in Matter Bridge App

### DIFF
--- a/applications/matter_bridge/src/app_task.cpp
+++ b/applications/matter_bridge/src/app_task.cpp
@@ -25,6 +25,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/clusters/identify-server/identify-server.h>
 #include <setup_payload/OnboardingCodesUtil.h>
 
 #ifdef CONFIG_BRIDGED_DEVICE_BT
@@ -41,21 +42,32 @@ LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 using namespace ::chip;
 using namespace ::chip::app;
 using namespace ::chip::DeviceLayer;
+
 namespace
 {
 
+constexpr EndpointId kBridgeEndpointId = 1;
+constexpr uint16_t kTriggerEffectTimeout = 5000;
+constexpr uint16_t kTriggerEffectFinishTimeout = 1000;
+
+k_timer sTriggerEffectTimer;
+bool sIsTriggerEffectActive;
+
+Identify sIdentify = { kBridgeEndpointId, AppTask::IdentifyStartHandler, AppTask::IdentifyStopHandler,
+		       Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator, AppTask::TriggerIdentifyEffectHandler };
+
 #ifdef CONFIG_BRIDGED_DEVICE_BT
-static const bt_uuid *sUuidLbs = BT_UUID_LBS;
-static const bt_uuid *sUuidEs = BT_UUID_ESS;
-static const bt_uuid *sUuidServices[] = { sUuidLbs, sUuidEs };
-static constexpr uint8_t kUuidServicesNumber = ARRAY_SIZE(sUuidServices);
+const bt_uuid *sUuidLbs = BT_UUID_LBS;
+const bt_uuid *sUuidEs = BT_UUID_ESS;
+const bt_uuid *sUuidServices[] = { sUuidLbs, sUuidEs };
+constexpr uint8_t kUuidServicesNumber = ARRAY_SIZE(sUuidServices);
 /**
  * @brief Blink rates for indication the BLE Connectivity Manager state.
  *
  */
-constexpr static uint32_t kPairingBlinkRate{ 100 };
-constexpr static uint32_t kScanningBlinkRate_ms{ 300 };
-constexpr static uint32_t kLostBlinkRate_ms{ 1000 };
+constexpr uint32_t kPairingBlinkRate{ 100 };
+constexpr uint32_t kScanningBlinkRate_ms{ 300 };
+constexpr uint32_t kLostBlinkRate_ms{ 1000 };
 #ifndef CONFIG_BRIDGE_SMART_PLUG_SUPPORT
 void BLEStateChangeCallback(Nrf::BLEConnectivityManager::State state)
 {
@@ -102,6 +114,67 @@ void AppFactoryResetHandler(const ChipDeviceEvent *event, intptr_t /* unused */)
 #endif
 
 } /* namespace */
+
+void AppTask::IdentifyStartHandler(Identify *)
+{
+	Nrf::PostTask(
+		[] { Nrf::GetBoard().GetLED(Nrf::DeviceLeds::LED2).Blink(Nrf::LedConsts::kIdentifyBlinkRate_ms); });
+}
+
+void AppTask::IdentifyStopHandler(Identify *)
+{
+	Nrf::PostTask([] {
+		Nrf::GetBoard().GetLED(Nrf::DeviceLeds::LED2).Set(false);
+	});
+}
+
+void AppTask::TriggerEffectTimerTimeoutCallback(k_timer *timer)
+{
+	LOG_INF("Identify effect completed");
+
+	sIsTriggerEffectActive = false;
+
+	Nrf::GetBoard().GetLED(Nrf::DeviceLeds::LED2).Set(false);
+
+}
+
+void AppTask::TriggerIdentifyEffectHandler(Identify *identify)
+{
+	switch (identify->mCurrentEffectIdentifier) {
+	/* Just handle all effects in the same way. */
+	case Clusters::Identify::EffectIdentifierEnum::kBlink:
+	case Clusters::Identify::EffectIdentifierEnum::kBreathe:
+	case Clusters::Identify::EffectIdentifierEnum::kOkay:
+	case Clusters::Identify::EffectIdentifierEnum::kChannelChange:
+		LOG_INF("Identify effect identifier changed to %d",
+			static_cast<uint8_t>(identify->mCurrentEffectIdentifier));
+
+		sIsTriggerEffectActive = false;
+
+		k_timer_stop(&sTriggerEffectTimer);
+		k_timer_start(&sTriggerEffectTimer, K_MSEC(kTriggerEffectTimeout), K_NO_WAIT);
+
+		Nrf::GetBoard().GetLED(Nrf::DeviceLeds::LED2).Blink(Nrf::LedConsts::kIdentifyBlinkRate_ms);
+		break;
+	case Clusters::Identify::EffectIdentifierEnum::kFinishEffect:
+		LOG_INF("Identify effect finish triggered");
+		k_timer_stop(&sTriggerEffectTimer);
+		k_timer_start(&sTriggerEffectTimer, K_MSEC(kTriggerEffectFinishTimeout), K_NO_WAIT);
+		break;
+	case Clusters::Identify::EffectIdentifierEnum::kStopEffect:
+		if (sIsTriggerEffectActive) {
+			sIsTriggerEffectActive = false;
+
+			k_timer_stop(&sTriggerEffectTimer);
+
+			Nrf::GetBoard().GetLED(Nrf::DeviceLeds::LED2).Set(false);
+		}
+		break;
+	default:
+		LOG_ERR("Received invalid effect identifier.");
+		break;
+	}
+}
 
 CHIP_ERROR AppTask::RestoreBridgedDevices()
 {
@@ -215,6 +288,9 @@ CHIP_ERROR AppTask::Init()
 	 * */
 	ReturnErrorOnFailure(Nrf::Matter::RegisterEventHandler(AppFactoryResetHandler, 0));
 #endif
+
+	/* Initialize trigger effect timer */
+	k_timer_init(&sTriggerEffectTimer, &AppTask::TriggerEffectTimerTimeoutCallback, nullptr);
 
 	return Nrf::Matter::StartServer();
 }

--- a/applications/matter_bridge/src/app_task.h
+++ b/applications/matter_bridge/src/app_task.h
@@ -9,6 +9,9 @@
 #include "board/board.h"
 #include <platform/CHIPDeviceLayer.h>
 
+struct k_timer;
+struct Identify;
+
 class AppTask {
 public:
 	static AppTask &Instance()
@@ -23,6 +26,11 @@ public:
 	static void ButtonEventHandler(Nrf::ButtonState state, Nrf::ButtonMask hasChanged);
 	static void SmartplugOnOffEventHandler();
 #endif /* CONFIG_BRIDGE_SMART_PLUG_SUPPORT */
+
+static void IdentifyStartHandler(Identify *);
+static void IdentifyStopHandler(Identify *);
+static void TriggerIdentifyEffectHandler(Identify *);
+static void TriggerEffectTimerTimeoutCallback(k_timer *timer);
 
 private:
 	CHIP_ERROR Init();

--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -578,6 +578,15 @@ Matter
 
 The issues in this section are related to the :ref:`ug_matter` protocol.
 
+.. rst-class:: v3-0-2 v3-0-1 v3-0-0 v2-9-0-nRF54H20-1 v2-9-2 v2-9-1 v2-9-0 v2-8-0 v2-7-0
+
+KRKNWK-20019: The identify time does not update for the endpoint 1 in the Matter Bridge application
+  The identify cluster is enabled in the :file:`.zap` file, but not in the application.
+
+  **Affected platforms:** nRF7002, nRF5340
+
+  **Workaround:** Remove the identify cluster from the :file:`.zap` file, as this cluster is optional for the aggregator endpoint type.
+
 .. rst-class:: v3-0-1 v3-0-0
 
 KRKNWK-20308: The ``MyCluster.xml`` file example in the :ref:`ug_matter_creating_custom_cluster` user guide does not contain the ``ExtendedCommandResponse`` command

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -258,7 +258,8 @@ IPC radio firmware
 Matter bridge
 -------------
 
-|no_changes_yet_note|
+* Implemented the missing identify cluster for the endpoint 1.
+  This resolves the :ref:`known issue <known_issues>` KRKNWK-20019.
 
 nRF5340 Audio
 -------------


### PR DESCRIPTION
The identify cluster was enabled for EP1 in Matter Bridge App, whereas it was not implemented in the code.