### PR TITLE
dts: nrf54ls05b: switch entropy driver to cracen

### DIFF
--- a/dts/arm/nordic/nrf54ls05b_enga_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54ls05b_enga_cpuapp.dtsi
@@ -12,7 +12,7 @@ nvic: &cpuapp_nvic {};
 
 / {
 	chosen {
-		zephyr,entropy = &prng;
+		zephyr,entropy = &rng;
 	};
 
 	soc {
@@ -28,6 +28,11 @@ nvic: &cpuapp_nvic {};
 
 	prng: prng {
 		compatible = "nordic,entropy-prng";
+		status = "disabled";
+	};
+
+	rng: rng {
+		compatible = "nordic,nrf-cracen-ctrdrbg";
 		status = "okay";
 	};
 };


### PR DESCRIPTION
Switched default nRF54LS05B entropy driver to CRACEN.