### PR TITLE
Modem trace to flash: Add tests and API to peek at offset

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -652,6 +652,11 @@ Modem libraries
     * The order of the ``LTE_LC_MODEM_EVT_SEARCH_DONE`` modem event, and registration and cell related events.
       See the :ref:`migration guide <migration_3.2_required>` for more information.
 
+* :ref:`nrf_modem_lib_readme` library:
+
+  * Added the :c:func:`nrf_modem_lib_trace_peek_at` function to the :c:struct:`nrf_modem_lib_trace_backend` interface to peek trace data at a byte offset without consuming it.
+    Support for this API has been added to the flash trace backend.
+
 Multiprotocol Service Layer libraries
 -------------------------------------
 

--- a/include/modem/nrf_modem_lib_trace.h
+++ b/include/modem/nrf_modem_lib_trace.h
@@ -103,6 +103,25 @@ int nrf_modem_lib_trace_read(uint8_t *buf, size_t len);
  */
 int nrf_modem_lib_trace_clear(void);
 
+/**
+ * @brief Peek trace data at offset without consuming it
+ *
+ * Copy up to @p len bytes starting at @p offset from the oldest available data into @p buf
+ * without advancing the backend read cursor.
+ *
+ * @param offset Byte offset relative to the oldest available byte
+ * @param buf Output buffer
+ * @param len Size of output buffer
+ *
+ * @return number of bytes copied, negative errno on failure.
+ * @retval -ENOTSUP if the operation is not supported by the trace backend.
+ * @retval -EPERM if the trace backend is not initialized.
+ * @retval -EINVAL if the buffer is NULL.
+ * @retval -EFAULT if the offset is beyond the available trace data.
+ * @retval -ENODATA if no data is available at the offset.
+ */
+int nrf_modem_lib_trace_peek_at(size_t offset, uint8_t *buf, size_t len);
+
 #if defined(CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE) || defined(__DOXYGEN__)
 /** @brief Get the last measured rolling average bitrate of the trace backend.
  *

--- a/include/modem/trace_backend.h
+++ b/include/modem/trace_backend.h
@@ -7,6 +7,8 @@
 #ifndef TRACE_BACKEND_H__
 #define TRACE_BACKEND_H__
 
+#include <zephyr/kernel.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -91,6 +93,22 @@ struct nrf_modem_lib_trace_backend {
 	 * @return 0 on success, negative errno on failure.
 	 */
 	int (*read)(void *buf, size_t len);
+
+	/**
+	 * @brief Peek trace data at a byte offset without consuming it.
+	 *
+	 * Copy up to @p len bytes starting at @p offset from the beginning of the
+	 * currently available trace data into @p buf. The oldest available byte is at offset 0.
+	 *
+	 * @note Set to @c NULL if this operation is not supported by the trace backend.
+	 *
+	 * @param offset Start offset from the oldest available byte.
+	 * @param buf Output buffer.
+	 * @param len Size of output buffer.
+	 *
+	 * @return Number of bytes copied on success, negative errno on failure.
+	 */
+	int (*peek_at)(size_t offset, void *buf, size_t len);
 
 	/**
 	 * @brief Erase all captured trace data in the compile-time selected trace backend.

--- a/lib/nrf_modem_lib/nrf_modem_lib_trace.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib_trace.c
@@ -516,6 +516,15 @@ int nrf_modem_lib_trace_read(uint8_t *buf, size_t len)
 	return read;
 }
 
+int nrf_modem_lib_trace_peek_at(size_t offset, uint8_t *buf, size_t len)
+{
+	if (!trace_backend.peek_at) {
+		return -ENOTSUP;
+	}
+
+	return trace_backend.peek_at(offset, buf, len);
+}
+
 int nrf_modem_lib_trace_clear(void)
 {
 	int err;

--- a/lib/nrf_modem_lib/trace_backends/flash/flash.c
+++ b/lib/nrf_modem_lib/trace_backends/flash/flash.c
@@ -429,6 +429,9 @@ int trace_backend_clear(void)
 int trace_backend_deinit(void)
 {
 	buffer_flush_to_flash();
+
+	is_initialized = false;
+
 	return 0;
 }
 

--- a/modules/memfault-firmware-sdk/memfault_lte_coredump.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_coredump.c
@@ -223,7 +223,7 @@ static void pdn_event_handler(uint8_t cid, enum pdn_event event, int reason)
 
 static void state_waiting_for_nrf_modem_lib_init_entry(void *o)
 {
-	struct fsm_state_object *state_object = o;
+	ARG_UNUSED(o);
 
 	LOG_DBG("state_waiting_for_nrf_modem_lib_init_entry");
 
@@ -250,7 +250,7 @@ static void state_running_entry(void *o)
 {
 	int err;
 
-	ARG_UNUSED(o);
+	struct fsm_state_object *state_object = o;
 
 	LOG_DBG("state_running_entry");
 
@@ -348,7 +348,7 @@ static enum smf_state_result state_waiting_for_network_connection_run(void *o)
 
 static void state_network_connected_entry(void *o)
 {
-	struct fsm_state_object *state_object = o;
+	ARG_UNUSED(o);
 
 	LOG_DBG("state_network_connected_entry");
 
@@ -380,7 +380,7 @@ static void state_coredump_send_attempt_entry(void *o)
 {
 	int err;
 
-	ARG_UNUSED(o);
+	struct fsm_state_object *state_object = o;
 
 	LOG_DBG("state_coredump_send_attempt_entry");
 	LOG_DBG("Triggering heartbeat");

--- a/modules/memfault-firmware-sdk/memfault_lte_coredump_modem_trace.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_coredump_modem_trace.c
@@ -124,13 +124,15 @@ static bool read_data_cb(uint32_t offset, void *buf, size_t buf_len)
 {
 	ARG_UNUSED(offset);
 
-	int err = nrf_modem_lib_trace_read(buf, buf_len);
+	int err = nrf_modem_lib_trace_peek_at(offset, buf, buf_len);
 
 	if (err == -ENODATA) {
-		LOG_WRN("No more modem trace data to read");
+		LOG_WRN("No more modem trace data to peek");
+
 		return false;
 	} else if (err < 0) {
-		LOG_ERR("Failed to read modem trace data: %d", err);
+		LOG_ERR("Failed to peek modem trace data: %d", err);
+
 		return false;
 	}
 

--- a/modules/memfault-firmware-sdk/memfault_lte_coredump_modem_trace.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_coredump_modem_trace.c
@@ -144,7 +144,6 @@ int memfault_lte_coredump_modem_trace_init(void)
 	static bool initialized;
 
 	if (initialized) {
-		LOG_ERR("Already initialized");
 		return -EALREADY;
 	}
 

--- a/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/src/main.c
+++ b/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/src/main.c
@@ -435,14 +435,19 @@ void test_nrf_modem_lib_trace_enotsup(void)
 	struct nrf_modem_lib_trace_backend trace_backend_orig;
 
 	trace_backend_orig.read = trace_backend.read;
+	trace_backend_orig.peek_at = trace_backend.peek_at;
 	trace_backend_orig.data_size = trace_backend.data_size;
 	trace_backend_orig.clear = trace_backend.clear;
 
 	trace_backend.read = NULL;
+	trace_backend.peek_at = NULL;
 	trace_backend.data_size = NULL;
 	trace_backend.clear = NULL;
 
 	ret = nrf_modem_lib_trace_read(buf, 10);
+	TEST_ASSERT_EQUAL(-ENOTSUP, ret);
+
+	ret = nrf_modem_lib_trace_peek_at(0, buf, 10);
 	TEST_ASSERT_EQUAL(-ENOTSUP, ret);
 
 	ret = nrf_modem_lib_trace_data_size();

--- a/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/trace_backend_mock.c
+++ b/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/trace_backend_mock.c
@@ -31,6 +31,11 @@ int trace_backend_read(void *buf, size_t len)
 	return 0;
 }
 
+int trace_backend_peek_at(size_t offset, void *buf, size_t len)
+{
+	return 0;
+}
+
 int trace_backend_clear(void)
 {
 	return 0;
@@ -42,5 +47,6 @@ struct nrf_modem_lib_trace_backend trace_backend = {
 	.write = trace_backend_write,
 	.data_size = trace_backend_data_size,
 	.read = trace_backend_read,
+	.peek_at = trace_backend_peek_at,
 	.clear = trace_backend_clear,
 };

--- a/tests/lib/nrf_modem_lib/trace_backends/flash/CMakeLists.txt
+++ b/tests/lib/nrf_modem_lib/trace_backends/flash/CMakeLists.txt
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(flash)
+
+target_include_directories(app PRIVATE src)
+
+# Add test sources
+target_sources(app PRIVATE src/main.c)
+
+# Provide compile-time definitions for configs expected by the backend
+target_compile_definitions(app PRIVATE
+        CONFIG_NRF_MODEM_LIB_TRACE_FLASH_SECTORS=16
+        CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH_BUF_SIZE=1024
+        CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH_PARTITION_SIZE=0x10000
+)
+
+# Generate runner for the test
+test_runner_generate(src/main.c)
+
+# Add the actual flash backend implementation
+target_sources(app PRIVATE
+  ${ZEPHYR_NRF_MODULE_DIR}/lib/nrf_modem_lib/trace_backends/flash/flash.c)

--- a/tests/lib/nrf_modem_lib/trace_backends/flash/boards/native_sim.overlay
+++ b/tests/lib/nrf_modem_lib/trace_backends/flash/boards/native_sim.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Keep boot and slot0 so chosen code-partition remains valid */
+		/delete-node/ slot1_partition;
+		/delete-node/ scratch_partition;
+		/delete-node/ storage_partition;
+
+		/* modem_trace partition - matches flash backend without partition manager */
+		modem_trace: partition@75000 {
+			label = "modem_trace";
+			reg = <0x00075000 0x00010000>; /* 64KB */
+		};
+	};
+};

--- a/tests/lib/nrf_modem_lib/trace_backends/flash/prj.conf
+++ b/tests/lib/nrf_modem_lib/trace_backends/flash/prj.conf
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_UNITY=y
+CONFIG_ASSERT=y
+
+# Enable real flash simulator and subsystems
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_FLASH_SIMULATOR=y
+CONFIG_FLASH_SIMULATOR_UNALIGNED_READ=y
+CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE=y
+CONFIG_FCB=y
+CONFIG_FCB_ALLOW_FIXED_ENDMARKER=y

--- a/tests/lib/nrf_modem_lib/trace_backends/flash/src/main.c
+++ b/tests/lib/nrf_modem_lib/trace_backends/flash/src/main.c
@@ -1,0 +1,484 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <unity.h>
+#include <zephyr/kernel.h>
+#include <zephyr/types.h>
+#include <zephyr/storage/flash_map.h>
+#include <zephyr/fs/fcb.h>
+#include <zephyr/drivers/flash.h>
+
+#include <modem/trace_backend.h>
+
+extern int unity_main(void);
+
+extern struct nrf_modem_lib_trace_backend trace_backend;
+
+/* The flash backend expects this semaphore to exist */
+K_SEM_DEFINE(trace_clear_sem, 0, 1);
+
+/* Callback for processed traces - not used in these tests */
+static int processed_cb(size_t len)
+{
+	/* No-op for testing */
+	return 0;
+}
+
+void setUp(void)
+{
+	/* Clear the trace backend before each test */
+	trace_backend.clear();
+
+	/* Ensure backend is deinitialized before each test */
+	trace_backend.deinit();
+}
+
+void tearDown(void)
+{
+	/* Clear the trace backend */
+	trace_backend.clear();
+
+	/* Ensure backend is deinitialized after each test */
+	trace_backend.deinit();
+}
+
+/* Test basic backend lifecycle - init/deinit for modem trace collection */
+void test_init_and_deinit(void)
+{
+	int ret;
+	/* Test initialization */
+	ret = trace_backend.init(processed_cb);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = trace_backend.deinit();
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/* Test write operation fails when backend is not initialized */
+void test_write_fails_when_not_initialized(void)
+{
+	int ret;
+	uint8_t data[200];
+
+	memset(data, 0x11, sizeof(data));
+
+	ret = trace_backend.write(data, sizeof(data));
+	TEST_ASSERT_EQUAL(-EPERM, ret);
+}
+
+/* Test read operation fails when backend is not initialized */
+void test_read_fails_when_not_initialized(void)
+{
+	int ret;
+	uint8_t out[16];
+
+	ret = trace_backend.read(out, sizeof(out));
+	TEST_ASSERT_EQUAL(-EPERM, ret);
+}
+
+/* Test basic write operation and data size tracking for modem traces */
+void test_basic_write_and_size(void)
+{
+	int ret;
+	uint8_t data[200];
+	size_t initial_size;
+
+	memset(data, 0xAA, sizeof(data));
+
+	ret = trace_backend.init(processed_cb);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	initial_size = trace_backend.data_size();
+	TEST_ASSERT_EQUAL(0, initial_size);
+
+	ret = trace_backend.write(data, sizeof(data));
+	TEST_ASSERT_EQUAL(sizeof(data), ret);
+
+	ret = (int)trace_backend.data_size();
+	TEST_ASSERT_EQUAL(sizeof(data), ret);
+}
+
+/* Test writing more than the flash partition size */
+void test_write_more_than_flash_partition_size(void)
+{
+	int ret;
+	static uint8_t data[CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH_PARTITION_SIZE + 400];
+
+	memset(data, 0x11, sizeof(data));
+
+	ret = trace_backend.init(processed_cb);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = trace_backend.write(data, sizeof(data));
+	/* When writing more data than the partition can hold, FCB rotation occurs.
+	 * The write function returns the amount actually stored after rotation. */
+	TEST_ASSERT_TRUE(ret > 0);
+	TEST_ASSERT_TRUE(ret <= sizeof(data));
+
+	size_t data_available = trace_backend.data_size();
+	/* Verify circular buffer behavior: */
+	TEST_ASSERT_EQUAL(ret, data_available); /* Available should match what was written */
+	TEST_ASSERT_TRUE(data_available <= CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH_PARTITION_SIZE);
+	/* Should retain at least 70% of partition size to be useful */
+	TEST_ASSERT_TRUE(data_available >= (CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH_PARTITION_SIZE * 7) / 10);
+
+	/* Verify we can actually read the data back */
+	uint8_t read_buffer[1024];
+	ret = trace_backend.read(read_buffer, sizeof(read_buffer));
+	TEST_ASSERT_TRUE(ret > 0); /* Should be able to read something */
+	TEST_ASSERT_TRUE(ret <= sizeof(read_buffer)); /* Shouldn't read more than requested */
+}
+
+/* Test handling different trace data sizes */
+void test_write_different_sizes(void)
+{
+	int ret;
+	uint8_t small_data[8];
+	uint8_t medium_data[32];
+	uint8_t large_data[128];
+	size_t initial_size;
+	size_t size_after_small;
+	size_t size_after_medium;
+	size_t final_size;
+
+	ret = trace_backend.init(processed_cb);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	/* Record initial size (may have data from previous tests) */
+	initial_size = trace_backend.data_size();
+	TEST_ASSERT_EQUAL(0, initial_size);
+
+	/* Test small write */
+	memset(small_data, 0xAA, sizeof(small_data));
+	ret = trace_backend.write(small_data, sizeof(small_data));
+	TEST_ASSERT_EQUAL(sizeof(small_data), ret);
+
+	size_after_small = trace_backend.data_size();
+	TEST_ASSERT_TRUE(size_after_small >= initial_size + sizeof(small_data));
+
+	/* Test medium write */
+	memset(medium_data, 0xBB, sizeof(medium_data));
+
+	ret = trace_backend.write(medium_data, sizeof(medium_data));
+	TEST_ASSERT_EQUAL(sizeof(medium_data), ret);
+
+	size_after_medium = trace_backend.data_size();
+	TEST_ASSERT_TRUE(size_after_medium >= size_after_small + sizeof(medium_data));
+
+	/* Test large write */
+	memset(large_data, 0xCC, sizeof(large_data));
+
+	ret = trace_backend.write(large_data, sizeof(large_data));
+	TEST_ASSERT_EQUAL(sizeof(large_data), ret);
+
+	/* Verify total accumulated size */
+	final_size = trace_backend.data_size();
+	TEST_ASSERT_TRUE(final_size >= size_after_medium + sizeof(large_data));
+}
+
+/* Test continuous modem trace streaming with multiple write operations */
+void test_multiple_write_operations(void)
+{
+	int ret;
+	size_t initial_size;
+	uint8_t data[1024] = {0x10};
+	const uint8_t iterations = 5;
+	size_t total_data;
+	size_t available_data;
+	size_t to_read_total;
+	size_t read_total = 0;
+	uint8_t read_buf[256];
+
+	ret = trace_backend.init(processed_cb);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	/* Record initial size (accumulates from previous tests) */
+	initial_size = trace_backend.data_size();
+	TEST_ASSERT_EQUAL(0, initial_size);
+
+	/* Simulate continuous modem trace fragments */
+	for (int i = 0; i < iterations; i++) {
+		size_t expected_min_size = (i + 1) * sizeof(data);
+		size_t current_size;
+
+		memset(data, 0x10 + i, sizeof(data));
+
+		ret = trace_backend.write(data, sizeof(data));
+		TEST_ASSERT_EQUAL(sizeof(data), ret);
+
+		/* Verify data size increases incrementally */
+		current_size = trace_backend.data_size();
+		TEST_ASSERT_TRUE(current_size >= expected_min_size);
+	}
+
+	/* Verify we can read back everything written, in order */
+	total_data = (size_t)iterations * sizeof(data);
+
+	available_data = trace_backend.data_size();
+	TEST_ASSERT_TRUE(available_data >= total_data);
+
+	/* Read back in chunks and verify pattern across all bytes */
+	to_read_total = total_data;
+
+	while (read_total < to_read_total) {
+		size_t request_size;
+		int ret;
+
+		request_size = MIN(sizeof(read_buf), to_read_total - read_total);
+		ret = trace_backend.read(read_buf, request_size);
+
+		TEST_ASSERT_TRUE(ret > 0);
+		TEST_ASSERT_TRUE(ret <= request_size);
+
+		for (size_t j = 0; j < (size_t)ret; j++) {
+			uint8_t expected;
+
+			expected = 0x10 + ((read_total + (size_t)j) / sizeof(data));
+			TEST_ASSERT_EQUAL_HEX8(expected, read_buf[j]);
+		}
+
+		read_total += (size_t)ret;
+	}
+
+	TEST_ASSERT_EQUAL(to_read_total, read_total);
+}
+
+/* Test error handling and edge cases for robust modem trace operation */
+void test_error_conditions(void)
+{
+	int ret;
+	uint8_t data[16];
+	uint8_t out[16];
+
+	/* Test NULL callback */
+	ret = trace_backend.init(NULL);
+	TEST_ASSERT_EQUAL(-EFAULT, ret);
+
+	ret = trace_backend.init(processed_cb);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	/* Test zero-length operations */
+	ret = trace_backend.write(data, 0);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	/* Zero-length read: backend may return 0 or -ENODATA when empty */
+	ret = trace_backend.read(out, 0);
+	TEST_ASSERT_TRUE(ret == 0 || ret == -ENODATA);
+
+	/* Read on empty backend should return -ENODATA */
+	ret = trace_backend.read(out, sizeof(out));
+	TEST_ASSERT_EQUAL(-ENODATA, ret);
+}
+
+/* Test trace data clearing for modem trace management and analysis */
+void test_clear_operation(void)
+{
+	int ret;
+	uint8_t test_data[32];
+	size_t size_after;
+	size_t size_before;
+
+	ret = trace_backend.init(processed_cb);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	/* Write some data first */
+	memset(test_data, 0xDD, sizeof(test_data));
+
+	ret = trace_backend.write(test_data, sizeof(test_data));
+	TEST_ASSERT_EQUAL(sizeof(test_data), ret);
+
+	size_before = trace_backend.data_size();
+	TEST_ASSERT_EQUAL(sizeof(test_data), size_before);
+
+	/* Clear the data */
+	ret = trace_backend.clear();
+	TEST_ASSERT_EQUAL(0, ret);
+
+	size_after = trace_backend.data_size();
+	TEST_ASSERT_EQUAL(0, size_after);
+}
+
+/* Test large buffer write that triggers flash flush for high-volume traces */
+void test_large_buffer_write(void)
+{
+	int ret;
+	static uint8_t large_data[CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH_BUF_SIZE * 3];
+	size_t initial_size;
+	size_t final_size;
+
+	memset(large_data, 0xEE, sizeof(large_data));
+
+	ret = trace_backend.init(processed_cb);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	initial_size = trace_backend.data_size();
+	TEST_ASSERT_EQUAL(0, initial_size);
+
+	ret = trace_backend.write(large_data, sizeof(large_data));
+	TEST_ASSERT_EQUAL(sizeof(large_data), ret);
+
+	final_size = trace_backend.data_size();
+	TEST_ASSERT_EQUAL(sizeof(large_data), final_size);
+}
+
+/* Test resumable upload failure: previously read data is not retained */
+void test_resumable_upload_failure(void)
+{
+	int ret;
+	uint8_t block[1024];
+	uint8_t read_buf[256];
+	size_t first_read;
+	size_t drain_offset;
+	size_t read_total;
+	int i;
+	const int iterations = 6;
+
+	/* Initialize backend */
+	ret = trace_backend.init(processed_cb);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	/* Write enough to span multiple entries/sectors to ensure rotation on read */
+	for (i = 0; i < iterations; i++) {
+		memset(block, 0xA0 + i, sizeof(block));
+
+		ret = trace_backend.write(block, sizeof(block));
+		TEST_ASSERT_EQUAL(sizeof(block), ret);
+	}
+
+	TEST_ASSERT_EQUAL((size_t)(iterations * sizeof(block)), trace_backend.data_size());
+
+	/* Simulate upload attempt: read an initial chunk */
+	first_read = 1500;
+	read_total = 0;
+
+	while (read_total < first_read) {
+		size_t request_size;
+
+		request_size = MIN(sizeof(read_buf), first_read - read_total);
+
+		ret = trace_backend.read(read_buf, request_size);
+		TEST_ASSERT_TRUE(ret > 0);
+
+		TEST_ASSERT_EQUAL(request_size, (size_t)ret);
+
+		/* Verify content matches the expected pattern across block boundaries */
+		for (size_t j = 0; j < (size_t)ret; j++) {
+			uint8_t expected;
+
+			expected = 0xA0 + ((read_total + j) / sizeof(block));
+			TEST_ASSERT_EQUAL_HEX8(expected, read_buf[j]);
+		}
+
+		read_total += (size_t)ret;
+	}
+
+	TEST_ASSERT_EQUAL(first_read, read_total);
+
+	/* Upload fails; in the meantime, consume the rest so earlier sectors rotate/erase */
+	drain_offset = first_read;
+
+	while (drain_offset < (size_t)iterations * sizeof(block)) {
+		ret = trace_backend.read(read_buf, sizeof(read_buf));
+		if (ret == -ENODATA) {
+			break;
+		}
+
+		TEST_ASSERT_TRUE(ret > 0);
+
+		/* Verify remaining content is as expected while draining */
+		for (size_t j = 0; j < (size_t)ret; j++) {
+			uint8_t expected;
+
+			expected = 0xA0 + ((drain_offset + j) / sizeof(block));
+			TEST_ASSERT_EQUAL_HEX8(expected, read_buf[j]);
+		}
+
+		drain_offset += (size_t)ret;
+	}
+
+	/* Verify we drained all the data and that we got what we expected */
+	TEST_ASSERT_EQUAL((size_t)iterations * sizeof(block), drain_offset);
+	TEST_ASSERT_EQUAL(0, trace_backend.data_size());
+
+	/* Retry: there is no way to resume from the previous offset; old data is gone */
+	ret = trace_backend.read(read_buf, sizeof(read_buf));
+	TEST_ASSERT_EQUAL(-ENODATA, ret);
+}
+/* Test that resume fails when no peek/ack mechanism is used and data is dropped */
+void test_resume_fails_without_peek(void)
+{
+	int ret;
+	uint8_t block[256];
+	uint8_t read_buf[256];
+	size_t first_read;
+	size_t drain_offset;
+	size_t read_total;
+	int i;
+	const int iterations = 8;
+
+	/* Initialize backend */
+	ret = trace_backend.init(processed_cb);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	/* Write enough to span multiple entries/sectors to ensure rotation on read */
+	for (i = 0; i < iterations; i++) {
+		memset(block, 0xA0 + i, sizeof(block));
+
+		ret = trace_backend.write(block, sizeof(block));
+		TEST_ASSERT_EQUAL(sizeof(block), ret);
+	}
+
+	TEST_ASSERT_EQUAL((size_t)(iterations * sizeof(block)), trace_backend.data_size());
+
+	/* Simulate upload attempt: read an initial chunk */
+	first_read = 1024;
+	read_total = 0;
+
+	while (read_total < first_read) {
+		size_t request_size;
+
+		request_size = MIN(sizeof(read_buf), first_read - read_total);
+
+		ret = trace_backend.read(read_buf, request_size);
+		TEST_ASSERT_TRUE(ret > 0);
+
+		TEST_ASSERT_EQUAL(request_size, (size_t)ret);
+
+		/* Verify content matches the expected pattern across block boundaries */
+		for (size_t j = 0; j < (size_t)ret; j++) {
+			uint8_t expected;
+
+			expected = 0xA0 + ((read_total + j) / sizeof(block));
+			TEST_ASSERT_EQUAL_HEX8(expected, read_buf[j]);
+		}
+
+		read_total += (size_t)ret;
+	}
+
+	TEST_ASSERT_EQUAL(first_read, read_total);
+
+	/* Upload fails, device resets and most recent read data is lost */
+	drain_offset = first_read - sizeof(read_buf);
+
+	ret = trace_backend.read(read_buf, sizeof(read_buf));
+	TEST_ASSERT_EQUAL(sizeof(read_buf), (size_t)ret);
+
+	/* Verify remaining content is as expected while draining, ie flash has been rotated,
+	 * and we are reading from the next sector. Data was lost.
+	 */
+	for (size_t j = 0; j < (size_t)ret; j++) {
+		uint8_t expected;
+
+		expected = 0xA0 + ((drain_offset + j) / sizeof(block));
+		TEST_ASSERT_NOT_EQUAL_HEX8(expected, read_buf[j]);
+	}
+}
+
+int main(void)
+{
+	(void)unity_main();
+	return 0;
+}

--- a/tests/lib/nrf_modem_lib/trace_backends/flash/testcase.yaml
+++ b/tests/lib/nrf_modem_lib/trace_backends/flash/testcase.yaml
@@ -1,0 +1,10 @@
+tests:
+  trace_backends.flash:
+    sysbuild: true
+    platform_allow: native_sim
+    integration_platforms:
+      - native_sim
+    tags:
+      - nrf_modem_lib
+      - modem_trace
+      - ci_tests_lib_nrf_modem_lib


### PR DESCRIPTION
At a glance
* Adds new API for peeking trace data at an arbitrary offset in the modem trace backend without consuming it
* Adds a corresponding backend implementation for the flash trace backend
* Updates the Memfault modem trace upload funcitonality to use the newly introduced API.
  * As part of the use of the API in Memfault, refactors the LTE coredump state machine for improved maintainability. 


### Trace peek-at-offset API and backend implementation

* Added a new function `nrf_modem_lib_trace_peek_at` to allow peeking trace data at a specified offset without advancing the read cursor, including documentation and integration into the trace backend interface (`nrf_modem_lib_trace.h`, `trace_backend.h`, `nrf_modem_lib_trace.c`). 

* Implemented the `peek_at` operation in the flash trace backend, including a caching mechanism to optimize repeated offset reads and proper cache invalidation on data changes (`flash.c`). 

* Ensured the backend never reports more data than the partition can hold and fixed partition selection logic for better compatibility with both partition manager and device tree-defined partitions (`flash.c`). 

### LTE coredump state machine refactoring

* Refactored the state machine in `memfault_lte_coredump.c` by introducing helper functions for state variable initialization and connectivity updates, and removed unused network event types.
* Updated state handlers to use the new helper functions, streamlined event handling logic, and improved state transitions for better reliability and readability (`memfault_lte_coredump.c`).

- [x] Add release notes entry