### PR TITLE
[Backport v3.1-branch] tools: Update nrfutil device version to 2.13.2

### DIFF
--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -29,4 +29,4 @@ pip:
 nrfutil:
   version: 8.1.1
   subcommands:
-    device: 2.13.0
+    device: 2.13.2

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -32,4 +32,4 @@ pip:
 nrfutil:
   version: 8.1.1
   subcommands:
-    device: 2.13.0
+    device: 2.13.2

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -28,4 +28,4 @@ pip:
 nrfutil:
   version: 8.1.1
   subcommands:
-    device: 2.13.0
+    device: 2.13.2


### PR DESCRIPTION
Backport 19259e162d9ae446d7fb76c85fbd6f0e99089bb2 from #24407.