### PR TITLE
applications: nrf5340_audio: The mixing of the test tone fails

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -541,6 +541,42 @@ int audio_datapath_tone_play(uint16_t freq, uint16_t dur_ms, float amplitude)
 	return 0;
 }
 
+int audio_datapath_tone_play_step(void)
+{
+	int ret;
+	static uint32_t test_tone_hz;
+
+	if (CONFIG_AUDIO_BIT_DEPTH_BITS != 16) {
+		LOG_WRN("Tone gen only supports 16 bits");
+		return -ECANCELED;
+	}
+
+	if (test_tone_hz == 0) {
+		test_tone_hz = TEST_TONE_BASE_FREQ_HZ;
+	} else if (test_tone_hz >= TEST_TONE_BASE_FREQ_HZ * 4) {
+		test_tone_hz = 0;
+	} else {
+		test_tone_hz = test_tone_hz * 2;
+	}
+
+	if (tone_active) {
+		audio_datapath_tone_stop();
+	}
+
+	if (test_tone_hz != 0) {
+		ret = audio_datapath_tone_play(test_tone_hz, 0, 0.5);
+		if (ret) {
+			LOG_ERR("Failed to generate test tone");
+			return ret;
+		}
+		LOG_INF("Test tone set at %d Hz", test_tone_hz);
+	} else {
+		LOG_INF("Test tone off");
+	}
+
+	return 0;
+}
+
 void audio_datapath_tone_stop(void)
 {
 	k_timer_stop(&tone_stop_timer);

--- a/applications/nrf5340_audio/src/audio/audio_datapath.h
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.h
@@ -25,6 +25,17 @@
 #include "audio_defines.h"
 
 #define SDU_REF_CH_DELTA_MAX_US (int)(CONFIG_AUDIO_FRAME_DURATION_US * 0.001)
+#define TEST_TONE_BASE_FREQ_HZ	1000
+
+/**
+ * @brief	Step through different test tones.
+ *
+ * @note	A stream must already be running to use this feature.
+ *		Will step through test tones: 1 kHz, 2 kHz, 4 kHz and off.
+ *
+ * @return	0 on success, error otherwise.
+ */
+int audio_datapath_tone_play_step(void);
 
 /**
  * @brief	Mixes a tone into the I2S TX stream.

--- a/applications/nrf5340_audio/src/audio/audio_system.c
+++ b/applications/nrf5340_audio/src/audio/audio_system.c
@@ -26,8 +26,7 @@ LOG_MODULE_REGISTER(audio_system, CONFIG_AUDIO_SYSTEM_LOG_LEVEL);
 #define FIFO_TX_BLOCK_COUNT (CONFIG_FIFO_FRAME_SPLIT_NUM * CONFIG_FIFO_TX_FRAME_COUNT)
 #define FIFO_RX_BLOCK_COUNT (CONFIG_FIFO_FRAME_SPLIT_NUM * CONFIG_FIFO_RX_FRAME_COUNT)
 
-#define DEBUG_INTERVAL_NUM     1000
-#define TEST_TONE_BASE_FREQ_HZ 1000
+#define DEBUG_INTERVAL_NUM 1000
 
 K_THREAD_STACK_DEFINE(encoder_thread_stack, CONFIG_ENCODER_STACK_SIZE);
 
@@ -112,7 +111,7 @@ static void audio_headset_configure(void)
 		sw_codec_cfg.decoder.channel_mode = SW_CODEC_MONO;
 		break;
 	case BT_AUDIO_LOCATION_FRONT_RIGHT:
-	    sw_codec_cfg.decoder.audio_ch = 1;
+		sw_codec_cfg.decoder.audio_ch = 1;
 		sw_codec_cfg.decoder.channel_mode = SW_CODEC_MONO;
 		break;
 	case (BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT):

--- a/applications/nrf5340_audio/unicast_server/main.c
+++ b/applications/nrf5340_audio/unicast_server/main.c
@@ -143,7 +143,7 @@ static void button_msg_sub_thread(void)
 					break;
 				}
 
-				ret = audio_system_encode_test_tone_step();
+				ret = audio_datapath_tone_play_step();
 				if (ret) {
 					LOG_WRN("Failed to play test tone, ret: %d", ret);
 				}


### PR DESCRIPTION
OCT-3449

The test tone mixing on the output of the unicast server dose not happen.

Ideally it would operate as the client and mix a series of tones into the output on pressing button 4.