### PR TITLE
mcuboot: Use dedicated type for slot numbers

### DIFF
--- a/modules/mcuboot/hooks/hooks_find_next_slot.c
+++ b/modules/mcuboot/hooks/hooks_find_next_slot.c
@@ -12,17 +12,18 @@
 /**
  * Finds the preferred slot containing the image based on bootloader requests.
  */
-int boot_find_next_slot_hook(struct boot_loader_state *state, uint8_t image, uint32_t *active_slot)
+int boot_find_next_slot_hook(struct boot_loader_state *state, uint8_t image,
+			     enum boot_slot *active_slot)
 {
 #ifdef CONFIG_NRF_MCUBOOT_BOOT_REQUEST
-	uint32_t slot = BOOT_REQUEST_NO_PREFERRED_SLOT;
+	enum boot_slot slot = BOOT_SLOT_NONE;
 
 	if (active_slot == NULL) {
 		return BOOT_HOOK_REGULAR;
 	}
 
 	slot = boot_request_get_preferred_slot(image);
-	if (slot != BOOT_REQUEST_NO_PREFERRED_SLOT) {
+	if (slot != BOOT_SLOT_NONE) {
 		if (state->slot_usage[image].slot_available[slot]) {
 			*active_slot = slot;
 			return 0;

--- a/samples/dfu/ab/src/ab_utils.c
+++ b/samples/dfu/ab/src/ab_utils.c
@@ -162,14 +162,14 @@ static void toggle_slot_for_single_boot(void)
 {
 	int err = 0;
 	enum ab_boot_slot active_slot = active_boot_slot_get();
-	enum ab_boot_slot new_slot = SLOT_INVALID;
+	enum boot_slot new_slot = BOOT_SLOT_NONE;
 
 	if (active_slot == SLOT_A) {
 		LOG_INF("Temporarily switching slots (A -> B)");
-		new_slot = SLOT_B;
+		new_slot = BOOT_SLOT_SECONDARY;
 	} else if (active_slot == SLOT_B) {
 		LOG_INF("Temporarily switching slots (B -> A)");
-		new_slot = SLOT_A;
+		new_slot = BOOT_SLOT_PRIMARY;
 	} else {
 		LOG_ERR("Cannot determine active slot, cannot toggle");
 		return;

--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 511e742327020ebe42df2e4b45a3ca8d0f3e6611
+      revision: 85349537b3bc4e8e9e7542abd0303adf28177dcb
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Change bootloader request module, so it uses the new, dedicated type to point to the specific slot.

Ref: NCSDK-35199