### PR TITLE
samples: dfu_target: Add success log for write operations

### DIFF
--- a/samples/dfu/dfu_target/src/dfu_target_shell.c
+++ b/samples/dfu/dfu_target/src/dfu_target_shell.c
@@ -142,6 +142,9 @@ static int cmd_dfu_target_write(const struct shell *shell, size_t argc, char **a
 	if (ret < 0) {
 		shell_error(shell, "DFU target write failed: %d", ret);
 		return ret;
+	} else {
+		shell_print(shell, "Successfully wrote %d bytes at offset %d", chunk_size,
+			    offset);
 	}
 
 	return 0;


### PR DESCRIPTION
Add log message when DFU target write operation
completes successfully.
This helps with testing, as it allows to avoid situations where a new command is written before the old write has finished.