### PR TITLE
boards: shields: coverage_support: extend app code partition at h20

### DIFF
--- a/boards/shields/coverage_support/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/boards/shields/coverage_support/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -7,3 +7,18 @@
 &uart136 {
 	hw-flow-control;
 };
+
+/* Extend by 160 KB, taken from rad */
+&cpuapp_slot0_partition {
+	reg = <0x40000 DT_SIZE_K(488)>;
+};
+
+/* Shrink by 160 KB */
+/delete-node/ &cpurad_slot0_partition;
+&mram1x {
+	partitions {
+		cpurad_slot0_partition: partition@BA000 {
+			reg = <0xBA000 DT_SIZE_K(168)>;
+		};
+	};
+};

--- a/boards/shields/coverage_support/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/boards/shields/coverage_support/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -5,11 +5,11 @@
  */
 
 /* Shrink by 160 KB */
-&cpurad_slot0_partition {
-	reg = <0x54000 DT_SIZE_K(96)>;
-};
-
-/* To disable SDFW_SERVICES to save RAM */
-&cpusec_cpurad_ipc {
-	status = "disabled";
+/delete-node/ &cpurad_slot0_partition;
+&mram1x {
+	partitions {
+		cpurad_slot0_partition: partition@BA000 {
+			reg = <0xBA000 DT_SIZE_K(168)>;
+		};
+	};
 };


### PR DESCRIPTION
Still needed but removed during IRON integration.