### PR TITLE
net: downloader: coap: Request data fragment on retransmission flag

### DIFF
--- a/subsys/net/lib/downloader/src/transports/coap.c
+++ b/subsys/net/lib/downloader/src/transports/coap.c
@@ -72,6 +72,8 @@ struct transport_params_coap {
 
 BUILD_ASSERT(CONFIG_DOWNLOADER_TRANSPORT_PARAMS_SIZE >= sizeof(struct transport_params_coap));
 
+static int coap_request_send(struct downloader *dl);
+
 static int coap_get_current_from_response_pkt(const struct coap_packet *cpkt)
 {
 	int block = 0;
@@ -136,6 +138,7 @@ static int coap_get_recv_timeout(struct downloader *dl, uint32_t *timeout)
 int coap_initiate_retransmission(struct downloader *dl)
 {
 	struct transport_params_coap *coap;
+	int ret;
 
 	coap = (struct transport_params_coap *)dl->transport_internal;
 
@@ -146,6 +149,12 @@ int coap_initiate_retransmission(struct downloader *dl)
 	if (!coap_pending_cycle(&coap->pending)) {
 		LOG_ERR("CoAP max-retransmissions exceeded");
 		return -1;
+	}
+
+	ret = coap_request_send(dl);
+	if (ret) {
+		LOG_DBG("coap_request_send failed, err %d", ret);
+		return -ECONNRESET;
 	}
 
 	return 0;


### PR DESCRIPTION
Retransmission logic in the CoAP downloader was not correctly implemented, causing it to not retransmit requests as expected. 
this is a simple fix which just adds re-transmission flag as a trigger to request next fragment.