### PR TITLE
west_commands: fix ironside update script

### DIFF
--- a/scripts/west_commands/ncs_ironside_se_update.py
+++ b/scripts/west_commands/ncs_ironside_se_update.py
@@ -217,7 +217,9 @@ class NcsIronSideSEUpdate(WestCommand):
 
                     self.dbg("Reset to trigger update installation")
                     self._nrfutil_device(
-                        "reset --reset-kind RESET_VIA_SECDOM", **common_kwargs
+                        "reset --reset-kind RESET_VIA_SECDOM",
+                        die_on_error=False, # nrfutil will incorrectly fail, so don't die on error
+                        **common_kwargs,
                     )
                     self.dbg("Waiting for update to complete")
                     self._wait_for_bootstatus(**common_kwargs)


### PR DESCRIPTION
nrfutil device reset --reset-kind RESET_VIA_SECDOM will incorrectly fail as SDROM spends seconds applying the update and nrfutil times out. The reset has been correctly performed, and there is no reason to fail.

To work around this issue, we accept the failure and don't exit the script.

Ref: NCSDK-NONE