### PR TITLE
modules: tf-m: 54l: remove __ICACHE_PRESENT=1 compile definition

### DIFF
--- a/modules/trusted-firmware-m/tfm_boards/nrf54l10_cpuapp/CMakeLists.txt
+++ b/modules/trusted-firmware-m/tfm_boards/nrf54l10_cpuapp/CMakeLists.txt
@@ -27,13 +27,6 @@ target_include_directories(platform_s
   ${ZEPHYR_BASE}/soc/nordic/common
   )
 
-# nrf54l10_application.h should be defining __ICACHE_PRESENT, but
-# it is not, until this is fixed we define it here.
-target_compile_definitions(platform_s
-  PRIVATE
-  __ICACHE_PRESENT=1
-  )
-
 install(FILES       ${CMAKE_CURRENT_LIST_DIR}/ns/cpuarch_ns.cmake
         DESTINATION ${INSTALL_PLATFORM_NS_DIR}
         RENAME      cpuarch.cmake)

--- a/modules/trusted-firmware-m/tfm_boards/nrf54l15_cpuapp/CMakeLists.txt
+++ b/modules/trusted-firmware-m/tfm_boards/nrf54l15_cpuapp/CMakeLists.txt
@@ -27,13 +27,6 @@ target_include_directories(platform_s
   ${ZEPHYR_BASE}/soc/nordic/common
   )
 
-# nrf54l15_application.h should be defining __ICACHE_PRESENT, but
-# it is not, until this is fixed we define it here.
-target_compile_definitions(platform_s
-  PRIVATE
-  __ICACHE_PRESENT=1
-  )
-
 install(FILES       ${CMAKE_CURRENT_LIST_DIR}/ns/cpuarch_ns.cmake
         DESTINATION ${INSTALL_PLATFORM_NS_DIR}
         RENAME      cpuarch.cmake)

--- a/modules/trusted-firmware-m/tfm_boards/nrf54lv10a_cpuapp/CMakeLists.txt
+++ b/modules/trusted-firmware-m/tfm_boards/nrf54lv10a_cpuapp/CMakeLists.txt
@@ -27,13 +27,6 @@ target_include_directories(platform_s
   ${ZEPHYR_BASE}/soc/nordic/common
   )
 
-# nrf54lv10a_application.h should be defining __ICACHE_PRESENT, but
-# it is not, until this is fixed we define it here.
-target_compile_definitions(platform_s
-  PRIVATE
-  __ICACHE_PRESENT=1
-  )
-
 install(FILES       ${CMAKE_CURRENT_LIST_DIR}/ns/cpuarch_ns.cmake
         DESTINATION ${INSTALL_PLATFORM_NS_DIR}
         RENAME      cpuarch.cmake)


### PR DESCRIPTION
This shouldn't be needed anymore.
It seems that this define isn't really checked anywhere.