### PR TITLE
lib: lte_link_control: Improve receive only mode

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_guide_3.2.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_3.2.rst
@@ -95,6 +95,10 @@ This section describes the changes related to libraries.
      * Modem events ``LTE_LC_MODEM_EVT_CE_LEVEL_0``, ``LTE_LC_MODEM_EVT_CE_LEVEL_1``, ``LTE_LC_MODEM_EVT_CE_LEVEL_2`` and ``LTE_LC_MODEM_EVT_CE_LEVEL_3`` have been replaced by event :c:enumerator:`LTE_LC_MODEM_EVT_CE_LEVEL`.
        The CE level can be read from :c:member:`lte_lc_modem_evt.ce_level`.
 
+     * Changed the order of the :c:enumerator:`LTE_LC_MODEM_EVT_SEARCH_DONE` modem event, and registration and cell related events.
+       When the modem has completed the network selection, the registration and cell related events (:c:enumerator:`LTE_LC_EVT_NW_REG_STATUS`, :c:enumerator:`LTE_LC_EVT_CELL_UPDATE`, :c:enumerator:`LTE_LC_EVT_LTE_MODE_UPDATE` and :c:enumerator:`LTE_LC_EVT_PSM_UPDATE`) are sent first, followed by the :c:enumerator:`LTE_LC_MODEM_EVT_SEARCH_DONE` modem event.
+       If the application depends on the order of the events, it may need to be updated.
+
 Trusted Firmware-M
 ==================
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -634,11 +634,15 @@ Modem libraries
     * Support for NTN NB-IoT system mode.
     * eDRX support for NTN NB-IoT.
     * Support for new modem events :c:enumerator:`LTE_LC_MODEM_EVT_RF_CAL_NOT_DONE`, :c:enumerator:`LTE_LC_MODEM_EVT_INVALID_BAND_CONF`, and :c:enumerator:`LTE_LC_MODEM_EVT_DETECTED_COUNTRY`.
+    * Description of new features supported by mfw_nrf91x1 and mfw_nrf9151-ntn in receive only functional mode.
+    * Sending of the ``LTE_LC_EVT_PSM_UPDATE`` event with ``tau`` and ``active_time`` set to ``-1`` when registration status is ``LTE_LC_NW_REG_NOT_REGISTERED``.
 
   * Updated:
 
     * The type of the :c:member:`lte_lc_evt.modem_evt` field to :c:struct:`lte_lc_modem_evt`.
     * Replaced modem events ``LTE_LC_MODEM_EVT_CE_LEVEL_0``, ``LTE_LC_MODEM_EVT_CE_LEVEL_1``, ``LTE_LC_MODEM_EVT_CE_LEVEL_2`` and ``LTE_LC_MODEM_EVT_CE_LEVEL_3`` with the :c:enumerator:`LTE_LC_MODEM_EVT_CE_LEVEL` modem event.
+    * The order of the ``LTE_LC_MODEM_EVT_SEARCH_DONE`` modem event, and registration and cell related events.
+      See the :ref:`migration guide <migration_3.2_required>` for more information.
 
 Multiprotocol Service Layer libraries
 -------------------------------------

--- a/lib/lte_link_control/modules/cereg.c
+++ b/lib/lte_link_control/modules/cereg.c
@@ -314,6 +314,14 @@ static void at_handler_cereg(const char *response)
 
 	if ((reg_status != LTE_LC_NW_REG_REGISTERED_HOME) &&
 	    (reg_status != LTE_LC_NW_REG_REGISTERED_ROAMING)) {
+#if defined(CONFIG_LTE_LC_PSM_MODULE)
+		/* Clear PSM configuration if the device is not registered */
+		if (reg_status == LTE_LC_NW_REG_NOT_REGISTERED) {
+			psm_cfg.tau = -1;
+			psm_cfg.active_time = -1;
+			psm_evt_update_send(&psm_cfg);
+		}
+#endif
 		return;
 	}
 


### PR DESCRIPTION
Improved receive only functional mode description with mfw_nrf91x1 and mfw_nrf9151-ntn modem firmwares.

Changed the order of `LTE_LC_MODEM_EVT_SEARCH_DONE` modem event, and registration and cell related events. This makes it easier for the application to check if a suitable cell was found after the network selection has been completed.

Added sending of `LTE_LC_EVT_PSM_UPDATE` event with TAU interval and Active-Time set to -1 when registration status is
`LTE_LC_NW_REG_NOT_REGISTERED`. This makes sure that `LTE_LC_EVT_PSM_UPDATE` is sent for the next registration as expected.