### PR TITLE
dts: common: nordic: nrf7120: Edit AUXPLL default config

### DIFF
--- a/dts/common/nordic/nrf7120_enga.dtsi
+++ b/dts/common/nordic/nrf7120_enga.dtsi
@@ -829,11 +829,11 @@
 				 * not defined yet
 				 */
 				nordic,ficrs = <&ficr 0>;
-				nordic,out-div = <2>;
+				nordic,out-div = <12>;
 				nordic,out-drive = <0>;
 				nordic,current-tune = <9>;
 				nordic,sdm-disable;
-				nordic,range = "high";
+				nordic,range = "mid";
 				status = "disabled";
 			};
 


### PR DESCRIPTION
Auxpll config was setup incorrectly for the audio use-case.