### PR TITLE
[Backport v3.1-branch] tests: benchmarks: power_consumption: lpcomp: Fix test

### DIFF
--- a/tests/benchmarks/power_consumption/lpcomp/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/benchmarks/power_consumption/lpcomp/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -27,4 +27,5 @@
 	psel = "AIN2"; /* P1.02 */
 	refsel = "VDD_4_8";
 	status = "okay";
+	zephyr,pm-device-runtime-auto;
 };

--- a/tests/benchmarks/power_consumption/lpcomp/src/driver_test.c
+++ b/tests/benchmarks/power_consumption/lpcomp/src/driver_test.c
@@ -7,6 +7,7 @@
 #include <zephyr/drivers/comparator.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/kernel.h>
+#include <zephyr/pm/device_runtime.h>
 
 static const struct device *test_dev = DEVICE_DT_GET(DT_ALIAS(test_comp));
 static const struct gpio_dt_spec test_pin = GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), test_gpios);
@@ -15,6 +16,10 @@ volatile int counter;
 
 static void test_callback(const struct device *dev, void *user_data)
 {
+	int rc;
+
+	rc = pm_device_runtime_put(dev);
+	__ASSERT_NO_MSG(rc == 0);
 	counter++;
 }
 
@@ -32,10 +37,17 @@ void thread_definition(void)
 	k_msleep(10);
 
 	while (1) {
+		rc = pm_device_runtime_get(test_dev);
+		__ASSERT_NO_MSG(rc == 0);
+		k_busy_wait(100);
 		counter = 0;
 		gpio_pin_set_dt(&test_pin, 1);
 		k_msleep(10);
 		__ASSERT_NO_MSG(counter == 1);
+
+		rc = pm_device_runtime_get(test_dev);
+		__ASSERT_NO_MSG(rc == 0);
+		k_busy_wait(100);
 		gpio_pin_set_dt(&test_pin, 0);
 		k_msleep(10);
 		__ASSERT_NO_MSG(counter == 2);


### PR DESCRIPTION
Backport 9548019a7662b1678777d4e88fb0bb877846d95e from #24092.