### PR TITLE
applications: nrf5340_audio: Split pref_sample_rate for sink and source

### DIFF
--- a/applications/nrf5340_audio/broadcast_source/main.c
+++ b/applications/nrf5340_audio/broadcast_source/main.c
@@ -594,7 +594,7 @@ int main(void)
 	ERR_CHK_MSG(ret, "Failed to enable broadcaster(s)");
 
 	ret = audio_system_config_set(
-		bt_audio_codec_cfg_freq_to_freq_hz(CONFIG_BT_AUDIO_PREF_SAMPLE_RATE_VALUE),
+		bt_audio_codec_cfg_freq_to_freq_hz(CONFIG_BT_AUDIO_PREF_SINK_SAMPLE_RATE_VALUE),
 		CONFIG_BT_AUDIO_BITRATE_BROADCAST_SRC, VALUE_NOT_SET);
 	ERR_CHK_MSG(ret, "Failed to set sample- and bitrate");
 

--- a/applications/nrf5340_audio/src/bluetooth/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig
@@ -43,41 +43,74 @@ config BT_AUDIO_CONCURRENT_TX_STREAMS_MAX
 	  The maximum number of concurrent streams supported in the TX direction.
 	  This is the maximum number of streams that can be active at the same time.
 
-config BT_AUDIO_PREF_SAMPLE_RATE_VALUE
+config BT_AUDIO_PREF_SINK_SAMPLE_RATE_VALUE
 	hex
-	default 0x03 if BT_AUDIO_PREF_SAMPLE_RATE_16KHZ
-	default 0x05 if BT_AUDIO_PREF_SAMPLE_RATE_24KHZ
-	default 0x08 if BT_AUDIO_PREF_SAMPLE_RATE_48KHZ
+	default 0x03 if BT_AUDIO_PREF_SINK_SAMPLE_RATE_16KHZ
+	default 0x05 if BT_AUDIO_PREF_SINK_SAMPLE_RATE_24KHZ
+	default 0x08 if BT_AUDIO_PREF_SINK_SAMPLE_RATE_48KHZ
 
-choice BT_AUDIO_PREF_SAMPLE_RATE
-	prompt "Preferred BT audio sample rate"
-	default BT_AUDIO_PREF_SAMPLE_RATE_16KHZ if BT_BAP_BROADCAST_16_2_1
-	default BT_AUDIO_PREF_SAMPLE_RATE_16KHZ if BT_BAP_BROADCAST_16_2_2
-	default BT_AUDIO_PREF_SAMPLE_RATE_16KHZ if BT_BAP_UNICAST_16_2_1
-	default BT_AUDIO_PREF_SAMPLE_RATE_24KHZ if STREAM_BIDIRECTIONAL
-	default BT_AUDIO_PREF_SAMPLE_RATE_24KHZ if BT_BAP_BROADCAST_24_2_1
-	default BT_AUDIO_PREF_SAMPLE_RATE_24KHZ if BT_BAP_BROADCAST_24_2_2
-	default BT_AUDIO_PREF_SAMPLE_RATE_24KHZ if BT_BAP_UNICAST_24_2_1
-	default BT_AUDIO_PREF_SAMPLE_RATE_48KHZ
+choice BT_AUDIO_PREF_SINK_SAMPLE_RATE
+	prompt "Preferred BT audio sink sample rate"
+	default BT_AUDIO_PREF_SINK_SAMPLE_RATE_16KHZ if BT_BAP_BROADCAST_16_2_1
+	default BT_AUDIO_PREF_SINK_SAMPLE_RATE_16KHZ if BT_BAP_BROADCAST_16_2_2
+	default BT_AUDIO_PREF_SINK_SAMPLE_RATE_16KHZ if BT_BAP_UNICAST_16_2_1
+	default BT_AUDIO_PREF_SINK_SAMPLE_RATE_24KHZ if STREAM_BIDIRECTIONAL
+	default BT_AUDIO_PREF_SINK_SAMPLE_RATE_24KHZ if BT_BAP_BROADCAST_24_2_1
+	default BT_AUDIO_PREF_SINK_SAMPLE_RATE_24KHZ if BT_BAP_BROADCAST_24_2_2
+	default BT_AUDIO_PREF_SINK_SAMPLE_RATE_24KHZ if BT_BAP_UNICAST_24_2_1
+	default BT_AUDIO_PREF_SINK_SAMPLE_RATE_48KHZ
 	help
 	  Select the preferred sample rate to stream if there are more than one to choose from.
 	  Only valid when used by unicast_client if CONFIG_SAMPLE_RATE_CONVERTER=y and
 	  CONFIG_AUDIO_SAMPLE_RATE_48000_HZ=y, meaning 16, 24, and 48kHz are supported.
 
-config  BT_AUDIO_PREF_SAMPLE_RATE_48KHZ
+config  BT_AUDIO_PREF_SINK_SAMPLE_RATE_48KHZ
 	bool "48 kHz"
 	help
-	  Select 48000 Hz as the preferred sample rate.
+	  Select 48000 Hz as the preferred sink sample rate.
 
-config  BT_AUDIO_PREF_SAMPLE_RATE_24KHZ
+config  BT_AUDIO_PREF_SINK_SAMPLE_RATE_24KHZ
 	bool "24 kHz"
 	help
-	  Select 24000 Hz as the preferred sample rate.
+	  Select 24000 Hz as the preferred sink sample rate.
 
-config  BT_AUDIO_PREF_SAMPLE_RATE_16KHZ
+config  BT_AUDIO_PREF_SINK_SAMPLE_RATE_16KHZ
 	bool "16 kHz"
 	help
-	  Select 16000 Hz as the preferred sample rate.
+	  Select 16000 Hz as the preferred sink sample rate.
+endchoice
+
+config BT_AUDIO_PREF_SOURCE_SAMPLE_RATE_VALUE
+	hex
+	default 0x03 if BT_AUDIO_PREF_SOURCE_SAMPLE_RATE_16KHZ
+	default 0x05 if BT_AUDIO_PREF_SOURCE_SAMPLE_RATE_24KHZ
+	default 0x08 if BT_AUDIO_PREF_SOURCE_SAMPLE_RATE_48KHZ
+
+choice BT_AUDIO_PREF_SOURCE_SAMPLE_RATE
+	prompt "Preferred BT audio source sample rate"
+	default BT_AUDIO_PREF_SOURCE_SAMPLE_RATE_16KHZ if BT_BAP_UNICAST_16_2_1
+	default BT_AUDIO_PREF_SOURCE_SAMPLE_RATE_24KHZ if STREAM_BIDIRECTIONAL
+	default BT_AUDIO_PREF_SOURCE_SAMPLE_RATE_24KHZ if BT_BAP_UNICAST_24_2_1
+	default BT_AUDIO_PREF_SOURCE_SAMPLE_RATE_48KHZ
+	help
+	  Select the preferred sample rate to stream if there are more than one to choose from.
+	  Only valid when used by unicast_client if CONFIG_SAMPLE_RATE_CONVERTER=y and
+	  CONFIG_AUDIO_SAMPLE_RATE_48000_HZ=y, meaning 16, 24, and 48kHz are supported.
+
+config  BT_AUDIO_PREF_SOURCE_SAMPLE_RATE_48KHZ
+	bool "48 kHz"
+	help
+	  Select 48000 Hz as the preferred source sample rate.
+
+config  BT_AUDIO_PREF_SOURCE_SAMPLE_RATE_24KHZ
+	bool "24 kHz"
+	help
+	  Select 24000 Hz as the preferred source sample rate.
+
+config  BT_AUDIO_PREF_SOURCE_SAMPLE_RATE_16KHZ
+	bool "16 kHz"
+	help
+	  Select 16000 Hz as the preferred source sample rate.
 endchoice
 
 #----------------------------------------------------------------------------#

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
@@ -33,7 +33,7 @@
 #endif /* CONFIG_SAMPLE_RATE_CONVERTER */
 
 #define BT_BAP_LC3_PRESET_CONFIGURABLE(_loc, _stream_context, _bitrate)                            \
-	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG(CONFIG_BT_AUDIO_PREF_SAMPLE_RATE_VALUE,        \
+	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG(CONFIG_BT_AUDIO_PREF_SINK_SAMPLE_RATE_VALUE,   \
 						    BT_AUDIO_CODEC_CFG_DURATION_10, _loc,          \
 						    LE_AUDIO_SDU_SIZE_OCTETS(_bitrate), 1,         \
 						    _stream_context),                              \

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -444,7 +444,7 @@ static bool sink_parse_cb(struct bt_data *data, void *user_data)
 		supported_sample_rates_print(lc3_freq_bit, BT_AUDIO_DIR_SINK);
 
 		/* Try with the preferred sample rate first */
-		switch (CONFIG_BT_AUDIO_PREF_SAMPLE_RATE_VALUE) {
+		switch (CONFIG_BT_AUDIO_PREF_SINK_SAMPLE_RATE_VALUE) {
 		case BT_AUDIO_CODEC_CFG_FREQ_48KHZ:
 			if (lc3_freq_bit & BT_AUDIO_CODEC_CAP_FREQ_48KHZ) {
 				lc3_preset_sink = lc3_preset_sink_48_4_1;
@@ -603,7 +603,7 @@ static bool source_parse_cb(struct bt_data *data, void *user_data)
 		supported_sample_rates_print(lc3_freq_bit, BT_AUDIO_DIR_SOURCE);
 
 		/* Try with the preferred sample rate first */
-		switch (CONFIG_BT_AUDIO_PREF_SAMPLE_RATE_VALUE) {
+		switch (CONFIG_BT_AUDIO_PREF_SOURCE_SAMPLE_RATE_VALUE) {
 		case BT_AUDIO_CODEC_CFG_FREQ_48KHZ:
 			if (lc3_freq_bit & BT_AUDIO_CODEC_CAP_FREQ_48KHZ) {
 				lc3_preset_source = lc3_preset_source_48_4_1;


### PR DESCRIPTION
- Enable users to choose preferred sample rate for sink and source
- OCT-NONE