### PR TITLE
samples: matter: Fixed issue with spinlock assert on 53 family

### DIFF
--- a/applications/matter_bridge/sysbuild/ipc_radio/prj.conf
+++ b/applications/matter_bridge/sysbuild/ipc_radio/prj.conf
@@ -40,3 +40,6 @@ CONFIG_IPC_SERVICE=y
 # ipc_radio
 CONFIG_IPC_RADIO_BT=y
 CONFIG_IPC_RADIO_BT_HCI_IPC=y
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/applications/matter_weather_station/sysbuild/ipc_radio/prj.conf
+++ b/applications/matter_weather_station/sysbuild/ipc_radio/prj.conf
@@ -51,3 +51,6 @@ CONFIG_IPC_RADIO_BT_HCI_IPC=y
 # that is pulled in by NETCORE_IPC_RADIO_IEEE802154 in application's Kconfig.sysbuild.
 # For Wi-Fi builds, this option will not get applied anyway.
 CONFIG_NRF_802154_ENCRYPTION=y
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/light_bulb/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/light_bulb/sysbuild/ipc_radio/prj.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=n
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/light_bulb/sysbuild/ipc_radio/prj_release.conf
+++ b/samples/matter/light_bulb/sysbuild/ipc_radio/prj_release.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=y
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/light_switch/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/light_switch/sysbuild/ipc_radio/prj.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=n
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/lock/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/lock/sysbuild/ipc_radio/prj.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=n
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/lock/sysbuild/ipc_radio/prj_release.conf
+++ b/samples/matter/lock/sysbuild/ipc_radio/prj_release.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=y
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/manufacturer_specific/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/manufacturer_specific/sysbuild/ipc_radio/prj.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=n
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/smoke_co_alarm/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/smoke_co_alarm/sysbuild/ipc_radio/prj.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=n
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/smoke_co_alarm/sysbuild/ipc_radio/prj_release.conf
+++ b/samples/matter/smoke_co_alarm/sysbuild/ipc_radio/prj_release.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=y
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/template/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/template/sysbuild/ipc_radio/prj.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=n
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/template/sysbuild/ipc_radio/prj_release.conf
+++ b/samples/matter/template/sysbuild/ipc_radio/prj_release.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=y
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/thermostat/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/thermostat/sysbuild/ipc_radio/prj.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=n
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/window_covering/sysbuild/ipc_radio/prj.conf
+++ b/samples/matter/window_covering/sysbuild/ipc_radio/prj.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=n
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0

--- a/samples/matter/window_covering/sysbuild/ipc_radio/prj_release.conf
+++ b/samples/matter/window_covering/sysbuild/ipc_radio/prj_release.conf
@@ -9,3 +9,6 @@ CONFIG_UART_CONSOLE=n
 CONFIG_LOG=n
 
 CONFIG_RESET_ON_FATAL_ERROR=y
+
+# Workaround for the spinlock assertion issue.
+CONFIG_TIMESLICE_SIZE=0


### PR DESCRIPTION
Changed timeslice size to 0 to workaround the issue with spinlock assert on nRF5340.