### PR TITLE
samples: esb_monitor: Implemented sniffer feature

### DIFF
--- a/samples/esb/esb_monitor/CMakeLists.txt
+++ b/samples/esb/esb_monitor/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
-FILE(GLOB app_sources src/*.c)
 # NORDIC SDK APP START
-target_sources(app PRIVATE ${app_sources})
+target_sources(app PRIVATE src/main.c)
+target_sources_ifdef(CONFIG_ESB_SNIFFER app PRIVATE src/sniffer.c)
 # NORDIC SDK APP END

--- a/samples/esb/esb_monitor/Kconfig
+++ b/samples/esb/esb_monitor/Kconfig
@@ -14,6 +14,50 @@ config LED_ENABLE
 	help
 	  Turns on led updates when receiving packets from PTX sample.
 
+config ESB_SNIFFER
+	bool "Turn sample into a functional ESB sniffer"
+	select USE_SEGGER_RTT
+	help
+	  Enable sniffer functionality with RTT backend and runtime configuration updates through UART shell.
+	  Disable logging received packets through UART.
+
+if ESB_SNIFFER
+config ESB_SNIFFER_RTT_DATA_CHANNEL
+	int "RTT up channel number for data transfer"
+	range 0 3
+	default 1
+
+config ESB_SNIFFER_RTT_CMD_RET_CHANNEL
+	int "RTT up channel number for sniffer command returns"
+	range 0 3
+	default 2
+
+config ESB_SNIFFER_RTT_CMD_CHANNEL
+	int "RTT down channel number for sniffer commands"
+	range 0 3
+	default 1
+
+config ESB_SNIFFER_RTT_DATA_BUF_SZ
+	int "RTT data buffer size"
+	default 45000
+
+config ESB_SNIFFER_RTT_CMD_RET_BUF_SZ
+	int "RTT commands return buffer size"
+	default 128
+
+config ESB_SNIFFER_RTT_CMD_BUF_SZ
+	int "RTT commands buffer size"
+	default 128
+
+config ESB_SNIFFER_THREAD_PRIORITY
+	int "ESB sniffer thread priority"
+	default 10
+
+config ESB_SNIFFER_THREAD_STACK_SZ
+	int "ESB sniffer thread stack size"
+	default 1024
+endif
+
 module = ESB_MONITOR_APP
 module-str = "ESB Monitor app"
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/samples/esb/esb_monitor/README.rst
+++ b/samples/esb/esb_monitor/README.rst
@@ -45,6 +45,18 @@ Configuration
 
 |config|
 
+Configuration options
+=====================
+
+Check and configure the following options:
+
+.. _CONFIG_ESB_SNIFFER:
+
+CONFIG_ESB_SNIFFER
+   Disable logging received packets through UART, and set RTT as transport layer for the packets.
+   It is intended for use together with :file:`scripts/esb_sniffer/main.py` or :file:`scripts/esb_sniffer/capture_to_pcap.py` scripts.
+   This option is disabled by default.
+
 Building and running
 ********************
 
@@ -71,6 +83,20 @@ Complete the following steps to test the samples:
 #. Connect to the monitor DK with a terminal emulator (for example, the `Serial Terminal app`_).
    See :ref:`test_and_optimize` for the required settings and steps.
 #. Observe the logged traffic of the DK programmed with the Monitor sample.
+
+Complete the following steps to test the sample with the :ref:`CONFIG_ESB_SNIFFER <CONFIG_ESB_SNIFFER>` Kconfig option enabled:
+
+1. Power on the DK.
+#. Read and follow the instructions in the :ref:`esb_sniffer_scripts` file to configure your environment.
+#. Run the :file:`scripts/esb_sniffer/capture_to_pcap.py` script with the name of the output file as argument.
+   For example:
+
+   .. parsed-literal::
+      :class: highlight
+
+      python3 capture_to_pcap.py output.pcap
+
+#. Analyze the captured traffic in Wireshark.
 
 Dependencies
 ************

--- a/samples/esb/esb_monitor/src/main.c
+++ b/samples/esb/esb_monitor/src/main.c
@@ -25,12 +25,21 @@
 #if defined(NRF54LM20A_ENGA_XXAA)
 #include <hal/nrf_clock.h>
 #endif /* defined(NRF54LM20A_ENGA_XXAA) */
+#if defined(CONFIG_ESB_SNIFFER)
+#include <zephyr/sys/byteorder.h>
+#include <SEGGER_RTT.h>
+#include "sniffer.h"
+#endif /* defined(CONFIG_ESB_SNIFFER) */
 
 LOG_MODULE_REGISTER(esb_monitor, CONFIG_ESB_MONITOR_APP_LOG_LEVEL);
 
+#if defined(CONFIG_ESB_SNIFFER)
+static struct rtt_frame packet;
+#else
 static struct esb_payload rx_payload;
+#endif /* defined(CONFIG_ESB_SNIFFER) */
 
-#if defined(CONFIG_LED_ENABLE)
+#if defined(CONFIG_LED_ENABLE) && !defined(CONFIG_ESB_SNIFFER)
 static void leds_update(uint8_t value)
 {
 	uint32_t leds_mask =
@@ -41,27 +50,56 @@ static void leds_update(uint8_t value)
 
 	dk_set_leds(leds_mask);
 }
-#endif /* defined(CONFIG_LED_ENABLE) */
+#endif /* defined(CONFIG_LED_ENABLE) && !defined(CONFIG_ESB_SNIFFER) */
 
-static void log_packet(uint32_t timestamp)
+#if defined(CONFIG_ESB_SNIFFER)
+static void log_packet(void)
+{
+	uint32_t cycles, ms, len;
+
+	cycles = k_cycle_get_32();
+	ms = k_cyc_to_ms_floor32(cycles);
+	/* Calculate remaing cycles */
+	cycles = cycles - (ms * (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / 1000));
+
+	/* htonl */
+	packet.us = sys_cpu_to_be32(k_cyc_to_us_floor32(cycles));
+	packet.ms = sys_cpu_to_be32(ms);
+
+	SEGGER_RTT_LOCK();
+	len = SEGGER_RTT_WriteNoLock(CONFIG_ESB_SNIFFER_RTT_DATA_CHANNEL,
+					&packet, sizeof(struct rtt_frame));
+	SEGGER_RTT_UNLOCK();
+	if (len < sizeof(struct rtt_frame)) {
+		LOG_ERR("RTT failed to write, rtt buffer too small");
+	}
+}
+#else
+static void log_packet(void)
 {
 	LOG_INF("%u: length = %d, pipe = %d, rssi = %d, noack = %d, pid = %d",
-				timestamp, rx_payload.length, rx_payload.pipe,
-				rx_payload.rssi, rx_payload.noack, rx_payload.pid);
+				k_cyc_to_ms_floor32(k_cycle_get_32()), rx_payload.length,
+				rx_payload.pipe, rx_payload.rssi, rx_payload.noack, rx_payload.pid);
 
 	LOG_HEXDUMP_INF(rx_payload.data, rx_payload.length, "data:");
 	LOG_INF("--------------------------------------------------------------");
 }
+#endif /* !defined(CONFIG_ESB_SNIFFER) */
 
 void event_handler(struct esb_evt const *event)
 {
 	switch (event->evt_id) {
 	case ESB_EVENT_RX_RECEIVED:
+#if defined(CONFIG_ESB_SNIFFER)
+		if (esb_read_rx_payload(&packet.payload) == 0) {
+#else
 		if (esb_read_rx_payload(&rx_payload) == 0) {
-			log_packet(k_cyc_to_ms_floor32(k_cycle_get_32()));
-#if defined(CONFIG_LED_ENABLE)
+#endif /* !defined(CONFIG_ESB_SNIFFER) */
+			log_packet();
+
+#if defined(CONFIG_LED_ENABLE) && !defined(CONFIG_ESB_SNIFFER)
 			leds_update(rx_payload.data[1]);
-#endif /* defined(CONFIG_LED_ENABLE) */
+#endif /* defined(CONFIG_LED_ENABLE) && !defined(CONFIG_ESB_SNIFFER) */
 		} else {
 			LOG_ERR("Error while reading rx packet");
 		}
@@ -170,6 +208,7 @@ int esb_initialize(void)
 	config.bitrate = ESB_BITRATE_2MBPS;
 	config.mode = ESB_MODE_MONITOR;
 	config.event_handler = event_handler;
+	config.use_fast_ramp_up = true;
 
 	err = esb_init(&config);
 	if (err) {
@@ -219,6 +258,13 @@ int main(void)
 
 	LOG_INF("Initialization complete");
 
+#if defined(CONFIG_ESB_SNIFFER)
+	err = sniffer_init();
+	if (err) {
+		LOG_ERR("Sniffer initialization failed, err %d", err);
+		return 0;
+	}
+#else
 	err = esb_start_rx();
 	if (err) {
 		LOG_ERR("ESB start monitor failed, err %d", err);
@@ -226,6 +272,7 @@ int main(void)
 	}
 
 	LOG_INF("Start receiving packets");
+#endif /* !defined(CONFIG_ESB_SNIFFER) */
 
 	/* return to idle thread */
 	return 0;

--- a/samples/esb/esb_monitor/src/sniffer.c
+++ b/samples/esb/esb_monitor/src/sniffer.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/types.h>
+
+#include <hal/nrf_radio.h>
+#include <esb.h>
+
+#include <SEGGER_RTT.h>
+
+#include "sniffer.h"
+
+LOG_MODULE_REGISTER(esb_sniffer, CONFIG_ESB_MONITOR_APP_LOG_LEVEL);
+
+static uint8_t rtt_data_buff[CONFIG_ESB_SNIFFER_RTT_DATA_BUF_SZ];
+static uint8_t rtt_comm_ret_buff[CONFIG_ESB_SNIFFER_RTT_CMD_RET_BUF_SZ];
+static uint8_t rtt_comm_buff[CONFIG_ESB_SNIFFER_RTT_CMD_BUF_SZ];
+
+static k_tid_t rtt_comm_thread_id;
+static K_THREAD_STACK_DEFINE(rtt_comm_thread_stack, CONFIG_ESB_SNIFFER_THREAD_STACK_SZ);
+static struct k_thread rtt_comm_thread;
+
+static struct esb_sniffer_cfg sniffer_cfg;
+
+enum esb_sniffer_rtt_comm {
+	SNIFFER_START  = 1,
+	SNIFFER_STOP   = 2,
+	SNIFFER_STATUS = 3
+};
+
+/**
+ * @brief Convert radio register value into array
+ *
+ * This function takes value of address or prefix register and converts it
+ * into human readable array containing currently configured address or prefix
+ *
+ * @param reg value from base_addr0 or base_addr1 or prefix0 or prefix1 register
+ * @param array pointer to destination of the converted value
+ */
+static void radio_reg_to_array(uint32_t reg, uint8_t *array)
+{
+#if __CORTEX_M == (0x04U)
+	uint32_t inp = reg;
+
+	*((uint32_t *)array) = sys_cpu_to_be32((uint32_t)__RBIT(inp));
+#else
+	uint32_t inp = sys_cpu_to_le32(reg);
+
+	/* bytewise bit-swap */
+	inp = (inp & 0xF0F0F0F0) >> 4 | (inp & 0x0F0F0F0F) << 4;
+	inp = (inp & 0xCCCCCCCC) >> 2 | (inp & 0x33333333) << 2;
+	inp = (inp & 0xAAAAAAAA) >> 1 | (inp & 0x55555555) << 1;
+	memcpy(array, &inp, sizeof(uint32_t));
+#endif
+}
+
+static void rtt_comm_exec(enum esb_sniffer_rtt_comm command)
+{
+	int err;
+
+	switch (command) {
+	case SNIFFER_START:
+		LOG_INF("Start sniffer");
+		if (!sniffer_cfg.is_running) {
+			err = esb_start_rx();
+		} else {
+			err = 0;
+		}
+
+		if (err != 0) {
+			LOG_ERR("Failed to start sniffer, err: %d", err);
+		} else {
+			sniffer_cfg.is_running = true;
+		}
+
+		SEGGER_RTT_Write(CONFIG_ESB_SNIFFER_RTT_CMD_RET_CHANNEL,
+								&err, sizeof(int));
+		break;
+	case SNIFFER_STOP:
+		LOG_INF("Stop sniffer");
+		if (sniffer_cfg.is_running) {
+			err = esb_stop_rx();
+		} else {
+			err = 0;
+		}
+
+		if (err != 0) {
+			LOG_ERR("Failed to stop sniffer, err: %d", err);
+		} else {
+			sniffer_cfg.is_running = false;
+		}
+
+		SEGGER_RTT_Write(CONFIG_ESB_SNIFFER_RTT_CMD_RET_CHANNEL,
+								&err, sizeof(int));
+		break;
+	case SNIFFER_STATUS:
+		err = sniffer_cfg.is_running;
+		SEGGER_RTT_Write(CONFIG_ESB_SNIFFER_RTT_CMD_RET_CHANNEL,
+								&err, sizeof(int));
+		break;
+	default:
+		LOG_ERR("Unrecognized rtt command: %d", command);
+	}
+}
+
+static void rtt_comm_thread_fn(void)
+{
+	enum esb_sniffer_rtt_comm comm;
+	uint32_t read_len;
+
+	/* Send packet length to backend */
+	read_len = sizeof(struct rtt_frame);
+	read_len = sys_cpu_to_be32(read_len);
+
+	SEGGER_RTT_Write(CONFIG_ESB_SNIFFER_RTT_CMD_RET_CHANNEL,
+						&read_len, sizeof(uint32_t));
+	while (1) {
+		read_len = SEGGER_RTT_Read(CONFIG_ESB_SNIFFER_RTT_CMD_CHANNEL,
+						&comm, sizeof(enum esb_sniffer_rtt_comm));
+		if (read_len == sizeof(enum esb_sniffer_rtt_comm)) {
+			rtt_comm_exec(comm);
+		}
+
+		k_sleep(K_MSEC(500));
+	}
+}
+
+int sniffer_init(void)
+{
+	int err;
+
+	BUILD_ASSERT(
+		CONFIG_ESB_SNIFFER_RTT_DATA_CHANNEL != CONFIG_ESB_SNIFFER_RTT_CMD_RET_CHANNEL,
+		"RTT channels with the same direction must have different indexes!"
+	);
+
+	err = SEGGER_RTT_ConfigUpBuffer(CONFIG_ESB_SNIFFER_RTT_DATA_CHANNEL,
+					"Data", rtt_data_buff,
+					CONFIG_ESB_SNIFFER_RTT_DATA_BUF_SZ,
+					SEGGER_RTT_MODE_NO_BLOCK_SKIP);
+	if (err < 0) {
+		LOG_ERR("RTT initialization failed");
+		return err;
+	}
+
+	err = SEGGER_RTT_ConfigUpBuffer(CONFIG_ESB_SNIFFER_RTT_CMD_RET_CHANNEL,
+					 "Comm_ret", rtt_comm_ret_buff,
+					 CONFIG_ESB_SNIFFER_RTT_CMD_RET_BUF_SZ,
+					 SEGGER_RTT_MODE_NO_BLOCK_SKIP);
+	if (err < 0) {
+		LOG_ERR("RTT initialization failed");
+		return err;
+	}
+
+	err = SEGGER_RTT_ConfigDownBuffer(CONFIG_ESB_SNIFFER_RTT_CMD_CHANNEL,
+					   "Commands", rtt_comm_buff,
+					   CONFIG_ESB_SNIFFER_RTT_CMD_BUF_SZ,
+					   SEGGER_RTT_MODE_NO_BLOCK_SKIP);
+	if (err < 0) {
+		LOG_ERR("RTT initialization failed");
+		return err;
+	}
+
+	/* Setup sniffer_cfg from already initialized ESB */
+	sniffer_cfg.enabled_pipes = 0xFF;
+	sniffer_cfg.bitrate = (enum esb_bitrate)nrf_radio_mode_get(NRF_RADIO);
+	sniffer_cfg.is_running = false;
+
+	radio_reg_to_array(nrf_radio_base0_get(NRF_RADIO), sniffer_cfg.base_addr0);
+	radio_reg_to_array(nrf_radio_base1_get(NRF_RADIO), sniffer_cfg.base_addr1);
+	radio_reg_to_array(nrf_radio_prefix0_get(NRF_RADIO), sniffer_cfg.pipe_prefix);
+	radio_reg_to_array(nrf_radio_prefix1_get(NRF_RADIO), &sniffer_cfg.pipe_prefix[4]);
+
+	rtt_comm_thread_id = k_thread_create(&rtt_comm_thread,
+				rtt_comm_thread_stack,
+				CONFIG_ESB_SNIFFER_THREAD_STACK_SZ,
+				(k_thread_entry_t)rtt_comm_thread_fn,
+				NULL, NULL, NULL,
+				CONFIG_ESB_SNIFFER_THREAD_PRIORITY, 0, K_NO_WAIT);
+
+	return 0;
+}

--- a/samples/esb/esb_monitor/src/sniffer.h
+++ b/samples/esb/esb_monitor/src/sniffer.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#ifndef __ESB_SNIFFER_H
+#define __ESB_SNIFFER_H
+
+#include <esb.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct esb_sniffer_cfg {
+	uint8_t base_addr0[4];
+	uint8_t base_addr1[4];
+	uint8_t pipe_prefix[8];
+	uint8_t enabled_pipes;
+	enum esb_bitrate bitrate;
+	bool is_running;
+};
+
+struct rtt_frame {
+	uint32_t ms;
+	uint32_t us;
+	struct esb_payload payload;
+} __packed;
+
+int sniffer_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ESB_SNIFFER_H  */


### PR DESCRIPTION
    samples: esb_monitor: Implemented sniffer feature
    Sniffer sends received packets with timestamp via RTT instead of logging them.
    
    Jira: NCSDK-34716
