### PR TITLE
[Backport v3.1-branch] samples: bluetooth: peripheral_power_profiling: fix non conn adv for l15

### DIFF
--- a/samples/bluetooth/peripheral_power_profiling/sample.yaml
+++ b/samples/bluetooth/peripheral_power_profiling/sample.yaml
@@ -187,7 +187,7 @@ tests:
       - nrf54lm20pdk/nrf54lm20a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
     extra_args:
-      - platform:nrf54l15dk/nrf54l15/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15dk_nrf54l15_cpuapp_auto_conn_advert.overlay"
+      - platform:nrf54l15dk/nrf54l15/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15dk_nrf54l15_cpuapp_auto_non_conn_advert.overlay"
       - platform:nrf54lm20dk/nrf54lm20a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lm20dk_nrf54lm20a_cpuapp_non_conn_advert.overlay"
       - platform:nrf54lm20pdk/nrf54lm20a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lm20dk_nrf54lm20a_cpuapp_non_conn_advert.overlay"
       - platform:nrf54lm20pdk@0.2.0.csp/nrf54lm20a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lm20dk_nrf54lm20a_cpuapp_non_conn_advert.overlay"


### PR DESCRIPTION
Backport 9eb2bcac6379eeda79e4329361234bb0b31487b7 from #23692.