### PR TITLE
samples: bluetooth: peripheral_power_profiling: Fix 54h overlays

### DIFF
--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54h20dk_nrf54h20_cpuapp_auto_conn_advert.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54h20dk_nrf54h20_cpuapp_auto_conn_advert.overlay
@@ -8,7 +8,7 @@
 
 / {
 	/*
-	 * Redefine button0 to use RXD0 - P0.01
+	 * Redefine button0 to use RXD0 - P2.04
 	 * Thus, when sending character from host, there will be gpio interrupt,
 	 * the same as originally triggered by sw0 button.
 	 */
@@ -16,9 +16,17 @@
 		compatible = "gpio-keys";
 
 		button0: button_0 {
-			gpios = <&gpio0 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			gpios = <&gpio2 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Input 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&uart136 {
+	disable-rx;
 };

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54h20dk_nrf54h20_cpuapp_auto_non_conn_advert.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54h20dk_nrf54h20_cpuapp_auto_non_conn_advert.overlay
@@ -8,7 +8,7 @@
 
 / {
 	/*
-	 * Redefine button1 to use RXD0 - P0.01
+	 * Redefine button1 to use RXD0 - P2.04
 	 * Thus, when sending character from host, there will be gpio interrupt,
 	 * the same as originally triggered by sw0 button.
 	 */
@@ -16,9 +16,17 @@
 		compatible = "gpio-keys";
 
 		button1: button_1 {
-			gpios = <&gpio0 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			gpios = <&gpio2 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Input 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&uart136 {
+	disable-rx;
 };


### PR DESCRIPTION
Change redefinition of button0 and button1 to use RXD0 - P2.04