### PR TITLE
boards: nordic: nrf54lv10dk: Use pull-up for TX, RTS in sleep state

### DIFF
--- a/boards/nordic/nrf54lv10dk/nrf54lv10dk_nrf54lv10a-pinctrl.dtsi
+++ b/boards/nordic/nrf54lv10dk/nrf54lv10dk_nrf54lv10a-pinctrl.dtsi
@@ -43,8 +43,13 @@
 	/omit-if-no-ref/ uart30_sleep: uart30_sleep {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 0, 0)>,
-				<NRF_PSEL(UART_RX, 0, 1)>,
-				<NRF_PSEL(UART_RTS, 0, 2)>,
+				<NRF_PSEL(UART_RTS, 0, 2)>;
+			low-power-enable;
+			bias-pull-up;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 0, 1)>,
 				<NRF_PSEL(UART_CTS, 0, 3)>;
 			low-power-enable;
 		};


### PR DESCRIPTION
Even in sleep state TX and RTS should have pull as otherwise pins are floating and can give corrupted output on the console.