### PR TITLE
CRACEN: Add cracen_load_ikg_seed function

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/common.h
@@ -190,6 +190,13 @@ psa_status_t cracen_cipher_crypt_ecb(const struct sxkeyref *key, const uint8_t *
 				     size_t *output_length, enum cipher_operation dir);
 
 /**
+ * @brief Load IKG key seed
+ *
+ * @return True if IKG seed is loaded and locked, otherwise false.
+ */
+bool cracen_load_ikg_seed(void);
+
+/**
  * @brief Prepare ik key.
  *
  * @param user_data    Owner ID.


### PR DESCRIPTION
-This API addition is done to allow runtime checks whether the
 entirety of the IKG seed is preset (3 reserved slots) before trying to
 load and lock it. This is intended for usage in provisioning use cases
 to check if certain means of provisioning is possible, e.g.
 figuring out if encrypted keys can be provisioned (requires
 seed to be provisioned first)
-This API was added to allow single-session provisioning for seed
 as an early step, and provisioning of encrypted keys later on in
 the same runtime session.
-Additionally this prevents loading of partial seed if certain
 slots aren't filled