### PR TITLE
manifest: update zephyr, nrfxlib and nrf-802154 revisions

### DIFF
--- a/subsys/mpsl/fem/common/include/mpsl_fem_utils.h
+++ b/subsys/mpsl/fem/common/include/mpsl_fem_utils.h
@@ -71,14 +71,14 @@ static inline int mpsl_fem_utils_egu_channel_alloc(
 	(void)egu_instance_no;
 
 	/* The 802.15.4 radio driver is the only user of EGU peripheral on nRF5340 network core
-	 * and it uses channels: 0, 1, 2, 3, 4, 15. Therefore starting from channel 5, a consecutive
-	 * block of at most 10 channels can be allocated.
+	 * and it uses channels: 0, 1, 2, 3, 4, 5, 15. Therefore starting from channel 6,
+	 * a consecutive block of at most 9 channels can be allocated.
 	 */
-	if (size > 10U) {
+	if (size > 9U) {
 		return -ENOMEM;
 	}
 
-	uint8_t starting_channel = 5U;
+	uint8_t starting_channel = 6U;
 
 	for (int i = 0; i < size; i++) {
 		egu_channels[i] = starting_channel + i;

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: e78ab1d9e5814a0043b5fbfa8359fd021ec1f8fe
+      revision: 568a8ad16dc5c9f738f574d47b6a352a87541cf4
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The nrf-802154 clock platform now uses the software-triggered interrupt to de-escalate ZLI context to a regular interrupt in order to safely use Zephyr API.