### PR TITLE
boards: thingy91x: Fix device name on runner

### DIFF
--- a/boards/nordic/thingy91x/board.cmake
+++ b/boards/nordic/thingy91x/board.cmake
@@ -4,7 +4,7 @@
 if(CONFIG_BOARD_THINGY91X_NRF9151 OR CONFIG_BOARD_THINGY91X_NRF9151_NS)
   board_runner_args(nrfjprog)
   board_runner_args(nrfutil "--nrf-family=NRF91")
-  board_runner_args(jlink "--device=nRF9151_xxAA" "--speed=4000")
+  board_runner_args(jlink "--device=nRF9151_xxCA" "--speed=4000")
 elseif(CONFIG_BOARD_THINGY91X_NRF5340_CPUAPP OR CONFIG_BOARD_THINGY91X_NRF5340_CPUAPP_NS)
   board_runner_args(nrfjprog)
   board_runner_args(nrfutil "--nrf-family=NRF53")


### PR DESCRIPTION
Thingy91x runner configuration seem to be using wrong name for Jlink.

Flashing seem to work but debugging does not.