### PR TITLE
tests: subsys: Extend IPC latency test

### DIFF
--- a/tests/subsys/ipc/ipc_latency/src/main.c
+++ b/tests/subsys/ipc/ipc_latency/src/main.c
@@ -92,6 +92,9 @@ static uint64_t get_maximal_allowed_ping_pong_time_us(size_t test_message_len)
 		break;
 	}
 #endif
+	if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+		maximal_allowed_ping_pong_time_us *= 1.5;
+	}
 	return maximal_allowed_ping_pong_time_us;
 }
 

--- a/tests/subsys/ipc/ipc_latency/testcase.yaml
+++ b/tests/subsys/ipc/ipc_latency/testcase.yaml
@@ -23,3 +23,23 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
       - FILE_SUFFIX=icmsg
+  subsys.ipc.ipc_latency.app_rad.nrf54h.mram_always_on:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_configs:
+      - CONFIG_MRAM_LATENCY=y
+      - CONFIG_MRAM_LATENCY_AUTO_REQ=y
+  subsys.ipc.ipc_latency.app_rad.nrf54h.s2ram:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_configs:
+      - CONFIG_PM=y
+      - CONFIG_PM_S2RAM=y
+      - CONFIG_PM_S2RAM_CUSTOM_MARKING=y
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
+      - CONFIG_POWEROFF=y


### PR DESCRIPTION
Test with additional configurations for nrf54h:
- with MRAM always ON
- with S2RAM enabled