### PR TITLE
nrf_security: remove `CONFIG_PSA_ITS_ENCRYPTED`

### DIFF
--- a/doc/nrf/security/psa_certified_api_overview.rst
+++ b/doc/nrf/security/psa_certified_api_overview.rst
@@ -217,7 +217,7 @@ The following table provides an overview over features in Internal Trusted Stora
    * The PSA Crypto API is invoked by other APIs that are available from the NSPE.
      For example the PSA Protected Storage API or the PSA Crypto API ``import()`` and ``generate()``.
 
-   * Internal Trusted Storage has experimental support for encryption with the :kconfig:option:`CONFIG_PSA_ITS_ENCRYPTED` Kconfig option set.
+   * Internal Trusted Storage has experimental support for encryption with the :kconfig:option:`CONFIG_TFM_ITS_ENCRYPTED` Kconfig option.
 
 PSA Secure Storage API in Nordic hardware and the |NCS|
 =======================================================

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -227,7 +227,6 @@ config TFM_ITS_ENCRYPTED
 	depends on !CRACEN_NEED_MULTIPART_WORKAROUNDS
 	default y if SOC_SERIES_NRF54LX
 	select PSA_WANT_ALG_CHACHA20_POLY1305 if SOC_SERIES_NRF54LX
-	select PSA_ITS_ENCRYPTED
 	select PSA_WANT_GENERATE_RANDOM
 	help
 	  Enables authenticated encryption for PSA Internal Trusted Storage files

--- a/subsys/nrf_security/Kconfig.psa
+++ b/subsys/nrf_security/Kconfig.psa
@@ -98,12 +98,6 @@ config MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE
 	  to set here. The applications need to increase this buffer size in accordance
 	  with the enabled key types and sizes.
 
-config PSA_ITS_ENCRYPTED
-	bool
-	depends on MBEDTLS_PSA_CRYPTO_STORAGE_C
-	help
-	  Enables authenticated encryption for PSA Internal Trusted Storage files
-
 config PSA_CRYPTO_SYS_INIT
 	bool "Invoke psa_crypto_init during system initialization"
 	default y

--- a/subsys/nrf_security/cmake/config_to_tf-m.cmake
+++ b/subsys/nrf_security/cmake/config_to_tf-m.cmake
@@ -20,7 +20,7 @@ set_property(TARGET zephyr_property_target
   PROPERTY TFM_MBEDCRYPTO_PATH ${CMAKE_CURRENT_LIST_DIR}/../tfm
 )
 
-if(CONFIG_PSA_ITS_ENCRYPTED)
+if(CONFIG_TFM_ITS_ENCRYPTED)
   set_property(TARGET zephyr_property_target
     APPEND PROPERTY TFM_CMAKE_OPTIONS
       -DITS_ENCRYPTION=1


### PR DESCRIPTION
`CONFIG_TFM_ITS_ENCRYPTED` is the one that matters here, and this is only about TF-M.
Get rid of this confusing Kconfig option.