### PR TITLE
dfu: Fix incorrect files included in zip for merged slot

### DIFF
--- a/cmake/sysbuild/zip.cmake
+++ b/cmake/sysbuild/zip.cmake
@@ -178,8 +178,8 @@ function(dfu_app_zip_package)
           )
         else()
           list(APPEND bin_files
-               "${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.signed.bin"
-               "${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}_secondary_app.signed.bin"
+               "${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.merged.bin"
+               "${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}_secondary_app.merged.bin"
           )
         endif()
 


### PR DESCRIPTION
The application image was included istead of the merged image.