### PR TITLE
cmake/sysbuild/partition_manager: nRF54L reserve UICR.OTP for users

### DIFF
--- a/cmake/sysbuild/partition_manager.cmake
+++ b/cmake/sysbuild/partition_manager.cmake
@@ -530,7 +530,8 @@ foreach(d APP ${PM_DOMAINS})
 
     if(DEFINED ${image_name}_CONFIG_SOC_SERIES_NRF54LX)
       set(otp_start_addr "0xffd500")
-      set(otp_size 1276)  # 319 * 4
+      # 320 UICR words, minus 32 user-reserved words
+      set(otp_size 1148)  # (319 - 32) * 4
     endif()
   endif()
 


### PR DESCRIPTION
Made sure that 32 4-byte words of UICR.OTP are free for users. Default CONFIG_PM_PARTITION_SIZE_PROVISION==0x460 so this is not an issue for default partitioning.