### PR TITLE
samples: matter: Define device product name for each sample

### DIFF
--- a/applications/matter_bridge/prj.conf
+++ b/applications/matter_bridge/prj.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Bridge"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/bridge.zap"

--- a/applications/matter_bridge/prj_release.conf
+++ b/applications/matter_bridge/prj_release.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Bridge"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/bridge.zap"

--- a/applications/matter_weather_station/prj.conf
+++ b/applications/matter_weather_station/prj.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Weather Station"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/weather-station.zap"

--- a/applications/matter_weather_station/prj_release.conf
+++ b/applications/matter_weather_station/prj_release.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Weather Station"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/weather-station.zap"

--- a/samples/matter/contact_sensor/prj.conf
+++ b/samples/matter/contact_sensor/prj.conf
@@ -7,6 +7,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Contact Sensor"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/contact_sensor.zap"

--- a/samples/matter/contact_sensor/prj_release.conf
+++ b/samples/matter/contact_sensor/prj_release.conf
@@ -7,6 +7,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Contact Sensor"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/contact_sensor.zap"

--- a/samples/matter/light_bulb/prj.conf
+++ b/samples/matter/light_bulb/prj.conf
@@ -7,6 +7,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Light Bulb"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/light_bulb.zap"

--- a/samples/matter/light_bulb/prj_release.conf
+++ b/samples/matter/light_bulb/prj_release.conf
@@ -7,6 +7,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Light Bulb"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/light_bulb.zap"

--- a/samples/matter/light_switch/prj.conf
+++ b/samples/matter/light_switch/prj.conf
@@ -7,6 +7,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Light Switch"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/light_switch.zap"

--- a/samples/matter/light_switch/prj_release.conf
+++ b/samples/matter/light_switch/prj_release.conf
@@ -7,6 +7,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Light Switch"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/light_switch.zap"

--- a/samples/matter/lock/prj.conf
+++ b/samples/matter/lock/prj.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Door Lock"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/lock.zap"

--- a/samples/matter/lock/prj_release.conf
+++ b/samples/matter/lock/prj_release.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Door Lock"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/lock.zap"

--- a/samples/matter/lock/prj_thread_wifi_switched.conf
+++ b/samples/matter/lock/prj_thread_wifi_switched.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Door Lock"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/lock.zap"

--- a/samples/matter/manufacturer_specific/prj.conf
+++ b/samples/matter/manufacturer_specific/prj.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Manufacturer Specific"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/manufacturer_specific.zap"

--- a/samples/matter/smoke_co_alarm/prj.conf
+++ b/samples/matter/smoke_co_alarm/prj.conf
@@ -7,6 +7,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Smoke CO Alarm"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/smoke_co_alarm.zap"

--- a/samples/matter/smoke_co_alarm/prj_release.conf
+++ b/samples/matter/smoke_co_alarm/prj_release.conf
@@ -7,6 +7,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Smoke CO Alarm"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/smoke_co_alarm.zap"

--- a/samples/matter/temperature_sensor/prj.conf
+++ b/samples/matter/temperature_sensor/prj.conf
@@ -7,6 +7,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Temperature Sensor"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/temperature_sensor.zap"

--- a/samples/matter/temperature_sensor/prj_release.conf
+++ b/samples/matter/temperature_sensor/prj_release.conf
@@ -7,6 +7,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Temperature Sensor"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/temperature_sensor.zap"

--- a/samples/matter/template/prj.conf
+++ b/samples/matter/template/prj.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Template"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/template.zap"

--- a/samples/matter/template/prj_release.conf
+++ b/samples/matter/template/prj_release.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Template"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/template.zap"

--- a/samples/matter/thermostat/prj.conf
+++ b/samples/matter/thermostat/prj.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Thermostat"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/thermostat.zap"

--- a/samples/matter/thermostat/prj_release.conf
+++ b/samples/matter/thermostat/prj_release.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Thermostat"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/thermostat.zap"

--- a/samples/matter/window_covering/prj.conf
+++ b/samples/matter/window_covering/prj.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Window Covering"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/window-app.zap"

--- a/samples/matter/window_covering/prj_release.conf
+++ b/samples/matter/window_covering/prj_release.conf
@@ -11,6 +11,7 @@
 # Enable CHIP
 CONFIG_CHIP=y
 CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+CONFIG_CHIP_DEVICE_PRODUCT_NAME="Matter Window Covering"
 
 # Configure ZAP file name
 CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH="${APPLICATION_CONFIG_DIR}/src/default_zap/window-app.zap"


### PR DESCRIPTION
Each sample now contains appropriate product name in the prj.conf file. It can be used to indicate the sample type after flashing.