### PR TITLE
partition_manager: Move PCD partition to non secure flash

### DIFF
--- a/subsys/partition_manager/pm.yml.pcd
+++ b/subsys/partition_manager/pm.yml.pcd
@@ -3,6 +3,9 @@
 # This block of RAM is used for communicating Network Core firmware update
 # metadata
 pcd_sram:
-  placement: {after: [start]}
-  size: CONFIG_NRF_SPU_RAM_REGION_SIZE
+  placement: {before: end}
+  size: CONFIG_NRF_TRUSTZONE_RAM_REGION_SIZE
   region: sram_primary
+#ifdef CONFIG_BUILD_WITH_TFM
+  align: {start: CONFIG_NRF_TRUSTZONE_RAM_REGION_SIZE}
+#endif

--- a/subsys/partition_manager/pm.yml.trustzone
+++ b/subsys/partition_manager/pm.yml.trustzone
@@ -1,11 +1,11 @@
 # Create a span for the RAM to be configured as SECURE by TF-M.
 sram_secure:
   region: sram_primary
-  span:
-    - pcd_sram
+  span: []
 
 sram_nonsecure:
   region: sram_primary
   span:
     - sram_primary /* Here, sram_primary refers to the (NS) app's RAM. */
+    - pcd_sram
     - rpmsg_nrf53_sram


### PR DESCRIPTION
The PCD partition is configured as non secure from TF-M but it was placed in the secure area by partition manager. Move the PCD partition to the non secure region where it should be.

Ref: NCSDK-33735


(cherry picked from commit 2791fbf3e7f7e0048d7fe003200abb7fe18e0f14)