### PR TITLE
samples: zephyr: bluetooth: add support for LV10

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -665,11 +665,12 @@
 /samples/wifi/**/*.rst                    @nrfconnect/ncs-wifi-doc
 /samples/wifi/provisioning/softap/*.rst   @nrfconnect/ncs-cia-doc
 /samples/zephyr/basic/blinky/             @nrfconnect/ncs-low-level-test @nrfconnect/ncs-ll-ursus
+/samples/zephyr/bluetooth/                @nrfconnect/ncs-low-level-test
 /samples/zephyr/boards/nordic/spis_wakeup/ @nrfconnect/ncs-low-level-test
 /samples/zephyr/boards/nordic/system_off/ @nrfconnect/ncs-low-level-test
 /samples/zephyr/drivers/adc/              @nrfconnect/ncs-low-level-test
-/samples/zephyr/drivers/counter/          @nrfconnect/ncs-low-level-test
 /samples/zephyr/drivers/audio/dmic/       @nrfconnect/ncs-low-level-test
+/samples/zephyr/drivers/counter/          @nrfconnect/ncs-low-level-test
 /samples/zephyr/drivers/i2c/rtio_loopback/ @nrfconnect/ncs-low-level-test
 /samples/zephyr/drivers/jesd216/          @nrfconnect/ncs-low-level-test
 /samples/zephyr/drivers/mbox/             @nrfconnect/ncs-low-level-test
@@ -681,9 +682,9 @@
 /samples/zephyr/sensor/qdec/              @nrfconnect/ncs-low-level-test
 /samples/zephyr/smp_svr_mini_boot/        @nrfconnect/ncs-pluto @nrfconnect/ncs-charon
 /samples/zephyr/subsys/ipc/               @nrfconnect/ncs-low-level-test
+/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/ @nrfconnect/ncs-charon
 /samples/zephyr/subsys/settings/          @nrfconnect/ncs-low-level-test
 /samples/zephyr/subsys/usb/               @nrfconnect/ncs-low-level-test
-/samples/zephyr/subsys/mgmt/mcumgr/smp_svr/ @nrfconnect/ncs-charon
 /samples/zephyr/sysbuild/                 @nrfconnect/ncs-low-level-test
 
 /samples/**/*.svg                         @nrfconnect/ncs-doc-leads

--- a/samples/zephyr/bluetooth/beacon/CMakeLists.txt
+++ b/samples/zephyr/bluetooth/beacon/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(beacon)
+
+target_sources(app PRIVATE ${ZEPHYR_BASE}/samples/bluetooth/beacon/src/main.c)

--- a/samples/zephyr/bluetooth/beacon/README.txt
+++ b/samples/zephyr/bluetooth/beacon/README.txt
@@ -1,0 +1,4 @@
+This sample extends the same-named Zephyr sample to verify it
+with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/bluetooth/beacon.

--- a/samples/zephyr/bluetooth/beacon/sample.yaml
+++ b/samples/zephyr/bluetooth/beacon/sample.yaml
@@ -1,0 +1,20 @@
+sample:
+  name: Bluetooth Beacon
+tests:
+  nrf.extended.sample.bluetooth.beacon:
+    tags: bluetooth
+    platform_allow:
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
+    integration_platforms:
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+    harness: console
+    timeout: 10
+    harness_config:
+      type: multi_line
+      regex:
+        - "Starting Beacon Demo"
+        - "Bluetooth initialized"
+        - "Beacon started, advertising"
+    extra_args:
+      - CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/beacon/prj.conf"

--- a/samples/zephyr/bluetooth/hci_uart/CMakeLists.txt
+++ b/samples/zephyr/bluetooth/hci_uart/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(hci_uart)
+
+target_sources(app PRIVATE ${ZEPHYR_BASE}/samples/bluetooth/hci_uart/src/main.c)

--- a/samples/zephyr/bluetooth/hci_uart/README.txt
+++ b/samples/zephyr/bluetooth/hci_uart/README.txt
@@ -1,0 +1,4 @@
+This sample extends the same-named Zephyr sample to verify it
+with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/bluetooth/hci_uart.

--- a/samples/zephyr/bluetooth/hci_uart/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/samples/zephyr/bluetooth/hci_uart/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,6 @@
+&uart30 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <1000000>;
+	status = "okay";
+	hw-flow-control;
+};

--- a/samples/zephyr/bluetooth/hci_uart/sample.yaml
+++ b/samples/zephyr/bluetooth/hci_uart/sample.yaml
@@ -1,0 +1,14 @@
+sample:
+  name: Bluetooth HCI UART
+  description: Allows Zephyr to provide Bluetooth connectivity via UART
+tests:
+  nrf.extended.sample.bluetooth.hci_uart:
+    tags: bluetooth
+    platform_allow:
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
+    integration_platforms:
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+    build_only: true
+    extra_args:
+      - CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/hci_uart/prj.conf"

--- a/samples/zephyr/bluetooth/peripheral_hr/CMakeLists.txt
+++ b/samples/zephyr/bluetooth/peripheral_hr/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(peripheral_hr)
+
+target_sources(app PRIVATE ${ZEPHYR_BASE}/samples/bluetooth/peripheral_hr/src/main.c)
+
+zephyr_library_include_directories(${ZEPHYR_BASE}/samples/bluetooth)

--- a/samples/zephyr/bluetooth/peripheral_hr/README.txt
+++ b/samples/zephyr/bluetooth/peripheral_hr/README.txt
@@ -1,0 +1,4 @@
+This sample extends the same-named Zephyr sample to verify it
+with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/bluetooth/peripheral_hr.

--- a/samples/zephyr/bluetooth/peripheral_hr/sample.yaml
+++ b/samples/zephyr/bluetooth/peripheral_hr/sample.yaml
@@ -1,0 +1,21 @@
+sample:
+  name: Bluetooth Peripheral HR
+  description: Demonstrates the HR (Heart Rate) GATT Service
+tests:
+  nrf.extended.sample.bluetooth.peripheral_hr:
+    tags: bluetooth
+    platform_allow:
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
+    integration_platforms:
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+    harness: console
+    timeout: 10
+    harness_config:
+      type: multi_line
+      regex:
+        - "Bluetooth initialized"
+        - "Advertising successfully started"
+        - "Start blinking LED"
+    extra_args:
+      - CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/peripheral_hr/prj.conf"


### PR DESCRIPTION
For beacon, hci_uart and peripheral_hr.