### PR TITLE
applications: nrf_desktop: Fix system state LED control on nRF54L15 DK

### DIFF
--- a/applications/nrf_desktop/board_configuration.rst
+++ b/applications/nrf_desktop/board_configuration.rst
@@ -111,7 +111,7 @@ Sample mouse or keyboard (``nrf54l15dk/nrf54l05/cpuapp``)
       * The build types allow to build the application as a mouse or a keyboard.
       * Inputs are simulated based on the hardware button presses.
       * On the nRF54L05 SoC, you can only use the **GPIO1** port for PWM hardware peripheral output.
-        Because of that, on the DK PCA10156 revision v0.8.1, **LED 0** and **LED 2** cannot be used for PWM output.
+        Because of that, on the DK PCA10156 revision v0.9.3, **LED 0** and **LED 2** cannot be used for PWM output.
         You can still use these LEDs with the PWM LED driver, but you must set the LED color to ``LED_COLOR(255, 255, 255)`` or ``LED_COLOR(0, 0, 0)``.
         This ensures the PWM peripheral is not used for the mentioned LEDs.
       * Only Bluetooth LE transport is enabled.
@@ -131,7 +131,7 @@ Sample mouse or keyboard (``nrf54l15dk/nrf54l10/cpuapp``)
       * The build types allow to build the application as a mouse or a keyboard.
       * Inputs are simulated based on the hardware button presses.
       * On the nRF54L10 SoC, you can only use the **GPIO1** port for PWM hardware peripheral output.
-        Because of that, on the DK PCA10156 revision v0.8.1, **LED 0** and **LED 2** cannot be used for PWM output.
+        Because of that, on the DK PCA10156 revision v0.9.3, **LED 0** and **LED 2** cannot be used for PWM output.
         You can still use these LEDs with the PWM LED driver, but you must set the LED color to ``LED_COLOR(255, 255, 255)`` or ``LED_COLOR(0, 0, 0)``.
         This ensures the PWM peripheral is not used for the mentioned LEDs.
       * Only Bluetooth LE transport is enabled.
@@ -151,7 +151,7 @@ Sample mouse or keyboard (``nrf54l15dk/nrf54l15/cpuapp``)
       * The build types allow to build the application as a mouse or a keyboard.
       * Inputs are simulated based on the hardware button presses.
       * On the nRF54L15 SoC, you can only use the **GPIO1** port for PWM hardware peripheral output.
-        Because of that, on the DK PCA10156 revision v0.8.1, **LED 0** and **LED 2** cannot be used for PWM output.
+        Because of that, on the DK PCA10156 revision v0.9.3, **LED 0** and **LED 2** cannot be used for PWM output.
         You can still use these LEDs with the PWM LED driver, but you must set the LED color to ``LED_COLOR(255, 255, 255)`` or ``LED_COLOR(0, 0, 0)``.
         This ensures the PWM peripheral is not used for the mentioned LEDs.
       * Only Bluetooth LE transport is enabled.

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/hid_keyboard_leds_def_keyboard.h
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/hid_keyboard_leds_def_keyboard.h
@@ -16,12 +16,13 @@
 const struct {} hid_keyboard_leds_def_include_once;
 
 /* On the nRF54L05 SoC, you can only use the **GPIO1** port for PWM hardware peripheral output.
- * Because of that, on the DK PCA10156 revision v0.8.1, **LED 0** and **LED 2** cannot be used for
+ * Because of that, on the DK PCA10156 revision v0.9.3, **LED 0** and **LED 2** cannot be used for
  * PWM output.
  *
  * You can still use these LEDs with the PWM LED driver, but you must set the LED color to
- * `LED_COLOR(255, 255, 255)` or `LED_COLOR(0, 0, 0)`. This ensures the PWM peripheral is not
- * used for the mentioned LEDs.
+ * `LED_COLOR(255, 255, 255)` or `LED_COLOR(0, 0, 0)`. You must also disable the
+ * `CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100` Kconfig option. This ensures the PWM peripheral is not used
+ * for the mentioned LEDs.
  */
 static const struct led_effect keyboard_led_on = LED_EFFECT_LED_ON(LED_COLOR(255, 255, 255));
 static const struct led_effect keyboard_led_off = LED_EFFECT_LED_OFF();

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/led_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/led_state_def.h
@@ -24,12 +24,13 @@ static const uint8_t led_map[LED_ID_COUNT] = {
 };
 
 /* On the nRF54L05 SoC, you can only use the **GPIO1** port for PWM hardware peripheral output.
- * Because of that, on the DK PCA10156 revision v0.8.1 **LED 0** and **LED 2** cannot be used
+ * Because of that, on the DK PCA10156 revision v0.9.3 **LED 0** and **LED 2** cannot be used
  * for PWM output.
  *
  * You can still use these LEDs with the PWM LED driver, but you must set the LED color to
- * `LED_COLOR(255, 255, 255)` or `LED_COLOR(0, 0, 0)`. This ensures the PWM peripheral is not
- * used for the mentioned LEDs.
+ * `LED_COLOR(255, 255, 255)` or `LED_COLOR(0, 0, 0)`. You must also disable the
+ * `CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100` Kconfig option. This ensures the PWM peripheral is not used
+ * for the mentioned LEDs.
  */
 
 static const struct led_effect led_system_state_effect[LED_SYSTEM_STATE_COUNT] = {

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj.conf
@@ -77,6 +77,9 @@ CONFIG_PWM=y
 
 CONFIG_LED=y
 CONFIG_LED_PWM=y
+# Some of the on-board LEDs cannot be controlled using PWM hardware peripheral output.
+# See the `led_state_def.h` configuration file for details.
+CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100=n
 
 CONFIG_BT_MAX_PAIRED=2
 CONFIG_BT_ID_MAX=3

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release.conf
@@ -79,6 +79,9 @@ CONFIG_PWM=y
 
 CONFIG_LED=y
 CONFIG_LED_PWM=y
+# Some of the on-board LEDs cannot be controlled using PWM hardware peripheral output.
+# See the `led_state_def.h` configuration file for details.
+CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100=n
 
 CONFIG_BT_MAX_PAIRED=2
 CONFIG_BT_ID_MAX=3

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release_fast_pair.conf
@@ -98,6 +98,9 @@ CONFIG_PWM=y
 
 CONFIG_LED=y
 CONFIG_LED_PWM=y
+# Some of the on-board LEDs cannot be controlled using PWM hardware peripheral output.
+# See the `led_state_def.h` configuration file for details.
+CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100=n
 
 CONFIG_BT_MAX_PAIRED=4
 CONFIG_BT_ID_MAX=3

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release_keyboard.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/prj_release_keyboard.conf
@@ -86,6 +86,9 @@ CONFIG_PWM=y
 
 CONFIG_LED=y
 CONFIG_LED_PWM=y
+# Some of the on-board LEDs cannot be controlled using PWM hardware peripheral output.
+# See the `led_state_def.h` configuration file for details.
+CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100=n
 
 CONFIG_BT_MAX_PAIRED=2
 CONFIG_BT_ID_MAX=3

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/hid_keyboard_leds_def_keyboard.h
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/hid_keyboard_leds_def_keyboard.h
@@ -16,12 +16,13 @@
 const struct {} hid_keyboard_leds_def_include_once;
 
 /* On the nRF54L10 SoC, you can only use the **GPIO1** port for PWM hardware peripheral output.
- * Because of that, on the DK PCA10156 revision v0.8.1, **LED 0** and **LED 2** cannot be used for
+ * Because of that, on the DK PCA10156 revision v0.9.3, **LED 0** and **LED 2** cannot be used for
  * PWM output.
  *
  * You can still use these LEDs with the PWM LED driver, but you must set the LED color to
- * `LED_COLOR(255, 255, 255)` or `LED_COLOR(0, 0, 0)`. This ensures the PWM peripheral is not
- * used for the mentioned LEDs.
+ * `LED_COLOR(255, 255, 255)` or `LED_COLOR(0, 0, 0)`. You must also disable the
+ * `CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100` Kconfig option. This ensures the PWM peripheral is not used
+ * for the mentioned LEDs.
  */
 static const struct led_effect keyboard_led_on = LED_EFFECT_LED_ON(LED_COLOR(255, 255, 255));
 static const struct led_effect keyboard_led_off = LED_EFFECT_LED_OFF();

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/led_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/led_state_def.h
@@ -24,12 +24,13 @@ static const uint8_t led_map[LED_ID_COUNT] = {
 };
 
 /* On the nRF54L10 SoC, you can only use the **GPIO1** port for PWM hardware peripheral output.
- * Because of that, on the DK PCA10156 revision v0.8.1 **LED 0** and **LED 2** cannot be used
+ * Because of that, on the DK PCA10156 revision v0.9.3 **LED 0** and **LED 2** cannot be used
  * for PWM output.
  *
  * You can still use these LEDs with the PWM LED driver, but you must set the LED color to
- * `LED_COLOR(255, 255, 255)` or `LED_COLOR(0, 0, 0)`. This ensures the PWM peripheral is not
- * used for the mentioned LEDs.
+ * `LED_COLOR(255, 255, 255)` or `LED_COLOR(0, 0, 0)`. You must also disable the
+ * `CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100` Kconfig option. This ensures the PWM peripheral is not used
+ * for the mentioned LEDs.
  */
 
 static const struct led_effect led_system_state_effect[LED_SYSTEM_STATE_COUNT] = {

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/prj.conf
@@ -77,6 +77,9 @@ CONFIG_PWM=y
 
 CONFIG_LED=y
 CONFIG_LED_PWM=y
+# Some of the on-board LEDs cannot be controlled using PWM hardware peripheral output.
+# See the `led_state_def.h` configuration file for details.
+CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100=n
 
 CONFIG_BT_MAX_PAIRED=2
 CONFIG_BT_ID_MAX=3

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/prj_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/prj_fast_pair.conf
@@ -99,6 +99,9 @@ CONFIG_PWM=y
 
 CONFIG_LED=y
 CONFIG_LED_PWM=y
+# Some of the on-board LEDs cannot be controlled using PWM hardware peripheral output.
+# See the `led_state_def.h` configuration file for details.
+CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100=n
 
 # Enable MCUmgr Bluetooth transport and increase Bluetooth buffers to speed up DFU image transfer.
 CONFIG_MCUMGR_TRANSPORT_BT=y

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/prj_keyboard.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/prj_keyboard.conf
@@ -82,6 +82,9 @@ CONFIG_PWM=y
 
 CONFIG_LED=y
 CONFIG_LED_PWM=y
+# Some of the on-board LEDs cannot be controlled using PWM hardware peripheral output.
+# See the `led_state_def.h` configuration file for details.
+CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100=n
 
 CONFIG_BT_MAX_PAIRED=2
 CONFIG_BT_ID_MAX=3

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/prj_release.conf
@@ -78,6 +78,9 @@ CONFIG_PWM=y
 
 CONFIG_LED=y
 CONFIG_LED_PWM=y
+# Some of the on-board LEDs cannot be controlled using PWM hardware peripheral output.
+# See the `led_state_def.h` configuration file for details.
+CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100=n
 
 CONFIG_BT_MAX_PAIRED=2
 CONFIG_BT_ID_MAX=3

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/hid_keyboard_leds_def_keyboard.h
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/hid_keyboard_leds_def_keyboard.h
@@ -16,12 +16,13 @@
 const struct {} hid_keyboard_leds_def_include_once;
 
 /* On the nRF54L15 SoC, you can only use the **GPIO1** port for PWM hardware peripheral output.
- * Because of that, on the DK PCA10156 revision v0.8.1, **LED 0** and **LED 2** cannot be used for
+ * Because of that, on the DK PCA10156 revision v0.9.3, **LED 0** and **LED 2** cannot be used for
  * PWM output.
  *
  * You can still use these LEDs with the PWM LED driver, but you must set the LED color to
- * `LED_COLOR(255, 255, 255)` or `LED_COLOR(0, 0, 0)`. This ensures the PWM peripheral is not
- * used for the mentioned LEDs.
+ * `LED_COLOR(255, 255, 255)` or `LED_COLOR(0, 0, 0)`. You must also disable the
+ * `CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100` Kconfig option. This ensures the PWM peripheral is not used
+ * for the mentioned LEDs.
  */
 static const struct led_effect keyboard_led_on = LED_EFFECT_LED_ON(LED_COLOR(255, 255, 255));
 static const struct led_effect keyboard_led_off = LED_EFFECT_LED_OFF();

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/led_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/led_state_def.h
@@ -24,12 +24,13 @@ static const uint8_t led_map[LED_ID_COUNT] = {
 };
 
 /* On the nRF54L15 SoC, you can only use the **GPIO1** port for PWM hardware peripheral output.
- * Because of that, on the DK PCA10156 revision v0.8.1 **LED 0** and **LED 2** cannot be used
+ * Because of that, on the DK PCA10156 revision v0.9.3 **LED 0** and **LED 2** cannot be used
  * for PWM output.
  *
  * You can still use these LEDs with the PWM LED driver, but you must set the LED color to
- * `LED_COLOR(255, 255, 255)` or `LED_COLOR(0, 0, 0)`. This ensures the PWM peripheral is not
- * used for the mentioned LEDs.
+ * `LED_COLOR(255, 255, 255)` or `LED_COLOR(0, 0, 0)`. You must also disable the
+ * `CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100` Kconfig option. This ensures the PWM peripheral is not used
+ * for the mentioned LEDs.
  */
 
 static const struct led_effect led_system_state_effect[LED_SYSTEM_STATE_COUNT] = {

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/prj.conf
@@ -77,6 +77,9 @@ CONFIG_PWM=y
 
 CONFIG_LED=y
 CONFIG_LED_PWM=y
+# Some of the on-board LEDs cannot be controlled using PWM hardware peripheral output.
+# See the `led_state_def.h` configuration file for details.
+CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100=n
 
 CONFIG_BT_MAX_PAIRED=2
 CONFIG_BT_ID_MAX=3

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/prj_fast_pair.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/prj_fast_pair.conf
@@ -99,6 +99,9 @@ CONFIG_PWM=y
 
 CONFIG_LED=y
 CONFIG_LED_PWM=y
+# Some of the on-board LEDs cannot be controlled using PWM hardware peripheral output.
+# See the `led_state_def.h` configuration file for details.
+CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100=n
 
 # Enable MCUmgr Bluetooth transport and increase Bluetooth buffers to speed up DFU image transfer.
 CONFIG_MCUMGR_TRANSPORT_BT=y

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/prj_keyboard.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/prj_keyboard.conf
@@ -82,6 +82,9 @@ CONFIG_PWM=y
 
 CONFIG_LED=y
 CONFIG_LED_PWM=y
+# Some of the on-board LEDs cannot be controlled using PWM hardware peripheral output.
+# See the `led_state_def.h` configuration file for details.
+CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100=n
 
 CONFIG_BT_MAX_PAIRED=2
 CONFIG_BT_ID_MAX=3

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/prj_release.conf
@@ -78,6 +78,9 @@ CONFIG_PWM=y
 
 CONFIG_LED=y
 CONFIG_LED_PWM=y
+# Some of the on-board LEDs cannot be controlled using PWM hardware peripheral output.
+# See the `led_state_def.h` configuration file for details.
+CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100=n
 
 CONFIG_BT_MAX_PAIRED=2
 CONFIG_BT_ID_MAX=3


### PR DESCRIPTION
Change disables `CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100` to fix system state LED control in the application. The LED cannot be used for PWM output.

Jira: NCSDK-34743