### PR TITLE
Bluetooth: CS Reflector: add overlay for Android

### DIFF
--- a/samples/bluetooth/channel_sounding_ras_reflector/README.rst
+++ b/samples/bluetooth/channel_sounding_ras_reflector/README.rst
@@ -53,6 +53,17 @@ After programming the sample to your development kit, you can test it by connect
       I: CS security enabled.
       I: CS procedures enabled.
 
+Building for testing with Android 16 ranging module
+===================================================
+
+In order to enable Bluetooth configurations required to test Channel sounding with Android 16 phones with Channel sounding support,
+the android_ranging.conf fragment can be applied. For example, using the following command:
+
+.. parsed-literal::
+   :class: highlight
+
+   west build -bnrf54l15dk/nrf54l15/cpuapp -- -DEXTRA_CONF_FILE="android_ranging.conf"
+
 Dependencies
 ************
 

--- a/samples/bluetooth/channel_sounding_ras_reflector/android_ranging.conf
+++ b/samples/bluetooth/channel_sounding_ras_reflector/android_ranging.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# KConfig fragment file with the settings
+# required to run CS Ranging with Android 16
+# phones
+
+# Required for bonding
+CONFIG_BT_BONDABLE=y
+CONFIG_BT_SETTINGS=y
+CONFIG_SETTINGS=y
+CONFIG_FLASH=y
+CONFIG_FLASH_PAGE_LAYOUT=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
+
+# Enable support of 2 antenna paths for the case
+# when Initiator has 2 antennas
+CONFIG_BT_RAS_MAX_ANTENNA_PATHS=2
+CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS=2

--- a/samples/bluetooth/channel_sounding_ras_reflector/src/main.c
+++ b/samples/bluetooth/channel_sounding_ras_reflector/src/main.c
@@ -17,7 +17,7 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/cs.h>
 #include <bluetooth/services/ras.h>
-
+#include <zephyr/settings/settings.h>
 #include <dk_buttons_and_leds.h>
 
 #include <zephyr/logging/log.h>
@@ -206,6 +206,10 @@ int main(void)
 	if (err) {
 		LOG_ERR("Bluetooth init failed (err %d)", err);
 		return 0;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		settings_load();
 	}
 
 	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), NULL, 0);


### PR DESCRIPTION
Added kconfig file with the settings required to
run CS procedure with Android smartphone,
also added corresponding changes to main.c to
support bonding.

The changes required to support CS procedure with
Android:
- Enable bonding (includes settings, NVS etc)
- Enable 2 antenna paths support to allow CS procedures where initiator (a phone) has 2 antennas

It was tested manually with Google Pixel 10 Android 16 QPR2 Beta with the Ranging test application:
https://cs.android.com/android/platform/superproject/main/+/main:packages/modules/Uwb/ranging/test_app/