### PR TITLE
nrf_security: CRACEN: Update KMU provisioning slot

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54l/cryptography.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/cryptography.rst
@@ -78,7 +78,11 @@ The following table gives an overview of the KMU slots and their usage:
    * - 183-185
      - IKG seed
      - 384-bit random seed to generate keys using the CRACEN IKG.
-   * - 186-225
+   * - 186
+     - Provisioning slot
+     - | Reserved slot for internal KMU usage.
+       | This slot is used to validate that provisioning of the KMU slots is completed.
+   * - 187-225
      - Reserved
      - --
    * - 226-227

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/kmu.c
@@ -25,7 +25,7 @@
  *      Bits 15-8:  slot-id
  *      Bits 7-0:   number of slots
  */
-#define PROVISIONING_SLOT 250
+#define PROVISIONING_SLOT 186
 
 #define SECONDARY_SLOT_METADATA_VALUE UINT32_MAX
 


### PR DESCRIPTION
Change KMU provisioning slot from 250 to 186
Slot 250 is supposed to be reserved for other usage 
Slot 186 is directly after an already reserved slot