### PR TITLE
snippets: nrf70-wifi: Fix 54H boot issue

### DIFF
--- a/snippets/nrf70-wifi/nrf54h20_wifi_memory_map.overlay
+++ b/snippets/nrf70-wifi/nrf54h20_wifi_memory_map.overlay
@@ -47,3 +47,8 @@
 &uart135 {
 	status = "disabled";
 };
+
+/* Disable unbound feature for cpuapp to fix boot issues */
+&cpuapp_cpusys_ipc {
+	unbound = "disable";
+};


### PR DESCRIPTION
The IPC unbound feature was recently enabled by default to support link renewal, but it is causing the  boot issue when running Wi-Fi samples.
Disable the unbound feature for cpuapp domain to fix the issue.

Fixes SHEL-3773, SHEL-3772 and SHEL-3768.