### PR TITLE
errata: update check of nrf54h errata 216 presence

### DIFF
--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -28,17 +28,10 @@
 #include "fem_al/fem_al.h"
 #endif /* CONFIG_FEM */
 
-#define NRF54H20_ERRATA_216_PRESENT \
-	DT_NODE_HAS_STATUS(DT_NODELABEL(cpurad_cpusys_errata216_mboxes), okay)
-
-#if NRF54H20_ERRATA_216_PRESENT
+#include <nrf_erratas.h>
+#if NRF54H_ERRATA_216_PRESENT
 #include <zephyr/drivers/mbox.h>
-
-/* Delay time from triggering the task "ON" for SysCtrl to starting RADIO (setting RADIO TASK RXEN
- * or TXEN)
- */
-#define HMPAN_216_DELAY_US (40)
-#endif /* NRF54H20_ERRATA_216_PRESENT */
+#endif /* NRF54H_ERRATA_216_PRESENT */
 
 /* IEEE 802.15.4 default frequency. */
 #define IEEE_DEFAULT_FREQ         (5)
@@ -131,12 +124,19 @@ static void (**rx_timeout_cb)(void);
 static volatile bool cancel_request;
 static volatile bool test_is_running;
 
-#if NRF54H20_ERRATA_216_PRESENT
+#if NRF54H_ERRATA_216_PRESENT
 static const struct mbox_dt_spec on_channel =
 	MBOX_DT_SPEC_GET(DT_NODELABEL(cpurad_cpusys_errata216_mboxes), on_req);
 static const struct mbox_dt_spec off_channel =
 	MBOX_DT_SPEC_GET(DT_NODELABEL(cpurad_cpusys_errata216_mboxes), off_req);
-static K_SEM_DEFINE(errata216_sem, 0, 1);
+#endif /* NRF54H_ERRATA_216_PRESENT */
+
+/* Delay time from triggering the task "ON" for SysCtrl to starting RADIO (setting RADIO TASK RXEN
+ * or TXEN)
+ */
+#define HMPAN_216_DELAY_US (40)
+
+static K_SEM_DEFINE(errata_216_sem, 0, 1);
 
 /**
  * @brief Send errata HMPAN-216 on request signal to SysCtrl
@@ -146,8 +146,12 @@ static K_SEM_DEFINE(errata216_sem, 0, 1);
  *
  * @return 0 if successful, otherwise a negative error code
  */
-static int errata216_on_wait(void)
+static int errata_216_on_wait(void)
 {
+	if (!nrf54h_errata_216()) {
+		return 0;
+	}
+
 	int err = 0;
 
 	nrfx_timer_disable(&timer);
@@ -159,13 +163,15 @@ static int errata216_on_wait(void)
 		nrfx_timer_us_to_ticks(&timer, HMPAN_216_DELAY_US),
 		true);
 
+#if NRF54H_ERRATA_216_PRESENT
 	err = mbox_send_dt(&on_channel, NULL);
+#endif /* NRF54H_ERRATA_216_PRESENT */
 
 	if (!err) {
 		nrfx_timer_enable(&timer);
 
 		/* Wait for the TIMER to count the required delay before starting the Radio*/
-		err = k_sem_take(&errata216_sem, K_FOREVER);
+		err = k_sem_take(&errata_216_sem, K_FOREVER);
 	}
 
 	return err;
@@ -176,37 +182,33 @@ static int errata216_on_wait(void)
  *
  * @return 0 if successful, otherwise a negative error code
  */
-static int errata216_off(void)
+static int errata_216_off(void)
 {
+	if (!nrf54h_errata_216()) {
+		return 0;
+	}
+
+#if NRF54H_ERRATA_216_PRESENT
 	return mbox_send_dt(&off_channel, NULL);
+#else
+	return 0;
+#endif /* NRF54H_ERRATA_216_PRESENT */
 }
 
 /**
  * @brief Return to code execution after the required delay for errata HMPAN-216 has elapsed.
  */
-static void errata216_release(void)
+static void errata_216_release(void)
 {
-	/* Release the waiting semaphore, coninue code execution and disable TIMER */
-	k_sem_give(&errata216_sem);
+	if (!nrf54h_errata_216()) {
+		return;
+	}
+
+	/* Release the waiting semaphore, continue code execution and disable TIMER */
+	k_sem_give(&errata_216_sem);
 	nrfx_timer_disable(&timer);
 	nrf_timer_int_disable(timer.p_reg, ~0);
 }
-#else
-static int errata216_on_wait(void)
-{
-	return 0;
-}
-
-static int errata216_off(void)
-{
-	return 0;
-}
-
-static void errata216_release(void)
-{
-	/* Do nothing */
-}
-#endif /* NRF54H20_ERRATA_216_PRESENT */
 
 #if CONFIG_FEM
 static struct radio_test_fem fem;
@@ -1053,7 +1055,7 @@ void radio_test_start(const struct radio_test_config *config)
 #endif /* CONFIG_FEM */
 
 	/* Execute nRF54H20 errata 216 workaround */
-	if (errata216_on_wait()) {
+	if (errata_216_on_wait()) {
 		printk("Failed to send the nRF54H20 errata 216 on request to SysCtrl.\n");
 	}
 
@@ -1112,7 +1114,7 @@ static void cancel(void)
 	endpoints_clear();
 	radio_disable();
 
-	if (errata216_off()) {
+	if (errata_216_off()) {
 		printk("Failed to send errata HMPAN-216 off.\n");
 	}
 }
@@ -1178,7 +1180,7 @@ static void rx_timeout_work_handler(struct k_work *work)
 {
 	radio_disable();
 	/* Send off signal for nRF54H20 errata HMPAN-216 */
-	if (errata216_off()) {
+	if (errata_216_off()) {
 		printk("Failed to send errata HMPAN-216 off\n");
 	}
 	if (rx_timeout_cb != NULL && *rx_timeout_cb != NULL) {
@@ -1224,7 +1226,7 @@ static void timer_handler(nrf_timer_event_t event_type, void *context)
 			current_channel = channel_start;
 		}
 	} else if (event_type == NRF_TIMER_EVENT_COMPARE1) { /* HMPAN-216 errata */
-		errata216_release();
+		errata_216_release();
 	} else {
 		/* Do nothing */
 	}
@@ -1253,7 +1255,7 @@ void on_radio_end(const struct radio_test_config *config)
 	    config->type == MODULATED_TX) {
 		radio_disable();
 		/* Send off signal for nRF54H20 errata HMPAN-216 */
-		if (errata216_off()) {
+		if (errata_216_off()) {
 			printk("Failed to send errata HMPAN-216 off\n");
 		}
 		config->params.modulated_tx.cb();


### PR DESCRIPTION
Add call to nrf54h_errata_216 to verify chip revision before applying errata. Make most of the errata code visible outside of preprocessor if. Unify errata 216 function names with other errata functions.