### PR TITLE
samples: wifi: ble_coex: Fix crash when Zperf is started

### DIFF
--- a/samples/wifi/ble_coex/src/main.c
+++ b/samples/wifi/ble_coex/src/main.c
@@ -424,7 +424,7 @@ int main(void)
 	}
 
 	if (test_wlan) {
-		struct zperf_upload_params params;
+		struct zperf_upload_params params = { 0 };
 
 		/* Start Wi-Fi traffic */
 		LOG_INF("Starting Wi-Fi benchmark: Zperf client");


### PR DESCRIPTION
Zperf parameters data structure is not initialized, and with the upmerge changes a function pointer was added as part of the parameters, and if the uninitialized struct has set this to non-zero, then a random address is called by the custom loader function pointer, this causes a crash.

Initialize the parameters to zero.