### PR TITLE
scripts: quarantine and quarantine_zephyr

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -103,6 +103,8 @@
 - scenarios:
     - sample.bluetooth.peripheral_mds
   platforms:
+    - nrf52dk/nrf52832
+    - nrf52833dk/nrf52833
     - nrf52840dk/nrf52840
     - nrf54l15dk/nrf54l05/cpuapp
     - nrf54l15dk/nrf54l10/cpuapp

--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -246,6 +246,18 @@
     - nrf54lm20dk/nrf54lm20a/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-35490"
 
+- scenarios:
+    - libraries.encoding.jwt.rsa.psa
+  platforms:
+    - nrf54lm20dk/nrf54lm20a/cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-35542"
+
+- scenarios:
+    - libraries.encoding.jwt.rsa.legacy
+  platforms:
+    - nrf54lm20dk/nrf54lm20a/cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-35543"
+
 # ---------------------------------   Won't fix section -----------------------------------
 
 - scenarios:


### PR DESCRIPTION
* quarantine: extend platforms for sample.bluetooth.peripherals_mds
* zephyr: more samples for nrf54lm20dk/nrf54lm20a/cpuapp

Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>
