### PR TITLE
nrf_security: cracen: Move CM HW management to CRACENPSA layer

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/common/include/cracen/common.h
+++ b/subsys/nrf_security/src/drivers/cracen/common/include/cracen/common.h
@@ -1,4 +1,4 @@
-/*
+	/*
  * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
@@ -142,20 +142,6 @@ int cracen_be_cmp(const uint8_t *a, const uint8_t *b, size_t sz, int carry);
 void cracen_be_xor(uint8_t *buf, size_t buf_sz, size_t xor_val);
 
 /**
- * @brief Hash several elements at different locations in memory
- *
- * @param[in]  inputs			Array of pointers to elements that will be hashed.
- * @param[in]  input_lengths	Array of lengths of elements to be hashed.
- * @param[in]  input_count		Number of elements to be hashed.
- * @param[in]  hashalg			Hash algorithm to be used in sxhashalg format.
- * @param[out] digest			Buffer of at least sx_hash_get_alg_digestsz(hashalg) bytes.
- *
- * @return sxsymcrypt status code.
- */
-int cracen_hash_all_inputs(const uint8_t *inputs[], const size_t input_lengths[],
-			   size_t input_count, const struct sxhashalg *hashalg, uint8_t *digest);
-
-/**
  * @brief Hash several elements at different locations in memory with a previously created hash
  * context(sxhash)
  *
@@ -173,19 +159,6 @@ int cracen_hash_all_inputs_with_context(struct sxhash *sxhashopctx, const uint8_
 					const struct sxhashalg *hashalg, uint8_t *digest);
 
 /**
- * @brief Hash a single element
- *
- * @param[in]  input		Pointer to the element that will be hashed.
- * @param[in]  input_length	Length of the element to be hashed.
- * @param[in]  hashalg		Hash algorithm to be used in sxhashalg format.
- * @param[out] digest		Buffer of at least sx_hash_get_alg_digestsz(hashalg) bytes.
- *
- * @return sxsymcrypt status code.
- */
-int cracen_hash_input(const uint8_t *input, const size_t input_length,
-		      const struct sxhashalg *hashalg, uint8_t *digest);
-
-/**
  * @brief Hash a single element with a previously created hash context(sxhash)
  *
  * @param[in]  hashopctx	Pointer to the sxhash context.
@@ -199,6 +172,45 @@ int cracen_hash_input(const uint8_t *input, const size_t input_length,
 int cracen_hash_input_with_context(struct sxhash *hashopctx, const uint8_t *input,
 				   const size_t input_length, const struct sxhashalg *hashalg,
 				   uint8_t *digest);
+
+/**
+ * @brief Hash several elements, managing hardware reservation internally.
+ *
+ * Convenience wrapper that reserves the cryptomaster hardware, hashes all
+ * inputs using @ref cracen_hash_all_inputs_with_context, and releases the
+ * hardware. Must only be used when a single hardware reservation is needed
+ * for the entire call, do not use if the caller needs to hold the hardware
+ * across multiple operations. This operation should never be used more than once.
+ *
+ * @param inputs[in]		Array of pointers to elements that will be hashed.
+ * @param input_lengths[in]	Array of lengths of elements to be hashed.
+ * @param input_count[in]	Number of elements to be hashed.
+ * @param hashalg[in]		Hash algorithm to be used in sxhashalg format.
+ * @param digest[out]		Buffer of at least sx_hash_get_alg_digestsz(hashalg) bytes.
+ *
+ * @return sxsymcrypt status code.
+ */
+int cracen_hash_all_inputs(const uint8_t *inputs[], const size_t input_lengths[],
+			   size_t input_count, const struct sxhashalg *hashalg, uint8_t *digest);
+
+/**
+ * @brief Hash a single input, managing hardware reservation internally.
+ *
+ * Convenience wrapper that reserves the cryptomaster hardware, hashes the
+ * input using @ref cracen_hash_input_with_context, and releases the hardware.
+ * Must only be used when a single hardware reservation is needed for the
+ * entire call, do not use if the caller needs to hold the hardware across
+ * multiple operations This operation should never be used more than once.
+ *
+ * @param input[in]		Pointer to element that will be hashed.
+ * @param input_length[in]	Length of element to be hashed.
+ * @param hashalg[in]		Hash algorithm to be used in sxhashalg format.
+ * @param digest[out]		Buffer of at least sx_hash_get_alg_digestsz(hashalg) bytes.
+ *
+ * @return sxsymcrypt status code.
+ */
+int cracen_hash_input(const uint8_t *input, const size_t input_length,
+		      const struct sxhashalg *hashalg, uint8_t *digest);
 
 /**
  * @brief Generate a random number within the specified range.

--- a/subsys/nrf_security/src/drivers/cracen/common/src/cracen/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/common/src/cracen/common.c
@@ -433,25 +433,34 @@ int cracen_hash_all_inputs_with_context(struct sxhash *hashopctx, const uint8_t 
 	return status;
 }
 
-int cracen_hash_all_inputs(const uint8_t *inputs[], const size_t input_lengths[],
-			   size_t input_count, const struct sxhashalg *hashalg, uint8_t *digest)
-{
-	struct sxhash hashopctx;
-
-	return cracen_hash_all_inputs_with_context(&hashopctx, inputs, input_lengths, input_count,
-						   hashalg, digest);
-}
-
-int cracen_hash_input(const uint8_t *input, const size_t input_length,
-		      const struct sxhashalg *hashalg, uint8_t *digest)
-{
-	return cracen_hash_all_inputs(&input, &input_length, 1, hashalg, digest);
-}
-
 int cracen_hash_input_with_context(struct sxhash *hashopctx, const uint8_t *input,
 				   const size_t input_length, const struct sxhashalg *hashalg,
 				   uint8_t *digest)
 {
 	return cracen_hash_all_inputs_with_context(hashopctx, &input, &input_length, 1, hashalg,
 						   digest);
+}
+
+int cracen_hash_all_inputs(const uint8_t *inputs[], const size_t input_lengths[],
+			   size_t input_count, const struct sxhashalg *hashalg, uint8_t *digest)
+{
+	struct sxhash hashopctx;
+	int status;
+
+	status = sx_hw_reserve(&hashopctx.dma, SX_HW_RESERVE_DEFAULT);
+	if (status != SX_OK) {
+		return status;
+	}
+
+	status = cracen_hash_all_inputs_with_context(&hashopctx, inputs, input_lengths,
+						     input_count, hashalg, digest);
+	sx_hw_release(&hashopctx.dma);
+
+	return status;
+}
+
+int cracen_hash_input(const uint8_t *input, const size_t input_length,
+		      const struct sxhashalg *hashalg, uint8_t *digest)
+{
+	return cracen_hash_all_inputs(&input, &input_length, 1, hashalg, digest);
 }

--- a/subsys/nrf_security/src/drivers/cracen/common/src/cracen/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/common/src/cracen/common.c
@@ -414,22 +414,20 @@ int cracen_hash_all_inputs_with_context(struct sxhash *hashopctx, const uint8_t 
 
 	status = sx_hash_create(hashopctx, hashalg, sizeof(*hashopctx));
 	if (status != SX_OK) {
-		return status;
+		goto out;
 	}
-
 	for (size_t i = 0; i < input_count; i++) {
 		status = sx_hash_feed(hashopctx, inputs[i], input_lengths[i]);
 		if (status != SX_OK) {
-			return status;
+			goto out;
 		}
 	}
 	status = sx_hash_digest(hashopctx, digest);
 	if (status != SX_OK) {
-		return status;
+		goto out;
 	}
-
 	status = sx_hash_wait(hashopctx);
-
+out:
 	return status;
 }
 

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aead.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aead.c
@@ -33,6 +33,7 @@
 #include <sxsymcrypt/aead.h>
 #include <sxsymcrypt/aes.h>
 #include <sxsymcrypt/chachapoly.h>
+#include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
 #include <cracen/statuscodes.h>
 #endif
@@ -341,10 +342,21 @@ static bool is_nonce_length_supported(psa_algorithm_t alg, size_t nonce_length)
 static psa_status_t hw_initialize_ctx(cracen_aead_operation_t *operation)
 {
 	int sx_status = SX_ERR_INCOMPATIBLE_HW;
+	sx_hw_reserve_flags_t hw_flags = SX_HW_RESERVE_DEFAULT;
 
 	/* If the nonce_length is wrong then we must be in a bad state */
 	if (!is_nonce_length_supported(operation->alg, operation->nonce_length)) {
 		return PSA_ERROR_BAD_STATE;
+	}
+
+	/* GCM uses AES which needs countermeasures, ChaCha20 doesn't */
+	if (operation->alg == PSA_ALG_GCM) {
+		hw_flags |= SX_HW_RESERVE_CM_ENABLED;
+	}
+
+	sx_status = sx_hw_reserve(&operation->ctx.dma, hw_flags);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
 	}
 
 	switch (operation->alg) {
@@ -375,6 +387,10 @@ static psa_status_t hw_initialize_ctx(cracen_aead_operation_t *operation)
 		break;
 	}
 
+	if (sx_status != SX_OK) {
+		sx_hw_release(&operation->ctx.dma);
+	}
+
 	return silex_statuscodes_to_psa(sx_status);
 }
 
@@ -395,7 +411,8 @@ static psa_status_t hw_feed_data_to_hw(cracen_aead_operation_t *operation, const
 static psa_status_t hw_finalize_aead_encryption(cracen_aead_operation_t *operation, uint8_t *tag,
 						size_t tag_size, size_t *tag_length)
 {
-	int sx_status;
+	int sx_status = SX_ERR_UNINITIALIZED_OBJ;
+	psa_status_t psa_status = PSA_ERROR_CORRUPTION_DETECTED;
 
 	if (tag_size < operation->tag_size) {
 		return PSA_ERROR_BUFFER_TOO_SMALL;
@@ -403,37 +420,35 @@ static psa_status_t hw_finalize_aead_encryption(cracen_aead_operation_t *operati
 
 	sx_status = sx_aead_produce_tag(&operation->ctx, tag);
 	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+		goto exit;
 	}
 
 	sx_status = sx_aead_wait(&operation->ctx);
-	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+	if (sx_status == SX_OK) {
+		*tag_length = operation->tag_size;
 	}
 
-	*tag_length = operation->tag_size;
-
-	safe_memzero((void *)operation, sizeof(cracen_aead_operation_t));
-	return PSA_SUCCESS;
+exit:
+	psa_status = silex_statuscodes_to_psa(sx_status);
+	return psa_status;
 }
 
 static psa_status_t hw_finalize_aead_decryption(cracen_aead_operation_t *operation,
 						const uint8_t *tag)
 {
-	int sx_status;
+	int sx_status = SX_ERR_UNINITIALIZED_OBJ;
+	psa_status_t psa_status = PSA_ERROR_CORRUPTION_DETECTED;
 
 	sx_status = sx_aead_verify_tag(&operation->ctx, tag);
 	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+		goto exit;
 	}
 
 	sx_status = sx_aead_wait(&operation->ctx);
-	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
-	}
 
-	safe_memzero((void *)operation, sizeof(cracen_aead_operation_t));
-	return PSA_SUCCESS;
+exit:
+	psa_status = silex_statuscodes_to_psa(sx_status);
+	return psa_status;
 }
 
 static psa_status_t hw_setup(cracen_aead_operation_t *operation, enum cipher_operation dir,
@@ -513,12 +528,12 @@ psa_status_t cracen_aead_encrypt(const psa_key_attributes_t *attributes, const u
 		status = hw_setup(&operation, CRACEN_ENCRYPT, attributes, key_buffer,
 				  key_buffer_size, alg);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			goto exit;
 		}
 
 		status = hw_set_lengths(&operation, additional_data_length, plaintext_length);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			goto exit;
 		}
 
 		/* Do not call the cracen_aead_update*() functions to avoid using
@@ -527,38 +542,37 @@ psa_status_t cracen_aead_encrypt(const psa_key_attributes_t *attributes, const u
 
 		status = hw_set_nonce(&operation, nonce, nonce_length);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			goto exit;
 		}
 
 		status = hw_initialize_ctx(&operation);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			goto exit;
 		}
 
 		status = hw_feed_data_to_hw(&operation, additional_data, additional_data_length,
 					    NULL, true);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			goto exit;
 		}
 
 		status = hw_feed_data_to_hw(&operation, plaintext, plaintext_length, ciphertext,
 					    false);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			goto exit;
 		}
 
 		status = hw_finalize_aead_encryption(&operation, &ciphertext[plaintext_length],
 						     ciphertext_size - plaintext_length,
 						     &tag_length);
-		if (status != PSA_SUCCESS) {
-			goto error_exit;
+		if (status == PSA_SUCCESS) {
+			*ciphertext_length = plaintext_length + tag_length;
+			goto success_exit;
 		}
-
-		*ciphertext_length = plaintext_length + tag_length;
-		return PSA_SUCCESS;
-
-error_exit:
+exit:
 		*ciphertext_length = 0;
+success_exit:
+		sx_hw_release(&operation.ctx.dma);
 		safe_memzero((void *)&operation, sizeof(cracen_aead_operation_t));
 		return status;
 	}
@@ -593,52 +607,50 @@ psa_status_t cracen_aead_decrypt(const psa_key_attributes_t *attributes, const u
 		status = hw_setup(&operation, CRACEN_DECRYPT, attributes, key_buffer,
 				  key_buffer_size, alg);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			goto exit;
 		}
 
 		*plaintext_length = ciphertext_length - operation.tag_size;
 
 		if (plaintext_size < *plaintext_length) {
 			status = PSA_ERROR_BUFFER_TOO_SMALL;
-			goto error_exit;
+			goto exit;
 		}
 
 		status = hw_set_lengths(&operation, additional_data_length, *plaintext_length);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			goto exit;
 		}
 
 		status = hw_set_nonce(&operation, nonce, nonce_length);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			goto exit;
 		}
 
 		status = hw_initialize_ctx(&operation);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			goto exit;
 		}
 
 		status = hw_feed_data_to_hw(&operation, additional_data, additional_data_length,
 					    NULL, true);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			goto exit;
 		}
 
 		status = hw_feed_data_to_hw(&operation, ciphertext, *plaintext_length, plaintext,
 					    false);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			goto exit;
 		}
 
 		status = hw_finalize_aead_decryption(&operation, &ciphertext[*plaintext_length]);
+
+exit:
+		sx_hw_release(&operation.ctx.dma);
 		if (status != PSA_SUCCESS) {
-			goto error_exit;
+			*plaintext_length = 0;
 		}
-
-		return PSA_SUCCESS;
-
-error_exit:
-		*plaintext_length = 0;
 		safe_memzero((void *)&operation, sizeof(cracen_aead_operation_t));
 		return status;
 	}

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_cipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_cipher.c
@@ -554,15 +554,23 @@ psa_status_t cracen_cipher_update(cracen_cipher_operation_t *operation, const ui
 			}
 
 		} else {
+			/* ChaCha20 path - acquire HW before operations */
+			sx_status = sx_hw_reserve(&operation->cipher.dma, SX_HW_RESERVE_DEFAULT);
+			if (sx_status != SX_OK) {
+				return silex_statuscodes_to_psa(sx_status);
+			}
+
 			if (operation->initialized) {
 				sx_status = sx_blkcipher_resume_state(&operation->cipher);
 				if (sx_status != SX_OK) {
+					sx_hw_release(&operation->cipher.dma);
 					return silex_statuscodes_to_psa(sx_status);
 				}
 			} else {
 				psa_status = initialize_cipher(operation);
 
 				if (psa_status != PSA_SUCCESS) {
+					sx_hw_release(&operation->cipher.dma);
 					return psa_status;
 				}
 			}
@@ -574,6 +582,7 @@ psa_status_t cracen_cipher_update(cracen_cipher_operation_t *operation, const ui
 					&operation->cipher, operation->unprocessed_input,
 					operation->unprocessed_input_bytes, output);
 				if (sx_status != SX_OK) {
+					sx_hw_release(&operation->cipher.dma);
 					return silex_statuscodes_to_psa(sx_status);
 				}
 
@@ -586,16 +595,19 @@ psa_status_t cracen_cipher_update(cracen_cipher_operation_t *operation, const ui
 				sx_status = sx_blkcipher_crypt(&operation->cipher, input,
 							       block_bytes, output);
 				if (sx_status != SX_OK) {
+					sx_hw_release(&operation->cipher.dma);
 					return silex_statuscodes_to_psa(sx_status);
 				}
 			}
 
 			sx_status = sx_blkcipher_save_state(&operation->cipher);
 			if (sx_status != SX_OK) {
+				sx_hw_release(&operation->cipher.dma);
 				return silex_statuscodes_to_psa(sx_status);
 			}
 
 			sx_status = sx_blkcipher_wait(&operation->cipher);
+			sx_hw_release(&operation->cipher.dma);
 			if (sx_status != SX_OK) {
 				return silex_statuscodes_to_psa(sx_status);
 			}
@@ -678,15 +690,24 @@ psa_status_t cracen_cipher_finish(cracen_cipher_operation_t *operation, uint8_t 
 			}
 		}
 	}
+
+	/* ChaCha20 path - acquire HW before operations */
+	sx_status = sx_hw_reserve(&operation->cipher.dma, SX_HW_RESERVE_DEFAULT);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
 	if (operation->initialized) {
 		sx_status = sx_blkcipher_resume_state(&operation->cipher);
 		if (sx_status != SX_OK) {
+			sx_hw_release(&operation->cipher.dma);
 			return silex_statuscodes_to_psa(sx_status);
 		}
 	} else {
 		psa_status = initialize_cipher(operation);
 
 		if (psa_status != PSA_SUCCESS) {
+			sx_hw_release(&operation->cipher.dma);
 			return psa_status;
 		}
 	}
@@ -694,21 +715,25 @@ psa_status_t cracen_cipher_finish(cracen_cipher_operation_t *operation, uint8_t 
 	*output_length = operation->unprocessed_input_bytes;
 	if (*output_length > output_size) {
 		*output_length = 0;
+		sx_hw_release(&operation->cipher.dma);
 		return PSA_ERROR_BUFFER_TOO_SMALL;
 	}
 
 	sx_status = sx_blkcipher_crypt(&operation->cipher, operation->unprocessed_input,
 				       operation->unprocessed_input_bytes, output);
 	if (sx_status != SX_OK) {
+		sx_hw_release(&operation->cipher.dma);
 		return silex_statuscodes_to_psa(sx_status);
 	}
 
 	sx_status = sx_blkcipher_run(&operation->cipher);
 	if (sx_status != SX_OK) {
+		sx_hw_release(&operation->cipher.dma);
 		return silex_statuscodes_to_psa(sx_status);
 	}
 
 	sx_status = sx_blkcipher_wait(&operation->cipher);
+	sx_hw_release(&operation->cipher.dma);
 	if (sx_status != SX_OK) {
 		return silex_statuscodes_to_psa(sx_status);
 	}

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_common.c
@@ -7,6 +7,7 @@
 #include <sxsymcrypt/blkcipher.h>
 #include <sxsymcrypt/keyref.h>
 #include <sxsymcrypt/aes.h>
+#include <sxsymcrypt/internal.h>
 #include <cracen/statuscodes.h>
 #include <zephyr/logging/log.h>
 #include <cracen/common.h>
@@ -14,23 +15,27 @@
 
 LOG_MODULE_DECLARE(cracen, CONFIG_CRACEN_LOG_LEVEL);
 
-psa_status_t cracen_sw_aes_ecb_crypt(struct sxblkcipher *blkciph,
-				     const uint8_t *input, size_t input_length, uint8_t *output,
-				     size_t output_size, size_t *output_length)
+static psa_status_t cracen_sw_aes_ecb_crypt(struct sxblkcipher *blkciph,
+					    const uint8_t *input, size_t input_length,
+					    uint8_t *output, size_t output_size,
+					    size_t *output_length)
 {
 	int sx_status;
 
 	sx_status = sx_blkcipher_crypt(blkciph, input, input_length, output);
 	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+		goto exit;
 	}
 
 	sx_status = sx_blkcipher_run(blkciph);
 	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+		goto exit;
 	}
 
 	sx_status = sx_blkcipher_wait(blkciph);
+
+exit:
+	sx_hw_release(&blkciph->dma);
 	if (sx_status == SX_OK) {
 		*output_length = input_length;
 	}
@@ -51,8 +56,14 @@ psa_status_t cracen_sw_aes_ecb_encrypt(struct sxblkcipher *blkciph, const struct
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 
+	sx_status = sx_hw_reserve(&blkciph->dma, SX_HW_RESERVE_CM_ENABLED);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
 	sx_status = sx_blkcipher_create_aesecb_enc(blkciph, key);
 	if (sx_status != SX_OK) {
+		sx_hw_release(&blkciph->dma);
 		return silex_statuscodes_to_psa(sx_status);
 	}
 
@@ -74,8 +85,14 @@ psa_status_t cracen_sw_aes_ecb_decrypt(struct sxblkcipher *blkciph, const struct
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 
+	sx_status = sx_hw_reserve(&blkciph->dma, SX_HW_RESERVE_CM_ENABLED);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
 	sx_status = sx_blkcipher_create_aesecb_dec(blkciph, key);
 	if (sx_status != SX_OK) {
+		sx_hw_release(&blkciph->dma);
 		return silex_statuscodes_to_psa(sx_status);
 	}
 
@@ -89,8 +106,14 @@ psa_status_t cracen_sw_aes_primitive(struct sxblkcipher *blkciph, const struct s
 	int sx_status;
 	size_t output_size;
 
+	sx_status = sx_hw_reserve(&blkciph->dma, SX_HW_RESERVE_CM_ENABLED);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
 	sx_status = sx_blkcipher_create_aesecb_enc(blkciph, key);
 	if (sx_status != SX_OK) {
+		sx_hw_release(&blkciph->dma);
 		return silex_statuscodes_to_psa(sx_status);
 	}
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h
@@ -273,8 +273,8 @@ struct cracen_hash_operation_s {
 	/* Buffer for input data to fill up the next block. */
 	uint8_t input_buffer[SX_HASH_MAX_ENABLED_BLOCK_SIZE];
 
-	/* Flag to know if the hashing has already started. */
-	bool is_first_block;
+	/* Flag indicating saved state exists that needs to be resumed */
+	bool has_saved_state;
 };
 typedef struct cracen_hash_operation_s cracen_hash_operation_t;
 
@@ -396,7 +396,8 @@ struct cracen_mac_operation_s {
 	/* Buffer for input data to fill up the next block. */
 	uint8_t input_buffer[SX_MAX(SX_HASH_MAX_ENABLED_BLOCK_SIZE, SX_BLKCIPHER_PRIV_SZ)];
 
-	bool is_first_block;
+	/* Flag indicating saved state exists that needs to be resumed */
+	bool has_saved_state;
 	union {
 #if defined(PSA_NEED_CRACEN_HMAC)
 		struct {

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_aead.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_aead.c
@@ -114,10 +114,12 @@ static psa_status_t process_on_hw(cracen_aead_operation_t *operation)
 	int sx_status = sx_aead_save_state(&operation->ctx);
 
 	if (sx_status != SX_OK) {
+		sx_hw_release(&operation->ctx.dma);
 		return silex_statuscodes_to_psa(sx_status);
 	}
 
 	sx_status = sx_aead_wait(&operation->ctx);
+	sx_hw_release(&operation->ctx.dma);
 	if (sx_status != SX_OK) {
 		return silex_statuscodes_to_psa(sx_status);
 	}
@@ -125,13 +127,29 @@ static psa_status_t process_on_hw(cracen_aead_operation_t *operation)
 	return silex_statuscodes_to_psa(sx_status);
 }
 
+static sx_hw_reserve_flags_t aead_hw_reserve_flags(psa_algorithm_t alg)
+{
+	/* GCM and CCM use AES which needs countermeasures.
+	 * ChaCha20Poly1305 does not use AES.
+	 */
+	return ((alg == PSA_ALG_GCM) || (alg == PSA_ALG_CCM)) ? SX_HW_RESERVE_CM_ENABLED
+							       : SX_HW_RESERVE_DEFAULT;
+}
+
 static psa_status_t initialize_ctx(cracen_aead_operation_t *operation)
 {
 	int sx_status = SX_ERR_INCOMPATIBLE_HW;
+	sx_hw_reserve_flags_t flags;
 
 	/* If the nonce_length is wrong then we must be in a bad state */
 	if (!is_nonce_length_supported(operation->alg, operation->nonce_length)) {
 		return PSA_ERROR_BAD_STATE;
+	}
+
+	flags = aead_hw_reserve_flags(operation->alg);
+	sx_status = sx_hw_reserve(&operation->ctx.dma, flags);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
 	}
 
 	switch (operation->alg) {
@@ -177,32 +195,50 @@ static psa_status_t initialize_ctx(cracen_aead_operation_t *operation)
 		break;
 	}
 
+	if (sx_status != SX_OK) {
+		sx_hw_release(&operation->ctx.dma);
+	}
+
 	return silex_statuscodes_to_psa(sx_status);
 }
 
 static psa_status_t initialize_or_resume_context(cracen_aead_operation_t *operation)
 {
-	psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+	psa_status_t psa_status = PSA_ERROR_CORRUPTION_DETECTED;
+	int sx_status;
 
 	switch (operation->context_state) {
 	case CRACEN_NOT_INITIALIZED:
-		status = initialize_ctx(operation);
-
-		operation->context_state = CRACEN_HW_RESERVED;
+		psa_status = initialize_ctx(operation);
+		if (psa_status == PSA_SUCCESS) {
+			operation->context_state = CRACEN_HW_RESERVED;
+		}
 		break;
-	case CRACEN_CONTEXT_INITIALIZED:
-		status = silex_statuscodes_to_psa(sx_aead_resume_state(&operation->ctx));
+	case CRACEN_CONTEXT_INITIALIZED: {
+		sx_hw_reserve_flags_t flags = aead_hw_reserve_flags(operation->alg);
 
-		operation->context_state = CRACEN_HW_RESERVED;
+		sx_status = sx_hw_reserve(&operation->ctx.dma, flags);
+		if (sx_status != SX_OK) {
+			psa_status = silex_statuscodes_to_psa(sx_status);
+			break;
+		}
+		sx_status = sx_aead_resume_state(&operation->ctx);
+		if (sx_status != SX_OK) {
+			sx_hw_release(&operation->ctx.dma);
+		} else {
+			operation->context_state = CRACEN_HW_RESERVED;
+		}
+		psa_status = silex_statuscodes_to_psa(sx_status);
 		break;
+	}
 	case CRACEN_HW_RESERVED:
-		status = PSA_SUCCESS;
+		psa_status = PSA_SUCCESS;
 		break;
 	default: /* For compliance */
 		break;
 	}
 
-	return status;
+	return psa_status;
 }
 
 static void cracen_writebe(uint8_t *out, uint64_t data, uint16_t targetsz)
@@ -338,6 +374,11 @@ static psa_status_t cracen_feed_data_to_hw(cracen_aead_operation_t *operation, c
 		sx_status = sx_aead_feed_aad(&operation->ctx, input, input_length);
 	} else {
 		sx_status = sx_aead_crypt(&operation->ctx, input, input_length, output);
+	}
+
+	if (sx_status != SX_OK) {
+		sx_hw_release(&operation->ctx.dma);
+		operation->context_state = CRACEN_NOT_INITIALIZED;
 	}
 
 	return silex_statuscodes_to_psa(sx_status);
@@ -623,11 +664,10 @@ static psa_status_t finalize_aead_encryption(cracen_aead_operation_t *operation,
 	}
 
 	sx_status = sx_aead_produce_tag(&operation->ctx, tag);
-	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+	if (sx_status == SX_OK) {
+		sx_status = sx_aead_wait(&operation->ctx);
 	}
-
-	sx_status = sx_aead_wait(&operation->ctx);
+	sx_hw_release(&operation->ctx.dma);
 	if (sx_status != SX_OK) {
 		return silex_statuscodes_to_psa(sx_status);
 	}
@@ -680,11 +720,10 @@ static psa_status_t finalize_aead_decryption(cracen_aead_operation_t *operation,
 	int sx_status;
 
 	sx_status = sx_aead_verify_tag(&operation->ctx, tag);
-	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+	if (sx_status == SX_OK) {
+		sx_status = sx_aead_wait(&operation->ctx);
 	}
-
-	sx_status = sx_aead_wait(&operation->ctx);
+	sx_hw_release(&operation->ctx.dma);
 	if (sx_status != SX_OK) {
 		return silex_statuscodes_to_psa(sx_status);
 	}
@@ -738,6 +777,10 @@ psa_status_t cracen_aead_abort(cracen_aead_operation_t *operation)
 		return cracen_sw_aes_ccm_abort(operation);
 	}
 #endif
+
+	if (operation->context_state == CRACEN_HW_RESERVED) {
+		sx_hw_release(&operation->ctx.dma);
+	}
 
 	safe_memzero((void *)operation, sizeof(cracen_aead_operation_t));
 	return PSA_SUCCESS;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_cipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_cipher.c
@@ -72,6 +72,12 @@ static bool is_alg_supported(psa_algorithm_t alg, const psa_key_attributes_t *at
 	return is_supported;
 }
 
+/** AES ciphers need countermeasures; ChaCha20 does not. */
+static sx_hw_reserve_flags_t cipher_hw_reserve_flags(psa_algorithm_t alg)
+{
+	return (alg == PSA_ALG_STREAM_CIPHER) ? SX_HW_RESERVE_DEFAULT : SX_HW_RESERVE_CM_ENABLED;
+}
+
 static psa_status_t setup(enum cipher_operation dir, cracen_cipher_operation_t *operation,
 			  const psa_key_attributes_t *attributes, const uint8_t *key_buffer,
 			  size_t key_buffer_size, psa_algorithm_t alg)
@@ -136,7 +142,14 @@ static psa_status_t crypt_ecb(struct sxblkcipher *blkciph, const struct sxkeyref
 			      const uint8_t *input, size_t input_length, uint8_t *output,
 			      size_t output_size, size_t *output_length, enum cipher_operation dir)
 {
+	int sx_status;
 	psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+
+	/* Acquire HW before calling the SX layer create functions */
+	sx_status = sx_hw_reserve(&blkciph->dma, SX_HW_RESERVE_CM_ENABLED);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
 
 	if (dir == CRACEN_ENCRYPT) {
 		status = cracen_aes_ecb_encrypt(blkciph, key, input, input_length,
@@ -146,6 +159,7 @@ static psa_status_t crypt_ecb(struct sxblkcipher *blkciph, const struct sxkeyref
 						output, output_size, output_length);
 	}
 
+	sx_hw_release(&blkciph->dma);
 	return status;
 }
 
@@ -299,6 +313,12 @@ static psa_status_t initialize_cipher(cracen_cipher_operation_t *operation)
 {
 	int sx_status = SX_ERR_UNINITIALIZED_OBJ;
 
+	/* Acquire HW before calling the SX layer create functions */
+	sx_status = sx_hw_reserve(&operation->cipher.dma, cipher_hw_reserve_flags(operation->alg));
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
 	switch (operation->alg) {
 	case PSA_ALG_CBC_NO_PADDING:
 		if (IS_ENABLED(PSA_NEED_CRACEN_CBC_NO_PADDING_AES)) {
@@ -348,9 +368,13 @@ static psa_status_t initialize_cipher(cracen_cipher_operation_t *operation)
 		sx_status = SX_ERR_INCOMPATIBLE_HW;
 	}
 
+	if (sx_status != SX_OK) {
+		sx_hw_release(&operation->cipher.dma);
+		return silex_statuscodes_to_psa(sx_status);
+	}
 	operation->initialized = true;
 
-	return silex_statuscodes_to_psa(sx_status);
+	return PSA_SUCCESS;
 }
 
 psa_status_t cracen_cipher_encrypt_setup(cracen_cipher_operation_t *operation,
@@ -521,8 +545,15 @@ psa_status_t cracen_cipher_update(cracen_cipher_operation_t *operation, const ui
 
 		} else {
 			if (operation->initialized) {
+				/* Acquire HW before resuming state */
+				sx_status = sx_hw_reserve(&operation->cipher.dma,
+							  cipher_hw_reserve_flags(operation->alg));
+				if (sx_status != SX_OK) {
+					return silex_statuscodes_to_psa(sx_status);
+				}
 				sx_status = sx_blkcipher_resume_state(&operation->cipher);
 				if (sx_status != SX_OK) {
+					sx_hw_release(&operation->cipher.dma);
 					return silex_statuscodes_to_psa(sx_status);
 				}
 			} else {
@@ -540,6 +571,7 @@ psa_status_t cracen_cipher_update(cracen_cipher_operation_t *operation, const ui
 					&operation->cipher, operation->unprocessed_input,
 					operation->unprocessed_input_bytes, output);
 				if (sx_status != SX_OK) {
+					sx_hw_release(&operation->cipher.dma);
 					return silex_statuscodes_to_psa(sx_status);
 				}
 
@@ -552,16 +584,19 @@ psa_status_t cracen_cipher_update(cracen_cipher_operation_t *operation, const ui
 				sx_status = sx_blkcipher_crypt(&operation->cipher, input,
 							       block_bytes, output);
 				if (sx_status != SX_OK) {
+					sx_hw_release(&operation->cipher.dma);
 					return silex_statuscodes_to_psa(sx_status);
 				}
 			}
 
 			sx_status = sx_blkcipher_save_state(&operation->cipher);
 			if (sx_status != SX_OK) {
+				sx_hw_release(&operation->cipher.dma);
 				return silex_statuscodes_to_psa(sx_status);
 			}
 
 			sx_status = sx_blkcipher_wait(&operation->cipher);
+			sx_hw_release(&operation->cipher.dma);
 			if (sx_status != SX_OK) {
 				return silex_statuscodes_to_psa(sx_status);
 			}
@@ -622,9 +657,14 @@ psa_status_t cracen_cipher_finish(cracen_cipher_operation_t *operation, uint8_t 
 	}
 
 	if (operation->initialized) {
-		sx_status = sx_blkcipher_resume_state(&operation->cipher);
+		/* Acquire HW before resuming state */
+		sx_status = sx_hw_reserve(&operation->cipher.dma, SX_HW_RESERVE_CM_ENABLED);
 		if (sx_status != SX_OK) {
 			return silex_statuscodes_to_psa(sx_status);
+		}
+		sx_status = sx_blkcipher_resume_state(&operation->cipher);
+		if (sx_status != SX_OK) {
+			goto exit;
 		}
 	} else {
 		psa_status_t result = initialize_cipher(operation);
@@ -651,6 +691,7 @@ psa_status_t cracen_cipher_finish(cracen_cipher_operation_t *operation, uint8_t 
 			__ASSERT_NO_MSG(operation->blk_size == SX_BLKCIPHER_AES_BLK_SZ);
 
 			if (operation->unprocessed_input_bytes != SX_BLKCIPHER_AES_BLK_SZ) {
+				sx_hw_release(&operation->cipher.dma);
 				return PSA_ERROR_INVALID_ARGUMENT;
 			}
 
@@ -659,17 +700,18 @@ psa_status_t cracen_cipher_finish(cracen_cipher_operation_t *operation, uint8_t 
 			sx_status = sx_blkcipher_crypt(
 				&operation->cipher, operation->unprocessed_input,
 				operation->unprocessed_input_bytes, out_with_padding);
-			if (sx_status) {
-				return silex_statuscodes_to_psa(sx_status);
+			if (sx_status != SX_OK) {
+				goto exit;
 			}
 
 			sx_status = sx_blkcipher_run(&operation->cipher);
-			if (sx_status) {
-				return silex_statuscodes_to_psa(sx_status);
+			if (sx_status != SX_OK) {
+				goto exit;
 			}
 
 			sx_status = sx_blkcipher_wait(&operation->cipher);
-			if (sx_status) {
+			sx_hw_release(&operation->cipher.dma);
+			if (sx_status != SX_OK) {
 				return silex_statuscodes_to_psa(sx_status);
 			}
 
@@ -703,6 +745,7 @@ psa_status_t cracen_cipher_finish(cracen_cipher_operation_t *operation, uint8_t 
 
 	*output_length = operation->unprocessed_input_bytes;
 	if (*output_length > output_size) {
+		sx_hw_release(&operation->cipher.dma);
 		*output_length = 0;
 		return PSA_ERROR_BUFFER_TOO_SMALL;
 	}
@@ -710,26 +753,26 @@ psa_status_t cracen_cipher_finish(cracen_cipher_operation_t *operation, uint8_t 
 	if (IS_ENABLED(PSA_NEED_CRACEN_CBC_NO_PADDING_AES) &&
 	    operation->alg == PSA_ALG_CBC_NO_PADDING &&
 	    (operation->unprocessed_input_bytes % SX_BLKCIPHER_AES_BLK_SZ) != 0) {
+		sx_hw_release(&operation->cipher.dma);
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 
 	sx_status = sx_blkcipher_crypt(&operation->cipher, operation->unprocessed_input,
 				       operation->unprocessed_input_bytes, output);
 	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+		goto exit;
 	}
 
 	sx_status = sx_blkcipher_run(&operation->cipher);
 	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+		goto exit;
 	}
 
 	sx_status = sx_blkcipher_wait(&operation->cipher);
-	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
-	}
 
-	return PSA_SUCCESS;
+exit:
+	sx_hw_release(&operation->cipher.dma);
+	return silex_statuscodes_to_psa(sx_status);
 }
 
 psa_status_t cracen_cipher_abort(cracen_cipher_operation_t *operation)

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_ctr_drbg.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_ctr_drbg.c
@@ -122,25 +122,34 @@ static int trng_get_entropy(uint8_t *dst, int num_trng_bytes)
  */
 static psa_status_t ctr_drbg_update(uint8_t *data)
 {
-	psa_status_t status = SX_OK;
+	int sx_status;
 
 	ALIGN_ON_STACK(uint8_t, temp, CRACEN_ENTROPY_AND_NONCE_SIZE, CONFIG_DCACHE_LINE_SIZE);
 
 	size_t temp_length = 0;
 	_Static_assert(CRACEN_ENTROPY_AND_NONCE_SIZE % SX_BLKCIPHER_AES_BLK_SZ == 0, "");
 
+	sx_status = sx_hw_reserve(NULL, SX_HW_RESERVE_DEFAULT);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
 	while (temp_length < CRACEN_ENTROPY_AND_NONCE_SIZE) {
 		cracen_be_add(prng.V, SX_BLKCIPHER_AES_BLK_SZ, 1);
 
-		status = sx_blkcipher_ecb_simple(prng.key, sizeof(prng.key), prng.V, sizeof(prng.V),
-						 temp + temp_length, SX_BLKCIPHER_AES_BLK_SZ);
+		sx_status = sx_blkcipher_ecb_simple(prng.key, sizeof(prng.key), prng.V,
+						    sizeof(prng.V), temp + temp_length,
+						    SX_BLKCIPHER_AES_BLK_SZ);
 
-		if (status != PSA_SUCCESS) {
-			return status;
+		if (sx_status != SX_OK) {
+			sx_hw_release(NULL);
+			return silex_statuscodes_to_psa(sx_status);
 		}
 		temp_length += SX_BLKCIPHER_AES_BLK_SZ;
 		prng.reseed_counter++;
 	}
+
+	sx_hw_release(NULL);
 
 	if (data) {
 		cracen_xorbytes(temp, data, CRACEN_ENTROPY_AND_NONCE_SIZE);
@@ -149,7 +158,7 @@ static psa_status_t ctr_drbg_update(uint8_t *data)
 	memcpy(prng.key, temp, sizeof(prng.key));
 	memcpy(prng.V, temp + sizeof(prng.key), sizeof(prng.V));
 
-	return status;
+	return PSA_SUCCESS;
 }
 
 /* Instantiation of CTR_DRBG without derivation function. */
@@ -218,8 +227,8 @@ static psa_status_t cracen_reseed(void)
 psa_status_t cracen_get_random(cracen_prng_context_t *context, uint8_t *output, size_t output_size)
 {
 	(void)context;
-
-	psa_status_t status = PSA_SUCCESS;
+	int sx_status;
+	psa_status_t psa_status = PSA_SUCCESS;
 	size_t len_left = output_size;
 	size_t number_of_blocks = DIV_ROUND_UP(output_size, SX_BLKCIPHER_AES_BLK_SZ);
 
@@ -238,19 +247,25 @@ psa_status_t cracen_get_random(cracen_prng_context_t *context, uint8_t *output, 
 		 * mutex multiple times. So we can call cracen_init_random
 		 * here even though we hold the mutex.
 		 */
-		status = cracen_init_random(context);
-		if (status != PSA_SUCCESS) {
+		psa_status = cracen_init_random(context);
+		if (psa_status != PSA_SUCCESS) {
 			nrf_security_mutex_unlock(cracen_prng_trng_mutex);
-			return status;
+			return psa_status;
 		}
 	}
 
 	if (prng.reseed_counter + number_of_blocks >= RESEED_INTERVAL) {
-		status = cracen_reseed();
-		if (status != PSA_SUCCESS) {
+		psa_status = cracen_reseed();
+		if (psa_status != PSA_SUCCESS) {
 			nrf_security_mutex_unlock(cracen_prng_trng_mutex);
-			return status;
+			return psa_status;
 		}
+	}
+
+	sx_status = sx_hw_reserve(NULL, SX_HW_RESERVE_DEFAULT);
+	if (sx_status != SX_OK) {
+		nrf_security_mutex_unlock(cracen_prng_trng_mutex);
+		return silex_statuscodes_to_psa(sx_status);
 	}
 
 	while (len_left > 0) {
@@ -258,12 +273,13 @@ psa_status_t cracen_get_random(cracen_prng_context_t *context, uint8_t *output, 
 		ALIGN_ON_STACK(uint8_t, temp, SX_BLKCIPHER_AES_BLK_SZ, CONFIG_DCACHE_LINE_SIZE);
 
 		cracen_be_add(prng.V, SX_BLKCIPHER_AES_BLK_SZ, 1);
-		status = sx_blkcipher_ecb_simple(prng.key, sizeof(prng.key), prng.V, sizeof(prng.V),
-						 temp, SX_BLKCIPHER_AES_BLK_SZ);
+		sx_status = sx_blkcipher_ecb_simple(prng.key, sizeof(prng.key), prng.V,
+						    sizeof(prng.V), temp, SX_BLKCIPHER_AES_BLK_SZ);
 
-		if (status != PSA_SUCCESS) {
+		if (sx_status != SX_OK) {
+			sx_hw_release(NULL);
 			nrf_security_mutex_unlock(cracen_prng_trng_mutex);
-			return status;
+			return silex_statuscodes_to_psa(sx_status);
 		}
 
 		for (int i = 0; i < cur_len; i++) {
@@ -275,9 +291,11 @@ psa_status_t cracen_get_random(cracen_prng_context_t *context, uint8_t *output, 
 		prng.reseed_counter++;
 	}
 
-	status = ctr_drbg_update(NULL);
+	sx_hw_release(NULL);
+
+	psa_status = ctr_drbg_update(NULL);
 	nrf_security_mutex_unlock(cracen_prng_trng_mutex);
-	return status;
+	return psa_status;
 }
 
 psa_status_t cracen_free_random(cracen_prng_context_t *context)

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_hash.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_hash.c
@@ -43,8 +43,13 @@ psa_status_t cracen_hash_compute(psa_algorithm_t alg, const uint8_t *input, size
 
 	*hash_length = sx_hash_get_alg_digestsz(sx_hash_algo);
 
-	sx_status = sx_hash_create(&c, sx_hash_algo, sizeof(c));
+	sx_status = sx_hw_reserve(&c.dma, SX_HW_RESERVE_DEFAULT);
 	if (sx_status != SX_OK) {
+		goto exit;
+	}
+
+	sx_status = sx_hash_create(&c, sx_hash_algo, sizeof(c));
+	if (sx_status) {
 		goto exit;
 	}
 
@@ -72,7 +77,7 @@ psa_status_t cracen_hash_setup(cracen_hash_operation_t *operation, psa_algorithm
 	if (status != PSA_SUCCESS) {
 		return status;
 	}
-	operation->is_first_block = true;
+	operation->has_saved_state = false;
 
 	operation->bytes_left_for_next_block = sx_hash_get_alg_blocksz(operation->sx_hash_algo);
 
@@ -88,23 +93,19 @@ static int init_or_resume_context(cracen_hash_operation_t *operation)
 	 * therefore the create call is done here, then feed data and then safe
 	 * the context.
 	 */
-	if (operation->is_first_block == true) {
+	if (!operation->has_saved_state) {
 		sx_status = sx_hash_create(&operation->sx_ctx, operation->sx_hash_algo,
 					   sizeof(operation->sx_ctx));
 		if (sx_status != SX_OK) {
 			return sx_status;
 		}
-		operation->is_first_block = false;
+		operation->has_saved_state = true;
 
 	} else {
 		/* Get back the old state if previous operation had been done */
 		sx_status = sx_hash_resume_state(&operation->sx_ctx);
-		if (sx_status != SX_OK) {
-			return sx_status;
-		}
-	}
 
-	return SX_OK;
+	return sx_status;
 }
 
 psa_status_t cracen_hash_update(cracen_hash_operation_t *operation, const uint8_t *input,
@@ -137,6 +138,11 @@ psa_status_t cracen_hash_update(cracen_hash_operation_t *operation, const uint8_
 		return PSA_SUCCESS;
 	}
 
+	sx_status = sx_hw_reserve(&operation->sx_ctx.dma, SX_HW_RESERVE_DEFAULT);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
 	/* Initialize or resume an already initialized context. */
 	sx_status = init_or_resume_context(operation);
 	if (sx_status != SX_OK) {
@@ -164,6 +170,7 @@ psa_status_t cracen_hash_update(cracen_hash_operation_t *operation, const uint8_
 	if (sx_status != SX_OK) {
 		goto exit;
 	}
+
 	sx_status = sx_hash_save_state(&operation->sx_ctx);
 	if (sx_status != SX_OK) {
 		goto exit;
@@ -174,7 +181,6 @@ psa_status_t cracen_hash_update(cracen_hash_operation_t *operation, const uint8_
 	if (sx_status != SX_OK) {
 		goto exit;
 	}
-
 	/* As we just passed the last block reset the remaining size and clean
 	 * input buffer
 	 */
@@ -188,6 +194,7 @@ psa_status_t cracen_hash_update(cracen_hash_operation_t *operation, const uint8_
 	}
 
 exit:
+	sx_hw_release(&operation->sx_ctx.dma);
 	return silex_statuscodes_to_psa(sx_status);
 }
 
@@ -200,6 +207,11 @@ psa_status_t cracen_hash_finish(cracen_hash_operation_t *operation, uint8_t *has
 
 	if (sx_hash_get_alg_digestsz(operation->sx_hash_algo) > hash_size) {
 		return PSA_ERROR_BUFFER_TOO_SMALL;
+	}
+
+	sx_status = sx_hw_reserve(&operation->sx_ctx.dma, SX_HW_RESERVE_DEFAULT);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
 	}
 
 	sx_status = init_or_resume_context(operation);
@@ -227,5 +239,6 @@ psa_status_t cracen_hash_finish(cracen_hash_operation_t *operation, uint8_t *has
 	*hash_length = sx_hash_get_alg_digestsz(operation->sx_hash_algo);
 
 exit:
+	sx_hw_release(&operation->sx_ctx.dma);
 	return silex_statuscodes_to_psa(sx_status);
 }

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_hash.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_hash.c
@@ -27,8 +27,6 @@ _Static_assert(SX_HASH_MAX_ENABLED_BLOCK_SIZE != 1,
 psa_status_t cracen_hash_compute(psa_algorithm_t alg, const uint8_t *input, size_t input_length,
 				 uint8_t *hash, size_t hash_size, size_t *hash_length)
 {
-	int sx_status;
-	struct sxhash c = {0};
 	const struct sxhashalg *sx_hash_algo = NULL;
 
 	psa_status_t psa_status = hash_get_algo(alg, &sx_hash_algo);
@@ -43,30 +41,7 @@ psa_status_t cracen_hash_compute(psa_algorithm_t alg, const uint8_t *input, size
 
 	*hash_length = sx_hash_get_alg_digestsz(sx_hash_algo);
 
-	sx_status = sx_hw_reserve(&c.dma, SX_HW_RESERVE_DEFAULT);
-	if (sx_status != SX_OK) {
-		goto exit;
-	}
-
-	sx_status = sx_hash_create(&c, sx_hash_algo, sizeof(c));
-	if (sx_status) {
-		goto exit;
-	}
-
-	sx_status = sx_hash_feed(&c, input, input_length);
-	if (sx_status != SX_OK) {
-		goto exit;
-	}
-
-	sx_status = sx_hash_digest(&c, hash);
-	if (sx_status != SX_OK) {
-		goto exit;
-	}
-
-	sx_status = sx_hash_wait(&c);
-
-exit:
-	return silex_statuscodes_to_psa(sx_status);
+	return silex_statuscodes_to_psa(cracen_hash_input(input, input_length, sx_hash_algo, hash));
 }
 
 psa_status_t cracen_hash_setup(cracen_hash_operation_t *operation, psa_algorithm_t alg)
@@ -89,22 +64,15 @@ static int init_or_resume_context(cracen_hash_operation_t *operation)
 	int sx_status;
 
 	/* The SX driver expects to have gotten some data, before being able to
-	 * save the context,
-	 * therefore the create call is done here, then feed data and then safe
-	 * the context.
+	 * save the context; create or resume here.
 	 */
 	if (!operation->has_saved_state) {
 		sx_status = sx_hash_create(&operation->sx_ctx, operation->sx_hash_algo,
 					   sizeof(operation->sx_ctx));
-		if (sx_status != SX_OK) {
-			return sx_status;
-		}
-		operation->has_saved_state = true;
-
+		operation->has_saved_state = (sx_status == SX_OK);
 	} else {
-		/* Get back the old state if previous operation had been done */
 		sx_status = sx_hash_resume_state(&operation->sx_ctx);
-
+	}
 	return sx_status;
 }
 
@@ -112,6 +80,7 @@ psa_status_t cracen_hash_update(cracen_hash_operation_t *operation, const uint8_
 				const size_t input_length)
 {
 	int sx_status;
+	size_t block_sz;
 	size_t input_chunk_length = 0;
 	size_t remaining_bytes = 0;
 
@@ -125,12 +94,12 @@ psa_status_t cracen_hash_update(cracen_hash_operation_t *operation, const uint8_
 	 */
 	__ASSERT_NO_MSG(input != NULL);
 
+	block_sz = sx_hash_get_alg_blocksz(operation->sx_hash_algo);
 	if (input_length < operation->bytes_left_for_next_block) {
 		/* sx_hash_feed doesn't buffer the input data until sx_hash_wait
 		 * is called so a local buffer is used.
 		 */
-		size_t offset = sx_hash_get_alg_blocksz(operation->sx_hash_algo) -
-				operation->bytes_left_for_next_block;
+		size_t offset = block_sz - operation->bytes_left_for_next_block;
 		memcpy(operation->input_buffer + offset, input, input_length);
 		operation->bytes_left_for_next_block -= input_length;
 
@@ -143,7 +112,6 @@ psa_status_t cracen_hash_update(cracen_hash_operation_t *operation, const uint8_
 		return silex_statuscodes_to_psa(sx_status);
 	}
 
-	/* Initialize or resume an already initialized context. */
 	sx_status = init_or_resume_context(operation);
 	if (sx_status != SX_OK) {
 		goto exit;
@@ -151,8 +119,7 @@ psa_status_t cracen_hash_update(cracen_hash_operation_t *operation, const uint8_
 
 	/* Feed the data that are currently in the input buffer to the driver. */
 	sx_status = sx_hash_feed(&operation->sx_ctx, operation->input_buffer,
-				 sx_hash_get_alg_blocksz(operation->sx_hash_algo) -
-					 operation->bytes_left_for_next_block);
+				 block_sz - operation->bytes_left_for_next_block);
 	if (sx_status != SX_OK) {
 		goto exit;
 	}
@@ -162,7 +129,7 @@ psa_status_t cracen_hash_update(cracen_hash_operation_t *operation, const uint8_
 	 * power of two.
 	 */
 	input_chunk_length = input_length - ((input_length - operation->bytes_left_for_next_block) %
-					     sx_hash_get_alg_blocksz(operation->sx_hash_algo));
+					     block_sz);
 	remaining_bytes = input_length - input_chunk_length;
 
 	/* forward the data to the driver and process the data */
@@ -184,7 +151,7 @@ psa_status_t cracen_hash_update(cracen_hash_operation_t *operation, const uint8_
 	/* As we just passed the last block reset the remaining size and clean
 	 * input buffer
 	 */
-	operation->bytes_left_for_next_block = sx_hash_get_alg_blocksz(operation->sx_hash_algo);
+	operation->bytes_left_for_next_block = block_sz;
 	safe_memzero(operation->input_buffer, sizeof(operation->input_buffer));
 
 	/* Copy the remaining bytes to the local input buffer */
@@ -202,6 +169,7 @@ psa_status_t cracen_hash_finish(cracen_hash_operation_t *operation, uint8_t *has
 				size_t *hash_length)
 {
 	int sx_status;
+	size_t block_sz;
 
 	__ASSERT_NO_MSG(hash_length != NULL);
 
@@ -219,9 +187,9 @@ psa_status_t cracen_hash_finish(cracen_hash_operation_t *operation, uint8_t *has
 		goto exit;
 	}
 
+	block_sz = sx_hash_get_alg_blocksz(operation->sx_hash_algo);
 	sx_status = sx_hash_feed(&operation->sx_ctx, operation->input_buffer,
-				 sx_hash_get_alg_blocksz(operation->sx_hash_algo) -
-					 operation->bytes_left_for_next_block);
+				 block_sz - operation->bytes_left_for_next_block);
 	if (sx_status != SX_OK) {
 		goto exit;
 	}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/aes/cracen_aes_ecb.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/aes/cracen_aes_ecb.c
@@ -6,15 +6,11 @@
 
 #include <internal/aes/cracen_aes_ecb.h>
 
-#include <string.h>
 #include <stdbool.h>
-#include <silexpk/core.h>
 #include <sxsymcrypt/aes.h>
 #include <sxsymcrypt/blkcipher.h>
 #include <cracen/statuscodes.h>
-#include <cracen_psa.h>
 #include <cracen/common.h>
-#include <cracen_psa_primitives.h>
 
 /* The AES ECB does not support multipart operations in Cracen. This means that keeping
  * the state between calls is not supported. This function is using the single part

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecdsa.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecdsa.c
@@ -28,13 +28,13 @@
 #include <silexpk/core.h>
 #include <silexpk/iomem.h>
 #include <silexpk/cmddefs/ecc.h>
-#include <silexpk/core.h>
 #include <silexpk/ec_curves.h>
 #include <cracen/statuscodes.h>
 #include <sxsymcrypt/hash.h>
 #include <cracen_psa_primitives.h>
 #include <sxsymcrypt/hashdefs.h>
 #include <cracen/common.h>
+#include <sxsymcrypt/internal.h>
 #include <cracen/cracen_hmac.h>
 
 #define DETERMINISTIC_HMAC_STEPS 6
@@ -178,7 +178,6 @@ static int ecdsa_run_generate_sign(sx_pk_req *req,
 				    struct sx_pk_inops_ecdsa_generate *inputs)
 {
 	int status = sx_pk_list_ecc_inslots(req, curve, 0, (struct sx_pk_slot *)inputs);
-
 	if (status != SX_OK) {
 		return status;
 	}
@@ -199,6 +198,7 @@ int cracen_ecdsa_sign_message(const struct cracen_ecc_priv_key *privkey,
 	const size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
 	uint8_t digest[digestsz];
 
+	/* cracen_hash_input handles hardware acquire and release. */
 	status = cracen_hash_input(message, message_length, hashalg, digest);
 	if (status != SX_OK) {
 		return status;
@@ -280,23 +280,22 @@ int cracen_ecdsa_sign_digest(const struct cracen_ecc_priv_key *privkey,
 	return SX_OK;
 }
 
-static int deterministic_ecdsa_hmac(const struct sxhashalg *hashalg, const uint8_t *key,
-				    const uint8_t *v, size_t hash_len, uint8_t internal_octet,
-				    const uint8_t *sk, const uint8_t *hash, size_t key_len,
-				    uint8_t *hmac)
+static int deterministic_ecdsa_hmac(struct sxhash *hashctx, const struct sxhashalg *hashalg,
+				    const uint8_t *key, const uint8_t *v, size_t hash_len,
+				    uint8_t internal_octet, const uint8_t *sk,
+				    const uint8_t *hash, size_t key_len, uint8_t *hmac)
 {
 	int status;
-	struct sxhash hashopctx;
 	const size_t workmem_requirement =
 		sx_hash_get_alg_digestsz(hashalg) + sx_hash_get_alg_blocksz(hashalg);
 	uint8_t workmem[workmem_requirement];
 
-	status = mac_create_hmac(hashalg, &hashopctx, key, hash_len, workmem, workmem_requirement);
+	status = mac_create_hmac(hashalg, hashctx, key, hash_len, workmem, workmem_requirement);
 	if (status != SX_OK) {
 		return status;
 	}
-	/* The hash context is initialized in mac_create_hmac */
-	status = sx_hash_feed(&hashopctx, v, hash_len);
+
+	status = sx_hash_feed(hashctx, v, hash_len);
 	if (status != SX_OK) {
 		return status;
 	}
@@ -306,29 +305,30 @@ static int deterministic_ecdsa_hmac(const struct sxhashalg *hashalg, const uint8
 			[INTERNAL_OCTET_ZERO] = 0,
 			[INTERNAL_OCTET_ONE] = 1,
 		};
-		status = sx_hash_feed(&hashopctx, &internal_octet_values[internal_octet],
+		status = sx_hash_feed(hashctx, &internal_octet_values[internal_octet],
 				      sizeof(*internal_octet_values));
 		if (status != SX_OK) {
 			return status;
 		}
 	}
 	if (sk) {
-		status = sx_hash_feed(&hashopctx, sk, key_len);
+		status = sx_hash_feed(hashctx, sk, key_len);
 		if (status != SX_OK) {
 			return status;
 		}
 	}
 	if (hash) {
-		status = sx_hash_feed(&hashopctx, hash, key_len);
+		status = sx_hash_feed(hashctx, hash, key_len);
 		if (status != SX_OK) {
 			return status;
 		}
 	}
 
-	return hmac_produce(&hashopctx, hashalg, hmac, hash_len, workmem);
+	return hmac_produce(hashctx, hashalg, hmac, hash_len, workmem);
 }
 
-static int run_deterministic_ecdsa_hmac_step(const struct sxhashalg *hashalg, size_t opsz,
+static int run_deterministic_ecdsa_hmac_step(struct sxhash *hashctx,
+					     const struct sxhashalg *hashalg, size_t opsz,
 					     const uint8_t *curve_n, const size_t digestsz,
 					     size_t blocksz, uint8_t *workmem,
 					     struct ecdsa_hmac_operation *hmac_op,
@@ -353,24 +353,24 @@ static int run_deterministic_ecdsa_hmac_step(const struct sxhashalg *hashalg, si
 		 */
 		bits2octets(h1, digestsz, T, curve_n, opsz);
 
-		status = deterministic_ecdsa_hmac(hashalg, K, V, digestsz, INTERNAL_OCTET_ZERO,
-						  privkey->d, T, opsz, K);
+		status = deterministic_ecdsa_hmac(hashctx, hashalg, K, V, digestsz,
+						  INTERNAL_OCTET_ZERO, privkey->d, T, opsz, K);
 		break;
 
 	case 1: /* V = HMAC_K(V) */
-		status = deterministic_ecdsa_hmac(hashalg, K, V, digestsz, INTERNAL_OCTET_NOT_USED,
-						  NULL, NULL, opsz, V);
+		status = deterministic_ecdsa_hmac(hashctx, hashalg, K, V, digestsz,
+						  INTERNAL_OCTET_NOT_USED, NULL, NULL, opsz, V);
 		break;
 
 	case 2: /* K = HMAC_K(V || 0x01 || privkey || h1) */
-		status = deterministic_ecdsa_hmac(hashalg, K, V, digestsz, INTERNAL_OCTET_ONE,
-						  privkey->d, T, opsz, K);
+		status = deterministic_ecdsa_hmac(hashctx, hashalg, K, V, digestsz,
+						  INTERNAL_OCTET_ONE, privkey->d, T, opsz, K);
 		break;
 
 	case 3: /* V = HMAC_K(V) */
 	case 4: /* same as case 3. */
-		status = deterministic_ecdsa_hmac(hashalg, K, V, digestsz, INTERNAL_OCTET_NOT_USED,
-						  NULL, NULL, opsz, V);
+		status = deterministic_ecdsa_hmac(hashctx, hashalg, K, V, digestsz,
+						  INTERNAL_OCTET_NOT_USED, NULL, NULL, opsz, V);
 		break;
 
 	case 5: /* T = T || V */
@@ -409,8 +409,8 @@ static int run_deterministic_ecdsa_hmac_step(const struct sxhashalg *hashalg, si
 			hmac_op->tlen = 0;
 			hmac_op->deterministic_retries++;
 			/* K = HMAC_K(V || 0x00) */
-			deterministic_ecdsa_hmac(hashalg, K, V, digestsz, INTERNAL_OCTET_ZERO, NULL,
-						 NULL, 0, K);
+			deterministic_ecdsa_hmac(hashctx, hashalg, K, V, digestsz,
+						 INTERNAL_OCTET_ZERO, NULL, NULL, 0, K);
 			return SX_ERR_HW_PROCESSING;
 		}
 		memcpy(workmem, h1, digestsz);
@@ -424,10 +424,10 @@ static int run_deterministic_ecdsa_hmac_step(const struct sxhashalg *hashalg, si
 	return status;
 }
 
-int cracen_ecdsa_sign_digest_deterministic(const struct cracen_ecc_priv_key *privkey,
-					   const struct sxhashalg *hashalg,
-					   const struct sx_pk_ecurve *curve, const uint8_t *digest,
-					   const size_t digestsz, uint8_t *signature)
+static inline int ecdsa_sign_digest_deterministic_internal(
+	struct sxhash *hashctx, const struct cracen_ecc_priv_key *privkey,
+	const struct sxhashalg *hashalg, const struct sx_pk_ecurve *curve,
+	const uint8_t *digest, const size_t digestsz, uint8_t *signature)
 {
 	int status;
 	size_t opsz = (size_t)sx_pk_curve_opsize(curve);
@@ -458,9 +458,9 @@ int cracen_ecdsa_sign_digest_deterministic(const struct cracen_ecc_priv_key *pri
 
 		memcpy(h1, workmem, digestsz);
 		while (hmac_op.step <= DETERMINISTIC_HMAC_STEPS) {
-			status = run_deterministic_ecdsa_hmac_step(hashalg, opsz, curve_n, digestsz,
-								   blocksz, workmem, &hmac_op,
-								   privkey);
+			status = run_deterministic_ecdsa_hmac_step(hashctx, hashalg, opsz, curve_n,
+								   digestsz, blocksz, workmem,
+								   &hmac_op, privkey);
 			if (status != SX_OK && status != SX_ERR_HW_PROCESSING) {
 				sx_pk_release_req(&req);
 				return status;
@@ -491,23 +491,54 @@ int cracen_ecdsa_sign_digest_deterministic(const struct cracen_ecc_priv_key *pri
 	return status;
 }
 
+int cracen_ecdsa_sign_digest_deterministic(const struct cracen_ecc_priv_key *privkey,
+					   const struct sxhashalg *hashalg,
+					   const struct sx_pk_ecurve *curve, const uint8_t *digest,
+					   const size_t digestsz, uint8_t *signature)
+{
+	struct sxhash hashctx;
+	int status;
+
+	status = sx_hw_reserve(&hashctx.dma, SX_HW_RESERVE_DEFAULT);
+	if (status != SX_OK) {
+		return status;
+	}
+
+	status = ecdsa_sign_digest_deterministic_internal(&hashctx, privkey, hashalg, curve,
+							  digest, digestsz, signature);
+	sx_hw_release(&hashctx.dma);
+
+	return status;
+}
+
 int cracen_ecdsa_sign_message_deterministic(const struct cracen_ecc_priv_key *privkey,
 					    const struct sxhashalg *hashalg,
 					    const struct sx_pk_ecurve *curve,
 					    const uint8_t *message, size_t message_length,
 					    uint8_t *signature)
 {
+	struct sxhash hashctx;
 	int status;
 	const size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
 	uint8_t digest[digestsz];
 
-	status = cracen_hash_input(message, message_length, hashalg, digest);
+	status = sx_hw_reserve(&hashctx.dma, SX_HW_RESERVE_DEFAULT);
 	if (status != SX_OK) {
 		return status;
 	}
 
-	return cracen_ecdsa_sign_digest_deterministic(privkey, hashalg, curve, digest, digestsz,
-						      signature);
+	status = cracen_hash_input_with_context(&hashctx, message, message_length, hashalg,
+						digest);
+	if (status != SX_OK) {
+		sx_hw_release(&hashctx.dma);
+		return status;
+	}
+
+	status = ecdsa_sign_digest_deterministic_internal(&hashctx, privkey, hashalg, curve,
+							  digest, digestsz, signature);
+	sx_hw_release(&hashctx.dma);
+
+	return status;
 }
 
 int cracen_ecdsa_verify_message(const uint8_t *pubkey, const struct sxhashalg *hashalg,
@@ -518,6 +549,7 @@ int cracen_ecdsa_verify_message(const uint8_t *pubkey, const struct sxhashalg *h
 	const size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
 	uint8_t digest[digestsz];
 
+	/* cracen_hash_input handles hardware acquire and release. */
 	status = cracen_hash_input(message, message_length, hashalg, digest);
 	if (status != SX_OK) {
 		return status;
@@ -551,6 +583,10 @@ int cracen_ecdsa_verify_digest(const uint8_t *pubkey, const uint8_t *digest, con
 	digest2op(digest, digestsz, inputs.h.addr, opsz);
 	sx_pk_run(&req);
 	status = sx_pk_wait(&req);
+	if (status != SX_OK) {
+		sx_pk_release_req(&req);
+		return status;
+	}
 	sx_pk_release_req(&req);
 
 	return status;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_eddsa_ed25519.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_eddsa_ed25519.c
@@ -53,28 +53,31 @@ static uint8_t dom2[] = {0x53, 0x69, 0x67, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0
 			 0x6f, 0x20, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x63, 0x6f,
 			 0x6c, 0x6c, 0x69, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x01, 0x00};
 
-static int ed25519_calculate_r(uint8_t *workmem, const uint8_t *message, size_t message_length,
-			       bool prehash)
+static int ed25519_calculate_r(struct sxhash *ctx, uint8_t *workmem, const uint8_t *message,
+			       size_t message_length, bool prehash)
 {
 	uint8_t const *hash_array[] = {dom2, workmem, message};
 	size_t hash_array_lengths[] = {sizeof(dom2), SX_ED25519_SZ, message_length};
 	size_t offset = prehash ? 0 : 1;
 	size_t input_count = 3 - offset;
 
-	return cracen_hash_all_inputs(hash_array + offset, hash_array_lengths + offset, input_count,
-				      &sxhashalg_sha2_512, workmem + SX_ED25519_DGST_SZ);
+	return cracen_hash_all_inputs_with_context(ctx, hash_array + offset,
+						   hash_array_lengths + offset, input_count,
+						   &sxhashalg_sha2_512,
+						   workmem + SX_ED25519_DGST_SZ);
 }
 
-static int ed25519_calculate_k(uint8_t *workmem, uint8_t *point_r, const uint8_t *message,
-			       size_t message_length, bool prehash)
+static int ed25519_calculate_k(struct sxhash *ctx, uint8_t *workmem, uint8_t *point_r,
+			       const uint8_t *message, size_t message_length, bool prehash)
 {
 	uint8_t const *hash_array[] = {dom2, point_r, workmem, message};
 	size_t hash_array_lengths[] = {sizeof(dom2), SX_ED25519_SZ, SX_ED25519_SZ, message_length};
 	size_t offset = prehash ? 0 : 1;
 	size_t input_count = 4 - offset;
 
-	return cracen_hash_all_inputs(&hash_array[offset], &hash_array_lengths[offset], input_count,
-				      &sxhashalg_sha2_512, workmem);
+	return cracen_hash_all_inputs_with_context(ctx, &hash_array[offset],
+						   &hash_array_lengths[offset], input_count,
+						   &sxhashalg_sha2_512, workmem);
 }
 
 static int ed25519_sign_internal(const uint8_t *priv_key, uint8_t *signature,
@@ -87,19 +90,26 @@ static int ed25519_sign_internal(const uint8_t *priv_key, uint8_t *signature,
 	uint8_t *area_2 = workmem + AREA2_MEM_OFFSET;
 	uint8_t *area_4 = workmem + AREA4_MEM_OFFSET;
 	sx_pk_req req;
+	struct sxhash ctx;
 
-	/* Hash the private key, the digest is stored in the first 64 bytes of workmem*/
-	status = cracen_hash_input(priv_key, SX_ED25519_SZ, &sxhashalg_sha2_512, area_1);
+	status = sx_hw_reserve(&ctx.dma, SX_HW_RESERVE_DEFAULT);
 	if (status != SX_OK) {
 		return status;
+	}
+
+	/* Hash the private key, the digest is stored in the first 64 bytes of workmem*/
+	status = cracen_hash_input_with_context(&ctx, priv_key, SX_ED25519_SZ,
+						&sxhashalg_sha2_512, area_1);
+	if (status != SX_OK) {
+		goto exit;
 	}
 
 	/* Obtain r by hashing (prefix || message), where prefix is the second
 	 * half of the private key digest.
 	 */
-	status = ed25519_calculate_r(area_2, message, message_length, prehash);
+	status = ed25519_calculate_r(&ctx, area_2, message, message_length, prehash);
 	if (status != SX_OK) {
-		return status;
+		goto exit;
 	}
 
 	sx_pk_acquire_hw(&req);
@@ -112,7 +122,7 @@ static int ed25519_sign_internal(const uint8_t *priv_key, uint8_t *signature,
 				   (struct sx_ed25519_pt *)pnt_r);
 	if (status != SX_OK) {
 		sx_pk_release_req(&req);
-		return status;
+		goto exit;
 	}
 
 	/* The secret scalar s is computed in place from the first half of the
@@ -132,13 +142,13 @@ static int ed25519_sign_internal(const uint8_t *priv_key, uint8_t *signature,
 				   (struct sx_ed25519_pt *)area_2);
 	if (status != SX_OK) {
 		sx_pk_release_req(&req);
-		return status;
+		goto exit;
 	}
 
-	status = ed25519_calculate_k(area_2, pnt_r, message, message_length, prehash);
+	status = ed25519_calculate_k(&ctx, area_2, pnt_r, message, message_length, prehash);
 	if (status != SX_OK) {
 		sx_pk_release_req(&req);
-		return status;
+		goto exit;
 	}
 
 	/* Compute (r + k * s) mod L. This gives the second part of the
@@ -152,12 +162,14 @@ static int ed25519_sign_internal(const uint8_t *priv_key, uint8_t *signature,
 	sx_pk_release_req(&req);
 
 	if (status != SX_OK) {
-		return status;
+		goto exit;
 	}
 
 	memcpy(signature, pnt_r, SX_ED25519_DGST_SZ);
 	safe_memzero(workmem, sizeof(workmem));
 
+exit:
+	sx_hw_release(&ctx.dma);
 	return status;
 }
 
@@ -174,6 +186,7 @@ int cracen_ed25519ph_sign(const uint8_t *priv_key, uint8_t *signature, const uin
 	int status;
 
 	if (is_message) {
+		/* cracen_hash_input handles hardware acquire and release. */
 		status = cracen_hash_input(message, message_length, &sxhashalg_sha2_512,
 					   hashedmessage);
 		if (status != SX_OK) {
@@ -200,6 +213,7 @@ static int ed25519_verify_internal(const uint8_t *pub_key, const uint8_t *messag
 	uint8_t const *hash_array[] = {dom2, signature, pub_key, message};
 	size_t hash_array_lengths[] = {sizeof(dom2), ed25519_sz, ed25519_sz, message_length};
 
+	/* cracen_hash_all_inputs handles hardware acquire and release. */
 	status = cracen_hash_all_inputs(&hash_array[offset], &hash_array_lengths[offset],
 					input_count, &sxhashalg_sha2_512, digest);
 	if (status != SX_OK) {
@@ -232,6 +246,7 @@ int cracen_ed25519ph_verify(const uint8_t *pub_key, const uint8_t *message, size
 	uint8_t message_digest[SX_ED25519_DGST_SZ];
 
 	if (is_message) {
+		/* cracen_hash_input handles hardware acquire and release. */
 		status = cracen_hash_input(message, message_length, &sxhashalg_sha2_512,
 					   message_digest);
 		if (status != SX_OK) {
@@ -251,10 +266,12 @@ int cracen_ed25519_create_pubkey(const uint8_t *priv_key, uint8_t *pub_key)
 	uint8_t *pub_key_A = digest + SX_ED25519_SZ;
 	sx_pk_req req;
 
+	/* cracen_hash_input handles hardware acquire and release. */
 	status = cracen_hash_input(priv_key, SX_ED25519_SZ, &sxhashalg_sha2_512, digest);
 	if (status != SX_OK) {
 		return status;
 	}
+
 	/* The secret scalar s is computed in place from the first half of the
 	 * private key digest.
 	 */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_eddsa_ed448.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_eddsa_ed448.c
@@ -35,8 +35,8 @@
  */
 static uint8_t dom4[] = {0x53, 0x69, 0x67, 0x45, 0x64, 0x34, 0x34, 0x38, 0x01, 0x00};
 
-static int ed448_calculate_r(uint8_t *workmem, const uint8_t *message, size_t message_length,
-			       bool prehash)
+static int ed448_calculate_r(struct sxhash *ctx, uint8_t *workmem, const uint8_t *message,
+			     size_t message_length, bool prehash)
 {
 	/* update the PHflag in dom4*/
 	dom4[PHFLAG_BYTE] = prehash ? 0x01 : 0x00;
@@ -44,12 +44,13 @@ static int ed448_calculate_r(uint8_t *workmem, const uint8_t *message, size_t me
 	size_t hash_array_lengths[] = {sizeof(dom4), SX_ED448_SZ, message_length};
 	size_t input_count = 3;
 
-	return cracen_hash_all_inputs(hash_array, hash_array_lengths, input_count,
-				      &sxhashalg_shake256_114, workmem + SX_ED448_DGST_SZ);
+	return cracen_hash_all_inputs_with_context(ctx, hash_array, hash_array_lengths, input_count,
+						  &sxhashalg_shake256_114,
+						  workmem + SX_ED448_DGST_SZ);
 }
 
-static int ed448_calculate_k(uint8_t *workmem, uint8_t *point_r, const uint8_t *message,
-			       size_t message_length, bool prehash)
+static int ed448_calculate_k(struct sxhash *ctx, uint8_t *workmem, uint8_t *point_r,
+			     const uint8_t *message, size_t message_length, bool prehash)
 {
 	/* update the PHflag in dom4*/
 	dom4[PHFLAG_BYTE] = prehash ? 0x01 : 0x00;
@@ -57,8 +58,8 @@ static int ed448_calculate_k(uint8_t *workmem, uint8_t *point_r, const uint8_t *
 	size_t hash_array_lengths[] = {sizeof(dom4), SX_ED448_SZ, SX_ED448_SZ, message_length};
 	size_t input_count = 4;
 
-	return cracen_hash_all_inputs(hash_array, hash_array_lengths, input_count,
-				      &sxhashalg_shake256_114, workmem);
+	return cracen_hash_all_inputs_with_context(ctx, hash_array, hash_array_lengths, input_count,
+						   &sxhashalg_shake256_114, workmem);
 }
 
 static int ed448_sign_internal(const uint8_t *priv_key, uint8_t *signature,
@@ -71,19 +72,26 @@ static int ed448_sign_internal(const uint8_t *priv_key, uint8_t *signature,
 	uint8_t *area_2 = workmem + AREA2_MEM_OFFSET;
 	uint8_t *area_4 = workmem + AREA4_MEM_OFFSET;
 	sx_pk_req req;
+	struct sxhash ctx;
 
-	/* Hash the private key, the digest is stored in the first 114 bytes of workmem*/
-	status = cracen_hash_input(priv_key, SX_ED448_SZ, &sxhashalg_shake256_114, area_1);
+	status = sx_hw_reserve(&ctx.dma, SX_HW_RESERVE_DEFAULT);
 	if (status != SX_OK) {
 		return status;
+	}
+
+	/* Hash the private key, the digest is stored in the first 114 bytes of workmem*/
+	status = cracen_hash_input_with_context(&ctx, priv_key, SX_ED448_SZ,
+						&sxhashalg_shake256_114, area_1);
+	if (status != SX_OK) {
+		goto exit;
 	}
 
 	/* Obtain r by hashing (prefix || message), where prefix is the second
 	 * half of the private key digest.
 	 */
-	status = ed448_calculate_r(area_2, message, message_length, prehash);
+	status = ed448_calculate_r(&ctx, area_2, message, message_length, prehash);
 	if (status != SX_OK) {
-		return status;
+		goto exit;
 	}
 
 	sx_pk_acquire_hw(&req);
@@ -96,7 +104,7 @@ static int ed448_sign_internal(const uint8_t *priv_key, uint8_t *signature,
 				 (struct sx_ed448_pt *)pnt_r);
 	if (status != SX_OK) {
 		sx_pk_release_req(&req);
-		return status;
+		goto exit;
 	}
 
 	/* The secret scalar s is computed in place from the first half of the
@@ -116,13 +124,13 @@ static int ed448_sign_internal(const uint8_t *priv_key, uint8_t *signature,
 				 (struct sx_ed448_pt *)area_2);
 	if (status != SX_OK) {
 		sx_pk_release_req(&req);
-		return status;
+		goto exit;
 	}
 
-	status = ed448_calculate_k(area_2, pnt_r, message, message_length, prehash);
+	status = ed448_calculate_k(&ctx, area_2, pnt_r, message, message_length, prehash);
 	if (status != SX_OK) {
 		sx_pk_release_req(&req);
-		return status;
+		goto exit;
 	}
 
 	/* Compute (r + k * s) mod L. This gives the second part of the
@@ -136,12 +144,14 @@ static int ed448_sign_internal(const uint8_t *priv_key, uint8_t *signature,
 	sx_pk_release_req(&req);
 
 	if (status != SX_OK) {
-		return status;
+		goto exit;
 	}
 
 	memcpy(signature, pnt_r, SX_ED448_DGST_SZ);
 	safe_memzero(workmem, sizeof(workmem));
 
+exit:
+	sx_hw_release(&ctx.dma);
 	return status;
 }
 
@@ -158,6 +168,7 @@ int cracen_ed448ph_sign(const uint8_t *priv_key, uint8_t *signature, const uint8
 	int status;
 
 	if (is_message) {
+		/* cracen_hash_input handles hardware acquire and release. */
 		status = cracen_hash_input(message, message_length, &sxhashalg_shake256_64,
 					   hashedmessage);
 		if (status != SX_OK) {
@@ -165,7 +176,7 @@ int cracen_ed448ph_sign(const uint8_t *priv_key, uint8_t *signature, const uint8
 		}
 
 		return ed448_sign_internal(priv_key, signature, hashedmessage, SHAKE256_64_DGST,
-					     true);
+					   true);
 	} else {
 		return ed448_sign_internal(priv_key, signature, message, message_length, true);
 	}
@@ -185,8 +196,9 @@ static int ed448_verify_internal(const uint8_t *pub_key, const uint8_t *message,
 	uint8_t const *hash_array[] = {dom4, signature, pub_key, message};
 	size_t hash_array_lengths[] = {sizeof(dom4), ed448_sz, ed448_sz, message_length};
 
-	status = cracen_hash_all_inputs(hash_array, hash_array_lengths,
-					input_count, &sxhashalg_shake256_114, digest);
+	/* cracen_hash_all_inputs handles hardware acquire and release. */
+	status = cracen_hash_all_inputs(hash_array, hash_array_lengths, input_count,
+					&sxhashalg_shake256_114, digest);
 	if (status != SX_OK) {
 		return status;
 	}
@@ -217,6 +229,7 @@ int cracen_ed448ph_verify(const uint8_t *pub_key, const uint8_t *message, size_t
 	uint8_t message_digest[SX_ED448_DGST_SZ];
 
 	if (is_message) {
+		/* cracen_hash_input handles hardware acquire and release. */
 		status = cracen_hash_input(message, message_length, &sxhashalg_shake256_64,
 					   message_digest);
 		if (status != SX_OK) {
@@ -224,7 +237,7 @@ int cracen_ed448ph_verify(const uint8_t *pub_key, const uint8_t *message, size_t
 		}
 
 		return ed448_verify_internal(pub_key, message_digest, SHAKE256_64_DGST,
-					       signature, true);
+					     signature, true);
 	}
 	return ed448_verify_internal(pub_key, message, message_length, signature, true);
 }
@@ -236,10 +249,12 @@ int cracen_ed448_create_pubkey(const uint8_t *priv_key, uint8_t *pub_key)
 	uint8_t *pub_key_A = digest + SX_ED448_SZ;
 	sx_pk_req req;
 
+	/* cracen_hash_input handles hardware acquire and release. */
 	status = cracen_hash_input(priv_key, SX_ED448_SZ, &sxhashalg_shake256_114, digest);
 	if (status != SX_OK) {
 		return status;
 	}
+
 	/* The secret scalar s is computed in place from the first half of the
 	 * private key digest.
 	 */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ikg/cracen_ikg_operations.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ikg/cracen_ikg_operations.c
@@ -80,6 +80,7 @@ int cracen_ikg_sign_message(int identity_key_index, const struct sxhashalg *hash
 	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
 	uint8_t digest[digestsz];
 
+	/* cracen_hash_input handles hardware acquire and release. */
 	status = cracen_hash_input(message, message_length, hashalg, digest);
 	if (status != SX_OK) {
 		return status;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_common.c
@@ -9,8 +9,10 @@
 
 #include <stddef.h>
 #include <cracen/statuscodes.h>
+#include <cracen/common.h>
 #include <cracen/mem_helpers.h>
 #include <silexpk/core.h>
+#include <sxsymcrypt/internal.h>
 
 /* RFC3394 and RFC5649 */
 _Static_assert(CRACEN_KEY_WRAP_BLOCK_SIZE == PSA_BITS_TO_BYTES(64),
@@ -22,10 +24,17 @@ psa_status_t cracen_key_wrap(const struct sxkeyref *keyref, uint8_t *block_array
 {
 	psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 	struct sxblkcipher cipher;
+	int sx_status;
 	size_t length;
 	uint8_t intermediate_block[SX_BLKCIPHER_AES_BLK_SZ];
 	uint8_t cipher_input_data[SX_BLKCIPHER_AES_BLK_SZ];
 	size_t enc_step;
+
+	/* Acquire HW once for the entire wrap loop */
+	sx_status = sx_hw_reserve(&cipher.dma, SX_HW_RESERVE_CM_ENABLED);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
 
 	for (size_t j = 0; j <= CRACEN_KEY_WRAP_ITERATIONS_COUNT; j++) {
 		for (size_t i = 0; i < plaintext_blocks_count; i++) {
@@ -64,6 +73,7 @@ psa_status_t cracen_key_wrap(const struct sxkeyref *keyref, uint8_t *block_array
 	}
 
 exit:
+	sx_hw_release(&cipher.dma);
 	safe_memzero(intermediate_block, SX_BLKCIPHER_AES_BLK_SZ);
 	safe_memzero(cipher_input_data, SX_BLKCIPHER_AES_BLK_SZ);
 	return status;
@@ -74,9 +84,16 @@ psa_status_t cracen_key_unwrap(const struct sxkeyref *keyref, uint8_t *cipher_in
 {
 	psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 	struct sxblkcipher cipher;
+	int sx_status;
 	size_t length;
 	uint8_t intermediate_block[SX_BLKCIPHER_AES_BLK_SZ];
 	size_t enc_step;
+
+	/* Acquire HW once for the entire unwrap loop */
+	sx_status = sx_hw_reserve(&cipher.dma, SX_HW_RESERVE_CM_ENABLED);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
 
 	for (size_t j = CRACEN_KEY_WRAP_ITERATIONS_COUNT + 1; j > 0; j--) {
 		for (size_t i = ciphertext_blocks_count; i > 0; i--) {
@@ -105,6 +122,7 @@ psa_status_t cracen_key_unwrap(const struct sxkeyref *keyref, uint8_t *cipher_in
 	}
 
 exit:
+	sx_hw_release(&cipher.dma);
 	safe_memzero(intermediate_block, SX_BLKCIPHER_AES_BLK_SZ);
 	return status;
 }

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_kwp.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_kwp.c
@@ -10,8 +10,10 @@
 
 #include <stddef.h>
 #include <cracen/statuscodes.h>
+#include <cracen/common.h>
 #include <cracen/mem_helpers.h>
 #include <silexpk/core.h>
+#include <sxsymcrypt/internal.h>
 
 /* RFC5649 */
 #define CRACEN_KWP_MIN_KEY_SIZE			1u
@@ -51,6 +53,7 @@ psa_status_t cracen_key_wrap_kwp_wrap(const psa_key_attributes_t *wrapping_key_a
 	size_t pad_size;
 	struct sxkeyref keyref;
 	struct sxblkcipher cipher;
+	int sx_status;
 	size_t length;
 	size_t pad_data_size;
 	psa_key_type_t key_type = psa_get_key_type(wrapping_key_attributes);
@@ -86,10 +89,16 @@ psa_status_t cracen_key_wrap_kwp_wrap(const psa_key_attributes_t *wrapping_key_a
 
 	/* NIST.SP.800-38F 6.3 */
 	if (key_size <= CRACEN_KEY_WRAP_BLOCK_SIZE) {
+		sx_status = sx_hw_reserve(&cipher.dma, SX_HW_RESERVE_CM_ENABLED);
+		if (sx_status != SX_OK) {
+			status = silex_statuscodes_to_psa(sx_status);
+			goto exit;
+		}
 		status = cracen_aes_ecb_encrypt(&cipher, &keyref,
 					      data, pad_data_size,
 					      data, pad_data_size,
 					      &length);
+		sx_hw_release(&cipher.dma);
 		if (status != PSA_SUCCESS) {
 			goto exit;
 		}
@@ -119,6 +128,7 @@ psa_status_t cracen_key_wrap_kwp_unwrap(const psa_key_attributes_t *wrapping_key
 	size_t blocks_count;
 	struct sxkeyref keyref;
 	struct sxblkcipher cipher;
+	int sx_status;
 	size_t length;
 	size_t pad_size;
 	bool sig_check_fail;
@@ -148,10 +158,16 @@ psa_status_t cracen_key_wrap_kwp_unwrap(const psa_key_attributes_t *wrapping_key
 		(data_size - CRACEN_KEY_WRAP_INTEGRITY_CHECK_REG_SIZE) / CRACEN_KEY_WRAP_BLOCK_SIZE;
 
 	if (blocks_count == 1) {
+		sx_status = sx_hw_reserve(&cipher.dma, SX_HW_RESERVE_CM_ENABLED);
+		if (sx_status != SX_OK) {
+			status = silex_statuscodes_to_psa(sx_status);
+			goto exit;
+		}
 		status = cracen_aes_ecb_decrypt(&cipher, &keyref,
 					      data, data_size,
 					      cipher_output_block, SX_BLKCIPHER_AES_BLK_SZ,
 					      &length);
+		sx_hw_release(&cipher.dma);
 		if (status != PSA_SUCCESS) {
 			goto exit;
 		}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/mac/cracen_mac_cmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/mac/cracen_mac_cmac.c
@@ -10,12 +10,30 @@
 #include <psa/crypto_values.h>
 #include <string.h>
 #include <sxsymcrypt/cmac.h>
+#include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
 #include <cracen/common.h>
 #include <cracen/mem_helpers.h>
 #include <cracen/statuscodes.h>
 
 #define AES_BLOCK_SIZE (16)
+
+/**
+ * Resume CMAC state if a previous update was saved, or re-prepare the key if
+ * CRACEN was powered off since setup (which would lose IKG-derived keys).
+ */
+static int cmac_resume_or_prepare(cracen_mac_operation_t *operation)
+{
+	if (operation->has_saved_state) {
+		return sx_mac_resume_state(&operation->cmac.ctx);
+	}
+
+	if (operation->cmac.keyref.prepare_key) {
+		return operation->cmac.keyref.prepare_key(operation->cmac.keyref.user_data);
+	}
+
+	return SX_OK;
+}
 
 psa_status_t cracen_cmac_setup(cracen_mac_operation_t *operation,
 				      const psa_key_attributes_t *attributes,
@@ -49,14 +67,21 @@ psa_status_t cracen_cmac_setup(cracen_mac_operation_t *operation,
 		return status;
 	}
 
+	/* Acquire HW before calling the SX layer create function */
+	sx_status = sx_hw_reserve(&operation->cmac.ctx.dma, SX_HW_RESERVE_CM_ENABLED);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
 	sx_status = sx_mac_create_aescmac(&operation->cmac.ctx, &operation->cmac.keyref);
+	sx_hw_release(&operation->cmac.ctx.dma);
 	if (sx_status != SX_OK) {
 		return silex_statuscodes_to_psa(sx_status);
 	}
 
 	/* As only AES is supported it is always the same block size*/
 	operation->bytes_left_for_next_block = AES_BLOCK_SIZE;
-	operation->is_first_block = true;
+	operation->has_saved_state = false;
 
 	return PSA_SUCCESS;
 }
@@ -82,11 +107,15 @@ psa_status_t cracen_cmac_update(cracen_mac_operation_t *operation, const uint8_t
 	/* The state can only be resumed if is not the first time data are
 	 * processed.
 	 */
-	if (!operation->is_first_block) {
-		sx_status = sx_mac_resume_state(&operation->cmac.ctx);
-		if (sx_status != SX_OK) {
-			return silex_statuscodes_to_psa(sx_status);
-		}
+	/* Acquire HW before resuming state or processing data */
+	sx_status = sx_hw_reserve(&operation->cmac.ctx.dma, SX_HW_RESERVE_CM_ENABLED);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
+	sx_status = cmac_resume_or_prepare(operation);
+	if (sx_status != SX_OK) {
+		goto exit;
 	}
 
 	if (operation->bytes_left_for_next_block != AES_BLOCK_SIZE &&
@@ -111,38 +140,42 @@ psa_status_t cracen_cmac_update(cracen_mac_operation_t *operation, const uint8_t
 		sx_status =
 			sx_mac_feed(&operation->cmac.ctx, operation->input_buffer, AES_BLOCK_SIZE);
 		if (sx_status != SX_OK) {
-			return silex_statuscodes_to_psa(sx_status);
+			goto exit;
 		}
 		/* Input buffer was processed, reset the bytes for the next block and
 		 * empty input buffer
 		 */
 		operation->bytes_left_for_next_block = AES_BLOCK_SIZE;
-		operation->is_first_block = false;
+		operation->has_saved_state = true;
 	}
 
 	if (block_bytes) {
 		sx_status = sx_mac_feed(&operation->cmac.ctx, input, block_bytes);
 		if (sx_status != SX_OK) {
-			return silex_statuscodes_to_psa(sx_status);
+			goto exit;
 		}
-		operation->is_first_block = false;
+		operation->has_saved_state = true;
 	}
 
-	if (!operation->is_first_block) {
+	if (operation->has_saved_state) {
 		/* save state and wait until processed */
 		sx_status = sx_mac_save_state(&operation->cmac.ctx);
 		if (sx_status != SX_OK) {
-			return silex_statuscodes_to_psa(sx_status);
+			goto exit;
 		}
 		sx_status = sx_mac_wait(&operation->cmac.ctx);
-		if (sx_status != SX_OK) {
-			return silex_statuscodes_to_psa(sx_status);
+		if (sx_status == SX_OK) {
+			/* Clear the input_buffer only after sx_mac_wait since we need to ensure
+			 * the DMA transaction is finished
+			 */
+			safe_memzero(operation->input_buffer, sizeof(operation->input_buffer));
 		}
+	}
 
-		/* Clear the input_buffer only after the sx_mac_wait call is executed
-		 * since we need to make sure that the DMA transaction is finished
-		 */
-		safe_memzero(operation->input_buffer, sizeof(operation->input_buffer));
+exit:
+	sx_hw_release(&operation->cmac.ctx.dma);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
 	}
 
 	/* Copy the remaining bytes to the local input buffer */
@@ -162,11 +195,15 @@ psa_status_t cracen_cmac_finish(cracen_mac_operation_t *operation)
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 
-	if (!operation->is_first_block) {
-		sx_status = sx_mac_resume_state(&operation->cmac.ctx);
-		if (sx_status != SX_OK) {
-			return silex_statuscodes_to_psa(sx_status);
-		}
+	/* Acquire HW before resuming state or processing data */
+	sx_status = sx_hw_reserve(&operation->cmac.ctx.dma, SX_HW_RESERVE_CM_ENABLED);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
+	sx_status = cmac_resume_or_prepare(operation);
+	if (sx_status != SX_OK) {
+		goto exit;
 	}
 
 	/* If there are data left in the input buffer feed them to the driver.
@@ -175,15 +212,19 @@ psa_status_t cracen_cmac_finish(cracen_mac_operation_t *operation)
 		sx_status = sx_mac_feed(&operation->cmac.ctx, operation->input_buffer,
 				     AES_BLOCK_SIZE - operation->bytes_left_for_next_block);
 		if (sx_status != SX_OK) {
-			return silex_statuscodes_to_psa(sx_status);
+			goto exit;
 		}
 	}
 
 	/* Generate the MAC. */
 	sx_status = sx_mac_generate(&operation->cmac.ctx, operation->input_buffer);
 	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+		goto exit;
 	}
+
 	sx_status = sx_mac_wait(&operation->cmac.ctx);
+
+exit:
+	sx_hw_release(&operation->cmac.ctx.dma);
 	return silex_statuscodes_to_psa(sx_status);
 }

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/mac/cracen_mac_hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/mac/cracen_mac_hmac.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <sxsymcrypt/hash.h>
 #include <sxsymcrypt/hashdefs.h>
+#include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
 #include <cracen/common.h>
 #include <cracen/mem_helpers.h>
@@ -31,15 +32,35 @@ psa_status_t cracen_hmac_setup(cracen_mac_operation_t *operation,
 		return psa_status;
 	}
 
+	/* Acquire HW before HMAC setup */
+	sx_status = sx_hw_reserve(&operation->hmac.hashctx.dma, SX_HW_RESERVE_DEFAULT);
+	if (sx_status != SX_OK) {
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
 	/* HMAC operation creation and configuration. */
-	sx_status =  mac_create_hmac(sx_hash_algo, &operation->hmac.hashctx, key_buffer,
+	sx_status = mac_create_hmac(sx_hash_algo, &operation->hmac.hashctx, key_buffer,
 		key_buffer_size, operation->hmac.workmem, sizeof(operation->hmac.workmem));
+	if (sx_status != SX_OK) {
+		sx_hw_release(&operation->hmac.hashctx.dma);
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
+	/* Save state and release HW for multi-step operation */
+	sx_status = sx_hash_save_state(&operation->hmac.hashctx);
+	if (sx_status != SX_OK) {
+		sx_hw_release(&operation->hmac.hashctx.dma);
+		return silex_statuscodes_to_psa(sx_status);
+	}
+
+	sx_status = sx_hash_wait(&operation->hmac.hashctx);
+	sx_hw_release(&operation->hmac.hashctx.dma);
 	if (sx_status != SX_OK) {
 		return silex_statuscodes_to_psa(sx_status);
 	}
 
 	operation->bytes_left_for_next_block = sx_hash_get_alg_blocksz(sx_hash_algo);
-	operation->is_first_block = true;
+	operation->has_saved_state = true;
 
 	return PSA_SUCCESS;
 }
@@ -74,20 +95,24 @@ psa_status_t cracen_hmac_update(cracen_mac_operation_t *operation, const uint8_t
 		return PSA_SUCCESS;
 	}
 
-	if (!operation->is_first_block) {
-		sx_status = sx_hash_resume_state(&operation->hmac.hashctx);
+	if (operation->has_saved_state) {
+		sx_status = sx_hw_reserve(&operation->hmac.hashctx.dma, SX_HW_RESERVE_DEFAULT);
 		if (sx_status != SX_OK) {
 			return silex_statuscodes_to_psa(sx_status);
 		}
+		sx_status = sx_hash_resume_state(&operation->hmac.hashctx);
+		if (sx_status != SX_OK) {
+			goto exit;
+		}
 	}
 
-	operation->is_first_block = false;
+	operation->has_saved_state = true;
 
 	/* Feed the data that are currently in the input buffer to the driver */
 	sx_status = sx_hash_feed(&operation->hmac.hashctx, operation->input_buffer,
 			(block_size - operation->bytes_left_for_next_block));
 	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+		goto exit;
 	}
 
 	/* Add fill up the next block and add as many full blocks as possible by
@@ -100,15 +125,18 @@ psa_status_t cracen_hmac_update(cracen_mac_operation_t *operation, const uint8_t
 	/* forward the data to the driver */
 	sx_status = sx_hash_feed(&operation->hmac.hashctx, input, input_chunk_length);
 	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+		goto exit;
 	}
 
 	sx_status = sx_hash_save_state(&operation->hmac.hashctx);
 	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+		goto exit;
 	}
 
 	sx_status = sx_hash_wait(&operation->hmac.hashctx);
+
+exit:
+	sx_hw_release(&operation->hmac.hashctx.dma);
 	if (sx_status != SX_OK) {
 		return silex_statuscodes_to_psa(sx_status);
 	}
@@ -142,10 +170,14 @@ psa_status_t cracen_hmac_finish(cracen_mac_operation_t *operation)
 	digestsz = sx_hash_get_alg_digestsz(sx_hash_algo);
 	block_size = sx_hash_get_alg_blocksz(sx_hash_algo);
 
-	if (!operation->is_first_block) {
-		sx_status = sx_hash_resume_state(&operation->hmac.hashctx);
+	if (operation->has_saved_state) {
+		sx_status = sx_hw_reserve(&operation->hmac.hashctx.dma, SX_HW_RESERVE_DEFAULT);
 		if (sx_status != SX_OK) {
 			return silex_statuscodes_to_psa(sx_status);
+		}
+		sx_status = sx_hash_resume_state(&operation->hmac.hashctx);
+		if (sx_status != SX_OK) {
+			goto exit;
 		}
 	}
 
@@ -153,12 +185,14 @@ psa_status_t cracen_hmac_finish(cracen_mac_operation_t *operation)
 	sx_status = sx_hash_feed(&operation->hmac.hashctx, operation->input_buffer,
 			block_size - operation->bytes_left_for_next_block);
 	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+		goto exit;
 	}
 
-	/* Generate the MAC. */
+	/* Generate the MAC */
 	sx_status = hmac_produce(&operation->hmac.hashctx, sx_hash_algo, operation->input_buffer,
-			      sizeof(operation->input_buffer), operation->hmac.workmem);
+				 sizeof(operation->input_buffer), operation->hmac.workmem);
 
+exit:
+	sx_hw_release(&operation->hmac.hashctx.dma);
 	return silex_statuscodes_to_psa(sx_status);
 }

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_encryption_rsaes_oaep.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_encryption_rsaes_oaep.c
@@ -118,16 +118,16 @@ int cracen_rsa_oaep_decrypt(const struct sxhashalg *hashalg, struct cracen_rsa_k
 		return sx_status;
 	}
 
-	/* hash the label, even when label is empty, with result overwriting the seed */
-	if (label) {
-		sx_status = cracen_hash_input(label->bytes, label->sz, hashalg, workmem.wmem + 1);
-	} else {
-		sx_status = cracen_hash_input(0, 0, hashalg, workmem.wmem + 1);
-	}
+	/* Hash the label, even when label is empty, with result overwriting the seed.
+	 * cracen_hash_input handles hardware acquire and release.
+	 */
+	sx_status = cracen_hash_input(label ? label->bytes : NULL, label ? label->sz : 0, hashalg,
+				      workmem.wmem + 1);
 	if (sx_status != SX_OK) {
 		safe_memzero(workmem.workmem, sizeof(workmem.workmem));
 		return sx_status;
 	}
+
 	int r = 0;
 
 	/* pointer used to walk through the data block DB */
@@ -199,16 +199,17 @@ int cracen_rsa_oaep_encrypt(const struct sxhashalg *hashalg, struct cracen_rsa_k
 	if (text->sz > modulussz - 2 * digestsz - 2) {
 		return SX_ERR_TOO_BIG;
 	}
-	/* hash the label, even when the label is empty */
-	if (label) {
-		sx_status = cracen_hash_input(label->bytes, label->sz, hashalg, workmem.datablock);
-	} else {
-		sx_status = cracen_hash_input(0, 0, hashalg, workmem.datablock);
-	}
+
+	/* Hash the label, even when the label is empty.
+	 * cracen_hash_input handles hardware acquire and release.
+	 */
+	sx_status = cracen_hash_input(label ? label->bytes : NULL, label ? label->sz : 0, hashalg,
+				      workmem.datablock);
 	if (sx_status != SX_OK) {
 		safe_memzero(workmem.workmem, sizeof(workmem.workmem));
 		return sx_status;
 	}
+
 	/* start encoding and request generation of the random seed */
 
 	/* pointer used to walk through the data block DB */
@@ -260,12 +261,11 @@ int cracen_rsa_oaep_encrypt(const struct sxhashalg *hashalg, struct cracen_rsa_k
 	struct sx_pk_slot inputs[NUMBER_OF_SLOTS];
 
 	sx_pk_acquire_hw(&req);
-	/* modular exponentiation m^d mod n (RSASP1 sign primitive) */
 	sx_status =
 		cracen_rsa_modexp(&req, inputs, rsa_key, workmem.wmem, modulussz, input_sizes);
 	if (sx_status != SX_OK) {
-		safe_memzero(workmem.workmem, sizeof(workmem.workmem));
 		sx_pk_release_req(&req);
+		safe_memzero(workmem.workmem, sizeof(workmem.workmem));
 		return sx_status;
 	}
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_mgf1xor.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_mgf1xor.c
@@ -13,22 +13,23 @@
 #include <internal/rsa/cracen_rsa_common.h>
 
 #include <sxsymcrypt/hash.h>
+#include <sxsymcrypt/hashdefs.h>
 #include <cracen/statuscodes.h>
 #include <cracen/common.h>
 
 /* number of bytes used for the MGF1 internal counter */
 #define MGF1_COUNTER_SZ 4
 
-static int mgf1xor_hash(uint8_t *mgfctr, const struct sxhashalg *hashalg,
-			uint8_t *seed, size_t digestsz)
+static int mgf1xor_hash(struct sxhash *ctx, uint8_t *mgfctr, size_t workmemsz,
+			const struct sxhashalg *hashalg, uint8_t *seed, size_t digestsz)
 {
 	uint8_t *mask_segment = mgfctr + MGF1_COUNTER_SZ;
 	uint8_t const *hash_array[] = {seed, mgfctr};
 	size_t hash_array_lengths[] = {digestsz, MGF1_COUNTER_SZ};
 	size_t input_count = 2;
 
-	return cracen_hash_all_inputs(hash_array, hash_array_lengths, input_count, hashalg,
-				      mask_segment);
+	return cracen_hash_all_inputs_with_context(ctx, hash_array, hash_array_lengths, input_count,
+						  hashalg, mask_segment);
 }
 
 int cracen_run_mgf1xor(uint8_t *workmem, size_t workmemsz, const struct sxhashalg *hashalg,
@@ -48,32 +49,44 @@ int cracen_run_mgf1xor(uint8_t *workmem, size_t workmemsz, const struct sxhashal
 	mgfctr[2] = 0;
 	mgfctr[3] = 0;
 
-	sx_status = mgf1xor_hash(workmem, hashalg, seed, digestsz);
-	if (sx_status != SX_OK) {
-		return sx_status;
-	}
+	{
+		struct sxhash ctx;
 
-	size_t toxor;
-	uint8_t *mask_segment = workmem + MGF1_COUNTER_SZ;
-
-	/* this function: (1) computes the xor of the mask segment that was just
-	 * produced with the bytes pointed by xorinout, (2) increments the MGF1 counter
-	 */
-
-	while (masksz > 0) {
-		toxor = (masksz > digestsz) ? digestsz : masksz;
-
-		cracen_xorbytes(xorinout, mask_segment, toxor);
-
-		xorinout += toxor;
-		/* masksz holds the number of remaining mask bytes to produce */
-		masksz -= toxor;
-
-		cracen_be_add(mgfctr, MGF1_COUNTER_SZ, 1);
-		sx_status = mgf1xor_hash(mgfctr, hashalg, seed, digestsz);
+		sx_status = sx_hw_reserve(&ctx.dma, SX_HW_RESERVE_DEFAULT);
 		if (sx_status != SX_OK) {
 			return sx_status;
 		}
+
+		sx_status = mgf1xor_hash(&ctx, workmem, workmemsz, hashalg, seed, digestsz);
+		if (sx_status != SX_OK) {
+			sx_hw_release(&ctx.dma);
+			return sx_status;
+		}
+
+		size_t toxor;
+		uint8_t *mask_segment = workmem + MGF1_COUNTER_SZ;
+
+		/* this function: (1) computes the xor of the mask segment that was just
+		 * produced with the bytes pointed by xorinout, (2) increments the MGF1 counter
+		 */
+
+		while (masksz > 0) {
+			toxor = (masksz > digestsz) ? digestsz : masksz;
+
+			cracen_xorbytes(xorinout, mask_segment, toxor);
+
+			xorinout += toxor;
+			/* masksz holds the number of remaining mask bytes to produce */
+			masksz -= toxor;
+
+			cracen_be_add(mgfctr, MGF1_COUNTER_SZ, 1);
+			sx_status = mgf1xor_hash(&ctx, mgfctr, workmemsz, hashalg, seed, digestsz);
+			if (sx_status != SX_OK) {
+				sx_hw_release(&ctx.dma);
+				return sx_status;
+			}
+		}
+		sx_hw_release(&ctx.dma);
 	}
 	return SX_OK;
 }

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_signature_rsapss.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_signature_rsapss.c
@@ -105,6 +105,7 @@ int cracen_rsa_pss_sign_message(struct cracen_rsa_key *rsa_key, struct cracen_si
 	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
 	uint8_t digest[digestsz];
 
+	/* cracen_hash_input handles hardware acquire and release. */
 	status = cracen_hash_input(message, message_length, hashalg, digest);
 	if (status != SX_OK) {
 		return status;
@@ -199,6 +200,7 @@ int cracen_rsa_pss_sign_digest(struct cracen_rsa_key *rsa_key, struct cracen_sig
 	size_t hash_array_lengths[] = {ZERO_PADDING_BYTES + digestsz, saltsz};
 	size_t input_count = 2;
 
+	/* cracen_hash_all_inputs handles hardware acquire and release. */
 	sx_status = cracen_hash_all_inputs(hash_array, hash_array_lengths, input_count, hashalg,
 					   workmem.H);
 	if (sx_status != SX_OK) {
@@ -229,8 +231,8 @@ int cracen_rsa_pss_sign_digest(struct cracen_rsa_key *rsa_key, struct cracen_sig
 	sx_pk_req req;
 	struct sx_pk_slot inputs[NUMBER_OF_SLOTS];
 
-	sx_pk_acquire_hw(&req);
 	/* modular exponentiation m^d mod n (RSASP1 sign primitive) */
+	sx_pk_acquire_hw(&req);
 	sx_status =
 		cracen_rsa_modexp(&req, inputs, rsa_key, workmem.wmem, modulussz, input_sizes);
 	if (sx_status != SX_OK) {
@@ -274,6 +276,7 @@ int cracen_rsa_pss_verify_message(struct cracen_rsa_key *rsa_key,
 	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
 	uint8_t digest[digestsz];
 
+	/* cracen_hash_input handles hardware acquire and release. */
 	status = cracen_hash_input(message, message_length, hashalg, digest);
 	if (status != SX_OK) {
 		return status;
@@ -334,8 +337,8 @@ int cracen_rsa_pss_verify_digest(struct cracen_rsa_key *rsa_key,
 	sx_pk_req req;
 	struct sx_pk_slot inputs[NUMBER_OF_SLOTS];
 
+	/* modular exponentiation s^e mod n (RSAVP1 verify primitive) */
 	sx_pk_acquire_hw(&req);
-	/* modular exponentiation m^d mod n (RSASP1 sign primitive) */
 	sx_status = cracen_rsa_modexp(&req, inputs, rsa_key, signature->r, signature->sz,
 				      input_sizes);
 	if (sx_status != SX_OK) {
@@ -399,8 +402,10 @@ int cracen_rsa_pss_verify_digest(struct cracen_rsa_key *rsa_key,
 	size_t input_count = 3;
 
 	safe_memset(zeros, WORKMEM_SIZE, 0, ZERO_PADDING_BYTES);
+
+	/* cracen_hash_all_inputs handles hardware acquire and release. H' overwrites mHash. */
 	sx_status = cracen_hash_all_inputs(hash_array, hash_array_lengths, input_count, hashalg,
-					   workmem.mHash); /* H' overwrites mHash */
+					   workmem.mHash);
 	if (sx_status != SX_OK) {
 		return sx_status;
 	}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_signature_rsassa_pkcs1v15.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_signature_rsassa_pkcs1v15.c
@@ -93,6 +93,7 @@ int cracen_rsa_pkcs1v15_sign_message(struct cracen_rsa_key *rsa_key,
 	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
 	uint8_t digest[digestsz];
 
+	/* cracen_hash_input handles hardware acquire and release. */
 	status = cracen_hash_input(message, message_length, hashalg, digest);
 	if (status != SX_OK) {
 		return status;
@@ -206,6 +207,7 @@ int cracen_rsa_pkcs1v15_verify_message(struct cracen_rsa_key *rsa_key,
 	size_t digestsz = sx_hash_get_alg_digestsz(hashalg);
 	uint8_t digest[digestsz];
 
+	/* cracen_hash_input handles hardware acquire and release. */
 	status = cracen_hash_input(message, message_length, hashalg, digest);
 	if (status != SX_OK) {
 		return status;

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/aead.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/aead.h
@@ -327,25 +327,6 @@ int sx_aead_status(struct sxaead *c);
  */
 int sx_aead_truncate_tag(struct sxaead *c, const size_t tagsz);
 
-/** Reserve the hardware for an AEAD operation.
- *
- * This function initializes and reserves the hardware for an AEAD
- * (Authenticated Encryption with Associated Data) operation. In case
- * of a multithreading application this reservation also includes locking
- * a mutex.
- *
- * @param[in,out] c AEAD operation context
- *
- * Return:
- * @return ::SX_OK
- * @return ::SX_ERR_UNKNOWN_ERROR
- * @return ::SX_ERR_DMA_FAILED
- * @return ::SX_ERR_HW_PROCESSING
- * @return ::SX_ERR_INVALID_KEYREF
- * @return ::SX_ERR_PLATFORM_ERROR
- */
-int sx_aead_hw_reserve(struct sxaead *c);
-
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/hash.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/hash.h
@@ -250,23 +250,6 @@ size_t sx_hash_get_digestsz(struct sxhash *c);
  */
 size_t sx_hash_get_blocksz(struct sxhash *c);
 
-/** Free a created hash operation context.
- *
- * A created hash operation context can have reserved hardware and
- * software resources. Those are free-ed automatically on error
- * or when the operation finishes as reported by sx_hash_status() or
- * sx_hash_wait(). If for some reason, the hash operation will not
- * be started, it can be abandoned which will release all reserved
- * resources.
- *
- * Can only be called after a call to one of the sx_hash_create_*() or
- * after sx_hash_resume(). It must be called *BEFORE* starting to run
- * the operation with sx_hash_digest() or sx_hash_save_state().
- *
- * @param[in,out] c hash operation context
- */
-void sx_hash_free(struct sxhash *c);
-
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/internal.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/internal.h
@@ -169,6 +169,14 @@ struct sxcmmask {
 	struct sxchannel channel;
 };
 
+/** Flags for sx_hw_reserve() */
+typedef enum {
+	/** Default hardware reservation with no special features */
+	SX_HW_RESERVE_DEFAULT = 0,
+	/** Enable AES countermeasures (loads random mask) */
+	SX_HW_RESERVE_CM_ENABLED = 1,
+} sx_hw_reserve_flags_t;
+
 /**
  * @brief Function to handle CRACEN nested errors in the sxsymcrypt
  *
@@ -182,6 +190,27 @@ static inline int sx_handle_nested_error(int nested_err, int err)
 {
 	return nested_err != SX_OK ? nested_err : err;
 }
+
+/** Reserve the cryptomaster hardware instance.
+ *
+ * Acquires the symmetric mutex and powers on CRACEN if needed.
+ * Must be paired with sx_hw_release() when done.
+ *
+ * @param[in,out] dma DMA controller context, or NULL for standalone operations
+ * @param[in] flags Flags controlling hardware reservation behavior
+ *
+ * @retval SX_OK on success
+ * @retval SX_ERR_DMA_FAILED if countermeasures setup failed
+ */
+int sx_hw_reserve(struct sx_dmactl *dma, sx_hw_reserve_flags_t flags);
+
+/** Release the cryptomaster hardware instance.
+ *
+ * Releases the symmetric mutex and powers off CRACEN if no other users.
+ *
+ * @param[in,out] dma DMA controller context, or NULL for standalone operations
+ */
+void sx_hw_release(struct sx_dmactl *dma);
 
 #ifdef __cplusplus
 }

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/mac.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/mac.h
@@ -169,18 +169,6 @@ int sx_mac_status(struct sxmac *c);
  */
 int sx_mac_free(struct sxmac *c);
 
-/** Find an available MAC engine for the operation.
- *
- * @param[in,out] c MAC operation context
- * @param[in]     mode_compatible Compatible hardware for the operation
- *
- * @return ::SX_OK
- * @return ::SX_ERR_DMA_FAILED
- * @return ::SX_ERR_UNKNOWN_ERROR
- *
- */
-int sx_mac_hw_reserve(struct sxmac *c);
-
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/blkcipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/blkcipher.c
@@ -15,7 +15,6 @@
 #include "cmdma.h"
 #include "cmaes.h"
 #include <stdint.h>
-#include <cracen/prng_pool.h>
 
 /** Mode Register value for context loading */
 #define BLKCIPHER_MODEID_CTX_LOAD (1u << 4)
@@ -84,38 +83,21 @@ int sx_blkcipher_free(struct sxblkcipher *cipher_ctx)
 	if (cipher_ctx->key && cipher_ctx->key->clean_key) {
 		sx_err = cipher_ctx->key->clean_key(cipher_ctx->key->user_data);
 	}
-	sx_cmdma_release_hw(&cipher_ctx->dma);
 	return sx_err;
 }
 
-int sx_blkcipher_hw_reserve(struct sxblkcipher *cipher_ctx)
+static int sx_blkcipher_prepare_key(struct sxblkcipher *cipher_ctx)
 {
 	int err = SX_OK;
 
-	uint32_t prng_value;
-
-	err = cracen_prng_value_from_pool(&prng_value);
-	if (err != SX_OK) {
-		return err;
-	}
-
-	sx_hw_reserve(&cipher_ctx->dma);
-
-	err = sx_cm_load_mask(prng_value);
-	if (err != SX_OK) {
-		goto exit;
-	}
-
 	if (cipher_ctx->key && cipher_ctx->key->prepare_key) {
 		err = cipher_ctx->key->prepare_key(cipher_ctx->key->user_data);
+		if (err != SX_OK) {
+			return sx_handle_nested_error(sx_blkcipher_free(cipher_ctx), err);
+		}
 	}
 
-exit:
-	if (err != SX_OK) {
-		return sx_handle_nested_error(sx_blkcipher_free(cipher_ctx), err);
-	}
-
-	return SX_OK;
+	return err;
 }
 
 static int sx_blkcipher_create_aesxts(struct sxblkcipher *cipher_ctx, const struct sxkeyref *key1,
@@ -141,7 +123,7 @@ static int sx_blkcipher_create_aesxts(struct sxblkcipher *cipher_ctx, const stru
 	}
 
 	cipher_ctx->key = key1;
-	err = sx_blkcipher_hw_reserve(cipher_ctx);
+	err = sx_blkcipher_prepare_key(cipher_ctx);
 	if (err != SX_OK) {
 		return err;
 	}
@@ -212,7 +194,7 @@ static int sx_blkcipher_create_aes_ba411(struct sxblkcipher *cipher_ctx, const s
 	cipher_ctx->cfg = cfg;
 	cipher_ctx->textsz = 0;
 
-	err = sx_blkcipher_hw_reserve(cipher_ctx);
+	err = sx_blkcipher_prepare_key(cipher_ctx);
 	if (err != SX_OK) {
 		return err;
 	}
@@ -310,7 +292,7 @@ int sx_blkcipher_resume_state(struct sxblkcipher *cipher_ctx)
 {
 	int err;
 
-	if (cipher_ctx->dma.hw_acquired) {
+	if (!cipher_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
 
@@ -318,7 +300,7 @@ int sx_blkcipher_resume_state(struct sxblkcipher *cipher_ctx)
 		return SX_ERR_CONTEXT_SAVING_NOT_SUPPORTED;
 	}
 
-	err = sx_blkcipher_hw_reserve(cipher_ctx);
+	err = sx_blkcipher_prepare_key(cipher_ctx);
 	if (err != SX_OK) {
 		return err;
 	}
@@ -411,14 +393,12 @@ int sx_blkcipher_ecb_simple(uint8_t *key, size_t key_size, uint8_t *input, size_
 	int status = SX_ERR_HW_PROCESSING;
 
 	uint32_t cmd = CMDMA_BLKCIPHER_MODE_SET(BLKCIPHER_MODEID_ECB);
-	/* Both out_desc and in_descs are used after sx_hw_reserve which locks
-	 * the symmetric mutex, so it is safe to have them as static.
+	/* Both out_desc and in_descs are used while the CM hardware is reserved,
+	 * which locks the symmetric mutex, so it is safe to have them as static.
+	 * CM hardware must be reserved by the caller via sx_hw_reserve().
 	 */
 	static struct sxdesc out_desc;
 	static struct sxdesc in_descs[3];
-
-	/* This guards the static variables out_desc and in_descs */
-	sx_hw_reserve(NULL);
 
 	in_descs[0].addr = (uint8_t *)&cmd;
 	in_descs[0].sz = DMA_REALIGN | sizeof(cmd);
@@ -455,8 +435,6 @@ int sx_blkcipher_ecb_simple(uint8_t *key, size_t key_size, uint8_t *input, size_
 	while (status == SX_ERR_HW_PROCESSING) {
 		status = sx_cmdma_check();
 	}
-
-	sx_cmdma_release_hw(NULL);
 
 #if CONFIG_DCACHE
 	sys_cache_data_invd_range(output, output_size);

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/chachapoly.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/chachapoly.c
@@ -111,10 +111,9 @@ static int sx_aead_create_chacha20poly1305(struct sxaead *aead_ctx, const struct
 		return SX_ERR_INVALID_KEY_SZ;
 	}
 
-	/* has countermeasures and the key need to be set before callling sx_aead_hw_reserve */
+	/* ChaCha20Poly1305 doesn't use countermeasures */
 	aead_ctx->has_countermeasures = false;
 	aead_ctx->key = key;
-	sx_aead_hw_reserve(aead_ctx);
 
 	aead_ctx->cfg = &ba417chachapolycfg;
 
@@ -154,8 +153,6 @@ static int sx_blkcipher_create_chacha20(struct sxblkcipher *cipher_ctx, struct s
 	}
 
 	cipher_ctx->key = key;
-	sx_blkcipher_hw_reserve(cipher_ctx);
-
 	cipher_ctx->cfg = &ba417chacha20cfg;
 
 	sx_cmdma_newcmd(&cipher_ctx->dma, cipher_ctx->descs, BA417_MODE_CHACHA20 | dir,

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmac.c
@@ -15,7 +15,6 @@
 #include "hw.h"
 #include "cmdma.h"
 #include "cmaes.h"
-#include <cracen/prng_pool.h>
 
 #define CMDMA_BA411_BUS_MSK (0x0F)
 #define CMAC_MODEID_AES	    8
@@ -59,9 +58,13 @@ static int sx_cmac_create_aes_ba411(struct sxmac *mac_ctx, const struct sxkeyref
 	}
 
 	mac_ctx->key = key;
-	err = sx_mac_hw_reserve(mac_ctx);
-	if (err != SX_OK) {
-		return err;
+
+	/* Key preparation - CM setup is handled by CRACENPSA layer via sx_hw_reserve() */
+	if (key->prepare_key) {
+		err = key->prepare_key(key->user_data);
+		if (err != SX_OK) {
+			return err;
+		}
 	}
 
 	mac_ctx->cfg = &ba411cfg;

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hmac.c
@@ -59,7 +59,6 @@ static int sx_hash_create_hmac_ba413(struct sxmac *mac_ctx, const struct sxhasha
 	}
 
 	mac_ctx->key = keyref;
-	sx_hw_reserve(&mac_ctx->dma);
 
 	mac_ctx->cfg = &ba413cfg;
 	sx_cmdma_newcmd(&mac_ctx->dma, mac_ctx->descs,
@@ -121,7 +120,6 @@ static int sx_hash_create_hmac_ba418(struct sxmac *mac_ctx, const struct sxhasha
 	}
 
 	mac_ctx->key = keyref;
-	sx_hw_reserve(&mac_ctx->dma);
 
 	mac_ctx->cfg = &ba418cfg;
 

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hw.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hw.h
@@ -115,12 +115,4 @@ static inline uint32_t sx_rd_trng(uint32_t addr)
 	return v;
 }
 
-/** Reserve the cryptomaster instance
- *  and should be given back after use with sx_cmdma_release_hw().
- */
-void sx_hw_reserve(struct sx_dmactl *dma);
-
-/** Release the cryptomaster instance */
-void sx_cmdma_release_hw(struct sx_dmactl *dma);
-
 #endif

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/platform/baremetal/cmdma_hw.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/platform/baremetal/cmdma_hw.c
@@ -13,6 +13,10 @@
 #include "../../cmdma.h"
 #include <cracen/hardware.h>
 #include <cracen/statuscodes.h>
+#if defined(CONFIG_PSA_WANT_KEY_TYPE_AES)
+#include <cracen/prng_pool.h>
+#include <sxsymcrypt/cmmask.h>
+#endif
 
 #include <nrf_security_mutexes.h>
 
@@ -37,7 +41,7 @@ static void sx_hw_enable_interrupts(void)
 	nrf_cracen_int_enable(NRF_CRACEN, CRACEN_ENABLE_CRYPTOMASTER_Msk);
 }
 
-void sx_hw_reserve(struct sx_dmactl *dma)
+int sx_hw_reserve(struct sx_dmactl *dma, sx_hw_reserve_flags_t flags)
 {
 	cracen_acquire();
 	nrf_security_mutex_lock(cracen_mutex_symmetric);
@@ -48,9 +52,27 @@ void sx_hw_reserve(struct sx_dmactl *dma)
 	if (IS_ENABLED(CONFIG_CRACEN_USE_INTERRUPTS)) {
 		sx_hw_enable_interrupts();
 	}
+
+#if defined(CONFIG_PSA_WANT_KEY_TYPE_AES)
+	if (flags & SX_HW_RESERVE_CM_ENABLED) {
+		int err;
+		uint32_t prng_value;
+
+		err = cracen_prng_value_from_pool(&prng_value);
+		if (err == SX_OK) {
+			err = sx_cm_load_mask(prng_value);
+		}
+		if (err != SX_OK) {
+			sx_hw_release(dma);
+			return err;
+		}
+	}
+#endif
+
+	return SX_OK;
 }
 
-void sx_cmdma_release_hw(struct sx_dmactl *dma)
+void sx_hw_release(struct sx_dmactl *dma)
 {
 	if (dma == NULL || dma->hw_acquired) {
 		cracen_release();

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/platform/baremetal/interrupts.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/platform/baremetal/interrupts.c
@@ -85,7 +85,7 @@ static uint32_t cracen_wait_for_interrupt(nrf_security_event_t event)
 {
 	uint32_t ret = nrf_security_event_wait(event, 0xFFFFFFFF);
 
-	/* sx_hw_reserve, sx_cmdma_release_hw, and sx_pk_acquire_hw has
+	/* sx_hw_reserve, sx_hw_release, and sx_pk_acquire_hw have
 	 * assured single usage of CRACEN so there should be no race
 	 * condition between reading this event and clearing it.
 	 */

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/sha3.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/sha3.c
@@ -99,8 +99,6 @@ static int sx_hash_create_ba418(struct sxhash *hash_ctx, size_t csz)
 		return SX_ERR_ALLOCATION_TOO_SMALL;
 	}
 
-	sx_hw_reserve(&hash_ctx->dma);
-
 	hash_ctx->dmatags = &ba418tags;
 	sx_cmdma_newcmd(&hash_ctx->dma, hash_ctx->descs, hash_ctx->algo->cfgword,
 			hash_ctx->dmatags->cfg);


### PR DESCRIPTION
Move Cryptomaster hardware acquisition and release from the SX layer to the CRACENPSA layer, matching the pattern used for PKE operations. This allows holding hardware across multiple calls, reducing overhead for multi-part operations.

Add sx_cm_enable() helper function to simplify countermeasure setup. Add countermeasure flag to the reserve hardware function. Rename is_first_block to has_saved_state for clarity in HMAC.