### PR TITLE
samples: matter: Fixed configuration for 54lm20 internal

### DIFF
--- a/samples/matter/contact_sensor/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/contact_sensor/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
@@ -28,3 +28,7 @@ CONFIG_BOOT_MAX_IMG_SECTORS=512
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
+
+# Use minimal C library instead of picolibc due to fault on this SoC
+# KRKNWK-20774
+CONFIG_MINIMAL_LIBC=y

--- a/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
@@ -41,3 +41,7 @@ CONFIG_BOOT_MAX_IMG_SECTORS=512
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
+
+# Use minimal C library instead of picolibc due to fault on this SoC
+# KRKNWK-20774
+CONFIG_MINIMAL_LIBC=y

--- a/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
@@ -41,3 +41,7 @@ CONFIG_BOOT_MAX_IMG_SECTORS=512
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
+
+# Use minimal C library instead of picolibc due to fault on this SoC
+# KRKNWK-20774
+CONFIG_MINIMAL_LIBC=y

--- a/samples/matter/lock/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/lock/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
@@ -41,3 +41,7 @@ CONFIG_BOOT_MAX_IMG_SECTORS=512
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
+
+# Use minimal C library instead of picolibc due to fault on this SoC
+# KRKNWK-20774
+CONFIG_MINIMAL_LIBC=y

--- a/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
@@ -41,3 +41,7 @@ CONFIG_BOOT_MAX_IMG_SECTORS=512
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
+
+# Use minimal C library instead of picolibc due to fault on this SoC
+# KRKNWK-20774
+CONFIG_MINIMAL_LIBC=y

--- a/samples/matter/smoke_co_alarm/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/smoke_co_alarm/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
@@ -41,3 +41,7 @@ CONFIG_BOOT_MAX_IMG_SECTORS=512
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
+
+# Use minimal C library instead of picolibc due to fault on this SoC
+# KRKNWK-20774
+CONFIG_MINIMAL_LIBC=y

--- a/samples/matter/temperature_sensor/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/temperature_sensor/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
@@ -41,3 +41,7 @@ CONFIG_BOOT_MAX_IMG_SECTORS=512
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
+
+# Use minimal C library instead of picolibc due to fault on this SoC
+# KRKNWK-20774
+CONFIG_MINIMAL_LIBC=y

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
@@ -41,3 +41,7 @@ CONFIG_BOOT_MAX_IMG_SECTORS=512
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
+
+# Use minimal C library instead of picolibc due to fault on this SoC
+# KRKNWK-20774
+CONFIG_MINIMAL_LIBC=y

--- a/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
@@ -41,3 +41,7 @@ CONFIG_BOOT_MAX_IMG_SECTORS=512
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
+
+# Use minimal C library instead of picolibc due to fault on this SoC
+# KRKNWK-20774
+CONFIG_MINIMAL_LIBC=y

--- a/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
+++ b/samples/matter/window_covering/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp_internal.conf
@@ -41,3 +41,7 @@ CONFIG_BOOT_MAX_IMG_SECTORS=512
 # reset + 1. Hence, the reboot time increases more and more.
 # To avoid it enable tickles kernel for mcuboot.
 CONFIG_TICKLESS_KERNEL=y
+
+# Use minimal C library instead of picolibc due to fault on this SoC
+# KRKNWK-20774
+CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
The picolibc was enabled in mcuboot for nrf54lm20 internal configuration, what does not work and leads to mcuboot crash.