### PR TITLE
tests: nrf_compress: decompression: Move arm_thumb/lzma to dts

### DIFF
--- a/samples/zephyr/sysbuild/hello_world/Kconfig.sysbuild
+++ b/samples/zephyr/sysbuild/hello_world/Kconfig.sysbuild
@@ -1,8 +1,12 @@
 # Copyright (c) 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+config PARTITION_MANAGER
+	default n
 
 config REMOTE_BOARD
 	string
 	default "$(BOARD)/nrf54lv10a/cpuflpr" if SOC_NRF54LV10A_CPUAPP
+	default "$(BOARD)/nrf7120/cpuflpr" if SOC_NRF7120_ENGA_CPUAPP
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"

--- a/tests/subsys/nrf_compress/decompression/arm_thumb/Kconfig.sysbuild
+++ b/tests/subsys/nrf_compress/decompression/arm_thumb/Kconfig.sysbuild
@@ -1,0 +1,4 @@
+config PARTITION_MANAGER
+	default n if !BOARD_IS_NON_SECURE
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"

--- a/tests/subsys/nrf_compress/decompression/lzma/Kconfig.sysbuild
+++ b/tests/subsys/nrf_compress/decompression/lzma/Kconfig.sysbuild
@@ -1,0 +1,4 @@
+config PARTITION_MANAGER
+	default n if !BOARD_IS_NON_SECURE
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"


### PR DESCRIPTION
Disables PM for these builds, when not building for secure board targets