### PR TITLE
samples: Add missing empty line in sample's readme

### DIFF
--- a/samples/dfu/dfu_target/README.rst
+++ b/samples/dfu/dfu_target/README.rst
@@ -93,6 +93,7 @@ After programming the sample to your development kit, perform the following step
      ``<image_size>`` is the size, in bytes, of the file :file:`build_v2/dfu_target/zephyr/zephyr.signed.bin`.
 
    * Step-by-step update:
+
      #. Get the image type::
 
            dfu_target image_type


### PR DESCRIPTION
Sample's readme file is not generated properly due to missing an empty line.