### PR TITLE
lib: at_host: Require UART_INTERRUPT_DRIVEN

### DIFF
--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -7,6 +7,8 @@
 menuconfig AT_HOST_LIBRARY
 	bool "AT Host Library for nrf91"
 	depends on NRF_MODEM_LIB
+	depends on SERIAL_SUPPORT_INTERRUPT
+	select UART_INTERRUPT_DRIVEN
 	select AT_MONITOR
 
 if AT_HOST_LIBRARY


### PR DESCRIPTION
Adds dependency on UART_INTERRUPT_DRIVEN for the AT Host Library.

It is implemented through a direct dependency on SERIAL_SUPPORT_INTERRUPT and a reverse dependency to UART_INTERRUPT_DRIVEN, following common practice elsewhere in Zephyr.