### PR TITLE
tests: zephyr: drivers: spi: Disable execution on nrf54lv10dk@0.0.0

### DIFF
--- a/tests/zephyr/drivers/spi/dt_spec/testcase.yaml
+++ b/tests/zephyr/drivers/spi/dt_spec/testcase.yaml
@@ -8,7 +8,6 @@ tests:
       - nrf54ls05dk@0.0.0/nrf54ls05b/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54lv10dk@0.0.0/nrf54lv10a/cpuapp
       - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
     integration_platforms:
       - nrf54ls05dk/nrf54ls05b/cpuapp


### PR DESCRIPTION
Remove obsolete target nrf54lv10dk@0.0.0 from platform_allow list in nrf.extended.drivers.spi.dt_spec.