### PR TITLE
tests: zephyr: drivers: flash: common: require external_flash fixture

### DIFF
--- a/tests/zephyr/drivers/flash/common/testcase.yaml
+++ b/tests/zephyr/drivers/flash/common/testcase.yaml
@@ -3,6 +3,9 @@ common:
     - drivers
     - flash
     - ci_tests_drivers_hpf
+  harness: ztest
+  harness_config:
+    fixture: external_flash
 tests:
   nrf.extended.drivers.flash.common.hpf.quad:
     platform_allow:


### PR DESCRIPTION
As there are boards which has different configuration.