### PR TITLE
doc: FEM for nRF54LM20

### DIFF
--- a/doc/nrf/app_dev/device_guides/fem/2220ek_dev_guide.rst
+++ b/doc/nrf/app_dev/device_guides/fem/2220ek_dev_guide.rst
@@ -28,6 +28,8 @@ On the :zephyr:board:`nrf54l15dk` development kit, plug the nRF2220 EK board int
    The pin **P0.04** of the nRF54L15 SoC is connected also to **Button 3** of the development kit.
    Do not press this button while the firmware containing the code supporting the nRF2220 EK shield is running.
 
+On the :zephyr:board:`nrf54lm20dk` development kit, plug the nRF2220 EK board into the ``PORT0`` expansion slot.
+
 .. _ug_radio_fem_nrf2220ek_programming:
 
 Building and programming with nRF2220 EK

--- a/doc/nrf/app_dev/device_guides/fem/index.rst
+++ b/doc/nrf/app_dev/device_guides/fem/index.rst
@@ -9,88 +9,9 @@ Developing with Front-End Modules
 
 Zephyr and the |NCS| provides support for developing applications with the following :term:`Front-End Module (FEM)` devices according to :ref:`software_maturity`:
 
-.. tabs::
-
-   .. group-tab:: nRF52 Series
-
-      .. list-table:: Front-End Module support
-         :widths: auto
-         :header-rows: 1
-
-         * - FEM device
-           - Implementation
-           - nRF52833
-           - nRF52840
-         * - nRF2220
-           - nRF2220
-           - Supported
-           - Supported
-         * - nRF21540
-           - nRF21540 GPIO
-           - Supported
-           - Supported
-         * - nRF21540
-           - nRF21540 GPIO+SPI
-           - Supported
-           - Supported
-         * - SKY66112-11
-           - Simple GPIO
-           - Supported
-           - Supported
-
-   .. group-tab:: nRF53 Series
-
-      .. list-table:: Front-End Module support
-         :widths: auto
-         :header-rows: 1
-
-         * - FEM device
-           - Implementation
-           - nRF5340
-         * - nRF2220
-           - nRF2220
-           - Supported
-         * - nRF21540
-           - nRF21540 GPIO
-           - Supported
-         * - nRF21540
-           - nRF21540 GPIO+SPI
-           - Supported
-         * - SKY66112-11
-           - Simple GPIO
-           - Supported
-
-   .. group-tab:: nRF54 Series
-
-      .. list-table:: Front-End Module support
-         :widths: auto
-         :header-rows: 1
-
-         * - FEM device
-           - Implementation
-           - nRF54L10
-           - nRF54L15
-           - nRF54LM20
-         * - nRF2220
-           - nRF2220
-           - Supported
-           - Supported
-           - Supported
-         * - nRF21540
-           - nRF21540 GPIO
-           - Supported
-           - Supported
-           - --
-         * - nRF21540
-           - nRF21540 GPIO+SPI
-           - Supported
-           - Supported
-           - Supported
-         * - SKY66112-11
-           - Simple GPIO
-           - Supported
-           - Supported
-           - --
+.. include:: ../../../releases_and_maturity/software_maturity.rst
+    :start-after: software_maturity_fem_support_table_start
+    :end-before: software_maturity_fem_support_table_end
 
 The FEM support on SoCs that are not listed in the table above might still work, but it is not tested and not guaranteed to work.
 

--- a/doc/nrf/app_dev/device_guides/fem/index.rst
+++ b/doc/nrf/app_dev/device_guides/fem/index.rst
@@ -7,26 +7,87 @@ Developing with Front-End Modules
 
 .. include:: /includes/guides_complementary_to_app_dev.txt
 
-Zephyr and the |NCS| provides support for developing applications with the following :term:`Front-End Module (FEM)` devices:
+Zephyr and the |NCS| provides support for developing applications with the following :term:`Front-End Module (FEM)` devices according to :ref:`software_maturity`:
 
-.. list-table::
-   :header-rows: 1
+.. tabs::
 
-   * - FEM device
-     - Implementation
-     - Supported SoCs
-   * - nRF2220
-     - nRF2220
-     - nRF52, nRF53, nRF54L
-   * - nRF21540
-     - nRF21540 GPIO
-     - nRF52, nRF53, nRF54L
-   * - nRF21540
-     - nRF21540 GPIO+SPI
-     - nRF52, nRF53, nRF54L
-   * - SKY66112-11
-     - Simple GPIO
-     - nRF52, nRF53, nF54L
+   .. group-tab:: nRF52 Series
+
+      .. list-table:: Front-End Module support
+         :widths: auto
+         :header-rows: 1
+
+         * - FEM device
+           - Implementation
+           - nRF52833
+           - nRF52840
+         * - nRF2220
+           - nRF2220
+           - Supported
+           - Supported
+         * - nRF21540
+           - nRF21540 GPIO
+           - Supported
+           - Supported
+         * - nRF21540
+           - nRF21540 GPIO+SPI
+           - Supported
+           - Supported
+         * - SKY66112-11
+           - Simple GPIO
+           - Supported
+           - Supported
+
+   .. group-tab:: nRF53 Series
+
+      .. list-table:: Front-End Module support
+         :widths: auto
+         :header-rows: 1
+
+         * - FEM device
+           - Implementation
+           - nRF5340
+         * - nRF2220
+           - nRF2220
+           - Supported
+         * - nRF21540
+           - nRF21540 GPIO
+           - Supported
+         * - nRF21540
+           - nRF21540 GPIO+SPI
+           - Supported
+         * - SKY66112-11
+           - Simple GPIO
+           - Supported
+
+   .. group-tab:: nRF54 Series
+
+      .. list-table:: Front-End Module support
+         :widths: auto
+         :header-rows: 1
+
+         * - FEM device
+           - Implementation
+           - nRF54L10
+           - nRF54L15
+         * - nRF2220
+           - nRF2220
+           - Supported
+           - Supported
+         * - nRF21540
+           - nRF21540 GPIO
+           - Supported
+           - Supported
+         * - nRF21540
+           - nRF21540 GPIO+SPI
+           - Supported
+           - Supported
+         * - SKY66112-11
+           - Simple GPIO
+           - Supported
+           - Supported
+
+The FEM support on SoCs that are not listed in the table above might still work, but it is not tested and not guaranteed to work.
 
 The following hardware platforms with :term:`Front-End Module (FEM)` are supported by the |NCS|:
 

--- a/doc/nrf/app_dev/device_guides/fem/index.rst
+++ b/doc/nrf/app_dev/device_guides/fem/index.rst
@@ -70,22 +70,27 @@ Zephyr and the |NCS| provides support for developing applications with the follo
            - Implementation
            - nRF54L10
            - nRF54L15
+           - nRF54LM20
          * - nRF2220
            - nRF2220
+           - Supported
            - Supported
            - Supported
          * - nRF21540
            - nRF21540 GPIO
            - Supported
            - Supported
+           - --
          * - nRF21540
            - nRF21540 GPIO+SPI
+           - Supported
            - Supported
            - Supported
          * - SKY66112-11
            - Simple GPIO
            - Supported
            - Supported
+           - --
 
 The FEM support on SoCs that are not listed in the table above might still work, but it is not tested and not guaranteed to work.
 

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -3011,3 +3011,97 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - --
               - --
+
+Front-End Modules support
+*************************
+
+The following table indicates the software maturity levels of the support for Front-End Modules:
+
+.. toggle::
+
+  .. software_maturity_fem_support_table_start
+
+  .. tabs::
+
+    .. group-tab:: nRF52 Series
+
+        .. list-table:: Front-End Module support
+          :widths: auto
+          :header-rows: 1
+
+          * - FEM device
+            - Implementation
+            - nRF52833
+            - nRF52840
+          * - nRF2220
+            - nRF2220
+            - Supported
+            - Supported
+          * - nRF21540
+            - nRF21540 GPIO
+            - Supported
+            - Supported
+          * - nRF21540
+            - nRF21540 GPIO+SPI
+            - Supported
+            - Supported
+          * - SKY66112-11
+            - Simple GPIO
+            - Supported
+            - Supported
+
+    .. group-tab:: nRF53 Series
+
+        .. list-table:: Front-End Module support
+          :widths: auto
+          :header-rows: 1
+
+          * - FEM device
+            - Implementation
+            - nRF5340
+          * - nRF2220
+            - nRF2220
+            - Supported
+          * - nRF21540
+            - nRF21540 GPIO
+            - Supported
+          * - nRF21540
+            - nRF21540 GPIO+SPI
+            - Supported
+          * - SKY66112-11
+            - Simple GPIO
+            - Supported
+
+    .. group-tab:: nRF54 Series
+
+        .. list-table:: Front-End Module support
+          :widths: auto
+          :header-rows: 1
+
+          * - FEM device
+            - Implementation
+            - nRF54L10
+            - nRF54L15
+            - nRF54LM20
+          * - nRF2220
+            - nRF2220
+            - Supported
+            - Supported
+            - Supported
+          * - nRF21540
+            - nRF21540 GPIO
+            - Supported
+            - Supported
+            - --
+          * - nRF21540
+            - nRF21540 GPIO+SPI
+            - Supported
+            - Supported
+            - Supported
+          * - SKY66112-11
+            - Simple GPIO
+            - Supported
+            - Supported
+            - --
+
+  .. software_maturity_fem_support_table_end


### PR DESCRIPTION
The FEM support table is updated to the form where the term `Supported` refers to maturity levels. The layout is similar to the "Protocol support" you can see [here](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/releases_and_maturity/software_maturity.html#protocol_support)

The following FEM implementations support now nRF54LM20 SoC: `nRF2220`, `nRF21540 GPIO+SPI`. For them the SoC is claimed `Supported`. Note that implementations `nRF21540 GPIO` and `Simple GPIO` are not claimed as `Supported`.

The nRF2220EK doc is updated to mention nRF54LM20DK specifics.
