### PR TITLE
quarantine: Add quarantine for machine learning

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -100,3 +100,9 @@
   platforms:
     - thingy53/nrf5340/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-35522"
+
+- scenarios:
+    - applications.machine_learning.zdebug_rtt
+  platforms:
+    - thingy53/nrf5340/cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-35672"

--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -378,6 +378,8 @@
     - libraries.ring_buffer
     - libraries.hash_map.cxx.djb2
     - cpp.libcxx.glibcxx.picolibc
+    - cpp.libcxx.glibcxx.newlib
+    - cpp.libcxx.glibcxx.newlib_nano
     - portability.posix.eventfd
     - portability.posix.headers.newlib.without_posix_api
     - portability.posix.headers.newlib.with_posix_api


### PR DESCRIPTION
Test configuration for scenarios are added to quarantine due to FLASH overflow.

Jira: NCSDK-35522