### PR TITLE
doc: security: components version matrix

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -69,7 +69,8 @@
 .. _`MCUboot Kconfig option documentation`: https://github.com/nrfconnect/sdk-nrf/blob/main/modules/mcuboot/boot/zephyr/Kconfig#L27C11-L27C12
 
 .. _`sdk-mbedtls`: https://github.com/nrfconnect/sdk-mbedtls
-.. _`Arm Mbed TLS project`: https://github.com/ARMmbed/mbedtls
+.. _`official Mbed TLS releases`: https://github.com/Mbed-TLS/mbedtls/releases
+.. _`Arm Mbed TLS project`: https://github.com/Mbed-TLS/mbedtls
 
 .. _`nrfconnect GitHub organization`: https://github.com/nrfconnect
 .. _`sdk-nrf`: https://github.com/nrfconnect/sdk-nrf
@@ -1890,6 +1891,8 @@
 .. _`IEEE 802.15.4-2015 standard`: https://standards.ieee.org/ieee/802.15.4/5788/
 
 .. _`NX3215SA-32.768K-STD-MUA-9 datasheet`: https://www.ndk.com/en/products/upload/lineup/pdf/NDKX01-00001_en.pdf
+
+.. _`official TF-M releases`: https://trustedfirmware-m.readthedocs.io/en/latest/releases/index.html
 
 .. ### Temp: nRF54H and nRF54L related links, repositories, and documents
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -137,6 +137,8 @@ Security
 
   * Support for AES in counter mode using CRACEN for the :zephyr:board:`nrf54lm20dk`.
 
+* Updated the :ref:`security_index` page with a table that lists the versions of security components implemented in the |NCS|.
+
 Protocols
 =========
 
@@ -800,6 +802,7 @@ Trusted Firmware-M
   * Documentation to clarify the support for TF-M on devices emulated using the nRF54L15 DK.
     nRF54L05 does not support TF-M.
     nRF54L10 supports TF-M experimentally.
+
 
 Documentation
 =============

--- a/doc/nrf/security.rst
+++ b/doc/nrf/security.rst
@@ -7,6 +7,79 @@ Security
 This section provides an overview of core security features available in Nordic Semiconductor products.
 The features are made available either as built-ins in modules, drivers, and subsystems, or are shown in samples or applications in |NCS|.
 
+.. security_components_ver_table_start
+
+The |NCS| |release| allows you to develop applications with the following versions of security components:
+
+.. list-table:: |NCS|, TF-M, and Mbed TLS versions
+     :header-rows: 1
+     :widths: auto
+
+     * - |NCS| release
+       - TF-M version
+       - Mbed TLS version
+     * - |release|
+       - v2.1.2
+       - 3.6.4
+
+.. security_components_ver_table_end
+
+Expand the following section to see the table listing versions of different security components implemented since the |NCS| v2.1.0.
+
+.. toggle::
+
+   .. note::
+
+      Not all `official TF-M releases`_ are implemented by the |NCS|.
+      This is because the |NCS| implements TF-M through Zephyr.
+      Zephyr adds specific patches to the TF-M version, which are then upmerged into the |NCS| with changes specific to the |NCS|.
+
+      Similarly, not all `official Mbed TLS releases`_ are implemented by the |NCS| through the `sdk-mbedtls`_ repository.
+
+   .. list-table:: |NCS|, TF-M, and Mbed TLS versions
+     :header-rows: 1
+     :widths: auto
+
+     * - |NCS| release
+       - TF-M version
+       - Mbed TLS version
+     * - Upcoming release (currently on the ``main`` branch of `sdk-nrf`_)
+       - v2.2.0
+       - 3.6.4
+     * - v3.1.0, v3.1.1
+       - v2.1.2
+       - 3.6.4
+     * - v3.0.0 (up to v3.0.2)
+       - v2.1.1
+       - 3.6.3
+     * - v2.9.0 (up to v2.9.2)
+       - v2.1.1
+       - 3.6.2
+     * - v2.8.0
+       - v2.1.1
+       - 3.6.2
+     * - v2.7.0
+       - v2.0.0
+       - 3.5.2
+     * - v2.6.0 (up to v2.6.4)
+       - v2.0.0
+       - 3.5.2
+     * - v2.5.0 (up to v2.5.3)
+       - v1.8.0
+       - 3.3.0
+     * - v2.4.0 (up to v2.4.4)
+       - v1.7.0
+       - 3.3.0
+     * - v2.3.0
+       - v1.6.0
+       - 3.1.0
+     * - v2.2.0
+       - v1.6.0
+       - 3.1.0
+     * - v2.1.0 (up to v2.1.4)
+       - v1.6.0
+       - 3.1.0
+
 The following table lists the available general security features.
 Some of them are documented in detail in other parts of this documentation, while others are documented in the subpages in this section.
 

--- a/doc/nrf/security/tfm/tfm_supported_services.rst
+++ b/doc/nrf/security/tfm/tfm_supported_services.rst
@@ -9,6 +9,15 @@ TF-M support and limitations in the |NCS|
 
 This page lists the supported features and limitations of Trusted Firmware-M (TF-M) in the |NCS|.
 
+TF-M version in the |NCS|
+*************************
+
+.. include:: ../../security.rst
+   :start-after: security_components_ver_table_start
+   :end-before: security_components_ver_table_end
+
+For versions used in older releases of the |NCS|, check the expandable section on the :ref:`security` page.
+
 .. _ug_tfm_supported_services_profiles:
 
 Supported TF-M profiles


### PR DESCRIPTION
Added a table mapping security component versions to the nRF Connect SDK
releases. NCSDK-35652.