### PR TITLE
net: lib: nrf_cloud: Add missing CONFIG_ prefix

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -664,10 +664,18 @@ Libraries for networking
 
   * Fixed multiple bugs and enhanced error handling.
 
-* Deprecated the :ref:`lib_nrf_cloud_rest` library.
-  Use the :ref:`lib_nrf_cloud_coap` library instead.
+* :ref:`lib_nrf_cloud_rest` library:
 
-* Fixed occasional message truncation notifying that the download was complete in the :ref:`lib_nrf_cloud_fota` library.
+  * Deprecated the library.
+    Use the :ref:`lib_nrf_cloud_coap` library instead.
+
+* :ref:`lib_nrf_cloud_fota` library:
+
+  * Fixed occasional message truncation notifying that the download was complete.
+
+* :ref:`lib_nrf_cloud_log` library:
+
+  * Updated by adding a missing CONFIG prefix.
 
 Libraries for NFC
 -----------------

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_log_backend.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_log_backend.c
@@ -231,7 +231,7 @@ static int log_msg_filter(uint32_t src_id, int level)
 	if (level > nrf_cloud_log_control_get()) {
 		return -ENOMSG;
 	}
-	if ((level == 0) && !IS_ENABLED(NRF_CLOUD_LOG_INCLUDE_LEVEL_0)) {
+	if ((level == 0) && !IS_ENABLED(CONFIG_NRF_CLOUD_LOG_INCLUDE_LEVEL_0)) {
 		return -ENOMSG;
 	}
 #if !defined(CONFIG_LOG_RUNTIME_FILTERING)


### PR DESCRIPTION
A customer (@jens-ajisai) reported a missing prefix: https://github.com/nrfconnect/sdk-nrf/pull/24821
Thanks @jens-ajisai for the contribution. 