### PR TITLE
kconfig: Do not set variables that do not exist or duplicate strings

### DIFF
--- a/boards/nordic/thingy91/Kconfig
+++ b/boards/nordic/thingy91/Kconfig
@@ -59,6 +59,5 @@ endif # if BOARD_THINGY91_NRF9160_NS
 endif # BOARD_THINGY91_NRF9160 || BOARD_THINGY91_NRF9160_NS
 
 module=BOARD
-module-dep=LOG
-module-str=Log level for board
+module-str=board
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"

--- a/boards/nordic/thingy91x/Kconfig
+++ b/boards/nordic/thingy91x/Kconfig
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
 module=BOARD
-module-dep=LOG
-module-str=Log level for board
+module-str=board
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
 if BOARD_THINGY91X_NRF5340_CPUAPP || BOARD_THINGY91X_NRF5340_CPUAPP_NS

--- a/drivers/dect/Kconfig
+++ b/drivers/dect/Kconfig
@@ -167,8 +167,8 @@ config DECT_MDM_NET_IF_NO_AUTO_START
 	  immediately after initialization and instead call for net_if_up()
 	  manually.
 
-module = DECT_MDM
-module-str = Log level for DECT MDM driver
+module=DECT_MDM
+module-str=DECT MDM driver
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
 # Include vendor specifics

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -92,7 +92,6 @@ config ETH_POLL_ACTIVE_PERIOD_MS
 module=ETH_RTT
 module-dep=LOG
 module-str=Log level
-module-help=Sets log level for Ethernet over RTT driver.
 source "$(ZEPHYR_BASE)/subsys/net/Kconfig.template.log_config.net"
 
 config ETH_RTT_DEBUG_HEX_DUMP

--- a/lib/at_cmd_custom/Kconfig
+++ b/lib/at_cmd_custom/Kconfig
@@ -10,7 +10,6 @@ menuconfig AT_CMD_CUSTOM
 if AT_CMD_CUSTOM
 
 module=AT_CMD_CUSTOM
-module-dep=LOG
 module-str= AT custom command library
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/at_monitor/Kconfig
+++ b/lib/at_monitor/Kconfig
@@ -18,7 +18,6 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 	default 1152 if (LTE_LINK_CONTROL && LOG)
 
 module=AT_MONITOR
-module-dep=LOG
 module-str= AT notification monitor library
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/bin/lwm2m_carrier/Kconfig
+++ b/lib/bin/lwm2m_carrier/Kconfig
@@ -371,7 +371,6 @@ config LWM2M_CARRIER_SHELL
 	  Include LwM2M carrier shell
 
 module=LWM2M_CARRIER
-module-dep=LOG
 module-str=LwM2M carrier library
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/date_time/Kconfig
+++ b/lib/date_time/Kconfig
@@ -64,7 +64,6 @@ config DATE_TIME_NTP_QUERY_TIME_SECONDS
 	default 5
 
 module=DATE_TIME
-module-dep=LOG
 module-str=Date time module
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/edge_impulse/Kconfig
+++ b/lib/edge_impulse/Kconfig
@@ -98,7 +98,6 @@ config EI_WRAPPER_DEBUG_MODE
 	  Enables additional log information from Edge Impulse library.
 
 module=EI_WRAPPER
-module-dep=LOG
 module-str=Edge Impulse NCS wrapper
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -611,7 +611,6 @@ config LTE_LC_PDN_ESM_STRERROR
 endif # LTE_LC_PDN_MODULE
 
 module = LTE_LINK_CONTROL
-module-dep = LOG
 module-str = LTE link control library
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/modem_antenna/Kconfig
+++ b/lib/modem_antenna/Kconfig
@@ -78,7 +78,6 @@ config MODEM_ANTENNA_AT_MIPIRFFECTRL_PWROFF
 	  Leave empty if this command should not be sent.
 
 module=MODEM_ANTENNA
-module-dep=LOG
 module-str=Modem antenna
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/modem_battery/Kconfig
+++ b/lib/modem_battery/Kconfig
@@ -42,7 +42,6 @@ config MODEM_BATTERY_POFWARN_VOLTAGE
 	default 33 if MODEM_BATTERY_POFWARN_3300
 
 module = MODEM_BATTERY
-module-dep = LOG
 module-str = Modem battery library
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/modem_key_mgmt/Kconfig
+++ b/lib/modem_key_mgmt/Kconfig
@@ -11,7 +11,6 @@ config MODEM_KEY_MGMT
 if MODEM_KEY_MGMT
 
 module = MODEM_KEY_MGMT
-module-dep = LOG
 module-str = Modem key management
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/pdn/Kconfig
+++ b/lib/pdn/Kconfig
@@ -100,7 +100,6 @@ config PDN_ESM_STRERROR
 	  The table and function take about 2 KB of FLASH.
 
 module=PDN
-module-dep=LOG
 module-str=PDN library
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/lib/sms/Kconfig
+++ b/lib/sms/Kconfig
@@ -26,7 +26,6 @@ config SMS_STATUS_REPORT
 	  setting <ds> field enabled in SMS registration with AT+CNMI.
 
 module=SMS
-module-dep=LOG
 module-str= SMS library
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/modules/memfault-firmware-sdk/Kconfig
+++ b/modules/memfault-firmware-sdk/Kconfig
@@ -295,7 +295,6 @@ choice MEMFAULT_HTTP_PERIODIC_UPLOAD_CONTEXT
 endchoice
 
 module = MEMFAULT_NCS
-module-dep = LOG
 module-str = Memfault NCS module
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/modules/wfa-qt/Kconfig
+++ b/modules/wfa-qt/Kconfig
@@ -4,9 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-module = WFA_QT
-module-str = Log level for WFA Quick Track
-module-help = Sets log level for WFA Quick Track
+module=WFA_QT
+module-str=WFA Quick Track
 source "subsys/logging/Kconfig.template.log_config"
 
 config WFA_QT_CONTROL_APP

--- a/samples/cellular/lwm2m_client/Kconfig
+++ b/samples/cellular/lwm2m_client/Kconfig
@@ -146,9 +146,8 @@ config APP_LWM2M_CONFORMANCE_TESTING
 	  Enable functionality that uses LwM2M SEND operation to deliver test payload.
 	  This allows testing of SEND operation itself as well as "mute-send" resource.
 
-module = APP
-module-dep = LOG
-module-str = Log level for sample
+module=APP
+module-str=Sample
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 endmenu # Application sample
 

--- a/samples/dect/hello_dect/Kconfig
+++ b/samples/dect/hello_dect/Kconfig
@@ -14,8 +14,8 @@ config HELLO_DECT_MAC_DEMO_INTERVAL
 	help
 	  Interval in seconds for sending demo messages when connected.
 
-module = HELLO_DECT_MAC
-module-str = Log level for Hello DECT sample application
+module=HELLO_DECT_MAC
+module-str=Hello DECT sample application
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
 endmenu

--- a/samples/wifi/provisioning/internal/Kconfig
+++ b/samples/wifi/provisioning/internal/Kconfig
@@ -135,9 +135,8 @@ config WIFI_PROV_MAX_BASE64_SIZE
 	help
 	  Maximum size for base64 input string in bytes.
 
-module = WIFI_PROV_INTERNAL
-module-dep = LOG
-module-str = Log level for sample
+module=WIFI_PROV_INTERNAL
+module-str=WiFi provisioning internal
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
 source "Kconfig.zephyr"

--- a/samples/wifi/twt/modules/traffic_gen/Kconfig
+++ b/samples/wifi/twt/modules/traffic_gen/Kconfig
@@ -54,7 +54,6 @@ config TRAFFIC_GEN_TYPE_TCP
 	help
 	  Enable this option to select the TCP traffic type
 
-module = TRAFFIC_GEN
-module-dep = LOG
-module-str = Log level for sample
+module=TRAFFIC_GEN
+module-str=traffic generation
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"

--- a/subsys/dfu/dfu_multi_image/Kconfig
+++ b/subsys/dfu/dfu_multi_image/Kconfig
@@ -43,7 +43,6 @@ config DFU_MULTI_IMAGE_ALIGN
 endif # DFU_MULTI_IMAGE_SAVE_PROGRESS
 
 module=DFU_MULTI_IMAGE
-module-dep=LOG
 module-str=DFU Multi Image
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/dfu/dfu_target/Kconfig
+++ b/subsys/dfu/dfu_target/Kconfig
@@ -7,7 +7,7 @@
 menuconfig DFU_TARGET
 	bool "Device Firmware Upgrade target API"
 
-if (DFU_TARGET)
+if DFU_TARGET
 
 config DFU_TARGET_MCUBOOT
 	bool "MCUBoot update support"
@@ -128,7 +128,6 @@ config DFU_TARGET_CUSTOM
 	  Enable support for custom updates using DFU target
 
 module=DFU_TARGET
-module-dep=LOG
 module-str=Device Firmware Upgrade
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/dfu/fmfu_fdev/Kconfig
+++ b/subsys/dfu/fmfu_fdev/Kconfig
@@ -12,7 +12,7 @@ menuconfig FMFU_FDEV
 	depends on MBEDTLS_SHA256_C
 
 
-if (FMFU_FDEV)
+if FMFU_FDEV
 
 config FMFU_CDDL_DECODER_GENERATE
 	bool "Regenerate FMFU CBOR code from cddl using zcbor, for internal use."
@@ -36,7 +36,6 @@ if FMFU_FDEV_SKIP_PREVALIDATION
 endif
 
 module=FMFU_FDEV
-module-dep=LOG
 module-str=FMFU FDEV
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/mgmt/fmfu/Kconfig
+++ b/subsys/mgmt/fmfu/Kconfig
@@ -15,7 +15,6 @@ config MGMT_FMFU
 if MGMT_FMFU
 
 module=MGMT_FMFU
-module-dep=LOG
 module-str=FMFU
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/net/l2_dect/Kconfig
+++ b/subsys/net/l2_dect/Kconfig
@@ -30,16 +30,16 @@ config NET_L2_DECT_BR
 	  or Ethernet based NET_L2_ETHERNET mode can be used as a border router.
 	  If MODEM_CELLULAR is selected, then BR has only one sink and vice versa.
 
-module = NET_L2_DECT_BR
-module-str = Log level for DECT NR+ L2 Border Router / Sink
+module=NET_L2_DECT_BR
+module-str=DECT NR+ L2 Border Router / Sink
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
-module = NET_L2_DECT
-module-str = Log level for DECT NR+ L2
+module=NET_L2_DECT
+module-str=DECT NR+ L2
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
-module = NET_L2_DECT_MGMT
-module-str = Log level for DECT NR+ L2 management
+module=NET_L2_DECT_MGMT
+module-str=DECT NR+ L2 management
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
 endif # NET_L2_DECT

--- a/subsys/net/l2_dect/Kconfig.conn_mgr
+++ b/subsys/net/l2_dect/Kconfig.conn_mgr
@@ -49,8 +49,8 @@ config NET_L2_DECT_CONN_MGR_AUTO_CONNECT
 	  the option has a corresponding flag that can be set at run time by
 	  calling conn_mgr_if_set_flag().
 
-module = NET_L2_DECT_CONN_MGR
-module-str = Log level for DECT NR+ connection manager
+module=NET_L2_DECT_CONN_MGR
+module-str=DECT NR+ connection manager
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
 endif # NET_L2_DECT_CONN_MGR

--- a/subsys/net/lib/aws_fota/Kconfig
+++ b/subsys/net/lib/aws_fota/Kconfig
@@ -24,9 +24,7 @@ config AWS_FOTA_DOWNLOAD_SECURITY_TAG
 
 
 module=AWS_FOTA
-module-dep=LOG
-module-str=Log level for AWS Jobs FOTA
-module-help=Enables AWS Jobs FOTA log messages.
+module-str=AWS Jobs FOTA
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
 endif # AWS_FOTA

--- a/subsys/net/lib/aws_iot/Kconfig
+++ b/subsys/net/lib/aws_iot/Kconfig
@@ -57,7 +57,6 @@ config AWS_IOT_TOPIC_DELETE_REJECTED_SUBSCRIBE
 	bool "Subscribe to delete rejected shadow topic, $aws/things/<thing-name>/shadow/delete/rejected"
 
 module = AWS_IOT
-module-dep = LOG
 module-str = AWS IoT
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/net/lib/aws_jobs/Kconfig
+++ b/subsys/net/lib/aws_jobs/Kconfig
@@ -17,9 +17,7 @@ config UPDATE_JOB_PAYLOAD_LEN
 	default 1350
 
 module=AWS_JOBS
-module-dep=LOG
-module-str=Log level for AWS Jobs
-module-help=Enables AWS Jobs log messages.
+module-str=AWS Jobs
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
 endif # AWS_JOBS

--- a/subsys/net/lib/azure_fota/Kconfig
+++ b/subsys/net/lib/azure_fota/Kconfig
@@ -58,9 +58,7 @@ config AZURE_FOTA_DOWNLOAD_PORT
 	default 80
 
 module=AZURE_FOTA
-module-dep=LOG
-module-str=Log level for Azure FOTA
-module-help=Enables Azure FOTA log messages.
+module-str=Azure FOTA
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
 endif # AZURE_FOTA

--- a/subsys/net/lib/azure_iot_hub/Kconfig
+++ b/subsys/net/lib/azure_iot_hub/Kconfig
@@ -143,7 +143,6 @@ config AZURE_IOT_HUB_DPS_OPERATION_ID_BUFFER_SIZE
 endif # AZURE_IOT_HUB_DPS
 
 module=AZURE_IOT_HUB
-module-dep=LOG
 module-str=Azure IoT Hub
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/net/lib/downloader/Kconfig
+++ b/subsys/net/lib/downloader/Kconfig
@@ -61,7 +61,6 @@ config DOWNLOADER_SHELL_BUF_SIZE
 endif # DOWNLOADER_SHELL
 
 module=DOWNLOADER
-module-dep=LOG
 module-str=Download client
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/net/lib/fota_download/Kconfig
+++ b/subsys/net/lib/fota_download/Kconfig
@@ -67,7 +67,6 @@ config FOTA_DOWNLOAD_SEC_TAG_LIST_SIZE_MAX
 	  Maximum size of the list of security tags used to store TLS credentials.
 
 module=FOTA_DOWNLOAD
-module-dep=LOG
 module-str=Firmware Over the Air Download
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/net/lib/ftp_client/Kconfig
+++ b/subsys/net/lib/ftp_client/Kconfig
@@ -24,7 +24,6 @@ config FTP_CLIENT_TLS
 	bool "Connection over TLS"
 
 module=FTP_CLIENT
-module-dep=LOG
 module-str=FTP client
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/net/lib/icalendar_parser/Kconfig
+++ b/subsys/net/lib/icalendar_parser/Kconfig
@@ -45,7 +45,6 @@ config ICAL_PARSER_SUMMARY_SIZE
 	default 64
 
 module=ICAL_PARSER
-module-dep=LOG
 module-str=iCalendar parser
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/net/lib/lwm2m_client_utils/Kconfig
+++ b/subsys/net/lib/lwm2m_client_utils/Kconfig
@@ -286,7 +286,6 @@ config LWM2M_CLIENT_UTILS_DTLS_CON_MANAGEMENT
 endif #LWM2M_DTLS_CID
 
 module = LWM2M_CLIENT_UTILS
-module-dep = LOG
 module-str = LwM2M client utilities library
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/net/lib/mcumgr_smp_client/Kconfig
+++ b/subsys/net/lib/mcumgr_smp_client/Kconfig
@@ -28,7 +28,6 @@ config NRF_MCUMGR_SMP_CLIENT_SHELL
 	depends on SHELL
 
 module = NRF_MCUMGR_SMP_CLIENT
-module-dep = LOG
 module-str = NRF_MCUmgr_smp_client
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -187,9 +187,7 @@ config NRF_CLOUD_HTTPS_DOWNLOADS
 endchoice
 
 module=NRF_CLOUD
-module-dep=LOG
-module-str=Log level for nRF Cloud
-module-help=Enables nRF Cloud log messages.
+module-str=nRF Cloud
 source "subsys/logging/Kconfig.template.log_config"
 
 endmenu # "nRF Cloud"

--- a/subsys/net/lib/nrf_provisioning/Kconfig
+++ b/subsys/net/lib/nrf_provisioning/Kconfig
@@ -122,9 +122,7 @@ rsource "Kconfig.nrf_provisioning_http"
 rsource "Kconfig.nrf_provisioning_coap"
 
 module=NRF_PROVISIONING
-module-dep=LOG
-module-str=Log level for nRF Provisioning
-module-help=Enables nRF Provisioning log messages.
+module-str=nRF Provisioning
 source "subsys/logging/Kconfig.template.log_config"
 
 endif

--- a/subsys/net/lib/rest_client/Kconfig
+++ b/subsys/net/lib/rest_client/Kconfig
@@ -25,9 +25,7 @@ config REST_CLIENT_SCKT_TLS_SESSION_CACHE_IN_USE
 	  TLS session cache, disable or enable.
 
 module=REST_CLIENT
-module-dep=LOG
-module-str=Log level for REST Client lib
-module-help=Enables REST Client log messages.
+module-str=REST Client lib
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
 endif # REST_CLIENT

--- a/subsys/net/lib/wifi_prov_core/Kconfig
+++ b/subsys/net/lib/wifi_prov_core/Kconfig
@@ -18,6 +18,5 @@ config WIFI_PROV_CORE
 	  and should be enabled when using Wi-Fi provisioning features.
 
 module = WIFI_PROV_CORE
-module-dep = LOG
-module-str = Log level for sample
+module-str = WiFi provisioning core library
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"

--- a/subsys/net/openthread/otperf/Kconfig
+++ b/subsys/net/openthread/otperf/Kconfig
@@ -13,7 +13,7 @@ menuconfig OTPERF
 if OTPERF
 
 module = OTPERF
-module-str = Log level for otperf
+module-str = otperf
 source "subsys/logging/Kconfig.template.log_config"
 
 config OTPERF_SHELL

--- a/subsys/pcd/Kconfig
+++ b/subsys/pcd/Kconfig
@@ -49,7 +49,6 @@ config PCD_NET_CORE_APP_OFFSET
 	depends on PCD_USE_CONSTANTS
 
 module=PCD
-module-dep=LOG
 module-str=Peripheral Core DFU
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 


### PR DESCRIPTION
Removes setting Kconfig variables for the logging inclusion file that are wholly unused, also removes duplicate text of "Log level of..." since the logging include already adds that