### PR TITLE
doc: sml: fast_pair: add a note about FMDN rename

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -2457,6 +2457,8 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - --
 
+.. include:: /includes/fast_pair_fmdn_rename.txt
+
 .. _software_maturity_security_features:
 
 Security Feature Support


### PR DESCRIPTION
Added a missing note regarding the rename of the Find My Device Network (FMDN) extension in the Google Fast Pair ecosystem. This extension is now called Find Hub Network (FHN) extension.