### PR TITLE
doc: lib: fmfu_mgmt_stat.h doxygengroup link

### DIFF
--- a/doc/nrf/libraries/dfu/fmfu_mgmt.rst
+++ b/doc/nrf/libraries/dfu/fmfu_mgmt.rst
@@ -26,3 +26,5 @@ API documentation
 | Source files: :file:`subsys/mgmt/src/`
 
 .. doxygengroup:: fmfu_mgmt
+
+.. doxygengroup:: fmfu_mgmt_stat


### PR DESCRIPTION
Added missing link to the Doxygen group of fmfu_mgmt_stat.h. NCSDK-11537.