### PR TITLE
scripts: execute ironside IPC services from python

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -716,6 +716,8 @@
 /scripts/print_toolchain_checksum.sh      @nrfconnect/ncs-ci
 /scripts/hpf/                             @nrfconnect/ncs-ll-ursus
 /scripts/generate_psa_key_attributes.py   @nrfconnect/ncs-aegir
+/scripts/generate_ironside_ipc_request.py @nrfconnect/ncs-aurora
+/scripts/trigger_ironside_ipc_request.py  @nrfconnect/ncs-aurora
 /scripts/tests/                           @nrfconnect/ncs-pluto @fundakol
 /scripts/vale/                            @francescoser
 /scripts/esb_sniffer/                     @nrfconnect/ncs-si-muffin

--- a/scripts/generate_ironside_ipc_request.py
+++ b/scripts/generate_ironside_ipc_request.py
@@ -1,0 +1,319 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+"""
+Script for generating IPC request binary blobs for IronSide SE IPC requests.
+Two segments are created, one for the IPC shared memory, and one for placing the data
+that is pointed to by the IPC request.
+The resulting data is printed to stdout in intelhex format unless an output file is given.
+"""
+
+import argparse
+import binascii
+import ctypes as c
+import io
+import json
+
+from intelhex import IntelHex
+
+TFM_CRYPTO_IMPORT_KEY_SID = (
+    0x0203  # crypto import key function ID (group ID 2, function index 3)
+)
+TFM_CRYPTO_GENERATE_RANDOM_SID = (
+    0x0100  # crypto generate random function ID (group ID 1, function index 0)
+)
+IRONSIDE_CALL_ID_PSA_V1 = 0  # Ironside call ID for PSA v1
+PSA_IPC_CALL = 0x20000000  # PSA IPC call type
+TFM_CRYPTO_HANDLE = 0x40000100  # see include/tfm/ironside/se/ipc_service.h
+IPC_SHARED_MEM_ADDR = 0x2F88FB80  # Address used for IPC messages to/from IronSide SE
+IRONSIDE_CALL_STATUS_REQ = 6  # Indicates that a client request is in the IPC buffer
+KEY_ID_LEN = 4  # Length in bytes of key identifier
+
+
+class TfmCryptoPackIovec(c.LittleEndianStructure):
+    """Represents struct tfm_crypto_pack_iovec"""
+
+    _pack_ = 1
+    _fields_ = [
+        ("key_id", c.c_uint32),
+        ("alg", c.c_uint32),
+        ("op_handle", c.c_uint32),
+        ("ad_length", c.c_uint32),
+        ("plaintext_length", c.c_uint32),
+        ("aead_nonce", c.c_uint8 * 16),
+        ("aead_nonce_length", c.c_uint32),
+        ("function_id", c.c_uint16),
+        ("step", c.c_uint16),
+        ("_padding1", c.c_uint8 * 4),  # 4 bytes padding to align union
+        ("capacity_or_value", c.c_uint64),  # union
+        ("role", c.c_uint8),
+        ("_padding2", c.c_uint8 * 7),  # 7 bytes padding for 8-byte alignment
+    ]
+
+
+class PsaVec(c.LittleEndianStructure):
+    """Represents psa_[in/out]vec structure"""
+
+    _pack_ = 1
+    _fields_ = [("base", c.c_uint32), ("length", c.c_uint32)]
+
+
+class PsaInvec(PsaVec):
+    """Represents psa_invec structure"""
+
+
+class PsaOutvec(PsaVec):
+    """Represents psa_outvec structure"""
+
+
+IronsideCallBufArgs = c.c_uint32 * 7
+
+
+class IronsideCallBuf(c.LittleEndianStructure):
+    """Represents struct ironside_call_buf"""
+
+    _pack_ = 1
+    _fields_ = [
+        ("status", c.c_uint16),
+        ("id", c.c_uint16),
+        ("args", IronsideCallBufArgs),
+    ]
+
+
+class MemoryBlob:
+    """Manages a virtual memory blob with address tracking"""
+
+    def __init__(self, base_address: int):
+        self.base_address = base_address
+        self.data = bytearray()
+        self.current_address = base_address
+
+    def append(self, data: bytes) -> int:
+        """Append data to the blob and return its address"""
+        address = self.current_address
+        self.data.extend(data)
+        self.current_address += len(data)
+        return address
+
+
+def generate_psa_ipc_request(
+    function_id: int,
+    input_data_list: list[bytes],
+    output_specs: list[tuple[int, int]],
+    base_address: int,
+) -> tuple[bytes, bytes]:
+    """
+    Generate IPC request data for PSA crypto functions.
+
+    Args:
+        function_id: TFM crypto function ID
+        input_data_list: List of (address, length) tuples for input buffers (beyond the iovec)
+        output_specs: List of (address, length) tuples for output buffers
+        base_address: Base address for memory blob
+
+    Returns:
+        (ipc_request_data, memory_blob_data)
+    """
+    memory = MemoryBlob(base_address)
+
+    # All requests has this
+    iovec = TfmCryptoPackIovec(function_id=function_id)
+    iovec_addr = memory.append(bytes(iovec))
+    invecs = [PsaInvec(base=iovec_addr, length=c.sizeof(iovec))]
+
+    for data in input_data_list:
+        data_addr = memory.append(data)
+        invecs.append(PsaInvec(base=data_addr, length=len(data)))
+
+    in_vec_addr = memory.current_address
+    for vec in invecs:
+        memory.append(bytes(vec))
+
+    out_vecs = []
+    for address, length in output_specs:
+        out_vecs.append(PsaOutvec(base=address, length=length))
+
+    out_vec_addr = memory.current_address
+    for vec in out_vecs:
+        memory.append(bytes(vec))
+
+    call_buf = IronsideCallBuf(
+        status=IRONSIDE_CALL_STATUS_REQ,
+        id=IRONSIDE_CALL_ID_PSA_V1,
+        args=IronsideCallBufArgs(
+            TFM_CRYPTO_HANDLE,  # args[0] - TFM_CRYPTO_HANDLE
+            in_vec_addr,  # args[1] - address of in_vec
+            len(invecs),  # args[2] - number of entries in invecs
+            out_vec_addr,  # args[3] - address of out_vec
+            len(out_vecs),  # args[4] - number of entries in out_vec
+            0,  # args[5] - status, not set by the client
+            PSA_IPC_CALL,  # args[6] - PSA_IPC_CALL
+        ),
+    )
+
+    return bytes(call_buf), bytes(memory.data)
+
+
+def generate_import_key_request(
+    psa_key_attrs_hex: str,
+    key_value_hex: str,
+    base_address: int,
+    key_id_address: int,
+    key_id_len: int,
+) -> tuple[bytes, bytes]:
+    """
+    Generate IPC request data for the psa_import_key function.
+
+    Returns:
+        (ipc_request_data, memory_blob_data)
+    """
+
+    def parse_hex_string(hex_str: str) -> bytes:
+        return binascii.unhexlify(hex_str.removeprefix("0x"))
+
+    psa_key_attrs_data = parse_hex_string(psa_key_attrs_hex)
+    key_data = parse_hex_string(key_value_hex)
+
+    return generate_psa_ipc_request(
+        function_id=TFM_CRYPTO_IMPORT_KEY_SID,
+        input_data_list=[psa_key_attrs_data, key_data],
+        output_specs=[(key_id_address, key_id_len)],
+        base_address=base_address,
+    )
+
+
+def generate_random_request(
+    output_address: int,
+    output_length: int,
+    base_address: int,
+) -> tuple[bytes, bytes]:
+    """
+    Generate IPC request data for the psa_generate_random function.
+
+    Returns:
+        (ipc_request_data, memory_blob_data)
+    """
+    # psa_generate_random only needs the output buffer, no input data beyond iovec
+    return generate_psa_ipc_request(
+        function_id=TFM_CRYPTO_GENERATE_RANDOM_SID,
+        input_data_list=[],  # No additional input data beyond iovec
+        output_specs=[(output_address, output_length)],
+        base_address=base_address,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate IPC request binary blobs for PSA operations",
+        allow_abbrev=False,
+    )
+
+    parser.add_argument(
+        "--base-address",
+        help="Base address for memory blob. This acts as the working area for the requests. All "
+        "data pointed to by the request is stored here. Any unused RAM available to the core that "
+        "is used to execute the IPC request can be given",
+        default=0x22000000,
+        type=lambda x: int(x, 0),
+    )
+
+    parser.add_argument(
+        "--output",
+        help="Output JSON filename (if not provided, outputs Intel HEX to stdout)",
+        type=argparse.FileType("wb"),
+        required=False,
+    )
+
+    subparsers = parser.add_subparsers(
+        dest="operation",
+        help="IPC operation to perform",
+        required=True,
+    )
+
+    import_parser = subparsers.add_parser(
+        "psa_import_key",
+        help="Invoke psa_import_key through the PSA service",
+    )
+
+    import_parser.add_argument(
+        "--psa-key-attrs",
+        help="PSA key attributes as hex string. This can be found by running the "
+        "generate_psa_key_attributes.py script",
+        type=str,
+        required=True,
+    )
+
+    import_parser.add_argument(
+        "--key-value",
+        help="Key value as hex string",
+        type=str,
+        required=True,
+    )
+
+    import_parser.add_argument(
+        "--key-id-address",
+        help="The address to store the resulting key_id to. The psa_import_key outputs the key_id "
+        " of the imported key. For persistent keys this will be the same value that was given as "
+        "input. It is still required to provide an address where this output key_id can be "
+        "written.",
+        type=lambda x: int(x, 0),
+        default=0x22001000,
+    )
+
+    random_parser = subparsers.add_parser(
+        "psa_generate_random",
+        help="Invoke psa_generate_random through the PSA service",
+    )
+
+    random_parser.add_argument(
+        "--output-address",
+        help="Base address for random output buffer (hex or decimal)",
+        type=lambda x: int(x, 0),
+        required=True,
+    )
+
+    random_parser.add_argument(
+        "--output-length",
+        help="Length of random output buffer (hex or decimal)",
+        type=lambda x: int(x, 0),
+        required=True,
+    )
+
+    args = parser.parse_args()
+
+    if args.operation == "psa_import_key":
+        ipc_request, request_data = generate_import_key_request(
+            args.psa_key_attrs,
+            args.key_value,
+            args.base_address,
+            args.key_id_address,
+            KEY_ID_LEN,
+        )
+    elif args.operation == "psa_generate_random":
+        ipc_request, request_data = generate_random_request(
+            args.output_address,
+            args.output_length,
+            args.base_address,
+        )
+
+    if args.output:
+        output_data = {
+            "ipc_request": binascii.hexlify(ipc_request).decode("utf-8").upper(),
+            "request_data": binascii.hexlify(request_data).decode("utf-8").upper(),
+            "address": f"0x{args.base_address:08X}",
+        }
+
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(output_data, f, indent=4)
+    else:
+        # Output intelhex to stdout
+        ih = IntelHex()
+        ih.puts(args.base_address, request_data)
+        ih.puts(IPC_SHARED_MEM_ADDR, ipc_request)
+        output = io.StringIO()
+        ih.write_hex_file(output)
+        print(output.getvalue().rstrip())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_psa_key_attributes.py
+++ b/scripts/generate_psa_key_attributes.py
@@ -117,6 +117,7 @@ class PsaKeyPersistence(IntEnum):
 class PsaKeyLocation(IntEnum):
     """Location for storing key"""
 
+    LOCATION_LOCAL_STORAGE = 0
     LOCATION_CRACEN = 0x804E0000
     LOCATION_CRACEN_KMU = 0x804E4B00
 

--- a/scripts/trigger_ironside_ipc_request.py
+++ b/scripts/trigger_ironside_ipc_request.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+"""
+Script for triggering IronSide IPC requests via JLink connection.
+It does the following:
+- takes an (optional) intelhex as input from stdin and programs this to the device
+- triggers the IPC request by writing to the correct BELLBOARD.TASK
+- waits for the receiving BELLBOARD.EVENT to indicate that ironside has completed the request
+- prints the contents of the IPC buffer to stdout if ironside provided a response.
+
+The contents of the intelhex file passed as input must be such that IronSide SE has an IPC
+service compatible with the data. See generate_ironside_psa_ipc_request.py for an example.
+"""
+
+import argparse
+import binascii
+import ctypes as c
+import io
+import sys
+from enum import Enum
+from time import perf_counter
+from typing import List
+
+import pylink
+from intelhex import IntelHex
+
+
+class IronSideCallStatus(Enum):
+    IDLE = 0
+    SUCCESS = 1
+    RSP_ERR_UNKNOWN_STATUS = 2
+    RSP_ERR_EXPIRED_STATUS = 3
+    RSP_ERR_UNKNOWN_ID = 4
+    RSP_ERR_EXPIRED_ID = 5
+    REQ = 6
+
+    def __int__(self) -> int:
+        return self.value
+
+
+CallBufferArgs = c.c_uint32 * 7
+
+
+class CallBuffer(c.LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [("status", c.c_uint16), ("id", c.c_uint16), ("args", CallBufferArgs)]
+
+    @property
+    def status_enum(self) -> IronSideCallStatus:
+        return IronSideCallStatus(self.status)
+
+
+class IronSideCallResponseError(RuntimeError):
+    def __init__(self, rsp_err: IronSideCallStatus) -> None:
+        self._rsp_err = rsp_err
+        super().__init__(
+            f"server responded with error: {self._rsp_err.name} ({self._rsp_err.value})"
+        )
+
+    @property
+    def rsp_err(self) -> IronSideCallStatus:
+        return self._rsp_err
+
+
+class IronSideCallTimeoutError(TimeoutError): ...
+
+
+class IronSideCallUnknownStatusError(RuntimeError):
+    def __init__(self, status: int) -> None:
+        self._status = status
+        super().__init__(f"unknown status read from IPC buffer: {self._status}")
+
+
+class IronSideCall:
+    def __init__(
+        self,
+        jlink: pylink.JLink,
+        *,
+        tx_task_addr: int,
+        rx_event_addr: int,
+        buffer_addr: int,
+    ) -> None:
+        self._jlink = jlink
+        self._buffer_addr = buffer_addr
+        self._tx_task_addr = tx_task_addr
+        self._rx_event_addr = rx_event_addr
+
+    def trigger_request(self) -> None:
+        """Trigger the IPC request by setting the TX task"""
+        self._jlink.memory_write32(self._tx_task_addr, [0x1])
+
+    def read_response(
+        self,
+        timeout: int | float | None = 1.0,
+    ) -> List[c.c_uint32]:
+        timeout_s = timeout if timeout is not None else float("inf")
+        has_event = False
+        has_data = False
+        call_buffer = None
+
+        start = perf_counter()
+
+        while not has_data:
+            has_event = False
+            while not has_event:
+                has_event = bool(self._jlink.memory_read32(self._rx_event_addr, 1)[0])
+
+                if has_event:
+                    self._jlink.memory_write32(self._rx_event_addr, [0])
+                if (perf_counter() - start) > timeout_s:
+                    break
+
+            call_buffer_data = bytes(
+                self._jlink.memory_read8(self._buffer_addr, c.sizeof(CallBuffer))
+            )
+            call_buffer = CallBuffer.from_buffer_copy(call_buffer_data)
+            has_data = call_buffer.status not in (
+                IronSideCallStatus.IDLE.value,
+                IronSideCallStatus.REQ.value,
+            )
+            if (perf_counter() - start) > timeout_s:
+                break
+
+        if not has_event:
+            raise IronSideCallTimeoutError(
+                f"timed out waiting for RX event at 0x{self._rx_event_addr:09_x}"
+            )
+        if not has_data:
+            raise IronSideCallTimeoutError("timed out waiting for response status")
+
+        assert call_buffer is not None
+
+        try:
+            rsp_status = call_buffer.status_enum
+        except ValueError:
+            raise IronSideCallUnknownStatusError(call_buffer.status)
+
+        if rsp_status != IronSideCallStatus.SUCCESS:
+            raise IronSideCallResponseError(rsp_status)
+
+        return [c.c_uint32(a) for a in call_buffer.args]
+
+
+class IronSideIpcTrigger:
+    """Class for triggering IronSide IPC requests"""
+
+    def __init__(self, jlink_serial: int):
+        self.jlink = pylink.JLink()
+        self.jlink.open(jlink_serial)
+        self.jlink.set_tif(pylink.enums.JLinkInterfaces.SWD)
+        self.jlink.set_speed(4000)
+        self.jlink.coresight_configure()
+        self.jlink.connect("Cortex-M33")
+
+        self.ironside_call = IronSideCall(
+            self.jlink,
+            tx_task_addr=0x5F09_9030, # CPUSEC.BELLBOARD.TASK[12]
+            rx_event_addr=0x5F09_A100, # CPUAPP.BELLBOARD.EVENT[0]
+            buffer_addr=0x2F88_FB80, # Static location of IPC buffer
+        )
+
+    def trigger_and_read_response(self) -> List[c.c_uint32]:
+        """
+        Trigger an IronSide IPC request and read the response.
+
+        Returns:
+            List of response arguments
+        """
+
+        self.ironside_call.trigger_request()
+        return self.ironside_call.read_response()
+
+    def close(self):
+        """Close the JLink connection"""
+        self.jlink.close()
+
+
+def program_hex_data(trigger: IronSideIpcTrigger, hex_data: str) -> None:
+    """
+    Program Intel HEX data to the device using the JLink connection.
+
+    Args:
+        trigger: IronSideIpcTrigger instance with active JLink connection
+        hex_data: Intel HEX format data as a string
+
+    Raises:
+        SystemExit: If Intel HEX data is empty or invalid
+    """
+    # Parse Intel HEX data
+    ih = IntelHex()
+    hex_io = io.StringIO(hex_data)
+    ih.loadhex(hex_io)
+
+    if len(ih) == 0:
+        print("Error: Intel HEX data is empty", file=sys.stderr)
+        sys.exit(1)
+
+    print("Halting CPU before flashing...")
+    trigger.jlink.halt()
+
+    # Flash each segment in the Intel HEX data
+    segments = ih.segments()
+    print(f"Found {len(segments)} segment(s) in Intel HEX data")
+
+    for i, (start_addr, end_addr) in enumerate(segments):
+        segment_size = end_addr - start_addr
+        print(
+            f"Flashing segment {i+1}/{len(segments)}: 0x{start_addr:08X} - 0x{end_addr-1:08X} ({segment_size} bytes)"
+        )
+
+        # Extract binary data for this segment
+        segment_data = ih.tobinarray(start=start_addr, end=end_addr - 1)
+
+        # Convert numpy array to list of bytes for pylink
+        data_bytes = list(segment_data.tobytes())
+
+        # Flash this segment
+        trigger.jlink.flash(data_bytes, addr=start_addr)
+        print(f"  Successfully flashed segment {i+1}")
+
+    print("All segments flashed successfully")
+
+
+def print_response_result(response_args: List[c.c_uint32]):
+    """Print the IPC response result to stdout in hex format"""
+    print("IPC Response:")
+    print("=============")
+
+    for i, arg in enumerate(response_args):
+        print(f"  arg[{i}]: 0x{arg.value:08X} ({arg.value})")
+
+    # Print as continuous hex string like generate_ironside_psa_ipc_request.py
+    hex_bytes = []
+    for arg in response_args:
+        # Convert each uint32 to 4 bytes in little endian format
+        byte_data = arg.value.to_bytes(4, byteorder="little")
+        hex_bytes.extend(byte_data)
+
+    if hex_bytes:
+        hex_string = binascii.hexlify(bytes(hex_bytes)).decode("utf-8").upper()
+        print(f"\nHex data: {hex_string}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Trigger IronSide IPC requests via JLink. Reads Intel HEX data from stdin if available.",
+        allow_abbrev=False,
+    )
+
+    parser.add_argument(
+        "serial_number", type=int, help="Serial number of the JLink device"
+    )
+
+    args = parser.parse_args()
+
+    trigger = IronSideIpcTrigger(args.serial_number)
+
+    # Check if there's data on stdin
+    if not sys.stdin.isatty():
+        print("Reading Intel HEX data from stdin...")
+        program_hex_data(trigger, sys.stdin.read())
+
+    response = trigger.trigger_and_read_response()
+    print_response_result(response)
+
+    trigger.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add new scripts that shows how to execute ironside IPC services from python. Specifically the psa_import_key and psa_generate_random calls are supported.

See commit message for testing instructions. Note that current IronSide SE version does not support psa_import_key so its expected to get an error message in status of the response (args[5])

Since memory reserved for ITS is defined by the local domains through the UICR you need to configure this to use ITS, program the following hex file to get this:

```
:020000040FFFEC
:10800000A82823BDA82823BDA82823BDA82823BDB0
:10801000A82823BDA82823BDA82823BDA82823BDA0
:10802000A82823BDA82823BDA82823BDA82823BD90
:10803000A82823BDA82823BDA82823BDA82823BD80
:10804000A82823BDA82823BDA82823BDA82823BD70
:10805000A82823BDA82823BDA82823BDA82823BD60
:10806000A82823BDA82823BDFFFFFFFF00E01A0EAC
:1080700000040000A82823BDA82823BDA82823BDEC
:00000001FF
```

Generated from:

```
[TEST.SECURESTORAGE.ENABLE]
ENABLE = "Enabled"

[TEST.SECURESTORAGE.ADDRESS]
ADDRESS = 0xE1B0000

[TEST.SECURESTORAGE.CRYPTO.APPLICATIONSIZE1KB]
SIZE1KB = 8

[TEST.SECURESTORAGE.CRYPTO.RADIOCORESIZE1KB]
SIZE1KB = 8

[TEST.SECURESTORAGE.ITS.APPLICATIONSIZE1KB]
SIZE1KB = 8

[TEST.SECURESTORAGE.ITS.RADIOCORESIZE1KB]
SIZE1KB = 8
```

Ref: NCSDK-33336