### PR TITLE
sysbuild: Disable MCUBOOT_SIGNATURE_USING_KMU for nrf54ls05b

### DIFF
--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -211,7 +211,7 @@ config BOOT_IMG_HASH_ALG_SHA512
 
 config MCUBOOT_SIGNATURE_USING_KMU
 	bool "Use KMU stored keys for signature verification"
-	depends on SOC_SERIES_NRF54L
+	depends on SOC_SERIES_NRF54L && !SOC_NRF54LS05B
 	depends on BOOT_SIGNATURE_TYPE_ED25519
 	help
 	  The device needs to be provisioned with proper set of keys.


### PR DESCRIPTION
The hardware for nRF54LS05b does not support KMU.