### PR TITLE
[Backport v3.1-branch] ci: upgrade `nrfutil device==2.12.6`

### DIFF
--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -27,4 +27,4 @@ pip:
 nrfutil:
   version: 8.1.0
   subcommands:
-    device: 2.11.2
+    device: 2.12.6

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -32,4 +32,4 @@ pip:
 nrfutil:
   version: 8.1.0
   subcommands:
-    device: 2.11.2
+    device: 2.12.6

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -26,4 +26,4 @@ pip:
 nrfutil:
   version: 8.1.0
   subcommands:
-    device: 2.11.2
+    device: 2.12.6


### PR DESCRIPTION
Backport d75b6f785ccbbf8f374de349fea25d89e19f77e3 from #23730.