### PR TITLE
nrf_security: Add psa_purge_key to PSA core lite

### DIFF
--- a/subsys/nrf_security/src/core/lite/psa_core_lite.c
+++ b/subsys/nrf_security/src/core/lite/psa_core_lite.c
@@ -448,6 +448,13 @@ psa_status_t psa_lock_key(mbedtls_svc_key_id_t key_id)
 	return cracen_kmu_block(&attr);
 }
 
+psa_status_t psa_purge_key(mbedtls_svc_key_id_t key_id)
+{
+	(void) key_id;
+	/* Do nothing */
+	return PSA_SUCCESS;
+}
+
 #endif /* PSA_NEED_CRACEN_KMU_DRIVER */
 
 /* Initialization function */


### PR DESCRIPTION
-This API does nothing, but it is added to make sure ifdefs can
 be avoided in MCUboot which needs to support both PSA core lite
 and other implementations of PSA crypto core and drivers