### PR TITLE
samples: matter: Fix locales in Matter samples

### DIFF
--- a/samples/matter/common/src/app/matter_init.cpp
+++ b/samples/matter/common/src/app/matter_init.cpp
@@ -51,8 +51,8 @@
 #endif
 
 #ifdef CONFIG_OPENTHREAD
-#include <platform/OpenThread/GenericNetworkCommissioningThreadDriver.h>
 #include <openthread.h>
+#include <platform/OpenThread/GenericNetworkCommissioningThreadDriver.h>
 #endif
 
 #include <app/InteractionModelEngine.h>
@@ -94,6 +94,8 @@ chip::DeviceLayer::KMUSessionKeystore Nrf::Matter::InitData::sKMUSessionKeystore
 #ifdef CONFIG_CHIP_FACTORY_DATA
 FactoryDataProvider<InternalFlashFactoryData> Nrf::Matter::InitData::sFactoryDataProviderDefault{};
 #endif
+
+chip::DeviceLayer::DeviceInfoProviderImpl Nrf::Matter::InitData::sDeviceInfoProviderDefault{};
 
 namespace
 {
@@ -198,12 +200,12 @@ CHIP_ERROR InitNetworkingStack()
 #if CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
 void LockOpenThreadTask(void)
 {
-    chip::DeviceLayer::ThreadStackMgr().LockThreadStack();
+	chip::DeviceLayer::ThreadStackMgr().LockThreadStack();
 }
 
 void UnlockOpenThreadTask(void)
 {
-    chip::DeviceLayer::ThreadStackMgr().UnlockThreadStack();
+	chip::DeviceLayer::ThreadStackMgr().UnlockThreadStack();
 }
 #endif /* CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT */
 
@@ -437,7 +439,7 @@ FactoryDataProviderBase *GetFactoryDataProvider()
 }
 #endif
 
-PersistentStorageDelegate * GetPersistentStorageDelegate()
+PersistentStorageDelegate *GetPersistentStorageDelegate()
 {
 	return sLocalInitData.mServerInitParams->persistentStorageDelegate;
 }

--- a/samples/matter/common/src/app/matter_init.h
+++ b/samples/matter/common/src/app/matter_init.h
@@ -11,8 +11,8 @@
 #include <DeviceInfoProviderImpl.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
-#include <lib/core/Optional.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
+#include <lib/core/Optional.h>
 #include <lib/support/Variant.h>
 #include <platform/PlatformManager.h>
 
@@ -55,7 +55,7 @@ struct InitData {
 	/** @brief Pointer to the user provided custom server initialization parameters. */
 	chip::CommonCaseDeviceServerInitParams *mServerInitParams{ &sServerInitParamsDefault };
 	/** @brief Pointer to the user provided custom device info provider implementation. */
-	chip::DeviceLayer::DeviceInfoProviderImpl *mDeviceInfoProvider{ nullptr };
+	chip::DeviceLayer::DeviceInfoProviderImpl *mDeviceInfoProvider{ &sDeviceInfoProviderDefault };
 #ifdef CONFIG_CHIP_FACTORY_DATA
 	/** @brief Pointer to the user provided FactoryDataProvider implementation. */
 	chip::DeviceLayer::FactoryDataProviderBase *mFactoryDataProvider{ &sFactoryDataProviderDefault };
@@ -89,6 +89,7 @@ struct InitData {
 #ifdef CONFIG_CHIP_STORE_KEYS_IN_KMU
 	static chip::DeviceLayer::KMUSessionKeystore sKMUSessionKeystoreDefault;
 #endif
+	static chip::DeviceLayer::DeviceInfoProviderImpl sDeviceInfoProviderDefault;
 };
 
 /**
@@ -129,6 +130,6 @@ CHIP_ERROR StartServer();
 chip::DeviceLayer::FactoryDataProviderBase *GetFactoryDataProvider();
 #endif
 
-chip::PersistentStorageDelegate * GetPersistentStorageDelegate();
+chip::PersistentStorageDelegate *GetPersistentStorageDelegate();
 
 } /* namespace Nrf::Matter */

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: eaf8f2db49353f3518a5d3f3ace48a9eb695b7f1
+      revision: 1ef3e65e14a4baf112391dc7dded8ada1b0c3ab2
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
During the certification process we need to support more than one locale. We can use pre defined example for All Clusters that is available in Matter SDK to assign it in our samples.

Use AllClustersExampleDeviceInfoProviderImpl instead DeviceInfoProviderImpl in Matter samples.