### PR TITLE
samples: lwm2m_client: Allow defining sec_tags for script

### DIFF
--- a/samples/cellular/lwm2m_client/scripts/provision.py
+++ b/samples/cellular/lwm2m_client/scripts/provision.py
@@ -31,6 +31,8 @@ if __name__ == "__main__":
     parser.add_argument('-d', help='Enable debug logs', action='store_true')
     parser.add_argument('-p', '--purge', dest='purge', help='Wipe the security tags and remove the device from the server', action='store_true')
     parser.add_argument('--leshan', help='Provision to Leshan demo server', action='store_true')
+    parser.add_argument('--sec-tag', type=int, default=35724861, help='Security tag to use (default: 35724861)')
+    parser.add_argument('--bs-sec-tag', type=int, default=35724862, help='Bootstrap security tag to use (default: 35724862)')
     args = parser.parse_args()
 
     if args.d:
@@ -54,8 +56,8 @@ if __name__ == "__main__":
     logging.info('Identity: %s', identity)
 
     # Remove previous keys
-    dev.delete_sec_tag(35724861)
-    dev.delete_sec_tag(35724862)
+    dev.delete_sec_tag(args.sec_tag)
+    dev.delete_sec_tag(args.bs_sec_tag)
 
     if args.leshan:
         leshan = Leshan('https://leshan.eclipseprojects.io/api')
@@ -81,7 +83,7 @@ if __name__ == "__main__":
 
     # Generate and store Bootstrap keys
     psk = token_hex(16)
-    dev.store_psk(35724862, identity, psk)
+    dev.store_psk(args.bs_sec_tag, identity, psk)
 
     if args.leshan:
         leshan.create_psk_device(identity, psk)


### PR DESCRIPTION
Allow provisioning script to accept used security tags as a command line parameter.