### PR TITLE
cmake: toolchain: llvm: force omitting frame pointer

### DIFF
--- a/cmake/toolchain/llvm/Kconfig.defconfig
+++ b/cmake/toolchain/llvm/Kconfig.defconfig
@@ -12,3 +12,9 @@ endchoice
 choice RTLIB_IMPLEMENTATION
 	default COMPILER_RT_RTLIB
 endchoice
+
+config OVERRIDE_FRAME_POINTER_DEFAULT
+	default y
+
+config OMIT_FRAME_POINTER
+	default y if OVERRIDE_FRAME_POINTER_DEFAULT


### PR DESCRIPTION
At least some armclang versions implicitly enable
"-fno-omit-frame-pointer", leading to increased code size.

Make sure we build with "-fomit-frame-pointer" by default.