### PR TITLE
sysbuild: packaging: Fix selection of application image path

### DIFF
--- a/subsys/bootloader/cmake/packaging.cmake
+++ b/subsys/bootloader/cmake/packaging.cmake
@@ -17,7 +17,13 @@ if(SB_CONFIG_DFU_MULTI_IMAGE_PACKAGE_BUILD)
     sysbuild_get(${DEFAULT_IMAGE}_kernel_name IMAGE ${DEFAULT_IMAGE} VAR CONFIG_KERNEL_BIN_NAME KCONFIG)
 
     list(APPEND dfu_multi_image_ids 0)
-    list(APPEND dfu_multi_image_paths "${${DEFAULT_IMAGE}_image_dir}/zephyr/${${DEFAULT_IMAGE}_kernel_name}.signed.bin")
+
+    if(SB_CONFIG_BOOT_ENCRYPTION)
+      list(APPEND dfu_multi_image_paths "${${DEFAULT_IMAGE}_image_dir}/zephyr/${${DEFAULT_IMAGE}_kernel_name}.signed.encrypted.bin")
+    else()
+      list(APPEND dfu_multi_image_paths "${${DEFAULT_IMAGE}_image_dir}/zephyr/${${DEFAULT_IMAGE}_kernel_name}.signed.bin")
+    endif()
+
     list(APPEND dfu_multi_image_targets ${DEFAULT_IMAGE}_extra_byproducts ${dfu_multi_image_paths})
   endif()
 


### PR DESCRIPTION
Select the application image path based on encryption support, matching the behavior of zip packaging.

Tested using nRF54L15 and Matter OTA. This change only includes application image, as support for network core or mcuboot encryption is not present in the build system today. This addresses the customer needs.