### PR TITLE
applications: nrf5340_audio: Add scan for address

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/bt_management/scanning/Kconfig
@@ -20,6 +20,37 @@ config SCAN_MODE_ACTIVE
 
 endchoice
 
+choice BT_MGMT_CONNECT_BY
+	prompt "Scan Filter"
+	default BT_MGMT_CONNECT_BY_NAME
+
+config BT_MGMT_CONNECT_BY_NAME
+	bool "Name"
+	help
+	  If enabled, the scanner will look for a specific name instead of just connecting
+	  to the first device it finds. The name to look for is CONFIG_BT_DEVICE_NAME.
+	  This is useful for testing with a known device.
+	  Note: This is only used if no CSIP Set Identity Resolving Key (SIRK) is available
+	  in the bond information.
+
+config BT_MGMT_CONNECT_BY_ADDR
+	bool "Address"
+	help
+	  If enabled, the scanner will look for a specific address instead of a name.
+	  The address to look for is set in bt_mgmt_scan_for_conn.c in the addr_check()
+	  function. This is useful for testing with a known device.
+	  Note: This is only used if no CSIP Set Identity Resolving Key (SIRK) is available
+	  in the bond information.
+
+endchoice
+
+config CONNECT_TO_BT_ADDR_LE_STR
+	string "Bluetooth LE Address to connect to"
+	default "00:00:00:00:00:00"
+	help
+	  The Bluetooth LE address to connect to. This is useful for testing with a
+	  specific device.
+
 #----------------------------------------------------------------------------#
 menu "Connection"
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -231,6 +231,8 @@ nRF5340 Audio
 
   * The :ref:`Audio application API documentation <audio_api>` page.
   * The :ref:`config_audio_app_options` page.
+  * The API documentation in the header files listed on the :ref:`audio_api` page.
+  * Ability to connect by address as a unicast client.
 
 * Updated:
 


### PR DESCRIPTION
- Add possibility to scan for a given address
 - Useful for testing against a specific device with a static address
- OCT-NONE