### PR TITLE
doc: install: restore walkthrough links

### DIFF
--- a/doc/nrf/app_dev/create_application.rst
+++ b/doc/nrf/app_dev/create_application.rst
@@ -149,6 +149,9 @@ Using |nRFVSC| is the recommended method.
 Creating application in |nRFVSC|
 ================================
 
+.. note::
+   If you prefer, you can `start VS Code walkthrough`_ and create applications and build configurations from there.
+
 Use the following steps depending on the application placement:
 
 .. tabs::

--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -50,7 +50,7 @@ Depending on your preferred development environment, install the following softw
 
       Additionally, install |VSC|:
 
-      * The latest version of |VSC| for your operating system from the `Visual Studio Code download page`_.
+      * The latest version of |VSC| for your operating system from the `Visual Studio Code download page`_ or `using this direct link <start VS Code walkthrough_>`_.
       * In |VSC|, the latest version of the `nRF Connect for VS Code Extension Pack`_.
         |nRFVSC| comes with its own bundled version of some of the nRF Util commands.
 
@@ -119,6 +119,9 @@ Depending on your preferred development environment, complete the following step
 .. tabs::
 
    .. group-tab:: nRF Connect for VS Code
+
+      .. note::
+         If you prefer, you can now `start VS Code walkthrough`_ and install the toolchain and the SDK from there.
 
       1. Open the nRF Connect extension in |VSC| by clicking its icon in the :guilabel:`Activity Bar`.
          The extension loads and the `Welcome View`_ appears with two buttons: :guilabel:`Install SDK` and :guilabel:`Install Toolchain`.


### PR DESCRIPTION
Restored links to VSCode walkthroughs as they are now handled correctly. TECHDOC-3868.
Links were removed temporarily in #24415 .