### PR TITLE
samples: wifi: shell: Fix configuration with openthread overlay

### DIFF
--- a/samples/wifi/shell/overlay-openthread.conf
+++ b/samples/wifi/shell/overlay-openthread.conf
@@ -9,9 +9,9 @@ CONFIG_SHELL_ARGC_MAX=26
 CONFIG_SHELL_CMD_BUFF_SIZE=416
 
 # Enable OpenThread features set
-CONFIG_OPENTHREAD_NORDIC_LIBRARY_MASTER=y
-
 CONFIG_NET_L2_OPENTHREAD=y
+CONFIG_OPENTHREAD_NORDIC_LIBRARY_FTD=y
+
 # Openthread supports only IPv6 and is the first interface
 CONFIG_NET_CONFIG_MY_IPV4_ADDR=""
 CONFIG_NET_CONFIG_PEER_IPV4_ADDR=""
@@ -22,12 +22,8 @@ CONFIG_FPU=y
 
 CONFIG_GPIO_SHELL=y
 
-# Use printk to log messages
-CONFIG_LOG_MODE_MINIMAL=y
-
 # Log only errors/hard faults
 CONFIG_LOG_MAX_LEVEL=1
-
 
 # Enable LTO to save flash memory
 CONFIG_LTO=y
@@ -35,3 +31,7 @@ CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
 
 # Required by WIFI
 CONFIG_MBEDTLS_SHA1_C=y
+
+# Disable extra logging and advanced features to fit in flash
+CONFIG_NRF70_LOG_VERBOSE=n
+CONFIG_WIFI_NM_WPA_SUPPLICANT_NO_DEBUG=y

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -221,7 +221,10 @@ tests:
   sample.nrf7002.shell.otbr:
     sysbuild: true
     build_only: true
-    extra_args: EXTRA_CONF_FILE=overlay-openthread.conf
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-openthread.conf
+      - SB_CONFIG_NETCORE_IPC_RADIO=y
+      - SB_CONFIG_NETCORE_IPC_RADIO_IEEE802154=y
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
     platform_allow: nrf7002dk/nrf5340/cpuapp

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -6,12 +6,6 @@
     - net.lib.wifi_credentials_backend_psa
   comment: "Fix not known at time of upmerge, temporarily excluded to be fixed after upmerge"
 
-- scenarios:
-    - sample.nrf7002.shell.otbr
-  platforms:
-    - nrf7002dk/nrf5340/cpuapp
-  comment: https://nordicsemi.atlassian.net/browse/NCSDK-31155
-
 - platforms:
     - native_posix
   comment: "native_posix will be removed soon - native_sim platform is the default simulator now"


### PR DESCRIPTION
This commit fixes configuration of Wi-Fi shell with OpenThread overlay by enabling proper network core image as well as optimizing the flash size to fit on nRF7002 DK.