### PR TITLE
samples: cellular: nrf_cloud_rest_device_message: runtime log level

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -253,7 +253,11 @@ Bluetooth Fast Pair samples
 Cellular samples
 ----------------
 
-|no_changes_yet_note|
+* :ref:`nrf_cloud_rest_cell_location` sample:
+
+  * Added:
+
+    * Runtime setting of the log level for the nRF Cloud logging feature.
 
 Cryptography samples
 --------------------


### PR DESCRIPTION
Add runtime log level handling to nRF Cloud Device Message sample. This is motivated by a support request on DevZone.