### PR TITLE
samples: smp_svr: pure_dts: enable logs from MCUboot

### DIFF
--- a/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -38,7 +38,7 @@ tests:
     extra_args:
       - OVERLAY_CONFIG="overlay-bt.conf"
       - DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_ext_flash.overlay"
-      - mcuboot_CONF_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_ext_flash.conf"
+      - mcuboot_OVERLAY_CONFIG="boards/nrf54l15dk_nrf54l15_cpuapp_ext_flash.conf"
       - mcuboot_EXTRA_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_ext_flash.overlay"
       - SB_CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
       - SB_CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY=y
@@ -52,7 +52,7 @@ tests:
     extra_args:
       - OVERLAY_CONFIG="overlay-bt.conf"
       - DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_ext_flash.overlay"
-      - mcuboot_CONF_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_ext_flash.conf"
+      - mcuboot_OVERLAY_CONFIG="boards/nrf54l15dk_nrf54l15_cpuapp_ext_flash.conf"
       - mcuboot_EXTRA_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_ext_flash.overlay"
       - SB_CONFIG_PARTITION_MANAGER=n
     platform_allow:
@@ -61,12 +61,6 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
-    harness_config:
-      type: multi_line
-      ordered: false
-      regex:
-        - "smp_sample: build time"
-        - "smp_bt_sample: Advertising successfully started"
   sample.mcumgr.smp_svr.bt.nrf54h20dk:
     sysbuild: true
     extra_args:


### PR DESCRIPTION
Changed method to pass overlay config for MCUboot
image to get the default configuration file from MCUboot repo. It enables logging, so #24579 can be reverted.