### PR TITLE
doc: ug_nrf54h20: document how to assign peripherals to cores

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54h/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/index.rst
@@ -75,3 +75,4 @@ Zephyr and the |NCS| provide support and contain board definitions for developin
    :caption: Optimize the power management of your application
 
    ug_nrf54h20_pm_optimization
+   ug_nrf54h20_assigning_peripherals

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_architecture_cpu.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_architecture_cpu.rst
@@ -91,6 +91,7 @@ Global domain
 The global domain contains most of the memory and peripherals of the nRF54H20.
 This offers flexibility to assign memory regions and peripherals to different cores.
 If this flexibility is not needed, it is possible to use the |NCS| defaults, where most of the memory and peripherals are assigned to the application core.
+See :ref:`ug_nrf54h20_assigning_peripherals` for information on how to assign peripherals to different cores.
 
 The global domain includes two sets of power domains:
 

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_assigning_peripherals.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_assigning_peripherals.rst
@@ -1,0 +1,59 @@
+.. _ug_nrf54h20_assigning_peripherals:
+
+Assigning peripherals to cores on the nRF54H20 SoC
+##################################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+Peripherals in the global domain of the nRF54H20 SoC can have global ownership.
+However, you must assign each peripheral IRQ to a specific core by specifying the peripheral's interrupt controller and enabling the peripheral in the devicetree.
+You must also set the peripheral ownership using the ``status`` property.
+By default, the global peripherals are assigned to the application core.
+Their IRQs are also routed to the application core.
+To assign a global peripheral to a different core, do the following:
+
+1. Update the global peripheral's devicetree node in the application core as follows:
+
+   * If the IRQ is forwarded to a VPR that is owned by the application core, set ``status = "reserved"``.
+   * If the peripheral is assigned to the radio core, set ``status = "disabled"`` in the application core devicetree.
+
+See the following example of the application core devicetree forwarding the IRQ to the PPR core (owned by the application core itself):
+
+.. code-block:: devicetree
+
+    /* Will be used by PPR core */
+    &uart135 {
+        status = "reserved";
+    };
+
+#. For global peripherals whose interrupts are routed to the core to which they are assigned, update the interrupt parent in the application core devicetree accordingly:
+
+.. code-block:: devicetree
+
+    /* Will be used by FLPR core */
+    &can120 {
+        status = "reserved";
+        interrupt-parent = <&cpuflpr_clic>; /* FLPR core's interrupt controller */
+    };
+
+#. You can now enable and configure the peripheral in the devicetree of the core to which the peripheral is assigned. See the following examples.
+
+      * PPR core devicetree:
+
+      .. code-block:: devicetree
+
+        &uart120 {
+                status = "okay";
+                ...
+        };
+
+      * FLPR core devicetree:
+
+      .. code-block:: devicetree
+
+        &can120 {
+                status = "okay";
+                ...
+        };

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_flpr.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_flpr.rst
@@ -22,6 +22,7 @@ These peripherals have IRQs routed to FLPR:
 * SPIM120/UARTE120
 * SPIM121
 
+See :ref:`ug_nrf54h20_assigning_peripherals` for information on how to assign peripherals to the FLPR core.
 All other peripherals available to the application core can also be used with FLPR.
 However, they require the use of *polling mode*.
 

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_ppr.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_ppr.rst
@@ -16,6 +16,7 @@ Using Zephyr multithreaded mode on PPR
 
 The PPR core can operate as a general-purpose core, running under the full Zephyr kernel.
 Building the PPR target is similar to building the application core, but the application core build must include an overlay that enables the PPR core.
+See :ref:`ug_nrf54h20_assigning_peripherals` for information on how to assign peripherals to the PPR core.
 
 Bootstrapping the PPR core
 ==========================


### PR DESCRIPTION
Document how to assign peripherals and their interrupts to different cores, and add links to the new documentation in existing docs.