### PR TITLE
samples: cellular: modem_shell: Remove obsolete flagging

### DIFF
--- a/samples/cellular/modem_shell/src/sock/sock.c
+++ b/samples/cellular/modem_shell/src/sock/sock.c
@@ -7,15 +7,11 @@
 #include <zephyr/shell/shell.h>
 #include <assert.h>
 #include <stdio.h>
-#if defined(CONFIG_POSIX_API)
 #include <unistd.h>
 #include <netdb.h>
 #include <poll.h>
 #include <sys/socket.h>
 #include <zephyr/sys/fdtable.h>
-#else
-#include <zephyr/net/socket.h>
-#endif
 #include <zephyr/net/tls_credentials.h>
 #include <fcntl.h>
 #include <nrf_socket.h>

--- a/samples/cellular/modem_shell/src/sock/sock_shell.c
+++ b/samples/cellular/modem_shell/src/sock/sock_shell.c
@@ -7,14 +7,10 @@
 #include <zephyr/shell/shell.h>
 #include <assert.h>
 #include <stdio.h>
-#if defined(CONFIG_POSIX_API)
 #include <unistd.h>
 #include <netdb.h>
 #include <poll.h>
 #include <sys/socket.h>
-#else
-#include <zephyr/net/socket.h>
-#endif
 #include <zephyr/net/tls_credentials.h>
 #include <fcntl.h>
 #include <getopt.h>


### PR DESCRIPTION
`CONFIG_NET_SOCKETS_POSIX_NAMES` has been deprecated and removed from Zephyr, so modem_shell requires `CONFIG_POSIX` to be enabled. Removed flagging which was related to `CONFIG_NET_SOCKETS_POSIX_NAMES`.