### PR TITLE
samples: cellular: modem_shell: Add support for DTLS connection ID

### DIFF
--- a/samples/cellular/modem_shell/src/sock/sock.h
+++ b/samples/cellular/modem_shell/src/sock/sock.h
@@ -27,7 +27,7 @@ int sock_open_and_connect(
 	int family, int type, char *address, int port,
 	int bind_port, int pdn_cid, bool secure, uint32_t sec_tag,
 	bool session_cache, bool keep_open, int peer_verify,
-	char *peer_hostname);
+	char *peer_hostname, int dtls_cid);
 
 int sock_send_data(
 	int socket_id, char *data, int data_length, int interval, bool packet_number_prefix,


### PR DESCRIPTION
Added an option to "sock connect" command for enabling DTLS connection ID support.

Fixed setting socket options `TLS_DTLS_CONN_SAVE` and `TLS_DTLS_CONN_LOAD` using "sock option set". Modem requires that a value is provided for these options.