### PR TITLE
[Backport v3.1-branch] tests: benchmarks: multicore: idle_grtc: Fix fails

### DIFF
--- a/tests/benchmarks/multicore/idle_clock_control/src/main.c
+++ b/tests/benchmarks/multicore/idle_clock_control/src/main.c
@@ -138,6 +138,22 @@ static const struct test_clk_ctx lfclk_test_clk_ctx[] = {
 };
 
 #if defined(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP)
+const struct nrf_clock_spec test_clk_specs_auxpll[] = {
+	{
+		.frequency = MHZ(80),
+		.accuracy = 0,
+		.precision = NRF_CLOCK_CONTROL_PRECISION_DEFAULT,
+	},
+};
+
+static const struct test_clk_ctx auxpll_test_clk_ctx[] = {
+	{
+		.clk_dev = DEVICE_DT_GET(DT_NODELABEL(canpll)),
+		.clk_specs = test_clk_specs_auxpll,
+		.clk_specs_size = ARRAY_SIZE(test_clk_specs_auxpll),
+	},
+};
+
 const struct nrf_clock_spec test_clk_specs_hfxo[] = {
 	{
 		.frequency = MHZ(32),
@@ -209,31 +225,11 @@ static void test_clock_control_request(const struct test_clk_ctx *clk_contexts,
 	k_busy_wait(REQUEST_SERVING_WAIT_TIME_US);
 }
 
-#if defined(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP)
-static void test_auxpll_control(const struct device *clk_dev)
-{
-	int err;
-	enum clock_control_status clk_status;
-
-	err = clock_control_on(clk_dev, NULL);
-	LOG_INF("Auxpll: %s ON request, status: %d", clk_dev->name, err);
-	k_msleep(10);
-	clk_status = clock_control_get_status(clk_dev, NULL);
-	__ASSERT_NO_MSG(clk_status == CLOCK_CONTROL_STATUS_ON);
-	err = clock_control_off(clk_dev, NULL);
-	LOG_INF("Auxpll: %s OFF request, status: %d", clk_dev->name, err);
-	k_msleep(10);
-	clk_status = clock_control_get_status(clk_dev, NULL);
-	__ASSERT_NO_MSG(clk_status == CLOCK_CONTROL_STATUS_OFF);
-	k_busy_wait(REQUEST_SERVING_WAIT_TIME_US);
-}
-#endif /* CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP */
-
 void run_tests(void)
 {
 	gpio_pin_set_dt(&led, 1);
 #if defined(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP)
-	test_auxpll_control(DEVICE_DT_GET(DT_NODELABEL(canpll)));
+	test_clock_control_request(auxpll_test_clk_ctx, ARRAY_SIZE(auxpll_test_clk_ctx));
 	test_clock_control_request(hfxo_test_clk_ctx, ARRAY_SIZE(hfxo_test_clk_ctx));
 	test_clock_control_request(hsfll_test_clk_ctx, ARRAY_SIZE(hsfll_test_clk_ctx));
 #endif /* CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP */

--- a/tests/benchmarks/multicore/idle_grtc/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_grtc/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuppr
     extra_args:
+      - vpr_launcher_CONFIG_SOC_NRF54H20_CPURAD_ENABLE=y
       - vpr_launcher_EXTRA_CONF_FILE=${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_grtc/vpr_launcher.conf
       - vpr_launcher_EXTRA_DTC_OVERLAY_FILE=${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_grtc/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
     harness: pytest

--- a/tests/benchmarks/multicore/idle_ppr/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_ppr/testcase.yaml
@@ -22,6 +22,7 @@ tests:
   benchmarks.multicore.idle_ppr.idle:
     tags: ppk_power_measure
     extra_args:
+      - CONFIG_SOC_NRF54H20_CPURAD_ENABLE=y
       - idle_ppr_CONF_FILE=prj_s2ram.conf
       - remote_rad_CONF_FILE=prj_s2ram.conf
       - remote_ppr_CONF_FILE=prj_s2ram.conf
@@ -38,6 +39,7 @@ tests:
   benchmarks.multicore.idle_ppr.s2ram:
     tags: ppk_power_measure
     extra_args:
+      - CONFIG_SOC_NRF54H20_CPURAD_ENABLE=y
       - idle_ppr_CONF_FILE=prj_s2ram.conf
       - remote_rad_CONF_FILE=prj_s2ram.conf
       - remote_ppr_CONF_FILE=prj_s2ram.conf


### PR DESCRIPTION
Backport a563b64af32d4018d1eacc603f9019183303cd27 from #24006.