### PR TITLE
sysbuild: Fix typo in HMAC-SHA512 selector for MCUboot encryption

### DIFF
--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -185,7 +185,7 @@ config MCUBOOT_GENERATE_DEFAULT_KMU_KEYFILE
 	  If enabled, the build system will generate keyfile.json file in the build directory.
 
 config NRF_MCUBOOT_HMAC_SHA512
-	bool "Use SHA256 for HMAC"
+	bool "Use SHA512 for HMAC"
 	depends on BOOT_ENCRYPTION && SOC_SERIES_NRF54LX && BOOT_SIGNATURE_TYPE_ED25519
 	help
 	  Default is to use SHA256 for HMAC/HKDF ECIES-X25519 key exchange is used.


### PR DESCRIPTION
Prompt was incorrectly stating selection of SHA256.

fixup! sysbuild: Allow selecting SHA512 for HMAC/HKDF in MCUboot