### PR TITLE
samples: nrf_rpc: ps_server: use async API for logging

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/server/Kconfig
+++ b/samples/nrf_rpc/protocols_serialization/server/Kconfig
@@ -59,6 +59,36 @@ config LOG_BACKEND_UART
 
 endif # LOG
 
+if LOG_BACKEND_UART_ASYNC
+
+# Using UART async API by the logging backend significantly reduces CPU load imposed by logging.
+# To make it work, the corresponding UART instance needs to be configured to use the async API
+# as well, which requires disabling the default, interrupt-driven API.
+# Do it for all possible UART instances for the supported nRF52 and nRF54L SoCs.
+
+uart_num = 0
+rsource "Kconfig.zephyr_console_async"
+
+uart_num = 1
+rsource "Kconfig.zephyr_console_async"
+
+uart_num = 00
+rsource "Kconfig.zephyr_console_async"
+
+uart_num = 20
+rsource "Kconfig.zephyr_console_async"
+
+uart_num = 21
+rsource "Kconfig.zephyr_console_async"
+
+uart_num = 22
+rsource "Kconfig.zephyr_console_async"
+
+uart_num = 30
+rsource "Kconfig.zephyr_console_async"
+
+endif # LOG_BACKEND_UART_ASYNC
+
 if SOC_NRF54L15
 
 config BT_LONG_WQ_STACK_SIZE

--- a/samples/nrf_rpc/protocols_serialization/server/Kconfig.zephyr_console_async
+++ b/samples/nrf_rpc/protocols_serialization/server/Kconfig.zephyr_console_async
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+DT_CHOSEN_ZEPHYR_CONSOLE := zephyr,console
+
+config UART_$(uart_num)_INTERRUPT_DRIVEN
+	default n
+	depends on $(dt_nodelabel_enabled,uart$(uart_num))
+	depends on "$(dt_nodelabel_path,uart$(uart_num))" = "$(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_CONSOLE))"

--- a/samples/nrf_rpc/protocols_serialization/server/snippets/debug/debug.conf
+++ b/samples/nrf_rpc/protocols_serialization/server/snippets/debug/debug.conf
@@ -7,9 +7,11 @@
 # Enable asserts
 CONFIG_ASSERT=y
 
-# Enable UART console
+# Enable UART console. Use async API to reduce CPU load.
 CONFIG_LOG=y
 CONFIG_LOG_BACKEND_UART=y
+CONFIG_UART_ASYNC_API=y
+CONFIG_LOG_BACKEND_UART_ASYNC=y
 
 # Enable verbose logging
 CONFIG_NRF_PS_SERVER_LOG_LEVEL_DBG=y


### PR DESCRIPTION
It turns out that the logging UART backend uses polling by default, which significantly increases CPU usage. Switch the logging to use the async API.