### PR TITLE
[Backport v3.1-branch] snippet: nrf91-modem-trace-uart: Support TPM530M SOC

### DIFF
--- a/snippets/nrf91-modem-trace-uart/snippet.yml
+++ b/snippets/nrf91-modem-trace-uart/snippet.yml
@@ -3,6 +3,10 @@ append:
   EXTRA_CONF_FILE: modem-trace-uart-common.conf
 
 boards:
+  /.*/tpm530m/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: modem-trace-uart-nrf91.overlay
+      EXTRA_CONF_FILE: modem-trace-uart-nrf91.conf
   /.*/nrf91[0-9][0-9]/.*/:
     append:
       EXTRA_DTC_OVERLAY_FILE: modem-trace-uart-nrf91.overlay


### PR DESCRIPTION
Backport 22555da99cfb629700e7499de485f4ab7570146c from #23693.