### PR TITLE
doc: kconfig reference fix

### DIFF
--- a/samples/crypto/psa_tls/README.rst
+++ b/samples/crypto/psa_tls/README.rst
@@ -117,7 +117,7 @@ The table mirrors the test setup used for TLS verification.
            - Also supports :ref:`PSA Crypto nrf_oberon driver<nrf_security_drivers_oberon>`
          * - ``nrf54h20dk/nrf54h20/cpuapp``
              ``nrf54h20dk/nrf54h20/cpurad``
-           - `SSF Crypto <CONFIG_PSA_SSF_CRYPTO_CLIENT_>`_
+           - SSF Crypto (`CONFIG_PSA_SSF_CRYPTO_CLIENT`_)
            - No
            - Yes
            - RSA not supported
@@ -155,7 +155,7 @@ The table mirrors the test setup used for TLS verification.
            - Also supports :ref:`PSA Crypto nrf_oberon driver<nrf_security_drivers_oberon>`
          * - ``nrf54h20dk/nrf54h20/cpuapp``
              ``nrf54h20dk/nrf54h20/cpurad``
-           - `SSF Crypto <CONFIG_PSA_SSF_CRYPTO_CLIENT_>`_
+           - SSF Crypto (`CONFIG_PSA_SSF_CRYPTO_CLIENT`_)
            - No
            - No
            - RSA not supported


### PR DESCRIPTION
A tool is incorrectly misinterpreting the doc link as an instance of Kconfig.

Similar to this issue: https://github.com/nrfconnect/sdk-nrf/pull/23339#discussion_r2213238695