### PR TITLE
boards: shields: coverage_support: add flow-control for uart at nrf52840

### DIFF
--- a/boards/shields/coverage_support/boards/nrf52840dk_nrf52840.overlay
+++ b/boards/shields/coverage_support/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&uart0 {
+	hw-flow-control;
+};


### PR DESCRIPTION
Needed as there is a lot of data at uart in coverage mode. The same as for other platforms in this shield.