### PR TITLE
applications: nrf_desktop: update documentation for nRF54LM20 DK target

### DIFF
--- a/applications/nrf_desktop/board_configuration.rst
+++ b/applications/nrf_desktop/board_configuration.rst
@@ -178,15 +178,10 @@ Sample mouse (``nrf54lm20dk/nrf54lm20a/cpuapp``)
         For detailed information on working with the nRF54LM20 DK, see the :ref:`ug_nrf54l15_gs` documentation.
       * In ``llvm`` configurations, the partition layout is different to accommodate for the higher memory footprint of the ``llvm``  toolchain.
       * The configurations use the MCUboot bootloader built in the direct-xip mode (``MCUBOOT+XIP``) and support firmware updates using the :ref:`nrf_desktop_dfu`.
+        All of the configurations enable hardware cryptography for the MCUboot bootloader.
         The application image is verified using a pure ED25519 signature.
-
-      .. note::
-         Currently, the ``nrf54lm20dk/nrf54lm20a/cpuapp`` board target has the following limitations:
-
-         * The software-based cryptography is used in the MCUboot bootloader and application image.
-           The hardware-based cryptography is not yet supported.
-         * The public key that MCUboot uses for validating the application image is stored in the bootloader partition.
-           The hardware Key Management Unit (KMU) is not supported yet.
+        The public key that MCUboot uses for validating the application image is securely stored in the hardware Key Management Unit (KMU).
+        For more details on nRF54L Series cryptography, see :ref:`ug_nrf54l_cryptography`.
 
 Sample mouse or dongle (``nrf54h20dk/nrf54h20/cpuapp``)
       * The configuration uses the nRF54H20 DK.

--- a/applications/nrf_desktop/bootloader_dfu.rst
+++ b/applications/nrf_desktop/bootloader_dfu.rst
@@ -208,9 +208,6 @@ You can enhance security further by enabling the following sysbuild Kconfig opti
      This option enables generating a default :file:`keyfile.json` file during the build process based on the input file provided by the :kconfig:option:`SB_CONFIG_BOOT_SIGNATURE_KEY_FILE` sysbuild Kconfig option.
      The automatic provisioning is only performed if the west flash command is executed with the ``--erase`` or ``--recover`` flag.
 
-  .. note::
-     KMU is not yet supported for the ``nrf54lm20dk/nrf54lm20a/cpuapp`` board target.
-
 .. _nrf_desktop_bootloader_background_dfu:
 
 Background Device Firmware Upgrade

--- a/applications/nrf_desktop/description.rst
+++ b/applications/nrf_desktop/description.rst
@@ -1029,9 +1029,6 @@ The private key is used to sign the application image.
 The public key is generated from the private key and is used by MCUboot to validate the application image.
 The public key is securely stored in the Key Management Unit (KMU) hardware peripheral of the nRF54L device.
 
-.. note::
-   KMU is not yet supported for the ``nrf54lm20dk/nrf54lm20a/cpuapp`` board target.
-
 In this application, the application image is automatically signed with a private key by the |NCS| build system.
 The private keys are stored in the application configuration directory of the board.
 Path to the private key is defined by the ``SB_CONFIG_BOOT_SIGNATURE_KEY_FILE`` sysbuild Kconfig option.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -208,7 +208,17 @@ nRF5340 Audio
 nRF Desktop
 -----------
 
-|no_changes_yet_note|
+  * Updated:
+
+    * The memory layouts for the ``nrf54lm20dk/nrf54lm20a/cpuapp`` board target to make more space for the application code.
+      This change in the partition map of every nRF54LM20 configuration is a breaking change and cannot be performed using DFU.
+      As a result, the DFU procedure will fail if you attempt to upgrade the application firmware based on one of the |NCS| v3.1 releases.
+    * The application and MCUboot configurations for the ``nrf54lm20dk/nrf54lm20a/cpuapp`` board target to use the CRACEN hardware crypto driver instead of the Oberon software crypto driver.
+      The application image signature is verified with the CRACEN hardware peripheral.
+    * The MCUboot configurations for the ``nrf54lm20dk/nrf54lm20a/cpuapp`` board target to use the KMU-based key storage.
+      The public key used by MCUboot for validating the application image is securely stored in the KMU hardware peripheral.
+      To simplify the programming procedure, the application is configured to use the automatic KMU provisioning.
+      The KMU provisioning is performed by the west runner as a part of the ``west flash`` command when the ``--erase`` or ``--recover`` flag is used.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
Updated the nRF Desktop documentation for the nRF54LM20 DK target to align it with the newest configuration changes. The nRF54LM20 DK target now uses the KMU to store the MCUboot public key for image verification and hardware-based cryptography based on the CRACEN HW peripheral. The hardware cryptography is enabled for both the MCUboot bootloader and the application image.

Ref: NCSDK-34043

Depends on the following PR:

https://github.com/nrfconnect/sdk-nrf/pull/24161