### PR TITLE
treewide: use proper placeholder for invalid sec_tag

### DIFF
--- a/applications/serial_lte_modem/src/nativetls/slm_native_tls.c
+++ b/applications/serial_lte_modem/src/nativetls/slm_native_tls.c
@@ -27,7 +27,7 @@ struct tls_cred_buf {
 };
 static struct tls_cred_buf cred_buf[CONFIG_SLM_NATIVE_TLS_CREDENTIAL_BUFFER_COUNT] = {
 	[0 ... CONFIG_SLM_NATIVE_TLS_CREDENTIAL_BUFFER_COUNT - 1] = {
-		.sec_tag = -1
+		.sec_tag = 0xFFFFFFFF
 	}
 };
 static uint8_t cred_buf_next; /* Index of next cred_buf to use. */
@@ -201,7 +201,7 @@ static int unload_tls_cred_buf(sec_tag_t sec_tag)
 			}
 		}
 	}
-	cred->sec_tag = -1;
+	cred->sec_tag = 0xFFFFFFFF;
 	cred->type_flags = 0;
 
 	return 0;

--- a/applications/serial_lte_modem/src/slm_defines.h
+++ b/applications/serial_lte_modem/src/slm_defines.h
@@ -11,7 +11,7 @@
 #include "slm_trap_macros.h"
 
 #define INVALID_SOCKET       -1
-#define INVALID_SEC_TAG      -1
+#define INVALID_SEC_TAG      NRF_SEC_TAG_TLS_INVALID
 #define INVALID_ROLE         -1
 #define INVALID_DTLS_CID     -1
 

--- a/samples/cellular/http_update/modem_delta_update/src/main.c
+++ b/samples/cellular/http_update/modem_delta_update/src/main.c
@@ -30,7 +30,7 @@
 #ifdef CONFIG_USE_HTTPS
 #define SEC_TAG (TLS_SEC_TAG)
 #else
-#define SEC_TAG (-1)
+#define SEC_TAG (NRF_SEC_TAG_TLS_INVALID)
 #endif
 
 /* We assume that modem version strings (not UUID) will not be more than this */
@@ -287,7 +287,7 @@ static int update_download(void)
 	int err;
 	const char *file;
 	int sec_tag = SEC_TAG;
-	uint8_t sec_tag_count = sec_tag < 0 ? 0 : 1;
+	uint8_t sec_tag_count = sec_tag == NRF_SEC_TAG_TLS_INVALID ? 0 : 1;
 
 	err = modem_info_string_get(MODEM_INFO_FW_VERSION, modem_version,
 				    MAX_MODEM_VERSION_LEN);

--- a/samples/cellular/http_update/modem_full_update/src/main.c
+++ b/samples/cellular/http_update/modem_full_update/src/main.c
@@ -31,7 +31,7 @@
 #ifdef CONFIG_USE_HTTPS
 #define SEC_TAG (TLS_SEC_TAG)
 #else
-#define SEC_TAG (-1)
+#define SEC_TAG (NRF_SEC_TAG_TLS_INVALID)
 #endif
 
 /* We assume that modem version strings (not UUID) will not be more than this. */
@@ -429,7 +429,7 @@ static int update_download(void)
 	int err;
 	const char *file;
 	int sec_tag = SEC_TAG;
-	uint8_t sec_tag_count = sec_tag < 0 ? 0 : 1;
+	uint8_t sec_tag_count = sec_tag == NRF_SEC_TAG_TLS_INVALID ? 0 : 1;
 	const struct dfu_target_full_modem_params params = {
 		.buf = fmfu_buf,
 		.len = sizeof(fmfu_buf),

--- a/samples/cellular/modem_shell/src/sock/sock.c
+++ b/samples/cellular/modem_shell/src/sock/sock.c
@@ -260,7 +260,7 @@ static int sock_validate_parameters(
 			return -EINVAL;
 		}
 
-		if (sec_tag < 0) {
+		if (sec_tag == NRF_SEC_TAG_TLS_INVALID) {
 			mosh_error("Security tag must be given when security is enabled");
 			return -EINVAL;
 		}

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -344,7 +344,7 @@ cleanup:
 static int job_update_accepted(struct mqtt_client *const client, uint32_t payload_len)
 {
 	int err;
-	int sec_tag = -1;
+	int sec_tag = 0xFFFFFFFF;
 
 	err = get_published_payload(client, payload_buf, payload_len);
 	if (err) {

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -601,7 +601,7 @@ int fota_download_start(const char *host, const char *file, int sec_tag, uint8_t
 			size_t fragment_size)
 {
 	int sec_tag_list[1] = { sec_tag };
-	uint8_t sec_tag_count = sec_tag < 0 ? 0 : 1;
+	uint8_t sec_tag_count = sec_tag == 0xFFFFFFFF ? 0 : 1;
 
 	return fota_download_any(host, file, sec_tag_list, sec_tag_count, pdn_id, fragment_size);
 }
@@ -611,7 +611,7 @@ int fota_download_start_with_image_type(const char *host, const char *file,
 					const enum dfu_target_image_type expected_type)
 {
 	int sec_tag_list[1] = { sec_tag };
-	uint8_t sec_tag_count = sec_tag < 0 ? 0 : 1;
+	uint8_t sec_tag_count = sec_tag == 0xFFFFFFFF ? 0 : 1;
 
 	return fota_download(host, file, sec_tag_list, sec_tag_count, pdn_id, fragment_size,
 			     expected_type);

--- a/subsys/net/lib/fota_download/src/util/fota_download_util.c
+++ b/subsys/net/lib/fota_download/src/util/fota_download_util.c
@@ -53,7 +53,7 @@ static K_WORK_DEFINE(download_work, start_fota_download);
 static fota_download_callback_t fota_client_callback;
 static char fota_path[CONFIG_FOTA_DOWNLOAD_FILE_NAME_LENGTH];
 static char fota_host[CONFIG_FOTA_DOWNLOAD_HOST_NAME_LENGTH];
-static int fota_sec_tag = -1;
+static int fota_sec_tag = 0xFFFFFFFF;
 static bool download_active;
 static enum dfu_target_image_type active_dfu_type;
 

--- a/subsys/net/lib/ftp_client/src/ftp_client.c
+++ b/subsys/net/lib/ftp_client/src/ftp_client.c
@@ -126,7 +126,7 @@ static int establish_data_channel(const char *pasv_msg)
 	LOG_DBG("data port: %d", data_port);
 
 	/* open data socket */
-	if (client.sec_tag <= 0) {
+	if (client.sec_tag == 0xFFFFFFFF) {
 		client.data_sock = zsock_socket(client.family, SOCK_STREAM, IPPROTO_TCP);
 	} else {
 		client.data_sock = zsock_socket(client.family, SOCK_STREAM, IPPROTO_TLS_1_2);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
@@ -875,7 +875,7 @@ static int start_job(struct nrf_cloud_fota_job *const job, const bool send_evt)
 		.path = job->info.path,
 		.dl_host_conf = {
 			.sec_tag_list = &sec_tag,
-			.sec_tag_count = (sec_tag < 0 ? 0 : 1),
+			.sec_tag_count = (sec_tag == 0xFFFFFFFF ? 0 : 1),
 			.pdn_id = 0,
 			.range_override = CONFIG_NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE,
 		},

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_poll.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_poll.c
@@ -541,7 +541,7 @@ static int start_download(void)
 		.path = job.path,
 		.dl_host_conf = {
 			.sec_tag_list = &sec_tag,
-			.sec_tag_count = (sec_tag < 0 ? 0 : 1),
+			.sec_tag_count = (sec_tag == 0xFFFFFFFF ? 0 : 1),
 			.pdn_id = 0,
 			.range_override =
 				ctx_ptr->fragment_size


### PR DESCRIPTION
The fact that the modem uses uint32_t for sec_tags, while Zephyr uses int, is a bit unfortunate.
Often, -1 or 0 are used to indicate an invalid sec_tag, and it is checked whether a sec_tag is positive.

However, there are some "debug" sec_tags for the modem, that register as negative values, while being valid. To avoid confusion, use a proper placeholder for an invalid sec_tag, which is NRF_SEC_TAG_TLS_INVALID (0xFFFFFFFF) for the modem, and 0xFFFFFFFF for libraries not specific to nRF91 modems.