### PR TITLE
scripts: sbom: Fix sbom crash for package.name None

### DIFF
--- a/scripts/west_commands/sbom/output_pre_process.py
+++ b/scripts/west_commands/sbom/output_pre_process.py
@@ -94,13 +94,17 @@ def pre_process(data: Data):
     # Give more user friendly information of each package
     package_name_map = dict()
     for package in data.packages.values():
-        if (package.url is None) or (package.version is None):
+        if package.version is None:
+            package.version = 'NoneVersion'
+        if package.url is None:
             continue
         if (package.name is None) and ('github.com' in package.url):
             offs = package.url.find('github.com') + len('github.com') + 1
             package.name = package.url[offs:]
             if package.name.endswith('.git'):
                 package.name = package.name[:-4]
+        if package.name is None:
+            package.name = package.id or package.url or 'NoneName'
         if package.name in package_name_map:
             existing = package_name_map[package.name]
             del package_name_map[package.name]


### PR DESCRIPTION
Fixed the crash that happens when 2+ packages enter the post-process stage with package.url/package.version set but package.name still None. That scenario occurs whenever the git remote URL doesn`t match the “github.com“ , regardless of whether any license was detected.