### PR TITLE
soc: nordic: nrf71: select NRFX_CLOCK_USE_LFRC_CALIBRATION config

### DIFF
--- a/soc/nordic/nrf71/Kconfig
+++ b/soc/nordic/nrf71/Kconfig
@@ -9,6 +9,8 @@ config SOC_SERIES_NRF71X
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 	select SOC_EARLY_INIT_HOOK
 	select SOC_RESET_HOOK
+# To be moved to zephyr/drivers/clock_control/Kconfig.nrf once nrf7120 is present upstream
+	select NRFX_CLOCK_USE_LFRC_CALIBRATION
 
 config SOC_NRF7120_ENGA_CPUAPP
 	select ARM


### PR DESCRIPTION
Add NRFX_CLOCK_USE_LFRC_CALIBRATION to configs for nrf7120 This config should be moved upstream once nrf7120 support is added upstream

Requires Upstream Zephyr PR 93915 to be merged first

