### PR TITLE
applications: nrf_desktop: Allow for delayed HID provider registration

### DIFF
--- a/applications/nrf_desktop/src/modules/hid_provider_consumer_ctrl.c
+++ b/applications/nrf_desktop/src/modules/hid_provider_consumer_ctrl.c
@@ -196,6 +196,7 @@ static void trigger_report_transmission(void)
 	report_data.update_needed = true;
 
 	if (active_sub) {
+		__ASSERT_NO_MSG(hid_state_api);
 		(void)hid_state_api->trigger_report_send(REPORT_ID_CONSUMER_CTRL);
 	} else {
 		LOG_DBG("Subscription not enabled");
@@ -287,6 +288,7 @@ static bool handle_hid_report_provider_event(const struct hid_report_provider_ev
 				consumer_ctrl_report_connection_state_changed);
 		__ASSERT_NO_MSG(!hid_state_api);
 		__ASSERT_NO_MSG(event->hid_state_api);
+		__ASSERT_NO_MSG(event->hid_state_api->trigger_report_send);
 		hid_state_api = event->hid_state_api;
 	}
 

--- a/applications/nrf_desktop/src/modules/hid_provider_keyboard.c
+++ b/applications/nrf_desktop/src/modules/hid_provider_keyboard.c
@@ -242,6 +242,7 @@ static void trigger_report_transmission(void)
 	report_data.update_needed = true;
 
 	if (active_sub) {
+		__ASSERT_NO_MSG(hid_state_api);
 		(void)hid_state_api->trigger_report_send(boot_mode ?
 							 REPORT_ID_BOOT_KEYBOARD :
 							  REPORT_ID_KEYBOARD_KEYS);
@@ -351,6 +352,7 @@ static bool handle_hid_report_provider_event(const struct hid_report_provider_ev
 				keyboard_report_connection_state_changed);
 		__ASSERT_NO_MSG(!hid_state_api);
 		__ASSERT_NO_MSG(event->hid_state_api);
+		__ASSERT_NO_MSG(event->hid_state_api->trigger_report_send);
 		hid_state_api = event->hid_state_api;
 	} else if (event->report_id == REPORT_ID_BOOT_KEYBOARD) {
 		__ASSERT_NO_MSG(event->provider_api->connection_state_changed ==

--- a/applications/nrf_desktop/src/modules/hid_provider_mouse.c
+++ b/applications/nrf_desktop/src/modules/hid_provider_mouse.c
@@ -277,6 +277,7 @@ static void trigger_report_transmission(void)
 	report_data.update_needed = true;
 
 	if (active_sub) {
+		__ASSERT_NO_MSG(hid_state_api);
 		(void)hid_state_api->trigger_report_send(boot_mode ?
 							 REPORT_ID_BOOT_MOUSE : REPORT_ID_MOUSE);
 	} else {
@@ -383,6 +384,7 @@ static bool handle_hid_report_provider_event(const struct hid_report_provider_ev
 				mouse_report_connection_state_changed);
 		__ASSERT_NO_MSG(!hid_state_api);
 		__ASSERT_NO_MSG(event->hid_state_api);
+		__ASSERT_NO_MSG(event->hid_state_api->trigger_report_send);
 		hid_state_api = event->hid_state_api;
 	} else if (event->report_id == REPORT_ID_BOOT_MOUSE) {
 		__ASSERT_NO_MSG(event->provider_api->connection_state_changed ==

--- a/applications/nrf_desktop/src/modules/hid_provider_system_ctrl.c
+++ b/applications/nrf_desktop/src/modules/hid_provider_system_ctrl.c
@@ -196,6 +196,7 @@ static void trigger_report_transmission(void)
 	report_data.update_needed = true;
 
 	if (active_sub) {
+		__ASSERT_NO_MSG(hid_state_api);
 		(void)hid_state_api->trigger_report_send(REPORT_ID_SYSTEM_CTRL);
 	} else {
 		LOG_DBG("Subscription not enabled");
@@ -287,6 +288,7 @@ static bool handle_hid_report_provider_event(const struct hid_report_provider_ev
 				system_ctrl_report_connection_state_changed);
 		__ASSERT_NO_MSG(!hid_state_api);
 		__ASSERT_NO_MSG(event->hid_state_api);
+		__ASSERT_NO_MSG(event->hid_state_api->trigger_report_send);
 		hid_state_api = event->hid_state_api;
 	}
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -262,6 +262,8 @@ nRF Desktop
       The implementation of serial recovery over USB CDC ACM still uses the deprecated APIs of the USB legacy stack (:kconfig:option:`CONFIG_USB_DEVICE_STACK`).
     * Configurations of the ``nrf52840dongle/nrf52840`` board target to align them after the ``bare`` variant of the board was introduced in Zephyr.
       The application did not switch to the ``bare`` board variant to keep backwards compatibility.
+    * The :ref:`nrf_desktop_hid_state` to allow for delayed registration of HID report providers.
+      Before the change was introduced, subscribing to a HID input report before the respective provider was registered triggered an assertion failure.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
Change updates HID state module to allow for delayed registration of HID report providers. Change also introduces an additional assertion in HID provider implementations to ensure safety.

Jira: NCSDK-35360