### PR TITLE
nrf_security: CRACEN: Remove single symbol variable names

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cipher.c
@@ -521,8 +521,8 @@ psa_status_t cracen_cipher_update(cracen_cipher_operation_t *operation, const ui
 	__ASSERT_NO_MSG(output_length != NULL);
 
 	int sx_status = SX_ERR_UNINITIALIZED_OBJ;
+	psa_status_t psa_status = PSA_ERROR_CORRUPTION_DETECTED;
 	*output_length = 0;
-	psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
 	if (input_length == 0) {
 		return PSA_SUCCESS;
@@ -577,23 +577,23 @@ psa_status_t cracen_cipher_update(cracen_cipher_operation_t *operation, const ui
 				if (operation->unprocessed_input_bytes) {
 					__ASSERT_NO_MSG(operation->unprocessed_input_bytes ==
 							operation->blk_size);
-					status = crypt_ecb(
+					psa_status = crypt_ecb(
 						&operation->keyref, operation->unprocessed_input,
 						operation->unprocessed_input_bytes, output,
 						output_size, output_length, operation->dir);
-					if (status != PSA_SUCCESS) {
-						return status;
+					if (psa_status != PSA_SUCCESS) {
+						return psa_status;
 					}
 					output += (uint32_t)operation->unprocessed_input_bytes;
 					operation->unprocessed_input_bytes = 0;
 				}
 
 				if (block_bytes) {
-					status = crypt_ecb(
+					psa_status = crypt_ecb(
 						&operation->keyref, input, block_bytes, output,
 						output_size, output_length, operation->dir);
-					if (status != PSA_SUCCESS) {
-						return status;
+					if (psa_status != PSA_SUCCESS) {
+						return psa_status;
 					}
 				}
 			}
@@ -605,10 +605,10 @@ psa_status_t cracen_cipher_update(cracen_cipher_operation_t *operation, const ui
 					return silex_statuscodes_to_psa(sx_status);
 				}
 			} else {
-				psa_status_t r = initialize_cipher(operation);
+				psa_status = initialize_cipher(operation);
 
-				if (r != PSA_SUCCESS) {
-					return r;
+				if (psa_status != PSA_SUCCESS) {
+					return psa_status;
 				}
 			}
 
@@ -659,7 +659,7 @@ psa_status_t cracen_cipher_update(cracen_cipher_operation_t *operation, const ui
 		operation->unprocessed_input_bytes = input_length - block_bytes;
 	}
 
-	(void)status;
+	(void)psa_status;
 	return PSA_SUCCESS;
 }
 
@@ -698,10 +698,10 @@ psa_status_t cracen_cipher_finish(cracen_cipher_operation_t *operation, uint8_t 
 			return silex_statuscodes_to_psa(sx_status);
 		}
 	} else {
-		psa_status_t r = initialize_cipher(operation);
+		psa_status_t result = initialize_cipher(operation);
 
-		if (r != PSA_SUCCESS) {
-			return r;
+		if (result != PSA_SUCCESS) {
+			return result;
 		}
 	}
 

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/src/blind.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/src/blind.c
@@ -15,8 +15,8 @@ void sx_pk_cnx_configure_blinding(struct sx_pk_cnx *cnx, struct sx_pk_blinder *p
 	if (!prng || !caps->blinding) {
 		return;
 	}
-	struct sx_pk_blinder **p = sx_pk_get_blinder(cnx);
-	*p = prng;
+	struct sx_pk_blinder **blinder_ptr = sx_pk_get_blinder(cnx);
+	*blinder_ptr = prng;
 }
 
 sx_pk_blind_factor sx_pk_default_blind_gen(struct sx_pk_blinder *blinder)

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/src/iomem.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/src/iomem.c
@@ -22,27 +22,27 @@
 void sx_clrpkmem(void *dst, size_t sz)
 {
 	typedef int64_t clrblk_t;
-	volatile char *d = (volatile char *)dst;
+	volatile char *dst_ptr = (volatile char *)dst;
 
 	if (sz == 0) {
 		return;
 	}
 
-	while (sz && (!IS_NATURAL_ALIGNED(d, clrblk_t))) {
-		*d = 0;
-		d++;
+	while (sz && (!IS_NATURAL_ALIGNED(dst_ptr, clrblk_t))) {
+		*dst_ptr = 0;
+		dst_ptr++;
 		sz--;
 	}
 
 #if !defined(__aarch64__)
-	memset((char *)d, 0, MASK_TO_NATURAL_SIZE(sz, clrblk_t));
-	d += MASK_TO_NATURAL_SIZE(sz, clrblk_t);
+	memset((char *)dst_ptr, 0, MASK_TO_NATURAL_SIZE(sz, clrblk_t));
+	dst_ptr += MASK_TO_NATURAL_SIZE(sz, clrblk_t);
 	sz -= MASK_TO_NATURAL_SIZE(sz, clrblk_t);
 
 #endif
 	while (sz) {
-		*d = 0;
-		d++;
+		*dst_ptr = 0;
+		dst_ptr++;
 		sz--;
 	}
 }
@@ -56,16 +56,16 @@ typedef struct uchunk tfrblk;
 
 void sx_wrpkmem(void *dst, const void *src, size_t sz)
 {
-	volatile char *d = (volatile char *)dst;
-	volatile const char *s = (volatile const char *)src;
+	volatile char *dst_ptr = (volatile char *)dst;
+	volatile const char *src_ptr = (volatile const char *)src;
 
-	while (sz && (!IS_NATURAL_ALIGNED(d, tfrblk) || !IS_NATURAL_SIZE(sz, tfrblk))) {
-		*d = *s;
-		d++;
-		s++;
+	while (sz && (!IS_NATURAL_ALIGNED(dst_ptr, tfrblk) || !IS_NATURAL_SIZE(sz, tfrblk))) {
+		*dst_ptr = *src_ptr;
+		dst_ptr++;
+		src_ptr++;
 		sz--;
 	}
-	memcpy((char *)d, (char *)s, sz);
+	memcpy((char *)dst_ptr, (char *)src_ptr, sz);
 }
 
 #else /* 54LM20A requires word-aligned, word-sized memory accesses */

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -132,40 +132,40 @@ int sx_pk_wait(sx_pk_req *req)
 	return read_status(req);
 }
 
-void sx_pk_wrreg(struct sx_regs *regs, uint32_t addr, uint32_t v)
+void sx_pk_wrreg(struct sx_regs *regs, uint32_t addr, uint32_t value)
 {
-	volatile uint32_t *p = (uint32_t *)(regs->base + addr);
+	volatile uint32_t *reg_ptr = (uint32_t *)(regs->base + addr);
 
 #ifdef SX_INSTRUMENT_MMIO_WITH_PRINTFS
-	printk("sx_pk_wrreg(addr=0x%x, p=%p, val=0x%x)\r\n", addr, p, v);
+	printk("sx_pk_wrreg(addr=0x%x, reg_ptr=%p, val=0x%x)\r\n", addr, reg_ptr, value);
 #endif
-	if ((uintptr_t)p % 4) {
-		SX_WARN_UNALIGNED_ADDR(p);
+	if ((uintptr_t)reg_ptr % 4) {
+		SX_WARN_UNALIGNED_ADDR(reg_ptr);
 	}
 
-	*p = v;
+	*reg_ptr = value;
 }
 
 uint32_t sx_pk_rdreg(struct sx_regs *regs, uint32_t addr)
 {
-	volatile uint32_t *p = (uint32_t *)(regs->base + addr);
-	uint32_t v;
+	volatile uint32_t *reg_ptr = (uint32_t *)(regs->base + addr);
+	uint32_t value;
 
 
 #ifdef SX_INSTRUMENT_MMIO_WITH_PRINTFS
-	printk("sx_pk_rdreg(addr=0x%x, p=%p)\r\n", addr, p);
+	printk("sx_pk_rdreg(addr=0x%x, reg_ptr=%p)\r\n", addr, reg_ptr);
 #endif
-	if ((uintptr_t)p % 4) {
-		SX_WARN_UNALIGNED_ADDR(p);
+	if ((uintptr_t)reg_ptr % 4) {
+		SX_WARN_UNALIGNED_ADDR(reg_ptr);
 	}
 
-	v = *p;
+	value = *reg_ptr;
 
 #ifdef SX_INSTRUMENT_MMIO_WITH_PRINTFS
-	printk("result = 0x%x\r\n", v);
+	printk("result = 0x%x\r\n", value);
 #endif
 
-	return v;
+	return value;
 }
 
 struct sx_pk_blinder **sx_pk_get_blinder(struct sx_pk_cnx *cnx)

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmac.c
@@ -43,9 +43,9 @@ static const struct sx_mac_cmdma_cfg ba411cfg = {
 	.dmatags = &ba411tags,
 };
 
-static int sx_cmac_create_aes_ba411(struct sxmac *c, const struct sxkeyref *key);
+static int sx_cmac_create_aes_ba411(struct sxmac *mac_ctx, const struct sxkeyref *key);
 
-static int sx_cmac_create_aes_ba411(struct sxmac *c, const struct sxkeyref *key)
+static int sx_cmac_create_aes_ba411(struct sxmac *mac_ctx, const struct sxkeyref *key)
 {
 	int err;
 
@@ -58,28 +58,28 @@ static int sx_cmac_create_aes_ba411(struct sxmac *c, const struct sxkeyref *key)
 		}
 	}
 
-	c->key = key;
-	err = sx_mac_hw_reserve(c);
+	mac_ctx->key = key;
+	err = sx_mac_hw_reserve(mac_ctx);
 	if (err != SX_OK) {
 		return err;
 	}
 
-	c->cfg = &ba411cfg;
-	c->cntindescs = 1;
-	sx_cmdma_newcmd(&c->dma, c->descs,
+	mac_ctx->cfg = &ba411cfg;
+	mac_ctx->cntindescs = 1;
+	sx_cmdma_newcmd(&mac_ctx->dma, mac_ctx->descs,
 			CMDMA_CMAC_MODE_SET(CMAC_MODEID_AES) | KEYREF_AES_HWKEY_CONF(key->cfg),
-			c->cfg->dmatags->cfg);
+			mac_ctx->cfg->dmatags->cfg);
 	if (KEYREF_IS_USR(key)) {
-		ADD_CFGDESC(c->dma, key->key, key->sz, c->cfg->dmatags->key);
-		c->cntindescs++;
+		ADD_CFGDESC(mac_ctx->dma, key->key, key->sz, mac_ctx->cfg->dmatags->key);
+		mac_ctx->cntindescs++;
 	}
-	c->feedsz = 0;
-	c->macsz = CMAC_MAC_SZ;
+	mac_ctx->feedsz = 0;
+	mac_ctx->macsz = CMAC_MAC_SZ;
 
 	return SX_OK;
 }
 
-int sx_mac_create_aescmac(struct sxmac *c, const struct sxkeyref *key)
+int sx_mac_create_aescmac(struct sxmac *mac_ctx, const struct sxkeyref *key)
 {
-	return sx_cmac_create_aes_ba411(c, key);
+	return sx_cmac_create_aes_ba411(mac_ctx, key);
 }

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmmask.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmmask.c
@@ -13,7 +13,7 @@
 
 int sx_cm_load_mask(uint32_t csprng_value)
 {
-	int r;
+	int status;
 	struct sxchannel channel;
 
 	/* This is a special case where "cfg" is used to transmit the random
@@ -26,11 +26,11 @@ int sx_cm_load_mask(uint32_t csprng_value)
 
 	sx_cmdma_start(&channel.dma, sizeof(channel.descs), channel.descs);
 
-	r = SX_ERR_HW_PROCESSING;
-	while (r == SX_ERR_HW_PROCESSING) {
-		r = sx_cmdma_check();
+	status = SX_ERR_HW_PROCESSING;
+	while (status == SX_ERR_HW_PROCESSING) {
+		status = sx_cmdma_check();
 	}
 
 	safe_memzero(&channel, sizeof(channel));
-	return r;
+	return status;
 }

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hash.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hash.c
@@ -26,142 +26,148 @@ static const struct sx_digesttags ba413tags = {
 #define HASH_INVALID_BYTES  4 /* number of invalid bytes when empty message, required by HW */
 #define CMDMA_BA413_MODE(x) ((x) | (HASH_HW_PAD | HASH_FINAL))
 
-static int sx_hash_create_ba413(struct sxhash *c, size_t csz);
+static int sx_hash_create_ba413(struct sxhash *hash_ctx, size_t csz);
 
 const struct sxhashalg sxhashalg_sha1 = {
 	CMDMA_BA413_MODE(0x02), HASH_HW_PAD, HASH_FINAL, SX_HASH_DIGESTSZ_SHA1,
-	SX_HASH_BLOCKSZ_SHA1, 20, 72, sx_hash_create_ba413};
+	SX_HASH_BLOCKSZ_SHA1,	20,	     72,	 sx_hash_create_ba413};
 const struct sxhashalg sxhashalg_sha2_224 = {
-	CMDMA_BA413_MODE(0x04), HASH_HW_PAD, HASH_FINAL, SX_HASH_DIGESTSZ_SHA2_224,
-	SX_HASH_BLOCKSZ_SHA2_224, 32, 72, sx_hash_create_ba413};
+	CMDMA_BA413_MODE(0x04),	  HASH_HW_PAD, HASH_FINAL, SX_HASH_DIGESTSZ_SHA2_224,
+	SX_HASH_BLOCKSZ_SHA2_224, 32,	       72,	   sx_hash_create_ba413};
 const struct sxhashalg sxhashalg_sha2_256 = {
-	CMDMA_BA413_MODE(0x08), HASH_HW_PAD, HASH_FINAL, SX_HASH_DIGESTSZ_SHA2_256,
-	SX_HASH_BLOCKSZ_SHA2_256, 32, 72, sx_hash_create_ba413};
+	CMDMA_BA413_MODE(0x08),	  HASH_HW_PAD, HASH_FINAL, SX_HASH_DIGESTSZ_SHA2_256,
+	SX_HASH_BLOCKSZ_SHA2_256, 32,	       72,	   sx_hash_create_ba413};
 const struct sxhashalg sxhashalg_sha2_384 = {
-	CMDMA_BA413_MODE(0x10), HASH_HW_PAD, HASH_FINAL, SX_HASH_DIGESTSZ_SHA2_384,
-	SX_HASH_BLOCKSZ_SHA2_384, 64, 144, sx_hash_create_ba413};
+	CMDMA_BA413_MODE(0x10),	  HASH_HW_PAD, HASH_FINAL, SX_HASH_DIGESTSZ_SHA2_384,
+	SX_HASH_BLOCKSZ_SHA2_384, 64,	       144,	   sx_hash_create_ba413};
 const struct sxhashalg sxhashalg_sha2_512 = {
-	CMDMA_BA413_MODE(0x20), HASH_HW_PAD, HASH_FINAL, SX_HASH_DIGESTSZ_SHA2_512,
-	SX_HASH_BLOCKSZ_SHA2_512, 64, 144, sx_hash_create_ba413};
+	CMDMA_BA413_MODE(0x20),	  HASH_HW_PAD, HASH_FINAL, SX_HASH_DIGESTSZ_SHA2_512,
+	SX_HASH_BLOCKSZ_SHA2_512, 64,	       144,	   sx_hash_create_ba413};
 const struct sxhashalg sxhashalg_sm3 = {
 	CMDMA_BA413_MODE(0x40), HASH_HW_PAD, HASH_FINAL, SX_HASH_DIGESTSZ_SM3,
-	SX_HASH_BLOCKSZ_SM3, 32, 72, sx_hash_create_ba413};
+	SX_HASH_BLOCKSZ_SM3,	32,	     72,	 sx_hash_create_ba413};
 
 #define CMDMA_BA413_BUS_MSK 3
 
-void sx_hash_free(struct sxhash *c)
+void sx_hash_free(struct sxhash *hash_ctx)
 {
-	sx_cmdma_release_hw(&c->dma);
+	sx_cmdma_release_hw(&hash_ctx->dma);
 }
 
-static void sx_hash_pad(struct sxhash *c)
+static void sx_hash_pad(struct sxhash *hash_ctx)
 {
-	unsigned char *padding = (unsigned char *)c->extramem;
+	unsigned char *padding = (unsigned char *)hash_ctx->extramem;
 	size_t padsz;
-	size_t v = c->totalfeedsz;
+	size_t total_feed_size = hash_ctx->totalfeedsz;
 
 	/* as per SHA standard, write the full hashed message size in
 	 * big endian form starting with 0x80 and as many 0 bytes as
 	 * needed to have full block size.
 	 */
-	size_t length_field_sz = (c->algo->digestsz >= 48) ? 16 : 8;
+	size_t length_field_sz = (hash_ctx->algo->digestsz >= 48) ? 16 : 8;
 
-	padsz = c->algo->blocksz - (c->totalfeedsz & (c->algo->blocksz - 1));
+	padsz = hash_ctx->algo->blocksz - (hash_ctx->totalfeedsz & (hash_ctx->algo->blocksz - 1));
 	if (padsz < (length_field_sz + 1)) {
-		padsz += c->algo->blocksz;
+		padsz += hash_ctx->algo->blocksz;
 	}
 
-	padding[padsz - 1] = (v & 0x1f) << 3; /* multiply by 8 for bits */
-	v >>= 5;
+	padding[padsz - 1] = (total_feed_size & 0x1f) << 3; /* multiply by 8 for bits */
+	total_feed_size >>= 5;
 	for (size_t i = padsz - 2; i > 0; i--) {
-		padding[i] = v & 0xFF;
-		v >>= 8;
+		padding[i] = total_feed_size & 0xFF;
+		total_feed_size >>= 8;
 	}
 	padding[0] = 0x80;
 
-	ADD_INDESC_PRIV_RAW(c->dma, OFFSET_EXTRAMEM(c), padsz, c->dmatags->data);
-	c->feedsz += padsz;
+	ADD_INDESC_PRIV_RAW(hash_ctx->dma, OFFSET_EXTRAMEM(hash_ctx), padsz,
+			    hash_ctx->dmatags->data);
+	hash_ctx->feedsz += padsz;
 	/* Padding is done only when sx_hash_resume_state() has been called and
 	 * sx_hash_resume_state() already reserved room for this extra
 	 * descriptor.
 	 */
 }
 
-void sx_ba413_digest(struct sxhash *c, char *digest)
+void sx_ba413_digest(struct sxhash *hash_ctx, char *digest)
 {
-	if (c->totalfeedsz == 0) {
+	if (hash_ctx->totalfeedsz == 0) {
 		/* If we get here it means an empty message hash will be
 		 * generated. 4 dummy bytes will be added to hash, these bytes
 		 * will be dropped by the hash engine.
 		 */
-		ADD_EMPTY_INDESC(c->dma, HASH_INVALID_BYTES, c->dmatags->data);
+		ADD_EMPTY_INDESC(hash_ctx->dma, HASH_INVALID_BYTES, hash_ctx->dmatags->data);
 	}
 
-	if (!(c->dma.dmamem.cfg & HASH_HW_PAD)) {
-		sx_hash_pad(c);
+	if (!(hash_ctx->dma.dmamem.cfg & HASH_HW_PAD)) {
+		sx_hash_pad(hash_ctx);
 	}
-	SET_LAST_DESC_IGN(c->dma, c->feedsz, CMDMA_BA413_BUS_MSK);
+	SET_LAST_DESC_IGN(hash_ctx->dma, hash_ctx->feedsz, CMDMA_BA413_BUS_MSK);
 
-	ADD_OUTDESCA(c->dma, digest, c->algo->digestsz, CMDMA_BA413_BUS_MSK);
+	ADD_OUTDESCA(hash_ctx->dma, digest, hash_ctx->algo->digestsz, CMDMA_BA413_BUS_MSK);
 
-	if (!(c->dma.dmamem.cfg & HASH_FINAL) && (c->algo->statesz - c->algo->digestsz)) {
-		ADD_DISCARDDESC(c->dma, (c->algo->statesz - c->algo->digestsz));
+	if (!(hash_ctx->dma.dmamem.cfg & HASH_FINAL) &&
+	    (hash_ctx->algo->statesz - hash_ctx->algo->digestsz)) {
+		ADD_DISCARDDESC(hash_ctx->dma,
+				(hash_ctx->algo->statesz - hash_ctx->algo->digestsz));
 	}
 }
 
-static int sx_hash_create_ba413(struct sxhash *c, size_t csz)
+static int sx_hash_create_ba413(struct sxhash *hash_ctx, size_t csz)
 {
-	if (csz < sizeof(*c)) {
+	if (csz < sizeof(*hash_ctx)) {
 		return SX_ERR_ALLOCATION_TOO_SMALL;
 	}
 
 	/* SM3 is not supported by CRACEN in nRF devices */
-	if (c->algo->cfgword & REG_BA413_CAPS_ALGO_SM3) {
+	if (hash_ctx->algo->cfgword & REG_BA413_CAPS_ALGO_SM3) {
 		return SX_ERR_INCOMPATIBLE_HW;
 	}
 
-	sx_hw_reserve(&c->dma);
+	sx_hw_reserve(&hash_ctx->dma);
 
-	c->dmatags = &ba413tags;
-	sx_cmdma_newcmd(&c->dma, c->descs, c->algo->cfgword, c->dmatags->cfg);
-	c->feedsz = 0;
-	c->totalfeedsz = 0;
-	c->digest = sx_ba413_digest;
+	hash_ctx->dmatags = &ba413tags;
+	sx_cmdma_newcmd(&hash_ctx->dma, hash_ctx->descs, hash_ctx->algo->cfgword,
+			hash_ctx->dmatags->cfg);
+	hash_ctx->feedsz = 0;
+	hash_ctx->totalfeedsz = 0;
+	hash_ctx->digest = sx_ba413_digest;
 
-	c->cntindescs = 1;
+	hash_ctx->cntindescs = 1;
 
 	return SX_OK;
 }
 
-int sx_hash_create(struct sxhash *c, const struct sxhashalg *alg, size_t csz)
+int sx_hash_create(struct sxhash *hash_ctx, const struct sxhashalg *alg, size_t csz)
 {
-	c->algo = alg;
+	hash_ctx->algo = alg;
 
-	return alg->reservehw(c, csz);
+	return alg->reservehw(hash_ctx, csz);
 }
 
-int sx_hash_resume_state(struct sxhash *c)
+int sx_hash_resume_state(struct sxhash *hash_ctx)
 {
-	if (!c->algo || c->dma.hw_acquired) {
+	if (!hash_ctx->algo || hash_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
-	size_t totalfeedsz = c->totalfeedsz;
-	int r = c->algo->reservehw(c, sizeof(*c));
+	size_t totalfeedsz = hash_ctx->totalfeedsz;
+	int status = hash_ctx->algo->reservehw(hash_ctx, sizeof(*hash_ctx));
 
-	if (r) {
-		return r;
+	if (status) {
+		return status;
 	}
-	c->totalfeedsz = totalfeedsz;
-	ADD_INDESC_PRIV(c->dma, (OFFSET_EXTRAMEM(c) + sizeof(c->extramem) - c->algo->statesz),
-			c->algo->statesz, c->dmatags->initialstate);
-	c->cntindescs += 2; /* ensure that we have a free descriptor for padding */
+	hash_ctx->totalfeedsz = totalfeedsz;
+	ADD_INDESC_PRIV(
+		hash_ctx->dma,
+		(OFFSET_EXTRAMEM(hash_ctx) + sizeof(hash_ctx->extramem) - hash_ctx->algo->statesz),
+		hash_ctx->algo->statesz, hash_ctx->dmatags->initialstate);
+	hash_ctx->cntindescs += 2; /* ensure that we have a free descriptor for padding */
 
 	return SX_OK;
 }
 
-int sx_hash_feed(struct sxhash *c, const char *msg, size_t sz)
+int sx_hash_feed(struct sxhash *hash_ctx, const char *msg, size_t sz)
 {
-	if (!c->dma.hw_acquired) {
+	if (!hash_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
 
@@ -169,99 +175,102 @@ int sx_hash_feed(struct sxhash *c, const char *msg, size_t sz)
 		return SX_OK;
 	}
 
-	if (c->cntindescs >= (ARRAY_SIZE(c->descs))) {
-		sx_hash_free(c);
+	if (hash_ctx->cntindescs >= (ARRAY_SIZE(hash_ctx->descs))) {
+		sx_hash_free(hash_ctx);
 		return SX_ERR_FEED_COUNT_EXCEEDED;
 	}
 
 	if (sz >= DMA_MAX_SZ) {
-		sx_hash_free(c);
+		sx_hash_free(hash_ctx);
 		return SX_ERR_TOO_BIG;
 	}
 
-	ADD_RAW_INDESC(c->dma, msg, sz, c->dmatags->data);
-	c->feedsz += sz;
-	c->totalfeedsz += sz;
-	c->cntindescs++;
+	ADD_RAW_INDESC(hash_ctx->dma, msg, sz, hash_ctx->dmatags->data);
+	hash_ctx->feedsz += sz;
+	hash_ctx->totalfeedsz += sz;
+	hash_ctx->cntindescs++;
 
 	return SX_OK;
 }
 
-static int start_hash_hw(struct sxhash *c)
+static int start_hash_hw(struct sxhash *hash_ctx)
 {
-	sx_cmdma_start(&c->dma, sizeof(c->descs) + sizeof(c->extramem), c->descs);
+	sx_cmdma_start(&hash_ctx->dma, sizeof(hash_ctx->descs) + sizeof(hash_ctx->extramem),
+		       hash_ctx->descs);
 
 	return 0;
 }
 
-int sx_hash_save_state(struct sxhash *c)
+int sx_hash_save_state(struct sxhash *hash_ctx)
 {
-	if (!c->dma.hw_acquired) {
+	if (!hash_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
 
-	if (c->totalfeedsz % c->algo->blocksz) {
-		sx_hash_free(c);
+	if (hash_ctx->totalfeedsz % hash_ctx->algo->blocksz) {
+		sx_hash_free(hash_ctx);
 		return SX_ERR_WRONG_SIZE_GRANULARITY;
 	}
-	if ((c->algo->statesz + c->algo->maxpadsz) > sizeof(c->extramem)) {
-		sx_hash_free(c);
+	if ((hash_ctx->algo->statesz + hash_ctx->algo->maxpadsz) > sizeof(hash_ctx->extramem)) {
+		sx_hash_free(hash_ctx);
 		return SX_ERR_ALLOCATION_TOO_SMALL;
 	}
 
-	c->dma.dmamem.cfg ^= c->algo->exportcfg;
-	c->dma.dmamem.cfg ^= c->algo->resumecfg;
-	ADD_OUTDESC_PRIV(c->dma, (OFFSET_EXTRAMEM(c) + sizeof(c->extramem) - c->algo->statesz),
-			 c->algo->statesz, CMDMA_BA413_BUS_MSK);
+	hash_ctx->dma.dmamem.cfg ^= hash_ctx->algo->exportcfg;
+	hash_ctx->dma.dmamem.cfg ^= hash_ctx->algo->resumecfg;
+	ADD_OUTDESC_PRIV(
+		hash_ctx->dma,
+		(OFFSET_EXTRAMEM(hash_ctx) + sizeof(hash_ctx->extramem) - hash_ctx->algo->statesz),
+		hash_ctx->algo->statesz, CMDMA_BA413_BUS_MSK);
 
-	return start_hash_hw(c);
+	return start_hash_hw(hash_ctx);
 }
 
-int sx_hash_digest(struct sxhash *c, char *digest)
+int sx_hash_digest(struct sxhash *hash_ctx, char *digest)
 {
-	if (!c->dma.hw_acquired) {
+	if (!hash_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
 
-	if (c->totalfeedsz != c->feedsz) {
-		c->dma.dmamem.cfg ^= c->algo->resumecfg;
+	if (hash_ctx->totalfeedsz != hash_ctx->feedsz) {
+		hash_ctx->dma.dmamem.cfg ^= hash_ctx->algo->resumecfg;
 	}
-	c->digest(c, digest);
+	hash_ctx->digest(hash_ctx, digest);
 
-	return start_hash_hw(c);
+	return start_hash_hw(hash_ctx);
 }
 
-int sx_hash_status(struct sxhash *c)
+int sx_hash_status(struct sxhash *hash_ctx)
 {
-	if (!c->dma.hw_acquired) {
+	if (!hash_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
 
-	int r;
+	int status;
 
-	r = sx_cmdma_check();
-	if (r == SX_ERR_HW_PROCESSING) {
-		return r;
+	status = sx_cmdma_check();
+	if (status == SX_ERR_HW_PROCESSING) {
+		return status;
 	}
 
 #if CONFIG_DCACHE
-	sys_cache_data_invd_range((void *)&c->extramem, sizeof(c->extramem));
+	sys_cache_data_invd_range((void *)&hash_ctx->extramem, sizeof(hash_ctx->extramem));
 #endif
 
-	sx_hash_free(c);
+	sx_hash_free(hash_ctx);
 
-	return r;
+	return status;
 }
 
-int sx_hash_wait(struct sxhash *c)
+int sx_hash_wait(struct sxhash *hash_ctx)
 {
-	int r = SX_ERR_HW_PROCESSING;
+	int status = SX_ERR_HW_PROCESSING;
 
-	while (r == SX_ERR_HW_PROCESSING) {
-		r = sx_hash_status(c);
+	while (status == SX_ERR_HW_PROCESSING) {
+		status = sx_hash_status(hash_ctx);
 	}
 
-	return r;
+	return status;
 }
 
 size_t sx_hash_get_alg_digestsz(const struct sxhashalg *alg)
@@ -274,12 +283,12 @@ size_t sx_hash_get_alg_blocksz(const struct sxhashalg *alg)
 	return alg->blocksz;
 }
 
-size_t sx_hash_get_digestsz(struct sxhash *c)
+size_t sx_hash_get_digestsz(struct sxhash *hash_ctx)
 {
-	return c->algo->digestsz;
+	return hash_ctx->algo->digestsz;
 }
 
-size_t sx_hash_get_blocksz(struct sxhash *c)
+size_t sx_hash_get_blocksz(struct sxhash *hash_ctx)
 {
-	return c->algo->blocksz;
+	return hash_ctx->algo->blocksz;
 }

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hmac.c
@@ -13,13 +13,13 @@
 #include "macdefs.h"
 #include "keyrefdefs.h"
 
-#define BA413_HMAC_CONF			   (1 << 8)
+#define BA413_HMAC_CONF		       (1 << 8)
 /** BA413-HASH Config register -> KeySel[3:0] = [31:28] */
-#define KEYREF_BA413_HWKEY_CONF(index) (((index)&0xF) << 28)
+#define KEYREF_BA413_HWKEY_CONF(index) (((index) & 0xF) << 28)
 /** BA418-HASH Config register hmac */
-#define BA418_HMAC_ENABLED (1 << 29)
+#define BA418_HMAC_ENABLED	       (1 << 29)
 /** BA418-HASH Config register Padding*/
-#define BA418_HW_PADDING (1 << 5)
+#define BA418_HW_PADDING	       (1 << 5)
 /** BA418-HASH Config register -> KeySel[4:0] = [28:24] */
 #define KEYREF_BA418_HWKEY_CONF(index) (((index) & 0x1F) << 24)
 
@@ -34,11 +34,10 @@ static const struct sx_mac_cmdma_cfg ba413cfg = {
 	.dmatags = &ba413tags,
 };
 
-static const struct sx_mac_cmdma_tags ba418tags = {
-	.cfg = DMATAG_BA418 | DMATAG_CONFIG(0),
-	.key = DMATAG_BA418 | DMATAG_DATATYPE(2) | DMATAG_LAST,
-	.data = DMATAG_BA418  | DMATAG_DATATYPE(0)
-};
+static const struct sx_mac_cmdma_tags ba418tags = {.cfg = DMATAG_BA418 | DMATAG_CONFIG(0),
+						   .key = DMATAG_BA418 | DMATAG_DATATYPE(2) |
+							  DMATAG_LAST,
+						   .data = DMATAG_BA418 | DMATAG_DATATYPE(0)};
 
 static struct sx_mac_cmdma_cfg ba418cfg = {
 	.cmdma_mask = CMDMA_BA418_BUS_MSK,
@@ -46,8 +45,8 @@ static struct sx_mac_cmdma_cfg ba418cfg = {
 	.dmatags = &ba418tags,
 };
 
-static int sx_hash_create_hmac_ba413(struct sxmac *c, const struct sxhashalg *algo,
-					 struct sxkeyref *keyref)
+static int sx_hash_create_hmac_ba413(struct sxmac *mac_ctx, const struct sxhashalg *algo,
+				     struct sxkeyref *keyref)
 {
 
 	if (KEYREF_IS_INVALID(keyref)) {
@@ -59,104 +58,108 @@ static int sx_hash_create_hmac_ba413(struct sxmac *c, const struct sxhashalg *al
 		return SX_ERR_INCOMPATIBLE_HW;
 	}
 
-	sx_hw_reserve(&c->dma);
+	sx_hw_reserve(&mac_ctx->dma);
 
-	c->cfg = &ba413cfg;
-	sx_cmdma_newcmd(&c->dma, c->descs,
+	mac_ctx->cfg = &ba413cfg;
+	sx_cmdma_newcmd(&mac_ctx->dma, mac_ctx->descs,
 			algo->cfgword | BA413_HMAC_CONF | KEYREF_BA413_HWKEY_CONF(keyref->cfg),
-			c->cfg->dmatags->cfg);
+			mac_ctx->cfg->dmatags->cfg);
 
 	if (KEYREF_IS_USR(keyref)) {
 		if (keyref->sz) {
-			ADD_INDESCA(c->dma, keyref->key, keyref->sz, c->cfg->dmatags->key,
-					CMDMA_BA413_BUS_MSK);
+			ADD_INDESCA(mac_ctx->dma, keyref->key, keyref->sz,
+				    mac_ctx->cfg->dmatags->key, CMDMA_BA413_BUS_MSK);
 		} else {
-			ADD_EMPTY_INDESC(c->dma, HASH_INVALID_BYTES, c->cfg->dmatags->key);
+			ADD_EMPTY_INDESC(mac_ctx->dma, HASH_INVALID_BYTES,
+					 mac_ctx->cfg->dmatags->key);
 		}
 	}
 
-	c->cntindescs = 2;
-	c->feedsz = 0;
-	c->macsz = algo->digestsz;
+	mac_ctx->cntindescs = 2;
+	mac_ctx->feedsz = 0;
+	mac_ctx->macsz = algo->digestsz;
 
 	return SX_OK;
 }
 
-int sx_mac_create_hmac_sha2_256(struct sxmac *c, struct sxkeyref *keyref)
+int sx_mac_create_hmac_sha2_256(struct sxmac *mac_ctx, struct sxkeyref *keyref)
 {
-	return sx_hash_create_hmac_ba413(c, &sxhashalg_sha2_256, keyref);
+	return sx_hash_create_hmac_ba413(mac_ctx, &sxhashalg_sha2_256, keyref);
 }
 
-int sx_mac_create_hmac_sha2_384(struct sxmac *c, struct sxkeyref *keyref)
+int sx_mac_create_hmac_sha2_384(struct sxmac *mac_ctx, struct sxkeyref *keyref)
 {
-	return sx_hash_create_hmac_ba413(c, &sxhashalg_sha2_384, keyref);
+	return sx_hash_create_hmac_ba413(mac_ctx, &sxhashalg_sha2_384, keyref);
 }
 
-int sx_mac_create_hmac_sha2_512(struct sxmac *c, struct sxkeyref *keyref)
+int sx_mac_create_hmac_sha2_512(struct sxmac *mac_ctx, struct sxkeyref *keyref)
 {
-	return sx_hash_create_hmac_ba413(c, &sxhashalg_sha2_512, keyref);
+	return sx_hash_create_hmac_ba413(mac_ctx, &sxhashalg_sha2_512, keyref);
 }
 
-int sx_mac_create_hmac_sha1(struct sxmac *c, struct sxkeyref *keyref)
+int sx_mac_create_hmac_sha1(struct sxmac *mac_ctx, struct sxkeyref *keyref)
 {
 	/* sha1 hmac and a hardware key in conjunction is not supported */
 	if (!KEYREF_IS_USR(keyref)) {
 		return SX_ERR_INCOMPATIBLE_HW;
 	}
 
-	return sx_hash_create_hmac_ba413(c, &sxhashalg_sha1, keyref);
+	return sx_hash_create_hmac_ba413(mac_ctx, &sxhashalg_sha1, keyref);
 }
 
-int sx_mac_create_hmac_sha2_224(struct sxmac *c, struct sxkeyref *keyref)
+int sx_mac_create_hmac_sha2_224(struct sxmac *mac_ctx, struct sxkeyref *keyref)
 {
-	return sx_hash_create_hmac_ba413(c, &sxhashalg_sha2_224, keyref);
+	return sx_hash_create_hmac_ba413(mac_ctx, &sxhashalg_sha2_224, keyref);
 }
 
-static int sx_hash_create_hmac_ba418(struct sxmac *c, const struct sxhashalg *algo,
+static int sx_hash_create_hmac_ba418(struct sxmac *mac_ctx, const struct sxhashalg *algo,
 				     struct sxkeyref *keyref)
 {
-	if (KEYREF_IS_INVALID(keyref))
+	if (KEYREF_IS_INVALID(keyref)) {
 		return SX_ERR_INVALID_KEYREF;
+	}
 
-	sx_hw_reserve(&c->dma);
+	sx_hw_reserve(&mac_ctx->dma);
 
-	c->cfg = &ba418cfg;
+	mac_ctx->cfg = &ba418cfg;
 
-	sx_cmdma_newcmd(&c->dma, c->descs, algo->cfgword | BA418_HMAC_ENABLED |
-					   KEYREF_BA418_HWKEY_CONF(keyref->cfg) | BA418_HW_PADDING,
-			c->cfg->dmatags->cfg);
+	sx_cmdma_newcmd(&mac_ctx->dma, mac_ctx->descs,
+			algo->cfgword | BA418_HMAC_ENABLED | KEYREF_BA418_HWKEY_CONF(keyref->cfg) |
+				BA418_HW_PADDING,
+			mac_ctx->cfg->dmatags->cfg);
 	if (KEYREF_IS_USR(keyref)) {
 		if (keyref->sz) {
-			ADD_INDESCA(c->dma, keyref->key, keyref->sz, c->cfg->dmatags->key,
-				CMDMA_BA418_BUS_MSK);
+			ADD_INDESCA(mac_ctx->dma, keyref->key, keyref->sz,
+				    mac_ctx->cfg->dmatags->key, CMDMA_BA418_BUS_MSK);
 		} else {
-			ADD_EMPTY_INDESC(c->dma, HASH_INVALID_BYTES, c->cfg->dmatags->key);
+			ADD_EMPTY_INDESC(mac_ctx->dma, HASH_INVALID_BYTES,
+					 mac_ctx->cfg->dmatags->key);
 		}
 	}
 
-	c->cntindescs = 2;
-	c->feedsz = 0;
-	c->macsz = algo->digestsz;
+	mac_ctx->cntindescs = 2;
+	mac_ctx->feedsz = 0;
+	mac_ctx->macsz = algo->digestsz;
 
 	return SX_OK;
 }
 
-int sx_mac_create_hmac_sha3_224(struct sxmac *c, struct sxkeyref *keyref)
+int sx_mac_create_hmac_sha3_224(struct sxmac *mac_ctx, struct sxkeyref *keyref)
 {
-	return sx_hash_create_hmac_ba418(c, &sxhashalg_sha3_224, keyref);
+	return sx_hash_create_hmac_ba418(mac_ctx, &sxhashalg_sha3_224, keyref);
 }
 
-int sx_mac_create_hmac_sha3_256(struct sxmac *c, struct sxkeyref *keyref)
+int sx_mac_create_hmac_sha3_256(struct sxmac *mac_ctx, struct sxkeyref *keyref)
 {
-	return sx_hash_create_hmac_ba418(c, &sxhashalg_sha3_256, keyref);
+	return sx_hash_create_hmac_ba418(mac_ctx, &sxhashalg_sha3_256, keyref);
 }
 
-int sx_mac_create_hmac_sha3_384(struct sxmac *c, struct sxkeyref *keyref)
+int sx_mac_create_hmac_sha3_384(struct sxmac *mac_ctx, struct sxkeyref *keyref)
 {
-	return sx_hash_create_hmac_ba418(c, &sxhashalg_sha3_384, keyref);
+	return sx_hash_create_hmac_ba418(mac_ctx, &sxhashalg_sha3_384, keyref);
 }
 
-int sx_mac_create_hmac_sha3_512(struct sxmac *c, struct sxkeyref *keyref)
+int sx_mac_create_hmac_sha3_512(struct sxmac *mac_ctx, struct sxkeyref *keyref)
 {
-	return sx_hash_create_hmac_ba418(c, &sxhashalg_sha3_512, keyref);
+	return sx_hash_create_hmac_ba418(mac_ctx, &sxhashalg_sha3_512, keyref);
 }

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/keyref.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/keyref.c
@@ -8,14 +8,14 @@
 
 struct sxkeyref sx_keyref_load_material(size_t keysz, const char *keymaterial)
 {
-	struct sxkeyref k;
+	struct sxkeyref keyref;
 
-	k.key = keymaterial;
-	k.sz = keysz;
-	k.cfg = 0;
-	k.prepare_key = 0;
-	k.clean_key = 0;
-	k.user_data = 0;
+	keyref.key = keymaterial;
+	keyref.sz = keysz;
+	keyref.cfg = 0;
+	keyref.prepare_key = 0;
+	keyref.clean_key = 0;
+	keyref.user_data = 0;
 
-	return k;
+	return keyref;
 }

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/mac.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/mac.c
@@ -16,17 +16,17 @@
 #include "cmaes.h"
 #include <cracen/prng_pool.h>
 
-int sx_mac_free(struct sxmac *c)
+int sx_mac_free(struct sxmac *mac_ctx)
 {
 	int sx_err = SX_OK;
-	if (c->key->clean_key) {
-		sx_err = c->key->clean_key(c->key->user_data);
+	if (mac_ctx->key->clean_key) {
+		sx_err = mac_ctx->key->clean_key(mac_ctx->key->user_data);
 	}
-	sx_cmdma_release_hw(&c->dma);
+	sx_cmdma_release_hw(&mac_ctx->dma);
 	return sx_err;
 }
 
-int sx_mac_hw_reserve(struct sxmac *c)
+int sx_mac_hw_reserve(struct sxmac *mac_ctx)
 {
 	int err = SX_OK;
 
@@ -37,161 +37,165 @@ int sx_mac_hw_reserve(struct sxmac *c)
 		return err;
 	}
 
-	sx_hw_reserve(&c->dma);
+	sx_hw_reserve(&mac_ctx->dma);
 
 	err = sx_cm_load_mask(prng_value);
 	if (err != SX_OK) {
 		goto exit;
 	}
 
-	if (c->key->prepare_key) {
-		err = c->key->prepare_key(c->key->user_data);
+	if (mac_ctx->key->prepare_key) {
+		err = mac_ctx->key->prepare_key(mac_ctx->key->user_data);
 	}
 
 exit:
 	if (err != SX_OK) {
-		return sx_handle_nested_error(sx_mac_free(c), err);
+		return sx_handle_nested_error(sx_mac_free(mac_ctx), err);
 	}
 
 	return SX_OK;
 }
 
-int sx_mac_feed(struct sxmac *c, const char *datain, size_t sz)
+int sx_mac_feed(struct sxmac *mac_ctx, const char *datain, size_t sz)
 {
-	if (!c->dma.hw_acquired) {
+	if (!mac_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
 	if (sz >= DMA_MAX_SZ) {
-		return sx_handle_nested_error(sx_mac_free(c), SX_ERR_TOO_BIG);
+		return sx_handle_nested_error(sx_mac_free(mac_ctx), SX_ERR_TOO_BIG);
 	}
-	if (c->cntindescs >= (ARRAY_SIZE(c->descs))) {
-		return sx_handle_nested_error(sx_mac_free(c), SX_ERR_FEED_COUNT_EXCEEDED);
+	if (mac_ctx->cntindescs >= (ARRAY_SIZE(mac_ctx->descs))) {
+		return sx_handle_nested_error(sx_mac_free(mac_ctx), SX_ERR_FEED_COUNT_EXCEEDED);
 	}
 
 	if (sz != 0) {
-		ADD_RAW_INDESC(c->dma, datain, sz, c->cfg->dmatags->data);
-		c->cntindescs++;
-		c->feedsz += sz;
+		ADD_RAW_INDESC(mac_ctx->dma, datain, sz, mac_ctx->cfg->dmatags->data);
+		mac_ctx->cntindescs++;
+		mac_ctx->feedsz += sz;
 	}
 
 	return SX_OK;
 }
 
-static int sx_mac_run(struct sxmac *c)
+static int sx_mac_run(struct sxmac *mac_ctx)
 {
-	if ((c->feedsz == 0) && (c->dma.dmamem.cfg & c->cfg->loadstate)) {
-		return sx_handle_nested_error(sx_mac_free(c), SX_ERR_INPUT_BUFFER_TOO_SMALL);
+	if ((mac_ctx->feedsz == 0) && (mac_ctx->dma.dmamem.cfg & mac_ctx->cfg->loadstate)) {
+		return sx_handle_nested_error(sx_mac_free(mac_ctx), SX_ERR_INPUT_BUFFER_TOO_SMALL);
 	}
-	sx_cmdma_start(&c->dma, sizeof(c->descs), c->descs);
+	sx_cmdma_start(&mac_ctx->dma, sizeof(mac_ctx->descs), mac_ctx->descs);
 
 	return SX_OK;
 }
 
-int sx_mac_generate(struct sxmac *c, char *mac)
+int sx_mac_generate(struct sxmac *mac_ctx, char *mac)
 {
-	if (!c->dma.hw_acquired) {
+	if (!mac_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
 
-	if (c->feedsz == 0) {
-		ADD_EMPTY_INDESC(c->dma, (c->cfg->cmdma_mask + 1), c->cfg->dmatags->data);
+	if (mac_ctx->feedsz == 0) {
+		ADD_EMPTY_INDESC(mac_ctx->dma, (mac_ctx->cfg->cmdma_mask + 1),
+				 mac_ctx->cfg->dmatags->data);
 	}
-	SET_LAST_DESC_IGN(c->dma, c->feedsz, c->cfg->cmdma_mask);
+	SET_LAST_DESC_IGN(mac_ctx->dma, mac_ctx->feedsz, mac_ctx->cfg->cmdma_mask);
 
-	ADD_OUTDESCA(c->dma, mac, c->macsz, c->cfg->cmdma_mask);
+	ADD_OUTDESCA(mac_ctx->dma, mac, mac_ctx->macsz, mac_ctx->cfg->cmdma_mask);
 
-	c->dma.dmamem.cfg &= ~c->cfg->savestate;
+	mac_ctx->dma.dmamem.cfg &= ~mac_ctx->cfg->savestate;
 
-	return sx_mac_run(c);
+	return sx_mac_run(mac_ctx);
 }
 
-int sx_mac_resume_state(struct sxmac *c)
+int sx_mac_resume_state(struct sxmac *mac_ctx)
 {
 	int err;
 
-	if (c->dma.hw_acquired) {
+	if (mac_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
 
-	if (!c->cfg->statesz) {
+	if (!mac_ctx->cfg->statesz) {
 		return SX_ERR_CONTEXT_SAVING_NOT_SUPPORTED;
 	}
 
 	/* Note that the sx_mac APIs are used only with CMAC at the moment so we always need to
 	 * enable the AES countermeasures.
 	 */
-	err = sx_mac_hw_reserve(c);
+	err = sx_mac_hw_reserve(mac_ctx);
 	if (err != SX_OK) {
 		return err;
 	}
 
-	sx_cmdma_newcmd(&c->dma, c->descs, c->dma.dmamem.cfg, c->cfg->dmatags->cfg);
-	c->cntindescs = 1;
-	if (KEYREF_IS_USR(c->key)) {
-		ADD_CFGDESC(c->dma, c->key->key, c->key->sz, c->cfg->dmatags->key);
-		c->cntindescs++;
+	sx_cmdma_newcmd(&mac_ctx->dma, mac_ctx->descs, mac_ctx->dma.dmamem.cfg,
+			mac_ctx->cfg->dmatags->cfg);
+	mac_ctx->cntindescs = 1;
+	if (KEYREF_IS_USR(mac_ctx->key)) {
+		ADD_CFGDESC(mac_ctx->dma, mac_ctx->key->key, mac_ctx->key->sz,
+			    mac_ctx->cfg->dmatags->key);
+		mac_ctx->cntindescs++;
 	}
-	ADD_INDESC_PRIV(c->dma, OFFSET_EXTRAMEM(c), c->cfg->statesz, c->cfg->dmatags->state);
-	c->cntindescs++;
-	c->dma.dmamem.cfg |= c->cfg->loadstate;
-	c->feedsz = 0;
+	ADD_INDESC_PRIV(mac_ctx->dma, OFFSET_EXTRAMEM(mac_ctx), mac_ctx->cfg->statesz,
+			mac_ctx->cfg->dmatags->state);
+	mac_ctx->cntindescs++;
+	mac_ctx->dma.dmamem.cfg |= mac_ctx->cfg->loadstate;
+	mac_ctx->feedsz = 0;
 
 	return SX_OK;
 }
 
-int sx_mac_save_state(struct sxmac *c)
+int sx_mac_save_state(struct sxmac *mac_ctx)
 {
 	uint32_t sz;
 
-	if (!c->dma.hw_acquired) {
+	if (!mac_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
-	sz = c->feedsz;
+	sz = mac_ctx->feedsz;
 
-	if (sz < c->cfg->blocksz) {
-		return sx_handle_nested_error(sx_mac_free(c), SX_ERR_INPUT_BUFFER_TOO_SMALL);
+	if (sz < mac_ctx->cfg->blocksz) {
+		return sx_handle_nested_error(sx_mac_free(mac_ctx), SX_ERR_INPUT_BUFFER_TOO_SMALL);
 	}
-	if (sz % c->cfg->granularity) {
-		return sx_handle_nested_error(sx_mac_free(c), SX_ERR_WRONG_SIZE_GRANULARITY);
+	if (sz % mac_ctx->cfg->granularity) {
+		return sx_handle_nested_error(sx_mac_free(mac_ctx), SX_ERR_WRONG_SIZE_GRANULARITY);
 	}
 
-	c->dma.dmamem.cfg |= c->cfg->savestate;
+	mac_ctx->dma.dmamem.cfg |= mac_ctx->cfg->savestate;
 
-	ADD_OUTDESC_PRIV(c->dma, OFFSET_EXTRAMEM(c), c->cfg->statesz, 0x0F);
+	ADD_OUTDESC_PRIV(mac_ctx->dma, OFFSET_EXTRAMEM(mac_ctx), mac_ctx->cfg->statesz, 0x0F);
 
-	return sx_mac_run(c);
+	return sx_mac_run(mac_ctx);
 }
 
-int sx_mac_status(struct sxmac *c)
+int sx_mac_status(struct sxmac *mac_ctx)
 {
-	int r;
+	int status;
 
-	if (!c->dma.hw_acquired) {
+	if (!mac_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
-	r = sx_cmdma_check();
-	if (r == SX_ERR_HW_PROCESSING) {
-		return r;
+	status = sx_cmdma_check();
+	if (status == SX_ERR_HW_PROCESSING) {
+		return status;
 	}
 
 #if CONFIG_DCACHE
-	sys_cache_data_invd_range((void *)&c->extramem, sizeof(c->extramem));
+	sys_cache_data_invd_range((void *)&mac_ctx->extramem, sizeof(mac_ctx->extramem));
 #endif
 
-	return sx_handle_nested_error(sx_mac_free(c), r);
+	return sx_handle_nested_error(sx_mac_free(mac_ctx), status);
 }
 
-int sx_mac_wait(struct sxmac *c)
+int sx_mac_wait(struct sxmac *mac_ctx)
 {
-	int r = SX_ERR_HW_PROCESSING;
+	int status = SX_ERR_HW_PROCESSING;
 
-	if (!c->dma.hw_acquired) {
+	if (!mac_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
 
-	while (r == SX_ERR_HW_PROCESSING) {
-		r = sx_mac_status(c);
+	while (status == SX_ERR_HW_PROCESSING) {
+		status = sx_mac_status(mac_ctx);
 	}
 
-	return r;
+	return status;
 }


### PR DESCRIPTION
Update variable naming to remove single symbol variable names 
Ignored mathmatical notation
Counter variables were not changed
This should make the code more readable