### PR TITLE
doc: wifi: Fix `CONFIG_NRF70_UTIL` config setting

### DIFF
--- a/doc/nrf/protocols/wifi/regulatory_certification/using_wifi_shell_sample.rst
+++ b/doc/nrf/protocols/wifi/regulatory_certification/using_wifi_shell_sample.rst
@@ -19,6 +19,8 @@ Build instructions
 
 For information on the build instructions, see :ref:`Wi-Fi Shell sample building and running <wifi_shell_sample_building_and_running>`.
 
+Set the :kconfig:option:`CONFIG_NRF70_UTIL` Kconfig option to ``y`` in the :file:`<ncs_repo>/nrf/samples/wifi/shell/prj.conf` file to enable the ``nrf70 util`` commands.
+
 Scan, connect, and ping to a network using the Wi-Fi Shell sample
 *****************************************************************
 

--- a/doc/nrf/protocols/wifi/regulatory_certification/using_wifi_station_sample.rst
+++ b/doc/nrf/protocols/wifi/regulatory_certification/using_wifi_station_sample.rst
@@ -19,7 +19,7 @@ Build instructions
 
 For information on the build instructions, see :ref:`Wi-Fi Station sample building and running <wifi_station_sample_building_and_running>`.
 
-Set the :kconfig:option:`CONFIG_NRF70_UTIL` Kconfig option to ``y`` in the :file:`<ncs_repo>/nrf/samples/wifi/shell/prj.conf` file to enable ``nrf70 util`` commands.
+Set the :kconfig:option:`CONFIG_NRF70_UTIL` Kconfig option to ``y`` in the :file:`<ncs_repo>/nrf/samples/wifi/sta/prj.conf` file to enable the ``nrf70 util`` commands.
 
 Wi-Fi Station sample
 ********************


### PR DESCRIPTION
Update build instructions to use the correct
config file for enabling `CONFIG_NRF70_UTIL`.
Also add the missing instruction in the
`using_wifi_shell_sample` doc.

Fixes SHEL-3750.