### PR TITLE
samples: mgmt: mcumgr: smp_svr: fix console log checking

### DIFF
--- a/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -6,7 +6,7 @@ common:
   harness: console
   harness_config:
     type: multi_line
-    ordered: true
+    ordered: false
     regex:
       - "Starting .*bootloader"
       - "Jumping to the .*image slot"


### PR DESCRIPTION
Order of logs from ble (adv) and main are not deterministic, do not verify console logs order.