### PR TITLE
manifest: point sdk-zephyr to test branch

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -20,6 +20,8 @@ manifest:
     # NCS repositories are hosted here.
     - name: ncs
       url-base: https://github.com/nrfconnect
+    - name: nrbrook
+      url-base: https://github.com/nrbrook
     # Third-party repository sources:
     - name: zephyrproject
       url-base: https://github.com/zephyrproject-rtos
@@ -64,8 +66,9 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/introduction/index.html
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
+      remote: nrbrook
       repo-path: sdk-zephyr
-      revision: adaa514f58593090bf23cf204da95d28f1aa4602
+      revision: fix/pm-rom-end-offset-linker
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update the zephyr manifest entry to use the forked branch that contains this PR's linker fix so NCS CI can validate it through a companion sdk-nrf PR https://github.com/nrfconnect/sdk-zephyr/pull/3876.