### PR TITLE
net: lib: nrf70_fw_ext: Fix dependencies for flash integrity check

### DIFF
--- a/subsys/net/lib/nrf70_fw_ext/Kconfig
+++ b/subsys/net/lib/nrf70_fw_ext/Kconfig
@@ -51,7 +51,7 @@ config NRF_WIFI_FW_FLASH_CHUNK_SIZE
 config NRF_WIFI_FW_PATCH_INTEGRITY_CHECK
 	bool "Enable integrity check of nRF70 FW patches"
 	select FLASH_AREA_CHECK_INTEGRITY
-	# TODO: Fix MbedTLS dependency issues to enable this option
+	default y
 	help
 	  Select this option to enable integrity check of nRF70 FW patches using
 	  SHA-256 verification algorithm.This option impacts the loading time of the
@@ -80,10 +80,10 @@ config NRF_WIFI_FW_PATCH_DFU
 	  before enabling this option. Refer to the documentation for detailed
 	  instructions on partition configuration and the DFU process.
 
-# TC is the default but Wi-Fi uses MbedTLS, so, to avoid loading another library.
+# To work with nRF security always use PSA (even for non-TFM builds)
 if NRF_WIFI_FW_PATCH_INTEGRITY_CHECK
 choice FLASH_AREA_CHECK_INTEGRITY_BACKEND
-	default FLASH_AREA_CHECK_INTEGRITY_MBEDTLS
+	default FLASH_AREA_CHECK_INTEGRITY_PSA
 endchoice
 endif
 endif


### PR DESCRIPTION
The legacy option is now removed from nRF security, and instead PSA variant should be used for all build (including non-TF-M builds).

Fix NCSDK-29649.