### PR TITLE
bluetooth: hci_driver: Add missing mpsl.h include

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -24,6 +24,7 @@
 #include <sdc_soc.h>
 #include <sdc_hci.h>
 #include <sdc_hci_vs.h>
+#include <mpsl.h>
 #include <mpsl/mpsl_work.h>
 #include <mpsl/mpsl_lib.h>
 

--- a/subsys/mpsl/pm/mpsl_pm_utils.c
+++ b/subsys/mpsl/pm/mpsl_pm_utils.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <mpsl_pm.h>
 #include <mpsl_pm_config.h>
+#include <nrf_errno.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/logging/log.h>
 


### PR DESCRIPTION
Due to change in Zephyr hal, use of mpsl_hwres.h the mpsl.h is not included silently with nrf header files. That causes some functions to be not declared in the hci_driver.c.

Also the mpsl_pm_util.c requires additional header: nrf_errno.h provided in nrfxlib with MPSL header files. The header is required because integration layer uses error codes from the headed in the sdk-nrf and MPSL integration layer.