### PR TITLE
nrf_security: Add get TRNG function to Cracen driver

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa.h
@@ -365,4 +365,6 @@ psa_status_t cracen_derive_key(const psa_key_attributes_t *attributes, const uin
 			       size_t input_length, uint8_t *key, size_t key_size,
 			       size_t *key_length);
 
+psa_status_t cracen_get_trng(uint8_t *output, size_t output_size);
+
 #endif /* CRACEN_PSA_H */


### PR DESCRIPTION
Adds a function to get TRNG from the Cracen driver at the same file that we have the PRNG driver so that we can reuse the same mutex for PRNG and TRNG.

Ref: NCSDK-34036