### PR TITLE
tests: app_jwt: Update expected JWT

### DIFF
--- a/tests/lib/app_jwt/src/main.c
+++ b/tests/lib/app_jwt/src/main.c
@@ -32,20 +32,20 @@ static psa_key_id_t kid;
 #define EXPECTED_JWT_MIN                                                                           \
 	"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9."                                                    \
 	"eyJzdWIiOiJucmYtMzU4Mjk5ODQwMTIzNDU2IiwiZXhwIjoxNzM5ODgxODg5fQ."                          \
-	"OG3Ug9iPJmKYoV5AbhlVuxXxRloNL80QsJmBexR40f5BVISYg4FjXc8FdVnCLMaRlMGTKRd5cFaST4_DB21Vkw"
+	"duytcUdESlbKf6OnpTl683GcX0rPuxF2WRn9bHJsfyEbi9UEnx9m9t1JJfCHwshvSce8Sy_0BiTS6xqOEtOWRg"
 
 #define EXPECTED_JWT_MIN_UUID                                                                      \
 	"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9."                                                    \
 	"eyJzdWIiOiI2YzBmMTIyNi1mNTA2LTExZWYtYTViYi05Mzc2M2I0YmRmMTEiLCJleHAiOjE3Mzk4ODE4ODl9."    \
-	"je3nWh-f5IaBsypVQReXZY1z10gYAwyfFckhkXDAJOK8bDpdS3UVNRpN5eBBGph-RVEgqZG5RhRLD8gENa7a0w"
+	"4JrHsAPnqzYoLnnhHroJx8B8ui8uoSpzyV6hJjQhcDPcFyRa6JlI5lRPnCnzczhvlIQGwOzjxA-S1D7en3--XQ"
 
 #define EXPECTED_JWT_NRF91                                                                         \
 	"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJhNTNkMjBmODcxYjFkZWVhYjUzYTFiZmNlMDJhZTVk" \
 	"NWVmYzEyZjFlMGY0YjVjZTY2YzRhMWMyOGRhZDExMmMifQ."                                          \
 	"eyJpYXQiOjE3Mzk4ODEyODksImp0aSI6Im5SRjkxNjAuNTY0YWIzNTYtZjUwNS0xMWVmLWIyODctYjc2OTAyMWQ1" \
 	"ZmQ2LjlmZjE3NTI0OWFmZTQ4OTQxMiIsImlzcyI6Im5SRjkxNjAuNTY0YWIzNTYtZjUwNS0xMWVmLWIyODctYjc2" \
-	"OTAyMWQ1ZmQ2Iiwic3ViIjoibnJmLTM1ODI5OTg0MDEyMzQ1NiIsImV4cCI6MTczOTg4MTg4OX0.YhaArF-_"     \
-	"7NNOd4ngnTT_KCQCcNfarxDlDuRvsSbE_RX_r5HC1nXduc4KDjc-7FJ9NUaKNcPAHg3BwJ7kOZ3NAQ"
+	"OTAyMWQ1ZmQ2Iiwic3ViIjoibnJmLTM1ODI5OTg0MDEyMzQ1NiIsImV4cCI6MTczOTg4MTg4OX0."             \
+	"icQWyXMrqInwmDOnycuJ3mCre7T32RPWxFCM95iL9Y_dZTZGpODiopaTfGuu8KwSvTu32Wbmwsxiw-x2szcAfQ"
 
 #define EC_PRV_KEY                                                                                 \
 	"-----BEGIN PRIVATE KEY-----\n"                                                            \


### PR DESCRIPTION
This fixes a `native_sim` testcase that has been broken on main since: 006def8fe4eb91ca33426e5eae561090b1cfedec

After pulling in Mbed TLS 3.6.5, the expected outputs had changed again. They were last updated in: 395759f09caf7eb07a0410a3e4762715f45f9ea0