### PR TITLE
lib: lte_link_control: Rework modem events

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_guide_3.2.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_3.2.rst
@@ -84,7 +84,16 @@ Libraries
 
 This section describes the changes related to libraries.
 
-|no_changes_yet_note|
+.. toggle::
+
+   * :ref:`lte_lc_readme` library:
+
+     * The type of the :c:member:`lte_lc_evt.modem_evt` field has been changed to :c:struct:`lte_lc_modem_evt`.
+       The modem event type can be determined from the :c:member:`lte_lc_modem_evt.type` field.
+       Applications using modem events need to be updated to read the event type from ``modem_evt.type`` instead of ``modem_evt``.
+
+     * Modem events ``LTE_LC_MODEM_EVT_CE_LEVEL_0``, ``LTE_LC_MODEM_EVT_CE_LEVEL_1``, ``LTE_LC_MODEM_EVT_CE_LEVEL_2`` and ``LTE_LC_MODEM_EVT_CE_LEVEL_3`` have been replaced by event :c:enumerator:`LTE_LC_MODEM_EVT_CE_LEVEL`.
+       The CE level can be read from :c:member:`lte_lc_modem_evt.ce_level`.
 
 Trusted Firmware-M
 ==================

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -631,6 +631,12 @@ Modem libraries
     * Support for environment evaluation.
     * Support for NTN NB-IoT system mode.
     * eDRX support for NTN NB-IoT.
+    * Support for new modem events :c:enumerator:`LTE_LC_MODEM_EVT_RF_CAL_NOT_DONE`, :c:enumerator:`LTE_LC_MODEM_EVT_INVALID_BAND_CONF`, and :c:enumerator:`LTE_LC_MODEM_EVT_DETECTED_COUNTRY`.
+
+  * Updated:
+
+    * The type of the :c:member:`lte_lc_evt.modem_evt` field to :c:struct:`lte_lc_modem_evt`.
+    * Replaced modem events ``LTE_LC_MODEM_EVT_CE_LEVEL_0``, ``LTE_LC_MODEM_EVT_CE_LEVEL_1``, ``LTE_LC_MODEM_EVT_CE_LEVEL_2`` and ``LTE_LC_MODEM_EVT_CE_LEVEL_3`` with the :c:enumerator:`LTE_LC_MODEM_EVT_CE_LEVEL` modem event.
 
 Multiprotocol Service Layer libraries
 -------------------------------------

--- a/lib/lte_link_control/modules/mdmev.c
+++ b/lib/lte_link_control/modules/mdmev.c
@@ -19,76 +19,125 @@
 
 LOG_MODULE_DECLARE(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 
-/* MDMEV command parameters */
-#define AT_MDMEV_ENABLE_1	 "AT%%MDMEV=1"
-#define AT_MDMEV_ENABLE_2	 "AT%%MDMEV=2"
-#define AT_MDMEV_DISABLE	 "AT%%MDMEV=0"
-#define AT_MDMEV_RESPONSE_PREFIX "%MDMEV: "
-#define AT_MDMEV_OVERHEATED	 "ME OVERHEATED\r\n"
-#define AT_MDMEV_BATTERY_LOW	 "ME BATTERY LOW\r\n"
-#define AT_MDMEV_SEARCH_STATUS_1 "SEARCH STATUS 1\r\n"
-#define AT_MDMEV_SEARCH_STATUS_2 "SEARCH STATUS 2\r\n"
-#define AT_MDMEV_RESET_LOOP	 "RESET LOOP\r\n"
-#define AT_MDMEV_NO_IMEI	 "NO IMEI\r\n"
-#define AT_MDMEV_CE_LEVEL_0	 "PRACH CE-LEVEL 0\r\n"
-#define AT_MDMEV_CE_LEVEL_1	 "PRACH CE-LEVEL 1\r\n"
-#define AT_MDMEV_CE_LEVEL_2	 "PRACH CE-LEVEL 2\r\n"
-#define AT_MDMEV_CE_LEVEL_3	 "PRACH CE-LEVEL 3\r\n"
+/* %MDMEV commands */
+#define AT_MDMEV_ENABLE_1	"AT%%MDMEV=1"
+#define AT_MDMEV_ENABLE_2	"AT%%MDMEV=2"
+#define AT_MDMEV_DISABLE	"AT%%MDMEV=0"
+#define AT_MDMEV_NOTIF_PREFIX	"%MDMEV: "
+
+/* Fixed events */
+#define AT_MDMEV_OVERHEATED		"ME OVERHEATED\r\n"
+#define AT_MDMEV_BATTERY_LOW		"ME BATTERY LOW\r\n"
+#define AT_MDMEV_SEARCH_STATUS_1	"SEARCH STATUS 1\r\n"
+#define AT_MDMEV_SEARCH_STATUS_2	"SEARCH STATUS 2\r\n"
+#define AT_MDMEV_RESET_LOOP		"RESET LOOP\r\n"
+#define AT_MDMEV_NO_IMEI		"NO IMEI\r\n"
+#define AT_MDMEV_RF_CAL_NOT_DONE	"RF CALIBRATION NOT DONE\r\n"
+
+/* Events with values */
+#define AT_MDMEV_CE_LEVEL		"PRACH CE-LEVEL %u\r\n"
+#define AT_MDMEV_INVALID_BAND_CONF	"INVALID BAND CONFIGURATION %u %u %u\r\n"
+#define AT_MDMEV_DETECTED_COUNTRY	"DETECTED COUNTRY %u\r\n"
 
 AT_MONITOR(ltelc_atmon_mdmev, "%MDMEV", at_handler_mdmev);
 
 bool mdmev_enabled;
 
-static int mdmev_parse(const char *at_response, enum lte_lc_modem_evt *modem_evt)
+static int mdmev_fixed_parse(const char *notif, struct lte_lc_modem_evt *modem_evt)
 {
-	static const char *const event_types[] = {
-		[LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE] = AT_MDMEV_SEARCH_STATUS_1,
-		[LTE_LC_MODEM_EVT_SEARCH_DONE] = AT_MDMEV_SEARCH_STATUS_2,
-		[LTE_LC_MODEM_EVT_RESET_LOOP] = AT_MDMEV_RESET_LOOP,
-		[LTE_LC_MODEM_EVT_BATTERY_LOW] = AT_MDMEV_BATTERY_LOW,
-		[LTE_LC_MODEM_EVT_OVERHEATED] = AT_MDMEV_OVERHEATED,
-		[LTE_LC_MODEM_EVT_NO_IMEI] = AT_MDMEV_NO_IMEI,
-		[LTE_LC_MODEM_EVT_CE_LEVEL_0] = AT_MDMEV_CE_LEVEL_0,
-		[LTE_LC_MODEM_EVT_CE_LEVEL_1] = AT_MDMEV_CE_LEVEL_1,
-		[LTE_LC_MODEM_EVT_CE_LEVEL_2] = AT_MDMEV_CE_LEVEL_2,
-		[LTE_LC_MODEM_EVT_CE_LEVEL_3] = AT_MDMEV_CE_LEVEL_3,
+	struct event_type_map {
+		enum lte_lc_modem_evt_type type;
+		const char *notif;
+	};
+	static const struct event_type_map event_types[] = {
+		{ LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE, AT_MDMEV_SEARCH_STATUS_1 },
+		{ LTE_LC_MODEM_EVT_SEARCH_DONE, AT_MDMEV_SEARCH_STATUS_2 },
+		{ LTE_LC_MODEM_EVT_RESET_LOOP, AT_MDMEV_RESET_LOOP },
+		{ LTE_LC_MODEM_EVT_BATTERY_LOW, AT_MDMEV_BATTERY_LOW },
+		{ LTE_LC_MODEM_EVT_OVERHEATED, AT_MDMEV_OVERHEATED },
+		{ LTE_LC_MODEM_EVT_NO_IMEI, AT_MDMEV_NO_IMEI },
+		{ LTE_LC_MODEM_EVT_RF_CAL_NOT_DONE, AT_MDMEV_RF_CAL_NOT_DONE },
+		{ 0, NULL }
 	};
 
-	__ASSERT_NO_MSG(at_response != NULL);
+	__ASSERT_NO_MSG(notif != NULL);
 	__ASSERT_NO_MSG(modem_evt != NULL);
 
-	const char *start_ptr = at_response + sizeof(AT_MDMEV_RESPONSE_PREFIX) - 1;
-
 	for (size_t i = 0; i < ARRAY_SIZE(event_types); i++) {
-		if (strcmp(event_types[i], start_ptr) == 0) {
-			LOG_DBG("Occurrence found: %s", event_types[i]);
-			*modem_evt = i;
+		if (event_types[i].notif == NULL) {
+			break;
+		}
+
+		if (strcmp(event_types[i].notif, notif) == 0) {
+			modem_evt->type = event_types[i].type;
 
 			return 0;
 		}
 	}
 
-	LOG_DBG("No modem event type found: %s", at_response);
+	return -ENODATA;
+}
+
+static int mdmev_value_parse(const char *notif, struct lte_lc_modem_evt *modem_evt)
+{
+	uint32_t value1;
+	uint32_t value2;
+	uint32_t value3;
+
+	__ASSERT_NO_MSG(notif != NULL);
+	__ASSERT_NO_MSG(modem_evt != NULL);
+
+	if (sscanf(notif, AT_MDMEV_CE_LEVEL, &value1) == 1) {
+		modem_evt->type = LTE_LC_MODEM_EVT_CE_LEVEL;
+		modem_evt->ce_level = value1;
+		return 0;
+	}
+
+	/* Default value for NTN NB-IoT when it's not supported by the modem firmware. */
+	value3 = LTE_LC_BAND_CONF_STATUS_SYSTEM_NOT_SUPPORTED;
+
+	/* At least 2 values are expected (LTE-M and NB-IoT). */
+	if (sscanf(notif, AT_MDMEV_INVALID_BAND_CONF, &value1, &value2, &value3) >= 2) {
+		modem_evt->type = LTE_LC_MODEM_EVT_INVALID_BAND_CONF;
+		modem_evt->invalid_band_conf.status_ltem = value1;
+		modem_evt->invalid_band_conf.status_nbiot = value2;
+		modem_evt->invalid_band_conf.status_ntn_nbiot = value3;
+		return 0;
+	}
+
+	if (sscanf(notif, AT_MDMEV_DETECTED_COUNTRY, &value1) == 1) {
+		modem_evt->type = LTE_LC_MODEM_EVT_DETECTED_COUNTRY;
+		modem_evt->detected_country = value1;
+		return 0;
+	}
 
 	return -ENODATA;
 }
 
-static void at_handler_mdmev(const char *response)
+static void at_handler_mdmev(const char *notif)
 {
 	int err;
-	struct lte_lc_evt evt = {0};
+	struct lte_lc_evt evt = {
+		.type = LTE_LC_EVT_MODEM_EVENT
+	};
 
-	__ASSERT_NO_MSG(response != NULL);
+	__ASSERT_NO_MSG(notif != NULL);
 
-	LOG_DBG("%%MDMEV notification");
+	/* Remove the notification prefix. */
+	const char *start_ptr = notif + sizeof(AT_MDMEV_NOTIF_PREFIX) - 1;
 
-	err = mdmev_parse(response, &evt.modem_evt);
+	LOG_DBG("%%MDMEV notification: %.*s", (int)(strlen(start_ptr) - strlen("\r\n")), start_ptr);
+
+	/* Try to parse fixed events. */
+	err = mdmev_fixed_parse(start_ptr, &evt.modem_evt);
 	if (err) {
-		LOG_ERR("Can't parse modem event notification, error: %d", err);
-		return;
+		/* Try to parse events with values. */
+		err = mdmev_value_parse(start_ptr, &evt.modem_evt);
+		if (err) {
+			LOG_DBG("No modem event type found: %s", notif);
+			return;
+		}
 	}
-
-	evt.type = LTE_LC_EVT_MODEM_EVENT;
 
 	event_handler_list_dispatch(&evt);
 }

--- a/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
+++ b/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
@@ -334,7 +334,8 @@ static void pdn_event_handler(uint8_t cid, enum pdn_event event, int reason)
 
 static void lte_reg_handler(const struct lte_lc_evt *const evt)
 {
-	if (evt->type == LTE_LC_EVT_MODEM_EVENT && evt->modem_evt == LTE_LC_MODEM_EVT_RESET_LOOP) {
+	if (evt->type == LTE_LC_EVT_MODEM_EVENT &&
+	    evt->modem_evt.type == LTE_LC_MODEM_EVT_RESET_LOOP) {
 		LOG_WRN("The modem has detected a reset loop. LTE network attach is now "
 			"restricted for the next 30 minutes.");
 

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -193,7 +193,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 
 		break;
 	case LTE_LC_EVT_MODEM_EVENT:
-		if (evt->modem_evt == LTE_LC_MODEM_EVT_RESET_LOOP) {
+		if (evt->modem_evt.type == LTE_LC_MODEM_EVT_RESET_LOOP) {
 			MEMFAULT_METRIC_ADD(ncs_lte_reset_loop_detected_count, 1);
 		}
 		break;

--- a/samples/cellular/modem_shell/src/link/link_shell_print.c
+++ b/samples/cellular/modem_shell/src/link/link_shell_print.c
@@ -83,9 +83,9 @@ void link_shell_print_modem_sleep_notif(const struct lte_lc_evt *const evt)
 	}
 }
 
-void link_shell_print_modem_domain_event(enum lte_lc_modem_evt modem_evt)
+void link_shell_print_modem_domain_event(struct lte_lc_modem_evt modem_evt)
 {
-	switch (modem_evt) {
+	switch (modem_evt.type) {
 	case LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE:
 		mosh_print("Modem domain event: Light search done");
 		break;
@@ -104,17 +104,20 @@ void link_shell_print_modem_domain_event(enum lte_lc_modem_evt modem_evt)
 	case LTE_LC_MODEM_EVT_NO_IMEI:
 		mosh_print("Modem domain event: No IMEI");
 		break;
-	case LTE_LC_MODEM_EVT_CE_LEVEL_0:
-		mosh_print("Modem domain event: CE-level 0");
+	case LTE_LC_MODEM_EVT_CE_LEVEL:
+		mosh_print("Modem domain event: CE-level %d", modem_evt.ce_level);
 		break;
-	case LTE_LC_MODEM_EVT_CE_LEVEL_1:
-		mosh_print("Modem domain event: CE-level 1");
+	case LTE_LC_MODEM_EVT_RF_CAL_NOT_DONE:
+		mosh_print("Modem domain event: RF calibration not done");
 		break;
-	case LTE_LC_MODEM_EVT_CE_LEVEL_2:
-		mosh_print("Modem domain event: CE-level 2");
+	case LTE_LC_MODEM_EVT_INVALID_BAND_CONF:
+		mosh_print("Modem domain event: Invalid band configuration %d %d %d",
+			   modem_evt.invalid_band_conf.status_ltem,
+			   modem_evt.invalid_band_conf.status_nbiot,
+			   modem_evt.invalid_band_conf.status_ntn_nbiot);
 		break;
-	case LTE_LC_MODEM_EVT_CE_LEVEL_3:
-		mosh_print("Modem domain event: CE-level 3");
+	case LTE_LC_MODEM_EVT_DETECTED_COUNTRY:
+		mosh_print("Modem domain event: Detected country %u", modem_evt.detected_country);
 		break;
 	}
 }

--- a/samples/cellular/modem_shell/src/link/link_shell_print.h
+++ b/samples/cellular/modem_shell/src/link/link_shell_print.h
@@ -17,7 +17,7 @@ struct mapping_tbl_item {
 
 void link_shell_print_reg_status(enum lte_lc_nw_reg_status reg_status);
 void link_shell_print_modem_sleep_notif(const struct lte_lc_evt *const evt);
-void link_shell_print_modem_domain_event(enum lte_lc_modem_evt modem_evt);
+void link_shell_print_modem_domain_event(struct lte_lc_modem_evt modem_evt);
 const char *link_shell_funmode_to_string(int funmode, char *out_str_buff);
 const char *link_shell_sysmode_to_string(int sysmode, char *out_str_buff);
 const char *link_shell_sysmode_preferred_to_string(int sysmode_preference, char *out_str_buff);

--- a/samples/cellular/nidd/src/main.c
+++ b/samples/cellular/nidd/src/main.c
@@ -38,7 +38,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 		       evt->cell.id, evt->cell.tac);
 		break;
 	case LTE_LC_EVT_MODEM_EVENT:
-		printk("Modem event: %d\n", evt->modem_evt);
+		printk("Modem event: %d\n", evt->modem_evt.type);
 		break;
 	default:
 		break;

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -220,7 +220,33 @@ static void lte_lc_event_handler(const struct lte_lc_evt *const evt)
 		break;
 
 	case LTE_LC_EVT_MODEM_EVENT:
-		TEST_ASSERT_EQUAL(test_event_data[index].modem_evt, evt->modem_evt);
+		TEST_ASSERT_EQUAL(test_event_data[index].modem_evt.type, evt->modem_evt.type);
+		switch (evt->modem_evt.type) {
+		case LTE_LC_MODEM_EVT_CE_LEVEL:
+			TEST_ASSERT_EQUAL(
+				test_event_data[index].modem_evt.ce_level,
+				evt->modem_evt.ce_level);
+			break;
+		case LTE_LC_MODEM_EVT_INVALID_BAND_CONF:
+			TEST_ASSERT_EQUAL(
+				test_event_data[index].modem_evt.invalid_band_conf.status_ltem,
+				evt->modem_evt.invalid_band_conf.status_ltem);
+			TEST_ASSERT_EQUAL(
+				test_event_data[index].modem_evt.invalid_band_conf.status_nbiot,
+				evt->modem_evt.invalid_band_conf.status_nbiot);
+			TEST_ASSERT_EQUAL(
+				test_event_data[index].modem_evt.invalid_band_conf.status_ntn_nbiot,
+				evt->modem_evt.invalid_band_conf.status_ntn_nbiot);
+			break;
+		case LTE_LC_MODEM_EVT_DETECTED_COUNTRY:
+			TEST_ASSERT_EQUAL(
+				test_event_data[index].modem_evt.detected_country,
+				evt->modem_evt.detected_country);
+			break;
+		default:
+			/* No payload for this event type */
+			break;
+		}
 		break;
 
 	case LTE_LC_EVT_RAI_UPDATE:
@@ -4361,7 +4387,7 @@ void test_lte_lc_modem_events(void)
 	int ret;
 	int index = 0;
 
-	lte_lc_callback_count_expected = 10;
+	lte_lc_callback_count_expected = 11;
 
 	__mock_nrf_modem_at_printf_ExpectAndReturn("AT%MDMEV=2", EXIT_SUCCESS);
 	ret = lte_lc_modem_events_enable();
@@ -4374,61 +4400,81 @@ void test_lte_lc_modem_events(void)
 
 	strcpy(at_notif, "%MDMEV: ME OVERHEATED\r\n");
 	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
-	test_event_data[index].modem_evt = LTE_LC_MODEM_EVT_OVERHEATED;
+	test_event_data[index].modem_evt.type = LTE_LC_MODEM_EVT_OVERHEATED;
 	at_monitor_dispatch(at_notif);
 	index++;
 
 	strcpy(at_notif, "%MDMEV: NO IMEI\r\n");
 	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
-	test_event_data[index].modem_evt = LTE_LC_MODEM_EVT_NO_IMEI;
+	test_event_data[index].modem_evt.type = LTE_LC_MODEM_EVT_NO_IMEI;
 	at_monitor_dispatch(at_notif);
 	index++;
 
 	strcpy(at_notif, "%MDMEV: ME BATTERY LOW\r\n");
 	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
-	test_event_data[index].modem_evt = LTE_LC_MODEM_EVT_BATTERY_LOW;
+	test_event_data[index].modem_evt.type = LTE_LC_MODEM_EVT_BATTERY_LOW;
 	at_monitor_dispatch(at_notif);
 	index++;
 
 	strcpy(at_notif, "%MDMEV: RESET LOOP\r\n");
 	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
-	test_event_data[index].modem_evt = LTE_LC_MODEM_EVT_RESET_LOOP;
+	test_event_data[index].modem_evt.type = LTE_LC_MODEM_EVT_RESET_LOOP;
 	at_monitor_dispatch(at_notif);
 	index++;
 
 	strcpy(at_notif, "%MDMEV: SEARCH STATUS 1\r\n");
 	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
-	test_event_data[index].modem_evt = LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE;
+	test_event_data[index].modem_evt.type = LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE;
 	at_monitor_dispatch(at_notif);
 	index++;
 
 	strcpy(at_notif, "%MDMEV: SEARCH STATUS 2\r\n");
 	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
-	test_event_data[index].modem_evt = LTE_LC_MODEM_EVT_SEARCH_DONE;
-	at_monitor_dispatch(at_notif);
-	index++;
-
-	strcpy(at_notif, "%MDMEV: PRACH CE-LEVEL 0\r\n");
-	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
-	test_event_data[index].modem_evt = LTE_LC_MODEM_EVT_CE_LEVEL_0;
-	at_monitor_dispatch(at_notif);
-	index++;
-
-	strcpy(at_notif, "%MDMEV: PRACH CE-LEVEL 1\r\n");
-	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
-	test_event_data[index].modem_evt = LTE_LC_MODEM_EVT_CE_LEVEL_1;
+	test_event_data[index].modem_evt.type = LTE_LC_MODEM_EVT_SEARCH_DONE;
 	at_monitor_dispatch(at_notif);
 	index++;
 
 	strcpy(at_notif, "%MDMEV: PRACH CE-LEVEL 2\r\n");
 	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
-	test_event_data[index].modem_evt = LTE_LC_MODEM_EVT_CE_LEVEL_2;
+	test_event_data[index].modem_evt.type = LTE_LC_MODEM_EVT_CE_LEVEL;
+	test_event_data[index].modem_evt.ce_level = LTE_LC_CE_LEVEL_2;
 	at_monitor_dispatch(at_notif);
 	index++;
 
-	strcpy(at_notif, "%MDMEV: PRACH CE-LEVEL 3\r\n");
+	strcpy(at_notif, "%MDMEV: RF CALIBRATION NOT DONE\r\n");
 	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
-	test_event_data[index].modem_evt = LTE_LC_MODEM_EVT_CE_LEVEL_3;
+	test_event_data[index].modem_evt.type = LTE_LC_MODEM_EVT_RF_CAL_NOT_DONE;
+	at_monitor_dispatch(at_notif);
+	index++;
+
+	strcpy(at_notif, "%MDMEV: INVALID BAND CONFIGURATION 1 2\r\n");
+	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
+	test_event_data[index].modem_evt.type = LTE_LC_MODEM_EVT_INVALID_BAND_CONF;
+	test_event_data[index].modem_evt.invalid_band_conf.status_ltem =
+		LTE_LC_BAND_CONF_STATUS_INVALID;
+	test_event_data[index].modem_evt.invalid_band_conf.status_nbiot =
+		LTE_LC_BAND_CONF_STATUS_SYSTEM_NOT_SUPPORTED;
+	test_event_data[index].modem_evt.invalid_band_conf.status_ntn_nbiot =
+		LTE_LC_BAND_CONF_STATUS_SYSTEM_NOT_SUPPORTED;
+	at_monitor_dispatch(at_notif);
+	index++;
+
+	strcpy(at_notif, "%MDMEV: INVALID BAND CONFIGURATION 0 1 0\r\n");
+	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
+	test_event_data[index].modem_evt.type = LTE_LC_MODEM_EVT_INVALID_BAND_CONF;
+	test_event_data[index].modem_evt.invalid_band_conf.status_ltem =
+		LTE_LC_BAND_CONF_STATUS_OK;
+	test_event_data[index].modem_evt.invalid_band_conf.status_nbiot =
+		LTE_LC_BAND_CONF_STATUS_INVALID;
+	test_event_data[index].modem_evt.invalid_band_conf.status_ntn_nbiot =
+		LTE_LC_BAND_CONF_STATUS_OK;
+	at_monitor_dispatch(at_notif);
+	index++;
+
+	strcpy(at_notif, "%MDMEV: DETECTED COUNTRY 123\r\n");
+	test_event_data[index].type = LTE_LC_EVT_MODEM_EVENT;
+	test_event_data[index].modem_evt.type = LTE_LC_MODEM_EVT_DETECTED_COUNTRY;
+	test_event_data[index].modem_evt.detected_country = 123;
 	at_monitor_dispatch(at_notif);
 	index++;
 
@@ -4455,13 +4501,7 @@ void test_lte_lc_modem_events_fail(void)
 	strcpy(at_notif, "%MDMEV: SEARCH STATUS 3\r\n");
 	at_monitor_dispatch(at_notif);
 
-	strcpy(at_notif, "%MDMEV: PRACH CE-LEVEL 4\r\n");
-	at_monitor_dispatch(at_notif);
-
 	strcpy(at_notif, "%MDMEV: SEARCH STATUS 1 and then some\r\n");
-	at_monitor_dispatch(at_notif);
-
-	strcpy(at_notif, "%MDMEV: PRACH CE-LEVEL 0 and then some\r\n");
 	at_monitor_dispatch(at_notif);
 }
 


### PR DESCRIPTION
Because of new modem events which have values, there was need to rework how modem events are delivered in `struct lte_lc_evt`.

The `enum lte_lc_modem_evt` has been replaced by a `struct lte_lc_modem_evt` which contains the modem event type and possible associated payload. This requires a minor code change to all applications using modem events.

Modem events `LTE_LC_MODEM_EVT_CE_LEVEL_0`, `LTE_LC_MODEM_EVT_CE_LEVEL_1`, `LTE_LC_MODEM_EVT_CE_LEVEL_2` and `LTE_LC_MODEM_EVT_CE_LEVEL_3` have been replaced by event `LTE_LC_MODEM_EVT_CE_LEVEL`, which has associated payload for the value.

Added support for new modem events:

```
LTE_LC_MODEM_EVT_RF_CAL_NOT_DONE
LTE_LC_MODEM_EVT_INVALID_BAND_CONF
LTE_LC_MODEM_EVT_DETECTED_COUNTRY
```

TODO:

- [x] update changelog
- [x] add instructions to migration guide