### PR TITLE
nrf_security: Moving block_cipher.c to libmbedcrypto

### DIFF
--- a/subsys/nrf_security/src/CMakeLists.txt
+++ b/subsys/nrf_security/src/CMakeLists.txt
@@ -117,7 +117,6 @@ append_with_prefix(src_crypto_base ${ARM_MBEDTLS_PATH}/library
   base64.c
   bignum.c
   bignum_core.c
-  block_cipher.c
   nist_kw.c
   oid.c
   padlock.c

--- a/subsys/nrf_security/src/legacy/CMakeLists.txt
+++ b/subsys/nrf_security/src/legacy/CMakeLists.txt
@@ -24,6 +24,7 @@ if(CONFIG_MBEDTLS_LEGACY_CRYPTO_C OR
   CONFIG_PSA_CRYPTO_DRIVER_OBERON OR
   CONFIG_PSA_CRYPTO_DRIVER_CRACEN)
   append_with_prefix(src_crypto_legacy ${ARM_MBEDTLS_PATH}/library
+    block_cipher.c
     aes.c
     cmac.c
     ccm.c


### PR DESCRIPTION
-Due to a complex link order dependency, the fairly recent
 block_cipher module could end up without access to AES symbols
 and certain PSA convenience functions. This change moves the
 block_cipher API from libmbedcrypto_base.a to libmbedcrypto.a
 which ensures that block_cipher can link locally

Note: PSA Crypto APIs is not influenced by this change, this is only relevant for certain legacy functionalities