### PR TITLE
net: nrf_provisioning: Improve error handling

### DIFF
--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
@@ -436,16 +436,16 @@ static int response_code_to_error(int code)
 {
 	switch (code) {
 	case COAP_RESPONSE_CODE_UNAUTHORIZED:
-		LOG_ERR("Device didn't send auth credentials");
+		LOG_ERR("Device not authorized");
 		return -EACCES;
 	case COAP_RESPONSE_CODE_FORBIDDEN:
 		LOG_ERR("Device provided wrong auth credentials");
-		return -EACCES;
+		return -EPERM;
 	case COAP_RESPONSE_CODE_BAD_REQUEST:
 		LOG_ERR("Bad request");
 		return -EINVAL;
 	case COAP_RESPONSE_CODE_NOT_ACCEPTABLE:
-		LOG_ERR("Not acceptable");
+		LOG_ERR("Invalid Accept Headers");
 		return -EINVAL;
 	case COAP_RESPONSE_CODE_NOT_FOUND:
 		LOG_ERR("Resource not found");

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
@@ -309,11 +309,11 @@ static int status_code_to_error(int status_code)
 		LOG_ERR("Bad request");
 		return -EINVAL;
 	case NRF_PROVISIONING_HTTP_STATUS_UNAUTH:
-		LOG_ERR("Device didn't send auth credentials");
+		LOG_ERR("Device not authorized");
 		return -EACCES;
 	case NRF_PROVISIONING_HTTP_STATUS_FORBIDDEN:
 		LOG_ERR("Device provided wrong auth credentials");
-		return -EACCES;
+		return -EPERM;
 	case NRF_PROVISIONING_HTTP_STATUS_UNS_MEDIA_TYPE:
 		LOG_ERR("Unsupported content format");
 		return -ENOMSG;

--- a/tests/subsys/net/lib/nrf_provisioning/src/coap.c
+++ b/tests/subsys/net/lib/nrf_provisioning/src/coap.c
@@ -484,7 +484,7 @@ void test_coap_auth_failed(void)
 
 	int ret = nrf_provisioning_coap_req(&coap_ctx);
 
-	TEST_ASSERT_EQUAL_INT(-EACCES, ret);
+	TEST_ASSERT_EQUAL_INT(-EPERM, ret);
 }
 
 /*

--- a/tests/subsys/net/lib/nrf_provisioning/src/scheduled.c
+++ b/tests/subsys/net/lib/nrf_provisioning/src/scheduled.c
@@ -168,7 +168,7 @@ static int rest_client_request_not_found_cb(struct rest_client_req_context *req_
 					     struct rest_client_resp_context *resp_ctx,
 					     int cmock_num_calls)
 {
-	resp_ctx->http_status_code = NRF_PROVISIONING_HTTP_STATUS_FORBIDDEN;
+	resp_ctx->http_status_code = NRF_PROVISIONING_HTTP_STATUS_UNAUTH;
 	return 0;
 }
 
@@ -265,7 +265,7 @@ void test_provisioning_init_should_start_provisioning(void)
 		wait_for_provisioning_event(NRF_PROVISIONING_EVENT_START);
 
 		/* Test different scenarios in rotation */
-		int scenario = i % 6;
+		int scenario = i % 7;
 
 		switch (scenario) {
 		case 0: /* No commands from server */


### PR DESCRIPTION
Distinguish error responses for 401 and 403 status codes

Previously, both 401 (Unauthorized) and 403 (Forbidden) status codes returned the same error.