### PR TITLE
L2_DECT working ethernet bridge support

### DIFF
--- a/subsys/net/l2_dect/dect_net_l2.c
+++ b/subsys/net/l2_dect/dect_net_l2.c
@@ -397,6 +397,77 @@ static enum net_verdict dect_net_l2_recv(struct net_if *iface, struct net_pkt *p
 
 		/* ... and pass also to us */
 	}
+#if defined(CONFIG_NET_L2_DECT_BR)
+	/* PSY mod:  handle forwarding */
+	else if (!net_ipv6_is_ll_addr((struct in6_addr *)NET_IPV6_HDR(pkt)->dst) &&
+		!net_ipv6_is_addr_mcast_link((struct in6_addr *)NET_IPV6_HDR(pkt)->dst)) {
+
+
+		struct dect_net_l2_context *l2_ctx = net_if_l2_data(iface);
+		if (! l2_ctx->device_type & DECT_DEVICE_TYPE_FT) {
+			/* only handle FT, on't do anything more otherwise */
+			goto exit;
+		}
+
+		/* Check if this packet is destined for us — if so don't forward it */
+		struct net_if_addr *ifaddr = net_if_ipv6_addr_lookup(
+			(struct in6_addr *)NET_IPV6_HDR(pkt)->dst, NULL);
+		if (ifaddr) {
+			/* It's for us, let the stack handle it locally */
+			goto exit;
+		}
+
+		struct net_if *eth_iface =
+			net_if_get_first_by_type(&NET_L2_GET_NAME(ETHERNET));
+
+		if (eth_iface) {
+			//
+			struct net_linkaddr *eth_mac = net_if_get_link_addr(eth_iface);
+
+			/* Fix src: replace DECT RD ID with our ethernet MAC */
+			struct net_linkaddr *src = net_pkt_lladdr_src(pkt);
+			src->len = 0;
+			src->type = NET_LINK_ETHERNET;
+			memcpy(src->addr, eth_mac->addr, eth_mac->len);
+			src->len = eth_mac->len;
+
+			/* Fix dst: look up the default router's MAC on the ethernet interface */
+			struct net_if_router *router = net_if_ipv6_router_find_default(eth_iface, NULL);
+			if (router) {
+				struct net_nbr *nbr = net_ipv6_nbr_lookup(eth_iface, &router->address.in6_addr);
+				if (nbr) {
+					struct net_linkaddr *router_mac = net_nbr_get_lladdr(nbr);
+					struct net_linkaddr *dst = net_pkt_lladdr_dst(pkt);
+					dst->len = 0;
+					dst->type = NET_LINK_ETHERNET;
+					memcpy(dst->addr, router_mac->addr, router_mac->len);
+					dst->len = router_mac->len;
+				} else {
+					LOG_WRN("No neighbor entry for default router - cannot forward");
+					goto exit;
+				}
+			} else {
+				LOG_WRN("No default router on ethernet iface - cannot forward");
+				goto exit;
+			}
+
+			net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IPV6);
+			net_pkt_set_iface(pkt, eth_iface);
+			net_pkt_set_family(pkt, AF_INET6);
+
+			if (net_if_send_data(eth_iface, pkt) == NET_DROP) {
+				LOG_ERR("Failed to forward pkt to ethernet iface");
+				net_pkt_unref(pkt);
+			}
+			return NET_OK;
+		}
+	}
+#endif
+
+
+
+
+
 exit:
 	return NET_CONTINUE;
 }

--- a/subsys/net/l2_dect/dect_net_l2_ipv6.c
+++ b/subsys/net/l2_dect/dect_net_l2_ipv6.c
@@ -8,6 +8,8 @@
 #include <zephyr/net/net_if.h>
 
 #include "ipv6.h"
+#include "route.h"    /* for net_route_add / net_route_del / net_route_lookup */
+#include <zephyr/net/mld.h>
 
 #include <net/dect/dect_net_l2.h>
 #include <net/dect/dect_net_l2_mgmt.h>
@@ -57,6 +59,61 @@ static void dect_net_l2_ipv6_util_global_nbr_add(
 					"as a neighbor to dect iface",
 					(__func__), net_sprint_ipv6_addr(&nbr_addr),
 					net_sprint_ll_addr(net_if_get_link_addr(iface)->addr, 8));
+
+				struct dect_net_l2_context *l2_ctx = net_if_l2_data(iface);
+				if (l2_ctx->device_type & DECT_DEVICE_TYPE_FT) {
+					/* only handle FT, don't do anything more otherwise */
+
+					/* PSY mod Add a /128 host route so return traffic from the internet
+					 * is directed to the DECT interface rather than being swallowed
+					 * by the broader ethernet prefix route (e.g. /56).
+					 * The nexthop is the address itself — it is on-link on the DECT iface.
+					 * PREFERENCE_HIGH ensures this beats the ethernet prefix route.
+					 */
+					struct net_route_entry *route = net_route_add(
+						iface,
+						&nbr_addr, 128,
+						&nbr_addr,
+						NET_IPV6_ND_INFINITE_LIFETIME,
+						NET_ROUTE_PREFERENCE_HIGH);
+					if (!route) {
+						LOG_ERR("(%s): failed to add /128 host route for %s on iface %p",
+							(__func__), net_sprint_ipv6_addr(&nbr_addr), iface);
+					} else {
+						LOG_DBG("(%s): /128 host route added for %s via DECT iface %p",
+							(__func__), net_sprint_ipv6_addr(&nbr_addr), iface);
+					}
+
+
+
+					struct net_if *eth_iface = net_if_get_first_by_type(&NET_L2_GET_NAME(ETHERNET));
+					if (eth_iface) {
+						struct net_linkaddr *eth_mac = net_if_get_link_addr(eth_iface);
+						if (!net_ipv6_nbr_add(eth_iface, &nbr_addr, eth_mac, false,
+											  NET_IPV6_NBR_STATE_REACHABLE)) {
+							LOG_ERR("Failed to add PT global addr as neighbor on ethernet iface");
+						} else {
+							LOG_DBG("Added PT %s as neighbor on ethernet iface with FT MAC",
+								net_sprint_ipv6_addr(&nbr_addr));
+						}
+
+
+						/* Join the solicited-node multicast group for the PT's address
+						 * on the ethernet interface, so the FT responds to NS from the
+						 * upstream router on the PT's behalf (proxy NDP).
+						 */
+						struct in6_addr mcast;
+						net_ipv6_addr_create_solicited_node(&nbr_addr, &mcast);
+						int jmcast = net_ipv6_mld_join(eth_iface, &mcast);
+						if ( jmcast< 0) {
+							LOG_ERR("Failed to join solicited-node multicast for PT on ethernet (%i)", jmcast);
+						} else {
+							LOG_INF("Joined solicited-node multicast %s on ethernet for PT %s",
+								net_sprint_ipv6_addr(&mcast),
+								net_sprint_ipv6_addr(&nbr_addr));
+						}
+					}
+				}
 			}
 		}
 	}
@@ -115,6 +172,21 @@ static void dect_net_l2_ipv6_util_nbr_remove(struct net_if *iface,
 		ass_list_item->local_ipv6_addr_set = false;
 	}
 	if (ass_list_item->global_ipv6_addr_set) {
+
+		struct dect_net_l2_context *l2_ctx = net_if_l2_data(iface);
+		if (l2_ctx->device_type & DECT_DEVICE_TYPE_FT) {
+			/* PSY mod: If this is an FT, remove the /128 host route added when this child associated */
+			struct net_route_entry *route =
+				net_route_lookup(iface, &ass_list_item->global_ipv6_addr);
+			if (route) {
+				net_route_del(route);
+			} else {
+				LOG_WRN("(%s): no host route found for %s on iface %p to remove",
+					(__func__),
+					net_sprint_ipv6_addr(&ass_list_item->global_ipv6_addr),
+					iface);
+			}
+		}
 		if (!net_ipv6_nbr_rm(iface, &ass_list_item->global_ipv6_addr)) {
 			LOG_ERR("Failed to remove global IPv6 neighbor %s on iface %p",
 				net_sprint_ipv6_addr(&ass_list_item->global_ipv6_addr), iface);


### PR DESCRIPTION
These modifications to the dect_l2 net subsystem allow for transparent access to the wider network for PT connected through an FT sink that has an ethernet module (w5500 wiznet module tested here), by tweaking routes and massaging addresses.

Here you can see the FT, on the left in green, with 2 `net iface` interfaces (ethernet and dect radio) and the PT on the right with a single iface, ping google through the FT -> Ethernet:
<img width="3376" height="1289" alt="dect-ethernet" src="https://github.com/user-attachments/assets/cab244eb-07fd-48ac-b830-8037f7a3e59d" />

And here is the physical setup: the PT in foreground with the ethernet-equipped FT below:
![nr9151DKwithEthernet](https://github.com/user-attachments/assets/cc29acda-a79c-4437-acad-8b7fb02f15c4)


If interested in testing with a comparable setup, important prj.conf settings include:
```
CONFIG_SPI=y
CONFIG_ETH_W5500=y
CONFIG_ETH_W5500_TIMEOUT=1000


# crashes with stack overflow on DHCP without
# CONFIG_ETH_W5500_RX_THREAD_STACK_SIZE > than default 800
# 2048 good until we start getting packets from 
# internet -> FT -> PT
CONFIG_ETH_W5500_RX_THREAD_STACK_SIZE=3072


# Enable Ethernet support (required for W5500-based interface)
CONFIG_NET_L2_ETHERNET=y
CONFIG_NET_L2_ETHERNET_MGMT=y


CONFIG_NET_MGMT_EVENT_STACK_SIZE=4096
CONFIG_NET_MGMT_EVENT_QUEUE_SIZE=30

CONFIG_NET_ROUTING=y

# Multi-cast for our dect_l2 eth routing magic
CONFIG_NET_IF_MCAST_IPV6_ADDR_COUNT=25
```
and an overlay that enables the w5500.  Note that nothing worked until I manually set a local-mac-address on the ethernet module (?)

```
&spi3 {
	compatible = "nordic,nrf-spim";
	status = "okay";
        cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
	pinctrl-0 = <&spi3_default>;
	pinctrl-1 = <&spi3_sleep>;
	pinctrl-names = "default", "sleep";

    w5500: w5500@0 {
        compatible = "wiznet,w5500";
        reg = <0>;
        spi-max-frequency = <24000000>;  /* need more speed -- supports up to 80MHz in theory */
	local-mac-address = [de ad be ef ca fe];
        int-gpios   = <&gpio0  8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
        reset-gpios = <&gpio0  9 GPIO_ACTIVE_LOW>;
        status = "okay";
    };
};
```


