### PR TITLE
samples: subsys: mgmt: mcumgr: smp_svr: align expected logs

### DIFF
--- a/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -61,6 +61,12 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "smp_sample: build time"
+        - "smp_bt_sample: Advertising successfully started"
   sample.mcumgr.smp_svr.bt.nrf54h20dk:
     sysbuild: true
     extra_args:


### PR DESCRIPTION
No mcuboot logs in pure_dts variant.