### PR TITLE
[Backport v3.1-branch] manifest: sdk-nrfxlib: softperipheral: rev a9c676e2a695e9644c11fea3e9eef5d8e845247e

### DIFF
--- a/doc/nrf/drivers/mspi_sqspi.rst
+++ b/doc/nrf/drivers/mspi_sqspi.rst
@@ -79,11 +79,11 @@ See the following configuration example for the nRF54L15 SoC:
 				#address-cells = <1>;
 				#size-cells = <1>;
 
-				sqspi: sqspi@3c00 {
+				sqspi: sqspi@3b40 {
 					compatible = "nordic,nrf-sqspi";
 					#address-cells = <1>;
 					#size-cells = <0>;
-					reg = <0x3c00 0x200>;
+					reg = <0x3b40 0x200>;
 					status = "okay";
 					zephyr,pm-device-runtime-auto;
 				};
@@ -157,11 +157,11 @@ The following example configuration for the nRF54H20 SoC sets up the necessary p
 				#address-cells = <1>;
 				#size-cells = <1>;
 
-				sqspi: sqspi@3e00 {
+				sqspi: sqspi@3d40 {
 					compatible = "nordic,nrf-sqspi";
 					#address-cells = <1>;
 					#size-cells = <0>;
-					reg = <0x3e00 0x200>;
+					reg = <0x3d40 0x200>;
 					zephyr,pm-device-runtime-auto;
 					memory-regions = <&sqspi_buffers>;
 				};

--- a/drivers/mspi/CMakeLists.txt
+++ b/drivers/mspi/CMakeLists.txt
@@ -13,7 +13,7 @@ if(CONFIG_MSPI_NRF_SQSPI)
 
   dt_comp_path(sqspi_path COMPATIBLE "nordic,nrf-sqspi" IDX 0)
   dt_reg_addr(sqspi_addr PATH ${sqspi_path})
-  math(EXPR sqspi_sp_firmware_addr "${sqspi_addr} - 0x3c00")
+  math(EXPR sqspi_sp_firmware_addr "${sqspi_addr} - 0x3b40")
 
   zephyr_library_compile_definitions(
     NRF_SQSPI_ENABLED=1

--- a/drivers/mspi/CMakeLists.txt
+++ b/drivers/mspi/CMakeLists.txt
@@ -11,22 +11,22 @@ if(CONFIG_MSPI_NRF_SQSPI)
   set(SP_DIR ${ZEPHYR_NRFXLIB_MODULE_DIR}/softperipheral)
   set(SQSPI_DIR ${SP_DIR}/sQSPI)
 
+  dt_comp_path(sqspi_path COMPATIBLE "nordic,nrf-sqspi" IDX 0)
+  dt_reg_addr(sqspi_addr PATH ${sqspi_path})
+  math(EXPR sqspi_sp_firmware_addr "${sqspi_addr} - 0x3c00")
+
   zephyr_library_compile_definitions(
-    NRFX_QSPI2_ENABLED=1
-    NRFX_QSPI2_MAX_NUM_DATA_LINES=4
+    NRF_SQSPI_ENABLED=1
+    NRF_SQSPI_MAX_NUM_DATA_LINES=4
+    NRF_SQSPI_SP_FIRMWARE_ADDR=${sqspi_sp_firmware_addr}
   )
   zephyr_library_include_directories(
     ${SP_DIR}/include
     ${SQSPI_DIR}/include
-  )
-  zephyr_library_include_directories_ifdef(CONFIG_SOC_NRF54L15
-    ${SQSPI_DIR}/include/nrf54l15
-  )
-  zephyr_library_include_directories_ifdef(CONFIG_SOC_NRF54H20
-    ${SQSPI_DIR}/include/nrf54h20
+    ${SQSPI_DIR}/include/${CONFIG_SOC}
   )
   zephyr_library_sources(
-    ${SQSPI_DIR}/src/nrfx_qspi2.c
+    ${SQSPI_DIR}/src/nrf_sqspi.c
     mspi_sqspi.c
   )
 endif()

--- a/samples/zephyr/drivers/jesd216/boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
+++ b/samples/zephyr/drivers/jesd216/boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
@@ -48,11 +48,11 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			sqspi: sqspi@3c00 {
+			sqspi: sqspi@3b40 {
 				compatible = "nordic,nrf-sqspi";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x3c00 0x200>;
+				reg = <0x3b40 0x200>;
 				status = "okay";
 				zephyr,pm-device-runtime-auto;
 			};

--- a/samples/zephyr/drivers/spi_flash/boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
+++ b/samples/zephyr/drivers/spi_flash/boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
@@ -48,11 +48,11 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			sqspi: sqspi@3c00 {
+			sqspi: sqspi@3b40 {
 				compatible = "nordic,nrf-sqspi";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x3c00 0x200>;
+				reg = <0x3b40 0x200>;
 				status = "okay";
 				zephyr,pm-device-runtime-auto;
 			};

--- a/tests/drivers/mspi/mspi_with_spis/boards/nrf54h20dk_nrf54h20_cpuapp_sqspi.overlay
+++ b/tests/drivers/mspi/mspi_with_spis/boards/nrf54h20dk_nrf54h20_cpuapp_sqspi.overlay
@@ -136,11 +136,11 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			dut: sqspi: sqspi@3e00 {
+			dut: sqspi: sqspi@3d40 {
 				compatible = "nordic,nrf-sqspi";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x3e00 0x200>;
+				reg = <0x3d40 0x200>;
 				zephyr,pm-device-runtime-auto;
 				memory-regions = <&sqspi_buffers>;
 			};

--- a/tests/zephyr/drivers/flash/common/boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
+++ b/tests/zephyr/drivers/flash/common/boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
@@ -48,11 +48,11 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			sqspi: sqspi@3c00 {
+			sqspi: sqspi@3b40 {
 				compatible = "nordic,nrf-sqspi";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x3c00 0x200>;
+				reg = <0x3b40 0x200>;
 				status = "okay";
 				zephyr,pm-device-runtime-auto;
 			};

--- a/west.yml
+++ b/west.yml
@@ -145,7 +145,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: pull/1818/head
+      revision: 7894064ca985e13c673e0074ea73674c30d13516
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m

--- a/west.yml
+++ b/west.yml
@@ -145,7 +145,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: c87f126f2def9287127e366e452b027fa81d7f64
+      revision: pull/1818/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Backport commits from https://github.com/nrfconnect/sdk-nrf/pull/23514 and #23728 to v3.1-branch.