### PR TITLE
[Backport v3.1-branch] scripts: tag_west_repos: Use `git describe' for OSS repositoires

### DIFF
--- a/scripts/tag_west_repos.sh
+++ b/scripts/tag_west_repos.sh
@@ -47,8 +47,6 @@ PROJECT_TAGS[nrfxlib]=""
 PROJECT_TAGS[find-my]=""
 PROJECT_TAGS[matter]=""
 PROJECT_TAGS[nrf-802154]=""
-PROJECT_TAGS[suit-processor]=""
-PROJECT_TAGS[suit-generator]=""
 
 # OSS repositories: vX.Y.Z-ncsN(-I)(-rcM)
 PROJECT_TAGS[zephyr]=""

--- a/scripts/tag_west_repos.sh
+++ b/scripts/tag_west_repos.sh
@@ -74,6 +74,13 @@ hline() {
     printf '%*s\n' "$(tput cols)" '' | tr ' ' -
 }
 
+has_remote() {
+    project="$1"
+
+    [ "$project" == "zephyr" ] || [ "$project" == "mcuboot" ] ||
+    [ "$project" == "trusted-firmware-m" ] || [ "$project" == "mbedtls" ]
+}
+
 tag() {
     # Synopsis:
     #
@@ -99,6 +106,11 @@ tag() {
     remote_basename=$(west list -f '{url}' "$project" | xargs basename)
     local_path=$(west list -f '{abspath}' "$project")
     message="$remote_basename $tagname"
+
+    if has_remote "$project"; then
+        describe=$(git -C "$local_path" describe --exclude 'ncs-*')
+        message="$message"$'\n'"$project $describe"
+    fi
 
     echo "$project": creating tag "$tagname" for "$sha" in "$local_path"
     git -C "$local_path" tag -s -a -m "$message" "$tagname" "$sha" || exit 1

--- a/scripts/tag_west_repos.sh
+++ b/scripts/tag_west_repos.sh
@@ -53,12 +53,14 @@ PROJECT_TAGS[zephyr]=""
 PROJECT_TAGS[mcuboot]=""
 PROJECT_TAGS[trusted-firmware-m]=""
 PROJECT_TAGS[mbedtls]=""
+PROJECT_TAGS[oberon-psa-crypto]=""
 
 # Upstream OSS remotes
 UPSTREAM_REMOTES[zephyr]="https://github.com/zephyrproject-rtos/zephyr"
 UPSTREAM_REMOTES[mcuboot]="https://github.com/mcu-tools/mcuboot"
 UPSTREAM_REMOTES[trusted-firmware-m]="https://github.com/TrustedFirmware-M/trusted-firmware-m"
 UPSTREAM_REMOTES[mbedtls]="https://github.com/Mbed-TLS/mbedtls"
+UPSTREAM_REMOTES[oberon-psa-crypto]="" # Upstream skipped because it's private
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Backport ad0f701b5f2e437967c1519726eeae9200367a99~4..ad0f701b5f2e437967c1519726eeae9200367a99 from #23664.