### PR TITLE
applications: nrf_desktop: nrf54lm20a: remove workaround for mpsl assert

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/prj.conf
@@ -121,10 +121,6 @@ CONFIG_BT_ID_MAX=3
 CONFIG_BT_CTLR_SDC_LLPM=y
 CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 
-# Workaround for the MPSL assert issue.
-# This assert occurs when the HFCLK is not ready within the timeframe expected by MPSL.
-CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL=y
-
 # External FLASH is not used by the application. Disable the driver.
 CONFIG_SPI_NOR=n
 

--- a/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/prj_llvm.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/prj_llvm.conf
@@ -125,10 +125,6 @@ CONFIG_BT_ID_MAX=3
 CONFIG_BT_CTLR_SDC_LLPM=y
 CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 
-# Workaround for the MPSL assert issue.
-# This assert occurs when the HFCLK is not ready within the timeframe expected by MPSL.
-CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL=y
-
 # External FLASH is not used by the application. Disable the driver.
 CONFIG_SPI_NOR=n
 

--- a/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/prj_release.conf
@@ -117,10 +117,6 @@ CONFIG_BT_ID_MAX=3
 CONFIG_BT_CTLR_SDC_LLPM=y
 CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 
-# Workaround for the MPSL assert issue.
-# This assert occurs when the HFCLK is not ready within the timeframe expected by MPSL.
-CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL=y
-
 # External FLASH is not used by the application. Disable the driver.
 CONFIG_SPI_NOR=n
 

--- a/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/prj.conf
@@ -129,10 +129,6 @@ CONFIG_BT_ID_MAX=3
 CONFIG_BT_CTLR_SDC_LLPM=y
 CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 
-# Workaround for the MPSL assert issue.
-# This assert occurs when the HFCLK is not ready within the timeframe expected by MPSL.
-CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL=y
-
 # External FLASH is not used by the application. Disable the driver.
 CONFIG_SPI_NOR=n
 

--- a/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/prj_llvm.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/prj_llvm.conf
@@ -133,10 +133,6 @@ CONFIG_BT_ID_MAX=3
 CONFIG_BT_CTLR_SDC_LLPM=y
 CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 
-# Workaround for the MPSL assert issue.
-# This assert occurs when the HFCLK is not ready within the timeframe expected by MPSL.
-CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL=y
-
 # External FLASH is not used by the application. Disable the driver.
 CONFIG_SPI_NOR=n
 

--- a/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/prj_release.conf
@@ -125,10 +125,6 @@ CONFIG_BT_ID_MAX=3
 CONFIG_BT_CTLR_SDC_LLPM=y
 CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 
-# Workaround for the MPSL assert issue.
-# This assert occurs when the HFCLK is not ready within the timeframe expected by MPSL.
-CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL=y
-
 # External FLASH is not used by the application. Disable the driver.
 CONFIG_SPI_NOR=n
 


### PR DESCRIPTION
Removed the workaround for the MPSL assert in the nRF Desktop configuration for the nRF54LM20 SoC, as the MPSL layer is now properly fixed and works with the default clock source.

Ref: NCSDK-34000