### PR TITLE
samples: peripheral: 802154_phy_test: send multipurpose frames

### DIFF
--- a/samples/peripheral/802154_phy_test/include/rf_proc.h
+++ b/samples/peripheral/802154_phy_test/include/rf_proc.h
@@ -24,6 +24,12 @@
 /**< Start of PSDU payload */
 #define RF_PSDU_START (1u)
 
+/**< Start of PTT payload */
+#define RF_PTT_PAYLOAD_START (3u)
+
+/**< Frame control field size. */
+#define RF_FCF_SIZE (2u)
+
 /** @brief NRF radio driver initialization
  *
  *  @param none


### PR DESCRIPTION
The nrf-802154 driver does not accept invalid frames and recently has been hardened to prevent transmission of an invalid frame.

However, the PTT does not form valid IEEE 802.15.4 frames. To work around this, the frame type is set to multipurpose type, which is not validated by the nrf-802154 driver.