### PR TITLE
samples: dfu: smp_svr RAM load doc fix

### DIFF
--- a/samples/dfu/smp_svr/README.rst
+++ b/samples/dfu/smp_svr/README.rst
@@ -164,12 +164,12 @@ The following table describes the available configurations.
      - External flash
    * - sample.dfu.smp_svr.ram_load
      - UART
-     - Swap
      - RAM load
+     -
    * - sample.dfu.smp_svr.ram_load.kmu
      - UART
-     - Swap
-     - RAM load with KMU-based signature (Ed25519)
+     - RAM load
+     - KMU-based signature (Ed25519)
 
 Building and running
 ********************


### PR DESCRIPTION
The mode of the RAM load was incorrectly described as "SWAP", while RAM load is a mode in its own rights.