### PR TITLE
bluetooth: hci driver: issue cs event length vs command on open()

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -630,6 +630,13 @@ config BT_CTLR_SDC_CS_STEP_MODE3
 	  Enable optional step mode-3 support. Channel sounding will not automatically start using step mode-3 if this
 	  config is set. To use step mode-3, modify the configuration which is created using the LE CS Create config command.
 
+config BT_CTLR_SDC_CS_EVENT_LEN_DEFAULT
+	int "Default channel sounding event length [us]"
+	depends on BT_CTLR_CHANNEL_SOUNDING
+	default 5000
+	help
+	  The time set aside for channel sounding events in microseconds.
+
 config BT_CTLR_SDC_LE_POWER_CLASS_1
 	bool "Device supports transmitting at LE Power Class 1 level"
 	default y if BT_CTLR_TX_PWR_ANTENNA >= 10

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -1396,6 +1396,17 @@ static int hci_driver_open(const struct device *dev, bt_hci_recv_t recv_func)
 	}
 #endif /* CONFIG_BT_PER_ADV */
 
+#if defined(CONFIG_BT_CTLR_CHANNEL_SOUNDING)
+	sdc_hci_cmd_vs_set_cs_event_length_t cs_event_length_params = {
+		.cs_event_length_us = CONFIG_BT_CTLR_SDC_CS_EVENT_LEN_DEFAULT
+	};
+	err = sdc_hci_cmd_vs_set_cs_event_length(&cs_event_length_params);
+	if (err) {
+		MULTITHREADING_LOCK_RELEASE();
+		return -ENOTSUP;
+	}
+#endif /* CONFIG_BT_CTLR_CHANNEL_SOUNDING */
+
 #if defined(CONFIG_BT_CTLR_SDC_BIG_RESERVED_TIME_US)
 	sdc_hci_cmd_vs_big_reserved_time_set_t big_reserved_time_params = {
 		.reserved_time_us = CONFIG_BT_CTLR_SDC_BIG_RESERVED_TIME_US


### PR DESCRIPTION
Issue CS event length command when opening the HCI driver