### PR TITLE
samples: log_rpc_shell: print history usage thr

### DIFF
--- a/samples/nrf_rpc/protocols_serialization/client/src/log_rpc_shell.c
+++ b/samples/nrf_rpc/protocols_serialization/client/src/log_rpc_shell.c
@@ -141,6 +141,7 @@ static int cmd_log_rpc_history_threshold(const struct shell *sh, size_t argc, ch
 
 	shell = sh;
 	log_rpc_set_history_usage_threshold(history_threshold_reached_handler, (uint8_t)threshold);
+	shell_print(sh, "%u", log_rpc_get_history_usage_threshold());
 
 	return 0;
 }


### PR DESCRIPTION
Added a shell print statement to display the current history usage threshold after it is set in the log_rpc_history_threshold command. The change is required for test purposes.