### PR TITLE
samples: bluetooth: Add configurations for nRF54lv10a

### DIFF
--- a/samples/bluetooth/iso_combined_bis_and_cis/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
+++ b/samples/bluetooth/iso_combined_bis_and_cis/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_RX_STACK_SIZE=2048

--- a/samples/bluetooth/iso_time_sync/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
+++ b/samples/bluetooth/iso_time_sync/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_RX_STACK_SIZE=2048


### PR DESCRIPTION
Add missing configurations for nRF54lv10a to Bluetooth ISO samples.