### PR TITLE
tests: drivers: Run TWIM instances test on PPR

### DIFF
--- a/tests/drivers/i2c/twim_instances/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/i2c/twim_instances/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&pinctrl {
+	i2c130_default_test: i2c130_default_test {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 9, 5)>,
+				<NRF_PSEL(TWIM_SCL, 9, 4)>;
+		};
+	};
+
+	i2c130_sleep_test: i2c130_sleep_test {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 9, 5)>,
+				<NRF_PSEL(TWIM_SCL, 9, 4)>;
+			low-power-enable;
+		};
+	};
+
+	i2c131_default_test: i2c131_default_test {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 9, 0)>,
+				<NRF_PSEL(TWIM_SCL, 9, 1)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c131_sleep_test: i2c131_sleep_test {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 9, 0)>,
+				<NRF_PSEL(TWIM_SCL, 9, 1)>;
+			low-power-enable;
+		};
+	};
+
+	i2c132_default_test: i2c132_default_test {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 5)>,
+				<NRF_PSEL(TWIM_SCL, 0, 0)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c132_sleep_test: i2c132_sleep_test {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 5)>,
+				<NRF_PSEL(TWIM_SCL, 0, 0)>;
+			low-power-enable;
+		};
+	};
+
+	i2c133_default_test: i2c133_default_test {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 6)>,
+				<NRF_PSEL(TWIM_SCL, 0, 2)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c133_sleep_test: i2c133_sleep_test {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 6)>,
+				<NRF_PSEL(TWIM_SCL, 0, 2)>;
+			low-power-enable;
+		};
+	};
+
+	i2c134_default_test: i2c134_default_test {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 0)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c134_sleep_test: i2c134_sleep_test {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 0)>;
+			low-power-enable;
+		};
+	};
+};
+
+&can120 {
+	status = "disabled";
+};
+
+&i2c130 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	pinctrl-0 = <&i2c130_default_test>;
+	pinctrl-1 = <&i2c130_sleep_test>;
+	pinctrl-names = "default", "sleep";
+	zephyr,concat-buf-size = <256>;
+};
+
+&i2c131 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	pinctrl-0 = <&i2c131_default_test>;
+	pinctrl-1 = <&i2c131_sleep_test>;
+	pinctrl-names = "default", "sleep";
+	zephyr,concat-buf-size = <256>;
+};
+
+&i2c132 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	pinctrl-0 = <&i2c132_default_test>;
+	pinctrl-1 = <&i2c132_sleep_test>;
+	pinctrl-names = "default", "sleep";
+	zephyr,concat-buf-size = <256>;
+};
+
+&i2c133 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	pinctrl-0 = <&i2c133_default_test>;
+	pinctrl-1 = <&i2c133_sleep_test>;
+	pinctrl-names = "default", "sleep";
+	zephyr,concat-buf-size = <256>;
+};
+
+&i2c134 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	pinctrl-0 = <&i2c134_default_test>;
+	pinctrl-1 = <&i2c134_sleep_test>;
+	pinctrl-names = "default", "sleep";
+	zephyr,concat-buf-size = <256>;
+};

--- a/tests/drivers/i2c/twim_instances/testcase.yaml
+++ b/tests/drivers/i2c/twim_instances/testcase.yaml
@@ -9,6 +9,7 @@ tests:
   drivers.i2c.twim_instances:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpuppr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54ls05dk@0.0.0/nrf54ls05b/cpuapp
@@ -17,6 +18,7 @@ tests:
       - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpuppr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp


### PR DESCRIPTION
Enable execution of 'drivers.i2c.twim_instances' on H20 PPR