### PR TITLE
applications: nrf5340_audio: lc3 init and deinit refactoring

### DIFF
--- a/applications/nrf5340_audio/src/audio/sw_codec_select.c
+++ b/applications/nrf5340_audio/src/audio/sw_codec_select.c
@@ -395,6 +395,7 @@ int sw_codec_uninit(struct sw_codec_config sw_codec_cfg)
 		LOG_ERR("Trying to uninit a codec that is not first initialized");
 		return -ENODEV;
 	}
+
 	switch (m_config.sw_codec) {
 	case SW_CODEC_LC3:
 #if (CONFIG_SW_CODEC_LC3)
@@ -404,10 +405,12 @@ int sw_codec_uninit(struct sw_codec_config sw_codec_cfg)
 					"initialized");
 				return -EALREADY;
 			}
+
 			ret = sw_codec_lc3_enc_uninit_all();
 			if (ret) {
 				return ret;
 			}
+
 			m_config.encoder.enabled = false;
 		}
 
@@ -422,7 +425,13 @@ int sw_codec_uninit(struct sw_codec_config sw_codec_cfg)
 			if (ret) {
 				return ret;
 			}
+
 			m_config.decoder.enabled = false;
+		}
+
+		ret = sw_codec_lc3_uninit();
+		if (ret) {
+			return ret;
 		}
 #endif /* (CONFIG_SW_CODEC_LC3) */
 		break;
@@ -443,9 +452,23 @@ int sw_codec_init(struct sw_codec_config sw_codec_cfg)
 	switch (sw_codec_cfg.sw_codec) {
 	case SW_CODEC_LC3: {
 #if (CONFIG_SW_CODEC_LC3)
-		if (m_config.sw_codec != SW_CODEC_LC3) {
+		if (!m_config.initialized) {
 			/* Check if LC3 is already initialized */
-			ret = sw_codec_lc3_init(NULL, NULL, CONFIG_AUDIO_FRAME_DURATION_US);
+			uint16_t encoder_sample_rate = 0;
+			uint16_t decoder_sample_rate = 0;
+
+			if (sw_codec_cfg.encoder.enabled) {
+				encoder_sample_rate = sw_codec_cfg.encoder.sample_rate_hz;
+			}
+
+			if (sw_codec_cfg.decoder.enabled) {
+				decoder_sample_rate = sw_codec_cfg.decoder.sample_rate_hz;
+			}
+
+			ret = sw_codec_lc3_single_rate_init(encoder_sample_rate,
+							    decoder_sample_rate,
+							    NULL, NULL,
+							    CONFIG_AUDIO_FRAME_DURATION_US);
 			if (ret) {
 				return ret;
 			}
@@ -456,6 +479,7 @@ int sw_codec_init(struct sw_codec_config sw_codec_cfg)
 				LOG_WRN("The LC3 encoder is already initialized");
 				return -EALREADY;
 			}
+
 			uint16_t pcm_bytes_req_enc;
 
 			LOG_DBG("Encode: %dHz %dbits %dus %dbps %d channel(s)",

--- a/tests/nrf5340_audio/sw_codec_lc3/main.c
+++ b/tests/nrf5340_audio/sw_codec_lc3/main.c
@@ -473,7 +473,8 @@ static void *test_sw_codec_lc3_init(void)
 {
 	int ret;
 
-	sw_codec_lc3_init(NULL, NULL, LC3_FRAME_SIZE_US);
+	sw_codec_lc3_single_rate_init(PCM_SAMPLE_RATE, PCM_SAMPLE_RATE,
+				      NULL, NULL, LC3_FRAME_SIZE_US);
 
 	ret = sw_codec_lc3_enc_init(PCM_SAMPLE_RATE, PCM_BIT_DEPTH, LC3_FRAME_SIZE_US, LC3_BITRATE,
 				    LC3_NUM_CHANNELS, &pcm_bytes_req_enc);


### PR DESCRIPTION
- added fixed encoder and decoder lc3 sample rate;
- changed condition to init lc3 codec to if (!m_config.initialized).
It forces codec re-initialization when it was de-initialized
- added sw_codec_lc3_uninit() at the end of sw_codec_uninit()
to completely de-initialize lc3, and not just encoder or decoder.
It allows reconfigure sample rate at the next lc3 initialization.

This commit reduces lc3 heap usage by ~12KB due to using less
memory in sw_codec_lc3_init() call.
Also it reduces time to call sw_codec_lc3_init() from ~4ms to ~2ms,
but adds additional calls to sw_codec_lc3_init() because of
full de-initialization of lc3 every time sw_codec_uninit() is called.
sw_codec_lc3_uninit() call takes around 50 us.

The timing measurements were made with pin-toggling on nrf5340 audio
dk in unicast client app.
