### PR TITLE
doc: reqs: add macOS 26 to tools OS table

### DIFF
--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -346,6 +346,10 @@ For firmware OS support, see :ref:`the table at the top of the page <supported_O
     - Not supported
     - Not supported
     - Not supported
+  * - `macOS 26`_
+    - n/a
+    - Tier 3
+    - Tier 3
   * - `macOS 15`_
     - n/a
     - Tier 3

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1573,6 +1573,7 @@
 
 .. ### Source: apple.com
 
+.. _`macOS 26`: https://www.apple.com/os/macos/
 .. _`macOS 15`: https://www.apple.com/macos/macos-sequoia/
 .. _`macOS 14`: https://www.apple.com/macos/sonoma/
 .. _`macOS 13`: https://www.apple.com/macos/ventura/

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -33,7 +33,7 @@ The following sections provide detailed lists of changes by component.
 IDE, OS, and tool support
 =========================
 
-|no_changes_yet_note|
+* Added macOS 26 support (Tier 3) to the table listing :ref:`supported operating systems for proprietary tools <additional_nordic_sw_tools_os_support>`.
 
 Board support
 =============


### PR DESCRIPTION
Added macOS 26 as Tier 3 to the proprietary tools supported OS table. NRFU-1594.