### PR TITLE
tools: Upgrade `nrfutil` from 8.0.0 to 8.1.0

### DIFF
--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -409,7 +409,9 @@ The `nRF Util development tool`_ is a unified command line utility for Nordic pr
 Its functionality is provided through installable and upgradeable commands that are served on a central package registry on the Internet.
 
 The utility follows its own release cycle and has its own `operating system requirements <nRF Util_>`_.
+
 The |NCS| toolchain bundle includes the nRF Util version :ncs-tool-version:`NRFUTIL_VERSION_WIN10` and the device command version :ncs-tool-version:`NRFUTIL_DEVICE_VERSION_WIN10`, as listed in :ref:`requirements_toolchain_tools`.
+When you :ref:`gs_installing_toolchain`, you get both these versions `locked <Locking nRF Util home directory_>`_ to prevent unwanted changes to the toolchain bundle.
 
 .. note::
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -915,6 +915,7 @@
 
 .. _`nRF Util`: https://docs.nordicsemi.com/bundle/nrfutil/page/README.html
 .. _`Installing nRF Util`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html
+.. _`Locking nRF Util home directory`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html#locking-the-home-directory
 .. _`nRF Util prerequisites`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html#prerequisites
 .. _`Upgrading nRF Util core module`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html#upgrading-nrf-util
 .. _`Installing and upgrading nRF Util commands`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing_commands.html

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -36,6 +36,7 @@ IDE, OS, and tool support
 * Updated the required `SEGGER J-Link`_ version to v8.42.
 * Removed the separate requirement for installation of the `nRF Util's device command <Device command overview_>`_ from the :ref:`install_ncs` page under :ref:`installing_vsc`.
   The tool and the command are now included in the |NCS| toolchain bundle.
+  When you :ref:`gs_installing_toolchain`, you get both these versions `locked <Locking nRF Util home directory_>`_ to prevent unwanted changes to the toolchain bundle.
 
   .. note::
 

--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -25,6 +25,6 @@ doxygen:
 pip:
   version: 24.2
 nrfutil:
-  version: 8.0.0
+  version: 8.1.0
   subcommands:
     device: 2.11.2

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -30,6 +30,6 @@ doxygen:
 pip:
   version: 24.2
 nrfutil:
-  version: 8.0.0
+  version: 8.1.0
   subcommands:
     device: 2.11.2

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -24,6 +24,6 @@ doxygen:
 pip:
   version: 24.2
 nrfutil:
-  version: 8.0.0
+  version: 8.1.0
   subcommands:
     device: 2.11.2


### PR DESCRIPTION
Including this version instead of version 8.0.0 would be preferred as it supports the "locked" mode in `nrfutil`. This mode, which is controlled by inserting a file named "locked" in the root of NRFUTIL_HOME, allows locking all functionality that changes the installed versions, both of `nrfutil` itself and of installed command. This will lower the risk of users accidentally upgrading the bundled `nrfutil`/`nrfutil device`.