### PR TITLE
samples: matter: Fix doorlock auto-relock

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -310,7 +310,10 @@ Keys samples
 Matter samples
 --------------
 
-|no_changes_yet_note|
+* :ref:`matter_lock_sample` sample:
+
+   * Added a callback for the auto-relock feature.
+     This resolves the :ref:`known issue <known_issues>` KRKNWK-20691.
 
 Networking samples
 ------------------

--- a/samples/matter/lock/src/zcl_callbacks.cpp
+++ b/samples/matter/lock/src/zcl_callbacks.cpp
@@ -89,6 +89,11 @@ bool emberAfPluginDoorLockOnDoorUnlockCommand(EndpointId endpointId, const Nulla
 	return success;
 }
 
+void emberAfPluginDoorLockOnAutoRelock(chip::EndpointId endpointId)
+{
+	BoltLockMgr().Lock(BoltLockManager::OperationSource::kAuto);
+}
+
 void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
 {
 	DoorLockServer::Instance().InitServer(endpoint);


### PR DESCRIPTION
The Matter Lock sample did not react to auto-relock after invoking this request by the controller.

The issue was that the callback for this feature was not implemented in the Lock sample.