### PR TITLE
samples: zephyr: smp_svr_mini_boot: buffer adjustment

### DIFF
--- a/samples/zephyr/smp_svr_mini_boot/prj.conf
+++ b/samples/zephyr/smp_svr_mini_boot/prj.conf
@@ -44,9 +44,9 @@ CONFIG_BT=y
 CONFIG_BT_PERIPHERAL=y
 
 # Allow for large Bluetooth data packets.
-CONFIG_BT_L2CAP_TX_MTU=498
-CONFIG_BT_BUF_ACL_RX_SIZE=502
-CONFIG_BT_BUF_ACL_TX_SIZE=502
+CONFIG_BT_L2CAP_TX_MTU=247
+CONFIG_BT_BUF_ACL_RX_SIZE=251
+CONFIG_BT_BUF_ACL_TX_SIZE=251
 CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
 
 # Enable the Bluetooth mcumgr transport (unauthenticated).
@@ -62,9 +62,9 @@ CONFIG_MCUMGR_TRANSPORT_SHELL=y
 
 # Enable the mcumgr Packet Reassembly feature over Bluetooth and its configuration dependencies.
 # MCUmgr buffer size is optimized to fit one SMP packet divided into five Bluetooth Write Commands,
-# transmitted with the maximum possible MTU value: 498 bytes.
+# transmitted with the maximum possible MTU value: 247 bytes.
 CONFIG_MCUMGR_TRANSPORT_BT_REASSEMBLY=y
-CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE=2475
+CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE=1220
 CONFIG_MCUMGR_GRP_OS_MCUMGR_PARAMS=y
 CONFIG_MCUMGR_TRANSPORT_WORKQUEUE_STACK_SIZE=4608
 


### PR DESCRIPTION
Update sample to use new buffer configuration proposed in PR #24293 to get better test coverage with the new default configurations.