### PR TITLE
applications: serial_lte_modem: Fix compilation without pins

### DIFF
--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -22,6 +22,46 @@ tests:
       - ci_build
       - sysbuild
       - ci_applications_serial_lte_modem
+  applications.serial_lte_modem_no_power_indicate:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_SLM_POWER_PIN=-1
+      - CONFIG_SLM_INDICATE_PIN=-1
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_serial_lte_modem
+  applications.serial_lte_modem_no_power:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_SLM_POWER_PIN=-1
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_serial_lte_modem
+  applications.serial_lte_modem_no_indicate:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_SLM_INDICATE_PIN=-1
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_serial_lte_modem
   applications.serial_lte_modem.extmcu:
     sysbuild: true
     build_only: true


### PR DESCRIPTION
Fix compilation errors without power or indicate pins configured, i.e., having them -1. This is regression from PR #22870. Also added these configurations into twister runs.

Jira: SLM-121