### PR TITLE
samples: Prevent UART PM suspend/resume in interrupt context

### DIFF
--- a/samples/bluetooth/direct_test_mode/src/main.c
+++ b/samples/bluetooth/direct_test_mode/src/main.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/pm/device_runtime.h>
 
 #include "transport/dtm_transport.h"
 
@@ -15,6 +16,18 @@ int main(void)
 	union dtm_tr_packet cmd;
 
 	printk("Starting Direct Test Mode sample\n");
+
+#if defined(CONFIG_SOC_SERIES_NRF54HX)
+	const struct device *dtm_uart = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(ncs_dtm_uart));
+
+	if (dtm_uart != NULL) {
+		int ret = pm_device_runtime_get(dtm_uart);
+
+		if (ret < 0) {
+			printk("Failed to get DTM UART runtime PM: %d\n", ret);
+		}
+	}
+#endif /* defined(CONFIG_SOC_SERIES_NRF54HX) */
 
 	err = dtm_tr_init();
 	if (err) {

--- a/samples/peripheral/radio_test/src/main.c
+++ b/samples/peripheral/radio_test/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
+#include <zephyr/pm/device_runtime.h>
 #if defined(NRF54L15_XXAA)
 #include <hal/nrf_clock.h>
 #endif /* defined(NRF54L15_XXAA) */
@@ -164,6 +165,27 @@ BUILD_ASSERT(false, "No Clock Control driver");
 int main(void)
 {
 	printk("Starting Radio Test sample\n");
+
+#if defined(CONFIG_SOC_SERIES_NRF54HX)
+	const struct device *console_uart = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_console));
+	const struct device *shell_uart = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_shell_uart));
+
+	if (console_uart != NULL) {
+		int ret = pm_device_runtime_get(console_uart);
+
+		if (ret < 0) {
+			printk("Failed to get console UART runtime PM: %d\n", ret);
+		}
+	}
+
+	if (shell_uart != NULL && shell_uart != console_uart) {
+		int ret = pm_device_runtime_get(shell_uart);
+
+		if (ret < 0) {
+			printk("Failed to get shell UART runtime PM: %d\n", ret);
+		}
+	}
+#endif /* defined(CONFIG_SOC_SERIES_NRF54HX) */
 
 	clock_init();
 


### PR DESCRIPTION
Use pm_device_runtime_get() to keep the UART powered
on the nRF54H20 in the Radio Test and DTM samples.
