### PR TITLE
[Backport v3.1-branch] boards: shields: pca63565: enable NRF_SYS_EVENT

### DIFF
--- a/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NRF_SYS_EVENT=y

--- a/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
+++ b/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NRF_SYS_EVENT=y


### PR DESCRIPTION
Backport 4b123b6398722d7feb6c2e5a9c3bec73a72ed5b1 from #23657.