### PR TITLE
soc: nrf71: Add support for CONSTLAT and LOWPWR modes

### DIFF
--- a/soc/nordic/nrf71/soc.c
+++ b/soc/nordic/nrf71/soc.c
@@ -53,6 +53,11 @@ void soc_early_init_hook(void)
 	/* Enable ICACHE */
 	sys_cache_instr_enable();
 #endif
+
+	if (IS_ENABLED(CONFIG_SOC_NRF_FORCE_CONSTLAT)) {
+		nrf_power_task_trigger(NRF_POWER, NRF_POWER_TASK_CONSTLAT);
+	}
+
 }
 
 void arch_busy_wait(uint32_t time_us)

--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -433,7 +433,8 @@ static int32_t mpsl_lib_init_internal(void)
 #endif /* CONFIG_CLOCK_CONTROL_NRF && DT_NODE_EXISTS(DT_NODELABEL(hfxo)) */
 #endif /* !CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL */
 	if (IS_ENABLED(CONFIG_SOC_NRF_FORCE_CONSTLAT) &&
-		!IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF54LX)) {
+		!IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF54LX) &&
+		!IS_ENABLED(CONFIG_SOC_SERIES_NRF71X)) {
 		mpsl_pan_rfu();
 	}
 
@@ -576,7 +577,7 @@ int32_t mpsl_lib_uninit(void)
 #endif /* IS_ENABLED(CONFIG_MPSL_DYNAMIC_INTERRUPTS) */
 }
 
-#if defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
+#if defined(CONFIG_SOC_COMPATIBLE_NRF54LX) || defined(CONFIG_SOC_SERIES_NRF71X)
 void mpsl_constlat_request_callback(void)
 {
 #if defined(CONFIG_NRFX_POWER)
@@ -594,7 +595,7 @@ void mpsl_lowpower_request_callback(void)
 	nrf_power_task_trigger(NRF_POWER, NRF_POWER_TASK_LOWPWR);
 #endif
 }
-#endif /* defined(CONFIG_SOC_COMPATIBLE_NRF54LX) */
+#endif /* defined(CONFIG_SOC_COMPATIBLE_NRF54LX) || defined(CONFIG_SOC_SERIES_NRF71X) */
 
 #if defined(CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL)
 #define MPSL_INIT_LEVEL POST_KERNEL


### PR DESCRIPTION
Constant latency mode keeps all clocks active and power domains up to minimise latency at the cost of active power and is used by the MSPL. Low power mode effectively turns off CONSTLAT mode. Logic in mspl_init is the same as for nrf54lX