### PR TITLE
hids: Propagate errors in output and feature report handlers

### DIFF
--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -182,10 +182,13 @@ typedef void (*bt_hids_notify_ext_handler_t) (uint8_t report_id, enum bt_hids_no
  * @param rep	Pointer to the report descriptor.
  * @param conn	Pointer to Connection Object.
  * @param write	@c true if handler is called for report write.
+ *
+ * @return 0 If the operation was successful. Otherwise, a (negative) error
+ *	     code is returned.
  */
-typedef void (*bt_hids_rep_handler_t) (struct bt_hids_rep *rep,
-				       struct bt_conn *conn,
-				       bool write);
+typedef int (*bt_hids_rep_handler_t) (struct bt_hids_rep *rep,
+				      struct bt_conn *conn,
+				      bool write);
 
 /** @brief Input Report.
  */

--- a/subsys/bluetooth/services/hids.c
+++ b/subsys/bluetooth/services/hids.c
@@ -291,7 +291,9 @@ static ssize_t hids_outp_rep_read(struct bt_conn *conn,
 		    .data = buf,
 		    .size = rep->size,
 		};
-		rep->handler(&report, conn, false);
+
+		if (rep->handler(&report, conn, false) < 0)
+			ret_len = BT_GATT_ERR(BT_ATT_ERR_INVALID_PDU);
 	}
 
 	bt_conn_ctx_release(hids->conn_ctx, (void *)conn_data);
@@ -336,7 +338,9 @@ static ssize_t hids_outp_rep_write(struct bt_conn *conn,
 		    .data = rep_data,
 		    .size = rep->size,
 		};
-		rep->handler(&report, conn, true);
+
+		if (rep->handler(&report, conn, true) < 0)
+			ret = BT_GATT_ERR(BT_ATT_ERR_INVALID_PDU);
 	}
 release_ctx:
 	bt_conn_ctx_release(hids->conn_ctx, (void *)conn_data);
@@ -392,7 +396,9 @@ static ssize_t hids_feat_rep_read(struct bt_conn *conn,
 		    .data = buf,
 		    .size = rep->size,
 		};
-		rep->handler(&report, conn, false);
+		if (rep->handler(&report, conn, false) < 0)
+			ret_len = BT_GATT_ERR(BT_ATT_ERR_INVALID_PDU);
+
 	}
 
 	bt_conn_ctx_release(hids->conn_ctx, (void *)conn_data);
@@ -443,7 +449,9 @@ static ssize_t hids_feat_rep_write(struct bt_conn *conn,
 		    .data = rep_data,
 		    .size = rep->size,
 		};
-		rep->handler(&report, conn, true);
+
+		if (rep->handler(&report, conn, true) < 0)
+			ret = BT_GATT_ERR(BT_ATT_ERR_INVALID_PDU);
 	}
 release_ctx:
 	bt_conn_ctx_release(hids->conn_ctx, (void *)conn_data);


### PR DESCRIPTION
Custom feature reports are often (ab)used in custom HID devices to implement arbitrary command/response handling and as such often require an ability to reject a given payload and signal an error condition. USB HID implementation in Zephyr allows that, so implement a similar capability in HIDS to match.