### PR TITLE
lib: sample_rate_converter: Only include DSP headers if needed

### DIFF
--- a/include/sample_rate_converter.h
+++ b/include/sample_rate_converter.h
@@ -19,8 +19,10 @@
  * @{
  */
 
+#ifdef CONFIG_SAMPLE_RATE_CONVERTER
 #include <zephyr/sys/ring_buffer.h>
 #include <dsp/filtering_functions.h>
+#endif /* CONFIG_SAMPLE_RATE_CONVERTER */
 
 /**
  * Maximum size for the internal state buffers.


### PR DESCRIPTION
- Don't include filtering_functions.h if sample_rate_converter is not enabled
- OCT-3404