### PR TITLE
bluetooth: controller: Use new sdc_support_le_privacy

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -1073,6 +1073,13 @@ static int configure_supported_features(void)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_CTLR_PRIVACY)) {
+		err = sdc_support_le_privacy();
+		if (err) {
+			return -ENOTSUP;
+		}
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
This is added to ensure the controller does not have the local feature bit set for privacy unless the hci commands are supported.

This was an issue after 7599d81 where the feature bits were moved from nrf to internal sdc.