### PR TITLE
samples: dfu_multi_image: Add success log for write operations

### DIFF
--- a/samples/dfu/dfu_multi_image/src/dfu_multi_image_shell.c
+++ b/samples/dfu/dfu_multi_image/src/dfu_multi_image_shell.c
@@ -73,6 +73,9 @@ static int cmd_dfu_multi_image_write(const struct shell *shell, size_t argc, cha
 	if (ret < 0) {
 		shell_error(shell, "DFU multi image write failed: %d", ret);
 		return ret;
+	} else {
+		shell_print(shell, "Successfully wrote %d bytes at offset %d", chunk_size,
+			    write_offset);
 	}
 
 	return 0;


### PR DESCRIPTION
Add log message when DFU multi image write operation completes successfully.
This helps with testing, as it allows to avoid situations where a new command is written before the old write has finished.