### PR TITLE
docker: Use absolute path for bash in CMD

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -33,4 +33,4 @@ LABEL org.opencontainers.image.description="This image contains toolchain for sd
 
 ENTRYPOINT ["/bin/bash", "-c"]
 SHELL ["/bin/bash", "-c"]
-CMD ["bin/bash"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
This fixes the following error
```
/bin/bash: line 1: bin/bash: No such file or directory
```
which happens when changing working directory (e.g. in a Dockerfile that uses this image as base and changes `WORKDIR` or by using `-w` flag in `docker run`)