### PR TITLE
boards: shields: pca63565: enable NRF_SYS_EVENT

### DIFF
--- a/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NRF_SYS_EVENT=y

--- a/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
+++ b/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NRF_SYS_EVENT=y


### PR DESCRIPTION
PCA63565 shield uses SPI21 on P2, which qualifies as usage of cross domain pins. It requires NRF_SYS_EVENT to be enabled in order to use constant latency mode.