### PR TITLE
tests: zephyr: drivers: counter: Add test support for nRF7120

### DIFF
--- a/boards/nordic/nrf7120pdk/CMakeLists.txt
+++ b/boards/nordic/nrf7120pdk/CMakeLists.txt
@@ -2,6 +2,3 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
 zephyr_library_sources(board.c)
-
-zephyr_compile_definitions_ifdef(CONFIG_BOARD_NRF7120PDK_NRF7120_CPUAPP_EMU NRFX_COREDEP_DELAY_US_LOOP_CYCLES=6)
-zephyr_compile_definitions_ifdef(CONFIG_BOARD_NRF7120PDK_NRF7120_CPUAPP NRFX_COREDEP_DELAY_US_LOOP_CYCLES=6)

--- a/tests/zephyr/drivers/counter/counter_basic_api/boards/nrf7120pdk_nrf7120_cpuapp.overlay
+++ b/tests/zephyr/drivers/counter/counter_basic_api/boards/nrf7120pdk_nrf7120_cpuapp.overlay
@@ -1,28 +1,34 @@
 &timer00 {
+	prescaler = <6>;
 	status = "okay";
 };
 
-// Timer 10 not working on the board, will be fixed in the future
-// &timer10 {
-//	status = "okay";
-// };
+&timer10 {
+	prescaler = <4>;
+	status = "okay";
+};
 
 &timer20 {
+	prescaler = <4>;
 	status = "okay";
 };
 
 &timer21 {
+	prescaler = <4>;
 	status = "okay";
 };
 
 &timer22 {
+	prescaler = <4>;
 	status = "okay";
 };
 
 &timer23 {
+	prescaler = <4>;
 	status = "okay";
 };
 
 &timer24 {
+	prescaler = <4>;
 	status = "okay";
 };


### PR DESCRIPTION
Provide overlay file including prescalers for nrf7120 when running counter_basic_api tests.
Update NRFX_COREDEP_DELAY_US_LOOP_CYCLES to default value of 3 based on measurements on emulator and FPGA.