### PR TITLE
lib: at_parser: Fix handling of unquoted strings

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -755,6 +755,10 @@ Modem libraries
 
   * Removed the deprecated ``CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART_ZEPHYR`` kconfig option.
 
+* :ref:`at_parser_readme` library:
+
+  * Fixed an issue where an unquoted string parameter in the middle of a response would not be parsed correctly.
+
 * :ref:`pdn_readme` library:
 
   * Fixed:

--- a/lib/at_parser/at_match.re
+++ b/lib/at_parser/at_match.re
@@ -177,18 +177,22 @@ struct at_token at_match_str(const char *at, const char **remainder)
 
 	SPACE = " ";
 	CRLF = "\r\n";
+	TERM = ","|CRLF;
 	STR = [A-Za-z0-9][A-Za-z_\-+.0-9 ]*;
 
-	str         = SPACE? @t1 STR @t2 CRLF?;
+	str         = SPACE? @t1 STR @t2 TERM?;
 
 	*           { return (struct at_token){ .type = AT_TOKEN_TYPE_INVALID }; }
 
 	str
 	{
-		if (remainder) *remainder = t2;
+		char last = *(cursor - 1);
+
+		if (remainder) *remainder = cursor;
 		return (struct at_token){
 			.start = t1, .len = t2 - t1,
 			.type = AT_TOKEN_TYPE_STRING,
+			.var = last == ',' ? AT_TOKEN_VAR_COMMA : AT_TOKEN_VAR_NO_COMMA,
 		};
 	}
 */

--- a/lib/at_parser/generated/at_match.c
+++ b/lib/at_parser/generated/at_match.c
@@ -871,6 +871,9 @@ yy45:
 		case 'x':
 		case 'y':
 		case 'z': goto yy45;
+		case ',':
+			yyt2 = cursor;
+			goto yy49;
 		default:
 			yyt2 = cursor;
 			goto yy46;
@@ -879,10 +882,13 @@ yy46:
 	t1 = yyt1;
 	t2 = yyt2;
 	{
-		if (remainder) *remainder = t2;
+		char last = *(cursor - 1);
+
+		if (remainder) *remainder = cursor;
 		return (struct at_token){
 			.start = t1, .len = t2 - t1,
 			.type = AT_TOKEN_TYPE_STRING,
+			.var = last == ',' ? AT_TOKEN_VAR_COMMA : AT_TOKEN_VAR_NO_COMMA,
 		};
 	}
 yy47:

--- a/tests/lib/at_parser/src/main.c
+++ b/tests/lib/at_parser/src/main.c
@@ -168,6 +168,108 @@ ZTEST(at_parser, test_at_parser_quoted_string)
 	zassert_mem_equal("FOOBAR", buffer, buffer_len);
 }
 
+ZTEST(at_parser, test_unquoted_string)
+{
+	int ret;
+	struct at_parser parser;
+	char buffer[32];
+	uint32_t buffer_len;
+	int32_t num;
+
+	const char *str1 = "+TEST:1,AB\r\n";
+	const char *str2 = "%TEST:1,C\r\n";
+	const char *str3 = "+TEST:1,DE,2\r\n";
+	const char *str4 = "#TEST:1,F,2\r\n";
+
+	/* Unquoted string at the end of the parameters (str1) */
+	ret = at_parser_init(&parser, str1);
+	zassert_ok(ret);
+
+	buffer_len = sizeof(buffer);
+	ret = at_parser_string_get(&parser, 0, buffer, &buffer_len);
+	zassert_ok(ret);
+	zassert_equal(strlen("+TEST"), buffer_len);
+	zassert_mem_equal("+TEST", buffer, buffer_len);
+
+	ret = at_parser_num_get(&parser, 1, &num);
+	zassert_ok(ret);
+	zassert_equal(num, 1);
+
+	buffer_len = sizeof(buffer);
+	ret = at_parser_string_get(&parser, 2, buffer, &buffer_len);
+	zassert_ok(ret);
+	zassert_equal(strlen("AB"), buffer_len);
+	zassert_mem_equal("AB", buffer, buffer_len);
+
+	/* Unquoted single character string at the end of the parameters (str2) */
+	ret = at_parser_init(&parser, str2);
+	zassert_ok(ret);
+
+	buffer_len = sizeof(buffer);
+	ret = at_parser_string_get(&parser, 0, buffer, &buffer_len);
+	zassert_ok(ret);
+	zassert_equal(strlen("%TEST"), buffer_len);
+	zassert_mem_equal("%TEST", buffer, buffer_len);
+
+	ret = at_parser_num_get(&parser, 1, &num);
+	zassert_ok(ret);
+	zassert_equal(num, 1);
+
+	buffer_len = sizeof(buffer);
+	ret = at_parser_string_get(&parser, 2, buffer, &buffer_len);
+	zassert_ok(ret);
+	zassert_equal(strlen("C"), buffer_len);
+	zassert_mem_equal("C", buffer, buffer_len);
+
+	/* Unquoted string between parameters (str3) */
+	ret = at_parser_init(&parser, str3);
+	zassert_ok(ret);
+
+	buffer_len = sizeof(buffer);
+	ret = at_parser_string_get(&parser, 0, buffer, &buffer_len);
+	zassert_ok(ret);
+	zassert_equal(strlen("+TEST"), buffer_len);
+	zassert_mem_equal("+TEST", buffer, buffer_len);
+
+	ret = at_parser_num_get(&parser, 1, &num);
+	zassert_ok(ret);
+	zassert_equal(num, 1);
+
+	buffer_len = sizeof(buffer);
+	ret = at_parser_string_get(&parser, 2, buffer, &buffer_len);
+	zassert_ok(ret);
+	zassert_equal(strlen("DE"), buffer_len);
+	zassert_mem_equal("DE", buffer, buffer_len);
+
+	ret = at_parser_num_get(&parser, 3, &num);
+	zassert_ok(ret);
+	zassert_equal(num, 2);
+
+	/* Unquoted single character string between parameters (str4) */
+	ret = at_parser_init(&parser, str4);
+	zassert_ok(ret);
+
+	buffer_len = sizeof(buffer);
+	ret = at_parser_string_get(&parser, 0, buffer, &buffer_len);
+	zassert_ok(ret);
+	zassert_equal(strlen("#TEST"), buffer_len);
+	zassert_mem_equal("#TEST", buffer, buffer_len);
+
+	ret = at_parser_num_get(&parser, 1, &num);
+	zassert_ok(ret);
+	zassert_equal(num, 1);
+
+	buffer_len = sizeof(buffer);
+	ret = at_parser_string_get(&parser, 2, buffer, &buffer_len);
+	zassert_ok(ret);
+	zassert_equal(strlen("F"), buffer_len);
+	zassert_mem_equal("F", buffer, buffer_len);
+
+	ret = at_parser_num_get(&parser, 3, &num);
+	zassert_ok(ret);
+	zassert_equal(num, 2);
+}
+
 ZTEST(at_parser, test_at_parser_empty)
 {
 	int ret;


### PR DESCRIPTION
Unquoted strings in the middle of a response were not handled properly,
fix this and add some unit tests.