### PR TITLE
manifest: Update sdk-mcuboot with fix for KMU configuration

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: b6b46a782d503cc52b41672e096fb526daaac31c
+      revision: pull/500/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Removes need for key import support and reduces size of binary.