### PR TITLE
[Backport v3.1-branch] nrf_security: Moving block_cipher.c to libmbedcrypto

### DIFF
--- a/subsys/nrf_security/src/CMakeLists.txt
+++ b/subsys/nrf_security/src/CMakeLists.txt
@@ -117,7 +117,6 @@ append_with_prefix(src_crypto_base ${ARM_MBEDTLS_PATH}/library
   base64.c
   bignum.c
   bignum_core.c
-  block_cipher.c
   nist_kw.c
   oid.c
   padlock.c

--- a/subsys/nrf_security/src/legacy/CMakeLists.txt
+++ b/subsys/nrf_security/src/legacy/CMakeLists.txt
@@ -24,6 +24,7 @@ if(CONFIG_MBEDTLS_LEGACY_CRYPTO_C OR
   CONFIG_PSA_CRYPTO_DRIVER_OBERON OR
   CONFIG_PSA_CRYPTO_DRIVER_CRACEN)
   append_with_prefix(src_crypto_legacy ${ARM_MBEDTLS_PATH}/library
+    block_cipher.c
     aes.c
     cmac.c
     ccm.c


### PR DESCRIPTION
Backport 4dca821cd51b3b34440cc30e765f86e38bce27b1 from #24053.