### PR TITLE
doc: nrf: add nrf_peripherals chapter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -239,6 +239,8 @@
 /doc/nrf/libraries/security/trusted_storage.rst @nrfconnect/ncs-aegir-doc
 /doc/nrf/libraries/shell/                 @nrfconnect/ncs-doc-leads
 /doc/nrf/libraries/index.rst              @nrfconnect/ncs-doc-leads
+/doc/nrf/peripherals_drivers.rst          @nrfconnect/ncs-lowlevel-doc
+/doc/nrf/peripherals_drivers/*            @nrfconnect/ncs-lowlevel-doc
 /doc/nrf/protocols/aliro/                 @annwoj @b-gent
 /doc/nrf/protocols/amazon_sidewalk/       @nrfconnect/ncs-sidewalk-doc
 /doc/nrf/protocols/bt/                    @nrfconnect/ncs-dragoon-doc

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -235,6 +235,8 @@
 /doc/nrf/libraries/security/trusted_storage.rst @nrfconnect/ncs-aegir-doc
 /doc/nrf/libraries/shell/                 @nrfconnect/ncs-doc-leads
 /doc/nrf/libraries/index.rst              @nrfconnect/ncs-doc-leads
+/doc/nrf/peripherals_drivers.rst          @nrfconnect/ncs-lowlevel-doc
+/doc/nrf/peripherals_drivers/*            @nrfconnect/ncs-lowlevel-doc
 /doc/nrf/protocols/aliro/                 @annwoj @b-gent
 /doc/nrf/protocols/amazon_sidewalk/       @nrfconnect/ncs-sidewalk-doc
 /doc/nrf/protocols/bt/                    @nrfconnect/ncs-dragoon-doc

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -52,6 +52,7 @@ Varied reference designs
    applications
    samples
    drivers
+   peripherals_drivers
    libraries/index
    scripts
    integrations

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -137,7 +137,8 @@
 .. _`nrfx`: https://github.com/NordicSemiconductor/nrfx/
 .. _`nrfx API documentation`: https://docs.nordicsemi.com/bundle/nrfx-apis-latest/page/index.html
 .. _`nrfx 4.0 migration note`: https://docs.nordicsemi.com/bundle/nrfx_4.0.1/page/md_doc_nrfx_4_0_migration_guide.html
-.. _`nrfx NVMC driver`: https://docs.nordicsemi.com/bundle/nrfx-apis-latest/page/group_nrfx_nvmc.html
+.. _`nrfx NVMC driver`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrfx/html/group__nrfx__nvmc.html
+.. _`nrfx SPIM driver`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrfx/html/group__nrfx__spim.html
 .. _`Changelog for nrfx 2.2.0`: https://github.com/NordicSemiconductor/nrfx/blob/master/CHANGELOG.md#user-content-220---2020-04-28
 .. _`Changelog for nrfx 2.3.0`: https://github.com/NordicSemiconductor/nrfx/blob/master/CHANGELOG.md#user-content-230---2020-08-19
 .. _`Changelog for nrfx 2.4.0`: https://github.com/NordicSemiconductor/nrfx/blob/master/CHANGELOG.md#user-content-240---2020-11-13
@@ -258,6 +259,8 @@
 .. _`Zephyr hostap fork`: https://github.com/zephyrproject-rtos/hostap
 
 .. _`tfm_secure_peripheral_partition.yaml`: https://github.com/nrfconnect/sdk-nrf/blob/main/samples/tfm/tfm_secure_peripheral/secure_peripheral_partition/tfm_secure_peripheral_partition.yaml.in
+
+.. _`nrfx SPIM sample`: https://github.com/zephyrproject-rtos/hal_nordic/tree/master/nrfx/samples/src/nrfx_spim
 
 .. ### Source: github.io
 
@@ -551,6 +554,7 @@
 .. _`nRF9160 CRYPTOCELL - Arm TrustZone CryptoCell 310`: https://docs.nordicsemi.com/bundle/ps_nrf9160/page/cryptocell.html
 .. _`nRF9160 Key management unit`: https://docs.nordicsemi.com/bundle/ps_nrf9160/page/kmu.html
 .. _`nRF9160 OTP`: https://docs.nordicsemi.com/bundle/ps_nrf9160/page/kmu.html#kmu_otp
+.. _`nRF9160 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf9160/page/spim.html
 
 .. _`nRF9160 DK Hardware`: https://docs.nordicsemi.com/bundle/ug_nrf9160_dk/page/UG/nrf91_DK/intro.html
 .. _`nRF9160 DK board control section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9160_dk/page/UG/nrf91_DK/hw_description/nrf9160_board_controller.html
@@ -563,6 +567,7 @@
 .. _`nRF9161 GPS receiver specification`: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/gps.html
 .. _`nRF9161 DECT NR+ specification`: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/dect.html
 .. _`nRF9161 System Protection Unit`: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/spu.html
+.. _`nRF9161 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/spim.html
 
 .. _`nRF9161 DK Hardware`: https://docs.nordicsemi.com/bundle/ug_nrf9161_dk/page/UG/nrf91_DK/intro.html
 .. _`nRF9161 DK board control section in the nRF9161 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9161_dk/page/UG/nrf91_DK/hw_description/nrf9161_board_controller.html
@@ -572,6 +577,7 @@
 .. _`nRF9151 DECT NR+ specification`: https://docs.nordicsemi.com/bundle/ps_nrf9151/page/dect.html
 .. _`nRF9151 GPS receiver specification`: https://docs.nordicsemi.com/bundle/ps_nrf9151/page/gps.html
 .. _`nRF9151 Key management unit`: https://docs.nordicsemi.com/bundle/ps_nrf9151/page/kmu.html
+.. _`nRF9151 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf9151/page/spim.html
 
 .. _`nRF9151 DK Hardware`: https://docs.nordicsemi.com/bundle/ug_nrf9151_dk/page/UG/nrf91_DK/intro.html
 .. _`nRF9151 DK board control section in the nRF9151 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9151_dk/page/UG/nrf91_DK/hw_description/nrf9161_board_controller.html
@@ -625,14 +631,17 @@
 .. _`nRF54L15 RRAM programming parameters`: https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/_tmp/nrf54l15/autodita/RRAMC/parameters.rram_programming.html
 .. _`nRF54L15 CRACEN`: https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/cracen.html
 .. _`nRF54L15 Power and clock management`: https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/pmu.html
+.. _`nRF54L15 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/spim.html
 
 .. _`nRF54LM20A Datasheet`: https://docs.nordicsemi.com/bundle/ps_nrf54LM20A/page/keyfeatures_html5.html
 .. _`nRF54LM20 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf54lm20_dk/page/UG/nRF54LM20_DK/intro/intro.html
 .. _`nRF54LM20A Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54lm20a/page/COMP/nrf54lm20a/nrf54lm20a_comp_matrix.html
+.. _`nRF54LM20A SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf54LM20A/page/spim.html
 
 .. _`nRF54LV10A Datasheet`: https://docs.nordicsemi.com/bundle/ps_nrf54LV10A/page/keyfeatures_html5.html
 .. _`nRF54LV10 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf54lv10_dk/page/UG/nRF54LV10_DK/intro/intro.html
 .. _`nRF54LV10 Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54lv10a/page/COMP/nrf54lv10a/nrf54lv10a_comp_matrix.html
+.. _`nRF54LV10A SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf54LV10A/page/spim.html
 
 .. _`nRF54LS05A/B Datasheet`: https://docs.nordicsemi.com/bundle/ps_nrf54LS05A/page/keyfeatures_html5.html
 
@@ -642,6 +651,7 @@
 .. _`nRF5340 CRYPTOCELL - Arm TrustZone CryptoCell 312`: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/cryptocell.html
 .. _`nRF5340 Key management unit`: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/kmu.html
 .. _`nRF5340 OTP`: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/kmu.html#kmu_otp
+.. _`nRF5340 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/spim.html
 
 .. _`nRF5340 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf5340_dk/page/UG/dk/intro.html
 .. _`Execute in place page in the nRF5340 Product Specification`: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/qspi.html#d1789e363
@@ -661,23 +671,30 @@
 .. _`nRF52840 DK Debug output`: https://docs.nordicsemi.com/bundle/ug_nrf52840_dk/page/UG/dk/hw_debug_out.html
 .. _`nRF52840 Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf52840/page/COMP/nrf52840/nrf52840_comp_matrix.html
 .. _`nRF52840 DK Access Control Lists`: https://docs.nordicsemi.com/bundle/ps_nrf52840/page/acl.html
+.. _`nRF52840 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52840/page/spim.html
 
 .. _`nRF52833 Product Specification`: https://docs.nordicsemi.com/bundle?labelkey=nrf52833&labelkey=product-specification
 .. _`nRF52833 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf52833_dk/page/UG/dk/intro.html
+.. _`nRF52833 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52833/page/spim.html
 
 .. _`nRF52 Series`: https://docs.nordicsemi.com/category/nrf-52-series
 .. _`nRF52832 Product Specification`: https://docs.nordicsemi.com/bundle/ps_nrf52832/page/nrf52832_ps.html
 .. _`nRF52832 Temperature Sensor Electrical Specification`: https://docs.nordicsemi.com/bundle/ps_nrf52832/page/temp.html#d949e9367
+.. _`nRF52832 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52832/page/spim.html
 
 .. _`nRF52 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf52832_dk/page/UG/dk/intro.html
 
 .. _`nRF52820 Product Specification`: https://docs.nordicsemi.com/bundle/ps_nrf52820/page/keyfeatures_html5.html
+.. _`nRF52820 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52820/page/spim.html
 
 .. _`nRF52811 Product Specification`: https://docs.nordicsemi.com/bundle?labelkey=nrf52811&labelkey=product-specification
+.. _`nRF52811 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52811/page/spim.html
 
 .. _`nRF52810 Product Specification`: https://docs.nordicsemi.com/bundle?labelkey=nrf52810&labelkey=product-specification
+.. _`nRF52810 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52810/page/spim.html
 
 .. _`nRF52805 Product Specification`: https://docs.nordicsemi.com/bundle?labelkey=nrf52805&labelkey=product-specification
+.. _`nRF52805 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52805/page/spim.html
 
 .. _`nRF21540`:
 .. _`nRF21540 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf21540_dk/page/UG/nrf21540_DK/intro.html
@@ -2133,7 +2150,14 @@
 .. _`BICR configuration example in JSON format`: https://github.com/nrfconnect/sdk-zephyr/blob/v4.0.99-ncs1/boards/nordic/nrf54h20dk/bicr.json
 
 .. _`Zephyr's device driver API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers
+.. _`Zephyr's pinctrl pin configuration`: https://docs.zephyrproject.org/latest/hardware/pinctrl/index.html#pin-configuration
+.. _`Zephyr's pinctrl API`: https://docs.zephyrproject.org/latest/doxygen/html/group__pinctrl__interface.html
+.. _`Zephyr's SPI driver API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers/spi.h
+.. _`Zephyr's SPI RTIO driver API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers/spi/rtio.h
+.. _`Zephyr's sensor driver API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers/sensor.h
 .. _`Zephyr's nRF clock control API extensions`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers/clock_control/nrf_clock_control.h
+.. _`Zephyr's SPI driver twister test`: https://github.com/nrfconnect/sdk-zephyr/tree/main/tests/drivers/spi/spi_loopback
+.. _`Zephyr's pressure sensor sample`: https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/sensor/pressure_interrupt
 .. _`clocks devicetree macro API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/devicetree/clocks.h
 
 .. _`nRF54H20 DK memory map`: https://github.com/nrfconnect/sdk-zephyr/blob/main/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -140,7 +140,8 @@
 .. _`nrfx`: https://github.com/NordicSemiconductor/nrfx/
 .. _`nrfx API documentation`: https://docs.nordicsemi.com/bundle/nrfx-apis-latest/page/index.html
 .. _`nrfx 4.0 migration note`: https://docs.nordicsemi.com/bundle/nrfx_4.0.1/page/md_doc_nrfx_4_0_migration_guide.html
-.. _`nrfx NVMC driver`: https://docs.nordicsemi.com/bundle/nrfx-apis-latest/page/group_nrfx_nvmc.html
+.. _`nrfx NVMC driver`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrfx/html/group__nrfx__nvmc.html
+.. _`nrfx SPIM driver`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrfx/html/group__nrfx__spim.html
 .. _`Changelog for nrfx 2.2.0`: https://github.com/NordicSemiconductor/nrfx/blob/master/CHANGELOG.md#user-content-220---2020-04-28
 .. _`Changelog for nrfx 2.3.0`: https://github.com/NordicSemiconductor/nrfx/blob/master/CHANGELOG.md#user-content-230---2020-08-19
 .. _`Changelog for nrfx 2.4.0`: https://github.com/NordicSemiconductor/nrfx/blob/master/CHANGELOG.md#user-content-240---2020-11-13
@@ -244,6 +245,8 @@
 
 
 .. _`Zephyr hostap fork`: https://github.com/zephyrproject-rtos/hostap
+
+.. _`nrfx SPIM sample`: https://github.com/zephyrproject-rtos/hal_nordic/tree/master/nrfx/samples/src/nrfx_spim
 
 .. ### Source: github.io
 
@@ -537,6 +540,7 @@
 .. _`nRF9160 CRYPTOCELL - Arm TrustZone CryptoCell 310`: https://docs.nordicsemi.com/bundle/ps_nrf9160/page/cryptocell.html
 .. _`nRF9160 Key management unit`: https://docs.nordicsemi.com/bundle/ps_nrf9160/page/kmu.html
 .. _`nRF9160 OTP`: https://docs.nordicsemi.com/bundle/ps_nrf9160/page/kmu.html#kmu_otp
+.. _`nRF9160 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf9160/page/spim.html
 
 .. _`nRF9160 DK Hardware`: https://docs.nordicsemi.com/bundle/ug_nrf9160_dk/page/UG/nrf91_DK/intro.html
 .. _`nRF9160 DK board control section in the nRF9160 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9160_dk/page/UG/nrf91_DK/hw_description/nrf9160_board_controller.html
@@ -549,6 +553,7 @@
 .. _`nRF9161 GPS receiver specification`: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/gps.html
 .. _`nRF9161 DECT NR+ specification`: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/dect.html
 .. _`nRF9161 System Protection Unit`: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/spu.html
+.. _`nRF9161 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/spim.html
 
 .. _`nRF9161 DK Hardware`: https://docs.nordicsemi.com/bundle/ug_nrf9161_dk/page/UG/nrf91_DK/intro.html
 .. _`nRF9161 DK board control section in the nRF9161 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9161_dk/page/UG/nrf91_DK/hw_description/nrf9161_board_controller.html
@@ -558,6 +563,7 @@
 .. _`nRF9151 DECT NR+ specification`: https://docs.nordicsemi.com/bundle/ps_nrf9151/page/dect.html
 .. _`nRF9151 GPS receiver specification`: https://docs.nordicsemi.com/bundle/ps_nrf9151/page/gps.html
 .. _`nRF9151 Key management unit`: https://docs.nordicsemi.com/bundle/ps_nrf9151/page/kmu.html
+.. _`nRF9151 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf9151/page/spim.html
 
 .. _`nRF9151 DK Hardware`: https://docs.nordicsemi.com/bundle/ug_nrf9151_dk/page/UG/nrf91_DK/intro.html
 .. _`nRF9151 DK board control section in the nRF9151 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf9151_dk/page/UG/nrf91_DK/hw_description/nrf9161_board_controller.html
@@ -613,14 +619,17 @@
 .. _`nRF54L15 RRAM programming parameters`: https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/_tmp/nrf54l15/autodita/RRAMC/parameters.rram_programming.html
 .. _`nRF54L15 CRACEN`: https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/cracen.html
 .. _`nRF54L15 Power and clock management`: https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/pmu.html
+.. _`nRF54L15 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/spim.html
 
 .. _`nRF54LM20A Datasheet`: https://docs.nordicsemi.com/bundle/ps_nrf54LM20A/page/keyfeatures_html5.html
 .. _`nRF54LM20 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf54lm20_dk/page/UG/nRF54LM20_DK/intro/intro.html
 .. _`nRF54LM20A Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54lm20a/page/COMP/nrf54lm20a/nrf54lm20a_comp_matrix.html
+.. _`nRF54LM20A SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf54LM20A/page/spim.html
 
 .. _`nRF54LV10A Datasheet`: https://docs.nordicsemi.com/bundle/ps_nrf54LV10A/page/keyfeatures_html5.html
 .. _`nRF54LV10 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf54lv10_dk/page/UG/nRF54LV10_DK/intro/intro.html
 .. _`nRF54LV10 Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54lv10a/page/COMP/nrf54lv10a/nrf54lv10a_comp_matrix.html
+.. _`nRF54LV10A SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf54LV10A/page/spim.html
 
 .. _`nRF54LS05A/B Datasheet`: https://docs.nordicsemi.com/bundle/ps_nrf54LS05A/page/keyfeatures_html5.html
 
@@ -630,6 +639,7 @@
 .. _`nRF5340 CRYPTOCELL - Arm TrustZone CryptoCell 312`: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/cryptocell.html
 .. _`nRF5340 Key management unit`: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/kmu.html
 .. _`nRF5340 OTP`: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/kmu.html#kmu_otp
+.. _`nRF5340 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/spim.html
 
 .. _`nRF5340 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf5340_dk/page/UG/dk/intro.html
 .. _`Execute in place page in the nRF5340 Product Specification`: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/qspi.html#d1789e363
@@ -649,23 +659,30 @@
 .. _`nRF52840 DK Debug output`: https://docs.nordicsemi.com/bundle/ug_nrf52840_dk/page/UG/dk/hw_debug_out.html
 .. _`nRF52840 Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf52840/page/COMP/nrf52840/nrf52840_comp_matrix.html
 .. _`nRF52840 DK Access Control Lists`: https://docs.nordicsemi.com/bundle/ps_nrf52840/page/acl.html
+.. _`nRF52840 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52840/page/spim.html
 
 .. _`nRF52833 Product Specification`: https://docs.nordicsemi.com/bundle?labelkey=nrf52833&labelkey=product-specification
 .. _`nRF52833 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf52833_dk/page/UG/dk/intro.html
+.. _`nRF52833 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52833/page/spim.html
 
 .. _`nRF52 Series`: https://docs.nordicsemi.com/category/nrf-52-series
 .. _`nRF52832 Product Specification`: https://docs.nordicsemi.com/bundle/ps_nrf52832/page/nrf52832_ps.html
 .. _`nRF52832 Temperature Sensor Electrical Specification`: https://docs.nordicsemi.com/bundle/ps_nrf52832/page/temp.html#d949e9367
+.. _`nRF52832 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52832/page/spim.html
 
 .. _`nRF52 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf52832_dk/page/UG/dk/intro.html
 
 .. _`nRF52820 Product Specification`: https://docs.nordicsemi.com/bundle/ps_nrf52820/page/keyfeatures_html5.html
+.. _`nRF52820 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52820/page/spim.html
 
 .. _`nRF52811 Product Specification`: https://docs.nordicsemi.com/bundle?labelkey=nrf52811&labelkey=product-specification
+.. _`nRF52811 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52811/page/spim.html
 
 .. _`nRF52810 Product Specification`: https://docs.nordicsemi.com/bundle?labelkey=nrf52810&labelkey=product-specification
+.. _`nRF52810 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52810/page/spim.html
 
 .. _`nRF52805 Product Specification`: https://docs.nordicsemi.com/bundle?labelkey=nrf52805&labelkey=product-specification
+.. _`nRF52805 SPIM`: https://docs.nordicsemi.com/bundle/ps_nrf52805/page/spim.html
 
 .. _`nRF21540`:
 .. _`nRF21540 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf21540_dk/page/UG/nrf21540_DK/intro.html
@@ -2102,7 +2119,14 @@
 .. _`BICR configuration example in JSON format`: https://github.com/nrfconnect/sdk-zephyr/blob/v4.0.99-ncs1/boards/nordic/nrf54h20dk/bicr.json
 
 .. _`Zephyr's device driver API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers
+.. _`Zephyr's pinctrl pin configuration`: https://docs.zephyrproject.org/latest/hardware/pinctrl/index.html#pin-configuration
+.. _`Zephyr's pinctrl API`: https://docs.zephyrproject.org/latest/doxygen/html/group__pinctrl__interface.html
+.. _`Zephyr's SPI driver API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers/spi.h
+.. _`Zephyr's RTIO subsystem`: https://docs.zephyrproject.org/latest/services/rtio/index.html
+.. _`Zephyr's sensor driver API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers/sensor.h
 .. _`Zephyr's nRF clock control API extensions`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers/clock_control/nrf_clock_control.h
+.. _`Zephyr's SPI driver twister test`: https://github.com/nrfconnect/sdk-zephyr/tree/main/tests/drivers/spi/spi_loopback
+.. _`Zephyr's pressure sensor sample`: https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/sensor/pressure_interrupt
 .. _`clocks devicetree macro API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/devicetree/clocks.h
 
 .. _`nRF54H20 DK memory map`: https://github.com/nrfconnect/sdk-zephyr/blob/main/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -2101,6 +2101,7 @@
 .. _`BICR configuration example in DTS format`: https://github.com/nrfconnect/sdk-zephyr/blob/v3.7.99-ncs2/boards/nordic/nrf54h20dk/nrf54h20dk_bicr.dtsi
 .. _`BICR configuration example in JSON format`: https://github.com/nrfconnect/sdk-zephyr/blob/v4.0.99-ncs1/boards/nordic/nrf54h20dk/bicr.json
 
+.. _`Zephyr's device driver API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers
 .. _`Zephyr's nRF clock control API extensions`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers/clock_control/nrf_clock_control.h
 .. _`clocks devicetree macro API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/devicetree/clocks.h
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -2132,6 +2132,7 @@
 .. _`BICR configuration example in DTS format`: https://github.com/nrfconnect/sdk-zephyr/blob/v3.7.99-ncs2/boards/nordic/nrf54h20dk/nrf54h20dk_bicr.dtsi
 .. _`BICR configuration example in JSON format`: https://github.com/nrfconnect/sdk-zephyr/blob/v4.0.99-ncs1/boards/nordic/nrf54h20dk/bicr.json
 
+.. _`Zephyr's device driver API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers
 .. _`Zephyr's nRF clock control API extensions`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers/clock_control/nrf_clock_control.h
 .. _`clocks devicetree macro API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/devicetree/clocks.h
 

--- a/doc/nrf/peripherals_drivers.rst
+++ b/doc/nrf/peripherals_drivers.rst
@@ -1,0 +1,15 @@
+.. _peripherals_drivers:
+
+Peripherals drivers
+###################
+
+Nordic Semiconductor SoCs contain a variety of hardware peripherals that can be used for many purposes in context of |NCS| applications.
+Some of them can be utilized using `Zephyr's device driver API`_, while others are accessible only through `nrfx`_.
+There are also various subsystems or libraries available, that may access hardware peripheral underneath.
+
+Here you can find documentation for using supported hardware peripherals in the |NCS|.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Subpages:
+   :glob:

--- a/doc/nrf/peripherals_drivers.rst
+++ b/doc/nrf/peripherals_drivers.rst
@@ -13,3 +13,5 @@ Here you can find documentation for using supported hardware peripherals in the 
    :maxdepth: 1
    :caption: Subpages:
    :glob:
+
+   peripherals_drivers/spim

--- a/doc/nrf/peripherals_drivers.rst
+++ b/doc/nrf/peripherals_drivers.rst
@@ -13,3 +13,5 @@ The following pages describe how to use the supported hardware peripherals in th
    :maxdepth: 1
    :caption: Subpages:
    :glob:
+
+   peripherals_drivers/spim

--- a/doc/nrf/peripherals_drivers.rst
+++ b/doc/nrf/peripherals_drivers.rst
@@ -1,0 +1,15 @@
+.. _peripherals_drivers:
+
+Peripherals drivers
+###################
+
+Nordic Semiconductor SoCs contain a variety of hardware peripherals that can be used for many purposes in the context of |NCS| applications.
+Some of them can be utilized using `Zephyr's device driver API`_, while others are accessible only through `nrfx`_.
+Various subsystems and libraries are also available that may access the underlying hardware peripherals.
+
+The following pages describe how to use the supported hardware peripherals in the |NCS|.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Subpages:
+   :glob:

--- a/doc/nrf/peripherals_drivers/spim.rst
+++ b/doc/nrf/peripherals_drivers/spim.rst
@@ -1,0 +1,78 @@
+.. _spim_peripheral:
+
+SPIM
+####
+
+.. contents::
+   :local:
+   :depth: 2
+
+The SPI controller peripheral (SPIM) provides a full duplex, 4-wire synchronous serial communication interface.
+
+You can find more details about SPIM hardware peripheral in the respective Product Specification:
+
+* `nRF52805 SPIM`_
+* `nRF52810 SPIM`_
+* `nRF52811 SPIM`_
+* `nRF52832 SPIM`_
+* `nRF52833 SPIM`_
+* `nRF52840 SPIM`_
+* `nRF5340 SPIM`_
+* `nRF9151 SPIM`_
+* `nRF9160 SPIM`_
+* `nRF9161 SPIM`_
+* `nRF54L15 SPIM`_
+* `nRF54LM20A SPIM`_
+* `nRF54LV10A SPIM`_
+
+Related software components
+***************************
+
+Here you can find a list of software components that can be used to interact with the SPIM peripheral:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Component
+     - Link
+     - Description
+   * - `spi` Zephyr driver
+     - `Zephyr's SPI driver API`_
+     - general-purpose, standardized Zephyr driver API for SPI peripherals
+   * - `spi_rtio` Zephyr driver
+     - `Zephyr's SPI RTIO driver API`_
+     - general-purpose, standardized Zephyr driver API utilizing RTIO framework for SPI peripherals
+   * - `sensor` driver
+     - `Zephyr's sensor driver API`_
+     - general-purpose, standardized Zephyr driver API for interacting with external sensors
+
+Reference code
+**************
+
+Here you can find a list of samples or tests that utilize SPIM peripheral and can be used as a usage reference:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Application
+     - Link
+     - Comment
+   * - Zephyr `spi` driver twister loopback test
+     - `Zephyr's SPI driver twister test`_
+     - Test utilizing `Zephyr's SPI driver API`_ to send data between MOSI and MISO pins connected using jumper wire
+   * - Zephyr `sensor` driver sample for pressure sensor
+     - `Zephyr's pressure sensor sample`_
+     - Sample utilizing `Zephyr's sensor driver API`_ to communicate with external pressure sensor over SPI bus.
+
+Usage guides
+************
+
+Here you can find a description on how the peripheral hardware capabilities are mapped into software component interfaces and what are their limitations.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Subpages:
+   :glob:
+
+   spim_zephyr_spi
+   spim_zephyr_spi_rtio

--- a/doc/nrf/peripherals_drivers/spim.rst
+++ b/doc/nrf/peripherals_drivers/spim.rst
@@ -1,0 +1,78 @@
+.. _spim_peripheral:
+
+SPIM
+####
+
+.. contents::
+   :local:
+   :depth: 2
+
+The SPI controller peripheral (SPIM) provides a full-duplex, 4-wire synchronous serial communication interface.
+
+You can find more details about the SPIM hardware peripheral in the respective Product Specification documents:
+
+* `nRF52805 SPIM`_
+* `nRF52810 SPIM`_
+* `nRF52811 SPIM`_
+* `nRF52832 SPIM`_
+* `nRF52833 SPIM`_
+* `nRF52840 SPIM`_
+* `nRF5340 SPIM`_
+* `nRF9151 SPIM`_
+* `nRF9160 SPIM`_
+* `nRF9161 SPIM`_
+* `nRF54L15 SPIM`_
+* `nRF54LM20A SPIM`_
+* `nRF54LV10A SPIM`_
+
+Related software components
+***************************
+
+The following software components can be used to interact with the SPIM peripheral:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Component
+     - Link
+     - Description
+   * - ``spi`` Zephyr driver
+     - `Zephyr's SPI driver API`_
+     - general-purpose, standardized Zephyr driver API for SPI peripherals
+   * - ``spi_rtio`` Zephyr driver
+     - `Zephyr's RTIO subsystem`_
+     - general-purpose, standardized Zephyr driver API utilizing RTIO framework for SPI peripherals
+   * - ``sensor`` driver
+     - `Zephyr's sensor driver API`_
+     - general-purpose, standardized Zephyr driver API for interacting with external sensors
+
+Reference code
+**************
+
+The following samples and tests use the SPIM peripheral and can serve as a usage reference:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Application
+     - Link
+     - Comment
+   * - Zephyr ``spi`` driver twister loopback test
+     - `Zephyr's SPI driver twister test`_
+     - Test utilizing `Zephyr's SPI driver API`_ to send data between MOSI and MISO pins connected using a jumper wire
+   * - Zephyr ``sensor`` driver sample for pressure sensor
+     - `Zephyr's pressure sensor sample`_
+     - Sample utilizing `Zephyr's sensor driver API`_ to communicate with external pressure sensor over SPI bus.
+
+Usage guides
+************
+
+The following guides describe how the peripheral's hardware capabilities are mapped to software component interfaces, along with their limitations.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Subpages:
+   :glob:
+
+   spim_zephyr_spi
+   spim_zephyr_spi_rtio

--- a/doc/nrf/peripherals_drivers/spim_zephyr_spi.rst
+++ b/doc/nrf/peripherals_drivers/spim_zephyr_spi.rst
@@ -1,0 +1,243 @@
+.. _spim_zephyr_spi:
+
+SPIM Zephyr driver
+##################
+
+Complete driver API reference can be found under the following link: `Zephyr's SPI driver API`_
+
+Purpose of this page is to present peripheral usage scenarios covered by the driver API.
+
+Configuration
+*************
+
+Static configuration
+====================
+
+The Zephyr SPI driver is configured statically through the devicetree.
+Before the driver can be used at runtime, the corresponding devicetree node must be enabled and its properties set according to the desired operating mode.
+
+A typical SPI controller node in an application overlay looks as follows:
+
+.. code-block:: devicetree
+
+   &spi20 {
+       status = "okay";
+       pinctrl-0 = <&spi20_default>;
+       pinctrl-names = "default";
+       cs-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+
+       my_device: my-device@0 {
+           compatible = "vnd,my-spi-device";
+           reg = <0>;
+           spi-max-frequency = <DT_FREQ_M(8)>;
+       };
+   };
+
+The ``pinctrl-0`` property references a pin control state defined in the board or application overlay, per `Zephyr's pinctrl pin configuration`_.
+The ``cs-gpios`` property specifies the GPIO pin used for chip select control.
+Each SPI peripheral device on the bus is represented as a child node, with the ``reg`` property indicating its chip select index.
+
+Kconfig configuration
+=====================
+
+To enable the Zephyr SPI driver for nRF SoCs, set the following Kconfig option:
+
+.. code-block:: kconfig
+
+   CONFIG_SPI=y
+
+Depending on the specific nRF SoC and SPIM instance used, the appropriate hardware-specific driver backend is selected automatically by Zephyr's build system.
+
+Runtime configuration
+=====================
+
+At runtime, SPI transfers are configured using the :c:struct:`spi_config` structure.
+This structure defines the operational parameters for each transfer, such as frequency, operation mode flags, and slave select.
+
+To obtain a reference to the SPI device and prepare the configuration:
+
+.. code-block:: c
+
+   #include <zephyr/drivers/spi.h>
+   #include <zephyr/devicetree.h>
+
+   #define MY_SPI_NODE DT_NODELABEL(my_device)
+
+   static const struct device *spi_dev = DEVICE_DT_GET(DT_BUS(MY_SPI_NODE));
+
+   static const struct spi_config spi_cfg = {
+       .frequency = DT_PROP(MY_SPI_NODE, spi_max_frequency),
+       .operation = SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_MODE_CPOL | SPI_MODE_CPHA,
+       .slave = DT_REG_ADDR(MY_SPI_NODE),
+       .cs = SPI_CS_CONTROL_INIT(DT_NODELABEL(my_device), 2),
+   };
+
+   int main(void) {
+       if (!device_is_ready(spi_dev)) {
+           return -ENODEV;
+       }
+   }
+
+The ``operation`` field is composed of OR'ed bitmasks defined in ``<zephyr/drivers/spi.h>``, specifying word size, bit order, and SPI mode (clock polarity and phase).
+
+The above approach requires manual population of :c:struct:`spi_config` from devicetree macros.
+The preferred modern approach is to use :c:struct:`spi_dt_spec`, which bundles the device reference and :c:struct:`spi_config` into a single struct populated at build time from devicetree using the :c:macro:`SPI_DT_SPEC_GET` macro:
+
+.. code-block:: c
+
+   #include <zephyr/drivers/spi.h>
+   #include <zephyr/devicetree.h>
+
+   #define MY_SPI_NODE DT_NODELABEL(my_device)
+
+   static const struct spi_dt_spec spi_spec =
+       SPI_DT_SPEC_GET(MY_SPI_NODE, SPI_WORD_SET(8) | SPI_TRANSFER_MSB, 0);
+
+   int main(void) {
+       if (!spi_is_ready_dt(&spi_spec)) {
+           return -ENODEV;
+       }
+   }
+
+The second argument to :c:macro:`SPI_DT_SPEC_GET` is the ``operation`` bitmask, and the third is an optional delay in microseconds applied after asserting chip select.
+Frequency and chip select configuration are derived automatically from the devicetree node.
+When using :c:struct:`spi_dt_spec`, the corresponding :c:func:`spi_transceive_dt` API function should be used in place of :c:func:`spi_transceive`, passing the spec directly:
+
+.. code-block:: c
+
+   err = spi_transceive_dt(&spi_spec, &tx_set, &rx_set);
+
+Chip select management
+======================
+
+The Zephyr SPI driver controls the chip select signal automatically as part of each transfer, using the GPIO specified in the ``cs-gpios`` devicetree property.
+The :c:macro:`SPI_CS_CONTROL_INIT` macro initialises the :c:struct:`spi_cs_control` structure from devicetree, including the GPIO device reference, pin, flags, and delay.
+
+If manual chip select control is required, the ``cs`` field of :c:struct:`spi_config` may be set to ``{0}`` and the chip select GPIO managed explicitly by the application using the GPIO driver API.
+
+Data transfer
+*************
+
+After completing device and configuration initialisation, the driver is ready to perform transfers using the :c:func:`spi_transceive` function, or its blocking and asynchronous variants.
+
+Each transfer is described by two sets of :c:struct:`spi_buf_set` structures: one for the transmit buffers and one for the receive buffers.
+Each :c:struct:`spi_buf_set` points to an array of :c:struct:`spi_buf` descriptors, allowing scatter-gather transfers composed of multiple non-contiguous memory regions.
+
+.. caution::
+
+   Depending on the specific SoC, buffers provided via :c:struct:`spi_buf` may need to comply with specific alignment or RAM location requirements imposed by the underlying DMA hardware.
+   Refer to the respective Product Specification for more details.
+
+Basic TX-RX transfer
+====================
+
+To perform a simultaneous transmit and receive transfer, provide both a transmit and a receive :c:struct:`spi_buf_set` to :c:func:`spi_transceive`:
+
+.. code-block:: c
+
+   static uint8_t tx_data[4] = { 0x01, 0x02, 0x03, 0x04 };
+   static uint8_t rx_data[4];
+
+   static const struct spi_buf tx_buf = {
+       .buf = tx_data,
+       .len = sizeof(tx_data),
+   };
+
+   static const struct spi_buf rx_buf = {
+       .buf = rx_data,
+       .len = sizeof(rx_data),
+   };
+
+   static const struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+   static const struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+   int main(void) {
+       int err;
+
+       err = spi_transceive(spi_dev, &spi_cfg, &tx_set, &rx_set);
+       if (err < 0) {
+           ...
+       }
+   }
+
+The call blocks until the transfer completes.
+Passing ``NULL`` for either ``tx_bufs`` or ``rx_bufs`` results in a transmit-only or receive-only transfer, respectively.
+
+Scatter-gather transfer
+=======================
+
+The :c:struct:`spi_buf_set` abstraction supports scatter-gather transfers, where the data to be transmitted or received is spread across multiple non-contiguous buffers.
+This is useful when sending a header followed by a variable-length payload without copying the data into a single contiguous buffer:
+
+.. code-block:: c
+
+   static uint8_t header[2] = { 0xAB, 0x01 };
+   static uint8_t payload[16] = { ... };
+
+   static const struct spi_buf tx_bufs[] = {
+       { .buf = header,  .len = sizeof(header)  },
+       { .buf = payload, .len = sizeof(payload) },
+   };
+
+   static const struct spi_buf_set tx_set = { .buffers = tx_bufs, .count = 2 };
+
+   err = spi_transceive(spi_dev, &spi_cfg, &tx_set, NULL);
+
+Asynchronous transfer
+=====================
+
+For non-blocking operation, use :c:func:`spi_transceive_cb`, which accepts a callback function invoked upon transfer completion:
+
+.. code-block:: c
+
+   void spi_callback(const struct device *dev, int result, void *data) {
+       if (result < 0) {
+           ...
+       }
+       /* Transfer complete — process rx_data here */
+   }
+
+   int main(void) {
+       err = spi_transceive_cb(spi_dev, &spi_cfg, &tx_set, &rx_set,
+                               spi_callback, NULL);
+       if (err < 0) {
+           ...
+       }
+   }
+
+.. caution::
+
+   Asynchronous transfer support depends on Zephyr's asynchronous SPI backend being enabled for the target SoC.
+   Enable it with the following Kconfig option:
+
+   .. code-block:: kconfig
+
+      CONFIG_SPI_ASYNC=y
+
+.. caution::
+
+   The ``spi_callback`` function is invoked from IRQ context.
+   Only ISR-safe Zephyr kernel APIs may be used inside the callback.
+   :c:func:`k_sem_give` is ISR-safe and can be used to signal a waiting thread.
+   The calling thread can then block on :c:func:`k_sem_take` after initiating the transfer and proceed once the callback has signalled completion:
+
+   .. code-block:: c
+
+      #include <zephyr/kernel.h>
+
+      static K_SEM_DEFINE(spi_done, 0, 1);
+
+      void spi_callback(const struct device *dev, int result, void *data) {
+          k_sem_give(&spi_done);
+      }
+
+      int main(void) {
+          err = spi_transceive_cb(spi_dev, &spi_cfg, &tx_set, &rx_set,
+                                  spi_callback, NULL);
+          if (err < 0) {
+              ...
+          }
+
+          k_sem_take(&spi_done, K_FOREVER);
+          /* Transfer complete — process rx_data here */
+      }

--- a/doc/nrf/peripherals_drivers/spim_zephyr_spi.rst
+++ b/doc/nrf/peripherals_drivers/spim_zephyr_spi.rst
@@ -1,0 +1,286 @@
+.. _spim_zephyr_spi:
+
+SPIM Zephyr driver
+##################
+
+The Zephyr SPI driver provides a standardized, general-purpose API for communicating with SPI peripherals on nRF SoCs.
+
+For the complete API reference, see `Zephyr's SPI driver API`_.
+
+This page describes the common usage scenarios covered by the driver API, including static and runtime configuration, chip select management, and different data transfer modes.
+
+Configuration
+*************
+
+Configuring the Zephyr SPI driver involves three parts: enabling the driver through Kconfig, describing the bus and connected devices statically in the devicetree, and setting the parameters for each transfer at runtime in the application code.
+
+Static configuration
+====================
+
+The Zephyr SPI driver is configured statically through the devicetree.
+Before the driver can be used at runtime, the corresponding devicetree node must be enabled and its properties set according to the desired operating mode.
+
+A typical SPI controller node in an application overlay looks as follows:
+
+.. code-block:: devicetree
+
+   &spi20 {
+       status = "okay";
+       pinctrl-0 = <&spi20_default>;
+       pinctrl-names = "default";
+       cs-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+
+       my_device: my-device@0 {
+           compatible = "vnd,my-spi-device";
+           reg = <0>;
+           spi-max-frequency = <DT_FREQ_M(8)>;
+       };
+   };
+
+The ``pinctrl-0`` property references a pin control state defined in the board or application overlay, per `Zephyr's pinctrl pin configuration`_.
+The ``cs-gpios`` property specifies the GPIO pin used for chip select control.
+Each SPI peripheral device on the bus is represented as a child node, with the ``reg`` property indicating its chip select index.
+
+Kconfig configuration
+=====================
+
+To enable the Zephyr SPI driver for nRF SoCs, set the following Kconfig option:
+
+.. code-block:: kconfig
+
+   CONFIG_SPI=y
+
+Depending on the specific nRF SoC and SPIM instance used, the appropriate hardware-specific driver backend is selected automatically by Zephyr's build system.
+
+Runtime configuration
+=====================
+
+At runtime, SPI transfers are configured using the :c:struct:`spi_config` structure.
+This structure defines the operational parameters for each transfer, such as frequency, operation mode flags, and slave select.
+
+To obtain a reference to the SPI device and prepare the configuration:
+
+.. code-block:: c
+
+   #include <zephyr/drivers/spi.h>
+   #include <zephyr/devicetree.h>
+
+   #define MY_SPI_NODE DT_NODELABEL(my_device)
+
+   static const struct device *spi_dev = DEVICE_DT_GET(DT_BUS(MY_SPI_NODE));
+
+   static const struct spi_config spi_cfg = {
+       .frequency = DT_PROP(MY_SPI_NODE, spi_max_frequency),
+       .operation = SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_MODE_CPOL | SPI_MODE_CPHA,
+       .slave = DT_REG_ADDR(MY_SPI_NODE),
+       .cs = SPI_CS_CONTROL_INIT(DT_NODELABEL(my_device), 2),
+   };
+
+   int main(void) {
+       if (!device_is_ready(spi_dev)) {
+           return -ENODEV;
+       }
+   }
+
+The ``operation`` field is composed of OR'ed bitmasks defined in ``<zephyr/drivers/spi.h>``, specifying word size, bit order, and SPI mode (clock polarity and phase).
+
+The above approach requires manual population of :c:struct:`spi_config` from devicetree macros.
+The preferred modern approach is to use :c:struct:`spi_dt_spec`, which bundles the device reference and :c:struct:`spi_config` into a single struct populated at build time from devicetree using the :c:macro:`SPI_DT_SPEC_GET` macro:
+
+.. code-block:: c
+
+   #include <zephyr/drivers/spi.h>
+   #include <zephyr/devicetree.h>
+
+   #define MY_SPI_NODE DT_NODELABEL(my_device)
+
+   static const struct spi_dt_spec spi_spec =
+       SPI_DT_SPEC_GET(MY_SPI_NODE, SPI_WORD_SET(8) | SPI_TRANSFER_MSB, 0);
+
+   int main(void) {
+       if (!spi_is_ready_dt(&spi_spec)) {
+           return -ENODEV;
+       }
+   }
+
+The second argument to :c:macro:`SPI_DT_SPEC_GET` is the ``operation`` bitmask, and the third is an optional delay in microseconds applied after asserting chip select.
+Frequency and chip select configuration are derived automatically from the devicetree node.
+When using :c:struct:`spi_dt_spec`, the corresponding :c:func:`spi_transceive_dt` API function should be used in place of :c:func:`spi_transceive`, passing the spec directly:
+
+.. code-block:: c
+
+   err = spi_transceive_dt(&spi_spec, &tx_set, &rx_set);
+
+Chip select management
+======================
+
+The Zephyr SPI driver controls the chip select signal automatically as part of each transfer, using the GPIO specified in the ``cs-gpios`` devicetree property.
+The :c:macro:`SPI_CS_CONTROL_INIT` macro initializes the :c:struct:`spi_cs_control` structure from devicetree, including the GPIO device reference, pin, flags, and delay.
+
+If manual chip select control is required, the ``cs`` field of :c:struct:`spi_config` may be set to ``{0}`` and the chip select GPIO managed explicitly by the application using the GPIO driver API.
+
+Data transfer
+*************
+
+After completing device and configuration initialization, the driver is ready to perform transfers using the :c:func:`spi_transceive` function, or its blocking and asynchronous variants.
+
+Each transfer is described by two sets of :c:struct:`spi_buf_set` structures: one for the transmit buffers and one for the receive buffers.
+Each :c:struct:`spi_buf_set` points to an array of :c:struct:`spi_buf` descriptors, allowing scatter-gather transfers composed of multiple non-contiguous memory regions.
+
+See `Buffer requirements`_ for the constraints that the nRF SPIM peripheral imposes on the transfer buffers.
+
+Basic TX-RX transfer
+====================
+
+To perform a simultaneous transmit and receive transfer, provide both a transmit and a receive :c:struct:`spi_buf_set` to :c:func:`spi_transceive`:
+
+.. code-block:: c
+
+   static uint8_t tx_data[4] = { 0x01, 0x02, 0x03, 0x04 };
+   static uint8_t rx_data[4];
+
+   static const struct spi_buf tx_buf = {
+       .buf = tx_data,
+       .len = sizeof(tx_data),
+   };
+
+   static const struct spi_buf rx_buf = {
+       .buf = rx_data,
+       .len = sizeof(rx_data),
+   };
+
+   static const struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+   static const struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+   int main(void) {
+       int err;
+
+       err = spi_transceive(spi_dev, &spi_cfg, &tx_set, &rx_set);
+       if (err < 0) {
+           ...
+       }
+   }
+
+The call blocks until the transfer completes.
+Passing ``NULL`` for either ``tx_bufs`` or ``rx_bufs`` results in a transmit-only or receive-only transfer, respectively.
+
+Scatter-gather transfer
+=======================
+
+The :c:struct:`spi_buf_set` abstraction supports scatter-gather transfers, where the data to be transmitted or received is spread across multiple non-contiguous buffers.
+This is useful when sending a header followed by a variable-length payload without copying the data into a single contiguous buffer:
+
+.. code-block:: c
+
+   static uint8_t header[2] = { 0xAB, 0x01 };
+   static uint8_t payload[16] = { ... };
+
+   static const struct spi_buf tx_bufs[] = {
+       { .buf = header,  .len = sizeof(header)  },
+       { .buf = payload, .len = sizeof(payload) },
+   };
+
+   static const struct spi_buf_set tx_set = { .buffers = tx_bufs, .count = 2 };
+
+   err = spi_transceive(spi_dev, &spi_cfg, &tx_set, NULL);
+
+Asynchronous transfer
+=====================
+
+For non-blocking operation, use :c:func:`spi_transceive_cb`, which accepts a callback function invoked upon transfer completion:
+
+.. code-block:: c
+
+   void spi_callback(const struct device *dev, int result, void *data) {
+       if (result < 0) {
+           ...
+       }
+       /* Transfer complete — process rx_data here */
+   }
+
+   int main(void) {
+       err = spi_transceive_cb(spi_dev, &spi_cfg, &tx_set, &rx_set,
+                               spi_callback, NULL);
+       if (err < 0) {
+           ...
+       }
+   }
+
+.. caution::
+
+   Asynchronous transfer support depends on Zephyr's asynchronous SPI backend being enabled for the target SoC.
+   Enable it with the following Kconfig option:
+
+   .. code-block:: kconfig
+
+      CONFIG_SPI_ASYNC=y
+
+.. caution::
+
+   The ``spi_callback`` function is invoked from IRQ context.
+   Only ISR-safe Zephyr kernel APIs may be used inside the callback.
+   :c:func:`k_sem_give` is ISR-safe and can be used to signal a waiting thread.
+   The calling thread can then block on :c:func:`k_sem_take` after initiating the transfer and proceed once the callback has signalled completion:
+
+   .. code-block:: c
+
+      #include <zephyr/kernel.h>
+
+      static K_SEM_DEFINE(spi_done, 0, 1);
+
+      void spi_callback(const struct device *dev, int result, void *data) {
+          k_sem_give(&spi_done);
+      }
+
+      int main(void) {
+          err = spi_transceive_cb(spi_dev, &spi_cfg, &tx_set, &rx_set,
+                                  spi_callback, NULL);
+          if (err < 0) {
+              ...
+          }
+
+          k_sem_take(&spi_done, K_FOREVER);
+          /* Transfer complete — process rx_data here */
+      }
+
+Buffer requirements
+===================
+
+The nRF SPIM peripheral moves data using EasyDMA, which places two constraints on the buffers referenced by the :c:struct:`spi_buf` descriptors:
+
+* Maximum transfer size
+
+  A single EasyDMA transfer is limited by the peripheral's ``MAXCNT`` register, whose width is SoC-specific.
+  The driver automatically splits larger transfers into chunks that fit this limit, so no action is required from the application beyond being aware that a large transfer is carried out as several DMA operations.
+
+* Memory location
+
+  EasyDMA can only access buffers located in specific memory regions.
+  Buffers placed in flash (for example ``const`` data) or in RAM that is not reachable by EasyDMA cannot be used directly.
+
+How buffers outside the EasyDMA-accessible region are handled depends on the SoC:
+
+* On SoCs without Device Memory Management (DMM), the driver copies the data through an internal RAM bounce buffer whose size is set by ``CONFIG_SPI_NRFX_RAM_BUFFER_SIZE`` (default ``8`` bytes per driver instance, applied to both the TX and RX paths).
+  Setting this option to ``0`` disables bounce buffering, in which case the application must ensure that every buffer is directly accessible by EasyDMA, otherwise the transfer fails.
+
+* On SoCs with Device Memory Management (DMM), the driver allocates the buffers from the DMM memory region and splits transfers into chunks limited by ``CONFIG_SPI_NRFX_DMM_BUFFER_SIZE`` (default ``256`` bytes). For a full-duplex transfer, twice the chunk size is allocated.
+
+Bounce buffering and DMM re-allocation add a data copy on every affected transfer.
+For the best performance, statically place the transmit and receive buffers in the memory region that EasyDMA can access for the given SPI controller, with the alignment required by the underlying DMA hardware.
+The Nordic Device Memory Management (DMM) subsystem provides the ``DMM_MEMORY_SECTION(node_id)`` variable attribute in ``<dmm.h>`` for exactly this purpose.
+It places a statically allocated buffer in the memory region associated with the given devicetree node and applies the alignment that the region requires.
+Pass the SPI controller node (obtained with ``DT_BUS()`` from the device node) so that the buffers are placed in the region associated with that controller:
+
+.. code-block:: c
+
+   #include <dmm.h>
+
+   #define MY_SPI_NODE DT_NODELABEL(my_device)
+
+   static uint8_t tx_data[4] DMM_MEMORY_SECTION(DT_BUS(MY_SPI_NODE));
+   static uint8_t rx_data[4] DMM_MEMORY_SECTION(DT_BUS(MY_SPI_NODE));
+
+Buffers declared this way are already in the correct region and alignment, so neither bounce buffering nor DMM re-allocation is needed at transfer time.
+On SoCs that do not associate a dedicated memory region with the controller, ``DMM_MEMORY_SECTION`` expands to a no-op, so the same code remains portable across nRF devices.
+
+Refer to the respective Product Specification for the exact memory regions, alignment, and ``MAXCNT`` limits.

--- a/doc/nrf/peripherals_drivers/spim_zephyr_spi_rtio.rst
+++ b/doc/nrf/peripherals_drivers/spim_zephyr_spi_rtio.rst
@@ -1,0 +1,279 @@
+.. _spim_zephyr_spi_rtio:
+
+SPIM Zephyr RTIO driver
+#######################
+
+Complete driver API reference can be found under the following links: `Zephyr's SPI driver API`_ and `Zephyr's SPI RTIO driver API`_.
+
+Purpose of this page is to present peripheral usage scenarios covered by the RTIO-based SPI driver API.
+
+Overview
+********
+
+The RTIO (Real-Time I/O) driver backend for the nRF SPIM peripheral provides a native, non-blocking I/O path built on top of Zephyr's :ref:`RTIO subsystem <rtio>`.
+Instead of the traditional :c:func:`spi_transceive` call model, applications submit I/O requests to a submission queue (SQ) and later consume results from a completion queue (CQ).
+
+This backend is selected automatically when ``CONFIG_SPI_RTIO=y`` is set and the ``nordic,nrf-spim`` compatible is present in the devicetree.
+It is mutually exclusive with the standard ``SPI_NRFX_SPIM`` backend:
+
+- ``CONFIG_SPI_NRFX_SPIM`` — selected when ``CONFIG_SPI_RTIO`` is **not** set.
+- ``CONFIG_SPI_NRFX_SPIM_RTIO`` — selected when ``CONFIG_SPI_RTIO=y`` is set.
+
+Configuration
+*************
+
+Static configuration
+====================
+
+The devicetree configuration is identical to the standard SPIM driver.
+A typical SPI controller node in an application overlay looks as follows:
+
+.. code-block:: devicetree
+
+   &spi20 {
+       status = "okay";
+       pinctrl-0 = <&spi20_default>;
+       pinctrl-names = "default";
+       cs-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+
+       my_device: my-device@0 {
+           compatible = "vnd,my-spi-device";
+           reg = <0>;
+           spi-max-frequency = <DT_FREQ_M(8)>;
+       };
+   };
+
+No additional devicetree properties are required to enable the RTIO backend.
+
+Kconfig configuration
+=====================
+
+Enable the RTIO subsystem and the SPI RTIO support:
+
+.. code-block:: kconfig
+
+   CONFIG_RTIO=y
+   CONFIG_SPI=y
+   CONFIG_SPI_RTIO=y
+
+When ``CONFIG_SPI_RTIO=y`` is set, the build system automatically selects ``CONFIG_SPI_NRFX_SPIM_RTIO`` for nRF SoCs with a ``nordic,nrf-spim`` devicetree node enabled.
+
+Two additional Kconfig options control the sizes of the per-device RTIO context queues:
+
+.. code-block:: kconfig
+
+   # Number of submission queue entries (SQEs) per SPIM RTIO context (default: 8)
+   CONFIG_SPI_NRFX_SPIM_RTIO_SQE_POOL_SIZE=8
+
+   # Number of completion queue entries (CQEs) per SPIM RTIO context (default: 8)
+   CONFIG_SPI_NRFX_SPIM_RTIO_CQE_POOL_SIZE=8
+
+Increase these values if the application submits more than eight in-flight requests to a single SPI device.
+
+Runtime configuration
+=====================
+
+The SPI iodev and the RTIO context are set up at build time using :c:macro:`SPI_IODEV_DEFINE` and :c:macro:`RTIO_DEFINE`.
+The :c:macro:`SPI_IODEV_DEFINE` macro binds a devicetree SPI device node to an iodev object, including the operation flags, frequency, and chip-select configuration derived from the devicetree:
+
+.. code-block:: c
+
+   #include <zephyr/drivers/spi.h>
+   #include <zephyr/rtio/rtio.h>
+   #include <zephyr/devicetree.h>
+
+   #define MY_SPI_NODE DT_NODELABEL(my_device)
+
+   /* Define the iodev for the SPI device node */
+   SPI_IODEV_DEFINE(spi_iodev, MY_SPI_NODE,
+                    SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_MODE_CPOL | SPI_MODE_CPHA,
+                    0 /* cs_delay_us */);
+
+   /* Define an RTIO context with 4 SQE slots and 4 CQE slots */
+   RTIO_DEFINE(spi_rtio_ctx, 4, 4);
+
+   int main(void) {
+       if (!spi_is_ready_iodev(&spi_iodev)) {
+           return -ENODEV;
+       }
+   }
+
+The second argument to :c:macro:`SPI_IODEV_DEFINE` is the ``operation`` bitmask (same flags as used with :c:macro:`SPI_DT_SPEC_GET`).
+The third argument is an optional chip-select delay in microseconds.
+Frequency and chip-select GPIO are derived automatically from the devicetree node.
+
+:c:func:`spi_is_ready_iodev` checks that the SPI controller device and, if configured, the chip-select GPIO are ready for use.
+
+Data transfer
+*************
+
+Transfers are performed by preparing submission queue entries (SQEs), submitting them to the RTIO context, and then consuming completion queue events (CQEs) to determine the result.
+
+The helper :c:func:`spi_rtio_copy` copies a pair of :c:struct:`spi_buf_set` descriptors into a set of SQEs chained on the iodev.
+This mirrors the buffer model of the traditional :c:func:`spi_transceive` API and is the recommended way to perform standard transfers.
+
+Basic TX-RX transfer
+====================
+
+To perform a simultaneous transmit and receive transfer:
+
+.. code-block:: c
+
+   #include <zephyr/drivers/spi.h>
+   #include <zephyr/rtio/rtio.h>
+
+   static uint8_t tx_data[4] = { 0x01, 0x02, 0x03, 0x04 };
+   static uint8_t rx_data[4];
+
+   static const struct spi_buf tx_buf = {
+       .buf = tx_data,
+       .len = sizeof(tx_data),
+   };
+   static const struct spi_buf rx_buf = {
+       .buf = rx_data,
+       .len = sizeof(rx_data),
+   };
+
+   static const struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+   static const struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+   int main(void) {
+       struct rtio_sqe *last_sqe = NULL;
+       struct rtio_cqe *cqe;
+       int err;
+
+       /* Copy buf_sets into chained SQEs on the iodev */
+       err = spi_rtio_copy(&spi_rtio_ctx, &spi_iodev,
+                           &tx_set, &rx_set, &last_sqe);
+       if (err < 0) {
+           return err;
+       }
+
+       /* Submit all prepared SQEs */
+       rtio_submit(&spi_rtio_ctx, 0);
+
+       /* Wait for and consume the completion event */
+       cqe = rtio_cqe_consume_block(&spi_rtio_ctx);
+       err = cqe->result;
+       rtio_cqe_release(&spi_rtio_ctx, cqe);
+
+       if (err < 0) {
+           /* Transfer failed */
+       }
+
+       /* rx_data now contains the received bytes */
+       return 0;
+   }
+
+Passing ``NULL`` for either ``tx_bufs`` or ``rx_bufs`` in :c:func:`spi_rtio_copy` results in a transmit-only or receive-only transfer, respectively.
+
+.. caution::
+
+   Depending on the specific SoC, buffers provided via :c:struct:`spi_buf` may need to comply with specific alignment or RAM location requirements imposed by the underlying DMA hardware.
+   Refer to the respective Product Specification for more details.
+
+Scatter-gather transfer
+=======================
+
+Because :c:func:`spi_rtio_copy` accepts a :c:struct:`spi_buf_set` containing multiple :c:struct:`spi_buf` descriptors, scatter-gather transfers work the same way as with the standard API.
+The following sends a two-part transmit buffer (header followed by payload) without copying into a single contiguous region:
+
+.. code-block:: c
+
+   static uint8_t header[2]  = { 0xAB, 0x01 };
+   static uint8_t payload[16] = { ... };
+
+   static const struct spi_buf tx_bufs[] = {
+       { .buf = header,  .len = sizeof(header)  },
+       { .buf = payload, .len = sizeof(payload) },
+   };
+   static const struct spi_buf_set tx_set = { .buffers = tx_bufs, .count = 2 };
+
+   struct rtio_sqe *last_sqe = NULL;
+
+   err = spi_rtio_copy(&spi_rtio_ctx, &spi_iodev, &tx_set, NULL, &last_sqe);
+   rtio_submit(&spi_rtio_ctx, 0);
+
+   struct rtio_cqe *cqe = rtio_cqe_consume_block(&spi_rtio_ctx);
+   err = cqe->result;
+   rtio_cqe_release(&spi_rtio_ctx, cqe);
+
+Asynchronous (non-blocking) transfer
+=====================================
+
+The primary advantage of the RTIO backend is that submission and completion are decoupled.
+An application can submit a transfer and continue doing other work, then check or wait for the CQE later:
+
+.. code-block:: c
+
+   struct rtio_sqe *last_sqe = NULL;
+
+   /* Prepare and submit — returns immediately */
+   err = spi_rtio_copy(&spi_rtio_ctx, &spi_iodev,
+                       &tx_set, &rx_set, &last_sqe);
+   if (err < 0) {
+       return err;
+   }
+   rtio_submit(&spi_rtio_ctx, 0);
+
+   /* ... do other work ... */
+
+   /* Block until the transfer completes */
+   struct rtio_cqe *cqe = rtio_cqe_consume_block(&spi_rtio_ctx);
+   err = cqe->result;
+   rtio_cqe_release(&spi_rtio_ctx, cqe);
+
+   if (err < 0) {
+       /* Transfer failed */
+   }
+   /* rx_data now contains received bytes */
+
+To poll for completion without blocking, use :c:func:`rtio_cqe_consume` instead, which returns ``NULL`` if no CQE is available yet:
+
+.. code-block:: c
+
+   struct rtio_cqe *cqe = rtio_cqe_consume(&spi_rtio_ctx);
+   if (cqe != NULL) {
+       err = cqe->result;
+       rtio_cqe_release(&spi_rtio_ctx, cqe);
+   }
+
+Chaining multiple transfers
+============================
+
+Multiple SQE chains can be queued before a single :c:func:`rtio_submit` call.
+All operations targeting the same iodev are serialised by the RTIO executor.
+Operations on different iodevs may proceed concurrently:
+
+.. code-block:: c
+
+   struct rtio_sqe *last_sqe = NULL;
+
+   /* First transfer: write a command */
+   err = spi_rtio_copy(&spi_rtio_ctx, &spi_iodev,
+                       &cmd_tx_set, NULL, &last_sqe);
+
+   /* Second transfer: read the response */
+   err = spi_rtio_copy(&spi_rtio_ctx, &spi_iodev,
+                       NULL, &resp_rx_set, &last_sqe);
+
+   /* Submit both chains at once */
+   rtio_submit(&spi_rtio_ctx, 0);
+
+   /* Consume two CQEs */
+   for (int i = 0; i < 2; i++) {
+       struct rtio_cqe *cqe = rtio_cqe_consume_block(&spi_rtio_ctx);
+       if (cqe->result < 0) { ... }
+       rtio_cqe_release(&spi_rtio_ctx, cqe);
+   }
+
+.. note::
+
+   The ordering of CQEs on the completion queue is not guaranteed to match the submission order across independent chains.
+   Within a single chain, ordering and failure cascading are preserved.
+
+Chip select management
+======================
+
+Chip select is managed automatically by the driver as part of each submission chain, using the GPIO specified in the ``cs-gpios`` devicetree property and the delay encoded in the iodev.
+Manual chip-select control is not available when using the RTIO API.

--- a/doc/nrf/peripherals_drivers/spim_zephyr_spi_rtio.rst
+++ b/doc/nrf/peripherals_drivers/spim_zephyr_spi_rtio.rst
@@ -1,0 +1,336 @@
+.. _spim_zephyr_spi_rtio:
+
+SPIM Zephyr RTIO driver
+#######################
+
+The RTIO-based Zephyr SPI driver provides a native, non-blocking API for communicating with SPI peripherals on nRF SoCs, built on top of Zephyr's :ref:`RTIO subsystem <rtio>`.
+
+For the complete API reference, see `Zephyr's SPI driver API`_ and `Zephyr's RTIO subsystem`_.
+
+This page describes the common usage scenarios covered by the RTIO-based API, including configuration, data transfer modes, transfer chaining, and chip select management.
+
+Overview
+********
+
+The RTIO (Real-Time I/O) driver backend for the nRF SPIM peripheral provides a native, non-blocking I/O path built on top of Zephyr's :ref:`RTIO subsystem <rtio>`.
+Instead of the traditional :c:func:`spi_transceive` call model, applications submit I/O requests to a submission queue (SQ) and later consume results from a completion queue (CQ).
+
+This backend is selected automatically when ``CONFIG_SPI_RTIO=y`` is set and the ``nordic,nrf-spim`` compatible is present in the devicetree.
+It is mutually exclusive with the standard ``SPI_NRFX_SPIM`` backend:
+
+* ``CONFIG_SPI_NRFX_SPIM`` — selected when ``CONFIG_SPI_RTIO`` is **not** set.
+* ``CONFIG_SPI_NRFX_SPIM_RTIO`` — selected when ``CONFIG_SPI_RTIO=y`` is set.
+
+Configuration
+*************
+
+Static configuration
+====================
+
+The devicetree configuration is identical to the standard SPIM driver.
+A typical SPI controller node in an application overlay looks as follows:
+
+.. code-block:: devicetree
+
+   &spi20 {
+       status = "okay";
+       pinctrl-0 = <&spi20_default>;
+       pinctrl-names = "default";
+       cs-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+
+       my_device: my-device@0 {
+           compatible = "vnd,my-spi-device";
+           reg = <0>;
+           spi-max-frequency = <DT_FREQ_M(8)>;
+       };
+   };
+
+No additional devicetree properties are required to enable the RTIO backend.
+
+Kconfig configuration
+=====================
+
+Enable the RTIO subsystem and the SPI RTIO support:
+
+.. code-block:: kconfig
+
+   CONFIG_RTIO=y
+   CONFIG_SPI=y
+   CONFIG_SPI_RTIO=y
+
+When ``CONFIG_SPI_RTIO=y`` is set, the build system automatically selects ``CONFIG_SPI_NRFX_SPIM_RTIO`` for nRF SoCs with a ``nordic,nrf-spim`` devicetree node enabled.
+
+Two additional Kconfig options control the sizes of the per-device RTIO context that the driver uses internally to service the legacy :c:func:`spi_transceive` API when ``CONFIG_SPI_RTIO`` is enabled:
+
+.. code-block:: kconfig
+
+   # Number of submission queue entries (SQEs) per SPIM RTIO context (default: 8)
+   CONFIG_SPI_NRFX_SPIM_RTIO_SQE_POOL_SIZE=8
+
+   # Number of completion queue entries (CQEs) per SPIM RTIO context (default: 8)
+   CONFIG_SPI_NRFX_SPIM_RTIO_CQE_POOL_SIZE=8
+
+These options apply only to that internal context.
+Increase them if the application submits more than eight in-flight requests to a single SPI device through the legacy :c:func:`spi_transceive` API.
+When using the RTIO API directly, the number of in-flight requests is instead bounded by the submission queue entries (SQEs) allocated by the application's own :c:macro:`RTIO_DEFINE`, described in the `Runtime configuration`_ section.
+
+Runtime configuration
+=====================
+
+The SPI iodev and the RTIO context are set up at build time using :c:macro:`SPI_DT_IODEV_DEFINE` and :c:macro:`RTIO_DEFINE`.
+The :c:macro:`SPI_DT_IODEV_DEFINE` macro binds a devicetree SPI device node to an iodev object, including the operation flags, frequency, and chip-select configuration derived from the devicetree:
+
+.. code-block:: c
+
+   #include <zephyr/drivers/spi.h>
+   #include <zephyr/rtio/rtio.h>
+   #include <zephyr/devicetree.h>
+
+   #define MY_SPI_NODE DT_NODELABEL(my_device)
+
+   /* Define the iodev for the SPI device node */
+   SPI_DT_IODEV_DEFINE(spi_iodev, MY_SPI_NODE,
+                       SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_MODE_CPOL | SPI_MODE_CPHA,
+                       0 /* cs_delay_us */);
+
+   /* Define an RTIO context with 4 SQE slots and 4 CQE slots */
+   RTIO_DEFINE(spi_rtio_ctx, 4, 4);
+
+   int main(void) {
+       if (!spi_is_ready_iodev(&spi_iodev)) {
+           return -ENODEV;
+       }
+   }
+
+The second argument to :c:macro:`SPI_DT_IODEV_DEFINE` is the ``operation`` bitmask (same flags as used with :c:macro:`SPI_DT_SPEC_GET`).
+The third argument is an optional chip-select delay in microseconds.
+Frequency and chip-select GPIO are derived automatically from the devicetree node.
+
+:c:func:`spi_is_ready_iodev` checks that the SPI controller device and, if configured, the chip-select GPIO are ready for use.
+
+Chip select management
+======================
+
+Chip select is managed automatically by the driver as part of each submission chain, using the GPIO specified in the ``cs-gpios`` devicetree property and the delay encoded in the iodev.
+Manual chip-select control is not available when using the RTIO API.
+
+Data transfer
+*************
+
+Transfers are performed by acquiring submission queue entries (SQEs) from the RTIO context, preparing them against the SPI iodev, submitting them, and then consuming completion queue events (CQEs) to determine the result.
+
+The SQEs are prepared using the generic submission helpers from Zephyr's :ref:`RTIO subsystem <rtio>`:
+
+* :c:func:`rtio_sqe_prep_transceive` for a simultaneous transmit and receive (full-duplex) transfer.
+* :c:func:`rtio_sqe_prep_write` for a transmit-only transfer.
+* :c:func:`rtio_sqe_prep_read` for a receive-only transfer.
+
+Each helper takes a plain buffer pointer and length rather than a :c:struct:`spi_buf_set`.
+:c:func:`rtio_sqe_prep_transceive` requires both the transmit and receive buffers to be valid.
+
+See `Buffer requirements`_ for the constraints that the nRF SPIM peripheral imposes on the transfer buffers.
+
+Basic TX-RX transfer
+====================
+
+To perform a simultaneous transmit and receive transfer, acquire an SQE, prepare it with :c:func:`rtio_sqe_prep_transceive`, submit it, and wait for the completion:
+
+.. code-block:: c
+
+   #include <zephyr/drivers/spi.h>
+   #include <zephyr/rtio/rtio.h>
+
+   static uint8_t tx_data[4] = { 0x01, 0x02, 0x03, 0x04 };
+   static uint8_t rx_data[4];
+
+   int main(void) {
+       struct rtio_sqe *sqe;
+       struct rtio_cqe *cqe;
+       int err;
+
+       /* Acquire an SQE and prepare a full-duplex transfer */
+       sqe = rtio_sqe_acquire(&spi_rtio_ctx);
+       if (sqe == NULL) {
+           return -ENOMEM;
+       }
+       rtio_sqe_prep_transceive(sqe, &spi_iodev, RTIO_PRIO_NORM,
+                                tx_data, rx_data, sizeof(tx_data), NULL);
+
+       /* Submit the prepared SQE and wait for one completion */
+       rtio_submit(&spi_rtio_ctx, 1);
+
+       /* Consume the completion event */
+       cqe = rtio_cqe_consume(&spi_rtio_ctx);
+       err = cqe->result;
+       rtio_cqe_release(&spi_rtio_ctx, cqe);
+
+       if (err < 0) {
+           /* Transfer failed */
+       }
+
+       /* rx_data now contains the received bytes */
+       return 0;
+   }
+
+The second argument to :c:func:`rtio_submit` is the number of completions to wait for before returning; passing ``0`` submits without blocking.
+For a transmit-only or receive-only transfer, use :c:func:`rtio_sqe_prep_write` or :c:func:`rtio_sqe_prep_read` respectively, each of which takes a single buffer.
+
+Multi-part (transaction) transfer
+=================================
+
+A single logical transfer can be split across multiple buffers by chaining SQEs with the :c:macro:`RTIO_SQE_TRANSACTION` flag.
+All SQEs in a transaction are executed against the same iodev without interruption, so the chip select stays asserted for the whole sequence, and the transaction produces a single CQE.
+This replaces the multi-buffer :c:struct:`spi_buf_set` scatter-gather model of the traditional API.
+
+The following sends a two-part transmit buffer (header followed by payload) without copying into a single contiguous region:
+
+.. code-block:: c
+
+   static uint8_t header[2]   = { 0xAB, 0x01 };
+   static uint8_t payload[16] = { ... };
+
+   struct rtio_sqe *sqe;
+   struct rtio_cqe *cqe;
+   int err;
+
+   /* First part: mark it as part of a transaction */
+   sqe = rtio_sqe_acquire(&spi_rtio_ctx);
+   rtio_sqe_prep_write(sqe, &spi_iodev, RTIO_PRIO_NORM,
+                       header, sizeof(header), NULL);
+   sqe->flags |= RTIO_SQE_TRANSACTION;
+
+   /* Second (final) part of the transaction */
+   sqe = rtio_sqe_acquire(&spi_rtio_ctx);
+   rtio_sqe_prep_write(sqe, &spi_iodev, RTIO_PRIO_NORM,
+                       payload, sizeof(payload), NULL);
+
+   rtio_submit(&spi_rtio_ctx, 1);
+
+   cqe = rtio_cqe_consume(&spi_rtio_ctx);
+   err = cqe->result;
+   rtio_cqe_release(&spi_rtio_ctx, cqe);
+
+Set the :c:macro:`RTIO_SQE_TRANSACTION` flag on every SQE in the sequence except the last one.
+
+Asynchronous (non-blocking) transfer
+=====================================
+
+The primary advantage of the RTIO backend is that submission and completion are decoupled.
+An application can submit a transfer without waiting, continue doing other work, and check or wait for the CQE later.
+Submit with a wait count of ``0`` so :c:func:`rtio_submit` returns immediately:
+
+.. code-block:: c
+
+   struct rtio_sqe *sqe;
+   struct rtio_cqe *cqe;
+   int err;
+
+   /* Prepare and submit without blocking */
+   sqe = rtio_sqe_acquire(&spi_rtio_ctx);
+   rtio_sqe_prep_transceive(sqe, &spi_iodev, RTIO_PRIO_NORM,
+                            tx_data, rx_data, sizeof(tx_data), NULL);
+   rtio_submit(&spi_rtio_ctx, 0);
+
+   /* ... do other work ... */
+
+   /* Block until the transfer completes */
+   cqe = rtio_cqe_consume_block(&spi_rtio_ctx);
+   err = cqe->result;
+   rtio_cqe_release(&spi_rtio_ctx, cqe);
+
+   if (err < 0) {
+       /* Transfer failed */
+   }
+   /* rx_data now contains received bytes */
+
+To poll for completion without blocking, use :c:func:`rtio_cqe_consume` instead, which returns ``NULL`` if no CQE is available yet:
+
+.. code-block:: c
+
+   struct rtio_cqe *cqe = rtio_cqe_consume(&spi_rtio_ctx);
+   if (cqe != NULL) {
+       err = cqe->result;
+       rtio_cqe_release(&spi_rtio_ctx, cqe);
+   }
+
+Chaining multiple transfers
+============================
+
+Independent operations can be queued as a chain using the :c:macro:`RTIO_SQE_CHAINED` flag.
+Chained SQEs are executed in order, and each one produces its own CQE.
+If an operation in the chain fails, the remaining chained operations are cancelled (failure cascading).
+This is useful for command and response sequences, such as writing a command and then reading the response:
+
+.. code-block:: c
+
+   struct rtio_sqe *sqe;
+
+   /* First transfer: write a command */
+   sqe = rtio_sqe_acquire(&spi_rtio_ctx);
+   rtio_sqe_prep_write(sqe, &spi_iodev, RTIO_PRIO_NORM,
+                       cmd_data, sizeof(cmd_data), NULL);
+   sqe->flags |= RTIO_SQE_CHAINED;
+
+   /* Second transfer: read the response */
+   sqe = rtio_sqe_acquire(&spi_rtio_ctx);
+   rtio_sqe_prep_read(sqe, &spi_iodev, RTIO_PRIO_NORM,
+                      resp_data, sizeof(resp_data), NULL);
+
+   /* Submit both operations and wait for both completions */
+   rtio_submit(&spi_rtio_ctx, 2);
+
+   /* Consume one CQE per chained operation */
+   for (int i = 0; i < 2; i++) {
+       struct rtio_cqe *cqe = rtio_cqe_consume(&spi_rtio_ctx);
+       if (cqe->result < 0) { ... }
+       rtio_cqe_release(&spi_rtio_ctx, cqe);
+   }
+
+Set the :c:macro:`RTIO_SQE_CHAINED` flag on every SQE in the chain except the last one.
+
+.. note::
+
+   Within a chain, execution order is preserved and a failure cancels the subsequent operations.
+   CQEs from independent submissions are not guaranteed to be completed in submission order.
+
+Buffer requirements
+===================
+
+The nRF SPIM peripheral moves data using EasyDMA, which places two constraints on the transmit and receive buffers passed to the RTIO submission helpers:
+
+* Maximum transfer size
+
+  A single EasyDMA transfer is limited by the peripheral's ``MAXCNT`` register, whose width is SoC-specific.
+  The driver automatically splits larger transfers into chunks that fit this limit, so no action is required from the application beyond being aware that a large transfer is carried out as several DMA operations.
+
+* Memory location
+
+  EasyDMA can only access buffers located in specific memory regions.
+  Buffers placed in flash (for example ``const`` data) or in RAM that is not reachable by EasyDMA cannot be used directly.
+
+How buffers outside the EasyDMA-accessible region are handled depends on the SoC:
+
+* On SoCs without Device Memory Management (DMM), the driver copies the data through an internal RAM bounce buffer whose size is set by ``CONFIG_SPI_NRFX_RAM_BUFFER_SIZE`` (default ``8`` bytes per driver instance, applied to both the TX and RX paths).
+  Setting this option to ``0`` disables bounce buffering, in which case the application must ensure that every buffer is directly accessible by EasyDMA, otherwise the transfer fails.
+
+* On SoCs with Device Memory Management (DMM), the driver allocates the buffers from the DMM memory region and splits transfers into chunks limited by ``CONFIG_SPI_NRFX_DMM_BUFFER_SIZE`` (default ``256`` bytes). For a full-duplex transfer, twice the chunk size is allocated.
+
+Bounce buffering and DMM re-allocation add a data copy on every affected transfer.
+For the best performance, statically place the transmit and receive buffers in the memory region that EasyDMA can access for the given SPI controller, with the alignment required by the underlying DMA hardware.
+The Nordic Device Memory Management (DMM) subsystem provides the ``DMM_MEMORY_SECTION(node_id)`` variable attribute in ``<dmm.h>`` for exactly this purpose.
+It places a statically allocated buffer in the memory region associated with the given devicetree node and applies the alignment that the region requires.
+Pass the SPI controller node (obtained with ``DT_BUS()`` from the device node) so that the buffers are placed in the region associated with that controller:
+
+.. code-block:: c
+
+   #include <dmm.h>
+
+   #define MY_SPI_NODE DT_NODELABEL(my_device)
+
+   static uint8_t tx_data[4] DMM_MEMORY_SECTION(DT_BUS(MY_SPI_NODE));
+   static uint8_t rx_data[4] DMM_MEMORY_SECTION(DT_BUS(MY_SPI_NODE));
+
+Buffers declared this way are already in the correct region and alignment, so neither bounce buffering nor DMM re-allocation is needed at transfer time.
+On SoCs that do not associate a dedicated memory region with the controller, ``DMM_MEMORY_SECTION`` expands to a no-op, so the same code remains portable across nRF devices.
+
+Refer to the respective Product Specification for the exact memory regions, alignment, and ``MAXCNT`` limits.


### PR DESCRIPTION
New documentation chapter explains how hardware peripherals present on nRF SoCs can be interacted with using software components.