### PR TITLE
samples: cellular: Use device UUID as device and cloud ID

### DIFF
--- a/samples/cellular/gnss/sample.yaml
+++ b/samples/cellular/gnss/sample.yaml
@@ -35,6 +35,7 @@ tests:
       - CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE="23.77588976"
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
       - CONFIG_LOG_BUFFER_SIZE=2048
+      - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID=y
     extra_args: gnss_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
@@ -62,6 +63,7 @@ tests:
       - CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE="23.77588976"
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
       - CONFIG_LOG_BUFFER_SIZE=2048
+      - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID=y
     extra_args: gnss_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
@@ -88,6 +90,7 @@ tests:
       - CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE="23.77588976"
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
       - CONFIG_LOG_BUFFER_SIZE=2048
+      - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID=y
     extra_args:
       - EXTRA_CONF_FILE=overlay-pgps.conf
       - gnss_SNIPPET="nrf91-modem-trace-uart"
@@ -117,6 +120,7 @@ tests:
       - CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE="23.77588976"
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
       - CONFIG_LOG_BUFFER_SIZE=2048
+      - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID=y
     extra_args: gnss_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/location/sample.yaml
+++ b/samples/cellular/location/sample.yaml
@@ -84,6 +84,7 @@ tests:
     extra_configs:
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
       - CONFIG_LOG_BUFFER_SIZE=2048
+      - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID=y
     extra_args: location_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -713,6 +713,7 @@ tests:
     extra_configs:
       - CONFIG_LTE_NETWORK_MODE_LTE_M=y
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
+      - CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID=y
     extra_args: modem_shell_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns


### PR DESCRIPTION
Change integration test configurations that use location services to use device UUID as device and cloud ID instead of current nrf-<IMEI> format.

test-sdk-nrf: sdk-nrf-pr-24599