### PR TITLE
samples: matter: Workaround for the KMU NOC key usage

### DIFF
--- a/samples/matter/common/src/app/matter_init.cpp
+++ b/samples/matter/common/src/app/matter_init.cpp
@@ -83,12 +83,11 @@ app::Clusters::NetworkCommissioning::InstanceAndDriver<NetworkCommissioning::Gen
 	sThreadNetworkDriver(0 /*endpointId*/);
 #endif
 
-#ifdef CONFIG_CHIP_CRYPTO_PSA
-chip::Crypto::PSAOperationalKeystore Nrf::Matter::InitData::sOperationalKeystoreDefault{};
-#endif
-
-#ifdef CONFIG_CHIP_STORE_KEYS_IN_KMU
+#if defined(CONFIG_CHIP_STORE_KEYS_IN_KMU)
+chip::DeviceLayer::KMUOperationalKeystore Nrf::Matter::InitData::sKMUOperationalKeystoreDefault{};
 chip::DeviceLayer::KMUSessionKeystore Nrf::Matter::InitData::sKMUSessionKeystoreDefault{};
+#elif defined(CONFIG_CHIP_CRYPTO_PSA)
+chip::Crypto::PSAOperationalKeystore Nrf::Matter::InitData::sOperationalKeystoreDefault{};
 #endif
 
 #ifdef CONFIG_CHIP_FACTORY_DATA
@@ -329,6 +328,7 @@ void DoInitChipServer(intptr_t /* unused */)
 	static KMUKeyAllocator kmuAllocator;
 	Crypto::SetPSAKeyAllocator(&kmuAllocator);
 	sLocalInitData.mServerInitParams->sessionKeystore = sLocalInitData.mSessionKeystore;
+	sLocalInitData.mServerInitParams->operationalKeystore = sLocalInitData.mOperationalKeyStore;
 #endif
 
 	VerifyOrReturn(sLocalInitData.mServerInitParams, LOG_ERR("No valid server initialization parameters"));

--- a/samples/matter/common/src/app/matter_init.h
+++ b/samples/matter/common/src/app/matter_init.h
@@ -20,12 +20,11 @@
 #include <platform/nrfconnect/wifi/NrfWiFiDriver.h>
 #endif
 
-#ifdef CONFIG_CHIP_CRYPTO_PSA
-#include <crypto/PSAOperationalKeystore.h>
-#endif
-
-#ifdef CONFIG_CHIP_STORE_KEYS_IN_KMU
+#if defined(CONFIG_CHIP_STORE_KEYS_IN_KMU)
+#include <platform/nrfconnect/KMUOperationalKeystore.h>
 #include <platform/nrfconnect/KMUSessionKeystore.h>
+#elif defined(CONFIG_CHIP_CRYPTO_PSA)
+#include <crypto/PSAOperationalKeystore.h>
 #endif
 
 #ifdef CONFIG_CHIP_FACTORY_DATA
@@ -60,14 +59,15 @@ struct InitData {
 	/** @brief Pointer to the user provided FactoryDataProvider implementation. */
 	chip::DeviceLayer::FactoryDataProviderBase *mFactoryDataProvider{ &sFactoryDataProviderDefault };
 #endif
-#ifdef CONFIG_CHIP_CRYPTO_PSA
+#if defined(CONFIG_CHIP_STORE_KEYS_IN_KMU)
 	/** @brief Pointer to the user provided OperationalKeystore implementation. */
-	chip::Crypto::OperationalKeystore *mOperationalKeyStore{ &sOperationalKeystoreDefault };
-#endif
-#ifdef CONFIG_CHIP_STORE_KEYS_IN_KMU
+	chip::Crypto::OperationalKeystore *mOperationalKeyStore{ &sKMUOperationalKeystoreDefault };
 	/** @brief Pointer to the user provided SessionKeystore implementation. */
 	chip::Crypto::SessionKeystore *mSessionKeystore{ &sKMUSessionKeystoreDefault };
-#endif
+#elif defined(CONFIG_CHIP_CRYPTO_PSA)
+	/** @brief Pointer to the user provided OperationalKeystore implementation. */
+	chip::Crypto::OperationalKeystore *mOperationalKeyStore{ &sOperationalKeystoreDefault };
+#endif //
 	/** @brief Custom code to execute in the Matter main event loop before the server initialization. */
 	CustomInit mPreServerInitClbk{ nullptr };
 	/** @brief Custom code to execute in the Matter main event loop after the server initialization. */
@@ -83,11 +83,11 @@ struct InitData {
 	static chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData>
 		sFactoryDataProviderDefault;
 #endif
-#ifdef CONFIG_CHIP_CRYPTO_PSA
-	static chip::Crypto::PSAOperationalKeystore sOperationalKeystoreDefault;
-#endif
-#ifdef CONFIG_CHIP_STORE_KEYS_IN_KMU
+#if defined(CONFIG_CHIP_STORE_KEYS_IN_KMU)
 	static chip::DeviceLayer::KMUSessionKeystore sKMUSessionKeystoreDefault;
+	static chip::DeviceLayer::KMUOperationalKeystore sKMUOperationalKeystoreDefault;
+#elif defined(CONFIG_CHIP_CRYPTO_PSA)
+	static chip::Crypto::PSAOperationalKeystore sOperationalKeystoreDefault;
 #endif
 	static chip::DeviceLayer::DeviceInfoProviderImpl sDeviceInfoProviderDefault;
 };

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: fe650a3ee4948ef1a2edd55a7fe4f6eb561c9e64
+      revision: pull/640/head
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Now, we copy the NOC key from volatile to persistent space during the commissioning OP keypair. Currently, psa_copy_key does not work for KMU, so we must export this key and import it again as a workaround. This PR is a workaround and can be fully reverted once the NCSDK-34997 issue is resolved.