### PR TITLE
applications: nrf_desktop: Update HID report provider event docs

### DIFF
--- a/applications/nrf_desktop/api.rst
+++ b/applications/nrf_desktop/api.rst
@@ -17,6 +17,14 @@ HID reports
 
 .. doxygengroup:: nrf_desktop_hid_reports
 
+HID report provider events
+**************************
+
+| Header file: :file:`applications/nrf_desktop/src/events/hid_report_provider_event.h`
+| Source file: :file:`applications/nrf_desktop/src/events/hid_report_provider_event.c`
+
+.. doxygengroup:: nrf_desktop_hid_report_provider_event
+
 LED states
 **********
 


### PR DESCRIPTION
Change updates documentation of the HID report provider event and adds the event under `api.rst` to generate doxygen documentation.

Jira: NCSDK-35005