### PR TITLE
samples: bluetooth: Add support for nRF54LV10

### DIFF
--- a/samples/bluetooth/central_smp_client/sample.yaml
+++ b/samples/bluetooth/central_smp_client/sample.yaml
@@ -13,6 +13,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
@@ -22,6 +23,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     tags:
       - bluetooth
       - ci_build

--- a/samples/bluetooth/multiple_adv_sets/sample.yaml
+++ b/samples/bluetooth/multiple_adv_sets/sample.yaml
@@ -14,6 +14,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
@@ -24,6 +25,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     tags:
       - bluetooth
       - ci_build

--- a/samples/bluetooth/peripheral_bms/sample.yaml
+++ b/samples/bluetooth/peripheral_bms/sample.yaml
@@ -13,6 +13,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
@@ -22,6 +23,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     tags:
       - bluetooth
       - ci_build


### PR DESCRIPTION
Added nRF54LV10 support in the following Bluetooth samples:
- central_smp_client
- multiple_adv_sets
- peripheral_bms