### PR TITLE
st25r3911b: Fixed wrong spinlock ussage

### DIFF
--- a/lib/st25r3911b/st25r3911b_interrupt.c
+++ b/lib/st25r3911b/st25r3911b_interrupt.c
@@ -8,7 +8,6 @@
 #include <zephyr/device.h>
 #include <soc.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/spinlock.h>
 #include <zephyr/logging/log.h>
 
 #include "st25r3911b_reg.h"
@@ -26,7 +25,7 @@ static const struct gpio_dt_spec irq_gpio =
 
 static struct gpio_callback gpio_cb;
 
-static struct k_spinlock spinlock;
+static K_MUTEX_DEFINE(irq_modify_lock);
 static struct k_sem *sem;
 
 static uint32_t irq_mask;
@@ -114,9 +113,12 @@ int st25r3911b_irq_modify(uint32_t clr_mask, uint32_t set_mask)
 	int err = 0;
 	uint32_t mask;
 	uint32_t old_mask;
-	k_spinlock_key_t key;
 
-	key = k_spin_lock(&spinlock);
+	err = k_mutex_lock(&irq_modify_lock, K_NO_WAIT);
+	if (err) {
+		LOG_DBG("Failed to lock irq_modify mutex (err %d)", err);
+		return err;
+	}
 
 	old_mask = irq_mask;
 	mask = (~old_mask & set_mask) | (old_mask & clr_mask);
@@ -140,7 +142,10 @@ int st25r3911b_irq_modify(uint32_t clr_mask, uint32_t set_mask)
 		}
 	}
 
-	k_spin_unlock(&spinlock, key);
+	err = k_mutex_unlock(&irq_modify_lock);
+	if (err) {
+		LOG_DBG("Failed to unlock irq_modify mutex (err %d)", err);
+	}
 
 	LOG_DBG("Interrupts modified, current state %u", old_mask);
 


### PR DESCRIPTION
Fixed spinlock ussage with the blocking SPI API,
using mutex instead.

JIRA: NCSDK-35618