### PR TITLE
nrf_security: Support STDC (libc) heap

### DIFF
--- a/subsys/nrf_security/Kconfig.legacy
+++ b/subsys/nrf_security/Kconfig.legacy
@@ -4,9 +4,12 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+config MBEDTLS_STDC_HEAP
+	bool "Use heap from libc"
+
 config MBEDTLS_PLATFORM_MEMORY
 	bool
-	default y
+	default y if !MBEDTLS_STDC_HEAP
 
 config MBEDTLS_PLATFORM_C
 	bool
@@ -18,7 +21,7 @@ config MBEDTLS_MEMORY_C
 
 config MBEDTLS_MEMORY_BUFFER_ALLOC_C
 	bool
-	default y
+	default y if !MBEDTLS_STDC_HEAP
 
 config MBEDTLS_THREADING_C
 	bool "Threading support for Mbed TLS and PSA crypto"

--- a/subsys/nrf_security/configs/legacy_crypto_config.h.template
+++ b/subsys/nrf_security/configs/legacy_crypto_config.h.template
@@ -170,7 +170,7 @@
  *
  * Enable this layer to allow use of alternative memory allocators.
  */
-#define MBEDTLS_PLATFORM_MEMORY
+#cmakedefine MBEDTLS_PLATFORM_MEMORY
 
 /**
  * \def MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
@@ -2374,7 +2374,7 @@
  *
  * Enable this module to enable the buffer memory allocator.
  */
-#define MBEDTLS_MEMORY_BUFFER_ALLOC_C
+#cmakedefine MBEDTLS_MEMORY_BUFFER_ALLOC_C
 
 /**
  * \def MBEDTLS_NET_C

--- a/subsys/nrf_security/src/CMakeLists.txt
+++ b/subsys/nrf_security/src/CMakeLists.txt
@@ -58,7 +58,7 @@ target_include_directories(psa_crypto_library_config
     ${OBERON_PSA_CORE_PATH}/oberon/drivers
 )
 
-if(CONFIG_MBEDTLS_ENABLE_HEAP)
+if(CONFIG_MBEDTLS_ENABLE_HEAP AND CONFIG_MBEDTLS_PLATFORM_MEMORY)
   if (CONFIG_BUILD_WITH_TFM)
     # Add replacement for memory_buffer_alloc.c for NS build
     list(APPEND src_crypto ${NRF_SECURITY_ROOT}/src/legacy/memory_buffer_alloc.c)

--- a/subsys/nrf_security/src/zephyr/CMakeLists.txt
+++ b/subsys/nrf_security/src/zephyr/CMakeLists.txt
@@ -22,7 +22,7 @@ if (CONFIG_MBEDTLS_DEBUG)
 endif()
 
 # Add mbed TLS heap library - Not for TF-M build
-if(CONFIG_MBEDTLS_ENABLE_HEAP)
+if(CONFIG_MBEDTLS_ENABLE_HEAP AND CONFIG_MBEDTLS_PLATFORM_MEMORY)
   list(APPEND src_zephyr
     mbedtls_heap.c
   )


### PR DESCRIPTION
-This provides heap-support from libc instead of utilizing
 MBEDTLS_MEMORY_BUFFER_C. To do this, set the Kconfig
 MBEDTLS_STDC_HEAP and control the heap via the libc support.
 When MBEDTLS_STDC_HEAP is set the following happens:
 -mbedtls_buffer_alloc.c isn't compiled
 -mbedtls_heap.c isn't compiled
 -Mbed TLS uses libc provided calloc and free for memory management
-Added Kconfig MBEDTLS_STDC_HEAP
-Added dependencies for MBEDTLS_STDC_HEAP for
 MBEDTLS_PLATFORM_MEMORY and MBEDTLS_MEMORY_BUFFER_ALLOC_C