### PR TITLE
doc: software_maturity: Remove 20-connection limit from BLE support docs

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -947,7 +947,7 @@ The following table indicates the software maturity levels of the support for ea
              - --
              - --
 
-  | [1]: Concurrent central, observer, peripheral, and broadcaster roles with up to 20 concurrent connections along with one Observer and one Broadcaster (subject to RAM availability)
+  | [1]: Subject to RAM availability
   | [2]: Do not support encrypting and decrypting the Isochronous Channels packets
   | [3]: Only AoA transmitter is supported
 


### PR DESCRIPTION
SDC does not limit the number of connections to 20. Also, it is more than just the central, observer, peripheral, and broadcaster roles that can be used concurrently.