### PR TITLE
doc: crypto: feature update for Oberon 1.5.1

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54l/cryptography.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/cryptography.rst
@@ -150,7 +150,7 @@ The keys are not exportable, except for the public key associated with the asymm
 Programming model for referencing keys
 **************************************
 
-The keys which are stored in the KMU can be used by most cryptographic functions and key management functions in the PSA Crypto API (see `PSA Certified Crypto API 1.2.1`_), with a built-in key ID representing a particular KMU slot.
+The keys that are stored in the KMU can be used by most cryptographic functions and key management functions in the PSA Crypto API (see `PSA Certified Crypto API 1.3.1`_), with a built-in key ID representing a particular KMU slot.
 
 To identify that the KMU is used as a persistent storage backend for a specific ``psa_key_id_t``, you need to create a ``psa_key_attributes_t`` structure and set the required attributes from the list below.
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -254,7 +254,6 @@
 .. _`Keystore interface`: https://arm-software.github.io/psa-api/crypto/1.1/overview/goals.html#a-keystore-interface
 .. _`PSA Cryptography API 1.0.1`: https://armmbed.github.io/mbed-crypto/1.0.1/html/index.html
 .. _`PSA Certified Crypto API 1.0.0`: https://arm-software.github.io/psa-api/crypto/1.0/IHI0086-PSA_Cryptography_API-1.0.0.pdf
-.. _`PSA Certified Crypto API 1.2.1`: https://arm-software.github.io/psa-api/crypto/1.2/
 .. _`PSA Certified Crypto API 1.3.1`: https://arm-software.github.io/psa-api/crypto/1.3/
 .. _`PSA functions for key management`: https://arm-software.github.io/psa-api/crypto/1.1/api/keys/management.html
 

--- a/doc/nrf/security/crypto/crypto_supported_features.rst
+++ b/doc/nrf/security/crypto/crypto_supported_features.rst
@@ -73,18 +73,99 @@ The options are grouped by Series and drivers available for the device Series, a
                * - Chacha20
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
                  - Supported
-               * - ECC Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+               * - ECC Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                 - Supported
+               * - ECC Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                 - Supported
+               * - ECC Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                 - Supported
+               * - ECC Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                  - Supported
                * - ECC Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
                  - Supported
-               * - RSA Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+               * - RSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                 - Supported
+               * - RSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                 - Supported
+               * - RSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                 - Supported
+               * - RSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                  - Supported
                * - RSA Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
                  - Supported
+               * - XChaCha20
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                 - --
+               * - HSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                 - --
+               * - LMS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_LMS_PUBLIC_KEY`
+                 - --
+               * - XMSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                 - --
+               * - XMSS-MT Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_MT_PUBLIC_KEY`
+                 - --
+               * - ML-DSA-44
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                 - --
+               * - ML-DSA-65
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_65`
+                 - --
+               * - ML-DSA-87
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                 - --
+               * - ML-DSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_IMPORT`
+                 - --
+               * - ML-DSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                 - --
+               * - ML-DSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_GENERATE`
+                 - --
+               * - ML-DSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                 - --
+               * - ML-DSA Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_PUBLIC_KEY`
+                 - --
+               * - ML-KEM-512
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                 - --
+               * - ML-KEM-768
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_768`
+                 - --
+               * - ML-KEM-1024
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                 - --
+               * - ML-KEM Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_IMPORT`
+                 - --
+               * - ML-KEM Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                 - --
+               * - ML-KEM Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_GENERATE`
+                 - --
+               * - ML-KEM Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                 - --
+               * - ML-KEM Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -107,8 +188,23 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-               * - ECC Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+               * - ECC Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ECC Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ECC Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ECC Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                  - Supported
                  - Supported
                  - Supported
@@ -117,13 +213,133 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-               * - RSA Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+               * - RSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - RSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - RSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - RSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                  - Supported
                  - Supported
                  - Supported
                * - RSA Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - XChaCha20
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - HSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - LMS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_LMS_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - XMSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - XMSS-MT Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_MT_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA-44
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA-65
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_65`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA-87
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_IMPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_GENERATE`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM-512
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM-768
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_768`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM-1024
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_IMPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_GENERATE`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
                  - Supported
                  - Supported
                  - Supported
@@ -149,18 +365,99 @@ The options are grouped by Series and drivers available for the device Series, a
                * - Chacha20
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
                  - Supported
-               * - ECC Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+               * - ECC Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                 - Supported
+               * - ECC Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                 - Supported
+               * - ECC Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                 - Supported
+               * - ECC Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                  - Supported
                * - ECC Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
                  - Supported
-               * - RSA Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+               * - RSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                 - Supported
+               * - RSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                 - Supported
+               * - RSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                 - Supported
+               * - RSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                  - Supported
                * - RSA Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
                  - Supported
+               * - XChaCha20
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                 - --
+               * - HSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                 - --
+               * - LMS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_LMS_PUBLIC_KEY`
+                 - --
+               * - XMSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                 - --
+               * - XMSS-MT Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_MT_PUBLIC_KEY`
+                 - --
+               * - ML-DSA-44
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                 - --
+               * - ML-DSA-65
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_65`
+                 - --
+               * - ML-DSA-87
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                 - --
+               * - ML-DSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_IMPORT`
+                 - --
+               * - ML-DSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                 - --
+               * - ML-DSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_GENERATE`
+                 - --
+               * - ML-DSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                 - --
+               * - ML-DSA Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_PUBLIC_KEY`
+                 - --
+               * - ML-KEM-512
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                 - --
+               * - ML-KEM-768
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_768`
+                 - --
+               * - ML-KEM-1024
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                 - --
+               * - ML-KEM Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_IMPORT`
+                 - --
+               * - ML-KEM Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                 - --
+               * - ML-KEM Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_GENERATE`
+                 - --
+               * - ML-KEM Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                 - --
+               * - ML-KEM Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -177,17 +474,98 @@ The options are grouped by Series and drivers available for the device Series, a
                * - Chacha20
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
                  - Supported
-               * - ECC Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+               * - ECC Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                 - Supported
+               * - ECC Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                 - Supported
+               * - ECC Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                 - Supported
+               * - ECC Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                  - Supported
                * - ECC Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
                  - Supported
-               * - RSA Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+               * - RSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                 - Supported
+               * - RSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                 - Supported
+               * - RSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                 - Supported
+               * - RSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                  - Supported
                * - RSA Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
+                 - Supported
+               * - XChaCha20
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                 - Supported
+               * - HSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                 - Supported
+               * - LMS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_LMS_PUBLIC_KEY`
+                 - Supported
+               * - XMSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                 - Supported
+               * - XMSS-MT Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_MT_PUBLIC_KEY`
+                 - Supported
+               * - ML-DSA-44
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                 - Supported
+               * - ML-DSA-65
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_65`
+                 - Supported
+               * - ML-DSA-87
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                 - Supported
+               * - ML-DSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_IMPORT`
+                 - Supported
+               * - ML-DSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                 - Supported
+               * - ML-DSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_GENERATE`
+                 - Supported
+               * - ML-DSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                 - Supported
+               * - ML-DSA Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_PUBLIC_KEY`
+                 - Supported
+               * - ML-KEM-512
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                 - Supported
+               * - ML-KEM-768
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_768`
+                 - Supported
+               * - ML-KEM-1024
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                 - Supported
+               * - ML-KEM Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_IMPORT`
+                 - Supported
+               * - ML-KEM Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                 - Supported
+               * - ML-KEM Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_GENERATE`
+                 - Supported
+               * - ML-KEM Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                 - Supported
+               * - ML-KEM Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
                  - Supported
 
    .. tab:: nRF54 Series
@@ -217,8 +595,23 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
-              * - ECC Key Pair
-                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+              * - ECC Key Pair Import
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                - Supported
+                - Supported
+                - Supported
+              * - ECC Key Pair Export
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                - Supported
+                - Supported
+                - Supported
+              * - ECC Key Pair Generate
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                - Supported
+                - Supported
+                - Supported
+              * - ECC Key Pair Derive
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                 - Supported
                 - Supported
                 - Supported
@@ -227,8 +620,23 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
-              * - RSA Key Pair
-                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+              * - RSA Key Pair Import
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                - Supported
+                - Supported
+                - Supported
+              * - RSA Key Pair Export
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                - Supported
+                - Supported
+                - Supported
+              * - RSA Key Pair Generate
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                - Supported
+                - Supported
+                - Supported
+              * - RSA Key Pair Derive
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                 - Supported
                 - Supported
                 - Supported
@@ -237,6 +645,111 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+              * - XChaCha20
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                - --
+                - --
+                - --
+              * - HSS Public Key
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                - --
+                - --
+                - --
+              * - LMS Public Key
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_LMS_PUBLIC_KEY`
+                - --
+                - --
+                - --
+              * - XMSS Public Key
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                - --
+                - --
+                - --
+              * - XMSS-MT Public Key
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_MT_PUBLIC_KEY`
+                - --
+                - --
+                - --
+              * - ML-DSA-44
+                - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                - --
+                - --
+                - --
+              * - ML-DSA-65
+                - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_65`
+                - --
+                - --
+                - --
+              * - ML-DSA-87
+                - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                - --
+                - --
+                - --
+              * - ML-DSA Key Pair Import
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_IMPORT`
+                - --
+                - --
+                - --
+              * - ML-DSA Key Pair Export
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                - --
+                - --
+                - --
+              * - ML-DSA Key Pair Generate
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_GENERATE`
+                - --
+                - --
+                - --
+              * - ML-DSA Key Pair Derive
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                - --
+                - --
+                - --
+              * - ML-DSA Public Key
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_PUBLIC_KEY`
+                - --
+                - --
+                - --
+              * - ML-KEM-512
+                - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                - --
+                - --
+                - --
+              * - ML-KEM-768
+                - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_768`
+                - --
+                - --
+                - --
+              * - ML-KEM-1024
+                - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                - --
+                - --
+                - --
+              * - ML-KEM Key Pair Import
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_IMPORT`
+                - --
+                - --
+                - --
+              * - ML-KEM Key Pair Export
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                - --
+                - --
+                - --
+              * - ML-KEM Key Pair Generate
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_GENERATE`
+                - --
+                - --
+                - --
+              * - ML-KEM Key Pair Derive
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                - --
+                - --
+                - --
+              * - ML-KEM Public Key
+                - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
+                - --
+                - --
+                - --
 
          .. tab:: nrf_oberon
 
@@ -259,8 +772,23 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-               * - ECC Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+               * - ECC Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ECC Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ECC Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ECC Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                  - Supported
                  - Supported
                  - Supported
@@ -269,13 +797,133 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-               * - RSA Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+               * - RSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - RSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - RSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - RSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                  - Supported
                  - Supported
                  - Supported
                * - RSA Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - XChaCha20
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - HSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - LMS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_LMS_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - XMSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - XMSS-MT Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_MT_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA-44
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA-65
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_65`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA-87
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_IMPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_GENERATE`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM-512
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM-768
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_768`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM-1024
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_IMPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_GENERATE`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
                  - Supported
                  - Supported
                  - Supported
@@ -310,8 +958,26 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-               * - ECC Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+               * - ECC Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                 - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ECC Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                 - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ECC Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                 - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ECC Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                  - Experimental
                  - Supported
                  - Supported
@@ -322,8 +988,26 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-               * - RSA Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+               * - RSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                 - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
+               * - RSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                 - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
+               * - RSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                 - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
+               * - RSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                  - Experimental
                  - Supported
                  - Supported
@@ -334,6 +1018,132 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+               * - XChaCha20
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - HSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - LMS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_LMS_PUBLIC_KEY`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - XMSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - XMSS-MT Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_MT_PUBLIC_KEY`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-DSA-44
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-DSA-65
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_65`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-DSA-87
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-DSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_IMPORT`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-DSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-DSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_GENERATE`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-DSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-DSA Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_PUBLIC_KEY`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-KEM-512
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-KEM-768
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_768`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-KEM-1024
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-KEM Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_IMPORT`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-KEM Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-KEM Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_GENERATE`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-KEM Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-KEM Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
+                 - --
+                 - --
+                 - --
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -359,8 +1169,26 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-               * - ECC Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+               * - ECC Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ECC Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ECC Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ECC Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                  - Supported
                  - Supported
                  - Supported
@@ -371,14 +1199,158 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-               * - RSA Key Pair
-                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+               * - RSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - RSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - RSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - RSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                  - Supported
                  - Supported
                  - Supported
                  - Supported
                * - RSA Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - XChaCha20
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - HSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - LMS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_LMS_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - XMSS Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - XMSS-MT Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_MT_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA-44
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA-65
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_65`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA-87
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_IMPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_GENERATE`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-DSA Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_PUBLIC_KEY`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM-512
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM-768
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_768`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM-1024
+                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Key Pair Import
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_IMPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Key Pair Export
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Key Pair Generate
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_GENERATE`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Key Pair Derive
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - ML-KEM Public Key
+                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
                  - Supported
                  - Supported
                  - Supported
@@ -408,9 +1380,15 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                * - :kconfig:option:`CONFIG_PSA_USE_CC3XX_KEY_MANAGEMENT_DRIVER`
                  - | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_AES`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
 
          .. tab:: nrf_oberon
@@ -424,10 +1402,37 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                * - Configuration automatically generated based on the enabled key types. Acts as :ref:`software fallback <crypto_drivers_software_fallback>` for the other drivers.
                  - | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_AES`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_LMS_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_MT_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_65`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_768`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
 
    .. tab:: nRF53 Series
 
@@ -446,9 +1451,15 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                * - :kconfig:option:`CONFIG_PSA_USE_CC3XX_KEY_MANAGEMENT_DRIVER`
                  - | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_AES`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
 
          .. tab:: nrf_oberon
@@ -462,10 +1473,37 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                * - Configuration automatically generated based on the enabled key types. Acts as :ref:`software fallback <crypto_drivers_software_fallback>` for the other drivers.
                  - | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_AES`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_LMS_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_MT_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_65`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_768`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
 
    .. tab:: nRF54 Series
 
@@ -484,9 +1522,15 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                * - :kconfig:option:`CONFIG_PSA_USE_CRACEN_KEY_MANAGEMENT_DRIVER`
                  - | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_AES`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
 
          .. tab:: nrf_oberon
@@ -500,10 +1544,37 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                * - Configuration automatically generated based on the enabled key types. Acts as :ref:`software fallback <crypto_drivers_software_fallback>` for the other drivers.
                  - | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_AES`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_LMS_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_MT_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_65`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_768`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
 
    .. tab:: nRF91 Series
 
@@ -522,9 +1593,15 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                * - :kconfig:option:`CONFIG_PSA_USE_CC3XX_KEY_MANAGEMENT_DRIVER`
                  - | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_AES`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
 
          .. tab:: nrf_oberon
@@ -538,10 +1615,37 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                * - Configuration automatically generated based on the enabled key types. Acts as :ref:`software fallback <crypto_drivers_software_fallback>` for the other drivers.
                  - | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_AES`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
-                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                    | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_LMS_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_MT_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_65`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_PUBLIC_KEY`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_768`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_IMPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_GENERATE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                   | :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
 
 Cipher modes
 ============
@@ -1326,6 +2430,180 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                * - Configuration automatically generated based on the enabled key agreement algorithms. Acts as :ref:`software fallback <crypto_drivers_software_fallback>` for the other drivers.
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDH` (limited to curve types secp224r1, secp256r1, secp384r1, and Curve25519)
 
+Key encapsulation algorithms
+============================
+
+The following tables show the ``CONFIG_PSA_WANT_*`` Kconfig options for requesting Oberon PSA Crypto to use specific key encapsulation algorithms.
+The options are grouped by Series and drivers available for the device Series, and support level for each device is listed.
+
+.. tabs::
+
+   .. tab:: nRF52 Series
+
+      The following tables list the supported key encapsulation algorithms for nRF52 Series devices.
+
+      .. tabs::
+
+         .. tab:: nrf_oberon
+
+            .. list-table:: Key encapsulation algorithm support (nrf_oberon driver) - nRF52 Series
+               :header-rows: 1
+               :widths: auto
+
+               * - Key encapsulation algorithm
+                 - Configuration option
+                 - nRF52832
+                 - nRF52833
+                 - nRF52840
+               * - ML-KEM
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_KEM`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+
+   .. tab:: nRF53 Series
+
+      The following tables list the supported key encapsulation algorithms for nRF53 Series devices.
+
+      .. tabs::
+
+         .. tab:: nrf_oberon
+
+            .. list-table:: Key encapsulation algorithm support (nrf_oberon driver) - nRF53 Series
+               :header-rows: 1
+               :widths: auto
+
+               * - Key encapsulation algorithm
+                 - Configuration option
+                 - nRF5340
+               * - ML-KEM
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_KEM`
+                 - Experimental
+
+   .. tab:: nRF54 Series
+
+      The following tables list the supported key encapsulation algorithms for nRF54 Series devices.
+
+      .. tabs::
+
+         .. tab:: nrf_oberon
+
+            .. list-table:: Key encapsulation algorithm support (nrf_oberon driver) - nRF54 Series
+               :header-rows: 1
+               :widths: auto
+
+               * - Key encapsulation algorithm
+                 - Configuration option
+                 - nRF54L05
+                 - nRF54L10
+                 - nRF54L15
+               * - ML-KEM
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_KEM`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+
+   .. tab:: nRF91 Series
+
+      The following tables list the supported key encapsulation algorithms for nRF91 Series devices.
+
+      .. tabs::
+
+         .. tab:: nrf_oberon
+
+            .. list-table:: Key encapsulation algorithm support (nrf_oberon driver) - nRF91 Series
+               :header-rows: 1
+               :widths: auto
+
+               * - Key encapsulation algorithm
+                 - Configuration option
+                 - nRF9131
+                 - nRF9151
+                 - nRF9160
+                 - nRF9161
+               * - ML-KEM
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_KEM`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+
+Key encapsulation driver
+------------------------
+
+The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuring Oberon PSA Crypto to use specific drivers for the wanted key encapsulation algorithms.
+
+.. tabs::
+
+   .. tab:: nRF52 Series
+
+      The following tables list the key encapsulation driver support for nRF52 Series devices.
+
+      .. tabs::
+
+         .. tab:: nrf_oberon
+
+            .. list-table:: Key encapsulation driver support (nrf_oberon driver) - nRF52 Series
+               :header-rows: 1
+               :widths: auto
+
+               * - Kconfig option
+                 - Supported key encapsulation algorithms
+               * - Configuration automatically generated based on the enabled key encapsulation algorithms. Acts as :ref:`software fallback <crypto_drivers_software_fallback>` for the other drivers.
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_KEM`
+
+   .. tab:: nRF53 Series
+
+      The following tables list the key encapsulation driver support for nRF53 Series devices.
+
+      .. tabs::
+
+         .. tab:: nrf_oberon
+
+            .. list-table:: Key encapsulation driver support (nrf_oberon driver) - nRF53 Series
+               :header-rows: 1
+               :widths: auto
+
+               * - Kconfig option
+                 - Supported key encapsulation algorithms
+               * - Configuration automatically generated based on the enabled key encapsulation algorithms. Acts as :ref:`software fallback <crypto_drivers_software_fallback>` for the other drivers.
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_KEM`
+
+   .. tab:: nRF54 Series
+
+      The following tables list the key encapsulation driver support for nRF54 Series devices.
+
+      .. tabs::
+
+         .. tab:: nrf_oberon
+
+            .. list-table:: Key encapsulation driver support (nrf_oberon driver) - nRF54 Series
+               :header-rows: 1
+               :widths: auto
+
+               * - Kconfig option
+                 - Supported key encapsulation algorithms
+               * - Configuration automatically generated based on the enabled key encapsulation algorithms. Acts as :ref:`software fallback <crypto_drivers_software_fallback>` for the other drivers.
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_KEM`
+
+   .. tab:: nRF91 Series
+
+      The following tables list the key encapsulation driver support for nRF91 Series devices.
+
+      .. tabs::
+
+         .. tab:: nrf_oberon
+
+            .. list-table:: Key encapsulation driver support (nrf_oberon driver) - nRF91 Series
+               :header-rows: 1
+               :widths: auto
+
+               * - Kconfig option
+                 - Supported key encapsulation algorithms
+               * - Configuration automatically generated based on the enabled key encapsulation algorithms. Acts as :ref:`software fallback <crypto_drivers_software_fallback>` for the other drivers.
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_KEM`
+
+
 KDF algorithms
 ==============
 
@@ -1393,9 +2671,9 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - SP 800-108r1 CMAC w/counter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC`
-                 - --
-                 - --
-                 - --
+                 - Supported
+                 - Supported
+                 - Supported
                * - SP 800-108 HMAC counter mode
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_HMAC`
                  - Supported
@@ -1443,7 +2721,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - SP 800-108r1 CMAC w/counter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC`
-                 - --
+                 - Supported
                * - SP 800-108 HMAC counter mode
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_HMAC`
                  - Supported
@@ -1569,9 +2847,9 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - SP 800-108r1 CMAC w/counter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC`
-                 - --
-                 - --
-                 - --
+                 - Supported
+                 - Supported
+                 - Supported
                * - SP 800-108 HMAC counter mode
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_HMAC`
                  - Supported
@@ -1646,10 +2924,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - SP 800-108r1 CMAC w/counter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC`
-                 - --
-                 - --
-                 - --
-                 - --
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
                * - SP 800-108 HMAC counter mode
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_HMAC`
                  - Supported
@@ -1687,6 +2965,7 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PRF`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PSK_TO_MS`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_HMAC`
 
    .. tab:: nRF53 Series
@@ -1712,6 +2991,7 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PRF`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PSK_TO_MS`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_HMAC`
 
    .. tab:: nRF54 Series
@@ -1782,6 +3062,7 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PRF`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PSK_TO_MS`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_HMAC`
 
 MAC algorithms
@@ -2160,6 +3441,9 @@ The options are grouped by Series and drivers available for the device Series, a
                * - ChaCha20-Poly1305
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305`
                  - Supported
+               * - XChaCha20-Poly1305
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
+                 - --
 
             .. note::
 
@@ -2191,6 +3475,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+               * - XChaCha20-Poly1305
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
+                 - Experimental
+                 - Experimental
+                 - Experimental
 
    .. tab:: nRF53 Series
 
@@ -2216,6 +3505,9 @@ The options are grouped by Series and drivers available for the device Series, a
                * - ChaCha20-Poly1305
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305`
                  - Supported
+               * - XChaCha20-Poly1305
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -2235,6 +3527,9 @@ The options are grouped by Series and drivers available for the device Series, a
                * - ChaCha20-Poly1305
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305`
                  - Supported
+               * - XChaCha20-Poly1305
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
+                 - Experimental
 
    .. tab:: nRF54 Series
 
@@ -2268,6 +3563,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+               * - XChaCha20-Poly1305
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
+                 - --
+                 - --
+                 - --
 
          .. note::
 
@@ -2299,6 +3599,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+               * - XChaCha20-Poly1305
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
+                 - Experimental
+                 - Experimental
+                 - Experimental
 
    .. tab:: nRF91 Series
 
@@ -2336,6 +3641,12 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+               * - XChaCha20-Poly1305
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
+                 - --
+                 - --
+                 - --
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -2367,6 +3678,12 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+               * - XChaCha20-Poly1305
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
 
 AEAD driver
 -----------
@@ -2406,6 +3723,7 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                  - | :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_GCM`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
 
    .. tab:: nRF53 Series
 
@@ -2438,6 +3756,7 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                  - | :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_GCM`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
 
    .. tab:: nRF54 Series
 
@@ -2470,6 +3789,7 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                  - | :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_GCM`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
 
    .. tab:: nRF91 Series
 
@@ -2502,6 +3822,7 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                  - | :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_GCM`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
 
 Asymmetric signature algorithms
 ===============================
@@ -2553,9 +3874,24 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - RSA PSS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`
-                 - --
+                 - Supported
                * - RSA PSS any salt
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS_ANY_SALT`
+                 - Supported
+               * - HSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                 - --
+               * - LMS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_LMS`
+                 - --
+               * - ML-DSA
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - --
+               * - XMSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS`
+                 - --
+               * - XMSS-MT
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
                  - --
 
          .. tab:: nrf_oberon
@@ -2614,6 +3950,31 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+               * - HSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - LMS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_LMS`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - ML-DSA
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - XMSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - XMSS-MT
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
+                 - Experimental
+                 - Experimental
+                 - Experimental
 
    .. tab:: nRF53 Series
 
@@ -2653,14 +4014,25 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - RSA PSS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`
-                 - --
+                 - Supported
                * - RSA PSS any salt
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS_ANY_SALT`
+                 - Supported
+               * - HSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
                  - --
-
-            .. note::
-               - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN` is limited to RSA key sizes ≤ 2048 bits.
-               - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN_RAW` is limited to RSA key sizes ≤ 2048 bits.
+               * - LMS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_LMS`
+                 - --
+               * - ML-DSA
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - --
+               * - XMSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS`
+                 - --
+               * - XMSS-MT
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -2698,6 +4070,21 @@ The options are grouped by Series and drivers available for the device Series, a
                * - RSA PSS any salt
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS_ANY_SALT`
                  - Supported
+               * - HSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                 - Experimental
+               * - LMS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_LMS`
+                 - Experimental
+               * - ML-DSA
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - Experimental
+               * - XMSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS`
+                 - Experimental
+               * - XMSS-MT
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
+                 - Experimental
 
             .. note::
                - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA` is limited to ECC curve types secp224r1, secp256r1, and secp384r1.
@@ -2766,6 +4153,31 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+               * - HSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                 - --
+                 - --
+                 - --
+               * - LMS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_LMS`
+                 - --
+                 - --
+                 - --
+               * - ML-DSA
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - --
+                 - --
+                 - --
+               * - XMSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS`
+                 - --
+                 - --
+                 - --
+               * - XMSS-MT
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
+                 - --
+                 - --
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -2823,6 +4235,31 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+               * - HSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - LMS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_LMS`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - ML-DSA
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - XMSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - XMSS-MT
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
+                 - Experimental
+                 - Experimental
+                 - Experimental
 
             .. note::
                - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA` is limited to ECC curve types secp224r1, secp256r1, and secp384r1.
@@ -2891,20 +4328,46 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - RSA PSS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`
-                 - --
-                 - --
-                 - --
-                 - --
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
                * - RSA PSS any salt
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS_ANY_SALT`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - HSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
                  - --
                  - --
                  - --
                  - --
-
-            .. note::
-               - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN` is limited to RSA key sizes ≤ 2048 bits.
-               - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN_RAW` is limited to RSA key sizes ≤ 2048 bits.
+               * - LMS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_LMS`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - ML-DSA
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - XMSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - XMSS-MT
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
+                 - --
+                 - --
+                 - --
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -2972,6 +4435,36 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+               * - HSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - LMS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_LMS`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - ML-DSA
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - XMSS
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - XMSS-MT
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
 
             .. note::
                - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA` is limited to ECC curve types secp224r1, secp256r1, and secp384r1.
@@ -3004,8 +4497,10 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA_ANY`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ECDSA`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_PURE_EDDSA`
-                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN` (limited to RSA key sizes ≤ 2048 bits)
-                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN_RAW` (limited to RSA key sizes ≤ 2048 bits)
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS_ANY_SALT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN_RAW`
 
          .. tab:: nrf_oberon
 
@@ -3024,6 +4519,11 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN_RAW`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS_ANY_SALT` (does not support RSA key pair generation)
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_LMS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
 
    .. tab:: nRF53 Series
 
@@ -3044,8 +4544,10 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA_ANY`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ECDSA`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_PURE_EDDSA`
-                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN` (limited to RSA key sizes ≤ 2048 bits)
-                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN_RAW` (limited to RSA key sizes ≤ 2048 bits)
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS_ANY_SALT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN_RAW`
 
          .. tab:: nrf_oberon
 
@@ -3064,6 +4566,11 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN_RAW`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS_ANY_SALT` (does not support RSA key pair generation)
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_LMS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
 
    .. tab:: nRF54 Series
 
@@ -3105,6 +4612,11 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN_RAW`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS_ANY_SALT` (does not support RSA key pair generation)
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_LMS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
 
    .. tab:: nRF91 Series
 
@@ -3125,8 +4637,10 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA_ANY`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ECDSA`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_PURE_EDDSA`
-                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN` (limited to RSA key sizes ≤ 2048 bits)
-                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN_RAW` (limited to RSA key sizes ≤ 2048 bits)
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS_ANY_SALT`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN_RAW`
 
          .. tab:: nrf_oberon
 
@@ -3145,6 +4659,11 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN_RAW`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS_ANY_SALT` (does not support RSA key pair generation)
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_LMS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
 
 Asymmetric encryption algorithms
 ================================
@@ -4811,6 +6330,21 @@ The options are grouped by Series and drivers available for the device Series, a
                * - SHA3-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_512`
                  - --
+               * - SHA-256/192
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                 - --
+               * - SHAKE128 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                 - --
+               * - SHAKE256 192 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                 - --
+               * - SHAKE256 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                 - --
+               * - SHAKE256 512 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -4868,6 +6402,31 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+               * - SHA-256/192
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - SHAKE128 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - SHAKE256 192 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - SHAKE256 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - SHAKE256 512 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
+                 - Supported
+                 - Supported
+                 - Supported
 
    .. tab:: nRF53 Series
 
@@ -4911,6 +6470,21 @@ The options are grouped by Series and drivers available for the device Series, a
                * - SHA3-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_512`
                  - --
+               * - SHA-256/192
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                 - --
+               * - SHAKE128 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                 - --
+               * - SHAKE256 192 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                 - --
+               * - SHAKE256 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                 - --
+               * - SHAKE256 512 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -4948,6 +6522,21 @@ The options are grouped by Series and drivers available for the device Series, a
                * - SHA3-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_512`
                  - --
+               * - SHA-256/192
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                 - Supported
+               * - SHAKE128 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                 - Experimental
+               * - SHAKE256 192 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                 - Supported
+               * - SHAKE256 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                 - Supported
+               * - SHAKE256 512 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
+                 - Supported
 
    .. tab:: nRF54 Series
 
@@ -5011,6 +6600,31 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+               * - SHA-256/192
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - SHAKE128 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - SHAKE256 192 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - SHAKE256 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - SHAKE256 512 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
+                 - --
+                 - --
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -5068,6 +6682,31 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+               * - SHA-256/192
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - SHAKE128 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - SHAKE256 192 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - SHAKE256 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                 - Supported
+                 - Supported
+                 - Supported
+               * - SHAKE256 512 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
+                 - Supported
+                 - Supported
+                 - Supported
 
    .. tab:: nRF91 Series
 
@@ -5141,6 +6780,36 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+               * - SHA-256/192
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - SHAKE128 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - SHAKE256 192 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - SHAKE256 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                 - --
+                 - --
+                 - --
+                 - --
+               * - SHAKE256 512 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
+                 - --
+                 - --
+                 - --
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -5208,6 +6877,36 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+               * - SHA-256/192
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - SHAKE128 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+               * - SHAKE256 192 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - SHAKE256 256 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
+               * - SHAKE256 512 bits
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Supported
 
 Hash driver
 -----------
@@ -5249,6 +6948,11 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_384`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_512`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
 
    .. tab:: nRF53 Series
 
@@ -5283,6 +6987,11 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_384`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_512`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
 
    .. tab:: nRF54 Series
 
@@ -5323,6 +7032,11 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_384`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_512`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
 
    .. tab:: nRF91 Series
 
@@ -5357,15 +7071,17 @@ The following tables show the ``CONFIG_PSA_USE_*`` Kconfig options for configuri
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_384`
                    | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_512`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                   | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
 
 PAKE algorithms
 ===============
 
 The following tables show the ``CONFIG_PSA_WANT_*`` Kconfig options for requesting Oberon PSA Crypto to use specific password-authenticated key exchange (PAKE) algorithms.
 The options are grouped by Series and drivers available for the device Series, and support level for each device is listed.
-
-.. note::
-   The support for PAKE algorithms is :ref:`experimental <software_maturity>`.
 
 .. tabs::
 
@@ -5403,19 +7119,19 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - SPAKE2+ for Matter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SPAKE2P_MATTER`
-                 - Supported
-                 - Supported
-                 - Supported
+                 - Experimental
+                 - Experimental
+                 - Experimental
                * - SRP-6
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_6`
-                 - Supported
-                 - Supported
-                 - Supported
+                 - Experimental
+                 - Experimental
+                 - Experimental
                * - SRP password hashing
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_PASSWORD_HASH`
-                 - Supported
-                 - Supported
-                 - Supported
+                 - Experimental
+                 - Experimental
+                 - Experimental
 
    .. tab:: nRF53 Series
 
@@ -5443,13 +7159,13 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - SPAKE2+ for Matter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SPAKE2P_MATTER`
-                 - Supported
+                 - Experimental
                * - SRP-6
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_6`
-                 - Supported
+                 - Experimental
                * - SRP password hashing
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_PASSWORD_HASH`
-                 - Supported
+                 - Experimental
 
    .. tab:: nRF54 Series
 
@@ -5485,19 +7201,19 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - SPAKE2+ for Matter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SPAKE2P_MATTER`
-                 - Supported
-                 - Supported
-                 - Supported
+                 - Experimental
+                 - Experimental
+                 - Experimental
                * - SRP-6
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_6`
-                 - Supported
-                 - Supported
-                 - Supported
+                 - Experimental
+                 - Experimental
+                 - Experimental
                * - SRP password hashing
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_PASSWORD_HASH`
-                 - Supported
-                 - Supported
-                 - Supported
+                 - Experimental
+                 - Experimental
+                 - Experimental
 
          .. tab:: nrf_oberon
 
@@ -5527,19 +7243,19 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - SPAKE2+ for Matter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SPAKE2P_MATTER`
-                 - Supported
-                 - Supported
-                 - Supported
+                 - Experimental
+                 - Experimental
+                 - Experimental
                * - SRP-6
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_6`
-                 - Supported
-                 - Supported
-                 - Supported
+                 - Experimental
+                 - Experimental
+                 - Experimental
                * - SRP password hashing
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_PASSWORD_HASH`
-                 - Supported
-                 - Supported
-                 - Supported
+                 - Experimental
+                 - Experimental
+                 - Experimental
 
    .. tab:: nRF91 Series
 
@@ -5579,22 +7295,22 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - SPAKE2+ for Matter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SPAKE2P_MATTER`
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
                * - SRP-6
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_6`
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
                * - SRP password hashing
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_PASSWORD_HASH`
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
 
 PAKE driver
 -----------
@@ -6662,10 +8378,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - 192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_192`
-                 - -- (nrf_cc310)
+                 - --
                * - 256 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_256`
-                 - -- (nrf_cc310)
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -6714,10 +8430,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - 192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_192`
-                 - -- (nrf_cc310)
+                 - Supported
                * - 256 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_256`
-                 - -- (nrf_cc310)
+                 - Supported
 
          .. tab:: nrf_oberon
 
@@ -6824,16 +8540,16 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - 192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_192`
-                 - -- (nrf_cc310)
-                 - -- (nrf_cc310)
-                 - -- (nrf_cc310)
-                 - -- (nrf_cc310)
+                 - --
+                 - --
+                 - --
+                 - --
                * - 256 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_256`
-                 - -- (nrf_cc310)
-                 - -- (nrf_cc310)
-                 - -- (nrf_cc310)
-                 - -- (nrf_cc310)
+                 - --
+                 - --
+                 - --
+                 - --
 
          .. tab:: nrf_oberon
 
@@ -6900,7 +8616,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - 3072 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_3072`
-                 - Supported (nrf_cc312 only)
+                 - --
                * - 4096 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_4096`
                  - --
@@ -6984,7 +8700,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - 3072 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_3072`
-                 - Supported (nrf_cc312 only)
+                 - Supported
                * - 4096 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_4096`
                  - --
@@ -7164,10 +8880,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - 3072 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_3072`
-                 - Supported (nrf_cc312 only)
-                 - Supported (nrf_cc312 only)
-                 - Supported (nrf_cc312 only)
-                 - Supported (nrf_cc312 only)
+                 - --
+                 - --
+                 - --
+                 - --
                * - 4096 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_4096`
                  - --

--- a/doc/nrf/security/psa_certified_api_overview.rst
+++ b/doc/nrf/security/psa_certified_api_overview.rst
@@ -62,7 +62,7 @@ The following table provides an overview of the PSA Certified APIs support statu
    * - `PSA Certified Crypto API`_
      - Supported
      - | `PSA Certified Crypto API 1.3.1`_ for IronSide Secure Element firmware for nRF54H20
-       | `PSA Certified Crypto API 1.2.1`_ for :ref:`nRF54L cryptography <ug_nrf54l_cryptography>` and PSA Crypto API builds without TF-M
+       | `PSA Certified Crypto API 1.3.1`_ for :ref:`nRF54L cryptography <ug_nrf54l_cryptography>` and PSA Crypto API builds without TF-M
        | `PSA Certified Crypto API 1.0.0`_ for builds with TF-M
    * - `PSA Certified Attestation API`_
      - Supported
@@ -127,7 +127,7 @@ Depending on the implementation you are using, the |NCS| build system uses diffe
    * - Implementation
      - `PSA Crypto API version <PSA Certified Crypto API_>`_
    * - :ref:`Oberon PSA Crypto <ug_crypto_architecture_implementation_standards_oberon>`
-     - `v1.2.1 <PSA Certified Crypto API 1.2.1_>`_
+     - `v1.3.1 <PSA Certified Crypto API 1.3.1_>`_
    * - :ref:`TF-M Crypto Service <ug_crypto_architecture_implementation_standards_tfm>`
      - `v1.0.0 <PSA Certified Crypto API 1.0.0_>`_
    * - :ref:`IronSide Secure Element <ug_crypto_architecture_implementation_standards_ironside>`


### PR DESCRIPTION
Updated cryptographic support tables for Oberon Core 1.5.1. NCSDK-34593 and PR #23474.