### PR TITLE
samples: bluetooth: mesh: add poll toggle to sensor cli

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -316,6 +316,8 @@ Bluetooth Mesh samples
 
 * :ref:`bluetooth_mesh_sensor_client` sample:
 
+  * Added polling toggle to **Button 1** (**Button 0** on nRF54 DKs) to start/stop the periodic Sensor Get loop, ensuring the functionality is available on all supported devices including single-button hardware.
+
   * Updated:
 
     * To demonstrate the Bluetooth :ref:`ug_bt_mesh_nlc` HVAC Integration profile.
@@ -325,6 +327,10 @@ Bluetooth Mesh samples
       * :ref:`bluetooth_mesh_light_lc`
       * :ref:`bluetooth_mesh_sensor_server`
       * :ref:`bluetooth_mesh_sensor_client`
+
+    * Button functions.
+      Assignments are shifted down one index to accommodate the new polling toggle.
+      The descriptor action has been removed from button actions but is still available through mesh shell commands.
 
 Bluetooth Fast Pair samples
 ---------------------------

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -86,7 +86,7 @@ The models are used for the following purposes:
 * Sensor Client gets sensor data from one or more :ref:`Sensor Servers <bt_mesh_sensor_srv_readme>`.
 
 The model handling is implemented in :file:`src/model_handler.c`.
-A :c:struct:`k_work_delayable` item is submitted recursively to periodically request sensor data.
+Sensor data can be periodically requested using a :c:struct:`k_work_delayable` loop, which can be started and stopped with a button press.
 
 User interface
 **************
@@ -102,13 +102,13 @@ Once the provisioning procedure has completed, the buttons will have the followi
    .. group-tab:: nRF21 and nRF52 DKs
 
       Button 1:
-         Sends a get message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
+         Toggles the periodic Sensor Get data loop on/off.
 
       Button 2:
-         Sends a set message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor, switching between the ranges specified in the :c:var:`temp_ranges` variable.
+         Sends a get message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
 
       Button 3:
-         Sends a get message for a descriptor, requesting information about the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
+         Sends a set message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor, switching between the ranges specified in the :c:var:`temp_ranges` variable.
 
       Button 4:
          Sends a set message for the :c:var:`bt_mesh_sensor_motion_threshold` setting of the :c:var:`bt_mesh_sensor_presence_detected` sensor, switching between the ranges specified in the :c:var:`presence_motion_threshold` variable.
@@ -116,13 +116,13 @@ Once the provisioning procedure has completed, the buttons will have the followi
    .. group-tab:: nRF54 DKs
 
       Button 0:
-         Sends a get message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
+         Toggles the periodic Sensor Get loop (start/stop).
 
       Button 1:
-         Sends a set message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor, switching between the ranges specified in the :c:var:`temp_ranges` variable.
+         Sends a get message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
 
       Button 2:
-         Sends a get message for a descriptor, requesting information about the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor.
+         Sends a set message for the :c:var:`bt_mesh_sensor_dev_op_temp_range_spec` setting of the :c:var:`bt_mesh_sensor_present_dev_op_temp` sensor, switching between the ranges specified in the :c:var:`temp_ranges` variable.
 
       Button 3:
          Sends a set message for the :c:var:`bt_mesh_sensor_motion_threshold` setting of the :c:var:`bt_mesh_sensor_presence_detected` sensor, switching between the ranges specified in the :c:var:`presence_motion_threshold` variable.

--- a/samples/bluetooth/mesh/sensor_client/src/model_handler.c
+++ b/samples/bluetooth/mesh/sensor_client/src/model_handler.c
@@ -165,9 +165,27 @@ static const struct bt_mesh_comp2 comp_p2 = {
 #endif
 
 static struct k_work_delayable get_data_work;
+static bool poll_active;
+
+static void poll_toggle(void)
+{
+	if (poll_active) {
+		poll_active = false;
+		k_work_cancel_delayable(&get_data_work);
+		printk("Sensor polling stopped\n");
+	} else {
+		poll_active = true;
+		k_work_schedule(&get_data_work, K_NO_WAIT);
+		printk("Sensor polling started\n");
+	}
+}
 
 static void get_data(struct k_work *work)
 {
+	if (!poll_active) {
+		return;
+	}
+
 	if (!bt_mesh_is_provisioned()) {
 		k_work_schedule(&get_data_work, K_MSEC(GET_DATA_INTERVAL));
 		return;
@@ -278,6 +296,9 @@ static void button_handler_cb(uint32_t pressed, uint32_t changed)
 	int err;
 
 	if (pressed & changed & BIT(0)) {
+		poll_toggle();
+	}
+	if (pressed & changed & BIT(1)) {
 		err = bt_mesh_sensor_cli_setting_get(&sensor_cli, NULL,
 						     &bt_mesh_sensor_present_dev_op_temp,
 						     &bt_mesh_sensor_dev_op_temp_range_spec, NULL);
@@ -285,7 +306,7 @@ static void button_handler_cb(uint32_t pressed, uint32_t changed)
 			printk("Error getting range setting (%d)\n", err);
 		}
 	}
-	if (pressed & changed & BIT(1)) {
+	if (pressed & changed & BIT(2)) {
 		err = setting_set_int(&bt_mesh_sensor_present_dev_op_temp,
 				      &bt_mesh_sensor_dev_op_temp_range_spec,
 				      temp_ranges[temp_idx++]);
@@ -293,13 +314,6 @@ static void button_handler_cb(uint32_t pressed, uint32_t changed)
 			printk("Error setting range setting (%d)\n", err);
 		}
 		temp_idx = temp_idx % ARRAY_SIZE(temp_ranges);
-	}
-	if (pressed & changed & BIT(2)) {
-		err = bt_mesh_sensor_cli_desc_get(&sensor_cli, NULL,
-						  &bt_mesh_sensor_present_dev_op_temp, NULL);
-		if (err) {
-			printk("Error getting sensor descriptor (%d)\n", err);
-		}
 	}
 	if (pressed & changed & BIT(3)) {
 		err = setting_set_int(&bt_mesh_sensor_presence_detected,
@@ -391,7 +405,6 @@ const struct bt_mesh_comp *model_handler_init(void)
 	k_work_init_delayable(&motion_timeout_work, motion_timeout);
 
 	dk_button_handler_add(&button_handler);
-	k_work_schedule(&get_data_work, K_MSEC(GET_DATA_INTERVAL));
 
 	return &comp;
 }


### PR DESCRIPTION
* Added polling toggle on first button (to include single-button hardware). This was done to avoid messaging traffic when not needed.
* Updated button mapping.
* Removed descriptor action from buttons. This is still available via shell.
* Updated docs.

Note: all PTS tests are passed.