### PR TITLE
manifest: sdk-mcu-drivers update for Kconfig compliance

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -212,7 +212,7 @@ manifest:
     - name: cirrus
       repo-path: sdk-mcu-drivers
       path: modules/hal/cirrus-logic
-      revision: 3873a08377d93a479105a75ac390d3bbcd31d690
+      revision: 1c837bcc27de9ccc06b020b9500e1547e559a1df
       userdata:
         ncs:
           upstream-url: https://github.com/CirrusLogic/mcu-drivers


### PR DESCRIPTION
NCSDK-35792. Manifest update for sdk-mcu-drivers.
Changed wording for Kconfig compliance.