### PR TITLE
applications: nrf_desktop: nrf54h20: migrate to ironside dvfs service

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/app_common.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/app_common.dtsi
@@ -59,6 +59,8 @@
 	};
 
 	aliases {
+		nrfdesktop-dvfs-clock = &cpuapp_hsfll;
+
 		/delete-property/ pwm-led0;
 	};
 };

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj.conf
@@ -60,7 +60,6 @@ CONFIG_DESKTOP_CONFIG_CHANNEL_OUT_REPORT=y
 # Temporarily disable unsupported features.
 CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_ENABLE=n
 CONFIG_DESKTOP_DFU_MCUMGR_ENABLE=n
-CONFIG_DESKTOP_DVFS=n
 
 ################################################################################
 # Zephyr Configuration

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_dongle.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_dongle.conf
@@ -44,7 +44,6 @@ CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE=y
 
 # Temporarily disable unsupported features.
 CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_ENABLE=n
-CONFIG_DESKTOP_DVFS=n
 
 ################################################################################
 # Zephyr Configuration

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_release.conf
@@ -56,7 +56,6 @@ CONFIG_DESKTOP_CONFIG_CHANNEL_OUT_REPORT=y
 # Temporarily disable unsupported features.
 CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_ENABLE=n
 CONFIG_DESKTOP_DFU_MCUMGR_ENABLE=n
-CONFIG_DESKTOP_DVFS=n
 
 ################################################################################
 # Zephyr Configuration

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_release_dongle.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/prj_release_dongle.conf
@@ -43,7 +43,6 @@ CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE=y
 
 # Temporarily disable unsupported features.
 CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_ENABLE=n
-CONFIG_DESKTOP_DVFS=n
 
 ################################################################################
 # Zephyr Configuration

--- a/applications/nrf_desktop/src/modules/Kconfig.dvfs
+++ b/applications/nrf_desktop/src/modules/Kconfig.dvfs
@@ -8,9 +8,8 @@ menuconfig DESKTOP_DVFS
 	bool "DVFS module [EXPERIMENTAL]"
 	depends on SOC_NRF54H20_CPUAPP
 	select EXPERIMENTAL
-	select NRFS_DVFS_SERVICE_ENABLED
 	select CLOCK_CONTROL
-	select CLOCK_CONTROL_NRF2
+	select CLOCK_CONTROL_NRF_IRON_HSFLL_LOCAL
 	default y
 	help
 	  This option enable DVFS module which switches frequency and voltage according


### PR DESCRIPTION
Aligned the nRF Desktop DVFS module with the new nRF54H20 SW architecture that is based on the IronSide SE.

Reenabled the module for the nrf54h20dk/nrf54h20/cpuapp board target.

Ref: NCSDK-34151