### PR TITLE
doc: update nRF Util install calls

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54l/kmu_provision.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/kmu_provision.rst
@@ -13,14 +13,8 @@ The |NCS| provides a west command, ``ncs-provision``, allowing to upload keys to
 Prerequisites
 *************
 
-First, ensure that the `nRF Util`_ tool is installed.
-It should install automatically during the setup of the |NCS| working environment.
-Once completed, install the required additional commands for nRF Util:
-
-.. parsed-literal::
-   :class: highlight
-
-    nrfutil install device
+You need the `nRF Util`_ tool, which you get as part of the :ref:`nRF Connect SDK toolchain bundle <requirements_toolchain>` when you :ref:`gs_installing_toolchain`.
+The bundle also provides the ``nrfutil device`` command, which you can use to program the keys to the device.
 
 Additionally, before provisioning, make sure you familiarized yourself with the :ref:`ug_nrf54l_developing_basics_kmu_provisioning_keys` section.
 

--- a/doc/nrf/app_dev/device_guides/nrf70/nrf70_fw_patch_update.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/nrf70_fw_patch_update.rst
@@ -48,7 +48,7 @@ The following platforms are supported:
 .. note::
 
    For nRF7002 DK, this feature does not work with tools from the `nRF Command Line Tools`_ product page and nrfjprog programming tool.
-   To program the nRF7002 DK device, you need to use the nRF Util downloaded from  `nRF Util development tool`_ product page.
+   To program the nRF7002 DK device, you need to use the `nRF Util`_ tool that is part of the :ref:`nRF Connect SDK toolchain bundle <requirements_toolchain>` when you :ref:`gs_installing_toolchain`.
 
 Preparing the application
 =========================

--- a/doc/nrf/app_dev/device_guides/thingy91x/thingy91x_updating_fw_programmer.rst
+++ b/doc/nrf/app_dev/device_guides/thingy91x/thingy91x_updating_fw_programmer.rst
@@ -20,7 +20,7 @@ When developing with your Thingy:91 X, it is recommended to use an external debu
    The external debug probe must support Arm Cortex-M33, such as the nRF9151 DK.
    You need a 10-pin 2x5 socket-socket 1.27 mm IDC (:term:`Serial Wire Debug (SWD)`) JTAG cable to connect to the external debug probe.
 
-See `Installing nRF Util`_ and `Installing and upgrading nRF Util commands`_ for instructions on how to install the nrfutil device utility.
+Both nRF Util and the ``device`` command are part of the :ref:`nRF Connect SDK toolchain bundle <requirements_toolchain>` and you get them when you :ref:`gs_installing_toolchain`.
 
 .. _updating_firmware_nRF5340:
 
@@ -35,8 +35,7 @@ This section describes how you can update the firmware of the nRF5340 SoC on the
 
       To update the nRF5340 SoC firmware over USB, complete the following steps:
 
-      1. Install the ``nrfutil device`` command package by completing the steps in the `Installing and upgrading nRF Util commands`_ documentation.
-      #. Connect the Thingy:91 X to your computer with a USB-C cable.
+      1. Connect the Thingy:91 X to your computer with a USB-C cable.
       #. Power on the device by switching **SW1** to the **ON** position.
       #. Open a terminal window.
       #. Enter the following command to list the connected devices and their traits::
@@ -61,8 +60,7 @@ This section describes how you can update the firmware of the nRF5340 SoC on the
 
       To update the nRF5340 firmware using an external debug probe, complete the following steps:
 
-      2. Install the ``nrfutil device`` command package by completing the steps in the `Installing and upgrading nRF Util commands`_ documentation.
-      #. Connect the Thingy:91 X to your computer with a USB-C cable.
+      2. Connect the Thingy:91 X to your computer with a USB-C cable.
       #. Connect the 10-pin :term:`Serial Wire Debug (SWD)` programming cable from the external debug probe to the programming connector (**P8**) on the Thingy:91 X.
       #. Connect the external debug probe to your computer.
       #. Power on the device by switching **SW1** to the **ON** position.
@@ -101,8 +99,7 @@ When updating the firmware through USB and MCUboot method, you must not connect 
 
       To update the nRF9151 SiP application firmware over USB, complete the following steps:
 
-      1. Install the ``nrfutil device`` command package by completing the steps in the `Installing and upgrading nRF Util commands`_ documentation.
-      #. Connect the Thingy:91 X to your computer with a USB-C cable.
+      1. Connect the Thingy:91 X to your computer with a USB-C cable.
       #. Power on the device by switching **SW1** to the **ON** position.
       #. Open a terminal window.
       #. Enter the following command to list the connected devices and their traits::
@@ -126,8 +123,7 @@ When updating the firmware through USB and MCUboot method, you must not connect 
 
       To update the nRF9151 SiP application firmware using an external debug probe, complete the following steps:
 
-      1. Install the ``nrfutil device`` command package by completing the steps in the `Installing and upgrading nRF Util commands`_ documentation.
-      #. Connect the Thingy:91 X to your computer with a USB-C cable.
+      1. Connect the Thingy:91 X to your computer with a USB-C cable.
       #. Connect the 10-pin :term:`Serial Wire Debug (SWD)` programming cable from the external debug probe to the programming connector (**P8**) on the Thingy:91 X.
       #. Connect the external debug probe to your computer.
       #. Power on the device by switching **SW1** to the **ON** position.
@@ -155,8 +151,7 @@ Updating the modem firmware on the nRF9151 SiP
 
 To update the nRF9151 modem firmware using an external debug probe, complete the following steps:
 
-1. Install the ``nrfutil device`` command package by completing the steps in the `Installing and upgrading nRF Util commands`_ documentation.
-#. Connect the Thingy:91 X to your computer with a USB-C cable.
+1. Connect the Thingy:91 X to your computer with a USB-C cable.
 #. Connect the 10-pin :term:`Serial Wire Debug (SWD)` programming cable from the external debug probe to the programming connector (**P8**) on the Thingy:91 X.
 #. Connect the external debug probe to your computer.
 #. Power on the device by switching **SW1** to the **ON** position.

--- a/doc/nrf/app_dev/programming.rst
+++ b/doc/nrf/app_dev/programming.rst
@@ -59,7 +59,7 @@ If you want to change the runner used by ``west flash``, you can use one of the 
      west flash -r nrfjprog
 
 In either case, make sure you have the required tools installed on your system.
-`nRF Util`_ is a :ref:`prerequisite <installing_vsc>` for the |NCS|.
+`nRF Util`_ is part of the :ref:`nRF Connect SDK toolchain bundle <requirements_toolchain>`.
 For ``-r nrfjprog``, you need the archived `nRF Command Line Tools`_.
 
 To see which runners are available for your board, run the following command:
@@ -94,6 +94,7 @@ Programming the nRF52840 Dongle
 Programming the nRF54H20 DK
    To program the nRF54H20 DK, follow the programming instructions in the :ref:`nRF54H20 device guide <ug_nrf54h20_gs_sample>`.
    Programming the nRF54H20 DK with the |NCS| version earlier than v3.0.0 requires installing the `nrfutil device command <Installing and upgrading nRF Util commands_>`_ for the ``west flash`` command to work with this device.
+   Starting with the |NCS| v3.1.0, the ``nrfutil device`` command is part of the :ref:`nRF Connect SDK toolchain bundle <requirements_toolchain>` and you get it when you :ref:`gs_installing_toolchain`.
 
 .. _programming_params:
 

--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -115,6 +115,8 @@ Depending on your preferred development environment, complete the following step
    .. group-tab:: Command line
 
       1. Open a terminal window.
+      #. Remove the lock on the nRF Util installation to be able to install other nRF Util commands.
+         See `Locking nRF Util home directory`_ in the tool documentation for more information.
       #. Run the following command to install the nRF Util's ``sdk-manager`` command:
 
          .. code-block:: console

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -924,7 +924,7 @@
 .. _`Upgrading nRF Util core module`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html#upgrading-nrf-util
 .. _`Installing and upgrading nRF Util commands`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing_commands.html
 .. _`Installing specific versions of nRF Util commands`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing_commands.html#installing-specific-versions-of-commands
-.. _`Installing nRF Util for nRF5 SDK`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides-nrf5sdk/installing.html
+.. _`nrf5sdk-tools command overview`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-nrf5sdk-tools/guides/intro.html
 .. _`Generating DFU packages`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides-nrf5sdk/dfu_generating_packages.html
 .. _`DFU over a serial USB connection`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides-nrf5sdk/dfu_performing.html#dfu-over-a-serial-usb-connection
 .. _`Toolchain Manager command`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-toolchain-manager/nrfutil-toolchain-manager_0.14.1.html

--- a/doc/nrf/protocols/thread/tools.rst
+++ b/doc/nrf/protocols/thread/tools.rst
@@ -102,12 +102,22 @@ To program the nRF device with the RCP application, complete the following steps
 
       .. tab:: nRF52840 Dongle (USB transport)
 
-         a. Install nRF Util as described in `Installing nRF Util for nRF5 SDK`_.
+         This procedure uses the `nRF Util`_ tool, which is part of the :ref:`nRF Connect SDK toolchain bundle <requirements_toolchain>` and you get it when you :ref:`gs_installing_toolchain`.
+
+         1. Remove the lock on the nRF Util installation to be able to install other nRF Util commands.
+            See `Locking nRF Util home directory`_ in the tool documentation for more information.
+         #. Install nRF Util's ``nrf5sdk-tools`` command:
+
+            .. code-block:: console
+
+               nrfutil install nrf5sdk-tools
+
+            See `nrf5sdk-tools command overview`_ for more information.
          #. Generate the RCP firmware package:
 
             .. code-block:: console
 
-               nrfutil pkg generate --hw-version 52 --sd-req=0x00 \
+               nrfutil nrf5sdk-tools pkg generate --hw-version 52 --sd-req=0x00 \
                 --application build/zephyr/zephyr.hex --application-version 1 build/zephyr/zephyr.zip
 
          #. Connect the nRF52840 Dongle to the USB port.
@@ -117,7 +127,7 @@ To program the nRF device with the RCP application, complete the following steps
 
             .. code-block:: console
 
-               nrfutil dfu usb-serial -pkg build/zephyr/zephyr.zip -p /dev/ttyACM0
+               nrfutil nrf5sdk-tools dfu usb-serial -pkg build/zephyr/zephyr.zip -p /dev/ttyACM0
 
       .. tab:: nRF52840 Development Kit (UART transport)
 

--- a/doc/nrf/protocols/wifi/regulatory_certification/test_setup.rst
+++ b/doc/nrf/protocols/wifi/regulatory_certification/test_setup.rst
@@ -139,8 +139,7 @@ This describes the flashing, running, and use of the appropriate console ports w
 Programming firmware in the nRF7002 setup
 =========================================
 
-Before you begin, make sure you have the nRF Util tool installed on your computer.
-See `Installing nRF Util`_ and `Installing and upgrading nRF Util commands`_ for instructions on how to install the nRF Util device utility.
+This procedure uses the `nRF Util`_ tool, which is part of the :ref:`nRF Connect SDK toolchain bundle <requirements_toolchain>` and you get it when you :ref:`gs_installing_toolchain`.
 
 To program firmware in the nRF7002 DK or EK setup, complete the following steps.
 
@@ -177,7 +176,7 @@ To program firmware in the nRF7002 DK or EK setup, complete the following steps.
       $  nrfutil device program --firmware merged_CPUNET.hex --core Network --options chip_erase_mode=ERASE_ALL,reset=RESET_SYSTEM
 
 #. To run the firmware on the nRF7002 DK or EK, reset the device.
-   You can press the **RESET** button, use the ``reset`` command in nRF Util, or power cycle the development kit.
+   You can press the **RESET** button, use the ``nrfutil device reset`` command in nRF Util, or power cycle the development kit.
 
    .. note::
       Set the baud rate to 115,200 bps.

--- a/scripts/docker/README.rst
+++ b/scripts/docker/README.rst
@@ -10,12 +10,8 @@
 The image is based on Linux - Ubuntu 22.04 Docker image with the following additional tools:
 
 * Git
-* `nRF Util`_ with following commands:
-
-  * ``toolchain-manager``
-  * ``device``
-
-* |NCS| toolchain bundle
+* |NCS| toolchain bundle, which includes `nRF Util`_ and the ``device`` command
+* ``toolchain-manager`` command in nRF Util
 * SEGGER J-Link |jlink_ver| (installation requires accepting SEGGER License)
 
 Building image


### PR DESCRIPTION
Edited nRF Util installation calls.
nRF Util is now part of the toolchain bundle.
NRFU-1571 and PR #22969.

----

No changelog entry.