### PR TITLE
lib: lte_link_control: Remove obsolete Unity flagging

### DIFF
--- a/lib/lte_link_control/modules/cereg.c
+++ b/lib/lte_link_control/modules/cereg.c
@@ -52,15 +52,9 @@ static bool is_cellid_valid(uint32_t cellid)
 	return true;
 }
 
-#if defined(CONFIG_UNITY)
-int parse_cereg(const char *at_response, enum lte_lc_nw_reg_status *reg_status,
-		       struct lte_lc_cell *cell, enum lte_lc_lte_mode *lte_mode,
-		       struct lte_lc_psm_cfg *psm_cfg)
-#else
 static int parse_cereg(const char *at_response, enum lte_lc_nw_reg_status *reg_status,
 		       struct lte_lc_cell *cell, enum lte_lc_lte_mode *lte_mode,
 		       struct lte_lc_psm_cfg *psm_cfg)
-#endif /* CONFIG_UNITY */
 {
 	int err, temp;
 	struct at_parser parser;

--- a/lib/lte_link_control/modules/cscon.c
+++ b/lib/lte_link_control/modules/cscon.c
@@ -36,11 +36,7 @@ AT_MONITOR(ltelc_atmon_cscon, "+CSCON", at_handler_cscon);
  *
  * @return Zero on success or (negative) error code otherwise.
  */
-#if defined(CONFIG_UNITY)
-int parse_rrc_mode(const char *at_response, enum lte_lc_rrc_mode *mode, size_t mode_index)
-#else
 static int parse_rrc_mode(const char *at_response, enum lte_lc_rrc_mode *mode, size_t mode_index)
-#endif /* CONFIG_UNITY */
 {
 	int err, temp_mode;
 	struct at_parser parser;

--- a/lib/lte_link_control/modules/edrx.c
+++ b/lib/lte_link_control/modules/edrx.c
@@ -173,14 +173,9 @@ static void get_edrx_value(enum lte_lc_lte_mode lte_mode, uint8_t idx, float *ed
 	*edrx_value = multiplier == 0 ? 5.12 : multiplier * 10.24;
 }
 
-#if defined(CONFIG_UNITY)
-int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg, char *edrx_str,
-		      char *ptw_str)
-#else
 /* Parses eDRX parameters from a +CEDRXS notification or a +CEDRXRDP response. */
 static int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg, char *edrx_str,
 		      char *ptw_str)
-#endif /* CONFIG_UNITY */
 {
 	int err, tmp_int;
 	uint8_t idx;

--- a/lib/lte_link_control/modules/mdmev.c
+++ b/lib/lte_link_control/modules/mdmev.c
@@ -39,11 +39,7 @@ AT_MONITOR(ltelc_atmon_mdmev, "%MDMEV", at_handler_mdmev);
 
 bool mdmev_enabled;
 
-#if defined(CONFIG_UNITY)
-int mdmev_parse(const char *at_response, enum lte_lc_modem_evt *modem_evt)
-#else
 static int mdmev_parse(const char *at_response, enum lte_lc_modem_evt *modem_evt)
-#endif /* CONFIG_UNITY */
 {
 	static const char *const event_types[] = {
 		[LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE] = AT_MDMEV_SEARCH_STATUS_1,

--- a/lib/lte_link_control/modules/periodicsearchconf.c
+++ b/lib/lte_link_control/modules/periodicsearchconf.c
@@ -19,13 +19,8 @@
 
 LOG_MODULE_DECLARE(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 
-#if defined(CONFIG_UNITY)
-int periodicsearchconf_parse(const char *const pattern_str,
-				    struct lte_lc_periodic_search_pattern *pattern)
-#else
 static int periodicsearchconf_parse(const char *const pattern_str,
 				    struct lte_lc_periodic_search_pattern *pattern)
-#endif /* CONFIG_UNITY */
 {
 	int err;
 	int values[5];
@@ -79,15 +74,9 @@ static int periodicsearchconf_parse(const char *const pattern_str,
 	return 0;
 }
 
-#if defined(CONFIG_UNITY)
-char *
-periodicsearchconf_pattern_get(char *const buf, size_t buf_size,
-			       const struct lte_lc_periodic_search_pattern *const pattern)
-#else
 static char *
 periodicsearchconf_pattern_get(char *const buf, size_t buf_size,
 			       const struct lte_lc_periodic_search_pattern *const pattern)
-#endif /* CONFIG_UNITY */
 {
 	int len = 0;
 

--- a/lib/lte_link_control/modules/psm.c
+++ b/lib/lte_link_control/modules/psm.c
@@ -177,11 +177,7 @@ static int psm_encode_timer(char *encoded_timer_str, uint32_t requested_value,
 	return 0;
 }
 
-#if defined(CONFIG_UNITY)
-int psm_encode(char *tau_ext_str, char *active_time_str, int rptau, int rat)
-#else
 static int psm_encode(char *tau_ext_str, char *active_time_str, int rptau, int rat)
-#endif /* CONFIG_UNITY */
 {
 	int ret = 0;
 

--- a/lib/lte_link_control/modules/xmodemsleep.c
+++ b/lib/lte_link_control/modules/xmodemsleep.c
@@ -27,11 +27,7 @@ LOG_MODULE_DECLARE(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 
 AT_MONITOR(ltelc_atmon_xmodemsleep, "%XMODEMSLEEP", at_handler_xmodemsleep);
 
-#if defined(CONFIG_UNITY)
-int parse_xmodemsleep(const char *at_response, struct lte_lc_modem_sleep *modem_sleep)
-#else
 static int parse_xmodemsleep(const char *at_response, struct lte_lc_modem_sleep *modem_sleep)
-#endif /* CONFIG_UNITY */
 {
 	int err;
 	struct at_parser parser;

--- a/lib/lte_link_control/modules/xt3412.c
+++ b/lib/lte_link_control/modules/xt3412.c
@@ -26,11 +26,7 @@ AT_MONITOR(ltelc_atmon_xt3412, "%XT3412", at_handler_xt3412);
 #define AT_XT3412_TIME_INDEX 1
 #define T3412_MAX	     35712000000
 
-#if defined(CONFIG_UNITY)
-int parse_xt3412(const char *at_response, uint64_t *time)
-#else
 static int parse_xt3412(const char *at_response, uint64_t *time)
-#endif /* CONFIG_UNITY */
 {
 	int err;
 	struct at_parser parser;


### PR DESCRIPTION
Removed `CONFIG_UNITY` flagging which is no longer used.