### PR TITLE
doc: Fixed ot memory requirements for nRF54LM20

### DIFF
--- a/doc/nrf/protocols/thread/overview/ot_memory.rst
+++ b/doc/nrf/protocols/thread/overview/ot_memory.rst
@@ -45,6 +45,15 @@ The following tables present memory requirements for samples running on the :zep
 
 .. include:: memory_tables/nrf54l15.txt
 
+.. _thread_ot_memory_54lm20:
+
+nRF54LM20 DK RAM and flash memory requirements
+**********************************************
+
+The following tables present memory requirements for samples running on the :zephyr:board:`nrf54lm20dk` with the cryptography support provided by the :ref:`crypto_drivers_cracen`.
+
+.. include:: memory_tables/nrf54lm20a.txt
+
 .. _thread_ot_memory_5340:
 
 nRF5340 DK RAM and flash memory requirements


### PR DESCRIPTION
In the previous PR that added measured memory values for nRF54LM20, the change that includes table to ot memory requirements was missing.