### PR TITLE
tests: storage: Add tests for addr macros

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -975,6 +975,7 @@
 /tests/subsys/pcd/                        @nrfconnect/ncs-eris
 /tests/subsys/rtt/                        @nrfconnect/ncs-low-level-test
 /tests/subsys/swo/                        @nrfconnect/ncs-low-level-test
+/tests/subsys/storage/partition_macros/   @nrfconnect/ncs-eris
 /tests/subsys/usb/negotiated_speed/       @nrfconnect/ncs-low-level-test
 /tests/subsys/west_debug/                 @nrfconnect/ncs-low-level-test
 /tests/subsys/west_flash/                 @nrfconnect/ncs-low-level-test

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -1583,6 +1583,13 @@ ci_tests_subsys_kmu:
     - nrf/subsys/nrf_security/
     - nrf/tests/subsys/kmu/
 
+ci_tests_subsys_storage:
+  files:
+    - zephyr/subsys/storage/
+    - zephyr/include/zephyr/storage/
+    - zephyr/tests/subsys/storage/
+    - nrf/tests/subsys/storage/
+
 ci_applications_protocols_serialization:
   files:
     - modules/crypto/

--- a/tests/subsys/storage/partition_macros/CMakeLists.txt
+++ b/tests/subsys/storage/partition_macros/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(partition_macros)
+
+target_sources(app PRIVATE
+  src/main.c
+)

--- a/tests/subsys/storage/partition_macros/Kconfig.sysbuild
+++ b/tests/subsys/storage/partition_macros/Kconfig.sysbuild
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if !SOC_SERIES_NRF54H
+config PARTITION_MANAGER
+	default n
+endif
+
+source "share/sysbuild/Kconfig"

--- a/tests/subsys/storage/partition_macros/app.overlay
+++ b/tests/subsys/storage/partition_macros/app.overlay
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	dummy_flash@1000 {
+		compatible = "nordic,flash";
+		reg = <0x1000 DT_SIZE_K(32)>;
+		ranges = <0x0 0x1000 DT_SIZE_K(32)>;
+		status = "disabled";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			ranges;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			dummy_0x0: partition@0 {
+				reg = <0x0 DT_SIZE_K(4)>;
+			};
+
+			dummy_0x1000: partition@1000 {
+				compatible = "fixed-subpartitions";
+				reg = <0x1000 DT_SIZE_K(8)>;
+				ranges = <0x0 0x1000 DT_SIZE_K(8)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				dummy_0x1000_0x0: partition@0 {
+					reg = <0x0 DT_SIZE_K(2)>;
+				};
+
+				dummy_0x1000_0x800: partition@800 {
+					compatible = "fixed-subpartitions";
+					reg = <0x800 DT_SIZE_K(2)>;
+					ranges = <0x0 0x800 DT_SIZE_K(2)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					dummy_0x1000_0x800_0x0: partition@0 {
+						reg = <0x0 DT_SIZE_K(1)>;
+					};
+
+					dummy_0x1000_0x800_0x400: partition@400 {
+						reg = <0x400 DT_SIZE_K(1)>;
+					};
+				};
+
+				dummy_0x1000_0x1000: partition@1000 {
+					reg = <0x1000 DT_SIZE_K(4)>;
+				};
+			};
+
+			dummy_0x3000: partition@3000 {
+				compatible = "fixed-subpartitions";
+				reg = <0x3000 DT_SIZE_K(4)>;
+				/* Intentionally do not define ranges. */
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				dummy_0x3000_0x0: partition@0 {
+					reg = <0x0 DT_SIZE_K(2)>;
+				};
+
+				dummy_0x3000_0x800: partition@800 {
+					compatible = "fixed-subpartitions";
+					reg = <0x800 DT_SIZE_K(2)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					dummy_0x3000_0x800_0x0: partition@0 {
+						reg = <0x0 DT_SIZE_K(1)>;
+					};
+
+					dummy_0x3000_0x800_0x400: partition@400 {
+						reg = <0x400 DT_SIZE_K(1)>;
+					};
+				};
+
+				dummy_0x3000_0x1000: partition@1000 {
+					reg = <0x1000 DT_SIZE_K(4)>;
+				};
+			};
+
+			dummy_0x4000: partition@4000 {
+				reg = <0x4000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+
+	dummy_nrange_flash@11000 {
+		compatible = "nordic,flash";
+		reg = <0x11000 DT_SIZE_K(32)>;
+		status = "disabled";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			dummy_nrange_0x0: partition@0 {
+				reg = <0x0 DT_SIZE_K(4)>;
+			};
+
+			dummy_nrange_0x1000: partition@1000 {
+				compatible = "fixed-subpartitions";
+				reg = <0x1000 DT_SIZE_K(8)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				dummy_nrange_0x1000_0x0: partition@0 {
+					reg = <0x0 DT_SIZE_K(2)>;
+				};
+
+				dummy_nrange_0x1000_0x800: partition@800 {
+					compatible = "fixed-subpartitions";
+					reg = <0x800 DT_SIZE_K(2)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					dummy_nrange_0x1000_0x800_0x0: partition@0 {
+						reg = <0x0 DT_SIZE_K(1)>;
+					};
+
+					dummy_nrange_0x1000_0x800_0x400: partition@400 {
+						reg = <0x400 DT_SIZE_K(1)>;
+					};
+				};
+
+				dummy_nrange_0x1000_0x1000: partition@1000 {
+					reg = <0x1000 DT_SIZE_K(4)>;
+				};
+			};
+
+			dummy_nrange_0x4000: partition@4000 {
+				reg = <0x4000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};

--- a/tests/subsys/storage/partition_macros/prj.conf
+++ b/tests/subsys/storage/partition_macros/prj.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_ZTEST=y
+CONFIG_LOG=y

--- a/tests/subsys/storage/partition_macros/src/main.c
+++ b/tests/subsys/storage/partition_macros/src/main.c
@@ -1,0 +1,495 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/storage/flash_map.h>
+
+#define DUMMY_FLASH_OFFSET  0x1000
+#define DUMMY_NRANGE_OFFSET 0x11000
+
+ZTEST(partition_macros, test_dt_reg_addr)
+{
+	/* Test regular fixed partitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x0, DT_REG_ADDR(DT_NODELABEL(dummy_0x0)),
+		      "Expected 0x1000, got 0x%x", DT_REG_ADDR(DT_NODELABEL(dummy_0x0)));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x4000, DT_REG_ADDR(DT_NODELABEL(dummy_0x4000)),
+		      "Expected 0x5000, got 0x%x", DT_REG_ADDR(DT_NODELABEL(dummy_0x4000)));
+
+	/* Test regular fixed subpartitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x0,
+		      DT_REG_ADDR(DT_NODELABEL(dummy_0x1000_0x0)), "Expected 0x2000, got 0x%x",
+		      DT_REG_ADDR(DT_NODELABEL(dummy_0x1000_0x0)));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x1000,
+		      DT_REG_ADDR(DT_NODELABEL(dummy_0x1000_0x1000)), "Expected 0x3000, got 0x%x",
+		      DT_REG_ADDR(DT_NODELABEL(dummy_0x1000_0x1000)));
+
+	/* Test regular fixed sub-subpartitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x800 + 0x0,
+		      DT_REG_ADDR(DT_NODELABEL(dummy_0x1000_0x800_0x0)),
+		      "Expected 0x2800, got 0x%x",
+		      DT_REG_ADDR(DT_NODELABEL(dummy_0x1000_0x800_0x0)));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x800 + 0x400,
+		      DT_REG_ADDR(DT_NODELABEL(dummy_0x1000_0x800_0x400)),
+		      "Expected 0x2c00, got 0x%x",
+		      DT_REG_ADDR(DT_NODELABEL(dummy_0x1000_0x800_0x400)));
+
+	/* Test subpartitions that do not define "ranges"*/
+	zassert_equal(0x0, DT_REG_ADDR(DT_NODELABEL(dummy_0x3000_0x0)), "Expected 0x0, got 0x%x",
+		      DT_REG_ADDR(DT_NODELABEL(dummy_0x3000_0x0)));
+	zassert_equal(0x1000, DT_REG_ADDR(DT_NODELABEL(dummy_0x3000_0x1000)),
+		      "Expected 0x1000, got 0x%x", DT_REG_ADDR(DT_NODELABEL(dummy_0x3000_0x1000)));
+
+	/* Test sub-subpartitions that do not define "ranges"*/
+	zassert_equal(0x0, DT_REG_ADDR(DT_NODELABEL(dummy_0x3000_0x800_0x0)),
+		      "Expected 0x0, got 0x%x", DT_REG_ADDR(DT_NODELABEL(dummy_0x3000_0x800_0x0)));
+	zassert_equal(0x400, DT_REG_ADDR(DT_NODELABEL(dummy_0x3000_0x800_0x400)),
+		      "Expected 0x400, got 0x%x",
+		      DT_REG_ADDR(DT_NODELABEL(dummy_0x3000_0x800_0x400)));
+
+	/* Test fixed partition that contains subpartitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000, DT_REG_ADDR(DT_NODELABEL(dummy_0x1000)),
+		      "Expected 0x2000, got 0x%x", DT_REG_ADDR(DT_NODELABEL(dummy_0x1000)));
+
+	/* Test fixed partition that contains subpartitions and do not define "ranges" */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000, DT_REG_ADDR(DT_NODELABEL(dummy_0x3000)),
+		      "Expected 0x4000, got 0x%x", DT_REG_ADDR(DT_NODELABEL(dummy_0x3000)));
+}
+
+ZTEST(partition_macros, test_dt_reg_addr_nrange)
+{
+	/* Test regular fixed partitions */
+	zassert_equal(0x0, DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x0)), "Expected 0x0, got 0x%x",
+		      DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x0)));
+	zassert_equal(0x4000, DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x4000)),
+		      "Expected 0x4000, got 0x%x", DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x4000)));
+
+	/* Test regular fixed subpartitions */
+	zassert_equal(0x0, DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x0)),
+		      "Expected 0x0, got 0x%x", DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x0)));
+	zassert_equal(0x1000, DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x1000)),
+		      "Expected 0x1000, got 0x%x",
+		      DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x1000)));
+
+	/* Test regular fixed sub-subpartitions */
+	zassert_equal(0x0, DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x800_0x0)),
+		      "Expected 0x0, got 0x%x",
+		      DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x800_0x0)));
+	zassert_equal(0x400, DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x800_0x400)),
+		      "Expected 0x400, got 0x%x",
+		      DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x800_0x400)));
+
+	/* Test fixed partition that contains subpartitions */
+	zassert_equal(0x1000, DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x1000)),
+		      "Expected 0x1000, got 0x%x", DT_REG_ADDR(DT_NODELABEL(dummy_nrange_0x1000)));
+}
+
+ZTEST(partition_macros, test_dt_fixed_partition_addr)
+{
+	/* Test regular fixed partitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x0, DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_0x0)),
+		      "Expected 0x1000, got 0x%x",
+		      DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_0x0)));
+	zassert_equal(
+		DUMMY_FLASH_OFFSET + 0x4000, DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_0x4000)),
+		"Expected 0x5000, got 0x%x", DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_0x4000)));
+
+	/* Test fixed partition that contains subpartitions */
+	zassert_equal(
+		DUMMY_FLASH_OFFSET + 0x1000, DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_0x1000)),
+		"Expected 0x2000, got 0x%x", DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_0x1000)));
+
+	/* Test fixed partition that contains subpartitions and do not define "ranges" */
+	zassert_equal(
+		DUMMY_FLASH_OFFSET + 0x3000, DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_0x3000)),
+		"Expected 0x4000, got 0x%x", DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_0x3000)));
+}
+
+ZTEST(partition_macros, test_dt_fixed_partition_addr_nrange)
+{
+	/* Test regular fixed partitions */
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x0,
+		      DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x0)),
+		      "Expected 0x11000, got 0x%x",
+		      DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x0)));
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x4000,
+		      DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x4000)),
+		      "Expected 0x15000, got 0x%x",
+		      DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x4000)));
+
+	/* Test fixed partition that contains subpartitions */
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000,
+		      DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x1000)),
+		      "Expected 0x12000, got 0x%x",
+		      DT_FIXED_PARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x1000)));
+}
+
+ZTEST(partition_macros, test_dt_fixed_subpartition_addr)
+{
+	/* Test regular fixed subpartitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x0,
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x1000_0x0)),
+		      "Expected 0x2000, got 0x%x",
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x1000_0x0)));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x1000,
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x1000_0x1000)),
+		      "Expected 0x3000, got 0x%x",
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x1000_0x1000)));
+
+	/* Test regular fixed sub-subpartitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x800 + 0x0,
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x1000_0x800_0x0)),
+		      "Expected 0x2800, got 0x%x",
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x1000_0x800_0x0)));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x800 + 0x400,
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x1000_0x800_0x400)),
+		      "Expected 0x2c00, got 0x%x",
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x1000_0x800_0x400)));
+
+	/* Test subpartitions that do not define "ranges"*/
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000 + 0x0,
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x3000_0x0)),
+		      "Expected 0x4000, got 0x%x",
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x3000_0x0)));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000 + 0x1000,
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x3000_0x1000)),
+		      "Expected 0x5000, got 0x%x",
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x3000_0x1000)));
+
+	/* Test sub-subpartitions that do not define "ranges"*/
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000 + 0x800 + 0x0,
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x3000_0x800_0x0)),
+		      "Expected 0x4800, got 0x%x",
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x3000_0x800_0x0)));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000 + 0x800 + 0x400,
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x3000_0x800_0x400)),
+		      "Expected 0x4c00, got 0x%x",
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_0x3000_0x800_0x400)));
+}
+
+ZTEST(partition_macros, test_dt_fixed_subpartition_addr_nrange)
+{
+	/* Test regular fixed subpartitions */
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000 + 0x0,
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x0)),
+		      "Expected 0x12000, got 0x%x",
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x0)));
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000 + 0x1000,
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x1000)),
+		      "Expected 0x13000, got 0x%x",
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x1000)));
+
+	/* Test regular fixed sub-subpartitions */
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000 + 0x800 + 0x0,
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x800_0x0)),
+		      "Expected 0x12800, got 0x%x",
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x800_0x0)));
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000 + 0x800 + 0x400,
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x800_0x400)),
+		      "Expected 0x12c00, got 0x%x",
+		      DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(dummy_nrange_0x1000_0x800_0x400)));
+}
+
+ZTEST(partition_macros, test_fixed_partition_address)
+{
+	/* Test regular fixed partitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x0, FIXED_PARTITION_ADDRESS(dummy_0x0),
+		      "Expected 0x1000, got 0x%x", FIXED_PARTITION_ADDRESS(dummy_0x0));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x4000, FIXED_PARTITION_ADDRESS(dummy_0x4000),
+		      "Expected 0x5000, got 0x%x", FIXED_PARTITION_ADDRESS(dummy_0x4000));
+
+	/* Test regular fixed subpartitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x0, FIXED_PARTITION_ADDRESS(dummy_0x1000_0x0),
+		      "Expected 0x2000, got 0x%x", FIXED_PARTITION_ADDRESS(dummy_0x1000_0x0));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x1000,
+		      FIXED_PARTITION_ADDRESS(dummy_0x1000_0x1000), "Expected 0x3000, got 0x%x",
+		      FIXED_PARTITION_ADDRESS(dummy_0x1000_0x1000));
+
+	/* Test regular fixed sub-subpartitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x800 + 0x0,
+		      FIXED_PARTITION_ADDRESS(dummy_0x1000_0x800_0x0), "Expected 0x2800, got 0x%x",
+		      FIXED_PARTITION_ADDRESS(dummy_0x1000_0x800_0x0));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x800 + 0x400,
+		      FIXED_PARTITION_ADDRESS(dummy_0x1000_0x800_0x400),
+		      "Expected 0x2c00, got 0x%x",
+		      FIXED_PARTITION_ADDRESS(dummy_0x1000_0x800_0x400));
+
+	/* Test subpartitions that do not define "ranges"*/
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000 + 0x0, FIXED_PARTITION_ADDRESS(dummy_0x3000_0x0),
+		      "Expected 0x4000, got 0x%x", FIXED_PARTITION_ADDRESS(dummy_0x3000_0x0));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000 + 0x1000,
+		      FIXED_PARTITION_ADDRESS(dummy_0x3000_0x1000), "Expected 0x5000, got 0x%x",
+		      FIXED_PARTITION_ADDRESS(dummy_0x3000_0x1000));
+
+	/* Test sub-subpartitions that do not define "ranges"*/
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000 + 0x800 + 0x0,
+		      FIXED_PARTITION_ADDRESS(dummy_0x3000_0x800_0x0), "Expected 0x4800, got 0x%x",
+		      FIXED_PARTITION_ADDRESS(dummy_0x3000_0x800_0x0));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000 + 0x800 + 0x400,
+		      FIXED_PARTITION_ADDRESS(dummy_0x3000_0x800_0x400),
+		      "Expected 0x4c00, got 0x%x",
+		      FIXED_PARTITION_ADDRESS(dummy_0x3000_0x800_0x400));
+
+	/* Test fixed partition that contains subpartitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000, FIXED_PARTITION_ADDRESS(dummy_0x1000),
+		      "Expected 0x2000, got 0x%x", FIXED_PARTITION_ADDRESS(dummy_0x1000));
+
+	/* Test fixed partition that contains subpartitions and do not define "ranges" */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000, FIXED_PARTITION_ADDRESS(dummy_0x3000),
+		      "Expected 0x4000, got 0x%x", FIXED_PARTITION_ADDRESS(dummy_0x3000));
+}
+
+ZTEST(partition_macros, test_fixed_partition_node_address)
+{
+	/* Test regular fixed partitions */
+	zassert_equal(
+		DUMMY_FLASH_OFFSET + 0x0, FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x0)),
+		"Expected 0x1000, got 0x%x", FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x0)));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x4000,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x4000)),
+		      "Expected 0x5000, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x4000)));
+
+	/* Test regular fixed subpartitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x0,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x1000_0x0)),
+		      "Expected 0x2000, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x1000_0x0)));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x1000,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x1000_0x1000)),
+		      "Expected 0x3000, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x1000_0x1000)));
+
+	/* Test regular fixed sub-subpartitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x800 + 0x0,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x1000_0x800_0x0)),
+		      "Expected 0x2800, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x1000_0x800_0x0)));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000 + 0x800 + 0x400,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x1000_0x800_0x400)),
+		      "Expected 0x2c00, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x1000_0x800_0x400)));
+
+	/* Test subpartitions that do not define "ranges"*/
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000 + 0x0,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x3000_0x0)),
+		      "Expected 0x4000, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x3000_0x0)));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000 + 0x1000,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x3000_0x1000)),
+		      "Expected 0x5000, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x3000_0x1000)));
+
+	/* Test sub-subpartitions that do not define "ranges"*/
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000 + 0x800 + 0x0,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x3000_0x800_0x0)),
+		      "Expected 0x4800, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x3000_0x800_0x0)));
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000 + 0x800 + 0x400,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x3000_0x800_0x400)),
+		      "Expected 0x4c00, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x3000_0x800_0x400)));
+
+	/* Test fixed partition that contains subpartitions */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x1000,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x1000)),
+		      "Expected 0x2000, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x1000)));
+
+	/* Test fixed partition that contains subpartitions and do not define "ranges" */
+	zassert_equal(DUMMY_FLASH_OFFSET + 0x3000,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x3000)),
+		      "Expected 0x4000, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_0x3000)));
+}
+
+ZTEST(partition_macros, test_fixed_partition_address_nrange)
+{
+	/* Test regular fixed partitions */
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x0, FIXED_PARTITION_ADDRESS(dummy_nrange_0x0),
+		      "Expected 0x11000, got 0x%x", FIXED_PARTITION_ADDRESS(dummy_nrange_0x0));
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x4000, FIXED_PARTITION_ADDRESS(dummy_nrange_0x4000),
+		      "Expected 0x15000, got 0x%x", FIXED_PARTITION_ADDRESS(dummy_nrange_0x4000));
+
+	/* Test regular fixed subpartitions */
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000 + 0x0,
+		      FIXED_PARTITION_ADDRESS(dummy_nrange_0x1000_0x0),
+		      "Expected 0x12000, got 0x%x",
+		      FIXED_PARTITION_ADDRESS(dummy_nrange_0x1000_0x0));
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000 + 0x1000,
+		      FIXED_PARTITION_ADDRESS(dummy_nrange_0x1000_0x1000),
+		      "Expected 0x13000, got 0x%x",
+		      FIXED_PARTITION_ADDRESS(dummy_nrange_0x1000_0x1000));
+
+	/* Test regular fixed sub-subpartitions */
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000 + 0x800 + 0x0,
+		      FIXED_PARTITION_ADDRESS(dummy_nrange_0x1000_0x800_0x0),
+		      "Expected 0x12800, got 0x%x",
+		      FIXED_PARTITION_ADDRESS(dummy_nrange_0x1000_0x800_0x0));
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000 + 0x800 + 0x400,
+		      FIXED_PARTITION_ADDRESS(dummy_nrange_0x1000_0x800_0x400),
+		      "Expected 0x12c00, got 0x%x",
+		      FIXED_PARTITION_ADDRESS(dummy_nrange_0x1000_0x800_0x400));
+
+	/* Test fixed partition that contains subpartitions */
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000, FIXED_PARTITION_ADDRESS(dummy_nrange_0x1000),
+		      "Expected 0x2000, got 0x%x", FIXED_PARTITION_ADDRESS(dummy_nrange_0x1000));
+}
+
+ZTEST(partition_macros, test_fixed_partition_node_address_nrange)
+{
+	/* Test regular fixed partitions */
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x0,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x0)),
+		      "Expected 0x11000, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x0)));
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x4000,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x4000)),
+		      "Expected 0x15000, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x4000)));
+
+	/* Test regular fixed subpartitions */
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000 + 0x0,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x1000_0x0)),
+		      "Expected 0x12000, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x1000_0x0)));
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000 + 0x1000,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x1000_0x1000)),
+		      "Expected 0x13000, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x1000_0x1000)));
+
+	/* Test regular fixed sub-subpartitions */
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000 + 0x800 + 0x0,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x1000_0x800_0x0)),
+		      "Expected 0x12800, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x1000_0x800_0x0)));
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000 + 0x800 + 0x400,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x1000_0x800_0x400)),
+		      "Expected 0x12c00, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x1000_0x800_0x400)));
+
+	/* Test fixed partition that contains subpartitions */
+	zassert_equal(DUMMY_NRANGE_OFFSET + 0x1000,
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x1000)),
+		      "Expected 0x2000, got 0x%x",
+		      FIXED_PARTITION_NODE_ADDRESS(DT_NODELABEL(dummy_nrange_0x1000)));
+}
+
+ZTEST(partition_macros, test_fixed_partition_offset)
+{
+	/* Test regular fixed partitions */
+	zassert_equal(0x0, FIXED_PARTITION_OFFSET(dummy_0x0), "Expected 0x0, got 0x%x",
+		      FIXED_PARTITION_OFFSET(dummy_0x0));
+	zassert_equal(0x4000, FIXED_PARTITION_OFFSET(dummy_0x4000), "Expected 0x4000, got 0x%x",
+		      FIXED_PARTITION_OFFSET(dummy_0x4000));
+
+	/* Test regular fixed subpartitions */
+	zassert_equal(0x1000 + 0x0, FIXED_PARTITION_OFFSET(dummy_0x1000_0x0),
+		      "Expected 0x1000, got 0x%x", FIXED_PARTITION_OFFSET(dummy_0x1000_0x0));
+	zassert_equal(0x1000 + 0x1000, FIXED_PARTITION_OFFSET(dummy_0x1000_0x1000),
+		      "Expected 0x2000, got 0x%x", FIXED_PARTITION_OFFSET(dummy_0x1000_0x1000));
+
+	/* Test subpartitions that do not define "ranges"*/
+	zassert_equal(0x3000 + 0x0, FIXED_PARTITION_OFFSET(dummy_0x3000_0x0),
+		      "Expected 0x3000, got 0x%x", FIXED_PARTITION_OFFSET(dummy_0x3000_0x0));
+	zassert_equal(0x3000 + 0x1000, FIXED_PARTITION_OFFSET(dummy_0x3000_0x1000),
+		      "Expected 0x4000, got 0x%x", FIXED_PARTITION_OFFSET(dummy_0x3000_0x1000));
+
+	/* Test fixed partition that contains subpartitions */
+	zassert_equal(0x1000, FIXED_PARTITION_OFFSET(dummy_0x1000), "Expected 0x1000, got 0x%x",
+		      FIXED_PARTITION_OFFSET(dummy_0x1000));
+
+	/* Test fixed partition that contains subpartitions and do not define "ranges" */
+	zassert_equal(0x3000, FIXED_PARTITION_OFFSET(dummy_0x3000), "Expected 0x3000, got 0x%x",
+		      FIXED_PARTITION_OFFSET(dummy_0x3000));
+}
+
+ZTEST(partition_macros, test_fixed_partition_node_offset)
+{
+	/* Test regular fixed partitions */
+	zassert_equal(0x0, FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x0)),
+		      "Expected 0x0, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x0)));
+	zassert_equal(0x4000, FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x4000)),
+		      "Expected 0x4000, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x4000)));
+
+	/* Test regular fixed subpartitions */
+	zassert_equal(0x1000 + 0x0, FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x1000_0x0)),
+		      "Expected 0x1000, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x1000_0x0)));
+	zassert_equal(0x1000 + 0x1000,
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x1000_0x1000)),
+		      "Expected 0x2000, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x1000_0x1000)));
+
+	/* Test subpartitions that do not define "ranges"*/
+	zassert_equal(0x3000 + 0x0, FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x3000_0x0)),
+		      "Expected 0x3000, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x3000_0x0)));
+	zassert_equal(0x3000 + 0x1000,
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x3000_0x1000)),
+		      "Expected 0x4000, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x3000_0x1000)));
+
+	/* Test fixed partition that contains subpartitions */
+	zassert_equal(0x1000, FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x1000)),
+		      "Expected 0x1000, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x1000)));
+
+	/* Test fixed partition that contains subpartitions and do not define "ranges" */
+	zassert_equal(0x3000, FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x3000)),
+		      "Expected 0x3000, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_0x3000)));
+}
+
+ZTEST(partition_macros, test_fixed_partition_offset_nrange)
+{
+	/* Test regular fixed partitions */
+	zassert_equal(0x0, FIXED_PARTITION_OFFSET(dummy_nrange_0x0), "Expected 0x0, got 0x%x",
+		      FIXED_PARTITION_OFFSET(dummy_nrange_0x0));
+	zassert_equal(0x4000, FIXED_PARTITION_OFFSET(dummy_nrange_0x4000),
+		      "Expected 0x4000, got 0x%x", FIXED_PARTITION_OFFSET(dummy_nrange_0x4000));
+
+	/* Test regular fixed subpartitions */
+	zassert_equal(0x1000 + 0x0, FIXED_PARTITION_OFFSET(dummy_nrange_0x1000_0x0),
+		      "Expected 0x1000, got 0x%x", FIXED_PARTITION_OFFSET(dummy_nrange_0x1000_0x0));
+	zassert_equal(0x1000 + 0x1000, FIXED_PARTITION_OFFSET(dummy_nrange_0x1000_0x1000),
+		      "Expected 0x2000, got 0x%x",
+		      FIXED_PARTITION_OFFSET(dummy_nrange_0x1000_0x1000));
+
+	/* Test fixed partition that contains subpartitions */
+	zassert_equal(0x1000, FIXED_PARTITION_OFFSET(dummy_nrange_0x1000),
+		      "Expected 0x1000, got 0x%x", FIXED_PARTITION_OFFSET(dummy_nrange_0x1000));
+}
+
+ZTEST(partition_macros, test_fixed_partition_node_offset_nrange)
+{
+	/* Test regular fixed partitions */
+	zassert_equal(0x0, FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_nrange_0x0)),
+		      "Expected 0x0, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_nrange_0x0)));
+	zassert_equal(0x4000, FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_nrange_0x4000)),
+		      "Expected 0x4000, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_nrange_0x4000)));
+
+	/* Test regular fixed subpartitions */
+	zassert_equal(0x1000 + 0x0,
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_nrange_0x1000_0x0)),
+		      "Expected 0x1000, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_nrange_0x1000_0x0)));
+	zassert_equal(0x1000 + 0x1000,
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_nrange_0x1000_0x1000)),
+		      "Expected 0x2000, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_nrange_0x1000_0x1000)));
+
+	/* Test fixed partition that contains subpartitions */
+	zassert_equal(0x1000, FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_nrange_0x1000)),
+		      "Expected 0x1000, got 0x%x",
+		      FIXED_PARTITION_NODE_OFFSET(DT_NODELABEL(dummy_nrange_0x1000)));
+}
+
+ZTEST_SUITE(partition_macros, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/storage/partition_macros/testcase.yaml
+++ b/tests/subsys/storage/partition_macros/testcase.yaml
@@ -1,0 +1,10 @@
+common:
+  tags: ci_tests_subsys_storage
+
+tests:
+  subsys.storage.partition_macros:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf52840dk/nrf52840
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ea25a3c07014d540f1cdd3cbd73d8a6ee71d29e4
+      revision: pull/3777/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add tests that verify values returned by the following macros:
 - DT_REG_ADDR(..)
 - DT_FIXED_PARTITION_ADDR(..)
 - DT_FIXED_SUBPARTITION_ADDR(..)
 - FIXED_PARTITION_ADDRESS(..)
 - FIXED_PARTITION_OFFSET(..)