### PR TITLE
samples: bluetooth: DTM with FEM - fix assertion when setting tx power by nRF Connect for Desktop

### DIFF
--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -284,7 +284,7 @@ Vendor-specific commands can be divided into different categories as follows:
 * If the **Length** field is set to ``1`` (symbol ``CARRIER_TEST_STUDIO``), the field value is used by the nRFgo Studio to indicate that an unmodulated carrier is turned on at the channel.
   It remains turned on until a ``TEST_END`` or ``RESET`` command is issued.
 * If the **Length** field is set ``2`` (symbol ``SET_TX_POWER``), the **Frequency** field sets the TX power in dBm.
-  The valid TX power values are specified in the product specification ranging from –40 to +4, where ``0`` dBm is the reset value.
+  The valid TX power values are specified in the product specification of the SoC used, where ``0`` dBm is the reset value.
   Only the six least significant bits will fit in the **Length** field.
   The two most significant bits are calculated by the DTM module.
   This is possible because the six least significant bits of all valid TX power values are unique.


### PR DESCRIPTION
Fix assertion in the direct_test_mode sample working with FEM, where after setting the Tx power from the nRF Connect for Desktop app the FW would try setting power through FEM API passing the encoded power value as the "channel number" argument.
The vendor-specific command used by the app uses the "channel" field for passing the parameter value and the FW incorrectly recorded that value in it's static data.
Additionally clarified available power values in the FEM section of the sample README.rst file and removed unused defines.