### PR TITLE
Add Sercomm TPM530M EVK support to modem_shell and modem_antenna lib

### DIFF
--- a/lib/modem_antenna/Kconfig
+++ b/lib/modem_antenna/Kconfig
@@ -11,6 +11,7 @@ menuconfig MODEM_ANTENNA
 	default y if BOARD_NRF9161DK_NRF9161_NS
 	default y if BOARD_NRF9151DK_NRF9151_NS
 	default y if BOARD_THINGY91_NRF9160_NS
+	default y if BOARD_TPM530MEVK_TPM530M_NS
 
 if MODEM_ANTENNA
 
@@ -36,6 +37,10 @@ config MODEM_ANTENNA_AT_MAGPIO
 
 config MODEM_ANTENNA_AT_COEX0
 	string "AT%XCOEX0 command"
+	# TPM530M EVK does not have an onboard antenna and LNA needs to be always enabled.
+	# The next line is needed for correct configuration when CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL
+	# is enabled.
+	default "AT\%XCOEX0=1,1,1565,1586" if BOARD_TPM530MEVK_TPM530M_NS
 	default "AT\%XCOEX0=1,1,1565,1586" if MODEM_ANTENNA_GNSS_ONBOARD
 	default "AT\%XCOEX0" if MODEM_ANTENNA_GNSS_EXTERNAL
 	help

--- a/samples/cellular/modem_shell/boards/tpm530mevk_tpm530m_ns.conf
+++ b/samples/cellular/modem_shell/boards/tpm530mevk_tpm530m_ns.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_DK_LIBRARY=n


### PR DESCRIPTION
Added Kconfig overlay for the Sercomm TPM530M EVK in modem_shell.

Added LNA configuration for the Sercomm TPM530M EVK in modem_antenna library.