### PR TITLE
applications/samples: Don't use minimal libc for MCUboot in CHIP

### DIFF
--- a/applications/matter_bridge/sysbuild/mcuboot/prj.conf
+++ b/applications/matter_bridge/sysbuild/mcuboot/prj.conf
@@ -15,10 +15,9 @@ CONFIG_FPROTECT=y
 
 CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h"
 
-# Use minimal C library instead of the Picolib
-CONFIG_MINIMAL_LIBC=y
-
 # Bootloader size optimization
+CONFIG_CBPRINTF_NANO=y
+CONFIG_PRINTK=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/light_bulb/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/light_bulb/sysbuild/mcuboot/prj.conf
@@ -13,10 +13,9 @@ CONFIG_PM=n
 CONFIG_FLASH=y
 CONFIG_FPROTECT=y
 
-# Use minimal C library instead of the Picolib
-CONFIG_MINIMAL_LIBC=y
-
 # Bootloader size optimization
+CONFIG_CBPRINTF_NANO=y
+CONFIG_PRINTK=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/light_switch/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/light_switch/sysbuild/mcuboot/prj.conf
@@ -13,10 +13,9 @@ CONFIG_PM=n
 CONFIG_FLASH=y
 CONFIG_FPROTECT=y
 
-# Use minimal C library instead of the Picolib
-CONFIG_MINIMAL_LIBC=y
-
 # Bootloader size optimization
+CONFIG_CBPRINTF_NANO=y
+CONFIG_PRINTK=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/lock/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/lock/sysbuild/mcuboot/prj.conf
@@ -13,10 +13,9 @@ CONFIG_PM=n
 CONFIG_FLASH=y
 CONFIG_FPROTECT=y
 
-# Use minimal C library instead of the Picolib
-CONFIG_MINIMAL_LIBC=y
-
 # Bootloader size optimization
+CONFIG_CBPRINTF_NANO=y
+CONFIG_PRINTK=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/manufacturer_specific/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/manufacturer_specific/sysbuild/mcuboot/prj.conf
@@ -13,10 +13,9 @@ CONFIG_PM=n
 CONFIG_FLASH=y
 CONFIG_FPROTECT=y
 
-# Use minimal C library instead of the Picolib
-CONFIG_MINIMAL_LIBC=y
-
 # Bootloader size optimization
+CONFIG_CBPRINTF_NANO=y
+CONFIG_PRINTK=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/smoke_co_alarm/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/smoke_co_alarm/sysbuild/mcuboot/prj.conf
@@ -13,10 +13,9 @@ CONFIG_PM=n
 CONFIG_FLASH=y
 CONFIG_FPROTECT=y
 
-# Use minimal C library instead of the Picolib
-CONFIG_MINIMAL_LIBC=y
-
 # Bootloader size optimization
+CONFIG_CBPRINTF_NANO=y
+CONFIG_PRINTK=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/temperature_sensor/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/temperature_sensor/sysbuild/mcuboot/prj.conf
@@ -13,10 +13,9 @@ CONFIG_PM=n
 CONFIG_FLASH=y
 CONFIG_FPROTECT=y
 
-# Use minimal C library instead of the Picolib
-CONFIG_MINIMAL_LIBC=y
-
 # Bootloader size optimization
+CONFIG_CBPRINTF_NANO=y
+CONFIG_PRINTK=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/template/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/template/sysbuild/mcuboot/prj.conf
@@ -13,10 +13,9 @@ CONFIG_PM=n
 CONFIG_FLASH=y
 CONFIG_FPROTECT=y
 
-# Use minimal C library instead of the Picolib
-CONFIG_MINIMAL_LIBC=y
-
 # Bootloader size optimization
+CONFIG_CBPRINTF_NANO=y
+CONFIG_PRINTK=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/thermostat/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/thermostat/sysbuild/mcuboot/prj.conf
@@ -13,10 +13,9 @@ CONFIG_PM=n
 CONFIG_FLASH=y
 CONFIG_FPROTECT=y
 
-# Use minimal C library instead of the Picolib
-CONFIG_MINIMAL_LIBC=y
-
 # Bootloader size optimization
+CONFIG_CBPRINTF_NANO=y
+CONFIG_PRINTK=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/window_covering/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/window_covering/sysbuild/mcuboot/prj.conf
@@ -13,10 +13,9 @@ CONFIG_PM=n
 CONFIG_FLASH=y
 CONFIG_FPROTECT=y
 
-# Use minimal C library instead of the Picolib
-CONFIG_MINIMAL_LIBC=y
-
 # Bootloader size optimization
+CONFIG_CBPRINTF_NANO=y
+CONFIG_PRINTK=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n


### PR DESCRIPTION
Goes to piclibc

NCSDK-35362