### PR TITLE
boards: shields: pca63565: remove NRF_SYS_EVENT on FLPR

### DIFF
--- a/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
+++ b/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2025 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-CONFIG_NRF_SYS_EVENT=y


### PR DESCRIPTION
NRF_SYS_EVENT is currently not supported on FLPR cores.