### PR TITLE
samples: matter: Enable support for disabled OTA requestor

### DIFF
--- a/samples/matter/common/src/event_triggers/default_event_triggers.cpp
+++ b/samples/matter/common/src/event_triggers/default_event_triggers.cpp
@@ -267,10 +267,12 @@ CHIP_ERROR Register()
 	ReturnErrorOnFailure(Nrf::Matter::TestEventTrigger::Instance().RegisterICDTestEventTriggers());
 #endif
 
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
 	/* Register OTA test events handler */
 	static chip::OTATestEventTriggerHandler otaTestEventTrigger;
 	ReturnErrorOnFailure(
 		Nrf::Matter::TestEventTrigger::Instance().RegisterTestEventTriggerHandler(&otaTestEventTrigger));
+#endif
 
 	k_timer_init(&sDelayTimer, &DelayTimerCallback, nullptr);
 


### PR DESCRIPTION
This pr fixes the "test event triggers" build of matter samples when OTA is disabled.