### PR TITLE
shields: nrf2220ek: support for nrf54lm20dk/nrf54lm20a/cpuapp

### DIFF
--- a/boards/shields/nrf2220ek/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/boards/shields/nrf2220ek/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,77 @@
+/* Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Pin mapping suitable for use nRF2220-EK PCA63558 with nRF54LM20DK.
+ * The nRF2220-EK in PORT0 connector.
+ */
+
+/ {
+	nrf_radio_fem: nrf2220_fem {
+		compatible = "nordic,nrf2220-fem";
+		cs-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+		md-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+		twi-if = <&nrf_radio_fem_twi>;
+	};
+};
+
+&i2c30 {
+	status = "okay";
+
+	pinctrl-0 = <&i2c30_default>;
+	pinctrl-1 = <&i2c30_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	nrf_radio_fem_twi: nrf2220_fem_twi@36 {
+		compatible = "nordic,nrf2220-fem-twi";
+		status = "okay";
+		reg = <0x36>;
+	};
+};
+
+&pinctrl {
+	i2c30_default: i2c30_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 4)>,
+				<NRF_PSEL(TWIM_SCL, 0, 3)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c30_sleep: i2c30_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 4)>,
+				<NRF_PSEL(TWIM_SCL, 0, 3)>;
+			low-power-enable;
+		};
+	};
+};
+
+&dppic10 {
+	status = "okay";
+};
+
+&ppib11 {
+	status = "okay";
+};
+
+&ppib21 {
+	status = "okay";
+};
+
+&dppic20 {
+	status = "okay";
+};
+
+&ppib22 {
+	status = "okay";
+};
+
+&ppib30 {
+	status = "okay";
+};
+
+&dppic30 {
+	status = "okay";
+};


### PR DESCRIPTION
The support for nRF2220EK shield for nRF54LM20DK is added.