### PR TITLE
samples: bluetooth: Fix connected callback in peripheral_rscs

### DIFF
--- a/samples/bluetooth/peripheral_rscs/src/main.c
+++ b/samples/bluetooth/peripheral_rscs/src/main.c
@@ -145,6 +145,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
 		printk("Connection failed, err 0x%02x %s\n", err, bt_hci_err_to_str(err));
+		return;
 	} else {
 		printk("Connected\n");
 	}


### PR DESCRIPTION
Added a missing `return` statement in the `connected()` callback to exit early on connection failure, preventing the subsequent code from executing when an error occurs.