### PR TITLE
[Backport v3.1-branch] doc: Improvements to nRF54H documentation

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_gs.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_gs.rst
@@ -135,6 +135,10 @@ nRF54H20 DK bring-up
 
 The following sections describe the steps required for the nRF54H20 bring-up.
 
+.. note::
+   To program the nRF54H20 SoC binaries based on IronSide SE on your nRF54H20 SoC-based device, your device must be in lifecycle state (LCS) ``EMPTY``.
+   Devices already provisioned using SUIT-based binaries and in LCS RoT cannot be transitioned back to LCS EMPTY.
+
 .. rst-class:: numbered-step
 
 Programming the BICR

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1883,7 +1883,7 @@
 .. _`nRF54H20 SoC binaries v0.9.2`: https://files.nordicsemi.com/ui/native/SDSC/external/nrf54h20_soc_binaries_v0.9.2.zip
 .. _`nRF54H20 SoC binaries v0.9.6`: https://files.nordicsemi.com/ui/native/SDSC/external/nrf54h20_soc_binaries_v0.9.6.zip
 
-.. _`nRF54H20 SoC binaries v22.2.0+14`: https://eu.files.nordicsemi.com/ui/native/SDSC/external-confidential/nrf54h20_soc_binaries_v22.2.0+14.zip
+.. _`nRF54H20 SoC binaries v22.2.0+14`: https://files.nordicsemi.com/artifactory/SDSC/external/nrf54h20_soc_binaries_v22.2.0%2B14.zip
 
 .. _`BICR binary file`: https://files.nordicsemi.com/artifactory/SDSC/external/bicr_ext_loadcap.hex
 .. _`BICR new binary file`: https://files.nordicsemi.com/artifactory/SDSC/external/bicr/bicr.hex

--- a/doc/nrf/releases_and_maturity/abi_compatibility.rst
+++ b/doc/nrf/releases_and_maturity/abi_compatibility.rst
@@ -57,6 +57,11 @@ Additionally, maintaining ABI compatibility allows the nRF54H20 SoC binary compo
     The nRF54H20 SoC binaries only support specific versions of the |NCS| and do not support rollbacks to previous versions.
     Upgrading the nRF54H20 SoC binaries on your development kit might break the DK's compatibility with applications developed for earlier versions of the |NCS|.
 
+Provisioning the nRF54H20 SoC
+*****************************
+
+To provision the nRF54H20 SoC using the nRF54H20 SoC binaries, see :ref:`ug_nrf54h20_gs_bringup`.
+
 nRF54H20 SoC binaries v22.2.0+14 changelog
 ******************************************
 

--- a/doc/nrf/releases_and_maturity/migration/migration_3.1_54h_suit_ironside.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_3.1_54h_suit_ironside.rst
@@ -2,8 +2,8 @@
 
 .. _migration_3.1_54h_suit_ironside:
 
-Migration from SUIT to IronSide SE for the nRF54H20 SoC
-#######################################################
+Migrating applications from |NCS| v3.0.0 (SUIT) to |NCS| v3.1.0 (IronSide SE) on the nRF54H20 SoC
+#################################################################################################
 
 .. contents::
    :local:
@@ -17,9 +17,13 @@ To follow this guide, you must meet the following prerequisites:
 * You have installed the |NCS| v3.1.0 and its toolchain.
   For more information, see :ref:`install_ncs`.
 
+Moreover, to program your modified application on the nRF54H20 SoC, your nRF54H20-based device must be provisioned with the relevant nRF54H20 SoC binaries version.
+For more information, see :ref:`abi_compatibility`.
+
 .. note::
-   To program IronSide SE on your nRF54H20 SoC-based device, your device must be in lifecycle state (LCS) ``EMPTY``.
-   Devices using SUIT in LCS RoT cannot be transitioned back to LCS EMPTY.
+   To program the nRF54H20 SoC binaries based on IronSide SE on your nRF54H20 SoC-based device, your device must be in lifecycle state (LCS) ``EMPTY``.
+   Devices already provisioned using SUIT-based binaries and in LCS RoT cannot be transitioned back to LCS EMPTY.
+   For more information on provisioning new devices, see :ref:`ug_nrf54h20_gs_bringup`.
 
 Breaking changes
 ****************
@@ -74,7 +78,7 @@ To update your devicetree files, complete the following steps:
    In your board's DTS overlay, remove any node that defined the ``uicr`` partition.
 
 #. Add the PERIPHCONF array.
-   In your devicetree, under the ``mram1x`` partitions node, define a partition node labeled ``peripconf_partition`` with a size of at least 8 KB to embed the generated address-value blob.
+   In your devicetree, under the ``mram1x`` partitions node, define a partition node labeled ``periphconf_partition`` with a size of at least 8 KB to embed the generated address-value blob.
 
 #. Remove IPC-shared-memory reservation.
    As IronSide relocates the IPC buffer to a fixed RAM20 address, you can delete any manual reservation in RAM0.
@@ -132,7 +136,7 @@ When the following Kconfig options are set:
 
 the script does the following:
 
-  1. It reads the ``peripconf_partition`` node in the devicetree to discover the partition's address and size.
+  1. It reads the ``periphconf_partition`` node in the devicetree to discover the partition's address and size.
   #. It extracts the address/value pairs from the ``PERIPHCONF`` section of the Zephyr ELF image.
   #. It generates two Intel HEX files:
 
@@ -170,7 +174,7 @@ With IronSide SE, the memory map changed as follows:
   Remove memory access groups, such as ``cpuapp_rx_partitions``, ``cpurad_rx_partitions``, ``cpuapp_rw_partitions`` and define partitions under the ``partitions`` node under the ``mram1x`` node.
   Refer to the `nRF54H20 DK memory map`_ for details.
 
-To enable ``UICR/PERIPHCONF`` generation, ensure a DTS partition labeled ``peripconf_partition`` exists with sufficient size (for example, 8 KBs) to embed the generated address-value blob.
+To enable ``UICR/PERIPHCONF`` generation, ensure a DTS partition labeled ``periphconf_partition`` exists with sufficient size (for example, 8 KBs) to embed the generated address-value blob.
 
 DFU support with MCUboot
 ========================

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_3.1.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_3.1.rst
@@ -74,6 +74,19 @@ nRF54H20
 
 This section describes the changes specific to the nRF54H20 SoC and DK support in the |NCS|.
 
+nRF54H20 SoC binaries
+---------------------
+
+.. toggle::
+
+   * The nRF54H20 SoC binaries have been updated to version v22.2.0+14, and are now based on IronSide SE.
+     For more information, see :ref:`abi_compatibility`.
+
+     .. note::
+        To program the nRF54H20 SoC binaries based on IronSide SE on your nRF54H20 SoC-based device, your device must be in lifecycle state (LCS) ``EMPTY``.
+        Devices already provisioned using SUIT-based binaries and in LCS RoT cannot be transitioned back to LCS EMPTY.
+        For more information on provisioning new devices, see :ref:`ug_nrf54h20_gs_bringup`.
+
 SUIT to IronSide SE migration
 -----------------------------
 


### PR DESCRIPTION
Backport 893b0b6040e6b7bacdb5fcb57896e6a53d395066 from #24044.