### PR TITLE
samples: DTM and Radio Test - cleanup nRF54L errata

### DIFF
--- a/samples/bluetooth/direct_test_mode/src/dtm.c
+++ b/samples/bluetooth/direct_test_mode/src/dtm.c
@@ -802,12 +802,6 @@ int clock_init(void)
 		}
 	} while (err == -EAGAIN);
 
-#if NRF54L_ERRATA_20_PRESENT
-	if (nrf54l_errata_20()) {
-		nrf_power_task_trigger(NRF_POWER, NRF_POWER_TASK_CONSTLAT);
-	}
-#endif /* NRF54L_ERRATA_20_PRESENT */
-
 	return 0;
 }
 

--- a/samples/peripheral/radio_test/src/main.c
+++ b/samples/peripheral/radio_test/src/main.c
@@ -93,12 +93,6 @@ static void clock_init(void)
 		}
 	} while (err == -EAGAIN);
 
-#if NRF54L_ERRATA_20_PRESENT
-	if (nrf54l_errata_20()) {
-		nrf_power_task_trigger(NRF_POWER, NRF_POWER_TASK_CONSTLAT);
-	}
-#endif /* NRF54L_ERRATA_20_PRESENT */
-
 	printk("Clock has started\n");
 }
 


### PR DESCRIPTION
Improve code clarity: remove errata workarounds for the nRF54L family in the clock initialization for nRF54H (CLOCK_CONTROL_NRF2) as not relevant.