### PR TITLE
memfault: fix kconfig style issues

### DIFF
--- a/modules/memfault-firmware-sdk/Kconfig
+++ b/modules/memfault-firmware-sdk/Kconfig
@@ -144,9 +144,7 @@ config MEMFAULT_NCS_STACK_METRICS
 	default y
 	help
 	  Collect metrics for unused stack space for selected stacks.
-	  Currently the following stacks' unused space is monitored:
-		- connection_poll_thread, used by the cloud libraries for
-		  nRF Cloud, AWS IoT and Azure IoT Hub
+	  Currently the connection_poll_thread, BT RX, and BT TX threads are supported.
 
 config MEMFAULT_NCS_LTE_METRICS
 	bool "Collect LTE metrics"
@@ -252,11 +250,6 @@ config MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP
 	depends on FLASH
 	help
 	  Use internal flash to store coredump data
-
-config MEMFAULT_CDR_ENABLE
-	bool "Custom Data Recording"
-	select MEMFAULT_PLATFORM_EXTRA_CONFIG_FILE
-	default n
 
 if MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP
 config MEMFAULT_NCS_FLASH_REGION_SIZE

--- a/modules/memfault-firmware-sdk/config/memfault_platform_config_extra.h
+++ b/modules/memfault-firmware-sdk/config/memfault_platform_config_extra.h
@@ -10,10 +10,6 @@
  * "<NCS folder>/modules/lib/memfault-firmware-sdk/components/include/memfault/default_config.h"
  */
 
-#ifdef CONFIG_MEMFAULT_CDR_ENABLE
-#define MEMFAULT_CDR_ENABLE 1
-#endif
-
 #ifdef CONFIG_MEMFAULT_NCS_ETB_CAPTURE
 #define MEMFAULT_PLATFORM_FAULT_HANDLER_CUSTOM 1
 #endif


### PR DESCRIPTION
Three Kconfig style issues were caught by a style script shared in https://github.com/zephyrproject-rtos/zephyr/issues/94780#issuecomment-3210257794:

```
MEMFAULT_HTTP_USES_MBEDTLS in nrf/modules/memfault-firmware-sdk/Kconfig has issues:
	 * default n for bool
MEMFAULT_NCS_STACK_METRICS in nrf/modules/memfault-firmware-sdk/Kconfig has issues:
	 * wrong help text indent
MEMFAULT_CDR_ENABLE in nrf/modules/memfault-firmware-sdk/Kconfig has issues:
	 * default n for bool
```

This PR addresses 2/3 of these:

- `MEMFAULT_NCS_STACK_METRICS`
- `MEMFAULT_CDR_ENABLE` – this is a redefinition of a symbol in the Memfault module to override the `default y` and select another Kconfig:
  - There is no clear reason to make it `default y`. Code and RAM space added is reasonable: +460B flash, +224B RAM when building `samples/debug/memfault`, and can always be opted out of by the user
  - The `#define` in the extra platform config is no longer needed, so the select statement is unnecessary. The Memfault SDK now reads the Kconfig and sets this define automatically.

Re-running the style script confirmed these two issues were fixed by these changes.

The third failure (`MEMFAULT_HTTP_USES_MBEDTLS`) will be fixed in a follow-up PR after the next Memfault module release, which will include this default in the original definition.

Signed-off-by: Gillian Minnehan <gillian.minnehan@nordicsemi.no>