### PR TITLE
[Backport v3.1-branch] manifest: Update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 99b6861375caaeba6027fd2f68d5334fd2a6d860
+      revision: c0e99cb7578cdd18e9370af2043de091e134cb71
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Includes a fix for being able to use pure and sha512 for MCUboot signing