### PR TITLE
[Backport v3.1-branch] wifi: Fix sysbuild Kconfig references

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf70/fw_patches_ext_flash.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/fw_patches_ext_flash.rst
@@ -54,7 +54,7 @@ Using XIP access
 
 If the application supports XIP from external memory, then the firmware patches can be loaded as part of the nRF Wi-Fi driver code (RODATA) and then relocated to the external memory.
 The nRF Wi-Fi driver accesses the firmware patches using XIP feature and downloads the firmware patches to the nRF70 device.
-To enable this feature, set the ``SB_CONFIG_WIFI_PATCHES_EXT_FLASH_XIP`` sysbuild Kconfig option to ``y``.
+To enable this feature, set the :kconfig:option:`SB_CONFIG_WIFI_PATCHES_EXT_FLASH_XIP` sysbuild Kconfig option to ``y``.
 Once the build is complete, the feature can be verified by checking the memory regions summary in the build output.
 A new memory region called ``EXTFLASH`` is added to the memory regions summary, and the firmware patches are placed in this region.
 The size of the ``FLASH`` used is reduced by the size of the firmware patches.
@@ -89,7 +89,7 @@ Configuration
 
 The following configuration options are available:
 
-* ``SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE`` - Enables the option to store the firmware patch in external non-XIP memory.
+* :kconfig:option:`SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE` - Enables the option to store the firmware patch in external non-XIP memory.
 * :kconfig:option:`CONFIG_NRF_WIFI_FW_FLASH_CHUNK_SIZE` - Defines the size of the chunks used to read the firmware patches from the external non-XIP memory.
   The default value is 8192 bytes.
 
@@ -111,7 +111,7 @@ Building
 
 See :ref:`nrf7002dk_nrf5340` for general instructions on building.
 
-Additionally, you can build the sample using the ``nrf70-fw-patch-ext-flash`` snippet and set the ``SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE=y`` Kconfig option.
+Additionally, you can build the sample using the ``nrf70-fw-patch-ext-flash`` snippet and set the :kconfig:option:`SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE` Kconfig option to ``y``.
 
 For example, to build the :ref:`wifi_shell_sample` sample for the nRF5340 DK with the ``nrf70-fw-patch-ext-flash`` snippet enabled, run the following commands.
 

--- a/doc/nrf/app_dev/device_guides/wifi_coex.rst
+++ b/doc/nrf/app_dev/device_guides/wifi_coex.rst
@@ -133,9 +133,9 @@ To enable Wi-Fi coexistence on the nRF70 Series device, complete the following s
    The *image_name* value is ``ipc_radio`` (:ref:`ipc_radio`), which represents all applications with support for the combination of both 802.15.4 and Bluetooth.
    To configure your application, use the following sysbuild configurations:
 
-   * ``SB_CONFIG_NETCORE_IPC_RADIO=y`` for applications having support for 802.15.4, but not for Bluetooth.
-   * ``SB_CONFIG_NETCORE_IPC_RADIO_BT_HCI_IPC=y`` for an application having support for Bluetooth, but not for 802.15.4.
-   * ``SB_CONFIG_NETCORE_IPC_RADIO=y`` and ``SB_CONFIG_NETCORE_IPC_RADIO_BT_HCI_IPC=y`` for multiprotocol applications having support for both 802.15.4 and Bluetooth.
+   * Set the :kconfig:option:`SB_CONFIG_NETCORE_IPC_RADIO` Kconfig option to ``y`` for applications having support for 802.15.4, but not for Bluetooth.
+   * Set the :kconfig:option:`SB_CONFIG_NETCORE_IPC_RADIO_BT_HCI_IPC` Kconfig option to ``y`` for an application having support for Bluetooth, but not for 802.15.4.
+   * Set the :kconfig:option:`SB_CONFIG_NETCORE_IPC_RADIO` and :kconfig:option:`SB_CONFIG_NETCORE_IPC_RADIO_BT_HCI_IPC` Kconfig options to ``y`` for multiprotocol applications having support for both 802.15.4 and Bluetooth.
 
 #. Enable the following Kconfig options:
 
@@ -213,9 +213,9 @@ To enable the generic three-wire coexistence, complete the following steps:
    The *image_name* value is ``ipc_radio``, which represents all applications with support for the combination of both 802.15.4 and Bluetooth.
    To configure your application, use the following sysbuild configurations:
 
-   * ``SB_CONFIG_NETCORE_IPC_RADIO=y`` for applications having support for 802.15.4, but not for Bluetooth.
-   * ``SB_CONFIG_NETCORE_IPC_RADIO_BT_HCI_IPC=y`` for an application having support for Bluetooth, but not for 802.15.4.
-   * ``SB_CONFIG_NETCORE_IPC_RADIO=y`` and ``SB_CONFIG_NETCORE_IPC_RADIO_BT_HCI_IPC=y`` for multiprotocol applications having support for both 802.15.4 and Bluetooth.
+   * Set the :kconfig:option:`SB_CONFIG_NETCORE_IPC_RADIO` Kconfig option to ``y`` for applications having support for 802.15.4, but not for Bluetooth.
+   * Set the :kconfig:option:`SB_CONFIG_NETCORE_IPC_RADIO_BT_HCI_IPC` Kconfig option to ``y`` for an application having support for Bluetooth, but not for 802.15.4.
+   * Set the :kconfig:option:`SB_CONFIG_NETCORE_IPC_RADIO` and :kconfig:option:`SB_CONFIG_NETCORE_IPC_RADIO_BT_HCI_IPC` Kconfig options to ``y`` for multiprotocol applications having support for both 802.15.4 and Bluetooth.
 
 #. Enable the following Kconfig options:
 

--- a/samples/wifi/shell/README.rst
+++ b/samples/wifi/shell/README.rst
@@ -84,7 +84,7 @@ The following is an example of the CLI command:
    The nRF91 Series supports Wi-Fi through nR70 Series shields but is limited to scan-only operation to enhance location accuracy.
    However, it does not support full Wi-Fi operations.
 
-To build for the Thingy:91 X using the nRF5340 as the host chip, use the ``thingy91x/nrf5340/cpuapp`` board target with the ``SB_CONFIG_THINGY91X_STATIC_PARTITIONS_NRF53_EXTERNAL_FLASH=y`` CMake option set.
+To build for the Thingy:91 X using the nRF5340 as the host chip, use the ``thingy91x/nrf5340/cpuapp`` board target with the :kconfig:option:`SB_CONFIG_THINGY91X_STATIC_PARTITIONS_NRF53_EXTERNAL_FLASH` Kconfig option set to ``y``.
 This requires an external debugger since the nRF9151 normally owns the buses.
 This special configuration is not compatible with nRF9151 firmware compiled for the default configuration.
 You need to erase the nRF9151 first to avoid conflicts.


### PR DESCRIPTION
Backport f7e326b28451ef56183a3185bf7d82f75c6b4470 from #23686.