### PR TITLE
nrf_security: cracen: Fix identity key personalization

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/key_management.c
@@ -671,7 +671,8 @@ static psa_status_t handle_identity_key(const uint8_t *key_buffer, size_t key_bu
 
 	if (IS_ENABLED(PSA_NEED_CRACEN_ECDSA_SECP_R1_256)) {
 		data[0] = CRACEN_ECC_PUBKEY_UNCOMPRESSED;
-		return silex_statuscodes_to_psa(cracen_ikg_create_pub_key(key_buffer[0], data + 1));
+		return silex_statuscodes_to_psa(cracen_ikg_create_pub_key(
+			((const ikg_opaque_key *)key_buffer)->owner_id, data + 1));
 	}
 	return PSA_ERROR_NOT_SUPPORTED;
 }

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/sign.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/sign.c
@@ -105,7 +105,8 @@ cracen_signature_prepare_ec_pubkey(const uint8_t *key_buffer, size_t key_buffer_
 			if (key_buffer_size != sizeof(ikg_opaque_key)) {
 				return PSA_ERROR_INVALID_ARGUMENT;
 			}
-			sx_status = cracen_ikg_create_pub_key(key_buffer[0], pubkey_buffer);
+			sx_status = cracen_ikg_create_pub_key(
+				((const ikg_opaque_key *)key_buffer)->owner_id, pubkey_buffer);
 		}
 		return silex_statuscodes_to_psa(sx_status);
 	}
@@ -226,11 +227,13 @@ static psa_status_t handle_ikg_sign(bool is_message, const uint8_t *key_buffer,
 	status = hash_get_algo(alg, &hashalgpointer);
 	*signature_length = 2 * ecurve->sz;
 	if (is_message) {
-		status = cracen_ikg_sign_message(key_buffer[0], hashalgpointer, ecurve, input,
-						 input_length, signature);
+		status = cracen_ikg_sign_message(((const ikg_opaque_key *)key_buffer)->owner_id,
+						 hashalgpointer, ecurve, input, input_length,
+						 signature);
 	} else {
-		status = cracen_ikg_sign_digest(key_buffer[0], hashalgpointer, ecurve, input,
-						input_length, signature);
+		status = cracen_ikg_sign_digest(((const ikg_opaque_key *)key_buffer)->owner_id,
+						hashalgpointer, ecurve, input, input_length,
+						signature);
 	}
 	return silex_statuscodes_to_psa(status);
 }


### PR DESCRIPTION
This fixes an old regression introduced by this commit:

(1) 166d9eb182289281c608aafed93ce148b297725e

which managed to undo some changes from here:

(2) a013ce7bd7811cbc9989e505b4da2e6aa7e61dbf

This seems to be unintentional, likely a result of a rebasing mistake, because the PR containing (1) was opened before the PR containing (2), but the second one was merged first.

The fix entails changing the `identity_key_index` argument to existing function calls from `ikg_signature.c`. Note: this argument only has an effect when CONFIG_CRACEN_IKG_PERSONALIZED_KEYS=y.

The argument value will now be `owner_id`, from the second byte of the opaque key buffer, rather than the first byte, which is `slot_number`.

It doesn't make sense to use `slot_number` anymore, because this field is not populated for CRACEN_BUILTIN_IDENTITY_KEY_ID in the first place (see `cracen_set_ikg_key_buffer()`), which means that its value is a constant zero. It used to be an explicit zero prior to this refactor:

(3) a8918df9ee256dab98a4bedc94316c041f455855

Ref: NRFX-8427