### PR TITLE
tests: Fix incorrect average result calculation in the latency tests

### DIFF
--- a/tests/drivers/adc/adc_latency/src/main.c
+++ b/tests/drivers/adc/adc_latency/src/main.c
@@ -110,7 +110,7 @@ static void test_adc_latency(uint32_t acquisition_time_us, uint32_t sampling_int
 
 		timer_value_us[repeat_counter] =
 			counter_ticks_to_us(tst_timer_dev, tst_timer_value);
-		average_timer_value_us += timer_value_us[repeat_counter] / MEASUREMENT_REPEATS;
+		average_timer_value_us += timer_value_us[repeat_counter];
 
 #if !defined(CONFIG_SOC_NRF52840)
 		/*
@@ -124,6 +124,8 @@ static void test_adc_latency(uint32_t acquisition_time_us, uint32_t sampling_int
 		}
 #endif
 	}
+
+	average_timer_value_us /= MEASUREMENT_REPEATS;
 
 	TC_PRINT("Calculated ADC sampling time for %uus acquisition time, %uus sampling interval, "
 		 "%u "

--- a/tests/drivers/i2c/i2c_latency/src/main.c
+++ b/tests/drivers/i2c/i2c_latency/src/main.c
@@ -245,11 +245,13 @@ static void test_i2c_read_latency(size_t buffer_size, uint8_t i2c_speed_setting)
 		counter_stop(tst_timer_dev);
 		timer_value_us[repeat_counter] =
 			counter_ticks_to_us(tst_timer_dev, tst_timer_value);
-		average_timer_value_us += timer_value_us[repeat_counter] / MEASUREMENT_REPEATS;
+		average_timer_value_us += timer_value_us[repeat_counter];
 
 		zassert_ok(ret);
 		zassert_mem_equal(fixture.master_buffer, fixture.slave_buffer, buffer_size);
 	}
+
+	average_timer_value_us /= MEASUREMENT_REPEATS;
 
 	TC_PRINT("Calculated transmission time (for %u bytes) [us]: %u\n", buffer_size,
 		 theoretical_transmission_time_us);
@@ -291,11 +293,13 @@ static void test_i2c_write_latency(size_t buffer_size, uint8_t i2c_speed_setting
 		counter_stop(tst_timer_dev);
 		timer_value_us[repeat_counter] =
 			counter_ticks_to_us(tst_timer_dev, tst_timer_value);
-		average_timer_value_us += timer_value_us[repeat_counter] / MEASUREMENT_REPEATS;
+		average_timer_value_us += timer_value_us[repeat_counter];
 
 		zassert_ok(ret);
 		zassert_mem_equal(fixture.slave_buffer, fixture.slave_buffer, buffer_size);
 	}
+
+	average_timer_value_us /= MEASUREMENT_REPEATS;
 
 	TC_PRINT("Calculated transmission time (for %u bytes) [us]: %u\n", buffer_size,
 		 theoretical_transmission_time_us);

--- a/tests/drivers/i2s/i2s_latency/src/main.c
+++ b/tests/drivers/i2s/i2s_latency/src/main.c
@@ -207,8 +207,10 @@ static void test_i2s_transmission_latency(const struct device *dev, uint32_t fra
 
 		timer_value_us[repeat_counter] =
 			counter_ticks_to_us(tst_timer_dev, tst_timer_value);
-		average_timer_value_us += timer_value_us[repeat_counter] / MEASUREMENT_REPEATS;
+		average_timer_value_us += timer_value_us[repeat_counter];
 	}
+
+	average_timer_value_us /= MEASUREMENT_REPEATS;
 
 	theoretical_transmission_time_us =
 		calculate_theoretical_transsmison_time_us(WORDS_COUNT, frame_clk_freq);

--- a/tests/drivers/spi/spi_latency/src/main.c
+++ b/tests/drivers/spi/spi_latency/src/main.c
@@ -126,11 +126,13 @@ static void test_spim_transmission_latency(size_t buffer_size)
 		counter_stop(tst_timer_dev);
 		timer_value_us[repeat_counter] =
 			counter_ticks_to_us(tst_timer_dev, tst_timer_value);
-		average_timer_value_us += timer_value_us[repeat_counter] / MEASUREMENT_REPEATS;
+		average_timer_value_us += timer_value_us[repeat_counter];
 
 		zassert_ok(err, "SPI transceive failed");
 		zassert_mem_equal(tx_buffer, rx_buffer, buffer_size);
 	}
+
+	average_timer_value_us /= MEASUREMENT_REPEATS;
 
 	TC_PRINT("Calculated transmission time (for %u bytes) [us]: %u\n", buffer_size,
 		 theoretical_transmission_time_us);

--- a/tests/drivers/uart/uart_latency/src/async.c
+++ b/tests/drivers/uart/uart_latency/src/async.c
@@ -96,11 +96,13 @@ static void test_uart_latency(size_t buffer_size, uint32_t baudrate)
 		dk_set_led_off(DK_LED1);
 		timer_value_us[repeat_counter] =
 			counter_ticks_to_us(tst_timer_dev, tst_timer_value);
-		average_timer_value_us += timer_value_us[repeat_counter] / MEASUREMENT_REPEATS;
+		average_timer_value_us += timer_value_us[repeat_counter];
 		zassert_equal(err, 0, "UART transmission failed");
 		uart_rx_disable(uart_dev);
 		check_transmitted_data(&test_data);
 	}
+
+	average_timer_value_us /= MEASUREMENT_REPEATS;
 
 	TC_PRINT("Calculated transmission time (for %u bytes) [us]: %u\n", buffer_size,
 		 theoretical_transmission_time_us);

--- a/tests/drivers/uart/uart_latency/src/int_driven.c
+++ b/tests/drivers/uart/uart_latency/src/int_driven.c
@@ -128,12 +128,14 @@ static void test_uart_latency(size_t buffer_size, uint32_t baudrate)
 		dk_set_led_off(DK_LED1);
 		timer_value_us[repeat_counter] =
 			counter_ticks_to_us(tst_timer_dev, tst_timer_value);
-		average_timer_value_us += timer_value_us[repeat_counter] / MEASUREMENT_REPEATS;
+		average_timer_value_us += timer_value_us[repeat_counter];
 
 		uart_irq_rx_disable(uart_dev);
 		uart_irq_tx_disable(uart_dev);
 		check_transmitted_data(&test_data);
 	}
+
+	average_timer_value_us /= MEASUREMENT_REPEATS;
 
 	TC_PRINT("Calculated transmission time (for %u bytes) [us]: %u\n", buffer_size,
 		 theoretical_transmission_time_us);

--- a/tests/drivers/uart/uart_latency/src/polling.c
+++ b/tests/drivers/uart/uart_latency/src/polling.c
@@ -65,10 +65,12 @@ static void test_uart_latency(size_t buffer_size, uint32_t baudrate)
 
 		timer_value_us[repeat_counter] =
 			counter_ticks_to_us(tst_timer_dev, tst_timer_value);
-		average_timer_value_us += timer_value_us[repeat_counter] / MEASUREMENT_REPEATS;
+		average_timer_value_us += timer_value_us[repeat_counter];
 
 		check_transmitted_data(&test_data);
 	}
+
+	average_timer_value_us /= MEASUREMENT_REPEATS;
 
 	TC_PRINT("Calculated transmission time (for %u bytes) [us]: %u\n", buffer_size,
 		 theoretical_transmission_time_us);

--- a/tests/subsys/ipc/ipc_latency/src/main.c
+++ b/tests/subsys/ipc/ipc_latency/src/main.c
@@ -40,19 +40,19 @@ static uint64_t get_maximal_allowed_ping_pong_time_us(size_t test_message_len)
 #if defined(CONFIG_SOC_NRF54H20_CPUAPP)
 	switch (test_message_len) {
 	case 1:
-		maximal_allowed_ping_pong_time_us = 120;
-		break;
-	case 16:
 		maximal_allowed_ping_pong_time_us = 130;
 		break;
-	case 32:
+	case 16:
 		maximal_allowed_ping_pong_time_us = 140;
 		break;
-	case 64:
+	case 32:
 		maximal_allowed_ping_pong_time_us = 150;
 		break;
+	case 64:
+		maximal_allowed_ping_pong_time_us = 160;
+		break;
 	case 128:
-		maximal_allowed_ping_pong_time_us = 169;
+		maximal_allowed_ping_pong_time_us = 170;
 		break;
 	case 256:
 		maximal_allowed_ping_pong_time_us = 180;
@@ -185,10 +185,12 @@ static void test_ipc_latency(struct ipc_ept *endpoint, size_t test_message_len)
 		zassert_mem_equal(test_data, rx_data, test_message_len, "TX data != RX data\n");
 
 		timer_value_us[test_counter] = counter_ticks_to_us(tst_timer_dev, tst_timer_value);
-		average_timer_value_us += timer_value_us[test_counter] / MEASUREMENT_REPEATS;
+		average_timer_value_us += timer_value_us[test_counter];
 
 		k_msleep(SEND_DEAD_TIME_MS);
 	}
+
+	average_timer_value_us /= MEASUREMENT_REPEATS;
 
 	TC_PRINT("Measured IPC ping-pong time for %u bytes [us]: %llu\n", test_message_len,
 		 average_timer_value_us);


### PR DESCRIPTION
The average is now caluclated after adding all values properly.