### PR TITLE
samples: common: smp bt buffer adjustment

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -79,7 +79,7 @@ config PRIVILEGED_STACK_SIZE
 # nRF Connect SDK needs larger mcumgr buffers when supporting multi-image DFU
 # or when the Bluetooth Reassembly feature is enabled.
 config MCUMGR_TRANSPORT_NETBUF_SIZE
-	default 2475 if MCUMGR_TRANSPORT_BT_REASSEMBLY
+	default 1220 if MCUMGR_TRANSPORT_BT_REASSEMBLY
 	default 1024 if UPDATEABLE_IMAGE_NUMBER > 1
 
 config INIT_ARCH_HW_AT_BOOT

--- a/samples/common/mcumgr_bt_ota_dfu/Kconfig
+++ b/samples/common/mcumgr_bt_ota_dfu/Kconfig
@@ -48,8 +48,11 @@ config IMG_ERASE_PROGRESSIVELY
 
 if MCUMGR_TRANSPORT_BT_REASSEMBLY
 
+# MCUmgr buffer size is optimized to fit one SMP packet divided into five Bluetooth Write Commands,
+# transmitted with the maximum possible MTU value.
+# With the default BT_L2CAP_TX_MTU value: (247 - 3) * 5 = 1220
 config MCUMGR_TRANSPORT_NETBUF_SIZE
-	default 1230
+	default 1220
 
 config MCUMGR_GRP_OS_MCUMGR_PARAMS
 	default y


### PR DESCRIPTION
Related to PR #23746.

Change default netbuf size for smp bt transport from 1230/2475 to 1220 to match the new default MTU.