### PR TITLE
samples: bluetooth: add vs command for FEM GPIO loopback verification

### DIFF
--- a/samples/bluetooth/direct_test_mode/src/transport/dtm_uart_twowire.c
+++ b/samples/bluetooth/direct_test_mode/src/transport/dtm_uart_twowire.c
@@ -12,6 +12,13 @@
 
 #include "dtm_transport.h"
 
+#if defined(CONFIG_DTM_FEM_LOOPBACK)
+/* DTM FEM loopback: host sends 0xFE01, device returns pass (0x0000) or fail (0x0001). */
+#define DTM_CMD_FEM_LOOPBACK_VERIFY 0xFE01
+
+extern uint16_t dtm_fem_loopback_get_response(void);
+#endif
+
 LOG_MODULE_REGISTER(dtm_tw_tr, CONFIG_DTM_TRANSPORT_LOG_LEVEL);
 
 /* Mask of the CTE type in the CTEInfo. */
@@ -837,6 +844,18 @@ int dtm_tr_process(union dtm_tr_packet cmd)
 	uint16_t ret;
 
 	LOG_INF("Processing 0x%04x command", tmp);
+
+#if defined(CONFIG_DTM_FEM_LOOPBACK)
+	if (tmp == DTM_CMD_FEM_LOOPBACK_VERIFY) {
+		ret = dtm_fem_loopback_get_response();
+		LOG_INF("Sending 0x%04x response (FEM loopback verification)", ret);
+
+		uart_poll_out(dtm_uart, (ret >> 8) & 0xFF);
+		uart_poll_out(dtm_uart, ret & 0xFF);
+
+		return 0;
+	}
+#endif
 
 	ret = dtm_cmd_put(tmp);
 	LOG_INF("Sending 0x%04x response", ret);


### PR DESCRIPTION
Add support for a custom DTM vendor specific command (0xFE01) in the two-wire UART transport that queries the FEM GPIO loopback module. When CONFIG_DTM_FEM_LOOPBACK is enabled, the firmware receives this command and returns whether all three FEM control pins (TX_EN, RX_EN, PDN) toggled during radio operations.
This enables in-firmware verification of MPSL FEM pin activity without external test equipment.