### PR TITLE
doc: sml: fast_pair: update for NCS v3.1.0

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -2282,8 +2282,8 @@ The following table indicates the software maturity levels of the support for Go
             * - **Locator tag**
               - :ref:`fast_pair_locator_tag`
               - Experimental
-              - Experimental
-              - Experimental
+              - Supported
+              - Supported
               - Supported
       .. tab:: nRF91 Series
 
@@ -2397,8 +2397,8 @@ The following table indicates the software maturity levels of the support for ea
               - nRF54L15
             * - **Initial pairing**
               - Experimental
-              - Experimental
-              - Experimental
+              - Supported
+              - Supported
               - Supported
             * - **Subsequent pairing**
               - Experimental
@@ -2417,8 +2417,8 @@ The following table indicates the software maturity levels of the support for ea
               - Experimental
             * - **Find My Device Network extension**
               - Experimental
-              - Experimental
-              - Experimental
+              - Supported
+              - Supported
               - Supported
       .. tab:: nRF91 Series
 


### PR DESCRIPTION
Updated the Software Maturity tables for the Google Fast Pair category to align the documentation with the current status of nRF Connect SDK v3.1.0 codebase.

Ref: NCSDK-34512

Release note entry related to this change:

https://github.com/nrfconnect/sdk-nrf/pull/23631/files#r2266107211