### PR TITLE
lib: st25r3911b: Fix register validity check

### DIFF
--- a/lib/st25r3911b/st25r3911b_spi.c
+++ b/lib/st25r3911b/st25r3911b_spi.c
@@ -46,7 +46,7 @@ static const struct spi_config spi_cfg =  {
 
 static bool reg_is_valid(uint8_t reg)
 {
-	return (reg < ST25R3911B_REG_IC_IDENTITY);
+	return (reg <= ST25R3911B_REG_IC_IDENTITY);
 }
 
 static bool cmd_is_valid(uint8_t cmd)


### PR DESCRIPTION
Expand reg_is_valid() check to allow ST25R3911B_REG_IC_IDENTITY as valid register