### PR TITLE
doc: install: update for latest VSC release

### DIFF
--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -227,7 +227,9 @@ For more information about the repository and development model, see the :ref:`d
       #. In the extension's :guilabel:`Welcome View`, click on :guilabel:`Manage SDKs`.
          The list of actions appears in the |VSC|'s quick pick.
       #. Click :guilabel:`Install SDK`.
-         The list of available stable SDK versions appears in the |VSC|'s quick pick, grouped into two categories:
+         The list of available SDK types appears.
+      #. Select the SDK type to install.
+         The list of available stable SDK versions for the selected SDK type appears in the |VSC|'s quick pick, grouped into two categories:
 
          * Pre-packaged SDKs - Bundled by Nordic Semiconductor.
            Available mostly for stable releases and some preview tags.

--- a/doc/nrf/installation/updating.rst
+++ b/doc/nrf/installation/updating.rst
@@ -34,8 +34,8 @@ Depending on your preferred development method, you can start the correct CLI to
 
    .. group-tab:: nRF Connect for Visual Studio Code
 
-      Start the nRF Connect terminal profile from the :guilabel:`Panel View`.
-      See `the extension documentation <nRF Terminal documentation_>`_ for more information.
+      Start the nRF Connect terminal profile from the :guilabel:`Welcome View` (:guilabel:`Open terminal` action) or the :guilabel:`Panel View`.
+      See `How to use nRF Connect terminal profile`_ in the extension documentation for more information.
 
       .. note::
           Repositories and tools can be updated in the |nRFVSC| using GUI.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1013,6 +1013,7 @@
 .. _`Create a new application`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_sidebar_welcome.html#create-a-new-application
 .. _`Browse samples`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_sidebar_welcome.html#browse-samples
 .. _`nRF Terminal documentation`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_panel.html#nrf-connect-and-nrf-terminal-profiles
+.. _`How to use nRF Connect terminal profile`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/extension_nrfconnect_profile.html
 .. _`switch to the pre-release version of the extension`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/rel_notes_overview.html#switching-to-a-pre-release-version
 .. _`How to work with sysbuild domains`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/build_multi_domain.html
 


### PR DESCRIPTION
Updated install_ncs.rst and updating.rst for the latest VSC release. install_ncs.rst now mentions the step to select the SDK type. updating.rst mentions Open terminal in Welcome View.