### PR TITLE
[Backport v3.1-branch] doc: sml: fast_pair: add a note about FMDN rename

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -2457,6 +2457,8 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - --
 
+.. include:: /includes/fast_pair_fmdn_rename.txt
+
 .. _software_maturity_security_features:
 
 Security Feature Support


### PR DESCRIPTION
Backport bcc8f99aa6702792bc452f43c3f2cc8cf9c5062a from #23911.