### PR TITLE
applications: nrf_desktop: nrf54h20dk: use MCUboot custom code for PM

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/mcuboot/prj.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/mcuboot/prj.conf
@@ -14,12 +14,13 @@ CONFIG_BOOT_VERSION_CMP_USE_BUILD_NUMBER=y
 CONFIG_FLASH=y
 # CONFIG_FPROTECT is not supported yet on the nRF54H20 SoC
 
-# Configure Zephyr system power management
-# The Zephyr system power management is used by the MCUboot bootloader to detect wake-up from
-# S2RAM and redirect execution to the resume routine of the application image
+# Configure support for resuming the application execution after suspend to RAM (S2RAM)
+# that is requested by the application. MCUboot does not support S2RAM itself, but serves
+# as an immediate actor while waking up from suspension.
 CONFIG_PM=y
 CONFIG_PM_S2RAM=y
 CONFIG_PM_S2RAM_CUSTOM_MARKING=y
+CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE=y
 
 # Disable device power management as it is not used by the bootloader
 CONFIG_PM_DEVICE=n

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/mcuboot/prj_dongle.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/mcuboot/prj_dongle.conf
@@ -14,12 +14,13 @@ CONFIG_BOOT_VERSION_CMP_USE_BUILD_NUMBER=y
 CONFIG_FLASH=y
 # CONFIG_FPROTECT is not supported yet on the nRF54H20 SoC
 
-# Configure Zephyr system power management
-# The Zephyr system power management is used by the MCUboot bootloader to detect wake-up from
-# S2RAM and redirect execution to the resume routine of the application image
+# Configure support for resuming the application execution after suspend to RAM (S2RAM)
+# that is requested by the application. MCUboot does not support S2RAM itself, but serves
+# as an immediate actor while waking up from suspension.
 CONFIG_PM=y
 CONFIG_PM_S2RAM=y
 CONFIG_PM_S2RAM_CUSTOM_MARKING=y
+CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE=y
 
 # Disable device power management as it is not used by the bootloader
 CONFIG_PM_DEVICE=n

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/mcuboot/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/mcuboot/prj_release.conf
@@ -16,12 +16,13 @@ CONFIG_FLASH=y
 
 CONFIG_RESET_ON_FATAL_ERROR=y
 
-# Configure Zephyr system power management
-# The Zephyr system power management is used by the MCUboot bootloader to detect wake-up from
-# S2RAM and redirect execution to the resume routine of the application image
+# Configure support for resuming the application execution after suspend to RAM (S2RAM)
+# that is requested by the application. MCUboot does not support S2RAM itself, but serves
+# as an immediate actor while waking up from suspension.
 CONFIG_PM=y
 CONFIG_PM_S2RAM=y
 CONFIG_PM_S2RAM_CUSTOM_MARKING=y
+CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE=y
 
 # Disable device power management as it is not used by the bootloader
 CONFIG_PM_DEVICE=n

--- a/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/mcuboot/prj_release_dongle.conf
+++ b/applications/nrf_desktop/configuration/nrf54h20dk_nrf54h20_cpuapp/images/mcuboot/prj_release_dongle.conf
@@ -16,12 +16,13 @@ CONFIG_FLASH=y
 
 CONFIG_RESET_ON_FATAL_ERROR=y
 
-# Configure Zephyr system power management
-# The Zephyr system power management is used by the MCUboot bootloader to detect wake-up from
-# S2RAM and redirect execution to the resume routine of the application image
+# Configure support for resuming the application execution after suspend to RAM (S2RAM)
+# that is requested by the application. MCUboot does not support S2RAM itself, but serves
+# as an immediate actor while waking up from suspension.
 CONFIG_PM=y
 CONFIG_PM_S2RAM=y
 CONFIG_PM_S2RAM_CUSTOM_MARKING=y
+CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE=y
 
 # Disable device power management as it is not used by the bootloader
 CONFIG_PM_DEVICE=n


### PR DESCRIPTION
Enabled the CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE Kconfig option in the MCUboot image configuration for the nRF54H20 DK target. This change is aligned with the general direction of the MCUboot-based DFU solution for the nRF54H20 SoC. It limits the bootloader reponsibility for the wake-up from the Suspend To RAM (S2RAM) state to the bare minimum and allows more flexibility when it comes to future improvements for the power management system. These improvements can be easily updated with the DFU in the application image. On the other hand, the PM code cannot be changed in the MCUboot image in the most common case where the MCUboot is set up as an immutable bootloader.

Ref: NCSDK-35408