### PR TITLE
nrf_security: CRACEN: Fix failing TF-m test

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/asymmetric.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/asymmetric.c
@@ -91,9 +91,11 @@ cracen_asymmetric_crypt_internal(const psa_key_attributes_t *attributes, const u
 	}
 
 	if (sx_status != SX_OK) {
+		safe_memzero(output, output_size);
 		return silex_statuscodes_to_psa(sx_status);
 	}
-	if (text.sz > output_size) {
+	if (*output_length > output_size) {
+		safe_memzero(output, output_size);
 		return PSA_ERROR_BUFFER_TOO_SMALL;
 	}
 	return PSA_SUCCESS;


### PR DESCRIPTION
RSA OAEP incorrectly set the output length to the text size 
Updated to use correct key size instead
RSA OAEP incorrectly overwrote part of the hash value 
Updated to zero the correct part of the workmem
Remove variables that are not needed