### PR TITLE
tests: drivers: mspi_with_spis: Fix ranges property in sqspi overlay

### DIFF
--- a/doc/nrf/drivers/mspi_sqspi.rst
+++ b/doc/nrf/drivers/mspi_sqspi.rst
@@ -69,6 +69,10 @@ See the following configuration example for the nRF54L15 SoC:
 
 	/ {
 		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			softperiph_ram: memory@2003c000 {
 				reg = <0x2003c000 0x4000>;
 				ranges = <0 0x2003c000 0x4000>;
@@ -149,11 +153,11 @@ The following example configuration for the nRF54H20 SoC sets up the necessary p
 
 			softperiph_ram: memory@2f890000 {
 				reg = <0x2f890000 0x4000>;
-				ranges;
+				ranges = <0 0x2f890000 0x4000>;
 				#address-cells = <1>;
 				#size-cells = <1>;
 
-				dut: sqspi: sqspi@3e00 {
+				sqspi: sqspi@3e00 {
 					compatible = "nordic,nrf-sqspi";
 					#address-cells = <1>;
 					#size-cells = <0>;

--- a/tests/drivers/mspi/mspi_with_spis/boards/nrf54h20dk_nrf54h20_cpuapp_sqspi.overlay
+++ b/tests/drivers/mspi/mspi_with_spis/boards/nrf54h20dk_nrf54h20_cpuapp_sqspi.overlay
@@ -132,7 +132,7 @@
 	reserved-memory {
 		softperiph_ram: memory@2f890000 {
 			reg = <0x2f890000 0x4000>;
-			ranges;
+			ranges = <0 0x2f890000 0x4000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 


### PR DESCRIPTION
This is a follow-up to commit c960096b0a6929b9c7f2fb77101141c8d1738cca ("samples: update according to new nrf54h20 RAM memory map").

After the changes applied by the above commit, the `softperiph_ram` node can no longer use empty `ranges` property, since its base address is not 0 now. Add proper address translation, so that the `sqspi` node base address is correct (not 0x3e00, what results in a bus fault when the sQSPI is initialized).

Also correct the sQSPI MSPI shim driver documentation accordingly (apart from correcting the `ranges` property for nRF54H20, restore properties that were incorrectly removed from the `reserved-memory` node for nRF54L15).