### PR TITLE
samples: bluetooth: mesh: Remove deprecated configs from model handlers

### DIFF
--- a/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
+++ b/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
@@ -21,7 +21,7 @@ struct lightness_ctx {
 	uint32_t rem_time;
 };
 
-#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_CONF)
+#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_BASELINE)
 static const uint8_t cmp2_elem_offset1[2] = { 0, 1 };
 static const uint8_t cmp2_elem_offset2[1] = { 0 };
 
@@ -272,7 +272,7 @@ void model_handler_start(void)
 {
 	int err;
 
-#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_CONF)
+#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_BASELINE)
 	if (bt_mesh_comp2_register(&comp_p2)) {
 		printk("Failed to register comp2\n");
 	}

--- a/samples/bluetooth/mesh/light_dimmer/src/model_handler.c
+++ b/samples/bluetooth/mesh/light_dimmer/src/model_handler.c
@@ -51,7 +51,7 @@ struct scene_btn_ctx {
 	int64_t press_start_time;
 };
 
-#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_CONF)
+#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_BASELINE)
 static const uint8_t cmp2_elem_offset[1] = { 0 };
 
 static const struct bt_mesh_comp2_record comp_rec[2] = {
@@ -306,7 +306,7 @@ static const struct bt_mesh_comp comp = {
 
 const struct bt_mesh_comp *model_handler_init(void)
 {
-#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_CONF)
+#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_BASELINE)
 	if (bt_mesh_comp2_register(&comp_p2)) {
 		printf("Failed to register comp2\n");
 	}

--- a/samples/bluetooth/mesh/sensor_client/src/model_handler.c
+++ b/samples/bluetooth/mesh/sensor_client/src/model_handler.c
@@ -142,7 +142,7 @@ static const struct bt_mesh_sensor_cli_handlers bt_mesh_sensor_cli_handlers = {
 static struct bt_mesh_sensor_cli sensor_cli =
 	BT_MESH_SENSOR_CLI_INIT(&bt_mesh_sensor_cli_handlers);
 
-#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_CONF)
+#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_BASELINE)
 /* HVAC Integration NLC Profile composition data page 2 */
 static const uint8_t cmp2_elem_offset_hvac[1]; /* Profile uses element 0 */
 
@@ -380,7 +380,7 @@ static const struct bt_mesh_comp comp = {
 
 const struct bt_mesh_comp *model_handler_init(void)
 {
-#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_CONF)
+#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_BASELINE)
 	if (bt_mesh_comp2_register(&comp_p2)) {
 		printk("Failed to register comp2\n");
 	}

--- a/samples/bluetooth/mesh/sensor_server/src/model_handler.c
+++ b/samples/bluetooth/mesh/sensor_server/src/model_handler.c
@@ -89,7 +89,7 @@ static uint32_t prev_pres_detect;
 
 static uint32_t prev_mot_sensed;
 
-#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_CONF)
+#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_BASELINE)
 static const uint8_t cmp2_elem_offset_ambient_light[1] = { 0 };
 static const uint8_t cmp2_elem_offset_presence[1] = { 1 };
 static const uint8_t cmp2_elem_offset_motion[1] = { 2 };
@@ -1085,7 +1085,7 @@ static const struct bt_mesh_comp comp = {
 
 const struct bt_mesh_comp *model_handler_init(void)
 {
-#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_CONF)
+#if IS_ENABLED(CONFIG_BT_MESH_NLC_PERF_BASELINE)
 	if (bt_mesh_comp2_register(&comp_p2)) {
 		printf("Failed to register comp2\n");
 	}


### PR DESCRIPTION
Fixed an issue in some mesh samples where deprecated configs remained in model handlers but were not enabled in prj.conf.

Updated samples:
- light_ctrl
- light_dimmer
- sensor_client
- sensor_server