### PR TITLE
doc: working_with_nrf: Add npm1304 pmic

### DIFF
--- a/doc/nrf/app_dev/device_guides/pmic/index.rst
+++ b/doc/nrf/app_dev/device_guides/pmic/index.rst
@@ -25,6 +25,14 @@ Zephyr and the |NCS| provides support for developing applications with the follo
        | `nPM1300 EK get started`_
      - | `nPM1300 EK product page`_
        | `nPM1300 Power Management IC (PMIC) <nPM1300 product website_>`_
+   * - :ref:`zephyr:npm1304_ek`
+     - PCA10195
+     - See :ref:`ug_npm1304_compatible_boards`
+     - | `Data sheet <nPM1304 Data sheet_>`_
+       | `User Guide <nPM1304 EK User Guide_>`_
+       | `nPM1304 EK get started`_
+     - | `nPM1304 EK product page`_
+       | `nPM1304 Power Management IC (PMIC) <nPM1304 product website_>`_
    * - `nPM2100 EK <nPM2100 EK User Guide_>`_
      - PCA10170
      - See :ref:`ug_npm2100_compatible_boards`
@@ -41,4 +49,5 @@ Zephyr and the |NCS| provides support for developing applications with the follo
    :caption: Subpages:
 
    npm1300
+   npm1304
    npm2100

--- a/doc/nrf/app_dev/device_guides/pmic/npm1304.rst
+++ b/doc/nrf/app_dev/device_guides/pmic/npm1304.rst
@@ -1,0 +1,117 @@
+.. _ug_npm1304_developing:
+.. _ug_npm1304_gs:
+
+Developing with the nPM1304 PMIC
+################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The |NCS| provides support for development with the `nPM1304 Power Management IC (PMIC) <nPM1304 product website_>`_, using the `nPM1304 Evaluation Kit (PCA10195) <nPM1304 EK product page_>`_.
+
+.. _ug_npm1304_features:
+
+nPM1304 features
+****************
+
+nPM1304 is a PMIC with a linear-mode lithium-ion, lithium-polymer, and lithium ferro-phosphate battery charger.
+It has two dual-mode buck regulators, two dual purpose LDO/load switches, three LED drivers, and five GPIOs.
+
+nPM1304 is the perfect companion for nRF52, nRF53, and the nRF54 Series SoCs.
+It is ideal for compact and advanced IoT products, such as wearables and portable medical applications.
+
+For additional information on the nPM1304 PMIC and associated kits, see the `nPM1304`_ technical documentation, especially the `nPM1304 EK User Guide`_.
+
+.. _ug_npm1304_compatible_boards:
+
+Boards compatible with nPM1304
+******************************
+
+The following boards in the `Zephyr`_ open source project and in the |NCS| are compatible with nPM1304 PMIC through the nPM1304 EK:
+
+.. list-table::
+   :header-rows: 1
+
+   * - DK or Prototype platform
+     - Companion module
+     - PCA number
+     - Board target
+     - Documentation
+   * - :zephyr:board:`nrf54l15dk`
+     - nPM1304 EK
+     - PCA10156
+     - | ``nrf54l15dk/nrf54l15/cpuapp``
+     - | `Datasheet <nRF54L15 Datasheet_>`_
+       | `Quick Start app`_
+       | `User Guide <nRF54L15 DK User Guide_>`_
+   * - :zephyr:board:`nrf5340dk`
+     - nPM1304 EK
+     - PCA10095
+     - ``nrf5340dk/nrf5340/cpuapp``
+     - | `Product Specification <nRF5340 Product Specification_>`_
+       | `Quick Start app`_
+       | `User Guide <nRF5340 DK User Guide_>`_
+   * - :zephyr:board:`nrf52840dk`
+     - nPM1304 EK
+     - PCA10056
+     - ``nrf52840dk/nrf52840``
+     - | `Product Specification <nRF52840 Product Specification_>`_
+       | `Quick Start app`_
+       | `User Guide <nRF52840 DK User Guide_>`_
+   * - :zephyr:board:`nrf52dk`
+     - nPM1304 EK
+     - PCA10040
+     - ``nrf52dk/nrf52832``
+     - | `Product Specification <nRF52832 Product Specification_>`_
+       | `Quick Start app`_
+       | `User Guide <nRF52 DK User Guide_>`_
+
+PMIC samples and libraries
+**************************
+
+The |NCS| provides several :ref:`pmic_samples` that demonstrate the features and capabilities of nPM1304 using the nPM1304 EK.
+The :ref:`nrfxlib:nrf_fuel_gauge` processes battery measurements made by PMICs and provides a state-of-charge (SOC) prediction, along with other metrics.
+
+PMIC tools
+**********
+
+The :ref:`nrfxlib:nrf_fuel_gauge` is supported by the `nPM PowerUP app`_ in `nRF Connect for Desktop`_.
+You can use this application together with the library to derive a battery model for your product.
+For this purpose, you can use the nPM1304 EK that characterizes the battery using an active load circuit.
+See `Evaluate nPM1304 using nPM PowerUP`_ in the `nPM1304 EK User Guide`_ for more information.
+
+.. _ug_npm1304_developing_overlay_import:
+
+Importing an overlay from the nPM PowerUP app
+=============================================
+
+The `nPM PowerUP app`_ from `nRF Connect for Desktop`_  supports exporting a full configuration of the nPM1304 in devicetree overlay format.
+You can use this exported overlay file to quickly configure the nPM1304 in your application.
+
+If there is no overlay file for your project, include the file directly in your :file:`app.overlay` in the application folder.
+If an overlay already exists, append the contents of the generated overlay to the existing file.
+
+For more information about devicetree overlays, see :ref:`zephyr:use-dt-overlays`.
+
+.. _npm1304_building:
+
+Building and programming for nPM1304
+************************************
+
+There is no firmware for nPM1304 that can be built and programmed onto the PMIC.
+
+Instead, you need to connect the compatible development kit to nPM1304 and program that kit with the firmware.
+
+Connecting the development kit to nPM1304
+=========================================
+
+If you are using the nRF54L15 DK, follow the steps in `Use the nPM1304 EK with an nRF54L15 DK`_ in the `nPM1304 EK User Guide`_.
+For other Nordic Semiconductor kits, use the wiring steps in the documentation for :ref:`pmic_samples` as reference (:ref:`wiring for the Fuel gauge sample <npm13xx_fuel_gauge_wiring>` and :ref:`wiring for the One button sample <npm13xx_one_button_wiring>`, respectively).
+
+If you are using custom hardware, the wiring process is similar to the `one for the nRF54L15 DK <Use the nPM1304 EK with an nRF54L15 DK_>`_, but board-specific steps are different.
+
+Programming the development kit with nPM1304-compatible firmware
+================================================================
+
+Follow the detailed instructions in the building and programming sections of the :ref:`pmic_samples` documentation to build the sample and flash it to the compatible DK.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -351,6 +351,8 @@
 .. _`nPM1300 EK get started`: https://www.nordicsemi.com/Products/Development-hardware/nPM1300-EK/Get-started?lang=en#infotabs
 
 .. _`nPM1304 product website`: https://www.nordicsemi.com/products/npm1304
+.. _`nPM1304 EK product page`: https://www.nordicsemi.com/Products/Development-hardware/nPM1304-EK
+.. _`nPM1304 EK get started`: https://www.nordicsemi.com/Products/Development-hardware/nPM1304-EK/Get-started?lang=en#infotabs
 
 .. _`nPM2100 product website`: https://www.nordicsemi.com/Products/nPM2100
 .. _`nRF Desktop reference design page`: https://www.nordicsemi.com/Products/Reference-designs/nRF-Desktop
@@ -894,7 +896,14 @@
 .. _`nPM1300 EK User Guide`: https://docs.nordicsemi.com/bundle/ug_npm1300_ek/page/UG/nPM1300_EK/intro.html
 .. _`Evaluate nPM1300 using nPM PowerUP`: https://docs.nordicsemi.com/bundle/ug_npm1300_ek/page/UG/nPM1300_EK/npm_powerup.html
 .. _`Use the nPM1300 EK with an nRF5340 DK`: https://docs.nordicsemi.com/bundle/ug_npm1300_ek/page/UG/nPM1300_EK/using_nrf5340_DK.html
-.. _`Using the nPM1300 Fuel Gauge`: https://docs.nordicsemi.com/bundle/nan_045/page/APP/nan_045/intro.html
+.. _`Using the nPM1300 and nPM1304 Fuel Gauge`: https://docs.nordicsemi.com/bundle/nan_045/page/APP/nan_045/intro.html
+
+.. _`nPM1304`: https://docs.nordicsemi.com/category/npm1304-category
+.. _`nPM1304 Data sheet`: https://docs.nordicsemi.com/bundle/ps_npm1304/page/keyfeatures_html5.html
+
+.. _`nPM1304 EK User Guide`: https://docs.nordicsemi.com/bundle/ug_npm1304_ek/page/UG/nPM1304_EK/intro.html
+.. _`Evaluate nPM1304 using nPM PowerUP`: https://docs.nordicsemi.com/bundle/ug_npm1304_ek/page/UG/nPM1304_EK/use_ek_power_up.html
+.. _`Use the nPM1304 EK with an nRF54L15 DK`: https://docs.nordicsemi.com/bundle/ug_npm1304_ek/page/UG/nPM1304_EK/using_nrf54L15_dk.html
 
 .. _`nRF21540 EK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf21540_ek/page/UG/nrf21540_DK/intro.html
 

--- a/samples/pmic/native/npm13xx_fuel_gauge/README.rst
+++ b/samples/pmic/native/npm13xx_fuel_gauge/README.rst
@@ -9,7 +9,7 @@ nPM1300 and nPM1304: Fuel gauge
 
 The Fuel gauge sample demonstrates how to calculate the state of charge of a development kit battery using `nPM1300 <nPM1300 product website_>`_ or  `nPM1304 <nPM1304 product website_>`_ and the :ref:`nrfxlib:nrf_fuel_gauge`.
 
-For more information about fuel gauging with the nPM1300 or nPM1304, see `Using the nPM1300 Fuel Gauge`_.
+For more information about fuel gauging with the nPM1300 or nPM1304, see `Using the nPM1300 and nPM1304 Fuel Gauge`_.
 
 Requirements
 ************
@@ -18,7 +18,7 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
-The sample also requires an `nPM1300 EK <nPM1300 EK product page_>`_ or nPM1304 EK that you need to connect to the development kit as described in `Wiring`_.
+The sample also requires an `nPM1300 EK <nPM1300 EK product page_>`_ or an `nPM1304 EK <nPM1304 EK product page_>`_ that you need to connect to the development kit as described in `Wiring`_.
 
 Overview
 ********

--- a/samples/pmic/native/npm13xx_one_button/README.rst
+++ b/samples/pmic/native/npm13xx_one_button/README.rst
@@ -16,7 +16,7 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
-The sample also requires an `nPM1300 EK <nPM1300 EK product page_>`_ or an nPM1304 EK that you need to connect to the development kit as described in `Wiring`_.
+The sample also requires an `nPM1300 EK <nPM1300 EK product page_>`_ or an `nPM1304 EK <nPM1304 EK product page_>`_ that you need to connect to the development kit as described in `Wiring`_.
 
 Overview
 ********


### PR DESCRIPTION
Add "Developing with the nPM1304 PMIC" document
to the list of "Developing with PMICs" guide document. Update links accordingly.