### PR TITLE
doc: Fixed SB configs references in Matter documents

### DIFF
--- a/applications/matter_weather_station/README.rst
+++ b/applications/matter_weather_station/README.rst
@@ -228,7 +228,7 @@ To build this application to work with the nRF7002 Wi-Fi expansion board:
 Generating factory data
 =======================
 
-To enable factory data support, you need to select the ``overlay-factory_data`` configuration overlay from the available application :ref:`build configuration overlays <matter_weather_station_app_build_configuration_overlays>`, set the ``SB_CONFIG_MATTER_FACTORY_DATA_GENERATE`` Kconfig option to ``y``, and use the ``factory_data`` file suffix.
+To enable factory data support, you need to select the ``overlay-factory_data`` configuration overlay from the available application :ref:`build configuration overlays <matter_weather_station_app_build_configuration_overlays>`, set the :kconfig:option:`SB_CONFIG_MATTER_FACTORY_DATA_GENERATE` Kconfig option to ``y``, and use the ``factory_data`` file suffix.
 You can generate new factory data set when building for the given board target by invoking the following command:
 
 .. code-block:: console

--- a/doc/nrf/protocols/matter/end_product/bootloader.rst
+++ b/doc/nrf/protocols/matter/end_product/bootloader.rst
@@ -115,7 +115,7 @@ MCUboot uses asymmetric cryptography to validate the authenticity of firmware.
 The public key embedded in the bootloader image is used to validate the signature of a firmware image that is about to be booted.
 If the signature check fails, MCUboot rejects the image and either:
 
-* rolls back to the last valid firmware image if the fallback recovery has not been disabled using the MCUboot's ``SB_CONFIG_MCUBOOT_MODE_OVERWRITE_ONLY`` Kconfig option.
+* rolls back to the last valid firmware image if the fallback recovery has not been disabled using the MCUboot's :kconfig:option:`SB_CONFIG_MCUBOOT_MODE_OVERWRITE_ONLY` Kconfig option.
 * fails to boot.
 
 .. note::
@@ -130,7 +130,7 @@ Downgrade protection
 
 The :ref:`downgrade protection <ug_fw_update_image_versions_mcuboot_downgrade>` mechanism makes it impossible for an attacker to trick a user to install a firmware image older than the currently installed one.
 The attacker might want to do this to reintroduce old security vulnerabilities that have already been fixed in newer firmware revisions.
-You should enable the downgrade protection mechanism if you choose to enable MCUboot's ``SB_CONFIG_MCUBOOT_MODE_OVERWRITE_ONLY`` Kconfig option, which disables the fallback recovery in case of a faulty upgrade.
+You should enable the downgrade protection mechanism if you choose to enable MCUboot's :kconfig:option:`SB_CONFIG_MCUBOOT_MODE_OVERWRITE_ONLY` Kconfig option, which disables the fallback recovery in case of a faulty upgrade.
 
 .. _ug_matter_device_bootloader_image_compression:
 

--- a/doc/nrf/protocols/matter/end_product/test_event_triggers.rst
+++ b/doc/nrf/protocols/matter/end_product/test_event_triggers.rst
@@ -100,7 +100,7 @@ The following table lists the available triggers and their activation codes:
     - ``0xFFFFFFFF60000000``
     - No additional value supported.
   * - OTA query
-    - :kconfig:option:`CONFIG_CHIP_OTA_REQUESTOR` = ``y``, and ``SB_CONFIG_MATTER_OTA`` = ``y``.
+    - :kconfig:option:`CONFIG_CHIP_OTA_REQUESTOR` = ``y``, and :kconfig:option:`SB_CONFIG_MATTER_OTA` = ``y``.
     - Trigger an OTA firmware update.
     - ``0x002a000000000100`` - ``0x01000000000001FF``
     - The range of ``0x00`` - ``0xFF`` is the fabric index value.
@@ -187,10 +187,10 @@ You cannot set the enable key to a specific value using factory data unless the 
 If it is not set, the default value ``00112233445566778899AABBCCDDEEFF`` will be used.
 For secure operation, you need to ensure that the enable key is unique for all of your devices.
 
-To specify the enable key through the build system, enable the ``SB_CONFIG_MATTER_FACTORY_DATA_GENERATE`` Kconfig option by setting it to ``y``.
+To specify the enable key through the build system, enable the :kconfig:option:`SB_CONFIG_MATTER_FACTORY_DATA_GENERATE` Kconfig option by setting it to ``y``.
 Then, set the :kconfig:option:`CONFIG_CHIP_DEVICE_ENABLE_KEY` Kconfig option to a 32-byte hexadecimal string value.
 
-If ``SB_CONFIG_MATTER_FACTORY_DATA_GENERATE`` is set to ``n``, you can follow the :doc:`matter:nrfconnect_factory_data_configuration` guide in the Matter documentation to generate the factory data set with the specific enable key value.
+If :kconfig:option:`SB_CONFIG_MATTER_FACTORY_DATA_GENERATE` is set to ``n``, you can follow the :doc:`matter:nrfconnect_factory_data_configuration` guide in the Matter documentation to generate the factory data set with the specific enable key value.
 
 If you do not use the |NCS| Matter common module, you need to read the enable key value manually from the factory data set and provide it to the ``TestEventTrigger`` class.
 

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -128,7 +128,7 @@ You can program a portion of the application code related to the nRF70 Series' W
 This option is available only when building for the nRF5340 DK with the nRF7002 EK shield attached.
 To prepare an application to use this feature, you need to create additional MCUboot partitions.
 To learn how to configure MCUboot partitions, see the :ref:`nrf70_fw_patch_update_adding_partitions` guide.
-To enable this feature for Matter, set the ``SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE``, ``SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_WIFI_FW_PATCH`` Kconfig options to ``y``, and set the ``SB_CONFIG_MCUBOOT_UPDATEABLE_IMAGES`` Kconfig option to ``3``.
+To enable this feature for Matter, set the :kconfig:option:`SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE`, :kconfig:option:`SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_WIFI_FW_PATCH` Kconfig options to ``y``, and set the :kconfig:option:`SB_CONFIG_MCUBOOT_UPDATEABLE_IMAGES` Kconfig option to ``3``.
 
 .. matter_door_lock_sample_nrf70_firmware_patch_end
 
@@ -348,7 +348,7 @@ Factory data support
    To disable factory data support, set the following Kconfig options to ``n``:
 
    * :kconfig:option:`CONFIG_CHIP_FACTORY_DATA`
-   * ``SB_CONFIG_MATTER_FACTORY_DATA_GENERATE``
+   * :kconfig:option:`SB_CONFIG_MATTER_FACTORY_DATA_GENERATE`
 
    To learn more about factory data, read the :doc:`matter:nrfconnect_factory_data_configuration` page in the Matter documentation.
 


### PR DESCRIPTION
Fixed few references in Matter docs to SB configs that were incorrect.