### PR TITLE
quarantine: add sample.bluetooth.peripheral_mds for nrf52833dk/nrf52833 and nrf52dk/nrf52832

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -110,3 +110,10 @@
     - nrf54lm20dk/nrf54lm20a/cpuapp
     - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-35468"
+
+- scenarios:
+    - sample.bluetooth.peripheral_mds.sample.bluetooth.peripheral_mds
+  platforms:
+    - nrf52833dk/nrf52833
+    - nrf52dk/nrf52832
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-35531"


### PR DESCRIPTION
- Add quarantine entry for sample.bluetooth.peripheral_mds.sample.bluetooth.peripheral_mds
- Affects platforms: nrf52833dk/nrf52833 and nrf52dk/nrf52832
- Build failure due to deprecated bt_hci_cmd_create function in memfault SDK
- References JIRA ticket NCSDK-35531
