### PR TITLE
memfault: upgrade to 1.29.0

### DIFF
--- a/modules/memfault-firmware-sdk/Kconfig
+++ b/modules/memfault-firmware-sdk/Kconfig
@@ -6,10 +6,6 @@
 
 if MEMFAULT
 
-config MEMFAULT_HTTP_USES_MBEDTLS
-	bool
-	default n if NRF_MODEM_LIB
-
 config MEMFAULT_NCS_PROJECT_KEY
 	string "Memfault API key"
 	help

--- a/west.yml
+++ b/west.yml
@@ -246,7 +246,7 @@ manifest:
       remote: throwtheswitch
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 1.28.0
+      revision: 1.29.0
       remote: memfault
     - name: bsim
       repo-path: bsim_west


### PR DESCRIPTION
Upgrade the Memfault Firmware SDK to version 1.29.0 to include a fix
required to remove a Kconfig style issue. The redefinition includes a
`default n`, which causes the Kconfig style check shared in
https://github.com/zephyrproject-rtos/zephyr/issues/94780#issuecomment-3210257794 to fail.
Kconfig style check script passes after this change.

Additionally, confirmed that the Kconfig values are expected from
building the samples/debug/memfault app for a nrf9160 target:
- CONFIG_NRF_MODEM_LIB=y
- CONFIG_MEMFAULT_HTTP_USES_MBEDTLS is not set

Note this is a follow-on PR to https://github.com/nrfconnect/sdk-nrf/pull/24402.

Signed-off-by: Gillian Minnehan <gillian.minnehan@nordicsemi.no>