### PR TITLE
[Backport v3.1-branch] Fast Pair, nRF Desktop & Coremark: note about the broken nRF54H20 DK target

### DIFF
--- a/applications/nrf_desktop/board_configuration.rst
+++ b/applications/nrf_desktop/board_configuration.rst
@@ -178,3 +178,9 @@ Sample mouse or dongle (``nrf54h20dk/nrf54h20/cpuapp``)
         For detailed information on working with the nRF54H20 DK, see the :ref:`ug_nrf54h20_gs` documentation.
       * The configurations use the Software Updates for Internet of Things (SUIT) and support firmware updates using the :ref:`nrf_desktop_dfu`.
         Configurations acting as HID peripherals also support firmware updates using the :ref:`nrf_desktop_dfu_mcumgr`.
+
+      .. note::
+         The nRF Desktop application does not build or run for the ``nrf54h20dk/nrf54h20/cpuapp`` board target due to the IronSide SE migration.
+         See the ``NCSDK-34299`` in the :ref:`known_issues` page for more information.
+         The :ref:`nrf_desktop` documentation may still refer to concepts that were valid before the IronSide SE migration (for example, to the SUIT solution).
+         The codebase and documentation will be updated in the future releases to address this issue.

--- a/samples/benchmarks/coremark/README.rst
+++ b/samples/benchmarks/coremark/README.rst
@@ -17,6 +17,11 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. note::
+   This sample does not build or run for the ``nrf54h20dk/nrf54h20/cpuapp`` board target due to the IronSide SE migration.
+   See the ``NCSDK-34698`` in the :ref:`known_issues` page for more information.
+   The codebase and documentation will be updated in the future releases to address this issue.
+
 Overview
 ********
 

--- a/samples/bluetooth/fast_pair/input_device/README.rst
+++ b/samples/bluetooth/fast_pair/input_device/README.rst
@@ -27,6 +27,11 @@ The sample supports the following development kits:
 
 .. include:: /includes/tfm.txt
 
+.. note::
+   This sample does not build or run for the ``nrf54h20dk/nrf54h20/cpuapp`` board target due to the IronSide SE migration.
+   See the ``NCSDK-34821`` in the :ref:`known_issues` page for more information.
+   The codebase and documentation will be updated in the future releases to address this issue.
+
 Overview
 ********
 

--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -27,6 +27,12 @@ The sample supports the following development kits:
 .. table-from-sample-yaml::
 
 .. note::
+   This sample does not build or run for the ``nrf54h20dk/nrf54h20/cpuapp`` board target due to the IronSide SE migration.
+   See the ``NCSDK-34821`` in the :ref:`known_issues` page for more information.
+   This documentation page may still refer to concepts that were valid before the IronSide SE migration (for example, to the SUIT solution).
+   The codebase and documentation will be updated in the future releases to address this issue.
+
+.. note::
    In case of the :zephyr:board:`nrf54h20dk` board target, the application still has high power consumption as the Bluetooth LE controller running on the radio core requires disabling MRAM latency (:kconfig:option:`CONFIG_MRAM_LATENCY_AUTO_REQ`).
    Enabling MRAM latency makes the Bluetooth LE controller unstable.
 


### PR DESCRIPTION
Backport 7db5d9bd5fb598bd783bd265c59674fa7d8c804b~3..7db5d9bd5fb598bd783bd265c59674fa7d8c804b from #23883.