### PR TITLE
nrf_rpc: configure thread names to ease debugging

### DIFF
--- a/subsys/nrf_rpc/nrf_rpc_os.c
+++ b/subsys/nrf_rpc/nrf_rpc_os.c
@@ -83,6 +83,7 @@ int nrf_rpc_os_init(nrf_rpc_os_work_t callback)
 			thread_pool_entry,
 			NULL, NULL, NULL,
 			CONFIG_NRF_RPC_THREAD_PRIORITY, 0, K_NO_WAIT);
+		k_thread_name_set(&pool_threads[i], "rpc");
 	}
 
 	return 0;

--- a/subsys/nrf_rpc/nrf_rpc_uart.c
+++ b/subsys/nrf_rpc/nrf_rpc_uart.c
@@ -335,6 +335,7 @@ static void serial_cb(const struct device *uart, void *user_data)
 static int init(const struct nrf_rpc_tr *transport, nrf_rpc_tr_receive_handler_t receive_cb,
 		void *context)
 {
+	const struct k_work_queue_config workq_cfg = {.name = "rpc uart rx"};
 	struct nrf_rpc_uart *uart_tr = transport->ctx;
 
 	if (uart_tr->transport != NULL) {
@@ -381,7 +382,8 @@ static int init(const struct nrf_rpc_tr *transport, nrf_rpc_tr_receive_handler_t
 
 	k_work_queue_init(&uart_tr->rx_workq);
 	k_work_queue_start(&uart_tr->rx_workq, uart_tr->rx_workq_stack,
-			   K_THREAD_STACK_SIZEOF(uart_tr->rx_workq_stack), K_PRIO_PREEMPT(0), NULL);
+			   K_THREAD_STACK_SIZEOF(uart_tr->rx_workq_stack), K_PRIO_PREEMPT(0),
+			   &workq_cfg);
 
 	k_work_init(&uart_tr->rx_work, work_handler);
 	ring_buf_init(&uart_tr->rx_ringbuf, sizeof(uart_tr->rx_buffer), uart_tr->rx_buffer);


### PR DESCRIPTION
Configure thread names for:
- nRF RPC UART RX work queue
- nRF RPC worker thread pool