### PR TITLE
samples: nrfcompress: disable FROTECT on nrf54l15dk

### DIFF
--- a/samples/nrf_compress/mcuboot_update/sample.yaml
+++ b/samples/nrf_compress/mcuboot_update/sample.yaml
@@ -26,3 +26,5 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+    extra_args:
+      - platform:nrf54l15dk/nrf54l15/cpuapp:mcuboot_CONFIG_FPROTECT=n


### PR DESCRIPTION
Disable FPROCECT for nrf54l15dk, because size of MCUboot is larger than 62KB.
Fixes: NCSDK-35414