### PR TITLE
bluetooth: cs_de: Fix issue with unpacking of pcts

### DIFF
--- a/subsys/bluetooth/cs_de/cs_de.c
+++ b/subsys/bluetooth/cs_de/cs_de.c
@@ -283,17 +283,17 @@ static void extract_pcts(cs_de_report_t *p_report, uint8_t channel_index,
 			return;
 		}
 
-		if (local_tone_info[antenna_path].quality_indicator !=
+		if (local_tone_info[tone_index].quality_indicator !=
 			    BT_HCI_LE_CS_TONE_QUALITY_HIGH ||
-		    remote_tone_info[antenna_path].quality_indicator !=
+		    remote_tone_info[tone_index].quality_indicator !=
 			    BT_HCI_LE_CS_TONE_QUALITY_HIGH) {
 			return;
 		}
 
 		struct bt_le_cs_iq_sample local_iq =
-			bt_le_cs_parse_pct(local_tone_info[antenna_path].phase_correction_term);
+			bt_le_cs_parse_pct(local_tone_info[tone_index].phase_correction_term);
 		struct bt_le_cs_iq_sample remote_iq =
-			bt_le_cs_parse_pct(remote_tone_info[antenna_path].phase_correction_term);
+			bt_le_cs_parse_pct(remote_tone_info[tone_index].phase_correction_term);
 
 		m_n_iqs[antenna_path][channel_index]++;
 		m_tone_quality_indicators[antenna_path][channel_index] = CS_DE_TONE_QUALITY_OK;


### PR DESCRIPTION
This commit fixes an issue where the pcts in
`bt_hci_le_cs_step_data_tone_info` were not mapped to the correct antenna path in the
`cs_de_report_t`.

This would cause pcts from random antenna
paths in `cs_de_report.iq_tones[n]`, which
is expected to only contain pcts from antenna
path `n`.