### PR TITLE
manifest: sdk-zephyr: [nrf fromtree] storage/stream_flash: Add API to query buffered data size

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: cf180fe3d39cdedcc05ce6fe8e9ada09f325c730
+      revision: 3722a2f2a16b998bdab8a230dc943e9e6c8367c4
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Auto-created action-manifest-pr was closed, re created for PR: https://github.com/nrfconnect/sdk-zephyr/pull/3247