### PR TITLE
lib: location: Use k_sem_give() when cancelling Wi-Fi location

### DIFF
--- a/lib/location/scan_wifi.c
+++ b/lib/location/scan_wifi.c
@@ -112,6 +112,8 @@ void scan_wifi_execute(int32_t timeout, struct k_sem *wifi_scan_ready)
 #if defined(CONFIG_LOCATION_METHOD_WIFI_NET_IF_UPDOWN)
 	ret = scan_wifi_startup_interface(wifi_iface);
 	if (ret) {
+		k_sem_give(scan_wifi_ready);
+		scan_wifi_ready = NULL;
 		return;
 	}
 #endif /* defined(CONFIG_LOCATION_METHOD_WIFI_NET_IF_UPDOWN) */
@@ -203,7 +205,7 @@ void scan_wifi_net_mgmt_event_handler(
 int scan_wifi_cancel(void)
 {
 	if (scan_wifi_ready != NULL) {
-		k_sem_reset(scan_wifi_ready);
+		k_sem_give(scan_wifi_ready);
 		scan_wifi_ready = NULL;
 	}
 	return 0;


### PR DESCRIPTION
If location is cancelled during Wi-Fi search, the semaphore
blocking the location positioning workqueue is not released due to
k_sem_reset() being used instead of k_sem_give(). This prevents
subsequent location requests to start Wi-Fi scans.
This commit changes k_sem_reset() to k_sem_give() and adds a test
for this scenario.

LRCS-343