### PR TITLE
[Backport v3.1-branch] doc: hpf and softperipherals comparison

### DIFF
--- a/doc/nrf/app_dev/device_guides/coprocessors/index.rst
+++ b/doc/nrf/app_dev/device_guides/coprocessors/index.rst
@@ -7,17 +7,70 @@ Developing with coprocessors
 
    The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15 device.
 
-The following pages provide a detailed guide on utilizing coprocessor effectively within the nRF54L15 platform.
+You can use the VPR coprocessor (Fast Lightweight Peripheral Processor - FLPR) as follows:
 
-The VPR coprocessor (Fast Lightweight Peripheral Processor - FLPR) can be utilized in two distinct ways:
+* As an additional core in a multicore system using Zephyr in multithreaded mode (see the :ref:`nRF54L15<vpr_flpr_nrf54l>` and :ref:`nRF54H20 devices<ug_nrf54h20_flpr>` pages).
+* As a peripheral emulator, using one of the following methods depending on the use case:
 
-* As an additional core in a multicore system using Zephyr in multithreaded mode.
-  See :ref:`vpr_flpr_nrf54l` for more details.
-* As a peripheral emulator using the High-Performance Framework (HPF).
-  For more information, refer to the following documentation.
+  * :ref:`High-Performance Framework (HPF)<hpf_index>`
+  * :ref:`nrfxlib:soft_peripherals`
+
+  .. note::
+
+   In these usage modes, it is important to clearly differentiate between the Soft Peripheral and HPF solutions.
+   Soft Peripherals serve as a direct replacement for hardware peripherals, offering guaranteed performance.
+   In contrast, the HPF will allow you to accelerate protocol operations, but performance depends on your implementation.
+   We recommend using the Soft Peripheral solution if it meets your product's requirements.
+
+The following table outlines the main differences between the usage modes.
+For detailed comparison see the :ref:`ug_hpf_softperipherals_comparison` page.
+
+.. list-table:: Main differences between usage modes
+   :header-rows: 1
+
+   * - Comparison category
+     - Zephyr
+     - HPF
+     - Soft Peripherals
+   * - Overview
+     - Comprehensive Zephyr application with full feature access.
+     - Bare-metal build from source featuring real-time I/O capabilities.
+     - Custom binary that emulates a hardware peripheral.
+   * - Advantages
+     - Full access to Zephyr's capabilities including drivers, libraries, and OS primitives.
+     - Enables custom protocol support with optimized execution latency and minimized code footprint.
+     - - Pre-validated product, fully compliant with the simulated hardware peripheral specifications.
+       - Compatible with higher layer driver.
+   * - Limitations
+     - Larger code size and higher execution latency.
+     - Requires development of custom code.
+     - Provided as a binary making modifications impossible.
+   * - Build system
+     - Built from source using Zephyr’s sysbuild.
+     - Built from source using Zephyr’s sysbuild.
+     - Custom HEX file loaded by the application core.
+       VPR is exposed to build system.
+       Only the GPIO ports and pins utilized by the VPR are configured within an overlay.
+   * - Inter-processor communication
+     - Zephyr’s IPC service or mbox API.
+     - Zephyr’s IPC service or mbox API.
+     - Managed through the peripheral driver API.
+   * - Work offloading
+     - Supports any task, including those requiring Zephyr libraries.
+     - Handles simple data pre-processing or post-processing based on specific protocol needs.
+     - Not supported.
+   * - Maturity level
+     - Experimental (nRF54L15 and nRF54H20)
+     - Experimental (nRF54L15)
+     - Supported (see :ref:`nrfxlib:soft_peripherals` documentation for the list of supported devices)
+   * - Example use case
+     - Utilizes VPR as a standard CPU and offloads tasks to VPR.
+     - Develops custom protocol emulators.
+     - Replaces conventional hardware peripherals.
 
 .. toctree::
    :maxdepth: 1
    :caption: Contents
 
+   ug_hpf_softperipherals_comparison.rst
    hpf.rst

--- a/doc/nrf/app_dev/device_guides/coprocessors/ug_hpf_softperipherals_comparison.rst
+++ b/doc/nrf/app_dev/device_guides/coprocessors/ug_hpf_softperipherals_comparison.rst
@@ -1,0 +1,119 @@
+﻿.. _ug_hpf_softperipherals_comparison:
+
+Introduction to Soft Peripherals and High-Performance Framework
+###############################################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+:ref:`nrfxlib:soft_peripherals` are a collection of pre-compiled binaries and API driver code designed to emulate commonly used peripherals.
+These peripherals allow application code to use the API driver to load the pre-compiled binaries onto a specific RAM location, where they are executed by the RISC-V coprocessor, named Fast Lightweight Peripheral Processor (FLPR) (see the :ref:`nRF54L15<vpr_flpr_nrf54l>` and :ref:`nRF54H20 devices<ug_nrf54h20_flpr>` pages).
+The application can then control the soft peripherals using API functions.
+
+The :ref:`High-Performance Framework (HPF)<hpf_index>` is a framework designed to support the development and integration of software peripherals using coprocessors.
+It offers tools such as Hardware Abstraction Layers (HALs) and CMake targets, along with application samples and guidelines on architectural issues like event, fault, and power management.
+These resources will help you create customized software peripherals tailored to specific application needs.
+
+Design rationale and usage
+**************************
+
+Both methods facilitate the creation of software-defined peripherals that emulate the functionality of physical hardware peripherals (IP) through software.
+Choosing between the solutions depends on the specific requirements of your project and the resources available.
+
+.. _nrf54l_hpf_softperi_comparison_use_case:
+
+Implementation and use cases
+============================
+
+The following comparison details implementation and typical use cases for Soft Peripherals and High Performance Framework:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Comparison aspect
+     - Soft Peripherals
+     - High Performance Framework
+   * - Development
+     - Optimized for performance and power consumption.
+     - Allows for the creation of specialized or custom peripherals.
+   * - Use cases
+     - - When an application requires an additional or unavailable peripheral and a corresponding Soft Peripheral is available.
+       - Suitable for applications built from pre-compiled sources.
+     - - When developing a custom peripheral or when high-degree control is needed.
+       - Enhances the main processor's functionality with real-time capabilities in a streamlined, bare metal environment.
+       - Integrated with the Zephyr build system.
+       - Ideal for applications where the FLPR handles higher layers of the software stack (it allows to offload parts of the protocol stack to the FLPR core).
+
+.. _nrf54l_hpf_softperi_comparison_features:
+
+Features comparison
+===================
+
+See the following detailed feature comparison between Soft Peripherals and High-Performance Framework:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Feature
+     - Soft Peripherals
+     - High Performance Framework
+   * - Integration
+     - Pre-compiled binary for FLPR, driver for the application core
+     - Built from source in Zephyr build system
+   * - Memory requirements
+     - Fixed (~16 K)
+     - Adjustable, depends on code and devicetree
+   * - Application compatibility
+     - Can be used on baremetal or Zephyr applications
+     - Uses Zephyr without kernel on FLPR side, full Zephyr on APP side
+   * - Integration complexity
+     - Minor integration required
+     - Samples provided for the start of development
+   * - IPC mechanism
+     - Register-based
+     - ic(b)msg or mbox-based
+   * - Compliance and testing
+     - Protocol-compliant, verified by Nordic Semiconductor
+     - Samples provided as-is, testing is done by the user
+   * - Delivery form
+     - Binary
+     - Source code, modifiable and extendable
+   * - API level
+     - Exposed at hardware driver level
+     - FLPR may handle parts of the software stack above hardware driver level
+
+.. _nrf54l_hpf_softperi_comparison_requirements:
+
+Requirements
+************
+
+For Soft Peripherals, there is a specific memory size requirement of approximately 16 K, but there is a flexibility in placement within the FLPR execution RAM.
+To enter low power consumption modes, Soft Peripherals require a slot at a specific memory address, which is platform-specific, and the application code must be able to access MEMCONF registers.
+See the requirements in the :ref:`Soft Peripherals section<nrfxlib:soft_peripherals>`.
+It provides essential information for proper integration and optimization.
+
+On the other hand, HPF necessitates that the application core uses the Zephyr operating system.
+The framework allows for a high degree of configurability, which you can tailor according to your needs using Kconfig and devicetree settings.
+This allows you to optimize the memory footprint and functionality of the custom peripherals, ensuring that the peripherals are well-integrated and perform efficiently within their specific application environments.
+
+.. _nrf54l_hpf_softperi_comparison_creating_peripherals:
+
+Creation of software-defined peripherals
+****************************************
+
+For Soft Peripherals, the integration process primarily involves incorporating glue code to facilitate their use.
+To learn how to use those peripherals, and to see what is currently supported, refer to the :ref:`nrfxlib:soft_peripherals` documentation.
+
+In contrast, HPF provides initial samples that serve as a starting point for development.
+For a detailed guide on creating your own custom peripherals, see the :ref:`hpf_index` page.
+
+.. _nrf54l_hpf_softperi_comparison_limitations:
+
+Performance and limitations
+***************************
+
+Each Soft Peripheral is unique and comes with its own set of limitations compared to traditional hardware IP.
+These limitations are specific to the functions that the peripheral is designed to emulate and how they integrate with the rest of the system.
+
+HPF, while offering extensive customization and control, is currently in an experimental stage and lacks full power management support.

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_flpr.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_flpr.rst
@@ -46,6 +46,12 @@ The primary purpose of this snippet is to enable the transfer of the FLPR code t
 When building for the ``nrf54h20dk/nrf54h20/cpuflpr`` target, a minimal sample is automatically loaded onto the application core.
 For more details, see :ref:`building_nrf54h_app_flpr_core`.
 
+Peripherals emulation on FLPR
+*****************************
+
+The FLPR core can emulate software-defined peripherals using :ref:`nrfxlib:soft_peripherals`.
+This setup is useful in scenarios where you need an additional peripheral functionality but do not have access to hardware peripherals.
+
 Memory allocation
 *****************
 

--- a/doc/nrf/app_dev/device_guides/nrf54l/vpr_flpr.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/vpr_flpr.rst
@@ -39,8 +39,19 @@ Snippet's primary function is to enable the code that transfers the FLPR code to
 When building for the ``nrf54l15dk/nrf54l15/cpuflpr`` target, a minimal sample is automatically loaded onto the application core.
 See more information on :ref:`building_nrf54l_app_flpr_core`.
 
-Using MCUboot with FLPR
-***********************
+Peripherals emulation on FLPR
+*****************************
+
+.. note::
+
+   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15 device.
+
+The FLPR core can emulate software peripherals using :ref:`nrfxlib:soft_peripherals` or the :ref:`HPF<hpf_index>`.
+This setup is useful in scenarios where you need additional peripheral functionality or want to optimize power consumption and performance.
+For detailed comparisons of implementation scenarios and use cases between the Soft Peripherals and the HPF, refer to the :ref:`ug_hpf_softperipherals_comparison` documentation page.
+
+MCUboot FLPR configuration
+**************************
 
 To ensure that MCUboot functions correctly with a FLPR-integrated application, several manual configurations are necessary.
 For details, see :ref:`nRF54l_signing_app_with_flpr_payload`.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -133,6 +133,11 @@ Developing with custom boards
 
 |no_changes_yet_note|
 
+Developing with coprocessors
+============================
+
+* Added the :ref:`ug_hpf_softperipherals_comparison` documentation page, describing potential use cases and differences between the two solutions.
+
 Security
 ========
 


### PR DESCRIPTION
Backport 1f634f38746c9a4a179d35a2cf25e16f65716fb3 from #23226.