### PR TITLE
manifest: sdk-zephyr and sdk-mcuboot rebase

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 9425c47819d9bfe1bee49174949135beed7e5ab3
+      revision: ncs-v3.0.99-snapshot1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 4e48cbdb3bce5e24b12fda26731dafcef4079d26
+      revision: ncs-v3.0.99-snapshot1
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ncs-v3.0.99-snapshot1
+      revision: 797a60e8542a450d615b7fd1007f3c407fae87b8
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: ncs-v3.0.99-snapshot1
+      revision: d69621e3032f03ddf462eb3a9d2df5af03955898
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Update sdk-zephyr and sdk-mcuboot SHAs, switching to the new rebased histories.