### PR TITLE
memfault: Update to 1.30.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -246,7 +246,7 @@ manifest:
       remote: throwtheswitch
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 1.30.0
+      revision: 1.30.1
       remote: memfault
     - name: bsim
       repo-path: bsim_west


### PR DESCRIPTION
Update the Memfault SDK version from 1.30.0 to 1.30.1 .

Release notes:

https://github.com/memfault/memfault-firmware-sdk/releases/tag/1.30.1

Primarily fixes a double fault error on nRF91 + TF-M applications, during certain fault types, when `CONFIG_LOG_MODE_DEFERRED=y`. This error prevents correctly capturing a coredump when the fault occurs.