### PR TITLE
cmake: Generate confirmed images in Direct XIP

### DIFF
--- a/cmake/sysbuild/image_signing_split.cmake
+++ b/cmake/sysbuild/image_signing_split.cmake
@@ -152,14 +152,25 @@ function(zephyr_mcuboot_tasks)
   # List of additional build byproducts.
   set(byproducts)
 
-  # 'west sign' arguments for confirmed, unconfirmed and encrypted images.
-  set(unconfirmed_args)
-  set(confirmed_args)
-  set(encrypted_args)
+  # Input files to sign
+  set(input_internal_arg)
+  set(input_external_arg)
+  # Additional (algorithm-dependent) args for encryption
+  set(imgtool_encrypt_extra_args)
 
   if(NOT "${keyfile_enc}" STREQUAL "")
     if(CONFIG_MCUBOOT_ENCRYPTION_ALG_AES_256)
       set(imgtool_args ${imgtool_args} --encrypt-keylen 256)
+    endif()
+
+    # Signature type determines key exchange scheme; ED25519 here means
+    # ECIES-X25519 is used. Default to HMAC-SHA512 for ECIES-X25519.
+    # Only .encrypted.bin file gets the ENCX25519/ENCX25519_SHA512, the
+    # just signed one does not.
+    # Only NRF54L gets the HMAC-SHA512, other remain with previously used
+    # SHA256.
+    if(CONFIG_SOC_SERIES_NRF54LX AND CONFIG_MCUBOOT_BOOTLOADER_SIGNATURE_TYPE_ED25519)
+      set(imgtool_encrypt_extra_args --hmac-sha 512)
     endif()
   endif()
 
@@ -176,12 +187,12 @@ function(zephyr_mcuboot_tasks)
     if(CONFIG_BUILD_WITH_TFM)
       # Merge the TFM secure hex file with the internal hex file
       set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py -o ${input_internal}.tfm.hex ${input_internal}.hex ${input_tfm_s}.hex)
-      set(unconfirmed_internal_args ${input_internal}.tfm.hex ${output_internal}.hex)
+      set(input_internal_arg ${input_internal}.tfm.hex)
     else()
-      set(unconfirmed_internal_args ${input_internal}.hex ${output_internal}.hex)
+      set(input_internal_arg ${input_internal}.hex)
     endif()
 
-    set(unconfirmed_external_args ${input_external}.hex ${output_external}.hex)
+    set(input_external_arg ${input_external}.hex)
     list(APPEND byproducts ${output_internal}.hex ${output_external}.hex)
 
     # Do not run zephyr_runner_file here as PM will provide the merged hex file from
@@ -191,7 +202,7 @@ function(zephyr_mcuboot_tasks)
     endif()
 
     set(BYPRODUCT_KERNEL_SIGNED_HEX_NAME "${output_merged}.hex"
-        CACHE FILEPATH "Signed kernel hex file" FORCE
+      CACHE FILEPATH "Signed kernel hex file" FORCE
     )
 
     # Add the west sign calls and their byproducts to the post-processing
@@ -202,9 +213,9 @@ function(zephyr_mcuboot_tasks)
     # calls to the "extra_post_build_commands" property ensures they run
     # after the commands which generate the unsigned versions.
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
-      ${imgtool_internal_sign} ${imgtool_args} ${unconfirmed_internal_args})
+      ${imgtool_internal_sign} ${imgtool_args} ${input_internal_arg} ${output_internal}.hex)
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
-      ${imgtool_external_sign} ${imgtool_args} ${unconfirmed_external_args})
+      ${imgtool_external_sign} ${imgtool_args} ${input_external_arg} ${output_external}.hex)
 
     # Combine the signed hex files into a single output hex file
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
@@ -212,25 +223,27 @@ function(zephyr_mcuboot_tasks)
 
     if(NOT "${keyfile_enc}" STREQUAL "")
       if(CONFIG_BUILD_WITH_TFM)
-        set(unconfirmed_internal_args ${input_internal}.tfm.hex ${output_internal}.encrypted.hex)
+        set(input_internal_arg ${input_internal}.tfm.hex)
       else()
-        set(unconfirmed_internal_args ${input_internal}.hex ${output_internal}.encrypted.hex)
+        set(input_internal_arg ${input_internal}.hex)
       endif()
 
-      set(unconfirmed_external_args ${input_external}.hex ${output_external}.encrypted.hex)
+      set(input_external_arg ${input_external}.hex)
       list(APPEND byproducts ${output_internal}.encrypted.hex ${output_external}.encrypted.hex)
       set(BYPRODUCT_KERNEL_SIGNED_ENCRYPTED_HEX_NAME "${output_merged}.encrypted.hex"
-          CACHE FILEPATH "Signed and encrypted kernel hex file" FORCE
+        CACHE FILEPATH "Signed and encrypted kernel hex file" FORCE
       )
 
       set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
-        ${imgtool_internal_sign} ${imgtool_args} --encrypt "${keyfile_enc}" ${unconfirmed_internal_args})
+        ${imgtool_internal_sign} ${imgtool_args} ${imgtool_encrypt_extra_args} --encrypt
+        "${keyfile_enc}" ${input_internal_arg} ${output_internal}.encrypted.hex)
       set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
-        ${imgtool_external_sign} ${imgtool_args} --encrypt "${keyfile_enc}" ${unconfirmed_external_args})
+        ${imgtool_external_sign} ${imgtool_args} ${imgtool_encrypt_extra_args} --encrypt
+        "${keyfile_enc}" ${input_external_arg} ${output_external}.encrypted.hex)
 
       # Combine the signed hex files into a single output hex file
       set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
-        ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py -o ${output_merged}.encrypted.hex ${output_internal}.hex ${output_external}.hex)
+        ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py -o ${output_merged}.encrypted.hex ${output_internal}.encrypted.hex ${output_external}.encrypted.hex)
     endif()
   endif()
 
@@ -245,7 +258,7 @@ function(zephyr_mcuboot_tasks)
     list(APPEND byproducts "${output_internal}.bin;${output_external}.bin")
 
     set(BYPRODUCT_KERNEL_SIGNED_BIN_NAME "${output_internal}.bin;${output_external}.bin"
-        CACHE FILEPATH "Signed kernel bin files" FORCE
+      CACHE FILEPATH "Signed kernel bin files" FORCE
     )
 
     if(NOT "${keyfile_enc}" STREQUAL "")
@@ -257,7 +270,7 @@ function(zephyr_mcuboot_tasks)
 
       list(APPEND byproducts "${output_internal}.encrypted.bin;${output_external}.encrypted.bin")
       set(BYPRODUCT_KERNEL_SIGNED_ENCRYPTED_BIN_NAME "${output_internal}.encrypted.bin;${output_external}.encrypted.bin"
-          CACHE FILEPATH "Signed and encrypted kernel bin files" FORCE
+        CACHE FILEPATH "Signed and encrypted kernel bin files" FORCE
       )
     endif()
   endif()

--- a/cmake/sysbuild/partition_manager.cmake
+++ b/cmake/sysbuild/partition_manager.cmake
@@ -256,7 +256,10 @@ function(partition_manager)
       # So for each domain we should just include the generated hex file.
       # Those are available thorugh sysbuild_get, but not locally as there is no parent image.
       list(APPEND explicitly_assigned ${part})
-      sysbuild_get(${part}_PM_HEX_FILE IMAGE ${part} VAR BYPRODUCT_KERNEL_SIGNED_HEX_NAME CACHE)
+      sysbuild_get(${part}_PM_HEX_FILE IMAGE ${part} VAR BYPRODUCT_KERNEL_SIGNED_CONFIRMED_HEX_NAME CACHE)
+      if(NOT ${part}_PM_HEX_FILE)
+        sysbuild_get(${part}_PM_HEX_FILE IMAGE ${part} VAR BYPRODUCT_KERNEL_SIGNED_HEX_NAME CACHE)
+      endif()
       if(NOT ${part}_PM_HEX_FILE)
         sysbuild_get(${part}_PM_HEX_FILE IMAGE ${part} VAR BYPRODUCT_KERNEL_HEX_NAME CACHE)
       endif()


### PR DESCRIPTION
If building with revert functionality, generate the confirmed images so the application will boot after flashing the default set of artifacts.

Ref: NCSIDB-1208