### PR TITLE
crypto: Changing setting AES key size support to "default y"

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_guide_3.3.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_3.3.rst
@@ -155,6 +155,8 @@ This section describes the changes related to libraries.
       * Removed the ``CONFIG_PSA_WANT_ALG_WPA3_SAE`` Kconfig option and replaced it by options :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_FIXED` and :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_GDH`.
       * Removed the ``CONFIG_MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE`` Kconfig option.
         The PSA Crypto core is able to infer the key slot buffer size based on the keys enabled in the build, so there is no need to define it manually.
+      * The configuration :kconfig:option:`PSA_WANT_AES_KEY_SIZE_192` is no longer enabled by default.
+        Please enable it manually if this is required in the project.
 
    * :ref:`zephyr:ftp_client_interface` library:
 

--- a/subsys/nrf_security/src/core/Kconfig
+++ b/subsys/nrf_security/src/core/Kconfig
@@ -13,9 +13,6 @@ config PSA_CORE_DISABLED
 
 config PSA_CORE_OBERON
 	bool "PSA Core implementation - Oberon"
-	select PSA_WANT_AES_KEY_SIZE_128
-	select PSA_WANT_AES_KEY_SIZE_192
-	select PSA_WANT_AES_KEY_SIZE_256
 	depends on !DT_HAS_NORDIC_IRONSIDE_CALL_ENABLED
 
 config PSA_CORE_LITE

--- a/subsys/nrf_security/src/drivers/Kconfig
+++ b/subsys/nrf_security/src/drivers/Kconfig
@@ -206,12 +206,14 @@ menu "AES key size configuration"
 
 config PSA_WANT_AES_KEY_SIZE_128
 	bool "AES 128 bits key"
+	default y
 
 config PSA_WANT_AES_KEY_SIZE_192
 	bool "AES 192 bits key"
 
 config PSA_WANT_AES_KEY_SIZE_256
 	bool "AES 256 bits key"
+	default y
 
 endmenu
 


### PR DESCRIPTION
- Changed AES Key sizes to "default y" (was select based). 
- Disabled AES key size of 192 bits as it never used. 
- Before this commit the AES key sizes 128, 192 and 256 were enabled
  by select statements in the Kconfig PSA_CORE_OBERON. This made
  it impossible to disable them from sample configuration files.