### PR TITLE
samples: cellular: remove PROJECT_NAME

### DIFF
--- a/samples/cellular/lwm2m_client/CMakeLists.txt
+++ b/samples/cellular/lwm2m_client/CMakeLists.txt
@@ -8,7 +8,6 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lwm2m_client)
-zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})
 
 # NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)

--- a/samples/cellular/nrf_cloud_multi_service/CMakeLists.txt
+++ b/samples/cellular/nrf_cloud_multi_service/CMakeLists.txt
@@ -8,7 +8,6 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf_cloud_multi_service)
-zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})
 
 # Include certs files if enabled.
 zephyr_include_directories_ifdef(CONFIG_NRF_CLOUD_PROVISION_CERTIFICATES certs)

--- a/samples/cellular/nrf_cloud_rest_cell_location/CMakeLists.txt
+++ b/samples/cellular/nrf_cloud_rest_cell_location/CMakeLists.txt
@@ -9,7 +9,6 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nRF_Cloud_REST_Cell_Location_Sample)
 
-zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})
 zephyr_include_directories(include/)
 
 # NORDIC SDK APP START

--- a/samples/cellular/nrf_cloud_rest_device_message/CMakeLists.txt
+++ b/samples/cellular/nrf_cloud_rest_device_message/CMakeLists.txt
@@ -9,7 +9,6 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nRF_Cloud_REST_Device_Message_Sample)
 
-zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})
 zephyr_include_directories(include/)
 
 # NORDIC SDK APP START

--- a/samples/cellular/nrf_cloud_rest_fota/CMakeLists.txt
+++ b/samples/cellular/nrf_cloud_rest_fota/CMakeLists.txt
@@ -8,7 +8,6 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nRF_Cloud_REST_FOTA_Sample)
-zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})
 
 # NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)

--- a/samples/cellular/nrf_provisioning/CMakeLists.txt
+++ b/samples/cellular/nrf_provisioning/CMakeLists.txt
@@ -9,7 +9,6 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nRF_Provisioning_Sample)
 
-zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})
 zephyr_include_directories(include/)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/cellular/smp_svr/CMakeLists.txt
+++ b/samples/cellular/smp_svr/CMakeLists.txt
@@ -8,7 +8,6 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(smp_client)
-zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})
 
 # NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)


### PR DESCRIPTION
Remove unnecessary PROJECT_NAME definition from CMakeLists.txt files.