### PR TITLE
sysbuild: mcuboot: direct_xip: enable custom overlay for secondary slot

### DIFF
--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -18,6 +18,14 @@ config MCUBOOT_BUILD_DIRECT_XIP_VARIANT
 	help
 	  Will build the alternative slot (variant) image of the main application.
 
+config MCUBOOT_BUILD_DIRECT_XIP_VARIANT_CUSTOM_OVERLAY
+	string "Use a custom DTS overlay for the secondary slot image"
+	depends on MCUBOOT_BUILD_DIRECT_XIP_VARIANT || !PARTITION_MANAGER
+	help
+	  When this value is not populated, the default DTS overlay is used for the secondary slot.
+	  Use this Kconfig option when you want to set a custom overlay file for the secondary slot
+	  image.
+
 menuconfig MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
 	bool "Downgrade prevention using hardware security counters"
 	depends on (SOC_NRF5340_CPUAPP || SOC_SERIES_NRF91X || SOC_SERIES_NRF54LX)

--- a/sysbuild/mcuboot.cmake
+++ b/sysbuild/mcuboot.cmake
@@ -23,7 +23,12 @@ if(SB_CONFIG_MCUBOOT_BUILD_DIRECT_XIP_VARIANT)
       )
     else()
       UpdateableImage_Add(APPLICATION ${image} GROUP "VARIANT")
-      set(secondary_overlay "${ZEPHYR_NRF_MODULE_DIR}/subsys/mcuboot/mcuboot_secondary_app.overlay")
+
+      string(CONFIGURE "${SB_CONFIG_MCUBOOT_BUILD_DIRECT_XIP_VARIANT_CUSTOM_OVERLAY}" secondary_overlay)
+      if("${secondary_overlay}" STREQUAL "")
+        set(secondary_overlay "${ZEPHYR_NRF_MODULE_DIR}/subsys/mcuboot/mcuboot_secondary_app.overlay")
+      endif()
+
       add_overlay_dts(${image} "${secondary_overlay}")
     endif()
 


### PR DESCRIPTION
Added a dedicated Kconfig option to sysbuild that allows the user to set a custom overlay file for their secondary slot build configuration. If used, the custom file replaces the default DTS overlay.