### PR TITLE
drivers: serial: nrf_sw_lpuart: Fix case of flushing RX FIFO

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -409,6 +409,8 @@ Drivers
 
 This section provides detailed lists of changes by :ref:`driver <drivers>`.
 
+* Fixed an issue where the low power UART may fail after a reset if the reset occurs during transmission.
+
 Wi-Fi drivers
 -------------
 

--- a/drivers/serial/uart_nrf_sw_lpuart.c
+++ b/drivers/serial/uart_nrf_sw_lpuart.c
@@ -992,7 +992,7 @@ static void api_irq_rx_enable(const struct device *dev)
 	struct lpuart_data *data = get_dev_data(dev);
 
 	data->int_driven.rx_enabled = true;
-	if (int_driven_rd_available(data)) {
+	if (int_driven_rd_available(data) || data->rx_state == RX_BLOCKED) {
 		/* We need to move to the interrupt context of the same priority as UARTE. */
 		k_timer_start(&data->int_driven.trampoline_timer, K_NO_WAIT, K_NO_WAIT);
 	}


### PR DESCRIPTION
In Bluetooth HCI there is a case where uart_fifo_read is called not from the UART interrupt context. If that happens and there is pending UART that then LPUART was not able to reset the receiver. Case like that happend when HCI device sends data to the host core after host core got reset but before HCI device is reset by the host. Calling uart_fifo_read not from UART interrupt handler is a violation of the API but it has been used like that to drain UART FIFO for years and it has been useful so LPUART adapts to it.