### PR TITLE
Bluetooth: Mesh: Remove nRF52832 from sensor_client

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -357,6 +357,8 @@ Bluetooth Mesh samples
       Assignments are shifted down one index to accommodate the new polling toggle.
       The descriptor action has been removed from button actions but is still available through mesh shell commands.
 
+  * Removed support for the ``nrf52dk/nrf52832``, since it does not have enough RAM space after NLC support was added.
+
 Bluetooth Fast Pair samples
 ---------------------------
 

--- a/samples/bluetooth/mesh/sensor_client/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_client/sample.yaml
@@ -6,14 +6,12 @@ tests:
     sysbuild: true
     build_only: true
     integration_platforms:
-      - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
     platform_allow:
-      - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -83,12 +83,6 @@
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-31463"
 
 - scenarios:
-    - sample.bluetooth.mesh.sensor_client
-  platforms:
-    - nrf52dk/nrf52832
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-35409"
-
-- scenarios:
     - sample.nrf7002_eb.thingy53.shell
   platforms:
     - thingy53/nrf5340/cpuapp


### PR DESCRIPTION
After the addition of NLC profile support, involving an increase in required RPL RAM usage, and the most recent upmerge adding a few extra bytes, this sample no longer fits in RAM on this platform. Per offline discussions, remove support for this platform.