### PR TITLE
doc: install: updates for bundled SDK/toolchain installation

### DIFF
--- a/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_partitioning.rst
+++ b/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_partitioning.rst
@@ -36,7 +36,7 @@ Depending on your development environment, you can use one of the following opti
    .. group-tab:: nRF Connect for VS Code
 
       Use the extension's `Memory report`_ feature, which shows the size and percentage of memory that each symbol uses on your device for RAM, ROM, and partitions.
-      Click the :guilabel:`Memory report` button in the :guilabel:`Actions View` to generate the report.
+      Click the :guilabel:`Memory report` button in the `Actions View`_ to generate the report.
       The partition map is available in the :guilabel:`Partitions` tab.
 
       Alternatively, you can also use the `Memory Explorer <How to work with the Memory Explorer_>`_ feature of the extension's nRF Debug to check memory sections for the partitions.

--- a/doc/nrf/app_dev/create_application.rst
+++ b/doc/nrf/app_dev/create_application.rst
@@ -159,7 +159,7 @@ Use the following steps depending on the application placement:
 
       1. Open |VSC|.
       #. Open |nRFVSC|.
-      #. In the :guilabel:`Welcome View`, click the :guilabel:`Create a new application` action.
+      #. In the `Welcome View`_, click the :guilabel:`Create a new application` action.
          A quick pick menu appears.
       #. Choose one of the following options:
 
@@ -172,7 +172,7 @@ Use the following steps depending on the application placement:
          The application creation process starts after you enter the name.
          When the application is created, a VS Code prompt appears asking you what to do with the application.
       #. Click :guilabel:`Open`.
-         This will open the new application and add it to the :guilabel:`Applications View` in the extension.
+         This will open the new application and add it to the `Applications View`_ in the extension.
          At this point, you have created a freestanding application.
       #. Add the :file:`west.yml` to create a west workspace around the application:
 
@@ -195,7 +195,7 @@ Use the following steps depending on the application placement:
 
       1. Open |VSC|.
       #. Open |nRFVSC|.
-      #. In the :guilabel:`Welcome View`, click the :guilabel:`Create a new application` action.
+      #. In the `Welcome View`_, click the :guilabel:`Create a new application` action.
          A quick pick menu appears.
       #. Choose one of the following options:
 
@@ -206,7 +206,7 @@ Use the following steps depending on the application placement:
          The application creation process starts after you enter the name.
          When the application is created, a VS Code prompt appears.
       #. Click :guilabel:`Open`.
-         This opens the new application and adds it to the :guilabel:`Applications View` in the extension.
+         This opens the new application and adds it to the `Applications View`_ in the extension.
 
       You can now start :ref:`configuring and building <configuration_and_build>` the application.
 
@@ -310,7 +310,7 @@ To create an application from the add-on index, complete the following steps:
 
       Complete the following steps in |nRFVSC|:
 
-      1. In the :guilabel:`Welcome View`, click :guilabel:`Create a new application`.
+      1. In the `Welcome View`_, click :guilabel:`Create a new application`.
       #. Select :guilabel:`Browse nRF Connect SDK Add-on Index`.
       #. Browse through the available add-ons and select one that matches your needs.
       #. Follow the creation wizard to set up your workspace application.

--- a/doc/nrf/app_dev/device_guides/nrf53/building_nrf53.rst
+++ b/doc/nrf/app_dev/device_guides/nrf53/building_nrf53.rst
@@ -44,7 +44,7 @@ Complete the following steps to program the sample or application onto nRF5340 D
 
 #. Connect the nRF5340 development kit to your PC using a USB cable.
 #. Make sure that the nRF5340 DK and the external debug probe are powered on.
-#. Click :guilabel:`Build` in the :guilabel:`Actions View` to start the build process.
+#. Click :guilabel:`Build` in the `Actions View`_ to start the build process.
 #. Click :guilabel:`Flash` in the :guilabel:`Actions View` to program the resulting image to your device.
 
 Using the command line

--- a/doc/nrf/app_dev/device_guides/thingy53/building_thingy53.rst
+++ b/doc/nrf/app_dev/device_guides/thingy53/building_thingy53.rst
@@ -135,7 +135,7 @@ Complete the following steps to build and program using |nRFVSC|:
    #. Connect the external debug probe to the PC using a micro-USB cable.
    #. Make sure that the Thingy:53 and the external debug probe are powered on.
       (On the Thingy:53, move the power switch **SW1** to the **ON** position.)
-   #. Click :guilabel:`Flash` in the :guilabel:`Actions View`.
+   #. Click :guilabel:`Flash` in the `Actions View`_.
 
 .. _thingy53_build_pgm_command_line:
 

--- a/doc/nrf/app_dev/device_guides/thingy91/thingy91_building_programming.rst
+++ b/doc/nrf/app_dev/device_guides/thingy91/thingy91_building_programming.rst
@@ -81,7 +81,7 @@ Complete the following steps to program firmware onto Thingy:91:
 
    .. group-tab:: nRF Connect for VS Code
 
-      5. In |nRFVSC|, click the :guilabel:`Flash` option in the **Actions View**.
+      5. In |nRFVSC|, click the :guilabel:`Flash` option in the `Actions View`_.
 
          If you have multiple boards connected, you are prompted to pick a device at the top of the screen.
 

--- a/doc/nrf/includes/matter_sample_wifi_flash.txt
+++ b/doc/nrf/includes/matter_sample_wifi_flash.txt
@@ -15,7 +15,7 @@ For example, to program the sample and minimize the erase time, use the followin
    west flash --ext-erase-mode=ranges
 
 You can also observe a longer programming process when using the :guilabel:`Erase and Flash to Board` option in the |nRFVSC|.
-To speed up this process, you can use the :guilabel:`Flash` button instead of :guilabel:`Erase and Flash to Board` in the :guilabel:`Actions View`.
+To speed up this process, you can use the :guilabel:`Flash` button instead of :guilabel:`Erase and Flash to Board` in the `Actions View`_.
 
 To disable storing the Wi-Fi firmware patch in the external memory, complete the following steps:
 

--- a/doc/nrf/includes/vsc_build_and_run_series.txt
+++ b/doc/nrf/includes/vsc_build_and_run_series.txt
@@ -10,7 +10,7 @@
       #. Power on the development kit.
       #. |exceptions_step|
       #. Open the nRF Connect extension in |VSC| by clicking its icon in the :guilabel:`Activity Bar`.
-      #. In the extension's :guilabel:`Actions View`, click on :guilabel:`Flash`.
+      #. In the extension's `Actions View`_, click on :guilabel:`Flash`.
          If you have more than one device connected, you will be prompted to select the device to program.
          If the build system considers the build incomplete, using this action also triggers a rebuild before flashing.
 

--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -11,7 +11,7 @@ Installing the |NCS|
 
 There are different ways to install the |NCS|, depending on your preferred development environment:
 
-* Using |VSC| and the :ref:`requirements_nrfvsc` (recommended)
+* Using |VSC| and :ref:`requirements_nrfvsc` (recommended)
 * Using command line and :ref:`requirements_nrf_util`
 
 Regardless of which way you choose, the following steps install the |NCS| source code and the |NCS| :term:`toolchain`.
@@ -75,127 +75,13 @@ Depending on your preferred development environment, install the following softw
 
 .. _gs_installing_toolchain:
 .. _gs_installing_tools:
-
-.. rst-class:: numbered-step
-
-Install the |NCS| toolchain
-***************************
-
-.. installncstoolchain-include-start
-
-The |NCS| :term:`toolchain` includes the Zephyr SDK and then adds tools and modules required to build |NCS| samples and applications on top of it.
-These include the :ref:`required SDK tools <requirements_toolchain_tools>`, the :ref:`Python dependencies <requirements_toolchain_python_deps>`, and the :ref:`GN tool <ug_matter_gs_tools_gn>` for creating :ref:`ug_matter` applications.
-
-.. note::
-    When you first install the |NCS|, it is recommended to install the latest released, stable versions of the SDK and the toolchain.
-
-Depending on your preferred development environment, complete the following steps:
-
-.. tabs::
-
-   .. group-tab:: nRF Connect for VS Code
-
-      You can install the toolchain together with or separately from the SDK code:
-
-      * When you install the toolchain together with the SDK code, you can download a pre-packaged bundle from the Nordic Semiconductor server that installs both the SDK and the toolchain.
-        Skip to :ref:`cloning_the_repositories` step now.
-      * When you install the toolchain separately from the SDK code, you can later install the SDK code from a GitHub tag.
-        To install the toolchain separately from the SDK code, complete the following steps:
-
-        1. Open the nRF Connect extension in |VSC| by clicking its icon in the :guilabel:`Activity Bar`.
-        #. In the extension's :guilabel:`Welcome View`, click on :guilabel:`Manage toolchains`.
-           The list of actions appears in the |VSC|'s quick pick.
-        #. Click :guilabel:`Install toolchain`.
-           The list of available stable toolchain versions appears in the |VSC|'s quick pick.
-        #. Select the toolchain version to install.
-           The toolchain version should match the |NCS| version you are going to work with.
-           |install_latest_version|
-
-           .. note::
-                If you have received a custom URL for installing the toolchain, you can provide it using the :guilabel:`Change Toolchain Index` button in the quick pick's header (wrench icon).
-                If you are working with a development tag, disable the filter in the quick pick's header to list all available toolchains.
-
-           The toolchain installation starts in the background, as can be seen in the notification that appears.
-
-   .. group-tab:: Command line
-
-      1. Open a terminal window.
-      #. Remove the lock on the nRF Util installation to be able to install other nRF Util commands.
-         See `Locking nRF Util home directory`_ in the tool documentation for more information.
-      #. Run the following command to install the nRF Util's ``sdk-manager`` command:
-
-         .. code-block:: console
-
-            nrfutil install sdk-manager
-
-      #. Run the following command to list the available installations:
-
-         .. code-block:: console
-
-            nrfutil sdk-manager search
-
-         The versions from this list correspond to the |NCS| versions and will be *version* in the following step.
-      #. Run the following command to install the toolchain version for the SDK version of your choice:
-
-         .. parsed-literal::
-            :class: highlight
-
-            nrfutil sdk-manager toolchain install --ncs-version *version*
-
-         For example:
-
-         .. parsed-literal::
-            :class: highlight
-
-            nrfutil sdk-manager toolchain install --ncs-version |release|
-
-         This example command installs the toolchain required for the |NCS| |release|.
-         |install_latest_version|
-
-      The ``sdk-manager`` command installs the toolchain by default at :file:`C:/ncs/toolchains` on Windows and at :file:`~/ncs/toolchains` on Linux.
-      These can be modified, as explained in the `command documentation <sdk-manager Configuration settings_>`_.
-      On macOS, :file:`/opt/nordic/ncs/toolchains` is used and no other location is allowed.
-
-      If you have received a custom URL for installing the toolchain, you can use the following commands to set it as default, replacing the respective parameters:
-
-      .. parsed-literal::
-         :class: highlight
-
-         nrfutil sdk-manager config toolchain-index add *index-name* *custom_toolchain_URL*
-         nrfutil sdk-manager config toolchain-index set *index-name*
-
-      If you have received a custom bundle ID for installing a specific toolchain version, you can use the following commands to provide it, replacing the respective parameter:
-
-      .. parsed-literal::
-         :class: highlight
-
-         nrfutil sdk-manager toolchain install --toolchain-bundle-id *custom_bundle_ID*
-
-      To read more about ``sdk-manager`` commands, use the ``nrfutil sdk-manager --help`` command, or see the `command documentation <sdk-manager command_>`_.
-
-With the default location to install the toolchain (:file:`C:/ncs/toolchains` on Windows, :file:`~/ncs/toolchains/` on Linux, and the non-modifiable :file:`/opt/nordic/ncs/toolchains/` on macOS), your directory structure now looks similar to this:
-
-.. code-block:: none
-
-   ncs
-   └─── toolchains
-      └─── <toolchain-installation>
-
-In this simplified structure preview, *<toolchain-installation>* corresponds to the version name you installed (most commonly, a SHA).
-
-You can check the versions of the required tools and Python dependencies on the :ref:`Requirements reference page <requirements_toolchain>`.
-
-.. installncstoolchain-include-end
-
 .. _cloning_the_repositories_win:
 .. _cloning_the_repositories:
 
 .. rst-class:: numbered-step
 
-Get the |NCS| code
-******************
-
-.. getncscode-include-start
+Install the |NCS| code and toolchain
+************************************
 
 Every |NCS| release consists of a combination of :ref:`ncs_git_intro` repositories at different versions and revisions, managed together by :ref:`ncs_west_intro`.
 The revision of each of those repositories is determined by the current revision of the main (or :ref:`manifest <zephyr:west-manifests>`) repository, `sdk-nrf`_.
@@ -217,46 +103,110 @@ Simply put, you can work with the following versions of the |NCS|:
      - Branch name (for example, ``main``)
      - `sdk-nrf`_ repository
 
+For each version of the |NCS|, Nordic Semiconductor provides a dedicated toolchain.
+The |NCS| :term:`toolchain` includes the Zephyr SDK and then adds tools and modules required to build |NCS| samples and applications on top of it.
+These include the :ref:`required SDK tools <requirements_toolchain_tools>`, the :ref:`Python dependencies <requirements_toolchain_python_deps>`, and the :ref:`GN tool <ug_matter_gs_tools_gn>` for creating :ref:`ug_matter` applications.
+You can check the versions of the required tools and Python dependencies on the :ref:`Requirements reference page <requirements_toolchain>`.
+
 .. note::
    Unless you are familiar with the :ref:`development process <dev-model>`, you should always work with a specific, stable release of the |NCS|.
 
 For more information about the repository and development model, see the :ref:`dm_code_base` page.
 
+When you install |NCS| for the first time, you have neither the SDK code nor the toolchain installed.
+Depending on your preferred development environment, complete the following steps:
+
 .. tabs::
 
    .. group-tab:: nRF Connect for VS Code
 
-      To clone the |NCS| code, complete the following steps:
-
       1. Open the nRF Connect extension in |VSC| by clicking its icon in the :guilabel:`Activity Bar`.
-      #. In the extension's :guilabel:`Welcome View`, click on :guilabel:`Manage SDKs`.
-         The list of actions appears in the |VSC|'s quick pick.
-      #. Click :guilabel:`Install SDK`.
+         The extension loads and the `Welcome View`_ appears with two buttons: :guilabel:`Install SDK` and :guilabel:`Install Toolchain`.
+      #. Click on :guilabel:`Install SDK`.
          The list of available SDK types appears.
-      #. Select the SDK type to install.
-         The list of available stable SDK versions for the selected SDK type appears in the |VSC|'s quick pick, grouped into two categories:
+      #. Select :guilabel:`nRF Connect SDK`.
+         The list of available stable versions for the |NCS| appears in the |VSC|'s quick pick, grouped into two categories:
 
-         * Pre-packaged SDKs & Toolchains - Available on the Nordic Semiconductor server.
-           The package downloads both the SDK and Toolchain, but skips the Toolchain if you have it already installed.
+         * :guilabel:`Pre-packaged SDKs & Toolchains` - Available on the Nordic Semiconductor server.
+           The package downloads both the SDK and toolchain, but skips the toolchain if you have it already installed.
            Available mostly for stable releases and some preview tags.
            Recommended for faster and more reliable download and installation.
-         * GitHub - Taken from the `nRF Connect by Nordic Semiconductor GitHub organization <nrfconnect GitHub organization_>`_.
-           Available for stable releases, but also preview tags and branches (after disabling the filter in the quick pick).
+         * :guilabel:`GitHub` - Taken from the `nRF Connect by Nordic Semiconductor GitHub organization <nrfconnect GitHub organization_>`_.
+           Available for stable releases, but also preview tags and branches.
 
-      #. Select the SDK version to install.
+      #. Select an |NCS| version to install from the :guilabel:`Pre-packaged SDKs & Toolchains` category.
          |install_latest_version|
 
-      The SDK installation starts and it can take several minutes.
+      The SDK and toolchain installation starts and it can take several minutes.
+      You can follow the progress in the notification that appears.
+
+      After the installation is complete, the extension's :guilabel:`Welcome View` is updated to feature :guilabel:`Manage toolchains` and :guilabel:`Manage SDKs` menus.
+      You can use these menus to install other versions of the |NCS| and toolchain, either together or separately.
+      See the `extension documentation <How to set up SDK and toolchain_>`_ for more information.
 
    .. group-tab:: Command line
 
-      To clone the repositories, complete the following steps:
+      1. Open a terminal window.
+      #. Remove the lock on the nRF Util installation to be able to install other nRF Util commands.
+         See `Locking nRF Util home directory`_ in the tool documentation for more information.
+      #. Run the following command to install the nRF Util's ``sdk-manager`` command:
 
-      1. On the command line, open the directory :file:`ncs`.
-         By default, this is one level up from the location where you installed the toolchain.
-         This directory will hold all |NCS| repositories.
+         .. code-block:: console
 
-      #. Start the toolchain environment for your operating system using the following command pattern, with ``--ncs-version`` corresponding to the toolchain version you have installed in the :ref:`previous step <gs_installing_tools>`:
+            nrfutil install sdk-manager
+
+      #. Run the following command to list the available installations:
+
+         .. code-block:: console
+
+            nrfutil sdk-manager search
+
+         The versions from this list correspond to the |NCS| versions and will be *version* in the following step.
+      #. Run the following command to install the SDK and the toolchain for the SDK version of your choice:
+
+         .. parsed-literal::
+            :class: highlight
+
+            nrfutil sdk-manager install *version*
+
+         For example:
+
+         .. parsed-literal::
+            :class: highlight
+
+            nrfutil sdk-manager install |release|
+
+         This example command installs both the SDK code and the toolchain for the |NCS| |release|.
+         |install_latest_version|
+
+         The ``sdk-manager`` command installs the SDK by default at :file:`C:/ncs/` on Windows and at :file:`~/ncs/` on Linux, and the toolchain in the :file:`toolchains` subdirectory.
+         The SDK installation location can be modified, as explained in the `command documentation <sdk-manager Configuration settings_>`_.
+         On macOS, :file:`/opt/nordic/ncs/` and :file:`/opt/nordic/ncs/toolchains` are used and no other locations are allowed.
+         The :file:`ncs` directory holds all |NCS| repositories.
+
+         If you have received a custom URL or a toolchain bundle ID for installing the toolchain, you can use dedicated commands to provide it.
+         Expand the section below to see the commands.
+
+         .. toggle::
+
+            If you have received a custom URL for installing the toolchain, you can use the following commands to set it as default, replacing the respective parameters:
+
+            .. parsed-literal::
+               :class: highlight
+
+               nrfutil sdk-manager config toolchain-index add *index-name* *custom_toolchain_URL*
+               nrfutil sdk-manager config toolchain-index set *index-name*
+
+            If you have received a custom bundle ID for installing a specific toolchain version, you can use the following commands to provide it, replacing the respective parameter:
+
+            .. parsed-literal::
+               :class: highlight
+
+               nrfutil sdk-manager toolchain install --toolchain-bundle-id *custom_bundle_ID*
+
+            To learn more about ``sdk-manager`` commands, use the ``nrfutil sdk-manager --help`` command, or see the `command documentation <sdk-manager command_>`_.
+
+      #. Start the toolchain environment for your operating system using the following command pattern, with ``--ncs-version`` corresponding to the |NCS| version you have installed:
 
          .. tabs::
 
@@ -381,9 +331,7 @@ For more information about the repository and development model, see the :ref:`d
 
             west zephyr-export
 
-..
-
-With the default location to install the toolchain (see the previous step) and the default location to install the SDK (:file:`C:/ncs` on Windows, :file:`~/ncs/` on Linux, and :file:`/opt/nordic/ncs/` on macOS), your directory structure now looks similar to this:
+With the default locations to install the SDK code (:file:`C:/ncs` on Windows, :file:`~/ncs/` on Linux, and :file:`/opt/nordic/ncs/` on macOS) and its toolchain (:file:`C:/ncs/toolchains` on Windows, :file:`~/ncs/toolchains/` on Linux, and the non-modifiable :file:`/opt/nordic/ncs/toolchains/` on macOS), your directory structure now looks similar to this:
 
 .. code-block:: none
 
@@ -399,11 +347,9 @@ With the default location to install the toolchain (see the previous step) and t
       ├─── zephyr
       └─── ...
 
-In this simplified structure preview, *<toolchain-installation>* corresponds to the toolchain version and *<west-workspace>* corresponds to the SDK version name.
+In this simplified structure preview, *<toolchain-installation>* corresponds to the toolchain version (most commonly, a SHA) and *<west-workspace>* corresponds to the SDK version name.
 There are also additional directories, and the structure might change over time, for example if you later :ref:`change the state of development to a different revision <updating_repos>`.
 The full set of repositories and directories is defined in the :ref:`manifest file <zephyr:west-manifest-files>` (`see the file in the repository <west manifest file_>`_).
-
-.. getncscode-include-end
 
 .. _build_environment_cli:
 

--- a/doc/nrf/installation/updating.rst
+++ b/doc/nrf/installation/updating.rst
@@ -34,7 +34,7 @@ Depending on your preferred development method, you can start the correct CLI to
 
    .. group-tab:: nRF Connect for VS Code
 
-      Start the nRF Connect terminal profile from the :guilabel:`Welcome View` (:guilabel:`Open terminal` action) or the :guilabel:`Panel View`.
+      Start the nRF Connect terminal profile from the `Welcome View`_ (:guilabel:`Open terminal` action) or the `Panel View`_.
       See `How to use nRF Connect terminal profile`_ in the extension documentation for more information.
 
       .. note::

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1003,7 +1003,7 @@
 
 .. _`Unauthorized Thread Network Key Update (SA-2023-234) vulnerability`: https://docs.nordicsemi.com/bundle/SA/resource/SA-2023-234-v1_1.pdf
 
-.. _`latest release notes for nRF Connect for Visual Studio Code`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/release_notes/connect/2024.2.214.html
+.. _`latest release notes for nRF Connect for Visual Studio Code`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/rel_notes_overview.html
 .. _`nRF Connect for Visual Studio Code`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/index.html
 .. _`Configuring with nRF Kconfig`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/work_with_kconfig.html
 .. _`How to create devicetree files`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/how_to_create_dt_files.html
@@ -1013,6 +1013,7 @@
 .. _`How to work with boards and devices`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/bd_work_with_boards.html
 .. _`How to install the extension`:
 .. _`Installing on Linux`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/get_started/install.html
+.. _`How to set up SDK and toolchain`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/get_started/quick_setup.html
 .. _`How to build an application`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/get_started/build_app_ncs.html
 .. _`Migrating IDE`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_sidebar_welcome.html#open-an-existing-application
 .. _`How to change SDK and toolchain versions`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/extension_migrate_sdk.html
@@ -1030,7 +1031,11 @@
 .. _`Application-specific flash options`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/bd_work_with_boards.html#how-to-flash-boards
 .. _`CMake build system`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/build_overview.html#cmake-build-system
 .. _`How to work with build configurations`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/build_config.html
+.. _`Welcome View`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_sidebar_welcome.html
+.. _`Applications View`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_sidebar_applications.html
+.. _`Actions View`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_sidebar_actions.html
 .. _`Details View`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_sidebar_details.html
+.. _`Panel View`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_panel.html
 .. _`Memory report`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/memory_overview.html
 .. _`Kconfig action in the Actions View`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_sidebar_actions.html
 .. _`Application support overview`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/applications.html

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_3.2.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_3.2.rst
@@ -52,7 +52,7 @@ Matter
           west flash --ext-erase-mode=ranges
 
        The longer programming time also occurs when using the :guilabel:`Erase and Flash to Board` option in the |nRFVSC|.
-       To speed up the process in the |nRFVSC|, use the :guilabel:`Flash` button instead of :guilabel:`Erase and Flash to Board` in the :guilabel:`Actions View`.
+       To speed up the process in the |nRFVSC|, use the :guilabel:`Flash` button instead of :guilabel:`Erase and Flash to Board` in the `Actions View`_.
 
        To disable storing the Wi-Fi firmware patch in external memory and revert to the previous approach, complete the following steps:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -34,7 +34,11 @@ IDE, OS, and tool support
 =========================
 
 * Added macOS 26 support (Tier 3) to the table listing :ref:`supported operating systems for proprietary tools <additional_nordic_sw_tools_os_support>`.
-* Updated the required `SEGGER J-Link`_ version to v8.60.
+* Updated:
+
+  * The required `SEGGER J-Link`_ version to v8.60.
+  * Steps on the :ref:`install_ncs` page for installing the |NCS| and toolchain together.
+    With this change, the separate steps to install the toolchain and the SDK were merged into a single step.
 
 Board support
 =============


### PR DESCRIPTION
Updated the page for simplified installation of SDK and toolchain
in one bundle.
Added links to the extension UI.
TECHDOC-4046.