### PR TITLE
Final nrf-802154 docs for 3.1.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -179,7 +179,7 @@ manifest:
     - name: nrf-802154
       repo-path: sdk-nrf-802154
       path: nrf-802154
-      revision: v3.1.0-rc2
+      revision: 3563374f3bd40d667812b49ef6dcf3e3d05b02aa
       groups:
         - nrf-802154
     - name: dragoon


### PR DESCRIPTION
* The documentation will be updated in the nrfxlib in the backport of this PR: https://github.com/nrfconnect/sdk-nrfxlib/pull/1826
* This PR updates the sha in manifest to point to the corresponding commit with updated docs in nrf-802154 release branch (https://github.com/nrfconnect/sdk-nrf-802154/commits/v3.1-branch/)