### PR TITLE
quarantine_windows: Removed Matter samples from quarantine

### DIFF
--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -27,10 +27,3 @@
     - thingy53/nrf5340/cpuapp/ns
     - thingy53/nrf5340/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/SHEL-3161"
-
-- scenarios:
-    - sample.matter.*
-    - applications.matter.*
-  platforms:
-    - all
-  comment: "https://nordicsemi.atlassian.net/browse/KRKNWK-20461"

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v3.1.0-rc1
+      revision: 964aa6d5e0a2cac7b3c2998952eb022be9661537
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Removed Matter samples from Windows quarantine as related build issue was solved.