### PR TITLE
manifest: update sdk-zephyr to have errata 4.0 alignment

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -141,24 +141,6 @@
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-35605"
 
 - scenarios:
-    - applications.nrf_desktop.*
-  platforms:
-    - nrf52kbd/nrf52832
-  comment: "Needs alignment to new errata system in nrfx - NRFX-8421"
-
-- scenarios:
-    - sample.bluetooth.mesh.light_ctrl
-  platforms:
-    - nrf52dk/nrf52832
-  comment: "Needs alignment to new errata system in nrfx - NRFX-8421"
-
-- scenarios:
-    - sample.bluetooth.nrf_dm.timeslot
-  platforms:
-    - nrf52dk/nrf52832
-  comment: "Needs alignment to new errata system in nrfx - NRFX-8421"
-
-- scenarios:
     - sample.bluetooth.mesh.light_ctrl.emds
   platforms:
     - thingy53/nrf5340/cpuapp

--- a/west.yml
+++ b/west.yml
@@ -66,7 +66,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0c9648fe64f0a4b82eaa5db7d0d1af5386cc91de
+      revision: pull/3288/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Based on #24471, with reverted c2e0c06177.