### PR TITLE
ci: revert permission change on contribs.yml action

### DIFF
--- a/.github/workflows/contribs.yml
+++ b/.github/workflows/contribs.yml
@@ -3,11 +3,6 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
-
 jobs:
   contribs:
     runs-on: ubuntu-24.04
@@ -16,7 +11,7 @@ jobs:
       - name: Contribs
         uses: carlescufi/action-contribs@d139e12dabbe631fcc94ec3e19e386a11d3e1a26 # main
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.NCS_GITHUB_TOKEN }}
           command: 'external'
           messages: |
                     Thank you for your contribution!


### PR DESCRIPTION
without full permissions the script cant detect org members