### PR TITLE
samples|tests: drivers: Adjust overlays to align with sQSPI v1.0.0

### DIFF
--- a/doc/nrf/drivers/mspi_sqspi.rst
+++ b/doc/nrf/drivers/mspi_sqspi.rst
@@ -79,11 +79,11 @@ See the following configuration example for the nRF54L15 SoC:
 				#address-cells = <1>;
 				#size-cells = <1>;
 
-				sqspi: sqspi@3c00 {
+				sqspi: sqspi@3b40 {
 					compatible = "nordic,nrf-sqspi";
 					#address-cells = <1>;
 					#size-cells = <0>;
-					reg = <0x3c00 0x200>;
+					reg = <0x3b40 0x200>;
 					status = "okay";
 					zephyr,pm-device-runtime-auto;
 				};
@@ -157,11 +157,11 @@ The following example configuration for the nRF54H20 SoC sets up the necessary p
 				#address-cells = <1>;
 				#size-cells = <1>;
 
-				sqspi: sqspi@3e00 {
+				sqspi: sqspi@3d40 {
 					compatible = "nordic,nrf-sqspi";
 					#address-cells = <1>;
 					#size-cells = <0>;
-					reg = <0x3e00 0x200>;
+					reg = <0x3d40 0x200>;
 					zephyr,pm-device-runtime-auto;
 					memory-regions = <&sqspi_buffers>;
 				};

--- a/drivers/mspi/CMakeLists.txt
+++ b/drivers/mspi/CMakeLists.txt
@@ -13,7 +13,7 @@ if(CONFIG_MSPI_NRF_SQSPI)
 
   dt_comp_path(sqspi_path COMPATIBLE "nordic,nrf-sqspi" IDX 0)
   dt_reg_addr(sqspi_addr PATH ${sqspi_path})
-  math(EXPR sqspi_sp_firmware_addr "${sqspi_addr} - 0x3c00")
+  math(EXPR sqspi_sp_firmware_addr "${sqspi_addr} - 0x3b40")
 
   zephyr_library_compile_definitions(
     NRF_SQSPI_ENABLED=1

--- a/samples/zephyr/drivers/jesd216/boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
+++ b/samples/zephyr/drivers/jesd216/boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
@@ -48,11 +48,11 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			sqspi: sqspi@3c00 {
+			sqspi: sqspi@3b40 {
 				compatible = "nordic,nrf-sqspi";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x3c00 0x200>;
+				reg = <0x3b40 0x200>;
 				status = "okay";
 				zephyr,pm-device-runtime-auto;
 			};

--- a/samples/zephyr/drivers/spi_flash/boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
+++ b/samples/zephyr/drivers/spi_flash/boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
@@ -48,11 +48,11 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			sqspi: sqspi@3c00 {
+			sqspi: sqspi@3b40 {
 				compatible = "nordic,nrf-sqspi";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x3c00 0x200>;
+				reg = <0x3b40 0x200>;
 				status = "okay";
 				zephyr,pm-device-runtime-auto;
 			};

--- a/tests/drivers/mspi/mspi_with_spis/boards/nrf54h20dk_nrf54h20_cpuapp_sqspi.overlay
+++ b/tests/drivers/mspi/mspi_with_spis/boards/nrf54h20dk_nrf54h20_cpuapp_sqspi.overlay
@@ -136,11 +136,11 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			dut: sqspi: sqspi@3e00 {
+			dut: sqspi: sqspi@3d40 {
 				compatible = "nordic,nrf-sqspi";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x3e00 0x200>;
+				reg = <0x3d40 0x200>;
 				zephyr,pm-device-runtime-auto;
 				memory-regions = <&sqspi_buffers>;
 			};

--- a/tests/zephyr/drivers/flash/common/boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
+++ b/tests/zephyr/drivers/flash/common/boards/nrf54l15dk_nrf54l15_cpuapp_sqspi.overlay
@@ -48,11 +48,11 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			sqspi: sqspi@3c00 {
+			sqspi: sqspi@3b40 {
 				compatible = "nordic,nrf-sqspi";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x3c00 0x200>;
+				reg = <0x3b40 0x200>;
 				status = "okay";
 				zephyr,pm-device-runtime-auto;
 			};


### PR DESCRIPTION
This is a follow-up to #23514.

Offsets of the register interface for sQSPI soft peripherals (so in consequence the base addresses of the related nodes in dts) have been changed in sQSPI v1.0.0 for both the nRF54l15 and nRF54h20. Update accordingly dts overlays in samples and tests, and also the sQSPI MSPI shim driver documentation and its cmake definitions.