### PR TITLE
manifest: Backport Bluetooth Host key destroy fix.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c0e99cb7578cdd18e9370af2043de091e134cb71
+      revision: pull/3222/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Backport key destroy fix in Bluetooth Host Gatt to 3.1.