### PR TITLE
doc: nRF54LM20 KMU support note edit

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54l/fota_update.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/fota_update.rst
@@ -173,7 +173,7 @@ In |NCS|, you can build and program the :zephyr:code-sample:`smp-svr` as any oth
             west build -b nrf54l15dk/nrf54l15/cpuapp -T sample.mcumgr.smp_svr.bt.nrf54l15dk.ext_flash
             west flash
 
-    .. group-tab:: nRF54l15 DK with SPI Flash as update image (DTS partitioning)
+    .. group-tab:: nRF54L15 DK with SPI Flash as update image (DTS partitioning)
 
        To build with the DTS partitioning, run the following command:
 
@@ -200,7 +200,7 @@ Provisioning of keys for Hardware KMU
 
 .. note::
 
-   The nRF54LM20A SoC currently does not support KMU.
+   The MCUboot bootloader does not yet support KMU for nRF54LM20.
 
 In case of FOTA implementations using the MCUboot bootloader, which includes hardware cryptography and KMU, you must complete key provisioning before booting any application.
 Otherwise, the bootloader :ref:`may not boot the firmware setup and might take unwanted actions<ug_nrf54l_developing_basics_kmu_provisioning_keys>`.

--- a/doc/nrf/app_dev/device_guides/nrf54l/kmu_basics.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/kmu_basics.rst
@@ -9,7 +9,7 @@ Introduction to KMU key provisioning
 
 .. note::
 
-   The nRF54LM20A SoC currently does not support KMU.
+   The MCUboot bootloader does not yet support KMU for nRF54LM20.
 
 The nRF54L devices are equipped with a Key Management Unit (KMU) that facilitates secure and confidential storage of keys.
 This feature is crucial not only for private keys but also for public keys, as the :ref:`KMU can directly transfer a key to the CRACEN RAM<ug_nrf54l_crypto_kmu_cracen_peripherals>`.

--- a/doc/nrf/app_dev/device_guides/nrf54l/kmu_provision.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/kmu_provision.rst
@@ -9,7 +9,7 @@ Performing KMU provisioning
 
 .. note::
 
-   The nRF54LM20A SoC currently does not support KMU.
+   The MCUboot bootloader does not yet support KMU for nRF54LM20.
 
 The nRF54L devices are equipped with Hardware Key Management Unit (KMU), that requires provisioning when in use.
 The |NCS| provides a west command, ``ncs-provision``, allowing to upload keys to the device though the Serial Write Debug (SWD) interface.


### PR DESCRIPTION
Rephrased notes stating that nRF54LM20 does not support KMU. Checked with the Security, MCUboot, and nRF Util teams.