### PR TITLE
cmake: NCS-only fix for variant configuration with no partition manager

### DIFF
--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -13,7 +13,7 @@ if(CONFIG_NCS_IS_VARIANT_IMAGE)
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${AUTOCONF_H})
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${DOTCONFIG})
 
-  if(CONFIG_NCS_VARIANT_MERGE_KCONFIG)
+  if(SB_CONFIG_PARTITION_MANAGER)
     # A variant build should reuse same .config and thus autoconf.h, therefore
     # copy files from original and bypass Kconfig invocation.
     set(preload_autoconf_h ${PRELOAD_BINARY_DIR}/zephyr/include/generated/zephyr/autoconf.h)
@@ -27,8 +27,55 @@ if(CONFIG_NCS_IS_VARIANT_IMAGE)
 
     import_kconfig("CONFIG" ${DOTCONFIG})
   else()
-    # First generate autoconf.h as well as .config files.
-    include(${ZEPHYR_BASE}/cmake/modules/kconfig.cmake)
+    dt_chosen(code_partition PROPERTY "zephyr,code-partition")
+    dt_reg_addr(code_partition_offset PATH "${code_partition}" REQUIRED)
+    dt_reg_size(code_partition_size PATH "${code_partition}" REQUIRED)
+
+    set(preload_autoconf_h ${PRELOAD_BINARY_DIR}/zephyr/include/generated/zephyr/autoconf.h)
+    set(preload_dotconfig  ${PRELOAD_BINARY_DIR}/zephyr/.config)
+
+    file(STRINGS ${preload_autoconf_h} autoconf_content)
+    file(STRINGS ${preload_dotconfig} dotconfig_content)
+
+    # Modify the CONFIG_FLASH_LOAD_OFFSET and CONFIG_FLASH_LOAD_SIZE for both the .config and autoconf.h files.
+    # If partition manager is not used, these values should be taken from the device tree.
+    set(dotconfig_variant_content)
+    foreach(line IN LISTS dotconfig_content)
+      if("${line}" MATCHES "^CONFIG_FLASH_LOAD_OFFSET=.*$")
+        string(REGEX REPLACE "CONFIG_FLASH_LOAD_OFFSET=(.*)" "CONFIG_FLASH_LOAD_OFFSET=${code_partition_offset}" line ${line})
+      endif()
+
+      if("${line}" MATCHES "^CONFIG_FLASH_LOAD_SIZE=.*$")
+        string(REGEX REPLACE "CONFIG_FLASH_LOAD_SIZE=(.*)" "CONFIG_FLASH_LOAD_SIZE=${code_partition_size}" line ${line})
+      endif()
+
+      list(APPEND dotconfig_variant_content "${line}\n")
+    endforeach()
+
+    set(autoconf_variant_content)
+    foreach(line IN LISTS autoconf_content)
+      if("${line}" MATCHES "^#define CONFIG_FLASH_LOAD_OFFSET .*$")
+        string(REGEX REPLACE "#define CONFIG_FLASH_LOAD_OFFSET (.*)" "#define CONFIG_FLASH_LOAD_OFFSET ${code_partition_offset}" line ${line})
+      endif()
+
+      if("${line}" MATCHES "^#define CONFIG_FLASH_LOAD_SIZE .*$")
+        string(REGEX REPLACE "#define CONFIG_FLASH_LOAD_SIZE (.*)" "#define CONFIG_FLASH_LOAD_SIZE ${code_partition_size}" line ${line})
+      endif()
+
+      list(APPEND autoconf_variant_content "${line}\n")
+    endforeach()
+
+    set(dest_autoconf_h ${PROJECT_BINARY_DIR}/include/generated/zephyr/autoconf.h)
+    set(dest_dotconfig  ${PROJECT_BINARY_DIR}/.config)
+
+    file(WRITE ${dest_autoconf_h} ${autoconf_variant_content})
+    file(WRITE ${dest_dotconfig} ${dotconfig_variant_content})
+
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${preload_autoconf_h})
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${preload_dotconfig})
+
+    import_kconfig("CONFIG" ${DOTCONFIG})
+
   endif()
 
   file(APPEND ${AUTOCONF_H} "#define CONFIG_NCS_IS_VARIANT_IMAGE 1")

--- a/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
+++ b/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
@@ -95,10 +95,8 @@ endfunction()
 # APPLICATION <name>: Name of the application which is used as the source for
 #                     the variant build.
 # VARIANT <name>:     Name of the variant build.
-# SPLIT_KCONFIG:      Flag indicating that the variant image should
-#                     not reuse the same .config files.
 function(ExternalNcsVariantProject_Add)
-  cmake_parse_arguments(VBUILD "SPLIT_KCONFIG" "APPLICATION;VARIANT" "" ${ARGN})
+  cmake_parse_arguments(VBUILD "" "APPLICATION;VARIANT" "" ${ARGN})
 
   ExternalProject_Get_Property(${VBUILD_APPLICATION} SOURCE_DIR BINARY_DIR)
   set(${VBUILD_APPLICATION}_BINARY_DIR ${BINARY_DIR})
@@ -122,14 +120,8 @@ function(ExternalNcsVariantProject_Add)
   set_property(TARGET ${VBUILD_VARIANT} PROPERTY NCS_VARIANT_APPLICATION ${VBUILD_APPLICATION})
   set_property(TARGET ${VBUILD_VARIANT} APPEND PROPERTY _EP_CMAKE_ARGS
     -DCONFIG_NCS_IS_VARIANT_IMAGE=y
+    -DPRELOAD_BINARY_DIR=${${VBUILD_APPLICATION}_BINARY_DIR}
   )
-
-  if(NOT VBUILD_SPLIT_KCONFIG)
-    set_property(TARGET ${VBUILD_VARIANT} APPEND PROPERTY _EP_CMAKE_ARGS
-      -DPRELOAD_BINARY_DIR=${${VBUILD_APPLICATION}_BINARY_DIR}
-      -DCONFIG_NCS_VARIANT_MERGE_KCONFIG=y
-    )
-  endif()
 
   # Configure variant image after application so that the configuration is present
   sysbuild_add_dependencies(CONFIGURE ${VBUILD_VARIANT} ${VBUILD_APPLICATION})

--- a/sysbuild/mcuboot.cmake
+++ b/sysbuild/mcuboot.cmake
@@ -14,32 +14,18 @@ if(SB_CONFIG_MCUBOOT_BUILD_DIRECT_XIP_VARIANT)
       set(image "${primary_image}_secondary_app")
     endif()
 
-    if(SB_CONFIG_PARTITION_MANAGER)
-      ExternalNcsVariantProject_Add(APPLICATION ${primary_image} VARIANT ${image})
+    ExternalNcsVariantProject_Add(APPLICATION ${primary_image} VARIANT ${image})
 
+    if(SB_CONFIG_PARTITION_MANAGER)
       set_property(GLOBAL APPEND PROPERTY
           PM_APP_IMAGES
           "${image}"
       )
     else()
-      # TODO: NCSDK-33774 add a general way to pass configuration options to the variant
-      # image
-      if(${primary_image} STREQUAL ${DEFAULT_IMAGE})
-        zephyr_get(extra_conf_file SYSBUILD LOCAL VAR EXTRA_CONF_FILE)
-      else()
-        # All variables with ${image}_ prefix are passed to the variant image automatically.
-        set(extra_conf_file)
-      endif()
-
-      ExternalNcsVariantProject_Add(APPLICATION ${primary_image} VARIANT ${image} SPLIT_KCONFIG true)
       UpdateableImage_Add(APPLICATION ${image} GROUP "VARIANT")
-      set(${image}_EXTRA_CONF_FILE "${extra_conf_file}" CACHE INTERNAL "")
-      set_target_properties(${image} PROPERTIES
-        IMAGE_CONF_SCRIPT ${ZEPHYR_BASE}/share/sysbuild/image_configurations/MAIN_image_default.cmake
-      )
       set(secondary_overlay "${ZEPHYR_NRF_MODULE_DIR}/subsys/mcuboot/mcuboot_secondary_app.overlay")
-
       add_overlay_dts(${image} "${secondary_overlay}")
     endif()
+
   endforeach()
 endif()


### PR DESCRIPTION
This commit introduces a (probably temporary) way of fixing passing Kconfigs to a variant image.

In the solution, when not using partition manager, both the .config and autoconf.h files are copied into the variant image. However, the CONFIG_FLASH_LOAD_OFFSET and CONFIG_FLASH_LOAD_SIZE are modified to match the values from zephyr,code-partition - as this are the values used for linking.

Note: there were attempts to make a non-hack, clean fix in zephyr:
https://github.com/zephyrproject-rtos/zephyr/pull/91591

However due to various issues, attempts to merge the PR take a lot of time and it is not sure that the "clean" solution is possible at all. A quick solution for 3.1.0 is needed, as we already get complains about the issue