### PR TITLE
boards: nordic: nrf54lv10dk: Add MCUboot button and LED aliases

### DIFF
--- a/boards/nordic/nrf54lv10dk/nrf54lv10a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lv10dk/nrf54lv10a_cpuapp_common.dtsi
@@ -21,6 +21,11 @@
 		zephyr,bt-hci = &bt_hci_sdc;
 		zephyr,ieee802154 = &ieee802154;
 	};
+
+	aliases {
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
+	};
 };
 
 &cpuapp_sram {


### PR DESCRIPTION
Adds aliases so that this board can be used in serial recovery mode for MCUboot