### PR TITLE
doc: Minor fix in samples which don't support thingy53

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -279,7 +279,7 @@ Bluetooth samples
 
    * :ref:`peripheral_lbs`
    * :ref:`peripheral_status`
-   * :ref:`peripheral_status`
+   * :ref:`peripheral_uart`
 
 Bluetooth Mesh samples
 ----------------------


### PR DESCRIPTION
There are three samples which recently removed support for the thingy53 non secure target, these are the peripheral lbs/status/uart.  In the docs by accident the peripheral_status was listed twice so fix this.