### PR TITLE
include: net: Include missing brackets

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -642,6 +642,11 @@ Multiprotocol Service Layer libraries
 Libraries for networking
 ------------------------
 
+* Added missing brackets that caused C++ compilation to fail in the following libraries:
+
+  * :ref:`lib_nrf_cloud_pgps`
+  * :ref:`lib_nrf_cloud_fota`
+
 * Updated the following libraries to use the new ``SEC_TAG_TLS_INVALID`` definition for checking whether a security tag is valid:
 
   * :ref:`lib_aws_fota`

--- a/include/net/nrf_cloud_fota_poll.h
+++ b/include/net/nrf_cloud_fota_poll.h
@@ -152,6 +152,7 @@ int nrf_cloud_fota_poll_update_apply(struct nrf_cloud_fota_poll_ctx *ctx);
 /** @} */
 
 #ifdef __cplusplus
+}
 #endif
 
 #endif /* NRF_CLOUD_FOTA_POLL_H_ */

--- a/include/net/nrf_cloud_pgps.h
+++ b/include/net/nrf_cloud_pgps.h
@@ -369,6 +369,7 @@ int nrf_cloud_pgps_init(struct nrf_cloud_pgps_init_param *param);
 /** @} */
 
 #ifdef __cplusplus
+}
 #endif
 
 #endif /* NRF_CLOUD_PGPS_H_ */


### PR DESCRIPTION
Missing brackets were reported by a customer through DevZone when trying to compile his project in C++.

Devzone ticket: 351769