### PR TITLE
[Test] Evaluate sdk-zephyr #3313

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 318b87179093864727c181d80c06565138a4d071
+      revision: pull/3313/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This PR updates the manifest to test https://github.com/nrfconnect/sdk-zephyr/pull/3313.
Other changes might be added in the future in order to better test the effects of that change and facilitate its integration in NCS.