### PR TITLE
doc: removed outdated 54H datasheet links

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf70/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf70/index.rst
@@ -76,8 +76,7 @@ Zephyr and the |NCS| provide support for developing networking applications with
      - nRF7002 EB
      - PCA20053
      - ``nrf54h20dk/nrf54h20/cpuapp``
-     - | `nRF54H20 Objective Product Specification 0.3.1`_
-       | :ref:`Getting started <ug_nrf54h20_gs>`
+     - :ref:`Getting started with the nRF54H20 DK <ug_nrf54h20_gs>`
    * - :zephyr:board:`nrf54l15dk`
      - nRF7002 EB
      - PCA20053

--- a/doc/nrf/app_dev/device_guides/pmic/npm1300.rst
+++ b/doc/nrf/app_dev/device_guides/pmic/npm1300.rst
@@ -51,8 +51,7 @@ The following boards in the `Zephyr`_ open source project and in the |NCS| are c
      - | ``nrf54h20dk/nrf54h20/cpuapp``
        | ``nrf54h20dk/nrf54h20/cpurad``
        | ``nrf54h20dk/nrf54h20/cpuppr``
-     - | `Objective Product Specification <nRF54H20 Objective Product Specification 0.3.1_>`_
-       | :ref:`Getting started <ug_nrf54h20_gs>`
+     - | :ref:`Getting started with the nRF54H20 DK <ug_nrf54h20_gs>`
    * - :zephyr:board:`nrf54l15dk`
      - nPM1300 EK
      - PCA10156

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1896,8 +1896,6 @@
 .. ### Temp: nRF54H and nRF54L related links, repositories, and documents
 
 .. _`nrf-regtool`: https://github.com/nrfconnect/nrf-regtool/
-.. _`nRF54H20 Objective Product Specification 0.3`: https://res.developer.nordicsemi.com/res/nrf54H20/OPS/nRF54H20_OPS_v0.3.pdf
-.. _`nRF54H20 Objective Product Specification 0.3.1`: https://res.developer.nordicsemi.com/res/nrf54H20/OPS/nRF54H20_OPS_v0.3.1.pdf
 
 .. _`Introduction to nRF54H20`: https://res.developer.nordicsemi.com/res/nrf54H20/intro/Introduction%20to%20nRF54H20%20v1_0_1.pdf
 .. _`nRF54H20 prototype difference`: https://res.developer.nordicsemi.com/res/nrf54H20/other/nRF54H20_proto_diff.pdf


### PR DESCRIPTION
Removed outdated 54H datasheet links.