### PR TITLE
[Backport v3.1-branch] applications: serial_lte_modem: Fix compilation without pins

### DIFF
--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -22,6 +22,46 @@ tests:
       - ci_build
       - sysbuild
       - ci_applications_serial_lte_modem
+  applications.serial_lte_modem_no_power_indicate:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_SLM_POWER_PIN=-1
+      - CONFIG_SLM_INDICATE_PIN=-1
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_serial_lte_modem
+  applications.serial_lte_modem_no_power:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_SLM_POWER_PIN=-1
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_serial_lte_modem
+  applications.serial_lte_modem_no_indicate:
+    sysbuild: true
+    build_only: true
+    extra_configs:
+      - CONFIG_SLM_INDICATE_PIN=-1
+    platform_allow:
+      - nrf9151dk/nrf9151/ns
+    integration_platforms:
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_applications_serial_lte_modem
   applications.serial_lte_modem.extmcu:
     sysbuild: true
     build_only: true


### PR DESCRIPTION
Backport 599a1788e1f3f84c5e017bc83ec431e5228b9987 from #24082.