### PR TITLE
doc: migration: Add Bluetooth LE legacy pairing entry for NCS 3.0

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_guide_3.0.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_3.0.rst
@@ -105,6 +105,19 @@ ZMS settings backend
    To migrate from the legacy backend to the new backend remove the Kconfig options :kconfig:option:`CONFIG_SETTINGS_ZMS_NAME_CACHE`
    and :kconfig:option:`CONFIG_SETTINGS_ZMS_NAME_CACHE_SIZE` from your conf files.
 
+Bluetooth LE legacy pairing
+---------------------------
+
+.. toggle::
+
+   Support for Bluetooth LE legacy pairing is no longer enabled by default, because it is not secure.
+   The :kconfig:option:`CONFIG_BT_SMP_SC_PAIR_ONLY` Kconfig option is enabled by default in Zephyr.
+   If you still need to support the Bluetooth LE legacy pairing and you accept the security risks, disable the option in the configuration.
+
+   .. note::
+      Using Bluetooth LE legacy pairing introduces, among others, a risk of passive eavesdropping.
+      Supporting Bluetooth LE legacy pairing makes devices vulnerable to downgrade attacks.
+
 nRF54H20
 ========
 


### PR DESCRIPTION
Change adds a migration guide entry to improve visibility.

Jira: NCSDK-35238