### PR TITLE
tests: drivers: watchdog: Make watchodg tests SOC agnostic

### DIFF
--- a/samples/zephyr/drivers/watchdog/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
+++ b/samples/zephyr/drivers/watchdog/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
@@ -1,3 +1,0 @@
-&wdt30 {
-	status = "okay";
-};

--- a/samples/zephyr/drivers/watchdog/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/samples/zephyr/drivers/watchdog/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,3 +1,0 @@
-&wdt31 {
-	status = "okay";
-};

--- a/samples/zephyr/drivers/watchdog/boards/nrf54lv10dk_nrf54lv10a_cpuflpr.overlay
+++ b/samples/zephyr/drivers/watchdog/boards/nrf54lv10dk_nrf54lv10a_cpuflpr.overlay
@@ -1,3 +1,0 @@
-&wdt31 {
-	status = "okay";
-};

--- a/samples/zephyr/drivers/watchdog/sample.yaml
+++ b/samples/zephyr/drivers/watchdog/sample.yaml
@@ -15,16 +15,12 @@ common:
       - "Waiting for reset..."
       - "Watchdog sample application"
   timeout: 30
+  extra_args: SNIPPET="test-watchdog"
+  filter: dt_alias_exists("watchdog0")
 
 tests:
   nrf.extended.sample.drivers.watchdog:
-    platform_allow:
-      - nrf54ls05dk/nrf54ls05b/cpuapp
-      - nrf54ls05dk@0.0.0/nrf54ls05b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuflpr
-      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
-      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuflpr
-    integration_platforms:
-      - nrf54ls05dk/nrf54ls05b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
+    platform_exclude:
+      - mps2/an385
+      - mps2/an521/cpu0
+      - qemu_cortex_m0/nrf51822

--- a/snippets/test-watchdog/README.rst
+++ b/snippets/test-watchdog/README.rst
@@ -1,0 +1,11 @@
+.. _nordic-flpr:
+
+Nordic snippet dedicated to testing of watchdog
+###############################################
+
+Overview
+********
+
+This snippet enables execution of watchdog tests and samples.
+It defines the 'watchdog0' alias which is required by multiple WDT tests/samples.
+It enables all available watchdog instances as required by the wdt_instances test.

--- a/snippets/test-watchdog/snippet.yml
+++ b/snippets/test-watchdog/snippet.yml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+name: test-watchdog
+
+boards:
+  /.*/nrf54ls05b/cpuapp/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/nrf54ls05b_cpuapp.overlay
+  /.*/nrf54lv10a/cpuapp/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/nrf54lv10a.overlay
+  /.*/nrf54lv10a/cpuapp/ns/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/nrf54lv10a_ns.overlay
+  /.*/nrf54lv10a/cpuflpr/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/nrf54lv10a.overlay

--- a/snippets/test-watchdog/soc/nrf54ls05b_cpuapp.overlay
+++ b/snippets/test-watchdog/soc/nrf54ls05b_cpuapp.overlay
@@ -1,8 +1,13 @@
 /*
  * Copyright (c) 2025 Nordic Semiconductor ASA
- *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/ {
+	aliases {
+		watchdog0 = &wdt30;
+	};
+};
 
 &wdt30 {
 	status = "okay";

--- a/snippets/test-watchdog/soc/nrf54lv10a.overlay
+++ b/snippets/test-watchdog/soc/nrf54lv10a.overlay
@@ -1,8 +1,13 @@
 /*
  * Copyright (c) 2025 Nordic Semiconductor ASA
- *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/ {
+	aliases {
+		watchdog0 = &wdt31;
+	};
+};
 
 &wdt30 {
 	status = "okay";

--- a/snippets/test-watchdog/soc/nrf54lv10a_ns.overlay
+++ b/snippets/test-watchdog/soc/nrf54lv10a_ns.overlay
@@ -1,9 +1,16 @@
 /*
  * Copyright (c) 2025 Nordic Semiconductor ASA
- *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-&wdt30 {
+/ {
+	aliases {
+		watchdog0 = &wdt31;
+	};
+};
+
+/* wdt30 can't be accessed by NS code */
+
+&wdt31 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/wdt_instances/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_instances/testcase.yaml
@@ -4,23 +4,12 @@ common:
     - ci_tests_drivers_watchdog
   harness: ztest
   timeout: 20
+  extra_args: SNIPPET="test-watchdog"
+  filter: dt_compat_enabled("nordic,nrf-wdt")
 
 tests:
   drivers.watchdog.wdt_instances:
-    platform_allow:
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54h20dk/nrf54h20/cpurad
-      - nrf54h20dk/nrf54h20/cpuppr
-      - nrf54h20dk/nrf54h20/cpuflpr
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54ls05dk@0.0.0/nrf54ls05b/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54ls05dk@0.0.0/nrf54ls05b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
+    platform_exclude:
+      - mps2/an385
+      - mps2/an521/cpu0
+      - qemu_cortex_m0/nrf51822

--- a/tests/zephyr/drivers/watchdog/wdt_basic_api/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_basic_api/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
@@ -1,3 +1,0 @@
-&wdt30 {
-	status = "okay";
-};

--- a/tests/zephyr/drivers/watchdog/wdt_basic_api/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_basic_api/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,3 +1,0 @@
-&wdt31 {
-	status = "okay";
-};

--- a/tests/zephyr/drivers/watchdog/wdt_basic_api/boards/nrf54lv10dk_nrf54lv10a_cpuflpr.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_basic_api/boards/nrf54lv10dk_nrf54lv10a_cpuflpr.overlay
@@ -1,3 +1,0 @@
-&wdt31 {
-	status = "okay";
-};

--- a/tests/zephyr/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/zephyr/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -4,15 +4,11 @@ common:
     - watchdog
     - ci_tests_zephyr_drivers_watchdog
   timeout: 30
+  extra_args: SNIPPET="test-watchdog"
+  filter: dt_alias_exists("watchdog0")
 tests:
   nrf.extended.drivers.watchdog:
-    platform_allow:
-      - nrf54ls05dk@0.0.0/nrf54ls05b/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuflpr
-      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
-      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuflpr
-    integration_platforms:
-      - nrf54ls05dk/nrf54ls05b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
+    platform_exclude:
+      - mps2/an385
+      - mps2/an521/cpu0
+      - qemu_cortex_m0/nrf51822

--- a/tests/zephyr/drivers/watchdog/wdt_error_cases/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_error_cases/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
@@ -1,3 +1,0 @@
-&wdt30 {
-	status = "okay";
-};

--- a/tests/zephyr/drivers/watchdog/wdt_error_cases/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_error_cases/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,3 +1,0 @@
-&wdt31 {
-	status = "okay";
-};

--- a/tests/zephyr/drivers/watchdog/wdt_error_cases/testcase.yaml
+++ b/tests/zephyr/drivers/watchdog/wdt_error_cases/testcase.yaml
@@ -3,17 +3,14 @@ common:
     - drivers
     - watchdog
     - ci_tests_zephyr_drivers_watchdog
-  # depends_on: watchdog
   harness: ztest
   timeout: 30
+  extra_args: SNIPPET="test-watchdog"
+  filter: dt_alias_exists("watchdog0")
 
 tests:
   nrf.extended.drivers.watchdog.wdt_error_cases:
-    platform_allow:
-      - nrf54ls05dk@0.0.0/nrf54ls05b/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
-    integration_platforms:
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+    platform_exclude:
+      - mps2/an385
+      - mps2/an521/cpu0
+      - qemu_cortex_m0/nrf51822

--- a/tests/zephyr/drivers/watchdog/wdt_variables/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_variables/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2025 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
- */
-
-&wdt31 {
-	status = "okay";
-};

--- a/tests/zephyr/drivers/watchdog/wdt_variables/boards/nrf54lv10dk_nrf54lv10a_cpuflpr.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_variables/boards/nrf54lv10dk_nrf54lv10a_cpuflpr.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2025 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
- */
-
-&wdt31 {
-	status = "okay";
-};

--- a/tests/zephyr/drivers/watchdog/wdt_variables/testcase.yaml
+++ b/tests/zephyr/drivers/watchdog/wdt_variables/testcase.yaml
@@ -9,16 +9,12 @@ common:
     type: one_line
     regex:
       - "Test completed successfully"
+  extra_args: SNIPPET="test-watchdog"
+  filter: dt_alias_exists("watchdog0")
 
 tests:
   nrf.extended.drivers.watchdog.wdt_variables.default:
-    platform_allow:
-      - nrf54ls05dk@0.0.0/nrf54ls05b/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuflpr
-      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuapp
-      - nrf54lv10dk@0.2.0/nrf54lv10a/cpuflpr
-    integration_platforms:
-      - nrf54ls05dk/nrf54ls05b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
+    platform_exclude:
+      - mps2/an385
+      - mps2/an521/cpu0
+      - qemu_cortex_m0/nrf51822


### PR DESCRIPTION
Add 'test-watchodg' snippet that defines all nodes required to execute watchdog tests and samples.

Modify watchdog tests and samples to apply 'test-watchdog' and use filter expression instead of static platform_allow list.