### PR TITLE
CODEOWNERS: Add ncs-matter to Matter-specific files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -983,3 +983,12 @@
 Kconfig*                                  @nrfconnect/ncs-co-build-system
 CMakeLists*                               @nrfconnect/ncs-co-build-system
 *.cmake	                                  @nrfconnect/ncs-co-build-system
+
+# ncs-matter-related files
+/samples/matter/**/*.cmake               @nrfconnect/ncs-co-build-system @nrfconnect/ncs-matter
+/samples/matter/**/Kconfig*              @nrfconnect/ncs-co-build-system @nrfconnect/ncs-matter
+/applications/matter_weather_station/**/Kconfig* @nrfconnect/ncs-co-build-system @nrfconnect/ncs-matter
+/applications/matter_bridge/**/Kconfig*  @nrfconnect/ncs-co-build-system @nrfconnect/ncs-matter
+/samples/matter/**/CMakeLists*           @nrfconnect/ncs-co-build-system @nrfconnect/ncs-matter
+/applications/matter_weather_station/**/CMakeLists* @nrfconnect/ncs-co-build-system @nrfconnect/ncs-matter
+/applications/matter_bridge/**/CMakeLists* @nrfconnect/ncs-co-build-system @nrfconnect/ncs-matter

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -992,3 +992,9 @@ CMakeLists*                               @nrfconnect/ncs-co-build-system
 /samples/matter/**/CMakeLists*           @nrfconnect/ncs-co-build-system @nrfconnect/ncs-matter
 /applications/matter_weather_station/**/CMakeLists* @nrfconnect/ncs-co-build-system @nrfconnect/ncs-matter
 /applications/matter_bridge/**/CMakeLists* @nrfconnect/ncs-co-build-system @nrfconnect/ncs-matter
+
+# ncs-thread-related files
+/modules/openthread/**/Kconfig*          @nrfconnect/ncs-co-build-system @nrfconnect/ncs-thread
+/samples/openthread/**/Kconfig*          @nrfconnect/ncs-co-build-system @nrfconnect/ncs-thread
+/samples/openthread/**/CMakeLists*       @nrfconnect/ncs-co-build-system @nrfconnect/ncs-thread
+/subsys/net/openthread/Kconfig*          @nrfconnect/ncs-co-build-system @nrfconnect/ncs-thread


### PR DESCRIPTION
The CODEOWNERS file overrides all Kconfig, CMakeLists and .cmake file patterns, and due to that, `ncs-matter` is not notified about these file types in Matter locations.

To fix it, assign both `nrfconnect/ncs-co-build-system` `nrfconnect/ncs-matter` to all Matter-related Kconfig, CMakeLists and .cmake files.