### PR TITLE
cmake: Support manifest for non-partition-manager

### DIFF
--- a/cmake/sysbuild/bootloader_dts_utils.cmake
+++ b/cmake/sysbuild/bootloader_dts_utils.cmake
@@ -19,6 +19,6 @@ function(get_address_from_dt_partition_nodelabel label address)
 
   dt_reg_addr(flash_area_addr TARGET ${DEFAULT_IMAGE} PATH ${flash_area_node})
 
-  math(EXPR ${address} "${flash_area_addr} + ${partition_offset}")
+  math(EXPR ${address} "${flash_area_addr} + ${partition_offset}" OUTPUT_FORMAT HEXADECIMAL)
   set(${address} ${${address}} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
nRF54H20 does not use partition manager, only Zephyr device tree fixed partitions. This causes a very niche issue when attempting to use the DFU zip payload with nRF Connect Device Manager mobile apps- the manifest contained in the DFU archive fails to parse, due to the subimage offset being a string instead of a JSON number:

```json
❯ cat build/dfu_application.zip_manifest.json
{
    "format-version": 1,
    "time": 1759849455,
    "files": [
        {
            "type": "application",
            "board": "nrf54h20dk",
            "soc": "nrf54h20",
            "load_address": "235143168",  <- string, not number
            "image_index": "0",
            "slot_index_primary": "1",
            "slot_index_secondary": "2",
            "version_MCUBOOT": "0.0.0+0",
            "size": 208100,
            "file": "peripheral_mds.signed.bin",
            "modtime": 1759849455
        },
```

Adjust the value extracted from DT in the case where partition manager is not used, when generating the DFU zip artifact, so it correctly produces a number for the field in question.

```json
❯ cat build/dfu_application.zip_manifest.json
{
    "format-version": 1,
    "time": 1759845147,
    "files": [
        {
            "type": "application",
            "board": "nrf54h20dk",
            "soc": "nrf54h20",
            "load_address": 235143168,  <- number, not string 🎉
            "image_index": "0",
            "slot_index_primary": "1",
            "slot_index_secondary": "2",
            "version_MCUBOOT": "0.0.0+0",
            "size": 220164,
            "file": "peripheral_mds.signed.bin",
            "modtime": 1759845134
        },
```

Note that I'm only solving the immediate issue- there are other fields in the manifest that look like numbers, but are strings, and in order to not cause unintended side-effects, I'm only fixing the known problem.