### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0351d6ecde6e92a5aa9be311a494b02c0e44eb53
+      revision: eb8daea884f248ca1ad2b403f496e0d373a3230d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
update sdk-zephyr to version which can handle
s2ram resume in multistage.

ref.: NCSIDB-1657