### PR TITLE
samples: dfu_target: fix partitions with partition manager

### DIFF
--- a/samples/dfu/dfu_target/pm_static_nrf52840dk_nrf52840.yml
+++ b/samples/dfu/dfu_target/pm_static_nrf52840dk_nrf52840.yml
@@ -1,0 +1,43 @@
+app:
+  address: 0xc200
+  end_address: 0x5a000
+  region: flash_primary
+  size: 0x4de00
+mcuboot:
+  address: 0x0
+  end_address: 0xc000
+  region: flash_primary
+  size: 0xc000
+mcuboot_pad:
+  address: 0xc000
+  end_address: 0xc200
+  region: flash_primary
+  size: 0x200
+mcuboot_primary:
+  address: 0xc000
+  end_address: 0x5a000
+  orig_span: &id001
+  - mcuboot_pad
+  - app
+  region: flash_primary
+  sharers: 0x1
+  size: 0x4e000
+  span: *id001
+mcuboot_primary_app:
+  address: 0xc200
+  end_address: 0x5a000
+  orig_span: &id002
+  - app
+  region: flash_primary
+  size: 0x4de00
+  span: *id002
+mcuboot_secondary:
+  address: 0x5a000
+  end_address: 0xa8000
+  region: flash_primary
+  size: 0x4e000
+dfu_target_helper:
+  address: 0xa8000
+  end_address: 0x100000
+  region: flash_primary
+  size: 0x58000

--- a/samples/dfu/dfu_target/src/dfu_target_shell.c
+++ b/samples/dfu/dfu_target/src/dfu_target_shell.c
@@ -14,9 +14,17 @@
 #include <dfu/dfu_target_mcuboot.h>
 #include <zephyr/dfu/mcuboot.h>
 
+#include <pm_config.h>
+
 #define STREAM_BUF_SIZE 256
+
+#ifdef CONFIG_PARTITION_MANAGER_ENABLED
+#define DFU_TARGET_HELPER_ADDRESS PM_DFU_TARGET_HELPER_ADDRESS
+#define DFU_TARGET_HELPER_SIZE PM_DFU_TARGET_HELPER_SIZE
+#else
 #define DFU_TARGET_HELPER_ADDRESS DT_REG_ADDR(DT_ALIAS(dfu_target_helper))
 #define DFU_TARGET_HELPER_SIZE DT_REG_SIZE(DT_ALIAS(dfu_target_helper))
+#endif
 
 static uint8_t stream_buf[STREAM_BUF_SIZE];
 


### PR DESCRIPTION
By default, partition manager is used - however,
the dfu_target_helper partition in the sample code was taken from the dts overlay.

This commit fixes this issue, adding a proper static partitioning file.