### PR TITLE
nrf_security: CRACEN: Use HAS_HW_NRF_XXX naming convention

### DIFF
--- a/include/hw_unique_key.h
+++ b/include/hw_unique_key.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 #include <zephyr/devicetree.h>
 
-#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_kmu) || defined(CONFIG_CRACEN_HW_PRESENT)
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_kmu) || defined(CONFIG_HAS_HW_NRF_CRACEN)
 #define HUK_HAS_KMU
 #endif
 #if defined(CONFIG_HAS_HW_NRF_CC310)
@@ -44,7 +44,7 @@ extern "C" {
 #define HUK_SIZE_WORDS 4
 #elif defined(HUK_HAS_CC312)
 #define HUK_SIZE_WORDS 8
-#elif defined(CONFIG_CRACEN_HW_PRESENT)
+#elif defined(CONFIG_HAS_HW_NRF_CRACEN)
 #define HUK_SIZE_WORDS 12
 #else
 #error "This library requires CryptoCell or Cracen to be available."

--- a/include/tfm/tfm_builtin_key_ids.h
+++ b/include/tfm/tfm_builtin_key_ids.h
@@ -9,7 +9,7 @@
 
 #include <nrf.h>
 
-#if defined(NRF_CRACENCORE) || defined(CONFIG_CRACEN_HW_PRESENT)
+#if defined(NRF_CRACENCORE) || defined(CONFIG_HAS_HW_NRF_CRACEN)
 
 #include <cracen_psa_key_ids.h>
 #define TFM_BUILTIN_KEY_LOADER_KEY_LOCATION PSA_KEY_LOCATION_CRACEN

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -65,7 +65,7 @@ config TFM_CRYPTO_BUILTIN_KEYS
 	prompt "TF-M crypto builtin keys"
 	default y
 	depends on !TFM_PROFILE_TYPE_MINIMAL
-	depends on !CRACEN_HW_PRESENT
+	depends on !HAS_HW_NRF_CRACEN
 	select PSA_WANT_ALG_HKDF
 	select PSA_WANT_ALG_HMAC
 	select PSA_WANT_ALG_SHA_256

--- a/modules/trusted-firmware-m/tfm_boards/common/attest_hal.c
+++ b/modules/trusted-firmware-m/tfm_boards/common/attest_hal.c
@@ -24,7 +24,7 @@
 #include <nrf_cc3xx_platform.h>
 #endif
 
-#if defined(CONFIG_CRACEN_HW_PRESENT)
+#if defined(CONFIG_HAS_HW_NRF_CRACEN)
 static bool boot_seed_set;
 static uint8_t boot_seed[BOOT_SEED_SIZE];
 #endif
@@ -126,7 +126,7 @@ enum tfm_plat_err_t tfm_plat_get_boot_seed(uint32_t size, uint8_t *buf)
 	if (nrf_err != NRF_CC3XX_PLATFORM_SUCCESS) {
 		return TFM_PLAT_ERR_SYSTEM_ERR;
 	}
-#elif defined(CONFIG_CRACEN_HW_PRESENT)
+#elif defined(CONFIG_HAS_HW_NRF_CRACEN)
 	if (!boot_seed_set) {
 		psa_status_t psa_err = psa_generate_random(boot_seed, sizeof(boot_seed));
 

--- a/samples/keys/hw_unique_key/src/derive_key_tfm.c
+++ b/samples/keys/hw_unique_key/src/derive_key_tfm.c
@@ -15,7 +15,7 @@
 
 #include "derive_key.h"
 
-#if CONFIG_CRACEN_HW_PRESENT
+#if CONFIG_HAS_HW_NRF_CRACEN
 /* On platforms with Cracen, the HUK is an AES key, suitable for CMAC KDF. */
 #define KDF_ALG	   PSA_ALG_SP800_108_COUNTER_CMAC
 #define INPUT_STEP PSA_KEY_DERIVATION_INPUT_LABEL

--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -59,7 +59,7 @@ if NRF_SECURITY
 
 config MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS
 	bool
-	default y if CRACEN_HW_PRESENT && PSA_CRYPTO_DRIVER_CRACEN
+	default y if HAS_HW_NRF_CRACEN && PSA_CRYPTO_DRIVER_CRACEN
 	default y if PSA_WANT_PLATFORM_KEYS
 	help
 	  Promptless option used to control if the PSA Crypto core should have support for builtin keys or not.

--- a/subsys/nrf_security/src/drivers/Kconfig
+++ b/subsys/nrf_security/src/drivers/Kconfig
@@ -10,7 +10,7 @@ config PSA_CRYPTO_DRIVER_OBERON
 	# The Oberon driver is required to provide HKDF needed for protected storage and bultin keys
 	prompt "Oberon PSA driver" if !(TFM_PARTITION_PROTECTED_STORAGE || TFM_CRYPTO_BUILTIN_KEYS)
 	bool
-	default y if ! CRACEN_HW_PRESENT
+	default y if !HAS_HW_NRF_CRACEN
 	help
 	  This configuration enables the usage of the Oberon PSA driver.
 
@@ -29,7 +29,7 @@ config PSA_CRYPTO_DRIVER_CC3XX
 config PSA_CRYPTO_DRIVER_CRACEN
 	bool "Cracen PSA driver"
 	depends on MBEDTLS_PSA_CRYPTO_C
-	depends on CRACEN_HW_PRESENT
+	depends on HAS_HW_NRF_CRACEN
 	# CRACEN uses the k_event_ API
 	select EVENTS if MULTITHREADING
 	default y

--- a/subsys/nrf_security/src/drivers/cracen/Kconfig
+++ b/subsys/nrf_security/src/drivers/cracen/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-config CRACEN_HW_PRESENT
+config HAS_HW_NRF_CRACEN
 	def_bool (SOC_SERIES_NRF54LX && !SOC_NRF54LS05B) || SOC_SERIES_NRF71X
 
 config CRACEN_HW_VERSION_BASE


### PR DESCRIPTION
The presence of CRACEN HW peripheral now uses the same pattern as others (HAS_HW_NRF_CRACEN).