### PR TITLE
samples: dfu_multi_image: Adjust nRF53 partition sizes

### DIFF
--- a/samples/dfu/dfu_multi_image/pm_static_nrf5340dk_nrf5340_cpuapp.yml
+++ b/samples/dfu/dfu_multi_image/pm_static_nrf5340dk_nrf5340_cpuapp.yml
@@ -1,34 +1,34 @@
 mcuboot:
   address: 0x0
   region: flash_primary
-  size: 0xc000
+  size: 0xd000
 mcuboot_pad:
-  address: 0xc000
+  address: 0xd000
   region: flash_primary
   size: 0x200
 app:
-  address: 0xc200
+  address: 0xd200
   region: flash_primary
-  size: 0x35e00
+  size: 0x35600
 mcuboot_primary:
-  address: 0xc000
+  address: 0xd000
   orig_span: &id001
   - mcuboot_pad
   - app
   region: flash_primary
-  size: 0x36000
+  size: 0x35800
   span: *id001
 mcuboot_primary_app:
-  address: 0xc200
+  address: 0xd200
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0x35e00
+  size: 0x35600
   span: *id002
 mcuboot_secondary:
-  address: 0x42000
+  address: 0x42800
   region: flash_primary
-  size: 0x36000
+  size: 0x35800
 mcuboot_secondary_1:
   address: 0x78000
   region: flash_primary


### PR DESCRIPTION
The current partition sizes resulted in an overflow for the encryption configuration.
This is a result of natural size code increase; the configuration was already at its limits, so no disabling of unneed configuration would help here.