### PR TITLE
net: lib: wifi_prov_core: Fix windows build

### DIFF
--- a/samples/wifi/provisioning/internal/CMakeLists.txt
+++ b/samples/wifi/provisioning/internal/CMakeLists.txt
@@ -37,7 +37,8 @@ if(CONFIG_WIFI_PROV_CONFIG)
         OUTPUT ${WIFI_CONFIG_BIN}
         COMMAND ${WIFI_CONFIG_CMD}
         DEPENDS ${WIFI_CONFIG_SCRIPT}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        DEPENDS wifi_prov_core
+        WORKING_DIRECTORY ${PROTO_DIR}
         COMMENT "Generating sample WiFi configuration"
     )
 

--- a/subsys/net/lib/wifi_prov_core/CMakeLists.txt
+++ b/subsys/net/lib/wifi_prov_core/CMakeLists.txt
@@ -11,6 +11,8 @@ set(nanopb_BUILD_RUNTIME OFF)
 set(CMAKE_MODULE_PATH ${ZEPHYR_NANOPB_MODULE_DIR}/extra)
 find_package(Nanopb REQUIRED)
 set(NANOPB_GENERATE_CPP_STANDALONE FALSE)
+
+# Generate nanopb C files for embedded code
 nanopb_generate_cpp(proto_sources proto_headers
 	proto/common.proto
 	proto/version.proto
@@ -18,6 +20,30 @@ nanopb_generate_cpp(proto_sources proto_headers
 	proto/request.proto
 	proto/response.proto
 )
+
+# Generate Python protobuf files for the configuration script
+if(PROTOBUF_PROTOC_EXECUTABLE)
+    set(PYTHON_PROTO_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/proto/common.proto
+        ${CMAKE_CURRENT_SOURCE_DIR}/proto/version.proto
+        ${CMAKE_CURRENT_SOURCE_DIR}/proto/result.proto
+        ${CMAKE_CURRENT_SOURCE_DIR}/proto/request.proto
+        ${CMAKE_CURRENT_SOURCE_DIR}/proto/response.proto
+    )
+
+    add_custom_target(generate_python_proto ALL
+        COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+            --python_out=${CMAKE_CURRENT_SOURCE_DIR}/proto
+            --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/proto
+            ${PYTHON_PROTO_FILES}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/proto
+        COMMENT "Generating Python protobuf files"
+        VERBATIM
+    )
+
+    # Make sure Python proto files are generated before the library
+    add_dependencies(wifi_prov_core generate_python_proto)
+endif()
 
 # Add include path to generated .pb.h header files
 zephyr_library_include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/subsys/net/lib/wifi_prov_core/proto/CMakeLists.txt
+++ b/subsys/net/lib/wifi_prov_core/proto/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMakeLists.txt for generating nanopb C definitions
+# CMakeLists.txt for generating protobuf definitions
 # Copyright (c) 2025 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
@@ -12,35 +12,35 @@ set(PROTO_FILES
     version.proto
 )
 
-# Create custom target for nanopb generation (for embedded code)
-add_custom_target(generate_nanopb ALL
-    COMMAND ${CMAKE_COMMAND} -E echo "Generating nanopb C definitions..."
-    COMMAND protoc --nanopb_out=. ${PROTO_FILES}
-    COMMAND ${CMAKE_COMMAND} -E echo "Generated nanopb files:"
-    COMMAND ${CMAKE_COMMAND} -E ls -la *.pb.c *.pb.h
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Generating nanopb C definitions"
-    VERBATIM
-)
+# Generate Python protobuf files for the configuration script
+if(PROTOBUF_PROTOC_EXECUTABLE)
+    add_custom_target(generate_python_proto_files ALL
+        COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+            --python_out=${CMAKE_CURRENT_SOURCE_DIR}
+            --proto_path=${CMAKE_CURRENT_SOURCE_DIR}
+            ${PROTO_FILES}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Generating Python protobuf files"
+        VERBATIM
+    )
+else()
+    message(WARNING "protoc not found - Python protobuf files will not be generated")
+endif()
 
 # Create custom target for cleaning
-add_custom_target(clean_nanopb
+add_custom_target(clean_proto_files
     COMMAND ${CMAKE_COMMAND} -E echo "Cleaning generated files..."
-    COMMAND ${CMAKE_COMMAND} -E remove *.pb.c *.pb.h
+    COMMAND ${CMAKE_COMMAND} -E remove *.pb.c *.pb.h *_pb2.py
     COMMAND ${CMAKE_COMMAND} -E echo "Cleaned!"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Cleaning generated nanopb files"
+    COMMENT "Cleaning generated protobuf files"
 )
 
 # Create custom target for testing
-add_custom_target(test_nanopb
+add_custom_target(test_proto_files
     COMMAND ${CMAKE_COMMAND} -E echo "Running auth mode validation tests..."
     COMMAND python3 test_auth_modes.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Running nanopb validation tests"
+    COMMENT "Running protobuf validation tests"
+    DEPENDS generate_python_proto_files
 )
-
-# Add dependencies to the main project if it exists
-if(TARGET ${PROJECT_NAME})
-    add_dependencies(${PROJECT_NAME} generate_nanopb)
-endif()

--- a/subsys/net/lib/wifi_prov_core/proto/generate_wifi_prov_config.py
+++ b/subsys/net/lib/wifi_prov_core/proto/generate_wifi_prov_config.py
@@ -23,34 +23,10 @@ try:
     from request_pb2 import Request, WifiConfig, EnterpriseCertConfig
     from common_pb2 import WifiInfo, AuthMode, Band, OpCode
 except ImportError:
-    # Auto-generate Python protobuf files if they don't exist
-    print("Python protobuf definitions not found. Auto-generating...")
-    import subprocess
-
-    # Check if protoc is available
-    try:
-        subprocess.run(['protoc', '--version'], capture_output=True, check=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        print("Error: 'protoc' not found. Please install protobuf compiler.")
-        sys.exit(1)
-
-    # Generate Python protobuf files
-    proto_files = ['request.proto', 'common.proto', 'response.proto', 'result.proto', 'version.proto']
-    try:
-        # Get the directory where this script is located
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-
-        # Run protoc from the script directory where .proto files are located
-        subprocess.run(['protoc', '--python_out=' + script_dir] + proto_files,
-                      cwd=script_dir, check=True)
-        print("✅ Generated Python protobuf definitions")
-
-        # Import the generated modules
-        from request_pb2 import Request, WifiConfig, EnterpriseCertConfig
-        from common_pb2 import WifiInfo, AuthMode, Band, OpCode
-    except subprocess.CalledProcessError as e:
-        print(f"Error generating protobuf definitions: {e}")
-        sys.exit(1)
+    print("Error: Python protobuf defigdnitions not found.")
+    print("Please ensure the CMake build has generated the protobuf files.")
+    print("The files should be generated automatically during the build process.")
+    sys.exit(1)
 
 def read_cert_file(file_path):
     """Read certificate file and return as bytes.


### PR DESCRIPTION
Move proto generation to cmake for cross-platform support, the python script checks for the files and doesn't try to generate them.