### PR TITLE
sysbuild: Enable BOOT_SIGNATURE_TYPE_PURE for nRF54H20

### DIFF
--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -156,7 +156,7 @@ endchoice
 
 config BOOT_SIGNATURE_TYPE_PURE
 	bool "Verify signature directly over image"
-	depends on SOC_SERIES_NRF54LX
+	depends on SOC_SERIES_NRF54LX || SOC_SERIES_NRF54HX
 	depends on BOOT_SIGNATURE_TYPE_ED25519
 	help
 	  The image signature will be verified over image rather than


### PR DESCRIPTION
This commit enables the BOOT_SIGNATURE_TYPE_PURE configuration for the nRF54H20 platform in sysbuild.