### PR TITLE
bluetooth: controller: kconfig missing type error

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -549,9 +549,11 @@ config BT_CTLR_SDC_CIS_SUBEVENT_LENGTH_US
 	  is chosen by the controller.
 
 config BT_CTLR_EXTENDED_FEAT_SET
+	bool
 	select EXPERIMENTAL
 
 config BT_CTLR_FRAME_SPACE_UPDATE
+	bool
 	select EXPERIMENTAL
 
 config BT_CTLR_CHANNEL_SOUNDING


### PR DESCRIPTION
Fix this build error:

warning: BT_CTLR_EXTENDED_FEAT_SET
  (defined at /nrf/subsys/bluetooth/controller/Kconfig:551)
   defined without a type

warning: BT_CTLR_FRAME_SPACE_UPDATE
  (defined at /nrf/subsys/bluetooth/controller/Kconfig:554)
   defined without a type

Error occurred in #23890