### PR TITLE
applications: nrf_desktop: nrf54h20dk: add uicr image configuration

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/uicr/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/uicr/app.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Aligning the DTS configuration between the UICR image and the application (default) image.
+ * The UICR image must use the same DTS configuration as the default image.
+ */
+#include "../../app.overlay"

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/uicr/app_dongle.overlay
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/uicr/app_dongle.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Aligning the DTS configuration between the UICR image and the application (default) image.
+ * The UICR image must use the same DTS configuration as the default image.
+ */
+#include "../../app_dongle.overlay"

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/uicr/app_release.overlay
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/uicr/app_release.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Aligning the DTS configuration between the UICR image and the application (default) image.
+ * The UICR image must use the same DTS configuration as the default image.
+ */
+#include "../../app_release.overlay"

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/uicr/app_release_dongle.overlay
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/uicr/app_release_dongle.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Aligning the DTS configuration between the UICR image and the application (default) image.
+ * The UICR image must use the same DTS configuration as the default image.
+ */
+#include "../../app_release_dongle.overlay"

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/uicr/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/uicr/prj.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Nothing here

--- a/applications/nrf_desktop/sysbuild/CMakeLists.txt
+++ b/applications/nrf_desktop/sysbuild/CMakeLists.txt
@@ -22,6 +22,10 @@ set(ipc_radio_APPLICATION_CONFIG_DIR
     "${CMAKE_CURRENT_LIST_DIR}/../configuration/\${NORMALIZED_BOARD_TARGET}/images/ipc_radio"
     CACHE INTERNAL "Application configuration dir controlled by sysbuild"
 )
+set(uicr_APPLICATION_CONFIG_DIR
+    "${CMAKE_CURRENT_LIST_DIR}/../configuration/\${NORMALIZED_BOARD_TARGET}/images/uicr"
+    CACHE INTERNAL "Application configuration dir controlled by sysbuild"
+)
 
 find_package(Sysbuild REQUIRED HINTS $ENV{ZEPHYR_BASE})
 


### PR DESCRIPTION
Updated the nRF Desktop configuration for the nRF54H20 DK board target to include the configuration of the new UICR sysbuild image.

Ref: NCSDK-35658