### PR TITLE
tests: drivers: gpio: add nrf54h20dk_nrf54h20_cpuppr

### DIFF
--- a/tests/drivers/gpio/gpio_more_loops/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/gpio/gpio_more_loops/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/* Test requirements:
+	 * out-gpios[0] wire connected with in-gpios[0],
+	 * out-gpios[1] wire connected with in-gpios[1],
+	 * etc.
+	 * Output-input GPIO pair must have identical active level flag.
+	 */
+	test_gpios {
+		compatible = "gpio-leds";
+		out_gpios: out_gpios {
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>, <&gpio2 8 GPIO_ACTIVE_HIGH>,
+					<&gpio1 2 GPIO_ACTIVE_HIGH>, <&gpio7 2 GPIO_ACTIVE_HIGH>,
+					<&gpio7 6 GPIO_ACTIVE_HIGH>, <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		in_gpios: in_gpios {
+			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>, <&gpio2 9 GPIO_ACTIVE_HIGH>,
+					<&gpio1 3 GPIO_ACTIVE_HIGH>, <&gpio1 0 GPIO_ACTIVE_HIGH>,
+					<&gpio7 7 GPIO_ACTIVE_HIGH>, <&gpio7 1 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpiote130 {
+	status = "okay";
+	owned-channels = <7>;
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio7 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_more_loops/testcase.yaml
+++ b/tests/drivers/gpio/gpio_more_loops/testcase.yaml
@@ -13,6 +13,7 @@ tests:
   drivers.gpio.gpio_more_loops:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpuppr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuflpr
       - nrf54lm20dk/nrf54lm20a/cpuapp

--- a/tests/drivers/gpio/gpio_nfct/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/gpio/gpio_nfct/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/* Test requirements:
+	 * NFC antenna connected to the DK.
+	 */
+	test_gpios {
+		compatible = "gpio-leds";
+		out_gpios: out_gpios {
+			gpios = <&gpio2 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		in_gpios: in_gpios {
+			gpios = <&gpio2 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&nfct {
+	status = "disabled";
+	nfct-pins-as-gpios;
+};
+
+&gpiote130 {
+	status = "okay";
+	owned-channels = <7>;
+};
+
+&gpio2 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_nfct/testcase.yaml
+++ b/tests/drivers/gpio/gpio_nfct/testcase.yaml
@@ -14,6 +14,7 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
+      - nrf54h20dk/nrf54h20/cpuppr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf7120pdk/nrf7120/cpuapp


### PR DESCRIPTION
Enable GPIO tests on nRF54H20 CPUPPR.