### PR TITLE
manifest: sdk-zephyr: Pull keepalive fixes.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 72ecd41ad7f33544dbe2e68437a3fe3f7cd8e5ad
+      revision: pull/3116/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull keepalive fixes for interop fixes and power-saving test plan.