### PR TITLE
net: openthread: rpc: allocate minimal buffer for read

### DIFF
--- a/subsys/net/openthread/rpc/server/ot_rpc_message.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_message.c
@@ -24,25 +24,25 @@ OT_RPC_RESOURCE_TABLE_REGISTER(msg, otMessage, CONFIG_OPENTHREAD_RPC_MESSAGE_POO
 static void ot_rpc_msg_free(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
 			    void *handler_data)
 {
-	ot_rpc_res_tab_key key = 0;
+	ot_rpc_res_tab_key key;
 	otMessage *message;
 
 	key = nrf_rpc_decode_uint(ctx);
+
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_FREE);
 		return;
 	}
 
+	ot_rpc_mutex_lock();
 	message = ot_res_tab_msg_get(key);
 
 	if (message != NULL) {
-		ot_rpc_mutex_lock();
 		otMessageFree(message);
-		ot_rpc_mutex_unlock();
+		ot_res_tab_msg_free(key);
 	}
 
-	ot_res_tab_msg_free(key);
-
+	ot_rpc_mutex_unlock();
 	nrf_rpc_rsp_send_void(group);
 }
 
@@ -50,7 +50,6 @@ static void ot_rpc_msg_append(const struct nrf_rpc_group *group, struct nrf_rpc_
 			      void *handler_data)
 {
 	otError error = OT_ERROR_INVALID_ARGS;
-	struct nrf_rpc_cbor_ctx rsp_ctx;
 	uint32_t key;
 	const void *data;
 	size_t size = 0;
@@ -59,14 +58,15 @@ static void ot_rpc_msg_append(const struct nrf_rpc_group *group, struct nrf_rpc_
 	key = nrf_rpc_decode_uint(ctx);
 	data = nrf_rpc_decode_buffer_ptr_and_size(ctx, &size);
 
-	if (data && size && nrf_rpc_decode_valid(ctx)) {
+	if (data) {
+		ot_rpc_mutex_lock();
 		message = ot_res_tab_msg_get(key);
 
 		if (message != NULL) {
-			ot_rpc_mutex_lock();
 			error = otMessageAppend(message, data, size);
-			ot_rpc_mutex_unlock();
 		}
+
+		ot_rpc_mutex_unlock();
 	}
 
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
@@ -74,16 +74,13 @@ static void ot_rpc_msg_append(const struct nrf_rpc_group *group, struct nrf_rpc_
 		return;
 	}
 
-	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(otError) + 1);
-	nrf_rpc_encode_uint(&rsp_ctx, error);
-	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
+	nrf_rpc_rsp_send_uint(group, error);
 }
 
 static void ot_rpc_msg_udp_new(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
 			       void *handler_data)
 {
 	ot_rpc_res_tab_key key;
-	struct nrf_rpc_cbor_ctx rsp_ctx;
 	otMessageSettings settings;
 	otMessageSettings *p_settings = &settings;
 
@@ -96,122 +93,114 @@ static void ot_rpc_msg_udp_new(const struct nrf_rpc_group *group, struct nrf_rpc
 
 	ot_rpc_mutex_lock();
 	key = ot_res_tab_msg_alloc(otUdpNewMessage(openthread_get_default_instance(), p_settings));
-	ot_rpc_mutex_unlock();
 
 	if (ot_res_tab_msg_get(key) == NULL) {
 		key = 0;
 	}
 
-	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(key) + 1);
-	nrf_rpc_encode_uint(&rsp_ctx, key);
-	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
+	ot_rpc_mutex_unlock();
+	nrf_rpc_rsp_send_uint(group, key);
 }
 
 static void ot_rpc_msg_length(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
 			      void *handler_data)
 {
 	ot_rpc_res_tab_key key;
-	struct nrf_rpc_cbor_ctx rsp_ctx;
 	uint16_t length = 0;
 	otMessage *message;
 
 	key = nrf_rpc_decode_uint(ctx);
+
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_GET_LENGTH);
 		return;
 	}
 
+	ot_rpc_mutex_lock();
 	message = ot_res_tab_msg_get(key);
 
 	if (message != NULL) {
-		ot_rpc_mutex_lock();
 		length = otMessageGetLength(message);
-		ot_rpc_mutex_unlock();
 	}
 
-	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(length) + 1);
-	nrf_rpc_encode_uint(&rsp_ctx, length);
-	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
+	ot_rpc_mutex_unlock();
+	nrf_rpc_rsp_send_uint(group, length);
 }
 
 static void ot_rpc_get_offset(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
 			      void *handler_data)
 {
 	ot_rpc_res_tab_key key;
-	struct nrf_rpc_cbor_ctx rsp_ctx;
 	uint16_t offset = 0;
 	otMessage *message;
 
 	key = nrf_rpc_decode_uint(ctx);
+
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_GET_OFFSET);
 		return;
 	}
 
+	ot_rpc_mutex_lock();
 	message = ot_res_tab_msg_get(key);
 
 	if (message != NULL) {
-		ot_rpc_mutex_lock();
 		offset = otMessageGetOffset(message);
-		ot_rpc_mutex_unlock();
 	}
 
-	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, sizeof(offset) + 1);
-	nrf_rpc_encode_uint(&rsp_ctx, offset);
-	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
+	ot_rpc_mutex_unlock();
+	nrf_rpc_rsp_send_uint(group, offset);
 }
 
 static void ot_rpc_msg_read(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
 			    void *handler_data)
 {
+	ot_rpc_res_tab_key key;
 	uint16_t offset;
 	uint16_t length;
-	ot_rpc_res_tab_key key;
-	struct nrf_rpc_cbor_ctx rsp_ctx;
-	const uint16_t chunk_size = 64;
-	uint8_t buf[chunk_size];
-	uint16_t read = 0;
 	otMessage *message;
+	struct nrf_rpc_cbor_ctx rsp_ctx;
+	uint16_t message_length;
+	uint16_t read = 0;
 
 	key = nrf_rpc_decode_uint(ctx);
 	offset = nrf_rpc_decode_uint(ctx);
 	length = nrf_rpc_decode_uint(ctx);
+
 	if (!nrf_rpc_decoding_done_and_check(group, ctx)) {
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_READ);
 		return;
 	}
 
-	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, length + 2);
-
+	ot_rpc_mutex_lock();
 	message = ot_res_tab_msg_get(key);
 
 	if (message == NULL) {
+		NRF_RPC_CBOR_ALLOC(group, rsp_ctx, 1);
 		nrf_rpc_encode_null(&rsp_ctx);
 		goto exit;
 	}
+
+	/* Get the actual message size before reading to allocate as small buffer as necessary. */
+	message_length = otMessageGetLength(message);
+	offset = MIN(offset, message_length);
+	length = MIN(length, message_length - offset);
+
+	NRF_RPC_CBOR_ALLOC(group, rsp_ctx, length + 3);
 
 	if (!zcbor_bstr_start_encode(rsp_ctx.zs)) {
 		goto exit;
 	}
 
-	ot_rpc_mutex_lock();
-
-	do {
-		read = otMessageRead(message, offset, buf,
-				     (chunk_size < length) ? chunk_size : length);
-		memcpy(rsp_ctx.zs[0].payload_mut, buf, read);
-		rsp_ctx.zs->payload_mut += read;
-		length -= read;
-		offset += read;
-	} while (read > 0 && length > 0);
-
-	ot_rpc_mutex_unlock();
+	read = otMessageRead(message, offset, rsp_ctx.zs->payload_mut, length);
+	rsp_ctx.zs->payload_mut += read;
 
 	if (!zcbor_bstr_end_encode(rsp_ctx.zs, NULL)) {
 		goto exit;
 	}
 
 exit:
+	ot_rpc_mutex_unlock();
 	nrf_rpc_cbor_rsp_no_err(group, &rsp_ctx);
 }
 
@@ -232,14 +221,15 @@ static void ot_rpc_msg_get_thread_link_info(const struct nrf_rpc_group *group,
 		return;
 	}
 
+	ot_rpc_mutex_lock();
 	message = ot_res_tab_msg_get(key);
 
 	if (!message) {
+		ot_rpc_mutex_unlock();
 		ot_rpc_report_cmd_decoding_error(OT_RPC_CMD_MESSAGE_GET_THREAD_LINK_INFO);
 		return;
 	}
 
-	ot_rpc_mutex_lock();
 	error = otMessageGetThreadLinkInfo(message, &link_info);
 	ot_rpc_mutex_unlock();
 

--- a/tests/subsys/net/openthread/rpc/common/test_rpc_env.h
+++ b/tests/subsys/net/openthread/rpc/common/test_rpc_env.h
@@ -20,9 +20,17 @@
 /* for value bigger than 0x17 */
 #define CBOR_UINT8(value)  0x18, (value)
 
-#define CBOR_LIST(...) 0x9F, __VA_ARGS__, 0xFF
-#define CBOR_EMPTY_BYTES 0x40
-#define CBOR_EMPTY_STRING 0x60
+#define CBOR_INT64(value) 0x3B, BT_BYTES_LIST_LE64(BSWAP_64(-1 - value))
+#define CBOR_INT32(value) 0x3A, BT_BYTES_LIST_LE32(BSWAP_32(-1 - value))
+#define CBOR_INT16(value) 0x39, BT_BYTES_LIST_LE16(BSWAP_16(-1 - value))
+/* for value smaller than -0x17 */
+#define CBOR_INT8(value)  0x38, (-1 - value)
+
+#define CBOR_LIST(...)	      0x9F __VA_OPT__(,) __VA_ARGS__, 0xFF
+#define CBOR_BSTR16(len, ...) (0x40 | 25), BT_BYTES_LIST_BE16(len) __VA_OPT__(,) __VA_ARGS__
+#define CBOR_BSTR8(len, ...)  (0x40 | 24), len __VA_OPT__(,) __VA_ARGS__
+#define CBOR_BSTR(len, ...)   (0x40 | len) __VA_OPT__(,) __VA_ARGS__
+#define CBOR_EMPTY_STRING     0x60
 
 /* Macros for constructing nRF RPC packets for the OpenThread command group. */
 

--- a/tests/subsys/net/openthread/rpc/server/src/coap_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/coap_suite.c
@@ -53,11 +53,6 @@ FAKE_VALUE_FUNC(otError, otCoapSendResponseWithParameters, otInstance *, otMessa
 		const otMessageInfo *, const otCoapTxParameters *);
 
 #define FOREACH_FAKE(f)                                                                            \
-	f(otMessageGetLength);                                                                     \
-	f(otMessageGetOffset);                                                                     \
-	f(otMessageRead);                                                                          \
-	f(otMessageFree);                                                                          \
-	f(otMessageAppend);                                                                        \
 	f(otCoapNewMessage);                                                                       \
 	f(otCoapMessageInit);                                                                      \
 	f(otCoapMessageInitResponse);                                                              \
@@ -89,8 +84,11 @@ static void tc_setup(void *f)
 
 	FOREACH_FAKE(RESET_FAKE);
 	FFF_RESET_HISTORY();
+}
 
-	/* Unit tests take up to two message slots. */
+static void tc_cleanup(void *f)
+{
+	/* This suite uses two messages at most. */
 	ot_res_tab_msg_free(1);
 	ot_res_tab_msg_free(2);
 }
@@ -576,4 +574,4 @@ ZTEST(ot_rpc_coap, test_otCoapSendResponse_failed)
 	zassert_not_null(ot_res_tab_msg_get(message_rep));
 }
 
-ZTEST_SUITE(ot_rpc_coap, NULL, NULL, tc_setup, NULL, NULL);
+ZTEST_SUITE(ot_rpc_coap, NULL, NULL, tc_setup, tc_cleanup, NULL);

--- a/tests/subsys/net/openthread/rpc/server/src/common_fakes.c
+++ b/tests/subsys/net/openthread/rpc/server/src/common_fakes.c
@@ -14,3 +14,5 @@ DEFINE_FAKE_VOID_FUNC(otMessageFree, otMessage *);
 DEFINE_FAKE_VALUE_FUNC(otError, otMessageAppend, otMessage *, const void *, uint16_t);
 DEFINE_FAKE_VALUE_FUNC(otMessage *, otUdpNewMessage, otInstance *, const otMessageSettings *);
 DEFINE_FAKE_VALUE_FUNC(void *, nrf_rpc_cbkproxy_out_get, int, void *);
+DEFINE_FAKE_VOID_FUNC(otCliInit, otInstance *, otCliOutputCallback, void *);
+DEFINE_FAKE_VOID_FUNC(otCliInputLine, char *);

--- a/tests/subsys/net/openthread/rpc/server/src/common_fakes.h
+++ b/tests/subsys/net/openthread/rpc/server/src/common_fakes.h
@@ -6,7 +6,9 @@
 
 #ifndef __COMMON_FAKES_H__
 #define __COMMON_FAKES_H__
+
 #include <zephyr/fff.h>
+#include <openthread/cli.h>
 #include <openthread/message.h>
 
 DECLARE_FAKE_VALUE_FUNC(otMessage *, otUdpNewMessage, otInstance *, const otMessageSettings *);
@@ -17,5 +19,7 @@ DECLARE_FAKE_VALUE_FUNC(uint16_t, otMessageRead, const otMessage *, uint16_t, vo
 DECLARE_FAKE_VOID_FUNC(otMessageFree, otMessage *);
 DECLARE_FAKE_VALUE_FUNC(otError, otMessageAppend, otMessage *, const void *, uint16_t);
 DECLARE_FAKE_VALUE_FUNC(void *, nrf_rpc_cbkproxy_out_get, int, void *);
+DECLARE_FAKE_VOID_FUNC(otCliInit, otInstance *, otCliOutputCallback, void *);
+DECLARE_FAKE_VOID_FUNC(otCliInputLine, char *);
 
 #endif

--- a/tests/subsys/net/openthread/rpc/server/src/ip6_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/ip6_suite.c
@@ -20,8 +20,6 @@
 /* Fake functions */
 
 DEFINE_FFF_GLOBALS;
-FAKE_VOID_FUNC(otCliInit, otInstance *, otCliOutputCallback, void *);
-FAKE_VOID_FUNC(otCliInputLine, char *);
 FAKE_VALUE_FUNC(const otNetifAddress *, otIp6GetUnicastAddresses, otInstance *);
 FAKE_VALUE_FUNC(const otNetifMulticastAddress *, otIp6GetMulticastAddresses, otInstance *);
 FAKE_VALUE_FUNC(otError, otIp6SubscribeMulticastAddress, otInstance *, const otIp6Address *);
@@ -30,8 +28,6 @@ FAKE_VALUE_FUNC(otError, otIp6SetEnabled, otInstance *, bool);
 FAKE_VALUE_FUNC(bool, otIp6IsEnabled, otInstance *);
 
 #define FOREACH_FAKE(f)                                                                            \
-	f(otCliInit);                                                                              \
-	f(otCliInputLine);                                                                         \
 	f(otIp6GetUnicastAddresses);                                                               \
 	f(otIp6GetMulticastAddresses);                                                             \
 	f(otIp6SubscribeMulticastAddress);                                                         \
@@ -233,6 +229,9 @@ ZTEST(ot_rpc_ip6, test_otIp6UnsubscribeMulticastAddress_failed)
 
 /*
  * Test reception of otIp6GetUnicastAddresses() command.
+ * Test serialization of the result:
+ * - fe80:aabb:aabb:aabb:aabb:aabb:aabb:aa01
+ * - fe80:aabb:aabb:aabb:aabb:aabb:aabb:aa02
  */
 ZTEST(ot_rpc_ip6, test_otIp6GetUnicastAddresses)
 {
@@ -278,6 +277,9 @@ ZTEST(ot_rpc_ip6, test_otIp6GetUnicastAddresses)
 
 /*
  * Test reception of otIp6GetMulticastAddresses() command.
+ * Test serialization of the result:
+ * - fe02::1
+ * - fe02::2
  */
 ZTEST(ot_rpc_ip6, test_otIp6GetMulticastAddresses)
 {

--- a/tests/subsys/net/openthread/rpc/server/src/message_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/message_suite.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include "common_fakes.h"
+
 #include <mock_nrf_rpc_transport.h>
 #include <ot_rpc_ids.h>
 #include <ot_rpc_lock.h>
@@ -15,17 +17,14 @@
 #include <zephyr/ztest.h>
 
 #include <openthread/message.h>
-#include "common_fakes.h"
-#include "zephyr/ztest_assert.h"
-#include <assert.h>
-#include <stddef.h>
-#include <stdint.h>
 
 /* Message address used when testing serialization of a function that takes otMessage* */
 #define MSG_ADDR UINT32_MAX
 
 /* Message TX callback ID */
 #define MSG_TX_CB_ID (UINT32_MAX - 1)
+
+#define LONG_BSTR_LEN 256
 
 FAKE_VOID_FUNC(otMessageRegisterTxCallback, otMessage *, otMessageTxCallback, void *);
 
@@ -52,6 +51,12 @@ static void tc_setup(void *f)
 
 	FOREACH_FAKE(RESET_FAKE);
 	FFF_RESET_HISTORY();
+}
+
+static void tc_cleanup(void *f)
+{
+	/* This suite uses one message at most. */
+	ot_res_tab_msg_free(1);
 }
 
 static otMessage *udp_new_message_failed_fake(otInstance *instance,
@@ -126,68 +131,286 @@ ZTEST(ot_rpc_message, test_otUdpNewMessage_free_working)
 	zassert_equal(otMessageFree_fake.call_count, 2);
 }
 
-ZTEST(ot_rpc_message, test_ot_res_tab_msg_alloc_free)
+/*
+ * Test ot_res_tab_msg functions.
+ */
+ZTEST(ot_rpc_message, test_ot_res_tab_msg)
 {
-
-	for (size_t i = 1; i < CONFIG_OPENTHREAD_RPC_MESSAGE_POOL + 1; i++) {
-		zassert_equal(ot_res_tab_msg_alloc((otMessage *)i), i);
+	/* Verify that the configured number of messages can be allocated. */
+	for (size_t i = 0; i < CONFIG_OPENTHREAD_RPC_MESSAGE_POOL; i++) {
+		zassert_equal(ot_res_tab_msg_alloc((otMessage *)(MSG_ADDR - i)), i + 1);
 	}
 
-	zassert_equal(ot_res_tab_msg_alloc((otMessage *)UINT32_MAX), 0);
+	/* Verify that no more messages can be allocated. */
+	zassert_equal(
+		ot_res_tab_msg_alloc((otMessage *)(MSG_ADDR - CONFIG_OPENTHREAD_RPC_MESSAGE_POOL)),
+		0);
 
-	for (size_t i = 1; i < CONFIG_OPENTHREAD_RPC_MESSAGE_POOL + 1; i++) {
-		ot_res_tab_msg_free(i);
+	/* Verify that all allocated messages can be retrieved. */
+	for (size_t i = 0; i < CONFIG_OPENTHREAD_RPC_MESSAGE_POOL; i++) {
+		zassert_equal(ot_res_tab_msg_get(i + 1), (otMessage *)(MSG_ADDR - i));
+	}
+
+	/* Verify that out-of-range keys return NULL. */
+	zassert_is_null(ot_res_tab_msg_get(0));
+	zassert_is_null(ot_res_tab_msg_get(CONFIG_OPENTHREAD_RPC_MESSAGE_POOL + 1));
+
+	/* Free all messages and verify they can no longer be retrieved. */
+	for (size_t i = 0; i < CONFIG_OPENTHREAD_RPC_MESSAGE_POOL; i++) {
+		ot_res_tab_msg_free(i + 1);
+		zassert_is_null(ot_res_tab_msg_get(i + 1));
 	}
 }
 
-ZTEST(ot_rpc_message, test_ot_res_tab_msg_get)
+/*
+ * Test reception of otMessageGetOffset().
+ * Test serialization of the result: 0 and 0xffff
+ */
+ZTEST(ot_rpc_message, test_otMessageGetOffset)
 {
+	otMessage *msg = (otMessage *)MSG_ADDR;
+	ot_rpc_res_tab_key msg_key = ot_res_tab_msg_alloc(msg);
 
-	zassert_equal(ot_res_tab_msg_alloc((otMessage *)1), 1);
-
-	zassert_equal(ot_res_tab_msg_get(1), (otMessage *)1);
-
-	zassert_equal(ot_res_tab_msg_get(CONFIG_OPENTHREAD_RPC_MESSAGE_POOL), NULL);
-
-	ot_res_tab_msg_free(1);
-}
-
-ZTEST(ot_rpc_message, test_get_length_offset)
-{
-	otUdpNewMessage_fake.return_val = (otMessage *)1;
-	otMessageGetLength_fake.return_val = 1;
-	otMessageGetOffset_fake.return_val = 1;
-
-	mock_nrf_rpc_tr_expect_add(RPC_RSP(1), NO_RSP);
-	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_UDP_NEW_MESSAGE, CBOR_NULL));
-
-	zassert_equal(otUdpNewMessage_fake.call_count, 1);
-	zassert_is_null(otUdpNewMessage_fake.arg1_val);
-
-	mock_nrf_rpc_tr_expect_add(RPC_RSP(1), NO_RSP);
-	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_MESSAGE_GET_LENGTH, 1));
-
-	zassert_equal(otMessageGetLength_fake.arg0_val, (otMessage *)1);
-
-	mock_nrf_rpc_tr_expect_add(RPC_RSP(1), NO_RSP);
-	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_MESSAGE_GET_OFFSET, 1));
-
-	zassert_equal(otMessageGetOffset_fake.arg0_val, (otMessage *)1);
+	otMessageGetOffset_fake.return_val = 0;
 
 	mock_nrf_rpc_tr_expect_add(RPC_RSP(0), NO_RSP);
-	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_MESSAGE_GET_LENGTH, 0));
+	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_MESSAGE_GET_OFFSET, msg_key));
 
-	mock_nrf_rpc_tr_expect_add(RPC_RSP(), NO_RSP);
-	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_MESSAGE_FREE, 1));
+	zassert_equal(otMessageGetOffset_fake.call_count, 1);
+	zassert_equal(otMessageGetOffset_fake.arg0_val, msg);
 
-	zassert_equal(otMessageFree_fake.arg0_val, (otMessage *)1);
+	otMessageGetOffset_fake.return_val = UINT16_MAX;
 
-	mock_nrf_rpc_tr_expect_done();
+	mock_nrf_rpc_tr_expect_add(RPC_RSP(CBOR_UINT16(UINT16_MAX)), NO_RSP);
+	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_MESSAGE_GET_OFFSET, msg_key));
 
-	zassert_equal(otMessageGetLength_fake.call_count, 1);
-	zassert_equal(otMessageFree_fake.call_count, 1);
+	zassert_equal(otMessageGetOffset_fake.call_count, 2);
+	zassert_equal(otMessageGetOffset_fake.arg0_val, msg);
 }
 
+/*
+ * Test reception of otMessageGetLength().
+ * Test serialization of the result: 0 and 0xffff
+ */
+ZTEST(ot_rpc_message, test_otMessageGetLength)
+{
+	otMessage *msg = (otMessage *)MSG_ADDR;
+	ot_rpc_res_tab_key msg_key = ot_res_tab_msg_alloc(msg);
+
+	otMessageGetLength_fake.return_val = 0;
+
+	mock_nrf_rpc_tr_expect_add(RPC_RSP(0), NO_RSP);
+	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_MESSAGE_GET_LENGTH, msg_key));
+
+	zassert_equal(otMessageGetLength_fake.call_count, 1);
+	zassert_equal(otMessageGetLength_fake.arg0_val, msg);
+
+	otMessageGetLength_fake.return_val = UINT16_MAX;
+
+	mock_nrf_rpc_tr_expect_add(RPC_RSP(CBOR_UINT16(UINT16_MAX)), NO_RSP);
+	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_MESSAGE_GET_LENGTH, msg_key));
+
+	zassert_equal(otMessageGetLength_fake.call_count, 2);
+	zassert_equal(otMessageGetLength_fake.arg0_val, msg);
+}
+
+/*
+ * Test reception of otMessageGetThreadLinkInfo().
+ * Test serialization of the result: OT_ERROR_NONE + link info.
+ */
+#define PANID		    0xabcd
+#define CHANNEL		    11
+#define RSS		    INT8_MIN
+#define LQI		    UINT8_MAX
+#define TIMESYNC_SEQ	    UINT8_MAX
+#define NETWORK_TIME_OFFSET INT64_MIN
+#define RADIO_TYPE	    UINT8_MAX
+
+otError get_thread_link_info(const otMessage *msg, otThreadLinkInfo *info)
+{
+	info->mPanId = PANID;
+	info->mChannel = CHANNEL;
+	info->mRss = RSS;
+	info->mLqi = LQI;
+	info->mLinkSecurity = true;
+	info->mIsDstPanIdBroadcast = false;
+	info->mTimeSyncSeq = TIMESYNC_SEQ;
+	info->mNetworkTimeOffset = NETWORK_TIME_OFFSET;
+	info->mRadioType = RADIO_TYPE;
+
+	return OT_ERROR_NONE;
+}
+
+ZTEST(ot_rpc_message, test_otMessageGetThreadLinkInfo)
+{
+
+	otMessage *msg = (otMessage *)MSG_ADDR;
+	ot_rpc_res_tab_key msg_key = ot_res_tab_msg_alloc(msg);
+
+	otMessageGetThreadLinkInfo_fake.custom_fake = get_thread_link_info;
+
+	mock_nrf_rpc_tr_expect_add(RPC_RSP(OT_ERROR_NONE, CBOR_UINT16(PANID), CHANNEL,
+					   CBOR_INT8(RSS), CBOR_UINT8(LQI), CBOR_TRUE, CBOR_FALSE,
+					   CBOR_UINT8(TIMESYNC_SEQ),
+					   CBOR_INT64(NETWORK_TIME_OFFSET), CBOR_UINT8(RADIO_TYPE)),
+				   NO_RSP);
+	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_MESSAGE_GET_THREAD_LINK_INFO, msg_key));
+
+	zassert_equal(otMessageGetThreadLinkInfo_fake.call_count, 1);
+	zassert_equal(otMessageGetThreadLinkInfo_fake.arg0_val, msg);
+}
+
+#undef PANID
+#undef CHANNEL
+#undef RSS
+#undef LQI
+#undef TIMESYNC_SEQ
+#undef NETWORK_TIME_OFFSET
+#undef RADIO_TYPE
+
+/*
+ * Test reception of otMessageRead() that takes the maximum offset and length 1000.
+ * Verify serialization of the result: empty byte string
+ */
+uint16_t message_read_empty(const otMessage *msg, uint16_t offset, void *buf, uint16_t len)
+{
+	return 0;
+}
+
+ZTEST(ot_rpc_message, test_otMessageRead_empty)
+{
+	const uint16_t offset = UINT16_MAX;
+	const uint16_t len = 1024;
+	otMessage *msg = (otMessage *)MSG_ADDR;
+	ot_rpc_res_tab_key msg_key = ot_res_tab_msg_alloc(msg);
+
+	otMessageGetLength_fake.return_val = 0;
+	otMessageRead_fake.custom_fake = message_read_empty;
+
+	mock_nrf_rpc_tr_expect_add(RPC_RSP(CBOR_BSTR(0)), NO_RSP);
+	mock_nrf_rpc_tr_receive(
+		RPC_CMD(OT_RPC_CMD_MESSAGE_READ, msg_key, CBOR_UINT16(offset), CBOR_UINT16(len)));
+
+	zassert_equal(otMessageRead_fake.call_count, 1);
+	zassert_equal(otMessageRead_fake.arg0_val, msg);
+	/* Expect 0 instead of 'offset' because the code checks the actual size before read. */
+	zassert_equal(otMessageRead_fake.arg1_val, 0);
+	zassert_not_null(otMessageRead_fake.arg2_val);
+	/* Expect 0 instead of 'len' because the code checks the actual size before read. */
+	zassert_equal(otMessageRead_fake.arg3_val, 0);
+}
+
+/*
+ * Test reception of otMessageRead() that takes the offset 0 and length 257.
+ * Verify serialization of the result: 256B string
+ */
+uint16_t message_read_long(const otMessage *msg, uint16_t offset, void *buf, uint16_t len)
+{
+	memset(buf, 'a', len);
+
+	return len;
+}
+
+ZTEST(ot_rpc_message, test_otMessageRead_long)
+{
+	const uint16_t offset = 1;
+	const uint16_t len = UINT16_MAX;
+	otMessage *msg = (otMessage *)MSG_ADDR;
+	ot_rpc_res_tab_key msg_key = ot_res_tab_msg_alloc(msg);
+
+	otMessageGetLength_fake.return_val = offset + LONG_BSTR_LEN;
+	otMessageRead_fake.custom_fake = message_read_long;
+
+	mock_nrf_rpc_tr_expect_add(RPC_RSP(CBOR_BSTR16(LONG_BSTR_LEN, STR_SEQUENCE(LONG_BSTR_LEN))),
+				   NO_RSP);
+	mock_nrf_rpc_tr_receive(
+		RPC_CMD(OT_RPC_CMD_MESSAGE_READ, msg_key, CBOR_UINT16(offset), CBOR_UINT16(len)));
+
+	zassert_equal(otMessageRead_fake.call_count, 1);
+	zassert_equal(otMessageRead_fake.arg0_val, msg);
+	zassert_equal(otMessageRead_fake.arg1_val, offset);
+	zassert_not_null(otMessageRead_fake.arg2_val);
+	/* Expect this instead of 'len' because the code checks the actual size before read. */
+	zassert_equal(otMessageRead_fake.arg3_val, LONG_BSTR_LEN);
+}
+
+/*
+ * Test reception of otMessageAppend() that takes 1 byte.
+ * Test serialization of the result: OT_ERROR_NONE
+ */
+otError message_append_small(otMessage *msg, const void *buf, uint16_t len)
+{
+	zassert_equal(len, 1);
+	zassert_equal(*((const uint8_t *)buf), 's');
+
+	return OT_ERROR_NONE;
+}
+
+ZTEST(ot_rpc_message, test_otMessageAppend_small)
+{
+	otMessage *msg = (otMessage *)MSG_ADDR;
+	ot_rpc_res_tab_key msg_key = ot_res_tab_msg_alloc(msg);
+
+	otMessageAppend_fake.custom_fake = message_append_small;
+
+	mock_nrf_rpc_tr_expect_add(RPC_RSP(OT_ERROR_NONE), NO_RSP);
+	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_MESSAGE_APPEND, msg_key, CBOR_BSTR(1, 's')));
+
+	zassert_equal(otMessageAppend_fake.call_count, 1);
+	zassert_equal(otMessageAppend_fake.arg0_val, msg);
+}
+
+/*
+ * Test reception of otMessageAppend() that takes 256 bytes.
+ * Test serialization of the result: OT_ERROR_NO_BUFS
+ */
+otError message_append_big(otMessage *msg, const void *buf, uint16_t len)
+{
+	const static uint8_t exp[] = {STR_SEQUENCE(LONG_BSTR_LEN)};
+
+	zassert_equal(len, LONG_BSTR_LEN);
+	zassert_mem_equal(buf, exp, LONG_BSTR_LEN);
+
+	return OT_ERROR_NO_BUFS;
+}
+
+ZTEST(ot_rpc_message, test_otMessageAppend_big)
+{
+	otMessage *msg = (otMessage *)MSG_ADDR;
+	ot_rpc_res_tab_key msg_key = ot_res_tab_msg_alloc(msg);
+
+	otMessageAppend_fake.custom_fake = message_append_big;
+
+	mock_nrf_rpc_tr_expect_add(RPC_RSP(OT_ERROR_NO_BUFS), NO_RSP);
+	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_MESSAGE_APPEND, msg_key,
+					CBOR_BSTR16(LONG_BSTR_LEN, STR_SEQUENCE(LONG_BSTR_LEN))));
+
+	zassert_equal(otMessageAppend_fake.call_count, 1);
+	zassert_equal(otMessageAppend_fake.arg0_val, msg);
+}
+
+/*
+ * Test reception of otMessageFree().
+ * Verify that the message is removed from the message table.
+ */
+ZTEST(ot_rpc_message, test_otMessageFree)
+{
+	otMessage *msg = (otMessage *)MSG_ADDR;
+	ot_rpc_res_tab_key msg_key = ot_res_tab_msg_alloc(msg);
+
+	mock_nrf_rpc_tr_expect_add(RPC_RSP(), NO_RSP);
+	mock_nrf_rpc_tr_receive(RPC_CMD(OT_RPC_CMD_MESSAGE_FREE, msg_key));
+
+	zassert_equal(otMessageFree_fake.call_count, 1);
+	zassert_equal(otMessageFree_fake.arg0_val, msg);
+	zassert_is_null(ot_res_tab_msg_get(msg_key));
+}
+
+/*
+ * Test reception of otMessageRegisterTxCallback() with non-null callback.
+ * Test serialization of otMessageTxCallback.
+ * Test reception of otMessageRegisterTxCallback() with null callback.
+ */
 ZTEST(ot_rpc_message, test_otMessageRegisterTxCallback)
 {
 	otMessage *msg = (otMessage *)MSG_ADDR;
@@ -224,9 +447,6 @@ ZTEST(ot_rpc_message, test_otMessageRegisterTxCallback)
 	zassert_equal(otMessageRegisterTxCallback_fake.call_count, 2);
 	zassert_equal(otMessageRegisterTxCallback_fake.arg0_val, msg);
 	zassert_is_null(otMessageRegisterTxCallback_fake.arg1_val);
-
-	/* Cleanup */
-	ot_res_tab_msg_free(msg_key);
 }
 
-ZTEST_SUITE(ot_rpc_message, NULL, NULL, tc_setup, NULL, NULL);
+ZTEST_SUITE(ot_rpc_message, NULL, NULL, tc_setup, tc_cleanup, NULL);

--- a/tests/subsys/net/openthread/rpc/server/src/srp_client_suite.c
+++ b/tests/subsys/net/openthread/rpc/server/src/srp_client_suite.c
@@ -32,8 +32,7 @@
 #define CBOR_IPV6_ADDR_3 _CBOR_IPV6_START, 0x03
 
 #define CBOR_EMPTY_LIST 0x80
-#define CBOR_EMPTY_MAP  0xa0
-#define CBOR_LIST(...) 0x9F, __VA_ARGS__, 0xFF
+#define CBOR_EMPTY_MAP	0xa0
 #define CBOR_MAP(...) 0xBF, __VA_ARGS__, 0xFF
 
 #define TEST_SERVICE_NAME "_test._udp.local"


### PR DESCRIPTION
otMessageRead() accepts the len argument, which can be specified to a larger number than the actual size. In such a case, OT RPC server would allocate needlessly large buffer before calling otMessageRead().

Optimize the heap usage by checking otMessageGetLength() before otMessageRead() and allocating only necessary space.

Also, make a few other enhancements for message APIs:
1. Significantly increase unit test coverage.
2. Make sure message table is always checked or modified with OT RPC mutex locked.
3. Use nrf_rpc_rsp_send_xxx() helpers.