### PR TITLE
samples: cellular: slm_shell: Add nRF54L15 support

### DIFF
--- a/applications/serial_lte_modem/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/applications/serial_lte_modem/boards/nrf9151dk_nrf9151_ns.overlay
@@ -26,6 +26,18 @@
 	pinctrl-names = "default", "sleep";
 };
 
+/ {
+	slm_gpio_pins: slm_gpio_pins {
+		compatible = "slm-gpio-pins";
+		power-gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		power-gpios-active-time-ms = <100>;
+		power-gpios-debounce-time-ms = <50>;
+		indicate-gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+		indicate-gpios-active-time-ms = <100>;
+		//power-gpios = <&gpio0 8 (GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+};
+
 &i2c2 {
 	status = "disabled";
 };

--- a/applications/serial_lte_modem/overlay-external-mcu.overlay
+++ b/applications/serial_lte_modem/overlay-external-mcu.overlay
@@ -18,3 +18,14 @@
 &uart0 {
 	status = "disabled";
 };
+
+/ {
+	slm_gpio_pins: slm_gpio_pins {
+		compatible = "slm-gpio-pins";
+		power-gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+		power-gpios-active-time-ms = <100>;
+		power-gpios-debounce-time-ms = <50>;
+		indicate-gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
+		indicate-gpios-active-time-ms = <100>;
+	};
+};

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -505,6 +505,7 @@ static int slm_at_send_indicate(const uint8_t *data, size_t len,
 		return -EFAULT;
 	}
 
+#if (INDICATE_PIN_IS_ENABLED)
 	if (indicate) {
 		enum pm_device_state state = PM_DEVICE_STATE_OFF;
 
@@ -513,6 +514,7 @@ static int slm_at_send_indicate(const uint8_t *data, size_t len,
 			slm_ctrl_pin_indicate();
 		}
 	}
+#endif
 
 	ret = at_backend.send(data, len);
 	if (!ret) {

--- a/applications/serial_lte_modem/src/slm_defines.h
+++ b/applications/serial_lte_modem/src/slm_defines.h
@@ -36,7 +36,7 @@ enum {
 #define SLM_NRF52_BLK_SIZE   4096 /** nRF52 flash block size for write operation */
 #define SLM_NRF52_BLK_TIME   2000 /** nRF52 flash block write time in millisecond (1.x second) */
 
-#define POWER_PIN_IS_ENABLED (CONFIG_SLM_POWER_PIN != -1)
-#define INDICATE_PIN_IS_ENABLED (CONFIG_SLM_INDICATE_PIN != -1)
+#define POWER_PIN_IS_ENABLED DT_NODE_HAS_PROP(DT_NODELABEL(slm_gpio_pins), power_gpios)
+#define INDICATE_PIN_IS_ENABLED DT_NODE_HAS_PROP(DT_NODELABEL(slm_gpio_pins), indicate_gpios)
 
 #endif

--- a/dts/bindings/gpio/slm-gpio-pins.yaml
+++ b/dts/bindings/gpio/slm-gpio-pins.yaml
@@ -1,0 +1,33 @@
+description: GPIO pins to control Serial LTE Modem
+
+compatible: "slm-gpio-pins"
+
+properties:
+  power-gpios:
+    type: phandle-array
+    required: true
+    description: |
+      Power pin.
+
+  power-gpios-active-time-ms:
+    type: int
+    default: 100
+    description: |
+      Power pin active time in milliseconds.
+
+  power-gpios-debounce-time-ms:
+    type: int
+    default: 50
+    description: |
+      Power pin debounce time in milliseconds.
+
+  indicate-gpios:
+    type: phandle-array
+    description: |
+      Indicate pin.
+
+  indicate-gpios-active-time-ms:
+    type: int
+    default: 100
+    description: |
+      Indicate pin active time in milliseconds.

--- a/samples/cellular/slm_shell/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/cellular/slm_shell/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -28,6 +28,17 @@
 	pinctrl-names = "default", "sleep";
 };
 
+/ {
+	slm_gpio_pins: slm_gpio_pins {
+		compatible = "slm-gpio-pins";
+		power-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		power-gpios-active-time-ms = <100>;
+		power-gpios-debounce-time-ms = <50>;
+		indicate-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+		indicate-gpios-active-time-ms = <100>;
+	};
+};
+
 &pinctrl {
 	uart2_default: uart2_default {
 		group1 {

--- a/samples/cellular/slm_shell/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/cellular/slm_shell/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Configuration file for nRF54L15DK.
+# This file is merged with prj.conf in the application folder, and options
+# set here will take precedence if they are present in both files.
+
+CONFIG_NRFX_UARTE20=y
+CONFIG_UART_20_INTERRUPT_DRIVEN=n
+CONFIG_UART_20_ASYNC=y

--- a/samples/cellular/slm_shell/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/cellular/slm_shell/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		ncs,slm-uart = &uart20;
+		ncs,slm-gpio = &gpio0;
+		zephyr,console = &uart30;
+		zephyr,shell-uart = &uart30;
+	};
+};
+
+/* Shell UART */
+&uart30 {
+	current-speed = <115200>;
+	status = "okay";
+};
+
+/* SLM Shell <-> SLM UART */
+&uart20 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	status = "okay";
+	hw-flow-control;
+	pinctrl-0 = <&uart20_default_alt>;
+	pinctrl-1 = <&uart20_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+};
+
+/ {
+	slm_gpio_pins: slm_gpio_pins {
+		compatible = "slm-gpio-pins";
+		power-gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
+		power-gpios-active-time-ms = <100>;
+		power-gpios-debounce-time-ms = <50>;
+		indicate-gpios = <&gpio2 9 GPIO_ACTIVE_LOW>;
+		indicate-gpios-active-time-ms = <100>;
+	};
+};
+
+/ {
+	aliases {
+		/delete-property/ led1;
+		/delete-property/ led3;
+	};
+};
+
+/delete-node/ &led1;
+/delete-node/ &led3;
+
+&pinctrl {
+	uart20_default_alt: uart20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 11)>,
+				<NRF_PSEL(UART_RTS, 1, 14)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 1, 12)>,
+				<NRF_PSEL(UART_CTS, 1, 10)>;
+			bias-pull-up;
+		};
+	};
+
+	uart20_sleep_alt: uart20_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 11)>,
+				<NRF_PSEL(UART_RX, 1, 12)>,
+				<NRF_PSEL(UART_RTS, 1, 14)>,
+				<NRF_PSEL(UART_CTS, 1, 10)>;
+			low-power-enable;
+		};
+	};
+};


### PR DESCRIPTION
Add overlay files to support compiling of nrf54l15dk/nrf54l15/cpuapp target.

PIN configurations for nRF54L15 is here: https://docs.nordicsemi.com/bundle/ug_nrf54l15_dk/page/UG/nRF54L15_DK/hw_desription/connector_if.html
By default uart20 in devicetree is UART1 from the mapping table and uart30 is UART0.

Jira: SLM-51

_Note: This requires PR #23625 first so just look at the nRF54 commit._