### PR TITLE
tests: subsys: bootloader: boot_chains: extend timeout

### DIFF
--- a/tests/subsys/bootloader/boot_chains/testcase.yaml
+++ b/tests/subsys/bootloader/boot_chains/testcase.yaml
@@ -7,6 +7,7 @@ common:
     - nrf54l15dk/nrf54l15/cpuapp
   tags:
     - ci_tests_subsys_bootloader
+  timeout: 240
   harness: console
   harness_config:
     type: one_line


### PR DESCRIPTION
Needed to erase ext flash.