### PR TITLE
treewide: use SEC_TAG_TLS_INVALID for unset security tag

### DIFF
--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -119,7 +119,7 @@ static int do_ftp_open(enum at_parser_cmd_type cmd_type, struct at_parser *parse
 	char hostname[SLM_MAX_URL];
 	int sz_hostname = sizeof(hostname);
 	uint16_t port = FTP_DEFAULT_PORT;
-	sec_tag_t sec_tag = INVALID_SEC_TAG;
+	sec_tag_t sec_tag = SEC_TAG_TLS_INVALID;
 
 	/* Parse AT command */
 	ret = util_string_get(parser, 2, username, &sz_username);

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -224,7 +224,7 @@ static int do_http_connect(void)
 	}
 
 	/* Open socket */
-	if (httpc.sec_tag == INVALID_SEC_TAG) {
+	if (httpc.sec_tag == SEC_TAG_TLS_INVALID) {
 		ret = zsock_socket(httpc.family, SOCK_STREAM, IPPROTO_TCP);
 	} else {
 		ret = zsock_socket(httpc.family, SOCK_STREAM, IPPROTO_TLS_1_2);
@@ -236,7 +236,7 @@ static int do_http_connect(void)
 	httpc.fd = ret;
 
 	/* Set socket options */
-	if (httpc.sec_tag != INVALID_SEC_TAG) {
+	if (httpc.sec_tag != SEC_TAG_TLS_INVALID) {
 #if defined(CONFIG_SLM_NATIVE_TLS)
 		ret = slm_native_tls_load_credentials(httpc.sec_tag);
 		if (ret < 0) {
@@ -444,7 +444,7 @@ static int handle_at_httpc_connect(enum at_parser_cmd_type cmd_type,
 				return -EINVAL;
 			}
 
-			httpc.sec_tag = INVALID_SEC_TAG;
+			httpc.sec_tag = SEC_TAG_TLS_INVALID;
 			if (param_count > 4) {
 				if (at_parser_num_get(parser, 4, &httpc.sec_tag)) {
 					return -EINVAL;
@@ -480,7 +480,7 @@ static int handle_at_httpc_connect(enum at_parser_cmd_type cmd_type,
 		break;
 
 	case AT_PARSER_CMD_TYPE_READ:
-		if (httpc.sec_tag != INVALID_SEC_TAG) {
+		if (httpc.sec_tag != SEC_TAG_TLS_INVALID) {
 			rsp_send("\r\n#XHTTPCCON: %d,\"%s\",%d,%d\r\n",
 				(httpc.fd == INVALID_SOCKET) ? 0 : 1,
 				httpc.host, httpc.port, httpc.sec_tag);

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -382,7 +382,7 @@ static int do_mqtt_connect(void)
 		/* ignore password if no user_name */
 	}
 #if defined(CONFIG_MQTT_LIB_TLS)
-	if (ctx.sec_tag != INVALID_SEC_TAG) {
+	if (ctx.sec_tag != SEC_TAG_TLS_INVALID) {
 		struct mqtt_sec_config *tls_config;
 
 		tls_config = &(client.transport).tls.config;
@@ -574,7 +574,7 @@ static int handle_at_mqtt_connect(enum at_parser_cmd_type cmd_type, struct at_pa
 			if (err) {
 				return err;
 			}
-			ctx.sec_tag = INVALID_SEC_TAG;
+			ctx.sec_tag = SEC_TAG_TLS_INVALID;
 			if (param_count > 6) {
 				err = at_parser_num_get(parser, 6, &ctx.sec_tag);
 				if (err) {
@@ -592,7 +592,7 @@ static int handle_at_mqtt_connect(enum at_parser_cmd_type cmd_type, struct at_pa
 
 	case AT_PARSER_CMD_TYPE_READ:
 		if (ctx.connected) {
-			if (ctx.sec_tag != INVALID_SEC_TAG) {
+			if (ctx.sec_tag != SEC_TAG_TLS_INVALID) {
 				rsp_send("\r\n#XMQTTCON: %d,\"%s\",\"%s\",%d,%d\r\n",
 					 ctx.connected, mqtt_clientid, mqtt_broker_url,
 					 mqtt_broker_port, ctx.sec_tag);
@@ -804,7 +804,7 @@ int slm_at_mqtt_init(void)
 {
 	pub_param.message_id = 0;
 	memset(&ctx, 0, sizeof(ctx));
-	ctx.sec_tag = INVALID_SEC_TAG;
+	ctx.sec_tag = SEC_TAG_TLS_INVALID;
 
 	strcpy(mqtt_clientid, SLM_DEFAULT_CID);
 	do_mqtt_config(CONFIG_MQTT_KEEPALIVE, CONFIG_MQTT_CLEAN_SESSION);

--- a/applications/serial_lte_modem/src/nativetls/slm_native_tls.c
+++ b/applications/serial_lte_modem/src/nativetls/slm_native_tls.c
@@ -27,7 +27,7 @@ struct tls_cred_buf {
 };
 static struct tls_cred_buf cred_buf[CONFIG_SLM_NATIVE_TLS_CREDENTIAL_BUFFER_COUNT] = {
 	[0 ... CONFIG_SLM_NATIVE_TLS_CREDENTIAL_BUFFER_COUNT - 1] = {
-		.sec_tag = -1
+		.sec_tag = SEC_TAG_TLS_INVALID
 	}
 };
 static uint8_t cred_buf_next; /* Index of next cred_buf to use. */
@@ -183,7 +183,7 @@ static int unload_tls_cred_buf(sec_tag_t sec_tag)
 {
 	struct tls_cred_buf *cred = get_tls_cred_buf(sec_tag);
 
-	if (cred == NULL || sec_tag == -1) {
+	if (cred == NULL || sec_tag == SEC_TAG_TLS_INVALID) {
 		return 0;
 	}
 
@@ -201,7 +201,7 @@ static int unload_tls_cred_buf(sec_tag_t sec_tag)
 			}
 		}
 	}
-	cred->sec_tag = -1;
+	cred->sec_tag = SEC_TAG_TLS_INVALID;
 	cred->type_flags = 0;
 
 	return 0;

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -216,7 +216,7 @@ static int do_fota_start(int op, const char *file_uri, int sec_tag,
 
 	/* start HTTP(S) FOTA */
 	if (slm_util_casecmp(schema, SCHEMA_HTTPS)) {
-		if (sec_tag == INVALID_SEC_TAG) {
+		if (sec_tag == SEC_TAG_TLS_INVALID) {
 			LOG_ERR("Missing sec_tag");
 			return -EINVAL;
 		}
@@ -319,7 +319,7 @@ static int handle_at_fota(enum at_parser_cmd_type cmd_type, struct at_parser *pa
 			char uri[FILE_URI_MAX];
 			uint16_t pdn_id;
 			int size = FILE_URI_MAX;
-			sec_tag_t sec_tag = INVALID_SEC_TAG;
+			sec_tag_t sec_tag = SEC_TAG_TLS_INVALID;
 			enum dfu_target_image_type type;
 
 			err = util_string_get(parser, 2, uri, &size);

--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -109,7 +109,7 @@ static void init_socket(struct slm_socket *socket)
 	}
 
 	socket->family = AF_UNSPEC;
-	socket->sec_tag = INVALID_SEC_TAG;
+	socket->sec_tag = SEC_TAG_TLS_INVALID;
 	socket->role = AT_SOCKET_ROLE_CLIENT;
 	socket->fd = INVALID_SOCKET;
 	socket->fd_peer = INVALID_SOCKET;
@@ -1117,7 +1117,7 @@ static int handle_at_secure_socket(enum at_parser_cmd_type cmd_type,
 				err = -EINVAL;
 				goto error;
 			}
-			sock->sec_tag = INVALID_SEC_TAG;
+			sock->sec_tag = SEC_TAG_TLS_INVALID;
 			err = at_parser_num_get(parser, 4, &sock->sec_tag);
 			if (err) {
 				goto error;
@@ -1284,7 +1284,7 @@ static int handle_at_secure_socketopt(enum at_parser_cmd_type cmd_type,
 
 	switch (cmd_type) {
 	case AT_PARSER_CMD_TYPE_SET:
-		if (sock->sec_tag == INVALID_SEC_TAG) {
+		if (sock->sec_tag == SEC_TAG_TLS_INVALID) {
 			LOG_ERR("Not secure socket");
 			return err;
 		}

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -72,7 +72,7 @@ static int do_tcp_server_start(uint16_t port)
 	int reuseaddr = 1;
 
 	/* Open socket */
-	if (proxy.sec_tag == INVALID_SEC_TAG) {
+	if (proxy.sec_tag == SEC_TAG_TLS_INVALID) {
 		ret = zsock_socket(proxy.family, SOCK_STREAM, IPPROTO_TCP);
 	} else {
 		ret = zsock_socket(proxy.family, SOCK_STREAM, IPPROTO_TLS_1_2);
@@ -84,7 +84,7 @@ static int do_tcp_server_start(uint16_t port)
 	}
 	proxy.sock = ret;
 
-	if (proxy.sec_tag != INVALID_SEC_TAG) {
+	if (proxy.sec_tag != SEC_TAG_TLS_INVALID) {
 #ifndef CONFIG_SLM_NATIVE_TLS
 		LOG_ERR("Not supported");
 		return -ENOTSUP;
@@ -199,7 +199,7 @@ static int do_tcp_client_connect(const char *url, uint16_t port, uint16_t cid)
 	struct sockaddr sa;
 
 	/* Open socket */
-	if (proxy.sec_tag == INVALID_SEC_TAG) {
+	if (proxy.sec_tag == SEC_TAG_TLS_INVALID) {
 		ret = zsock_socket(proxy.family, SOCK_STREAM, IPPROTO_TCP);
 	} else {
 		ret = zsock_socket(proxy.family, SOCK_STREAM, IPPROTO_TLS_1_2);
@@ -210,7 +210,7 @@ static int do_tcp_client_connect(const char *url, uint16_t port, uint16_t cid)
 	}
 	proxy.sock = ret;
 
-	if (proxy.sec_tag != INVALID_SEC_TAG) {
+	if (proxy.sec_tag != SEC_TAG_TLS_INVALID) {
 #if defined(CONFIG_SLM_NATIVE_TLS)
 		ret = slm_native_tls_load_credentials(proxy.sec_tag);
 		if (ret < 0) {
@@ -690,7 +690,7 @@ static int handle_at_tcp_server(enum at_parser_cmd_type cmd_type, struct at_pars
 			if (err) {
 				return err;
 			}
-			proxy.sec_tag = INVALID_SEC_TAG;
+			proxy.sec_tag = SEC_TAG_TLS_INVALID;
 			if (param_count > 3) {
 				err = at_parser_num_get(parser, 3, &proxy.sec_tag);
 				if (err) {
@@ -752,7 +752,7 @@ static int handle_at_tcp_client(enum at_parser_cmd_type cmd_type, struct at_pars
 			if (at_parser_num_get(parser, 3, &port)) {
 				return -EINVAL;
 			}
-			proxy.sec_tag = INVALID_SEC_TAG;
+			proxy.sec_tag = SEC_TAG_TLS_INVALID;
 			if (param_count > 4) { /* optional param */
 				err = at_parser_num_get(parser, 4, &proxy.sec_tag);
 				if (err != 0 && err != -EOPNOTSUPP) {
@@ -905,7 +905,7 @@ int slm_at_tcp_proxy_init(void)
 	proxy.family	= AF_UNSPEC;
 	proxy.sock_peer	= INVALID_SOCKET;
 	proxy.role	= INVALID_ROLE;
-	proxy.sec_tag	= INVALID_SEC_TAG;
+	proxy.sec_tag	= SEC_TAG_TLS_INVALID;
 	proxy.efd	= INVALID_SOCKET;
 
 	return 0;

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -69,7 +69,7 @@ static int do_udp_server_start(uint16_t port)
 	int ret;
 
 	/* Open socket */
-	if (proxy.sec_tag == INVALID_SEC_TAG) {
+	if (proxy.sec_tag == SEC_TAG_TLS_INVALID) {
 		ret = zsock_socket(proxy.family, SOCK_DGRAM, IPPROTO_UDP);
 	} else {
 		ret = zsock_socket(proxy.family, SOCK_DGRAM, IPPROTO_DTLS_1_2);
@@ -81,7 +81,7 @@ static int do_udp_server_start(uint16_t port)
 	}
 	proxy.sock = ret;
 
-	if (proxy.sec_tag != INVALID_SEC_TAG) {
+	if (proxy.sec_tag != SEC_TAG_TLS_INVALID) {
 #ifndef CONFIG_SLM_NATIVE_TLS
 		LOG_ERR("Not supported");
 		ret = -ENOTSUP;
@@ -190,7 +190,7 @@ static int do_udp_client_connect(const char *url, uint16_t port, uint16_t cid)
 	int ret;
 	struct sockaddr sa;
 	const bool using_cid = (proxy.dtls_cid != INVALID_DTLS_CID);
-	const bool using_dtls = (proxy.sec_tag != INVALID_SEC_TAG);
+	const bool using_dtls = (proxy.sec_tag != SEC_TAG_TLS_INVALID);
 
 	/* Open socket */
 	ret = zsock_socket(proxy.family, SOCK_DGRAM, using_dtls ? IPPROTO_DTLS_1_2 : IPPROTO_UDP);
@@ -452,7 +452,7 @@ static void udp_thread_func(void *p1, void *p2, void *p3)
 				ret = -EIO;
 				break;
 			}
-			if (proxy.role == UDP_ROLE_SERVER && proxy.sec_tag != INVALID_SEC_TAG &&
+			if (proxy.role == UDP_ROLE_SERVER && proxy.sec_tag != SEC_TAG_TLS_INVALID &&
 			    value == ECONNABORTED) {
 				util_get_peer_addr((struct sockaddr *)&proxy.remote, peer_addr,
 						   &peer_port);
@@ -470,7 +470,7 @@ static void udp_thread_func(void *p1, void *p2, void *p3)
 			break;
 		}
 		if ((fds[SOCK].revents & ZSOCK_POLLHUP) != 0) {
-			if (proxy.role == UDP_ROLE_SERVER && proxy.sec_tag != INVALID_SEC_TAG) {
+			if (proxy.role == UDP_ROLE_SERVER && proxy.sec_tag != SEC_TAG_TLS_INVALID) {
 				util_get_peer_addr((struct sockaddr *)&proxy.remote, peer_addr,
 						   &peer_port);
 				LOG_INF("DTLS client disconnected: \"%s\",%d\r\n", peer_addr,
@@ -564,7 +564,7 @@ static int handle_at_udp_server(enum at_parser_cmd_type cmd_type, struct at_pars
 			if (err) {
 				return err;
 			}
-			proxy.sec_tag = INVALID_SEC_TAG;
+			proxy.sec_tag = SEC_TAG_TLS_INVALID;
 			if (param_count > 3 &&
 			    at_parser_num_get(parser, 3, &proxy.sec_tag)) {
 				return -EINVAL;
@@ -623,7 +623,7 @@ static int handle_at_udp_client(enum at_parser_cmd_type cmd_type, struct at_pars
 			if (err) {
 				return err;
 			}
-			proxy.sec_tag = INVALID_SEC_TAG;
+			proxy.sec_tag = SEC_TAG_TLS_INVALID;
 			if (param_count > 4) { /* optional param */
 				err = at_parser_num_get(parser, 4, &proxy.sec_tag);
 				if ((err != 0 && err != -EOPNOTSUPP)) {
@@ -744,7 +744,7 @@ static int handle_at_udp_send(enum at_parser_cmd_type cmd_type, struct at_parser
 int slm_at_udp_proxy_init(void)
 {
 	proxy.sock	= INVALID_SOCKET;
-	proxy.sec_tag	= INVALID_SEC_TAG;
+	proxy.sec_tag	= SEC_TAG_TLS_INVALID;
 	proxy.efd	= INVALID_SOCKET;
 
 	return 0;

--- a/applications/serial_lte_modem/src/slm_defines.h
+++ b/applications/serial_lte_modem/src/slm_defines.h
@@ -11,7 +11,6 @@
 #include "slm_trap_macros.h"
 
 #define INVALID_SOCKET       -1
-#define INVALID_SEC_TAG      -1
 #define INVALID_ROLE         -1
 #define INVALID_DTLS_CID     -1
 

--- a/samples/cellular/http_update/application_update/src/main.c
+++ b/samples/cellular/http_update/application_update/src/main.c
@@ -35,7 +35,7 @@
 #ifdef CONFIG_USE_HTTPS
 #define SEC_TAG (TLS_SEC_TAG)
 #else
-#define SEC_TAG (-1)
+#define SEC_TAG (SEC_TAG_TLS_INVALID)
 #endif
 
 enum fota_state { IDLE, CONNECTED, UPDATE_DOWNLOAD, UPDATE_PENDING, UPDATE_APPLY };

--- a/samples/cellular/http_update/modem_delta_update/src/main.c
+++ b/samples/cellular/http_update/modem_delta_update/src/main.c
@@ -30,7 +30,7 @@
 #ifdef CONFIG_USE_HTTPS
 #define SEC_TAG (TLS_SEC_TAG)
 #else
-#define SEC_TAG (-1)
+#define SEC_TAG (SEC_TAG_TLS_INVALID)
 #endif
 
 /* We assume that modem version strings (not UUID) will not be more than this */
@@ -287,7 +287,7 @@ static int update_download(void)
 	int err;
 	const char *file;
 	int sec_tag = SEC_TAG;
-	uint8_t sec_tag_count = sec_tag < 0 ? 0 : 1;
+	uint8_t sec_tag_count = sec_tag == SEC_TAG_TLS_INVALID ? 0 : 1;
 
 	err = modem_info_string_get(MODEM_INFO_FW_VERSION, modem_version,
 				    MAX_MODEM_VERSION_LEN);

--- a/samples/cellular/http_update/modem_full_update/src/main.c
+++ b/samples/cellular/http_update/modem_full_update/src/main.c
@@ -31,7 +31,7 @@
 #ifdef CONFIG_USE_HTTPS
 #define SEC_TAG (TLS_SEC_TAG)
 #else
-#define SEC_TAG (-1)
+#define SEC_TAG (SEC_TAG_TLS_INVALID)
 #endif
 
 /* We assume that modem version strings (not UUID) will not be more than this. */
@@ -429,7 +429,7 @@ static int update_download(void)
 	int err;
 	const char *file;
 	int sec_tag = SEC_TAG;
-	uint8_t sec_tag_count = sec_tag < 0 ? 0 : 1;
+	uint8_t sec_tag_count = sec_tag == SEC_TAG_TLS_INVALID ? 0 : 1;
 	const struct dfu_target_full_modem_params params = {
 		.buf = fmfu_buf,
 		.len = sizeof(fmfu_buf),

--- a/samples/cellular/modem_shell/src/rest/rest_shell.c
+++ b/samples/cellular/modem_shell/src/rest/rest_shell.c
@@ -151,7 +151,7 @@ static int rest_shell(const struct shell *shell, size_t argc, char **argv)
 		case 's':
 			req_ctx.sec_tag = atoi(optarg);
 			if (req_ctx.sec_tag == 0) {
-				mosh_warn("sec_tag not an integer (> 0)");
+				mosh_warn("sec_tag not an integer (!= 0)");
 				ret = -EINVAL;
 				goto end;
 			}

--- a/samples/cellular/modem_shell/src/sock/sock_shell.c
+++ b/samples/cellular/modem_shell/src/sock/sock_shell.c
@@ -433,7 +433,7 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 	int arg_bind_port = 0;
 	int arg_pdn_cid = 0;
 	bool arg_secure = false;
-	uint32_t arg_sec_tag = 0;
+	uint32_t arg_sec_tag = SEC_TAG_TLS_INVALID;
 	bool arg_session_cache = false;
 	bool arg_keep_open = false;
 	int arg_peer_verify = 2;

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -344,7 +344,7 @@ cleanup:
 static int job_update_accepted(struct mqtt_client *const client, uint32_t payload_len)
 {
 	int err;
-	int sec_tag = -1;
+	int sec_tag = SEC_TAG_TLS_INVALID;
 
 	err = get_published_payload(client, payload_buf, payload_len);
 	if (err) {

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -601,7 +601,7 @@ int fota_download_start(const char *host, const char *file, int sec_tag, uint8_t
 			size_t fragment_size)
 {
 	int sec_tag_list[1] = { sec_tag };
-	uint8_t sec_tag_count = sec_tag < 0 ? 0 : 1;
+	uint8_t sec_tag_count = sec_tag == SEC_TAG_TLS_INVALID ? 0 : 1;
 
 	return fota_download_any(host, file, sec_tag_list, sec_tag_count, pdn_id, fragment_size);
 }
@@ -611,7 +611,7 @@ int fota_download_start_with_image_type(const char *host, const char *file,
 					const enum dfu_target_image_type expected_type)
 {
 	int sec_tag_list[1] = { sec_tag };
-	uint8_t sec_tag_count = sec_tag < 0 ? 0 : 1;
+	uint8_t sec_tag_count = sec_tag == SEC_TAG_TLS_INVALID ? 0 : 1;
 
 	return fota_download(host, file, sec_tag_list, sec_tag_count, pdn_id, fragment_size,
 			     expected_type);

--- a/subsys/net/lib/fota_download/src/util/fota_download_util.c
+++ b/subsys/net/lib/fota_download/src/util/fota_download_util.c
@@ -53,7 +53,7 @@ static K_WORK_DEFINE(download_work, start_fota_download);
 static fota_download_callback_t fota_client_callback;
 static char fota_path[CONFIG_FOTA_DOWNLOAD_FILE_NAME_LENGTH];
 static char fota_host[CONFIG_FOTA_DOWNLOAD_HOST_NAME_LENGTH];
-static int fota_sec_tag = -1;
+static int fota_sec_tag = SEC_TAG_TLS_INVALID;
 static bool download_active;
 static enum dfu_target_image_type active_dfu_type;
 

--- a/subsys/net/lib/ftp_client/src/ftp_client.c
+++ b/subsys/net/lib/ftp_client/src/ftp_client.c
@@ -16,7 +16,6 @@
 LOG_MODULE_REGISTER(ftp_client, CONFIG_FTP_CLIENT_LOG_LEVEL);
 
 #define INVALID_SOCKET		-1
-#define INVALID_SEC_TAG		-1
 
 #define FTP_MAX_BUFFER_SIZE	708 /* align with MSS on modem side */
 #define FTP_DATA_TIMEOUT_SEC	60  /* time in seconds to wait for "Transfer complete" */
@@ -135,7 +134,7 @@ static int establish_data_channel(const char *pasv_msg)
 		LOG_ERR("socket(data) failed: %d", -errno);
 		return -errno;
 	}
-	if (client.sec_tag != INVALID_SEC_TAG) {
+	if (client.sec_tag != SEC_TAG_TLS_INVALID) {
 		sec_tag_t sec_tag_list[] = { client.sec_tag };
 
 		ret = zsock_setsockopt(client.data_sock, SOL_TLS, TLS_SEC_TAG_LIST,
@@ -201,7 +200,7 @@ static void close_connection(int code, int error)
 		client.cmd_sock = INVALID_SOCKET;
 		client.data_sock = INVALID_SOCKET;
 		client.connected = false;
-		client.sec_tag = INVALID_SEC_TAG;
+		client.sec_tag = SEC_TAG_TLS_INVALID;
 	}
 }
 
@@ -460,7 +459,7 @@ int ftp_open(const char *hostname, uint16_t port, int sec_tag)
 	zsock_freeaddrinfo(ai);
 
 	/* open control socket */
-	if (sec_tag == INVALID_SEC_TAG) {
+	if (sec_tag == SEC_TAG_TLS_INVALID) {
 		client.cmd_sock = zsock_socket(client.family, SOCK_STREAM, IPPROTO_TCP);
 	} else {
 		client.cmd_sock = zsock_socket(client.family, SOCK_STREAM, IPPROTO_TLS_1_2);
@@ -469,7 +468,7 @@ int ftp_open(const char *hostname, uint16_t port, int sec_tag)
 		LOG_ERR("socket(ctrl) failed: %d", -errno);
 		ret = -errno;
 	}
-	if (sec_tag != INVALID_SEC_TAG) {
+	if (sec_tag != SEC_TAG_TLS_INVALID) {
 		sec_tag_t sec_tag_list[] = { sec_tag };
 
 		ret = zsock_setsockopt(client.cmd_sock, SOL_TLS, TLS_SEC_TAG_LIST,
@@ -842,7 +841,7 @@ int ftp_init(ftp_client_callback_t ctrl_callback, ftp_client_callback_t data_cal
 	client.cmd_sock = INVALID_SOCKET;
 	client.data_sock = INVALID_SOCKET;
 	client.connected = false;
-	client.sec_tag = INVALID_SEC_TAG;
+	client.sec_tag = SEC_TAG_TLS_INVALID;
 	client.ctrl_callback = ctrl_callback;
 	client.data_callback = data_callback;
 


### PR DESCRIPTION
This is another attempt of
https://github.com/nrfconnect/sdk-nrf/pull/23571 to fix handling sec_tags that have not been set.

The fact that the modem uses uint32_t for sec_tags, while Zephyr uses int, is a bit unfortunate.
Often, -1 or 0 are used to indicate an invalid sec_tag, and it is checked whether a sec_tag is positive.

However, there are some "debug" sec_tags for the modem, that register as negative values, while being valid. To avoid confusion, use a proper placeholder for an invalid sec_tag.