### PR TITLE
[Backport v3.1-branch] boards: shields: pca63565: remove NRF_SYS_EVENT on FLPR

### DIFF
--- a/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
+++ b/boards/shields/pca63565/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2025 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-CONFIG_NRF_SYS_EVENT=y

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -81,12 +81,3 @@
   platforms:
     - nrf54h20dk@0.9.0/nrf54h20/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-34187"
-
-- scenarios:
-    - nrf.extended.drivers.i2c.bme688_nrf54l
-    - nrf.extended.drivers.i2c.bme688_nrf54l_fast_speed
-    - nrf.extended.sample.sensor.accel_polling.nrf54l15_cpuflpr
-    - nrf.extended.sample.sensor.bme680.nrf54l_cpuflpr
-  platforms:
-    - nrf54l15dk/nrf54l15/cpuflpr
-  comment: "https://nordicsemi.atlassian.net/browse/NRFX-8205"


### PR DESCRIPTION
Backport 481c6e5ffc4809167758c41fce122f46b630f978~2..481c6e5ffc4809167758c41fce122f46b630f978 from #23694.