### PR TITLE
mpsl: Remove call to unecessary call to mpsl_pan_rfu

### DIFF
--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -432,10 +432,6 @@ static int32_t mpsl_lib_init_internal(void)
 	mpsl_clock_hfclk_latency_set(CONFIG_MPSL_HFCLK_LATENCY);
 #endif /* CONFIG_CLOCK_CONTROL_NRF && DT_NODE_EXISTS(DT_NODELABEL(hfxo)) */
 #endif /* !CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL */
-	if (IS_ENABLED(CONFIG_SOC_NRF_FORCE_CONSTLAT) &&
-		!IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF54LX)) {
-		mpsl_pan_rfu();
-	}
 
 #if MPSL_TIMESLOT_SESSION_COUNT > 0
 	err = mpsl_timeslot_session_count_set((void *) timeslot_context,


### PR DESCRIPTION
This API call is no longer needed. It has been a no-op for a long period of time.