### PR TITLE
Align nRF54LM20 mcuboot configs in Fast Pair and nRF Desktop

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/images/mcuboot/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/images/mcuboot/prj.conf
@@ -15,12 +15,6 @@ CONFIG_BOOT_VERSION_CMP_USE_BUILD_NUMBER=y
 
 CONFIG_FLASH=y
 
-# The following features will be enabled once they are available
-# - HW memory protection with FPROTECT library
-# - Watchdog functionality
-CONFIG_FPROTECT=n
-CONFIG_BOOT_WATCHDOG_FEED=n
-
 # Temporarily replace the HW crypto driver with SW driver until the HW driver is available.
 CONFIG_PSA_CRYPTO_DRIVER_CRACEN=n
 CONFIG_PSA_CRYPTO_DRIVER_OBERON=y

--- a/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/images/mcuboot/prj_llvm.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/images/mcuboot/prj_llvm.conf
@@ -15,12 +15,6 @@ CONFIG_BOOT_VERSION_CMP_USE_BUILD_NUMBER=y
 
 CONFIG_FLASH=y
 
-# The following features will be enabled once they are available
-# - HW memory protection with FPROTECT library
-# - Watchdog functionality
-CONFIG_FPROTECT=n
-CONFIG_BOOT_WATCHDOG_FEED=n
-
 # Temporarily replace the HW crypto driver with SW driver until the HW driver is available.
 CONFIG_PSA_CRYPTO_DRIVER_CRACEN=n
 CONFIG_PSA_CRYPTO_DRIVER_OBERON=y

--- a/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/images/mcuboot/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/images/mcuboot/prj_release.conf
@@ -16,12 +16,6 @@ CONFIG_BOOT_VERSION_CMP_USE_BUILD_NUMBER=y
 
 CONFIG_FLASH=y
 
-# The following features will be enabled once they are available
-# - HW memory protection with FPROTECT library
-# - Watchdog functionality
-CONFIG_FPROTECT=n
-CONFIG_BOOT_WATCHDOG_FEED=n
-
 # Temporarily replace the HW crypto driver with SW driver until the HW driver is available.
 CONFIG_PSA_CRYPTO_DRIVER_CRACEN=n
 CONFIG_PSA_CRYPTO_DRIVER_OBERON=y

--- a/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/images/mcuboot/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/images/mcuboot/prj.conf
@@ -15,12 +15,6 @@ CONFIG_BOOT_VERSION_CMP_USE_BUILD_NUMBER=y
 
 CONFIG_FLASH=y
 
-# The following features will be enabled once they are available
-# - HW memory protection with FPROTECT library
-# - Watchdog functionality
-CONFIG_FPROTECT=n
-CONFIG_BOOT_WATCHDOG_FEED=n
-
 # Temporarily replace the HW crypto driver with SW driver until the HW driver is available.
 CONFIG_PSA_CRYPTO_DRIVER_CRACEN=n
 CONFIG_PSA_CRYPTO_DRIVER_OBERON=y

--- a/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/images/mcuboot/prj_llvm.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/images/mcuboot/prj_llvm.conf
@@ -15,12 +15,6 @@ CONFIG_BOOT_VERSION_CMP_USE_BUILD_NUMBER=y
 
 CONFIG_FLASH=y
 
-# The following features will be enabled once they are available
-# - HW memory protection with FPROTECT library
-# - Watchdog functionality
-CONFIG_FPROTECT=n
-CONFIG_BOOT_WATCHDOG_FEED=n
-
 # Temporarily replace the HW crypto driver with SW driver until the HW driver is available.
 CONFIG_PSA_CRYPTO_DRIVER_CRACEN=n
 CONFIG_PSA_CRYPTO_DRIVER_OBERON=y

--- a/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/images/mcuboot/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54lm20pdk_nrf54lm20a_cpuapp/images/mcuboot/prj_release.conf
@@ -16,12 +16,6 @@ CONFIG_BOOT_VERSION_CMP_USE_BUILD_NUMBER=y
 
 CONFIG_FLASH=y
 
-# The following features will be enabled once they are available
-# - HW memory protection with FPROTECT library
-# - Watchdog functionality
-CONFIG_FPROTECT=n
-CONFIG_BOOT_WATCHDOG_FEED=n
-
 # Temporarily replace the HW crypto driver with SW driver until the HW driver is available.
 CONFIG_PSA_CRYPTO_DRIVER_CRACEN=n
 CONFIG_PSA_CRYPTO_DRIVER_OBERON=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
@@ -13,12 +13,6 @@ CONFIG_SPI_NOR=n
 CONFIG_NRF_GRTC_TIMER=n
 CONFIG_NRF_GRTC_START_SYSCOUNTER=n
 
-# The following features will be enabled once they are available
-# - HW memory protection with FPROTECT library
-# - Watchdog functionality
-CONFIG_FPROTECT=n
-CONFIG_BOOT_WATCHDOG_FEED=n
-
 # Temporarily replace the HW crypto driver with SW driver until the HW driver is available.
 CONFIG_PSA_CRYPTO_DRIVER_CRACEN=n
 CONFIG_PSA_CRYPTO_DRIVER_OBERON=y


### PR DESCRIPTION
Enables CONFIG_FPROTECT and CONFIG_BOOT_WATCHDOG_FEED in Mcuboot image for nRF54LM20A target.