### PR TITLE
nrf_security: IronSide SE support for PSA ITS API

### DIFF
--- a/include/tfm/ironside/se/ipc_service.h
+++ b/include/tfm/ironside/se/ipc_service.h
@@ -18,24 +18,22 @@ enum {
 	IRONSIDE_SE_IPC_INDEX_OUT_VEC,
 	IRONSIDE_SE_IPC_INDEX_OUT_LEN,
 	IRONSIDE_SE_IPC_INDEX_STATUS,
+	IRONSIDE_SE_IPC_INDEX_TYPE,
 	/* The last enum value is reserved for the size of the IPC buffer */
 	IRONSIDE_SE_IPC_DATA_LEN
 };
 
-/* IronSide call identifiers with implicit versions.
- *
- * With the initial "version 0", the service ABI is allowed to break until the
- * first public release of IronSide SE.
- */
-#define IRONSIDE_CALL_ID_PSA_CRYPTO_V0 0
+/* IronSide call identifiers with implicit versions */
+#define IRONSIDE_CALL_ID_PSA_V1 0
 
-/* We are adding the source files for the TF-M crypto partition to the build.
+/* We are adding the source files for the TF-M Crypto partition
+ * and the TF-M Internal Trusted Storage partition to the build.
  *
- * The crypto partition will include the file psa_manifest/sid.h and
- * expect the below three symbols to be there.
+ * These partitions will include the file psa_manifest/sid.h and
+ * expect the below triplets of symbols to be there.
  *
  * In a TF-M build, the TF-M build system will generate
- * psa_manifest/sid.h based on each partitions manifest.
+ * psa_manifest/sid.h based on each partition's manifest.
  *
  * See https://trustedfirmware-m.readthedocs.io/
  * en/latest/integration_guide/services/tfm_secure_partition_addition.html
@@ -45,5 +43,9 @@ enum {
 #define TFM_CRYPTO_SID	   (0x00000080U)
 #define TFM_CRYPTO_VERSION (1U)
 #define TFM_CRYPTO_HANDLE  (0x40000100U)
+
+#define TFM_INTERNAL_TRUSTED_STORAGE_SERVICE_SID     (0x00000070U)
+#define TFM_INTERNAL_TRUSTED_STORAGE_SERVICE_VERSION (1U)
+#define TFM_INTERNAL_TRUSTED_STORAGE_SERVICE_HANDLE  (0x40000102U)
 
 #endif /* __SDFW_PSA_IPC_SERVICE_H__ */

--- a/subsys/nrf_security/src/ssf_secdom/CMakeLists.txt
+++ b/subsys/nrf_security/src/ssf_secdom/CMakeLists.txt
@@ -6,12 +6,13 @@
 
 zephyr_library()
 zephyr_library_sources(
-  # ironside_psa_ns_api.c provides psa_call. psa_call is invoked by
-  # serialized functions from tfm_crypto_api.c and sends a message
-  # over IPC.
+  # ironside_psa_ns_api.c provides psa_call, which sends a message over IPC.
+  # psa_call is invoked by serialized functions from tfm_crypto_api.c and tfm_its_api.c.
   ${CMAKE_CURRENT_LIST_DIR}/ironside_se_psa_ns_api.c
   # tfm_crypto_api.c provides and serializes the PSA Crypto API.
   ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/interface/src/tfm_crypto_api.c
+  # tfm_its_api.c provides and serializes the PSA Internal Trusted Storage API.
+  ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/interface/src/tfm_its_api.c
   )
 
 zephyr_library_include_directories(

--- a/subsys/nrf_security/src/ssf_secdom/ironside_se_psa_ns_api.c
+++ b/subsys/nrf_security/src/ssf_secdom/ironside_se_psa_ns_api.c
@@ -30,19 +30,16 @@ static psa_status_t psa_call_buffered_and_flushed(psa_handle_t handle, int32_t t
 						  const psa_invec *in_vec, size_t in_len,
 						  psa_outvec *out_vec, size_t out_len)
 {
-	/* We have no need for this at this time */
-	ARG_UNUSED(type);
-
 	struct ironside_call_buf *const buf = ironside_call_alloc();
 
-	buf->id = IRONSIDE_CALL_ID_PSA_CRYPTO_V0;
+	buf->id = IRONSIDE_CALL_ID_PSA_V1;
 
-	buf->args[IRONSIDE_SE_IPC_INDEX_HANDLE] =
-		handle; /* i.e. TFM_CRYPTO_HANDLE defined to 0x40000100U */
+	buf->args[IRONSIDE_SE_IPC_INDEX_HANDLE] = handle;
 	buf->args[IRONSIDE_SE_IPC_INDEX_IN_VEC] = (uint32_t)in_vec;
 	buf->args[IRONSIDE_SE_IPC_INDEX_IN_LEN] = in_len;
 	buf->args[IRONSIDE_SE_IPC_INDEX_OUT_VEC] = (uint32_t)out_vec;
 	buf->args[IRONSIDE_SE_IPC_INDEX_OUT_LEN] = out_len;
+	buf->args[IRONSIDE_SE_IPC_INDEX_TYPE] = type;
 
 	ironside_call_dispatch(buf);
 


### PR DESCRIPTION
Allow IronSide SE to export the `psa_its_*` API over IPC. This makes it so that the Internal Trusted Storage can be used to store not only keys (via the PSA Crypto API) but other sensitive assets too.

Once again, the serialization code is reused from TF-M, which leverages the IronSide SE implementation of `psa_call()` that was initially added to support the PSA Crypto API.

The only change to `psa_call()` is that the `type` argument is no longer ignored. It has to be sent over IPC, because it identifies the ITS API.