### PR TITLE
Bluetooth: Host: Add support for custom L2CAP chan

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -135,7 +135,8 @@ Amazon Sidewalk
 Bluetooth® LE
 -------------
 
-|no_changes_yet_note|
+* Added support for a fixed custom L2CAP channel.
+  The feature is enabled by the :kconfig:option:`CONFIG_BT_L2CAP_FIXED` Kconfig option, and the channel ID is configurable with the :kconfig:option:`CONFIG_BT_L2CAP_FIXED_CID` Kconfig option.
 
 Bluetooth Mesh
 --------------

--- a/include/bluetooth/l2cap_fixed.h
+++ b/include/bluetooth/l2cap_fixed.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef BT_L2CAP_FIXED_CID_H__
+#define BT_L2CAP_FIXED_CID_H__
+
+/**
+ * @file
+ * @defgroup bt_l2cap_fixed Fixed L2CAP channel
+ * @{
+ * @brief APIs to use a fixed L2CAP channel
+ */
+
+#include <stdint.h>
+#include <zephyr/bluetooth/l2cap.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Register the callbacks for the fixed L2CAP channel
+ *
+ * The callbacks need to be registered before a connection is established.
+ *
+ * @param[in] ops The callbacks to be used.
+ *                Must point to memory that remains valid.
+ */
+void bt_l2cap_fixed_register(const struct bt_l2cap_chan_ops *ops);
+
+/** Send data on the fixed L2CAP channel
+ *
+ * The maximum data length that can be sent and received
+ * is defined by BT_L2CAP_TX_MTU and BT_L2CAP_RX_MTU.
+ * These are set by changing @kconfig{CONFIG_BT_L2CAP_TX_MTU}
+ * and @kconfig{CONFIG_BT_BUF_ACL_RX_SIZE}.
+ * The @kconfig{CONFIG_BT_BUF_ACL_RX_SIZE} needs to account for the 4 octets of
+ * the basic L2CAP header.
+ *
+ * @param[in] conn     The connection context
+ * @param[in] data     The data to be sent
+ * @param[in] data_len The length of the data to be sent
+ *
+ * @return 0 in case of success or negative value in case of error.
+ * @return -EMSGSIZE if `data_len` is larger than the MTU.
+ * @return -EINVAL if `conn` or `data` is NULL.
+ * @return -ENOTCONN if underlying conn is disconnected.
+ */
+int bt_l2cap_fixed_send(struct bt_conn *conn,
+			const uint8_t *data,
+			size_t data_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* BT_L2CAP_FIXED_CID_H__ */

--- a/subsys/bluetooth/host_extensions/CMakeLists.txt
+++ b/subsys/bluetooth/host_extensions/CMakeLists.txt
@@ -6,3 +6,8 @@
 
 zephyr_sources(host_extensions.c)
 zephyr_sources_ifdef(CONFIG_BT_RADIO_NOTIFICATION_CONN_CB radio_notification_conn_cb.c)
+zephyr_sources_ifdef(CONFIG_BT_L2CAP_FIXED l2cap_fixed.c)
+zephyr_library_include_directories_ifdef(
+  CONFIG_BT_L2CAP_FIXED
+  ${ZEPHYR_BASE}/subsys/bluetooth/host
+)

--- a/subsys/bluetooth/host_extensions/Kconfig
+++ b/subsys/bluetooth/host_extensions/Kconfig
@@ -16,3 +16,17 @@ config BT_RADIO_NOTIFICATION_CONN_CB
 	  connection event starts.
 	  This feature can be used to synchronize data sampling
 	  with on-air data transmission.
+
+config BT_L2CAP_FIXED
+	bool "Enable support for the fixed L2CAP channel"
+	depends on BT_CONN
+	help
+	  Enables support for a fixed L2CAP channel.
+	  Only a single fixed custom L2CAP channel is supported.
+
+config BT_L2CAP_FIXED_CID
+	hex "CID of the fixed L2CAP channel"
+	depends on BT_L2CAP_FIXED
+	range 0x20 0x3f
+	help
+	  The channel identifier to be used for the fixed L2CAP channel.

--- a/subsys/bluetooth/host_extensions/l2cap_fixed.c
+++ b/subsys/bluetooth/host_extensions/l2cap_fixed.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <bluetooth/l2cap_fixed.h>
+#include "conn_internal.h"
+#include "l2cap_internal.h"
+
+static int l2cap_fixed_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan);
+
+BT_L2CAP_CHANNEL_DEFINE(custom_fixed_chan, CONFIG_BT_L2CAP_FIXED_CID, l2cap_fixed_accept, NULL);
+
+const static struct bt_l2cap_chan_ops *registered_ops;
+static struct bt_l2cap_le_chan fixed_chans[CONFIG_BT_MAX_CONN];
+
+static int l2cap_fixed_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+{
+	if (!registered_ops) {
+		return -ENOMEM;
+	}
+
+	uint8_t conn_index = bt_conn_index(conn);
+
+	__ASSERT_NO_MSG(conn_index < ARRAY_SIZE(fixed_chans));
+
+	struct bt_l2cap_le_chan *fixed_chan = &fixed_chans[conn_index];
+
+	__ASSERT_NO_MSG(!fixed_chan->chan.conn);
+	memset(fixed_chan, 0, sizeof(*fixed_chan));
+
+	fixed_chan->chan.ops = registered_ops;
+	*chan = &fixed_chan->chan;
+
+	return 0;
+}
+
+static void sent_callback(struct bt_conn *conn, void *user_data, int err)
+{
+	uint8_t conn_index = bt_conn_index(conn);
+
+	__ASSERT_NO_MSG(conn_index < ARRAY_SIZE(fixed_chans));
+
+	struct bt_l2cap_le_chan *fixed_chan = &fixed_chans[conn_index];
+
+	registered_ops->sent(&fixed_chan->chan);
+}
+
+void bt_l2cap_fixed_register(const struct bt_l2cap_chan_ops *ops)
+{
+	__ASSERT(registered_ops == NULL, "Ops have already been registered");
+	registered_ops = ops;
+}
+
+static inline enum bt_conn_state bt_conn_get_state(const struct bt_conn *conn)
+{
+	int err;
+	struct bt_conn_info info;
+
+	err = bt_conn_get_info(conn, &info);
+	__ASSERT_NO_MSG(!err);
+
+	return info.state;
+}
+
+int bt_l2cap_fixed_send(struct bt_conn *conn, const uint8_t *data, size_t data_len)
+{
+	int err;
+	struct net_buf *buf;
+
+	if (!conn || !data) {
+		return -EINVAL;
+	}
+
+	if (data_len > CONFIG_BT_L2CAP_TX_MTU) {
+		return -EMSGSIZE;
+	}
+
+	buf = bt_l2cap_create_pdu(NULL, 0);
+	net_buf_add_mem(buf, data, data_len);
+
+	uint8_t conn_index = bt_conn_index(conn);
+
+	__ASSERT_NO_MSG(conn_index < ARRAY_SIZE(fixed_chans));
+
+	struct bt_l2cap_le_chan *fixed_chan = &fixed_chans[conn_index];
+
+	k_sched_lock();
+	if (bt_conn_get_state(conn) == BT_CONN_STATE_CONNECTED) {
+		err = bt_l2cap_send_pdu(fixed_chan, buf, sent_callback, NULL);
+	} else {
+		err = -ENOTCONN;
+	}
+	k_sched_unlock();
+
+	if (err) {
+		net_buf_unref(buf);
+	}
+
+	return err;
+}


### PR DESCRIPTION
Adds support for a custom, fixed L2CAP channel through the new Kconfig option BT_L2CAP_FIXED. The API consists of `bt_l2cap_fixed_register` used to register callbacks for the channel and `bt_l2cap_fixed_send` used to send data on the channel.