### PR TITLE
[Backport v3.1-branch] doc: fix for techdoc-3981

### DIFF
--- a/doc/nrfx/nrfx.doxyfile.in
+++ b/doc/nrfx/nrfx.doxyfile.in
@@ -1031,7 +1031,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which Doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = @DOCSET_SOURCE_BASE@/nrfx/doc/nrf9230_engb.dox
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
Backport 9497c4584480383dc4c146c8ae2f15a5d748e3c1 from #23871.