### PR TITLE
scripts: ci: tags: extend bluetooth tag with memfault

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -49,6 +49,7 @@ bluetooth:
     - modules/crypto/mbedtls/
     - modules/crypto/oberon-psa-crypto/
     - modules/crypto/tinycrypt/
+    - modules/lib/memfault-firmware-sdk/
     - nrf/applications/ipc_radio/
     - nrf/cmake/
     - nrf/drivers/mpsl/


### PR DESCRIPTION
MDS bluetooth sample depends on this.