### PR TITLE
KMU push driver

### DIFF
--- a/subsys/nrf_security/cmake/psa_crypto_config.cmake
+++ b/subsys/nrf_security/cmake/psa_crypto_config.cmake
@@ -244,6 +244,9 @@ kconfig_check_and_set_base_to_one(PSA_NEED_CRACEN_KEY_DERIVATION_DRIVER)
 # Key wrap driver
 kconfig_check_and_set_base_to_one(PSA_NEED_CRACEN_KEY_WRAP_DRIVER)
 
+# KMU push driver
+kconfig_check_and_set_base_to_one(PSA_NEED_KMU_PUSH_DRIVER)
+
 # Convert nrf_cc3xx_platform driver configurations
 kconfig_check_and_set_base_to_one(PSA_NEED_CC3XX_CTR_DRBG_DRIVER)
 kconfig_check_and_set_base_to_one(PSA_NEED_CC3XX_HMAC_DRBG_DRIVER)

--- a/subsys/nrf_security/configs/psa_crypto_config.h.template
+++ b/subsys/nrf_security/configs/psa_crypto_config.h.template
@@ -486,6 +486,8 @@
 
 #cmakedefine PSA_NEED_CRACEN_KEY_WRAP_DRIVER                    @PSA_NEED_CRACEN_KEY_WRAP_DRIVER@
 
+#cmakedefine PSA_NEED_KMU_PUSH_DRIVER                           @PSA_NEED_KMU_PUSH_DRIVER@
+
 /* Nordic specific */
 #cmakedefine PSA_CRYPTO_DRIVER_ALG_PRNG_TEST                    @PSA_CRYPTO_DRIVER_ALG_PRNG_TEST@
 #cmakedefine PSA_CRYPTO_DRIVER_IRONSIDE                         @PSA_CRYPTO_DRIVER_IRONSIDE@

--- a/subsys/nrf_security/src/drivers/CMakeLists.txt
+++ b/subsys/nrf_security/src/drivers/CMakeLists.txt
@@ -28,6 +28,10 @@ if(CONFIG_MBEDTLS_PSA_CRYPTO_C)
     add_subdirectory(ironside)
   endif()
 
+  if(CONFIG_PSA_CRYPTO_DRIVER_KMU_PUSH)
+    add_subdirectory(kmu_push)
+  endif()
+
   add_subdirectory(zephyr)
 endif()
 

--- a/subsys/nrf_security/src/drivers/Kconfig
+++ b/subsys/nrf_security/src/drivers/Kconfig
@@ -40,6 +40,14 @@ config PSA_CRYPTO_DRIVER_IRONSIDE
 	  Internal option selected by IronSide firmware to enable
 	  the IronSide PSA crypto driver.
 
+config PSA_CRYPTO_DRIVER_KMU_PUSH
+	bool "KMU push driver"
+	depends on PSA_CRYPTO_DRIVER_CRACEN
+	depends on MBEDTLS_PSA_CRYPTO_C
+	depends on HAS_HW_NRF_CRACEN
+	help
+	  PSA crypto driver to push KMU keys to arbitrary addresses
+
 menu "Choose DRBG algorithm"
 config PSA_WANT_ALG_CTR_DRBG
 	bool "CTR_DRBG"
@@ -268,5 +276,7 @@ rsource "nrf_cc3xx/Kconfig"
 rsource "cracen/Kconfig"
 
 rsource "nrf_oberon/Kconfig"
+
+rsource "kmu_push/Kconfig"
 
 rsource "zephyr/Kconfig"

--- a/subsys/nrf_security/src/drivers/kmu_push/CMakeLists.txt
+++ b/subsys/nrf_security/src/drivers/kmu_push/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+target_include_directories(psa_interface
+    INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_sources(cracen_psa_driver
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/kmu_push.c
+)

--- a/subsys/nrf_security/src/drivers/kmu_push/Kconfig
+++ b/subsys/nrf_security/src/drivers/kmu_push/Kconfig
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+config PSA_NEED_KMU_PUSH_DRIVER
+	bool
+	default y
+	depends on PSA_CRYPTO_DRIVER_KMU_PUSH

--- a/subsys/nrf_security/src/drivers/kmu_push/kmu_push.c
+++ b/subsys/nrf_security/src/drivers/kmu_push/kmu_push.c
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <cracen/mem_helpers.h>
+#include <cracen/lib_kmu.h>
+#include <cracen/cracen_kmu.h>
+#include <psa/crypto.h>
+#include <stdint.h>
+#include <string.h>
+#include <cracen/common.h>
+#include "kmu_push.h"
+
+/** @brief Metadata version is chosen to not conflict with CRACEN KMU versions */
+#define KMU_PUSH_METADATA_VERSION (15)
+
+/** @brief Union to punt KMU_push metadata to integer value
+ *
+ * This type holds the metadata for KMU push driver and provides a direct
+ * conversion via punting to an unsigned integer type.
+ */
+typedef union {
+	uint32_t value;
+	struct {
+		uint32_t metadata_version: 4;	/**!< Metadata in the same location as CRACEN KMU metadata. */
+		uint32_t num_slots: 8;		/**!< Size in number of KMU slots of this key. */
+		uint32_t num_slots_left: 8;	/**!< Number of KMU slots before end of key. */
+		uint32_t key_bits: 10;		/**!< Key size in bits. */
+		uint32_t rpolicy: 2;		/**!< Rpolicy of the KMU slot */
+	};
+} kmu_push_metadata;
+/** @brief structure type for volatile key representaation of a KMU push key */
+typedef struct {
+	uint16_t slot_id;
+	uint16_t num_slots;
+} kmu_push_opaque_key_buffer;
+
+static psa_status_t provision_slots(const psa_key_attributes_t *attributes, size_t slot_id,
+				    size_t num_slots, const kmu_push_key_buffer_t* kmu_push,
+				    size_t key_bits)
+{
+	int kmu_err = -LIB_KMU_ERROR;
+	const psa_key_lifetime_t lifetime = psa_get_key_lifetime(attributes);
+	const psa_key_persistence_t persistence = PSA_KEY_LIFETIME_GET_PERSISTENCE(lifetime);
+	kmu_push_metadata metadata = {0};
+	struct kmu_src kmu_src = {0};
+	size_t block_size = 0;
+	uint8_t *cur_src = kmu_push->key_buffer;
+	size_t size_left = kmu_push->buffer_size;
+
+	/* Metadata is stable */
+	switch(persistence){
+	case PSA_KEY_PERSISTENCE_DEFAULT:
+		kmu_src.rpolicy = LIB_KMU_REV_POLICY_ROTATING;
+		break;
+	case LIB_KMU_REV_POLICY_REVOKED:
+		/* Revokable key slots currently not supported */
+		return PSA_ERROR_NOT_SUPPORTED;
+	case LIB_KMU_REV_POLICY_LOCKED:
+		/* Read-only key slots currently not supported */
+		return PSA_ERROR_NOT_SUPPORTED;
+	default:
+		return PSA_ERROR_BAD_STATE;
+	}
+
+	/* Stable KMU push metadata */
+	metadata.metadata_version = KMU_PUSH_METADATA_VERSION;
+	metadata.num_slots = num_slots;
+	metadata.key_bits = key_bits;
+	metadata.rpolicy = kmu_src.rpolicy;
+
+	for (size_t i = 0; i < num_slots; i++) {
+		metadata.num_slots_left = num_slots - i - 1;
+		kmu_src.metadata = metadata.value;
+		block_size = size_left > CRACEN_KMU_SLOT_KEY_SIZE ?
+			CRACEN_KMU_SLOT_KEY_SIZE : size_left;
+		cur_src =  kmu_push->key_buffer + (i * CRACEN_KMU_SLOT_KEY_SIZE);
+		kmu_src.dest = kmu_push->dest_address + (i * CRACEN_KMU_SLOT_KEY_SIZE);
+
+		safe_memzero(kmu_src.value, CRACEN_KMU_SLOT_KEY_SIZE);
+		memcpy(kmu_src.value, cur_src, block_size);
+
+		kmu_err = lib_kmu_provision_slot(slot_id + i, &kmu_src);
+		if (kmu_err != LIB_KMU_SUCCESS) {
+			return PSA_ERROR_NOT_PERMITTED;
+		}
+
+		size_left -= block_size;
+	}
+
+	return PSA_SUCCESS;
+}
+
+static psa_status_t get_metadata(unsigned int slot_id, kmu_push_metadata *metadata)
+{
+	uint32_t metadata_val;
+	const int kmu_status = lib_kmu_read_metadata(slot_id, &metadata_val);
+	switch (kmu_status) {
+	case LIB_KMU_SUCCESS:
+		break;
+	case -LIB_KMU_REVOKED:
+		return PSA_ERROR_NOT_PERMITTED;
+	case -LIB_KMU_ERROR:
+		return PSA_ERROR_DOES_NOT_EXIST;
+	default:
+		return PSA_ERROR_BAD_STATE;
+	}
+
+	metadata->value = metadata_val;
+	return PSA_SUCCESS;
+}
+
+static psa_status_t get_lifetime(kmu_push_metadata *metadata, psa_key_lifetime_t * lifetime)
+{
+	psa_key_persistence_t persistence;
+	switch (metadata->rpolicy) {
+	case LIB_KMU_REV_POLICY_ROTATING:
+		persistence = PSA_KEY_PERSISTENCE_DEFAULT;
+		break;
+	case LIB_KMU_REV_POLICY_REVOKED:
+		/* Revokable key slots currently not supported */
+		return PSA_ERROR_NOT_SUPPORTED;
+	case LIB_KMU_REV_POLICY_LOCKED:
+		/* Read-only key slots currently not supported */
+		return PSA_ERROR_NOT_SUPPORTED;
+	default:
+		return PSA_ERROR_BAD_STATE;
+	}
+
+	*lifetime = PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(persistence,
+								   PSA_KEY_LOCATION_KMU_PUSH);
+	return PSA_SUCCESS;
+}
+
+static psa_status_t push_slots(size_t slot_id, size_t num_slots)
+{
+	int kmu_err = -LIB_KMU_ERROR;
+	psa_status_t error = PSA_SUCCESS;
+
+	/* Push all key material even if there is an error, but report it*/
+	for (size_t i = 0; i < num_slots; i++) {
+		kmu_err = lib_kmu_push_slot(slot_id + i);
+		if(kmu_err != LIB_KMU_SUCCESS) {
+			error = PSA_ERROR_NOT_PERMITTED;
+		}
+	}
+
+	return error;
+}
+
+static psa_status_t destroy_slots(size_t slot_id, size_t num_slots)
+{
+	int kmu_err = -LIB_KMU_ERROR;
+	psa_status_t error = PSA_SUCCESS;
+
+	/* Continue even if there is an error, but report it */
+	for (size_t i = 0; i < num_slots; i++) {
+		kmu_err = lib_kmu_revoke_slot(slot_id + i);
+		if (kmu_err != LIB_KMU_SUCCESS) {
+			error = PSA_ERROR_NOT_PERMITTED;
+		}
+	}
+
+	return error;
+}
+
+psa_status_t kmu_push_import_key(const psa_key_attributes_t *attributes, const uint8_t *data,
+				 size_t data_length, uint8_t *key_buffer, size_t key_buffer_size,
+				 size_t *key_buffer_length, size_t *key_bits)
+{
+	psa_status_t error;
+	const psa_key_lifetime_t lifetime = psa_get_key_lifetime(attributes);
+	const psa_key_persistence_t persistence = PSA_KEY_LIFETIME_GET_PERSISTENCE(lifetime);
+	const kmu_push_key_buffer_t *kmu_push_buffer = (kmu_push_key_buffer_t *) data;
+	size_t slot_id = CRACEN_PSA_GET_KMU_SLOT(
+				MBEDTLS_SVC_KEY_ID_GET_KEY_ID(psa_get_key_id(attributes)));
+	size_t num_slots = 0;
+	size_t num_key_bits = psa_get_key_bits(attributes);
+	bool push_immediately = false;
+	bool destroy_after = false;
+
+	/* KMU will not use a external buffer for key after call */
+	ARG_UNUSED(key_buffer);
+	ARG_UNUSED(key_buffer_length);
+	ARG_UNUSED(key_bits);
+
+	if(data == NULL || data_length == 0) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	if (data_length != sizeof(kmu_push_key_buffer_t)) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	if (num_key_bits == 0 || PSA_BITS_TO_BYTES(num_key_bits) > kmu_push_buffer->buffer_size) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	num_slots = DIV_ROUND_UP(kmu_push_buffer->buffer_size, CRACEN_KMU_SLOT_KEY_SIZE);
+
+	/* Ensure that we are not using slots not intended for general usage */
+	if ((slot_id + num_slots) >= PROTECTED_RAM_INVALIDATION_DATA_SLOT1) {
+		return PSA_ERROR_NOT_PERMITTED;
+	}
+
+	/* Ensure that the slots are empty */
+	for (size_t i = 0; i < num_slots; i++) {
+		if (!lib_kmu_is_slot_empty(slot_id + i)) {
+			return PSA_ERROR_NOT_PERMITTED;
+		}
+	}
+
+	push_immediately = (kmu_push_buffer->usage_mask &
+				KMU_PUSH_USAGE_MASK_PUSH_IMMEDIATELY) != 0;
+	destroy_after = (kmu_push_buffer->usage_mask &
+				KMU_PUSH_USAGE_MASK_DESTROY_AFTER) != 0;
+	/* Read-only and DESTROY_AFTER is not valid combination*/
+
+	error = provision_slots(attributes, slot_id, num_slots, kmu_push_buffer, num_key_bits);
+	if (error != PSA_SUCCESS) {
+		goto error;
+	}
+
+	if (push_immediately) {
+		error = push_slots(slot_id, num_slots);
+		if (error != PSA_SUCCESS) {
+			goto error;
+		}
+	}
+
+	if (destroy_after) {
+		error = destroy_slots(slot_id, num_slots);
+		if (error != PSA_SUCCESS) {
+			goto error;
+		}
+	}
+
+	*key_bits = num_key_bits;
+	return PSA_SUCCESS;
+
+error:
+	/* Read-only keys can't be erased. Return the error. */
+	if (persistence == CRACEN_KEY_PERSISTENCE_READ_ONLY) {
+		return error;
+	}
+
+	/* Erase all key slots swallowing errors. */
+	(void) destroy_slots(slot_id, num_slots);
+
+	return error;
+}
+
+psa_status_t kmu_push_get_key_slot(mbedtls_svc_key_id_t key_id, psa_key_lifetime_t *lifetime,
+				   psa_drv_slot_number_t *slot_number)
+{
+	psa_status_t error;
+	unsigned int slot_id = CRACEN_PSA_GET_KMU_SLOT(MBEDTLS_SVC_KEY_ID_GET_KEY_ID(key_id));
+	kmu_push_metadata metadata;
+
+	error = get_metadata(slot_id, &metadata);
+	if (error != PSA_SUCCESS) {
+		return error;
+	}
+	/* Check that this is the first slot */
+	if (metadata.metadata_version != KMU_PUSH_METADATA_VERSION ||
+	    metadata.num_slots - 1 != metadata.num_slots_left) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	/* Populate the lifetime */
+	error = get_lifetime(&metadata, lifetime);
+	if (error != PSA_SUCCESS) {
+		return error;
+	}
+
+	*slot_number = slot_id;
+
+	return PSA_SUCCESS;
+}
+
+psa_status_t kmu_push_get_opaque_size(const psa_key_attributes_t *attributes, size_t *key_size)
+{
+	*key_size = sizeof(kmu_push_opaque_key_buffer);
+	return PSA_SUCCESS;
+}
+
+psa_status_t kmu_push_get_builtin_key(psa_drv_slot_number_t slot_number,
+				      psa_key_attributes_t *attributes, uint8_t *key_buffer,
+				      size_t key_buffer_size, size_t *key_buffer_length)
+{
+	psa_status_t error;
+	psa_key_lifetime_t lifetime;
+	kmu_push_metadata metadata;
+	kmu_push_opaque_key_buffer *opaque_key_buffer;
+	mbedtls_svc_key_id_t key_id = mbedtls_svc_key_id_make(0,
+					PSA_KEY_HANDLE_FROM_CRACEN_KMU_SLOT(
+						CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED,slot_number));
+	size_t num_slots = DIV_ROUND_UP(
+				PSA_BITS_TO_BYTES(psa_get_key_bits(attributes)),
+					CRACEN_KMU_SLOT_KEY_SIZE);
+
+	error = get_metadata(slot_number, &metadata);
+	if (error != PSA_SUCCESS) {
+		return error;
+	}
+
+	/* Ensure we are only erasing KMU push key with this */
+	if (metadata.metadata_version != KMU_PUSH_METADATA_VERSION){
+		return PSA_ERROR_NOT_PERMITTED;
+	}
+
+	/* Ensure the number of keys to erase corresponds to store key */
+	if (metadata.num_slots != num_slots) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	/* Ensure that this is the first key if multiple slots is used*/
+	if (metadata.num_slots_left != (num_slots - 1)) {
+		return PSA_ERROR_DATA_INVALID;
+	}
+
+	error = get_lifetime(&metadata, &lifetime);
+	if (error != PSA_SUCCESS) {
+		return error;
+	}
+
+	psa_set_key_lifetime(attributes, lifetime);
+	psa_set_key_bits(attributes, metadata.key_bits);
+	psa_set_key_id(attributes, key_id);
+
+	if (key_buffer_size >= sizeof(kmu_push_opaque_key_buffer)) {
+		opaque_key_buffer = (kmu_push_opaque_key_buffer *) key_buffer;
+		opaque_key_buffer->slot_id = slot_number;
+		opaque_key_buffer->num_slots = metadata.num_slots;
+		*key_buffer_length = sizeof(kmu_opaque_key_buffer);
+	}
+
+	return PSA_SUCCESS;
+}
+
+
+psa_status_t kmu_push_destroy_key(const psa_key_attributes_t *attributes)
+{
+	psa_status_t error;
+	const psa_key_lifetime_t lifetime = psa_get_key_lifetime(attributes);
+	const psa_key_persistence_t persistence = PSA_KEY_LIFETIME_GET_PERSISTENCE(lifetime);
+	size_t slot_id = CRACEN_PSA_GET_KMU_SLOT(
+				MBEDTLS_SVC_KEY_ID_GET_KEY_ID(psa_get_key_id(attributes)));
+	size_t num_slots = 0;
+	size_t key_bits = psa_get_key_bits(attributes);
+
+	/* Check if key can be erased */
+	if (persistence == CRACEN_KEY_PERSISTENCE_READ_ONLY) {
+		return PSA_ERROR_NOT_PERMITTED;
+	}
+
+	/* Ensure that key size is given */
+	if (key_bits == 0) {
+		return PSA_ERROR_INVALID_ARGUMENT;
+	}
+
+	/* Get the slot count from bit size and verify range */
+	num_slots = DIV_ROUND_UP(PSA_BITS_TO_BYTES(key_bits), CRACEN_KMU_SLOT_KEY_SIZE);
+	if (slot_id + num_slots >= PROTECTED_RAM_INVALIDATION_DATA_SLOT1) {
+		return PSA_ERROR_NOT_PERMITTED;
+	}
+
+	error = destroy_slots(slot_id, num_slots);
+	if (error != PSA_SUCCESS) {
+		return error;
+	}
+
+	return error;
+}

--- a/subsys/nrf_security/src/drivers/kmu_push/kmu_push.h
+++ b/subsys/nrf_security/src/drivers/kmu_push/kmu_push.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef KMU_PUSH_H
+#define KMU_PUSH_H
+
+/** @brief Default mask value indicating no additional behavior */
+#define KMU_PUSH_USAGE_MASK_NONE		(0)
+
+/** @brief Mask value to immediately push a KMU slot when importing */
+#define KMU_PUSH_USAGE_MASK_PUSH_IMMEDIATELY	(1 << 0)
+
+/** @brief Mask value to immediately revoke a KMU slot after importing */
+#define KMU_PUSH_USAGE_MASK_DESTROY_AFTER	(2 << 0)
+
+/** @brief Key location identifier for KMU push.
+ *
+ * This macro defines the PSA key location value for keys stored KMU for
+ * push operations.
+ */
+#define PSA_KEY_LOCATION_KMU_PUSH (PSA_KEY_LOCATION_VENDOR_FLAG | ('@' << 8) | 'd')
+
+/** @brief Structure type for KMU push key buffer
+ *
+ * This structure type is used for KMU push driver which allows
+ * an arbitruary key buffer to be pushed to an arbitruary address in
+ * KMU-accessible memory location. This structure type is used directly when
+ * calling psa_import_key.
+ */
+typedef struct {
+	uint32_t usage_mask;	/**!< Usage mask controlling if imported data shall be pushed and optionally destroyed. */
+	uint32_t dest_address; 	/**!< Destination address of the KMU push operation. */
+	uint8_t *key_buffer;	/**!< Buffer containing the key to push. */
+	size_t buffer_size;	/**!< Size of the buffer containing the key. */
+} kmu_push_key_buffer_t;
+
+/** @brief Import a KMU push key.
+ *
+ * The key_buffer is required to be @ref kmu_push_key_buffer_t. Note that
+ * depending on usage_mask metadata in this structure, the KMU push key may be
+ * directly pushed and/or destroyed during the call to import the key.
+ *
+ * @param[in] attributes          Key attributes.
+ * @param[in] data                Key data to import.
+ * @param[in] data_length         Length of the key data in bytes.
+ * @param[out] key_buffer         Buffer to represent the stored key.
+ * @param[in] key_buffer_size     Size of the key buffer in bytes.
+ * @param[out] key_buffer_length  Length of key buffer for the imported key in bytes.
+ * @param[out] key_bits           Size of the key in bits.
+ *
+ * @retval PSA_SUCCESS                The operation completed successfully.
+ * @retval PSA_ERROR_NOT_SUPPORTED    A wrong lifetime was used (revoked or read-only).
+ * @retval PSA_ERROR_INVALID_ARGUMENT The key data is invalid.
+ * @retval PSA_ERROR_NOT_PERMITTED    Storing the KMU key is not permitted for given slots.
+ * @retval PSA_ERROR_BAD_STATE        The KMU metadata retrieval failed with unknown error.
+ */
+psa_status_t kmu_push_import_key(const psa_key_attributes_t *attributes, const uint8_t *data,
+				 size_t data_length, uint8_t *key_buffer, size_t key_buffer_size,
+				 size_t *key_buffer_length, size_t *key_bits);
+
+/** @brief Get the key slot and lifetime for a given key ID.
+ *
+ * @param[in] key_id       Key ID.
+ * @param[out] lifetime    Key lifetime.
+ * @param[out] slot_number Key slot number.
+ *
+ * @retval PSA_SUCCESS                The operation completed successfully.
+ * @retval PSA_ERROR_INVALID_ARGUMENT The key_id does not match a KMU push key.
+ * @retval PSA_ERROR_NOT_SUPPORTED    The key lifetime is unsupported.
+ * @retval PSA_ERROR_NOT_PERMITTED    The KMU slot is invalid (e.g. revoked or other format)
+ * @retval PSA_ERROR_INVALID_HANDLE   The key handle is invalid.
+ * @retval PSA_ERROR_DOES_NOT_EXIST   The key does not exist.
+ * @retval PSA_ERROR_BAD_STATE        The KMU metadata retrieval failed with unknown error.
+ */
+psa_status_t kmu_push_get_key_slot(mbedtls_svc_key_id_t key_id, psa_key_lifetime_t *lifetime,
+				   psa_drv_slot_number_t *slot_number);
+
+/** @brief Get the size of the represented KMU push key.
+ *
+ * @param[in] attributes Key attributes.
+ * @param[out] key_size  Size of the key representation in bytes.
+ *
+ * @retval PSA_SUCCESS              The operation completed successfully.
+ */
+psa_status_t kmu_push_get_opaque_size(const psa_key_attributes_t *attributes, size_t *key_size);
+
+
+/** @brief PSA driver API to get a KMU push key.
+ *
+ * @param[in] slot_number         Key slot number.
+ * @param[out] attributes         Key attributes.
+ * @param[out] key_buffer         Buffer representing the built-in key.
+ * @param[in] key_buffer_size     Size of the key buffer in bytes.
+ * @param[out] key_buffer_length  Length of key buffer for the built-in key in bytes.
+ *
+ * @retval PSA_SUCCESS                The operation completed successfully.
+ * @retval PSA_ERROR_DOES_NOT_EXIST   The key does not exist.
+ * @retval PSA_ERROR_BUFFER_TOO_SMALL The key buffer is too small.
+ */
+psa_status_t kmu_push_get_builtin_key(psa_drv_slot_number_t slot_number,
+				      psa_key_attributes_t *attributes, uint8_t *key_buffer,
+				      size_t key_buffer_size, size_t *key_buffer_length);
+
+/** @brief Function to destroying a KMU push key
+ *
+ * @param[in] attributes Attributes to the key to destroy.
+ *
+ * @retval PSA_SUCCESS                The operation completed successfully.
+ * @retval PSA_ERROR_NOT_SUPPORTED    Destroying unsupported type (revokable or read-only)
+ * @retval PSA_ERROR_INVALID_ARGUMENT One or more input parameters are wrong.
+ * @retval PSA_ERROR_NOT_PERMITTED    The KMU slot(s) are invalid (e.g. revoked or other format).
+ * @retval PSA_ERROR_DATA_INVALID     KMU slot(s) contain invalid or partial data.
+ * @retval PSA_ERROR_BAD_STATE        The KMU metadata retrieval failed with unknown error.
+ */
+psa_status_t kmu_push_destroy_key(const psa_key_attributes_t *attributes);
+
+#endif /* KMU_PUSH_H */

--- a/subsys/nrf_security/src/mbedtls_psa_platform.c
+++ b/subsys/nrf_security/src/mbedtls_psa_platform.c
@@ -13,6 +13,10 @@
 #include "ironside_psa.h"
 #endif
 
+#if defined(PSA_NEED_KMU_PUSH_DRIVER)
+#include "kmu_push.h"
+#endif
+
 psa_status_t mbedtls_psa_platform_get_builtin_key(mbedtls_svc_key_id_t key_id,
 						  psa_key_lifetime_t *lifetime,
 						  psa_drv_slot_number_t *slot_number)
@@ -28,7 +32,17 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(mbedtls_svc_key_id_t key_id,
 #endif
 
 #if defined(PSA_CRYPTO_DRIVER_CRACEN)
-	return cracen_get_key_slot(key_id, lifetime, slot_number);
+	status = cracen_get_key_slot(key_id, lifetime, slot_number);
+	if (status != PSA_ERROR_DOES_NOT_EXIST) {
+		return status;
+	}
+#endif
+
+#if defined(PSA_NEED_KMU_PUSH_DRIVER)
+	status = kmu_push_get_key_slot(key_id, lifetime, slot_number);
+	if (status != PSA_ERROR_DOES_NOT_EXIST) {
+		return status;
+	}
 #endif
 	return PSA_ERROR_DOES_NOT_EXIST;
 }

--- a/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -134,6 +134,10 @@
 #include "ironside_psa.h"
 #endif
 
+#if defined(PSA_NEED_KMU_PUSH_DRIVER)
+#include "kmu_push.h"
+#endif
+
 /* Repeat above block for each JSON-declared driver during autogeneration */
 #endif /* MBEDTLS_PSA_CRYPTO_DRIVERS */
 
@@ -487,6 +491,11 @@ psa_driver_wrapper_get_key_buffer_size_from_key_data(const psa_key_attributes_t 
 #endif
 		return cracen_get_opaque_size(attributes, key_buffer_size);
 #endif
+#if defined(PSA_NEED_KMU_PUSH_DRIVER)
+	case PSA_KEY_LOCATION_KMU_PUSH:
+		return kmu_push_get_opaque_size(attributes, key_buffer_size);
+#endif
+
 	default:
 		(void)key_type;
 		(void)data;
@@ -660,6 +669,7 @@ psa_status_t psa_driver_wrapper_import_key(const psa_key_attributes_t *attribute
 			return status;
 		}
 #endif /* PSA_NEED_OBERON_KEY_MANAGEMENT_DRIVER */
+
 		/*
 		 * Fall through, meaning no accelerator supports this operation.
 		 * Oberon doesn't support importing symmetric keys at the moment
@@ -674,6 +684,11 @@ psa_status_t psa_driver_wrapper_import_key(const psa_key_attributes_t *attribute
 		return cracen_import_key(attributes, data, data_length, key_buffer,
 					   key_buffer_size, key_buffer_length, bits);
 #endif
+#if defined(PSA_NEED_KMU_PUSH_DRIVER)
+	case PSA_KEY_LOCATION_KMU_PUSH:
+		return kmu_push_import_key(attributes, data, data_length, key_buffer,
+					   key_buffer_size, key_buffer_length, bits);
+#endif /* PSA_NEED_KMU_PUSH_DRIVER */
 
 	default:
 		(void)status;
@@ -791,6 +806,11 @@ psa_status_t psa_driver_wrapper_get_builtin_key(psa_drv_slot_number_t slot_numbe
 		return (cracen_get_builtin_key(slot_number, attributes, key_buffer, key_buffer_size,
 					       key_buffer_length));
 #endif /* PSA_CRYPTO_DRIVER_CRACEN */
+#if defined(PSA_NEED_KMU_PUSH_DRIVER)
+	case PSA_KEY_LOCATION_KMU_PUSH:
+		return kmu_push_get_builtin_key(slot_number, attributes, key_buffer, key_buffer_size,
+						key_buffer_length);
+#endif /* PSA_NEED_KMU_PUSH_DRIVER */
 #if defined(PSA_CRYPTO_DRIVER_TFM_BUILTIN_KEY_LOADER)
 	case TFM_BUILTIN_KEY_LOADER_KEY_LOCATION:
 		return tfm_builtin_key_loader_get_builtin_key(slot_number, attributes, key_buffer,
@@ -3226,6 +3246,10 @@ psa_status_t psa_driver_wrapper_destroy_builtin_key(const psa_key_attributes_t *
 #if defined(PSA_NEED_CRACEN_KMU_DRIVER)
 	case PSA_KEY_LOCATION_CRACEN_KMU:
 		return cracen_destroy_key(attributes);
+#endif
+#if defined(PSA_NEED_KMU_PUSH_DRIVER)
+	case PSA_KEY_LOCATION_KMU_PUSH:
+		return kmu_push_destroy_key(attributes);
 #endif
 	}
 

--- a/tests/subsys/nrf_security/kmu_push/CMakeLists.txt
+++ b/tests/subsys/nrf_security/kmu_push/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project("KMU push unit tests")
+
+# Add test sources
+target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/nrf_security/kmu_push/Kconfig.sysbuild
+++ b/tests/subsys/nrf_security/kmu_push/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/tests/subsys/nrf_security/kmu_push/prj.conf
+++ b/tests/subsys/nrf_security/kmu_push/prj.conf
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_ZTEST=y
+
+# The Zephyr CMSIS emulation assumes that ticks are ms, currently
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
+
+CONFIG_MAIN_STACK_SIZE=8192
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+
+# Enable logging
+CONFIG_CONSOLE=y
+CONFIG_LOG=y
+
+# Enable nordic security backend and PSA APIs
+CONFIG_NRF_SECURITY=y
+CONFIG_MBEDTLS_PSA_CRYPTO_C=y
+CONFIG_PSA_CRYPTO_DRIVER_CRACEN=y
+CONFIG_PSA_CRYPTO_DRIVER_KMU_PUSH=y
+
+# Only relevant for Oberon PSA Crypto
+CONFIG_MBEDTLS_PSA_STATIC_KEY_SLOTS=y
+
+# Enable at least one algorithm to ensure MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE
+# gets a value larger than 1
+CONFIG_PSA_WANT_ALG_GCM=y
+CONFIG_PSA_WANT_KEY_TYPE_AES=y

--- a/tests/subsys/nrf_security/kmu_push/src/main.c
+++ b/tests/subsys/nrf_security/kmu_push/src/main.c
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <psa/crypto.h>
+#include <cracen_psa.h>
+#include <cracen_psa_kmu.h>
+#include <cracen_psa_key_ids.h>
+#include <cracen/cracen_kmu.h>
+#include <cracen/mem_helpers.h>
+#include <kmu_push.h>
+#include <cracen/lib_kmu.h>
+#include <string.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(kmu_push_test, LOG_LEVEL_INF);
+
+/** @brief Max number of slots for a KMU push key */
+#define MAX_NUM_KMU_SLOTS_FOR_KEY (4)
+
+/* Max key size for this test */
+#define MAX_KEY_SIZE (CRACEN_KMU_SLOT_KEY_SIZE * MAX_NUM_KMU_SLOTS_FOR_KEY)
+
+/** @brief Key size for revokable key */
+#define REVOKABLE_KEY_SIZE (48)
+
+/** @brief Key size for read-only key */
+#define READ_ONLY_KEY_SIZE (32)
+
+/** @brief Lowest KMU slot for the tests */
+#define TEST_BASE_KMU_SLOT_ID (0)
+
+/** @brief Key ID for a KMU push key */
+#define KMU_PUSH_KEY_ID \
+	PSA_KEY_HANDLE_FROM_CRACEN_KMU_SLOT(CRACEN_KMU_KEY_USAGE_SCHEME_RAW, \
+		TEST_BASE_KMU_SLOT_ID)
+
+/** @brief Buffer used for key-material to be pushed */
+static uint8_t dest_buffer[CRACEN_KMU_SLOT_KEY_SIZE * MAX_NUM_KMU_SLOTS_FOR_KEY];
+
+/** @brief Key attributes */
+static psa_key_attributes_t key_attributes = {0};
+
+/** @brief test pattern for a cryptographic key to push */
+const uint8_t test_key[16] = {
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	0x08, 0x09, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff
+};
+
+BUILD_ASSERT(sizeof(test_key) == CRACEN_KMU_SLOT_KEY_SIZE, "Update the test_key to new KMU size");
+
+/** @brief Clear the RAM buffer */
+static void clear_dest_buffer(void) {
+	safe_memzero(dest_buffer, sizeof(dest_buffer));
+}
+
+/** @brief Fill the key with the test pattern */
+static void fill_key(uint8_t *key_buffer, size_t key_size)
+{
+	size_t num_slots = DIV_ROUND_UP(key_size, CRACEN_KMU_SLOT_KEY_SIZE);
+	size_t block_size = 0;
+	size_t size_left = key_size;
+
+	for(size_t i = 0; i < num_slots; i++) {
+		block_size = size_left > CRACEN_KMU_SLOT_KEY_SIZE ? CRACEN_KMU_SLOT_KEY_SIZE : size_left;
+		memcpy(key_buffer, test_key, block_size);
+		key_buffer += block_size;
+		size_left -= block_size;
+	}
+}
+
+static bool check_all_filled(uint32_t slot_id, size_t key_size)
+{
+	bool is_filled = true;
+	size_t num_slots = DIV_ROUND_UP(key_size, CRACEN_KMU_SLOT_KEY_SIZE);
+
+	for (size_t i = 0; i < num_slots; i++) {
+		if (lib_kmu_is_slot_empty(slot_id + i)) {
+			is_filled = false;
+		}
+	}
+
+	return is_filled;
+}
+
+static bool check_none_filled(uint32_t slot_id, size_t key_size)
+{
+	bool is_empty = true;
+	size_t num_slots = DIV_ROUND_UP(key_size, CRACEN_KMU_SLOT_KEY_SIZE);
+
+	for (size_t i = 0; i < num_slots; i++) {
+		if (!lib_kmu_is_slot_empty(slot_id + i)) {
+			is_empty = false;
+		}
+	}
+
+	return is_empty;
+}
+
+static bool check_key_value(uint8_t *key_buffer, size_t key_size)
+{
+	if (constant_memcmp(dest_buffer, key_buffer, key_size) == 0) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+static psa_status_t test_import_key(mbedtls_svc_key_id_t key_id, psa_key_persistence_t persistence,
+				    uint32_t usage_mask, uint8_t * key_buffer, size_t key_size)
+{
+	psa_key_lifetime_t lifetime =
+		PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(
+			persistence, PSA_KEY_LOCATION_KMU_PUSH);
+
+	kmu_push_key_buffer_t kmu_push_buffer = {
+		.usage_mask = usage_mask,
+		.dest_address = (uint32_t) &dest_buffer,
+		.buffer_size = key_size,
+	};
+
+	clear_dest_buffer();
+	fill_key(key_buffer, key_size);
+	kmu_push_buffer.key_buffer = key_buffer;
+
+	safe_memzero(&key_attributes, sizeof(psa_key_attributes_t));
+	psa_set_key_lifetime(&key_attributes, lifetime);
+	psa_set_key_bits(&key_attributes, PSA_BYTES_TO_BITS(key_size));
+	psa_set_key_id(&key_attributes, key_id);
+
+	return psa_import_key(&key_attributes, (uint8_t *) &kmu_push_buffer, sizeof(kmu_push_buffer), &key_id);
+}
+
+static psa_status_t test_destroy_key(mbedtls_svc_key_id_t key_id)
+{
+	return psa_destroy_key(key_id);
+}
+
+static void clear_kmu_slots()
+{
+	int err;
+	/* Clear out all slots prior to testing*/
+	for(size_t i = 0; i <= MAX_NUM_KMU_SLOTS_FOR_KEY; i++) {
+		if  (lib_kmu_is_slot_empty(i)) {
+			continue;
+		}
+
+		err = lib_kmu_revoke_slot(i);
+		zassert_equal(err, LIB_KMU_SUCCESS, "Failed to clear KMU slot: %i", i);
+	}
+}
+
+static void test_rotatable_import(void)
+{
+	psa_status_t err;
+	uint8_t test_key[MAX_KEY_SIZE] = {0};
+	mbedtls_svc_key_id_t key_id = KMU_PUSH_KEY_ID;
+	psa_key_persistence_t persistence = PSA_KEY_PERSISTENCE_DEFAULT;
+	uint32_t usage_flags = KMU_PUSH_USAGE_MASK_NONE;
+
+	LOG_DBG("Test rotatable: Import");
+
+	for (size_t i = 8; i <= MAX_KEY_SIZE; i+=8) {
+		LOG_DBG("Test rotatable: Import: key_size: %d", i);
+		err = test_import_key(key_id, persistence, usage_flags, test_key, i);
+
+		zassert_equal(err, PSA_SUCCESS,
+			      "Rotatable key (import): Import failed for size: %d, err: %d", i, err);
+		/* Only possible to check that KMU slot is filled as there is no push */
+		zassert_true(check_all_filled(key_id, i),
+			     "Rotatable key (import): Key not present for size: %d", i);
+		/* Rotatable key can be erased */
+		err = test_destroy_key(key_id);
+		zassert_equal(err, PSA_SUCCESS,
+			      "Rotatable key (import): Destroy failed for size: %d, err: %d", i, err);
+	}
+}
+
+static void test_rotatable_import_push(void) {
+	psa_status_t err;
+	uint8_t test_key[MAX_KEY_SIZE] = {0};
+	mbedtls_svc_key_id_t key_id = KMU_PUSH_KEY_ID;
+	psa_key_persistence_t persistence = PSA_KEY_PERSISTENCE_DEFAULT;
+	uint32_t usage_flags = KMU_PUSH_USAGE_MASK_PUSH_IMMEDIATELY;
+
+	LOG_DBG("Test rotatable: Import, push");
+
+	for (size_t i = 8; i <= MAX_KEY_SIZE; i+=8) {
+		LOG_DBG("Test rotatable: Import, push: key_size: %d", i);
+		err = test_import_key(key_id, persistence, usage_flags, test_key, i);
+		zassert_equal(err, PSA_SUCCESS,
+			      "Rotatable key (import, push): Import failed for size: %d, err: %d", i, err);
+		/* Check that key RAM is correct */
+		zassert_true(check_key_value(test_key, i),
+			     "Rotatable key (import, push): Key value mismatch for size: %d, err %d", i, err);
+		/* Rotatable key can be erased */
+		err = test_destroy_key(key_id);
+		zassert_equal(err, PSA_SUCCESS,
+			      "Rotatable key (import, push): Destroy failed for size: %d, err: %d", i, err);
+	}
+}
+
+static void test_rotatable_import_push_destroy(void) {
+	psa_status_t err;
+	uint8_t test_key[MAX_KEY_SIZE] = {0};
+	mbedtls_svc_key_id_t key_id = KMU_PUSH_KEY_ID;
+	psa_key_persistence_t persistence = PSA_KEY_PERSISTENCE_DEFAULT;
+	uint32_t usage_flags = KMU_PUSH_USAGE_MASK_PUSH_IMMEDIATELY | KMU_PUSH_USAGE_MASK_DESTROY_AFTER;
+
+	LOG_DBG("Test rotatable: Import, push, destroy");
+	for (size_t i = 8; i <= MAX_KEY_SIZE; i+=8) {
+		LOG_DBG("Test rotatable: Import, push, destroy: key_size: %d", i);
+		err = test_import_key(key_id, persistence, usage_flags, test_key, i);
+		zassert_equal(err, PSA_SUCCESS,
+			      "Rotatable key (import, push, destroy): Import failed for size: %d, err: %d", i, err);
+		/* Check that key RAM is correct */
+		zassert_true(check_key_value(test_key, i),
+			     "Rotatable key (import, push, destroy): Key value mismatch for size: %d, err %d", i, err);
+		/* Rotatable key already erased. Check that KMU is empty */
+		zassert_true(check_none_filled(key_id, i),
+			     "Rotatable key (import, push, destroy): Key still present for size: %d, err: %d", i, err);
+	}
+}
+
+static void test_revokable_import_not_supported(void) {
+	psa_status_t err;
+	uint8_t test_key[MAX_KEY_SIZE] = {0};
+	mbedtls_svc_key_id_t key_id = KMU_PUSH_KEY_ID;
+	psa_key_persistence_t persistence = CRACEN_KEY_PERSISTENCE_REVOKABLE;
+	uint32_t usage_flags = KMU_PUSH_USAGE_MASK_PUSH_IMMEDIATELY | KMU_PUSH_USAGE_MASK_DESTROY_AFTER;
+	const size_t key_size = REVOKABLE_KEY_SIZE;
+
+	LOG_DBG("Test revokable: Import, push, destroy");
+	err = test_import_key(key_id, persistence, usage_flags, test_key, key_size);
+	zassert_equal(err, PSA_ERROR_NOT_SUPPORTED,
+		      "Revokable key: Import should fail with PSA_ERROR_NOT_SUPPORTED, err: %d", err);
+}
+
+static void test_read_only_import_not_supported(void) {
+	psa_status_t err;
+	uint8_t test_key[MAX_KEY_SIZE] = {0};
+	mbedtls_svc_key_id_t key_id = KMU_PUSH_KEY_ID;
+	psa_key_persistence_t persistence = CRACEN_KEY_PERSISTENCE_READ_ONLY;
+	uint32_t usage_flags = KMU_PUSH_USAGE_MASK_PUSH_IMMEDIATELY | KMU_PUSH_USAGE_MASK_DESTROY_AFTER;
+	const size_t key_size = READ_ONLY_KEY_SIZE;
+
+	LOG_DBG("Test revokable not supported");
+	err = test_import_key(key_id, persistence, usage_flags, test_key, key_size);
+	zassert_equal(err, PSA_ERROR_NOT_SUPPORTED,
+		      "Read-only key: Import should fail with PSA_ERROR_NOT_SUPPORTED, err: %d", err);
+}
+
+void test_main(void)
+{
+	clear_kmu_slots();
+
+	test_rotatable_import();
+
+	test_rotatable_import_push();
+
+	test_rotatable_import_push_destroy();
+
+	test_revokable_import_not_supported();
+
+	test_read_only_import_not_supported();
+}

--- a/tests/subsys/nrf_security/kmu_push/testcase.yaml
+++ b/tests/subsys/nrf_security/kmu_push/testcase.yaml
@@ -1,0 +1,18 @@
+tests:
+  kmu_push.kmu_push:
+    sysbuild: true
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+    tags:
+      - sysbuild
+      - crypto
+      - ci_crypto
+      - ci_tests_crypto


### PR DESCRIPTION
This PR adds a PSA crypto driver for directly pushing KMU keys to arbitrary addresses in memory space.
This PR includes unit-tests for keys of varying sizes with KMU slot aligned and unaligned sizes