### PR TITLE
tests: benchmark: peripheral_load: Enable EXMIF peripheral

### DIFF
--- a/tests/benchmarks/peripheral_load/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/benchmarks/peripheral_load/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -38,6 +38,16 @@
 	};
 };
 
+&gpio6 {
+	status = "okay";
+	zephyr,pm-device-runtime-auto;
+};
+
+&exmif {
+	status = "okay";
+	zephyr,pm-device-runtime-auto;
+};
+
 &mx25uw63 {
 	status = "okay";
 };


### PR DESCRIPTION
Enable EXMIF and GPIO6 to support external flash memory chip.