### PR TITLE
modules: openthread: Fix OpenThread CSL Accuracy

### DIFF
--- a/modules/openthread/Kconfig.nrf5
+++ b/modules/openthread/Kconfig.nrf5
@@ -67,4 +67,12 @@ config NRF5_LOG_RX_FAILURES
 	  It can be helpful for the network traffic analyze but it generates also
 	  a lot of log records in a stress environment.
 
+config NRF5_DELAY_TRX_ACC
+	int "Clock accuracy for delayed operations"
+	default CLOCK_CONTROL_NRF_ACCURACY if BOARD_NRF52840DONGLE_NRF52840
+	default 20 # Value agreed after research as the best for power consumption and system reliability.
+	help
+	  Accuracy of the clock used for scheduling radio delayed operations (delayed transmission
+	  or delayed reception), in ppm.
+
 endif # !NET_L2_OPENTHREAD

--- a/modules/openthread/platform/radio_nrf5.c
+++ b/modules/openthread/platform/radio_nrf5.c
@@ -1328,7 +1328,7 @@ otError otPlatRadioReceiveAt(otInstance *aInstance, uint8_t aChannel, uint32_t a
 	LOG_DBG("nRF5 OT radio RX AT started (channel: %d, aStart: %u, aDuration: %u)", aChannel,
 		aStart, aDuration);
 
-	return result ? OT_ERROR_FAILED : OT_ERROR_NONE;
+	return result ? OT_ERROR_NONE : OT_ERROR_FAILED;
 }
 #endif
 
@@ -1554,7 +1554,7 @@ uint8_t otPlatRadioGetCslAccuracy(otInstance *aInstance)
 {
 	ARG_UNUSED(aInstance);
 
-	return CONFIG_CLOCK_CONTROL_NRF_ACCURACY;
+	return CONFIG_NRF5_DELAY_TRX_ACC;
 }
 
 #if defined(CONFIG_OPENTHREAD_PLATFORM_CSL_UNCERT)


### PR DESCRIPTION
The current accuracy is set to 50ppm, which is not compliant with IEEE 802.15.4-2015. Moreover, we cannot use the CONFIG_CLOCK_CONTROL_NRF_ACCURACY kconfig as a return in the otPlatRadioGetCslAccuracy function because it must be configurable by users, depending on the used oscillators.

Fixes a critical bug KRKNWK-20578