### PR TITLE
[Backport v3.1-branch] doc: Remove mention of SUIT in dfu_multi image doc

### DIFF
--- a/doc/nrf/libraries/dfu/dfu_multi_image.rst
+++ b/doc/nrf/libraries/dfu/dfu_multi_image.rst
@@ -37,40 +37,8 @@ The following options control which images are included:
 +----------------------------------------------------+-----------------------------------------+
 |``SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_WIFI_FW_PATCH`` | Include nRF700x Wi-Fi® firmware patches.|
 +----------------------------------------------------+-----------------------------------------+
-|``SB_CONFIG_SUIT_MULTI_IMAGE_PACKAGE_BUILD``        | Include SUIT envelope and cache images. |
-+----------------------------------------------------+-----------------------------------------+
 
 .. _lib_dfu_multi_image_suit_multi_image_package:
-
-SUIT multi-image package
-========================
-
-The DFU multi-image library supports building a SUIT multi-image package that includes a SUIT envelope and cache images.
-The SUIT envelope is always included in the package as image 0, while SUIT cache images are included as subsequent images starting from the image 2.
-
-The SUIT multi-image processing requires the SUIT system to support cache processing.
-To enable it, set one of the following Kconfig options to ``y``:
-
-* :kconfig:option:`CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL`
-* :kconfig:option:`SUIT_DFU_CANDIDATE_PROCESSING_PUSH_TO_CACHE`
-
-The build system merges all application images into a single :file:`dfu_cache_partition_1.bin` partition file and places its content into the multi-image image 2.
-This allows all application images to be stored in a single DFU multi-image, as they will be processed by SUIT.
-
-The :kconfig:option:`SB_CONFIG_SUIT_MULTI_IMAGE_PACKAGE_BUILD` Kconfig option enables building the SUIT multi-image package.
-As a result, the multi-image package will contain:
-
-* Image 0:
-   - SUIT envelope that contains manifests only.
-
-* Image 2:
-   - Application core image.
-   - Radio core image, if applicable.
-   - Additional images, if applicable.
-
-You can add more data to be processed by SUIT to the following images starting from image 3.
-This operation will require an additional binary file and the proper :file:`dfu_cache_partition_X` definition in a devicetree configuration file, where ``X`` is the image number minus 1.
-So for the image 3, you would need :file:`dfu_cache_partition_2`.
 
 Dependencies
 ************


### PR DESCRIPTION
Backport 4992ac53ce1b7777afc4d439b748a49c41a67cfa from #23808.