### PR TITLE
tests: pcm_stream_channel_modifier: Interleave and deinterleave support

### DIFF
--- a/lib/pcm_stream_channel_modifier/pcm_stream_channel_modifier.c
+++ b/lib/pcm_stream_channel_modifier/pcm_stream_channel_modifier.c
@@ -224,6 +224,11 @@ int pscm_interleave(void const *const input, size_t input_size, uint8_t channel,
 		return -EINVAL;
 	}
 
+	if (pcm_bit_depth % 8) {
+		LOG_ERR("PCM bit depth is not divisible by 8: %d", pcm_bit_depth);
+		return -EINVAL;
+	}
+
 	bytes_per_sample = pcm_bit_depth / 8;
 	step = bytes_per_sample * (output_channels - 1);
 	pointer_input = (uint8_t *)input;
@@ -256,6 +261,11 @@ int pscm_deinterleave(void const *const input, size_t input_size, uint8_t input_
 
 	if (output_size < (input_size / input_channels)) {
 		LOG_DBG("Output buffer too small to uninterleave input into");
+		return -EINVAL;
+	}
+
+	if (pcm_bit_depth % 8) {
+		LOG_ERR("PCM bit depth is not divisible by 8: %d", pcm_bit_depth);
 		return -EINVAL;
 	}
 

--- a/tests/lib/pcm_stream_channel_modifier/src/main.c
+++ b/tests/lib/pcm_stream_channel_modifier/src/main.c
@@ -125,7 +125,7 @@ ZTEST(suite_pscm_int, test_pscm_interleave_api_parameters)
 
 	ret = pscm_interleave(input, input_size, channel, 12, &output, output_size,
 			      output_channels);
-	zassert_equal(ret, -EINVAL, "Failed interleave pcm_bit_depth not devisable by 8: ret %d",
+	zassert_equal(ret, -EINVAL, "Failed interleave pcm_bit_depth not divisible by 8: ret %d",
 		      ret);
 
 	ret = pscm_interleave(input, input_size, channel, 40, &output, output_size,
@@ -174,7 +174,7 @@ ZTEST(suite_pscm_deint, test_pscm_deinterleave_api_parameters)
 
 	ret = pscm_deinterleave(input, input_size, input_channels, channel, 12, &output,
 				output_size);
-	zassert_equal(ret, -EINVAL, "Failed deinterleave pcm_bit_depth not devisable by 8: ret %d",
+	zassert_equal(ret, -EINVAL, "Failed deinterleave pcm_bit_depth not divisible by 8: ret %d",
 		      ret);
 
 	ret = pscm_deinterleave(input, input_size, input_channels, channel, 40, &output,


### PR DESCRIPTION
OCT-3463

Add a test for the PCM carrier not being divisible by 8.