### PR TITLE
boards: shields: coverage_support: enable rng for L15

### DIFF
--- a/boards/shields/coverage_support/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/boards/shields/coverage_support/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -14,6 +14,10 @@
 	};
 };
 
+&rng {
+	status = "okay";
+};
+
 &psa_rng {
 	status = "disabled";
 };


### PR DESCRIPTION
Was used with this shield but not enabled.