### PR TITLE
sample: dfu_multi_image: Fix pm_static for nrf5340

### DIFF
--- a/samples/dfu/dfu_multi_image/pm_static_nrf5340dk_nrf5340_cpuapp.yml
+++ b/samples/dfu/dfu_multi_image/pm_static_nrf5340dk_nrf5340_cpuapp.yml
@@ -1,34 +1,34 @@
 mcuboot:
   address: 0x0
   region: flash_primary
-  size: 0xd000
+  size: 0x10000
 mcuboot_pad:
-  address: 0xd000
+  address: 0x10000
   region: flash_primary
   size: 0x200
 app:
-  address: 0xd200
+  address: 0x10200
   region: flash_primary
-  size: 0x35600
+  size: 0x33e00
 mcuboot_primary:
-  address: 0xd000
+  address: 0x10000
   orig_span: &id001
   - mcuboot_pad
   - app
   region: flash_primary
-  size: 0x35800
+  size: 0x34000
   span: *id001
 mcuboot_primary_app:
-  address: 0xd200
+  address: 0x10200
   orig_span: &id002
   - app
   region: flash_primary
-  size: 0x35600
+  size: 0x33e00
   span: *id002
 mcuboot_secondary:
-  address: 0x42800
+  address: 0x44000
   region: flash_primary
-  size: 0x35800
+  size: 0x34000
 mcuboot_secondary_1:
   address: 0x78000
   region: flash_primary


### PR DESCRIPTION
The sample was building but wasn't functional due
to previous mistake.