### PR TITLE
[nrf cloud log backend]: fix missing CONFIG_ prefix for log level 0

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_log_backend.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_log_backend.c
@@ -231,7 +231,7 @@ static int log_msg_filter(uint32_t src_id, int level)
 	if (level > nrf_cloud_log_control_get()) {
 		return -ENOMSG;
 	}
-	if ((level == 0) && !IS_ENABLED(NRF_CLOUD_LOG_INCLUDE_LEVEL_0)) {
+	if ((level == 0) && !IS_ENABLED(CONFIG_NRF_CLOUD_LOG_INCLUDE_LEVEL_0)) {
 		return -ENOMSG;
 	}
 #if !defined(CONFIG_LOG_RUNTIME_FILTERING)


### PR DESCRIPTION
Since the IS_ENABLED(NRF_CLOUD_LOG_INCLUDE_LEVEL_0) check is missing the CONFIG_ prefix for the KConfig configuration, it will always return false.