### PR TITLE
mcuboot: Use secondary_app_partition

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/app_common.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/app_common.dtsi
@@ -77,6 +77,8 @@ slot1_partition: &cpuapp_slot1_partition {
 	label = "image-1";
 };
 
+secondary_app_partition: &cpuapp_slot1_partition {};
+
 /* Remove the undefined property value from the disabled VPR cores to prevent build errors. */
 &cpuflpr_vpr {
 	/delete-property/ source-memory;

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpurad/images/ipc_radio/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpurad/images/ipc_radio/app.overlay
@@ -13,3 +13,5 @@ slot0_partition: &cpurad_slot0_partition {
 slot1_partition: &cpurad_slot1_partition {
 	label = "image-1";
 };
+
+secondary_app_partition: &cpurad_slot1_partition {};

--- a/subsys/mcuboot/mcuboot_secondary_app.overlay
+++ b/subsys/mcuboot/mcuboot_secondary_app.overlay
@@ -6,6 +6,6 @@
 
 / {
 	chosen {
-		zephyr,code-partition = &slot1_partition;
+		zephyr,code-partition = &secondary_app_partition;
 	};
 };

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 047df0c5a1ba5a20a2f72ed8bf81dfdb99fcaaa2
+      revision: 40af3c982b9a743cea2feabe07d3db66337fb68e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Use secondary_app_partition as code partition in Direct XIP without partition manager.
This allows to define slot0/1 partitions independently from the application's code partition.

Ref: NCSDK-35612