### PR TITLE
nrf_security: cracen: Add generic IKG personalization

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/Kconfig
+++ b/subsys/nrf_security/src/drivers/cracen/Kconfig
@@ -83,6 +83,13 @@ config CRACEN_IKG_SEED_KMU_SLOT
 	  This defines the KMU slot (along with the two following it) to which
 	  the IKG seed is provisioned and that is pushed when loading the IKG seed.
 
+config CRACEN_IKG_PERSONALIZED_KEYS
+	bool "CRACEN IKG personalized keys"
+	help
+	  Personalize each IKG-generated key for the associated key owner.
+	  If an owner ID is encoded into the mbedtls_svc_key_id_t type,
+	  it will be passed to the IKG as a personalization string.
+
 config CRACEN_USE_INTERRUPTS
 	bool "Use cracen with interrupts"
 	default y

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.c
@@ -734,6 +734,10 @@ int cracen_prepare_ik_key(const uint8_t *user_data)
 	}
 #endif
 
+#ifdef CONFIG_CRACEN_IKG_PERSONALIZED_KEYS
+	cfg.key_bundle = (const uint32_t *)user_data;
+	cfg.key_bundle_sz = 1; /* size of the owner_id is one 32-bit word */
+#endif
 
 #if defined(CONFIG_CRACEN_IKG)
 	return sx_pk_ik_derive_keys(&cfg);

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/include/silexpk/ik.h
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/include/silexpk/ik.h
@@ -102,7 +102,7 @@ struct sx_pk_inops_ik_ptmult {
 
 struct sx_pk_config_ik {
 	/** Key Bundle name */
-	uint32_t *key_bundle;
+	const uint32_t *key_bundle;
 
 	/** Key Bundle size in 32 bit words
 	 *
@@ -112,7 +112,7 @@ struct sx_pk_config_ik {
 	int key_bundle_sz;
 
 	/** Device Secret */
-	uint32_t *device_secret;
+	const uint32_t *device_secret;
 
 	/** Device Secret size in 32 bit words
 	 *


### PR DESCRIPTION
On Haltium devices, each CRACEN built-in key ID is expected to reference a different IKG-generated key for each domain. This used to be a part of SUIT SDFW's platform key implementation, which is now unused and will be removed soon. When no personalization string is passed, all domains have the same IAK, MKEK, and MEXT keys.

To solve this, introduce a more generic key personalization scheme that leverages the owner ID already passed from `cracen_load_ikg_keyref()`. It's hidden behind a new Kconfig option, which is disabled by default, as it only makes sense when MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER.

Ref: NCSDK-35202