### PR TITLE
tests: drivers: adc: Add fixture to ADC latency test

### DIFF
--- a/tests/drivers/adc/adc_latency/testcase.yaml
+++ b/tests/drivers/adc/adc_latency/testcase.yaml
@@ -1,7 +1,11 @@
 common:
   tags:
     - drivers
+    - adc
     - ci_tests_zephyr_drivers_adc
+  harness: ztest
+  harness_config:
+    fixture: gpio_loopback
   platform_allow:
     - nrf54h20dk/nrf54h20/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
The ADC latency test requires 'gpio_loopback'