### PR TITLE
boards: nordic: nrf7120pdk: Disable cracen lib for emu board

### DIFF
--- a/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120_cpuapp_emu_defconfig
+++ b/boards/nordic/nrf7120pdk/nrf7120pdk_nrf7120_cpuapp_emu_defconfig
@@ -28,6 +28,9 @@ CONFIG_NRF_GRTC_START_SYSCOUNTER=y
 # LFRC is not working in EMU at the moment
 # CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
 
+# Disable CRACEN LIB as it is not supported in EMU
+CONFIG_CRACEN_LIB_KMU=n
+
 # Enable Debugging when working with emulator
 CONFIG_OUTPUT_DISASSEMBLY=y
 CONFIG_DEBUG=y


### PR DESCRIPTION
Set CONFIG_CRACEN_LIB_KMU to n for nrf7120 emu board since it is not supported on the emulator