### PR TITLE
bootloader: mcuboot: Fixed security counter overflow detected to late

### DIFF
--- a/include/bl_storage.h
+++ b/include/bl_storage.h
@@ -276,6 +276,19 @@ int get_monotonic_counter(uint16_t counter_desc, counter_t *counter_value);
 int set_monotonic_counter(uint16_t counter_desc, counter_t new_counter);
 
 /**
+ * @brief Checks whether it is possible to update the monotonic counter
+ *        to a new value.
+ *
+ * @param[in]  counter_desc Counter description.
+ *
+ * @retval 0        The counter was updated successfully.
+ * @retval -EINVAL  @p counter_desc is invalid.
+ * @retval -ENOMEM  There are no more free counter slots (see
+ *                  @kconfig{CONFIG_SB_NUM_VER_COUNTER_SLOTS}).
+ */
+int is_monotonic_counter_update_possible(uint16_t counter_desc);
+
+/**
  * @brief The PSA life cycle states a device can be in.
  *
  * The LCS can be only transitioned in the order they are defined here.

--- a/subsys/bootloader/bl_storage/bl_storage.c
+++ b/subsys/bootloader/bl_storage/bl_storage.c
@@ -390,6 +390,27 @@ int set_monotonic_counter(uint16_t counter_desc, counter_t new_counter)
 	return 0;
 }
 
+int is_monotonic_counter_update_possible(uint16_t counter_desc)
+{
+	int err;
+
+	const counter_t *next_counter_addr;
+	counter_t current_cnt_value;
+
+	err = get_counter(counter_desc, &current_cnt_value, &next_counter_addr);
+	(void) current_cnt_value;
+
+	if (err != 0) {
+		return err;
+	}
+
+	if (next_counter_addr == NULL) {
+		err = -ENOMEM;
+	}
+
+	return err;
+}
+
 static lcs_data_t bl_storage_lcs_get(uint32_t address)
 {
 #if defined(CONFIG_NRFX_NVMC)

--- a/subsys/bootloader/bl_storage/nrf_nv_counters.c
+++ b/subsys/bootloader/bl_storage/nrf_nv_counters.c
@@ -74,3 +74,19 @@ int32_t boot_nv_security_counter_update(uint32_t image_id, uint32_t img_security
 
 	return err == 0 ? 0 : -BOOT_EBADSTATUS;
 }
+
+fih_int boot_nv_security_counter_is_update_possible(uint32_t image_id,
+						    uint32_t img_security_cnt)
+{
+	int err;
+	(void) image_id;
+	(void) img_security_cnt;
+
+	err = is_monotonic_counter_update_possible(BL_MONOTONIC_COUNTERS_DESC_MCUBOOT_ID0);
+
+	if (err != 0) {
+		FIH_RET(FIH_FAILURE);
+	}
+
+	FIH_RET(FIH_SUCCESS);
+}

--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 6c096b8ed7bfddf044b20dfb512c4c1fd06c2ef6
+      revision: 0fadab126d9ba51365b3db1cdb6d55ed892c62b4
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
 This commit fixes the issue, occuring when the maximum amount of
 security counter updates has been reached.

 This fact was only detected after a permament update already
 happened - the updated firmware was unable to boot, as it
 failed when trying to update the security counter after
 the permament swap.

 This commit adds the check if the security counter can be
 updated (i. e. free security counter slots are still available)
 before the swap is performed, fixing the issue.