### PR TITLE
nrf_security: Cracen cipher stack reduction

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/include/cracen_sw_common.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/include/cracen_sw_common.h
@@ -17,6 +17,7 @@
  * This function is designed for CRACEN software workarounds that need
  * AES-ECB encryption functionality.
  *
+ * @param blkciph The block cipher struct.
  * @param key The AES key reference.
  * @param input Pointer to the input block.
  * @param input_length Length of the input block.
@@ -26,15 +27,16 @@
  *
  * @retval psa_status_t PSA_SUCCESS on success, error code otherwise.
  */
-psa_status_t cracen_aes_ecb_encrypt(const struct sxkeyref *key, const uint8_t *input,
-			      size_t input_length, uint8_t *output, size_t output_size,
-			      size_t *output_length);
+psa_status_t cracen_aes_ecb_encrypt(struct sxblkcipher *blkciph, const struct sxkeyref *key,
+				    const uint8_t *input, size_t input_length, uint8_t *output,
+				    size_t output_size, size_t *output_length);
 
 /** @brief Decrypt a single AES block using ECB mode.
  *
  * This function is designed for CRACEN software workarounds that need
  * AES-ECB decryption functionality.
  *
+ * @param blkciph The block cipher struct.
  * @param key The AES key reference.
  * @param input Pointer to the input block.
  * @param input_length Length of the input block.
@@ -44,22 +46,23 @@ psa_status_t cracen_aes_ecb_encrypt(const struct sxkeyref *key, const uint8_t *i
  *
  * @retval psa_status_t PSA_SUCCESS on success, error code otherwise.
  */
-psa_status_t cracen_aes_ecb_decrypt(const struct sxkeyref *key, const uint8_t *input,
-			      size_t input_length, uint8_t *output, size_t output_size,
-			      size_t *output_length);
+psa_status_t cracen_aes_ecb_decrypt(struct sxblkcipher *blkciph, const struct sxkeyref *key,
+				    const uint8_t *input, size_t input_length, uint8_t *output,
+				    size_t output_size, size_t *output_length);
 
 /** @brief Perform a single AES block encryption operation.
  *
  * This function is designed for use as an AES primitive in CRACEN software workarounds that require
  * it.
  *
+ * @param blkciph The block cipher struct.
  * @param key The AES key reference.
  * @param input Pointer to the input block.
  * @param output Pointer to a 16-byte output buffer.
  *
  * @retval psa_status_t PSA_SUCCESS on success, error code otherwise.
  */
-psa_status_t cracen_aes_primitive(const struct sxkeyref *key, const uint8_t *input,
-				  uint8_t *output);
+psa_status_t cracen_aes_primitive(struct sxblkcipher *blkciph, const struct sxkeyref *key,
+				  const uint8_t *input, uint8_t *output);
 
 #endif /* CRACEN_SW_COMMON_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aes_ctr.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aes_ctr.c
@@ -135,8 +135,8 @@ psa_status_t cracen_sw_aes_ctr_update(cracen_cipher_operation_t *operation, cons
 
 			memcpy(current_ctr, operation->iv, SX_BLKCIPHER_AES_BLK_SZ);
 
-			status = cracen_aes_primitive(&operation->keyref, current_ctr,
-							keystream_block);
+			status = cracen_aes_primitive(&operation->cipher, &operation->keyref,
+						      current_ctr, keystream_block);
 			if (status != PSA_SUCCESS) {
 				return status;
 			}

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_cipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_cipher.c
@@ -152,9 +152,7 @@ static psa_status_t encrypt_cbc(const struct sxkeyref *key, const uint8_t *input
 	}
 
 	memset(padded_input_block, padding, sizeof(padded_input_block));
-	if (remaining_bytes > 0) {
-		memcpy(padded_input_block, input + full_blocks_length, remaining_bytes);
-	}
+	memcpy(padded_input_block, input + full_blocks_length, remaining_bytes);
 
 	sx_status = sx_blkcipher_crypt(&cipher_ctx, padded_input_block, sizeof(padded_input_block),
 				       output + full_blocks_length);
@@ -170,10 +168,9 @@ static psa_status_t encrypt_cbc(const struct sxkeyref *key, const uint8_t *input
 	sx_status = sx_blkcipher_wait(&cipher_ctx);
 	if (sx_status == SX_OK) {
 		*output_length = padded_input_length;
-		return PSA_SUCCESS;
-	} else {
-		return silex_statuscodes_to_psa(sx_status);
 	}
+
+	return silex_statuscodes_to_psa(sx_status);
 }
 
 static psa_status_t decrypt_cbc(const struct sxkeyref *key, const uint8_t *input,

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_cipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_cipher.c
@@ -245,10 +245,14 @@ psa_status_t cracen_cipher_encrypt(const psa_key_attributes_t *attributes,
 				return PSA_ERROR_BUFFER_TOO_SMALL;
 			}
 
-			/* Handle inplace encryption by moving plaintext to right to free space for
-			 * iv
+			/* Handle inplace encryption by moving plaintext to the right by iv_length
+			 * bytes. This is done because in inplace encryption the input and output
+			 * should point to the same data so that the output can overwrite its own
+			 * input. If they are not in sync the output will overwrite the input of
+			 * another operation which is of course wrong.
+			 *
 			 */
-			if (input_length && output > input && output < input + input_length) {
+			if (output == input + iv_length) {
 				memmove(output, input, input_length);
 				input = output;
 			}

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_common.c
@@ -37,12 +37,11 @@ psa_status_t cracen_aes_ecb_crypt(struct sxblkcipher *blkciph,
 	return sx_status;
 }
 
-psa_status_t cracen_aes_ecb_encrypt(const struct sxkeyref *key, const uint8_t *input,
-				    size_t input_length, uint8_t *output, size_t output_size,
-				    size_t *output_length)
+psa_status_t cracen_aes_ecb_encrypt(struct sxblkcipher *blkciph, const struct sxkeyref *key,
+				    const uint8_t *input, size_t input_length, uint8_t *output,
+				    size_t output_size, size_t *output_length)
 {
 	int sx_status;
-	struct sxblkcipher blkciph;
 
 	if (output_size < input_length) {
 		return PSA_ERROR_BUFFER_TOO_SMALL;
@@ -52,21 +51,20 @@ psa_status_t cracen_aes_ecb_encrypt(const struct sxkeyref *key, const uint8_t *i
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 
-	sx_status = sx_blkcipher_create_aesecb_enc(&blkciph, key);
+	sx_status = sx_blkcipher_create_aesecb_enc(blkciph, key);
 	if (sx_status != SX_OK) {
 		return silex_statuscodes_to_psa(sx_status);
 	}
 
-	return cracen_aes_ecb_crypt(&blkciph, input, input_length, output, output_size,
+	return cracen_aes_ecb_crypt(blkciph, input, input_length, output, output_size,
 				    output_length);
 }
 
-psa_status_t cracen_aes_ecb_decrypt(const struct sxkeyref *key, const uint8_t *input,
-				    size_t input_length, uint8_t *output, size_t output_size,
-				    size_t *output_length)
+psa_status_t cracen_aes_ecb_decrypt(struct sxblkcipher *blkciph, const struct sxkeyref *key,
+				    const uint8_t *input, size_t input_length, uint8_t *output,
+				    size_t output_size, size_t *output_length)
 {
 	int sx_status;
-	struct sxblkcipher blkciph;
 
 	if (output_size < input_length) {
 		return PSA_ERROR_BUFFER_TOO_SMALL;
@@ -76,26 +74,26 @@ psa_status_t cracen_aes_ecb_decrypt(const struct sxkeyref *key, const uint8_t *i
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 
-	sx_status = sx_blkcipher_create_aesecb_dec(&blkciph, key);
+	sx_status = sx_blkcipher_create_aesecb_dec(blkciph, key);
 	if (sx_status != SX_OK) {
 		return silex_statuscodes_to_psa(sx_status);
 	}
 
-	return cracen_aes_ecb_crypt(&blkciph, input, input_length, output, output_size,
+	return cracen_aes_ecb_crypt(blkciph, input, input_length, output, output_size,
 				    output_length);
 }
 
-psa_status_t cracen_aes_primitive(const struct sxkeyref *key, const uint8_t *input, uint8_t *output)
+psa_status_t cracen_aes_primitive(struct sxblkcipher *blkciph, const struct sxkeyref *key,
+				  const uint8_t *input, uint8_t *output)
 {
 	int sx_status;
-	struct sxblkcipher blkciph;
 	size_t output_size;
 
-	sx_status = sx_blkcipher_create_aesecb_enc(&blkciph, key);
+	sx_status = sx_blkcipher_create_aesecb_enc(blkciph, key);
 	if (sx_status != SX_OK) {
 		return silex_statuscodes_to_psa(sx_status);
 	}
 
-	return cracen_aes_ecb_crypt(&blkciph, input, SX_BLKCIPHER_AES_BLK_SZ, output,
+	return cracen_aes_ecb_crypt(blkciph, input, SX_BLKCIPHER_AES_BLK_SZ, output,
 				    SX_BLKCIPHER_AES_BLK_SZ, &output_size);
 }

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_mac_cmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_mac_cmac.c
@@ -67,7 +67,8 @@ psa_status_t cracen_cmac_derive_subkeys(cracen_mac_operation_t *operation, uint8
 {
 	uint8_t empty_block[SX_BLKCIPHER_AES_BLK_SZ] = {0};
 	uint8_t L[SX_BLKCIPHER_AES_BLK_SZ]; /* L is defined in RFC 4493 */
-	psa_status_t status = cracen_aes_primitive(&operation->cmac.keyref, empty_block, L);
+	psa_status_t status = cracen_aes_primitive(&operation->cmac.cipher, &operation->cmac.keyref,
+						   empty_block, L);
 
 	if (status != PSA_SUCCESS) {
 		return status;
@@ -111,9 +112,9 @@ psa_status_t cracen_sw_cmac_update(cracen_mac_operation_t *operation, const uint
 			cracen_xorbytes(operation->cmac.sw_ctx.mac_state,
 					operation->cmac.sw_ctx.partial_block,
 					SX_BLKCIPHER_AES_BLK_SZ);
-			psa_status = cracen_aes_primitive(&operation->cmac.keyref,
-							    operation->cmac.sw_ctx.mac_state,
-							    operation->cmac.sw_ctx.mac_state);
+			psa_status = cracen_aes_primitive(
+				&operation->cmac.cipher, &operation->cmac.keyref,
+				operation->cmac.sw_ctx.mac_state, operation->cmac.sw_ctx.mac_state);
 			if (psa_status != PSA_SUCCESS) {
 				return psa_status;
 			}
@@ -152,9 +153,9 @@ psa_status_t cracen_sw_cmac_finish(cracen_mac_operation_t *operation)
 	/* Final MAC: encrypt (mac_state XOR last_block) */
 	cracen_xorbytes(operation->cmac.sw_ctx.mac_state, last_block, SX_BLKCIPHER_AES_BLK_SZ);
 
-	psa_status =
-		cracen_aes_primitive(&operation->cmac.keyref, operation->cmac.sw_ctx.mac_state,
-				       operation->cmac.sw_ctx.mac_state);
+	psa_status = cracen_aes_primitive(&operation->cmac.cipher, &operation->cmac.keyref,
+					  operation->cmac.sw_ctx.mac_state,
+					  operation->cmac.sw_ctx.mac_state);
 	if (psa_status != PSA_SUCCESS) {
 		return psa_status;
 	}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
@@ -20,8 +20,13 @@
 
 #define SX_BLKCIPHER_IV_SZ	(16U)
 #define SX_BLKCIPHER_AES_BLK_SZ (16U)
+
+#if defined(PSA_NEED_CRACEN_STREAM_CIPHER_CHACHA20)
 /* ChaCha20 has a 512 bit block size */
 #define SX_BLKCIPHER_MAX_BLK_SZ (64U)
+#else
+#define SX_BLKCIPHER_MAX_BLK_SZ SX_BLKCIPHER_AES_BLK_SZ
+#endif
 
 #define CRACEN_MAX_AES_KEY_SIZE (32u)
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
@@ -220,6 +220,7 @@ struct cracen_mac_operation_s {
 			uint8_t key_buffer[CRACEN_MAX_AES_KEY_SIZE];
 #if defined(CONFIG_CRACEN_NEED_MULTIPART_WORKAROUNDS)
 			cracen_cmac_context_t sw_ctx;
+			struct sxblkcipher cipher;
 #endif /* CONFIG_CRACEN_NEED_MULTIPART_WORKAROUNDS */
 		} cmac;
 #endif /* PSA_NEED_CRACEN_CMAC */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cipher.c
@@ -198,9 +198,7 @@ static psa_status_t encrypt_cbc(const struct sxkeyref *key, const uint8_t *input
 	}
 
 	memset(padded_input_block, padding, sizeof(padded_input_block));
-	if (remaining_bytes > 0) {
-		memcpy(padded_input_block, input + full_blocks_length, remaining_bytes);
-	}
+	memcpy(padded_input_block, input + full_blocks_length, remaining_bytes);
 
 	sx_status = sx_blkcipher_crypt(&cipher_ctx, padded_input_block, sizeof(padded_input_block),
 				       output + full_blocks_length);
@@ -216,10 +214,9 @@ static psa_status_t encrypt_cbc(const struct sxkeyref *key, const uint8_t *input
 	sx_status = sx_blkcipher_wait(&cipher_ctx);
 	if (sx_status == SX_OK) {
 		*output_length = padded_input_length;
-		return PSA_SUCCESS;
-	} else {
-		return silex_statuscodes_to_psa(sx_status);
 	}
+
+	return silex_statuscodes_to_psa(sx_status);
 }
 
 static psa_status_t decrypt_cbc(const struct sxkeyref *key, const uint8_t *input,

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.h
@@ -181,15 +181,6 @@ psa_status_t cracen_load_keyref(const psa_key_attributes_t *attributes, const ui
 				size_t key_buffer_size, struct sxkeyref *k);
 
 /**
- * @brief Do ECB operation.
- *
- * @return PSA status code.
- */
-psa_status_t cracen_cipher_crypt_ecb(const struct sxkeyref *key, const uint8_t *input,
-				     size_t input_length, uint8_t *output, size_t output_size,
-				     size_t *output_length, enum cipher_operation dir);
-
-/**
  * @brief Prepare ik key.
  *
  * @param user_data    Owner ID.

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/internal.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/internal.h
@@ -111,7 +111,7 @@ struct sxaead {
  */
 struct sxblkcipher {
 	const struct sx_blkcipher_cmdma_cfg *cfg;
-	struct sxkeyref key;
+	const struct sxkeyref *key;
 	uint32_t textsz;
 	struct sx_dmactl dma;
 	struct sxdesc descs[5];

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/chachapoly.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/chachapoly.c
@@ -151,9 +151,9 @@ static int sx_blkcipher_create_chacha20(struct sxblkcipher *cipher_ctx, struct s
 		return SX_ERR_INVALID_KEY_SZ;
 	}
 
-	memcpy(&cipher_ctx->key, key, sizeof(cipher_ctx->key));
 	sx_hw_reserve(&cipher_ctx->dma);
 	cipher_ctx->cfg = &ba417chacha20cfg;
+	cipher_ctx->key = key;
 
 	sx_cmdma_newcmd(&cipher_ctx->dma, cipher_ctx->descs, BA417_MODE_CHACHA20 | dir,
 			cipher_ctx->cfg->dmatags->cfg);


### PR DESCRIPTION
Refactoring of the Cracen driver for cipher to reduce stack usage. See commits for details.