### PR TITLE
esb: Ensure that ESB is not enabled when GPPI v1 is used

### DIFF
--- a/subsys/esb/Kconfig
+++ b/subsys/esb/Kconfig
@@ -9,6 +9,7 @@ menuconfig ESB
 	select NRFX_GPPI
 	select MPSL
 	select MPSL_FEM_ONLY if !ESB_DYNAMIC_INTERRUPTS && !ESB_MPSL_TIMESLOT
+	depends on !NRFX_GPPI_V1
 	help
 	  Enable ESB functionality.
 


### PR DESCRIPTION
GPPI v1 is a legacy shim that can be used on nrf54h20. ESB requires that is it not enabled. Add Kconfig guard.