### PR TITLE
[Backport v3.1-branch] doc: fast_pair: Describe nRF54LM20 support

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -2275,8 +2275,10 @@ The following table indicates the software maturity levels of the support for Go
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LM20
             * - **Input device**
               - :ref:`fast_pair_input_device`
+              - Experimental
               - Experimental
               - Experimental
               - Experimental
@@ -2287,6 +2289,7 @@ The following table indicates the software maturity levels of the support for Go
               - Supported
               - Supported
               - Supported
+              - Experimental
       .. tab:: nRF91 Series
 
          .. list-table:: Google Fast Pair use case support
@@ -2397,12 +2400,15 @@ The following table indicates the software maturity levels of the support for ea
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LM20
             * - **Initial pairing**
               - Experimental
               - Supported
               - Supported
               - Supported
+              - Experimental
             * - **Subsequent pairing**
+              - Experimental
               - Experimental
               - Experimental
               - Experimental
@@ -2412,7 +2418,9 @@ The following table indicates the software maturity levels of the support for ea
               - Experimental
               - Experimental
               - Experimental
+              - Experimental
             * - **Personalized Name extension**
+              - Experimental
               - Experimental
               - Experimental
               - Experimental
@@ -2422,6 +2430,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - Experimental
       .. tab:: nRF91 Series
 
          .. list-table:: Google Fast Pair feature support

--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -194,6 +194,7 @@ The configuration of the DFU solution varies depending on the board target:
 |              |                                | * ``nrf54l15dk/nrf54l05/cpuapp`` (only ``release`` configuration) |
 |              |                                | * ``nrf54l15dk/nrf54l10/cpuapp``                                  |
 |              |                                | * ``nrf54l15dk/nrf54l15/cpuapp``                                  |
+|              |                                | * ``nrf54lm20dk/nrf54lm20a/cpuapp``                               |
 +--------------+--------------------------------+-------------------------------------------------------------------+
 | MCUboot      | overwrite only mode            | * ``nrf5340dk/nrf5340/cpuapp``                                    |
 |              |                                | * ``nrf5340dk/nrf5340/cpuapp/ns``                                 |
@@ -231,6 +232,7 @@ The configuration of the signature algorithm and the public key storage solution
 | ED25519                        | * ``nrf54l15dk/nrf54l05/cpuapp`` (only ``release`` configuration) | Key Management Unit (KMU) | HW-accelerated (CRACEN),  |
 |                                | * ``nrf54l15dk/nrf54l10/cpuapp``                                  |                           | Signature derived from    |
 |                                | * ``nrf54l15dk/nrf54l15/cpuapp``                                  |                           | image (pure)              |
+|                                | * ``nrf54lm20dk/nrf54lm20a/cpuapp``                               |                           |                           |
 +--------------------------------+-------------------------------------------------------------------+---------------------------+---------------------------+
 
 .. note::


### PR DESCRIPTION
Backport ef853d886a5c7d7bb9b196f937d48121ad2449ac from #24110.