### PR TITLE
doc: audio: usb macOS issue note in building doc

### DIFF
--- a/applications/nrf5340_audio/doc/building.rst
+++ b/applications/nrf5340_audio/doc/building.rst
@@ -19,7 +19,10 @@ You can build and program the applications in one of the following ways:
    Building and programming using the |nRFVSC| is currently not supported.
 
 .. note::
-   You might want to check the :ref:`nRF5340 Audio application known issues <known_issues_nrf5340audio>` before building and programming the applications.
+   Check the :ref:`nRF5340 Audio application known issues <known_issues_nrf5340audio>` before building and programming the applications.
+   Some of them might impact running the application on certain platforms.
+
+   For example, one of the known issues (OCT-2154) mentions intermittent audio stream on the headset when using USB audio interface on macOS.
 
 .. _nrf53_audio_app_dk_testing_out_of_the_box:
 


### PR DESCRIPTION
Mentioned USB-related macOS issue on Building and running Audio apps page. OCT-2378.