### PR TITLE
lib: ram_pwrdn: replace deprecated NRF_POWER symbol

### DIFF
--- a/lib/ram_pwrdn/ram_pwrdn.c
+++ b/lib/ram_pwrdn/ram_pwrdn.c
@@ -86,8 +86,8 @@ static const struct ram_bank banks[] = {
 static void ram_bank_power_down(uint8_t bank_id, uint8_t first_section_id, uint8_t last_section_id)
 {
 #if defined(CONFIG_SOC_NRF52840) || defined(CONFIG_SOC_NRF52833)
-	uint32_t mask = GENMASK(NRF_POWER_RAMPOWER_S0POWER + last_section_id,
-				NRF_POWER_RAMPOWER_S0POWER + first_section_id);
+	uint32_t mask = GENMASK(NRF_POWER_RAMPOWER_S0POWER_POS + last_section_id,
+				NRF_POWER_RAMPOWER_S0POWER_POS + first_section_id);
 	nrf_power_rampower_mask_off(NRF_POWER, bank_id, mask);
 #elif defined(CONFIG_SOC_NRF5340_CPUAPP)
 	uint32_t mask = GENMASK(VMC_RAM_POWER_S0POWER_Pos + last_section_id,
@@ -106,8 +106,8 @@ static void ram_bank_power_down(uint8_t bank_id, uint8_t first_section_id, uint8
 static void ram_bank_power_up(uint8_t bank_id, uint8_t first_section_id, uint8_t last_section_id)
 {
 #if defined(CONFIG_SOC_NRF52840) || defined(CONFIG_SOC_NRF52833)
-	uint32_t mask = GENMASK(NRF_POWER_RAMPOWER_S0POWER + last_section_id,
-				NRF_POWER_RAMPOWER_S0POWER + first_section_id);
+	uint32_t mask = GENMASK(NRF_POWER_RAMPOWER_S0POWER_POS + last_section_id,
+				NRF_POWER_RAMPOWER_S0POWER_POS + first_section_id);
 	nrf_power_rampower_mask_on(NRF_POWER, bank_id, mask);
 #elif defined(CONFIG_SOC_NRF5340_CPUAPP)
 	uint32_t mask = GENMASK(VMC_RAM_POWER_S0POWER_Pos + last_section_id,


### PR DESCRIPTION
NRF_POWER_RAMPOWER_S0POWER is deprecated and is to be removed soon.