### PR TITLE
Fix Kconfig CONFIG_ZEPHYR to __ZEPHYR__

### DIFF
--- a/modules/wfa-qt/CMakeLists.txt
+++ b/modules/wfa-qt/CMakeLists.txt
@@ -21,10 +21,6 @@ zephyr_library_compile_options(
 	-Wno-format-overflow
 )
 
-zephyr_library_compile_definitions(
-	CONFIG_ZEPHYR
-)
-
 zephyr_library_compile_definitions(CONFIG_CTRL_IFACE_ZEPHYR)
 
 zephyr_include_directories(

--- a/west.yml
+++ b/west.yml
@@ -120,7 +120,7 @@ manifest:
     - name: wfa-qt-control-app
       repo-path: sdk-wi-fiquicktrack-controlappc
       path: modules/lib/wfa-qt-control-app
-      revision: af011c8a8d338ba529f17aed2cc2ef4c1c591a58
+      revision: d4bc010be69aa89290c5af6767702ff46c1829e5
       userdata:
         ncs:
           upstream-url: https://github.com/Wi-FiQuickTrack/Wi-FiQuickTrack-ControlAppC


### PR DESCRIPTION
Fix the Kconfig compliance error by using proper Zephyr macro
instead of a non-existent Kconfig option.