### PR TITLE
samples: benchmarks: coremark: enable for LV10

### DIFF
--- a/samples/benchmarks/coremark/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
+++ b/samples/benchmarks/coremark/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_COREMARK_ITERATIONS=4000
+
+CONFIG_LOG_MODE_IMMEDIATE=y

--- a/samples/benchmarks/coremark/sample.yaml
+++ b/samples/benchmarks/coremark/sample.yaml
@@ -9,25 +9,27 @@ tests:
     sysbuild: true
     build_only: true
     platform_allow:
-      - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     integration_platforms:
-      - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     tags:
       - ci_build
       - sysbuild
@@ -36,25 +38,27 @@ tests:
     sysbuild: true
     build_only: false
     platform_allow:
-      - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     integration_platforms:
-      - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     tags:
       - ci_build
       - sysbuild
@@ -71,25 +75,27 @@ tests:
     sysbuild: true
     build_only: true
     platform_allow:
-      - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     integration_platforms:
-      - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     tags:
       - ci_build
       - sysbuild
@@ -99,25 +105,27 @@ tests:
     sysbuild: true
     build_only: true
     platform_allow:
-      - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     integration_platforms:
-      - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     tags:
       - ci_build
       - sysbuild
@@ -127,25 +135,27 @@ tests:
     sysbuild: true
     build_only: true
     platform_allow:
-      - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     integration_platforms:
-      - nrf52840dk/nrf52840
       - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     tags:
       - ci_build
       - sysbuild

--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -585,40 +585,43 @@
 - scenarios:
     - sample.benchmark.coremark.heap_memory
   platforms:
-    - nrf52dk/nrf52832
     - nrf52833dk/nrf52833
+    - nrf52dk/nrf52832
     - nrf5340dk/nrf5340/cpuapp
+    - nrf54h20dk@0.9.0/nrf54h20/cpuapp
     - nrf54l15dk/nrf54l05/cpuapp
     - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54lm20dk/nrf54lm20a/cpuapp
-    - nrf54h20dk@0.9.0/nrf54h20/cpuapp
+    - nrf54lv10dk/nrf54lv10a/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
 
 - scenarios:
     - sample.benchmark.coremark.static_memory
   platforms:
-    - nrf52dk/nrf52832
     - nrf52833dk/nrf52833
+    - nrf52dk/nrf52832
     - nrf5340dk/nrf5340/cpuapp
+    - nrf54h20dk@0.9.0/nrf54h20/cpuapp
     - nrf54l15dk/nrf54l05/cpuapp
     - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54lm20dk/nrf54lm20a/cpuapp
-    - nrf54h20dk@0.9.0/nrf54h20/cpuapp
+    - nrf54lv10dk/nrf54lv10a/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
 
 - scenarios:
     - sample.benchmark.coremark.multiple_threads
   platforms:
-    - nrf52dk/nrf52832
     - nrf52833dk/nrf52833
+    - nrf52dk/nrf52832
     - nrf5340dk/nrf5340/cpuapp
+    - nrf54h20dk@0.9.0/nrf54h20/cpuapp
     - nrf54l15dk/nrf54l05/cpuapp
     - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54lm20dk/nrf54lm20a/cpuapp
-    - nrf54h20dk@0.9.0/nrf54h20/cpuapp
+    - nrf54lv10dk/nrf54lv10a/cpuapp
   comment: "Configurations excluded to limit resources usage in integration builds"
 
 - scenarios:


### PR DESCRIPTION
Enable building and execution for LV10.