### PR TITLE
scrips: add location value which is compatible with ironside SDFW

### DIFF
--- a/scripts/generate_psa_key_attributes.py
+++ b/scripts/generate_psa_key_attributes.py
@@ -117,8 +117,16 @@ class PsaKeyPersistence(IntEnum):
 class PsaKeyLocation(IntEnum):
     """Location for storing key"""
 
+    # LOCATION_CRACEN should be used if the key is stored on a nRF54H device with SUIT based secure
+    # domain firmware
     LOCATION_CRACEN = 0x804E0000
+
+    # LOCATION_CRACEN_KMU should be used if the key is stored on a nRF54L device
     LOCATION_CRACEN_KMU = 0x804E4B00
+
+    # LOCATION_LOCAL_STORAGE should be used if the key is stored on a nRF54H device with IronSide based
+    # secure domain firmware
+    LOCATION_LOCAL_STORAGE = 0x00000000
 
 
 class PsaAlgorithm(IntEnum):


### PR DESCRIPTION
Ironside SDFW is not compatible with any of the current location arguments that can be used in the generate_psa_key_attributes script. This commit adds a location argument that can be used to create ironside compatible key files.