### PR TITLE
boards: nordic: Clean up config name

### DIFF
--- a/boards/nordic/nrf54lv10dk/board.cmake
+++ b/boards/nordic/nrf54lv10dk/board.cmake
@@ -7,7 +7,7 @@ elseif(CONFIG_SOC_NRF54LV10A_ENGA_CPUFLPR)
   board_runner_args(jlink "--speed=4000")
 endif()
 
-if(CONFIG_SOC_NRF54LV10A_ENGA_CPUAPP_NS)
+if(CONFIG_BOARD_NRF54LV10DK_NRF54LV10A_CPUAPP_NS)
   set(TFM_PUBLIC_KEY_FORMAT "full")
 endif()
 


### PR DESCRIPTION
Replace soc with board.
Soc does not exist.