### PR TITLE
tests: current_consumpion: run anomaly 30 test on more targets

### DIFF
--- a/tests/benchmarks/current_consumption/nrf54l_errata30_idle/testcase.yaml
+++ b/tests/benchmarks/current_consumption/nrf54l_errata30_idle/testcase.yaml
@@ -9,8 +9,12 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     harness: pytest
     harness_config:
       fixture: ppk_power_measure


### PR DESCRIPTION
Added nRF54LM20A and nRF54LV10A to anomaly 30 current consumption test.