### PR TITLE
samples: matter: The DevKitName attribute must persist after reboot

### DIFF
--- a/samples/matter/manufacturer_specific/src/default_zap/manufacturer_specific.matter
+++ b/samples/matter/manufacturer_specific/src/default_zap/manufacturer_specific.matter
@@ -1721,7 +1721,7 @@ endpoint 1 {
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 1;
-    ram      attribute devKitName default = "Nordic Development Kit";
+    persist  attribute devKitName default = "Nordic Development Kit";
     ram      attribute userLED default = false;
     ram      attribute userButton default = false;
 

--- a/samples/matter/manufacturer_specific/src/default_zap/manufacturer_specific.zap
+++ b/samples/matter/manufacturer_specific/src/default_zap/manufacturer_specific.zap
@@ -2629,7 +2629,7 @@
               "side": "server",
               "type": "char_string",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "NVM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "Nordic Development Kit",

--- a/samples/matter/manufacturer_specific/src/default_zap/zap-generated/endpoint_config.h
+++ b/samples/matter/manufacturer_specific/src/default_zap/zap-generated/endpoint_config.h
@@ -317,7 +317,7 @@
                                                                                                                                                  \
 		/* Endpoint: 1, Cluster: NordicDevKit (server) */                                                                                \
 		{ ZAP_LONG_DEFAULTS_INDEX(8), 0xFFF10000, 255, ZAP_TYPE(CHAR_STRING),                                                            \
-		  ZAP_ATTRIBUTE_MASK(WRITABLE) }, /* DevKitName */                                                                               \
+		  ZAP_ATTRIBUTE_MASK(TOKENIZE) | ZAP_ATTRIBUTE_MASK(WRITABLE) }, /* DevKitName */                                                \
 		{ ZAP_SIMPLE_DEFAULT(false), 0xFFF10001, 1, ZAP_TYPE(BOOLEAN), 0 }, /* UserLED */                                                \
 		{ ZAP_SIMPLE_DEFAULT(false), 0xFFF10002, 1, ZAP_TYPE(BOOLEAN), 0 }, /* UserButton */                                             \
 		{ ZAP_SIMPLE_DEFAULT(0), 0x0000FFFC, 4, ZAP_TYPE(BITMAP32), 0 }, /* FeatureMap */                                                \


### PR DESCRIPTION
There was a wrong configuration for the DevKitName attribute. It was stored in RAM, whereas it should be stored in NVM.