### PR TITLE
drivers: entropy: kconfig: Add PSA selection

### DIFF
--- a/subsys/nrf_security/Kconfig.psa.nordic
+++ b/subsys/nrf_security/Kconfig.psa.nordic
@@ -644,3 +644,6 @@ config PSA_WANT_KEY_TYPE_ASCON
 	bool "ASCON key support" if !PSA_PROMPTLESS
 	help
 	  ASCON key support.
+
+config ENTROPY_PSA_CRYPTO_RNG
+	select PSA_WANT_GENERATE_RANDOM

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 221e95232775b6dcca88aaa94c9397ac8d2173c4
+      revision: pull/3766/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Allows reverting a no-up commit in sdk-zephyr. From sdk-zephyr noup commit message:

  -This is a [nrf noup] because PSA_WANT_GENERATE_RANDOM is a
   Nordic configuration that is not found upstream. This was
   previously in commit 5cfe5750b622efff77427425bf61854a95ade9fb
   but has been split out