### PR TITLE
doc: release-notes-changelog: nRF54LM20 support in Coremark and Fast Pair

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -250,7 +250,7 @@ Bluetooth Mesh samples
 Bluetooth Fast Pair samples
 ---------------------------
 
-|no_changes_yet_note|
+* Added experimental support for the :zephyr:board:`nrf54lm20dk` board in all Fast Pair samples.
 
 Cellular samples
 ----------------
@@ -360,7 +360,9 @@ Wi-Fi samples
 Other samples
 -------------
 
-|no_changes_yet_note|
+* :ref:`coremark_sample` sample:
+
+  * Added support for the :zephyr:board:`nrf54lm20dk` board target.
 
 Drivers
 =======


### PR DESCRIPTION
Mentions addition of nRF54LM20 support in Coremark and Fast Pair samples.

Jira: NCSDK-34262
Jira: NCSDK-35011