### PR TITLE
CRACEN: Add support to store AEAD keys with non-default tag len

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -121,6 +121,7 @@ Security
 
   * How the :kconfig:option:`CONFIG_NRF_SECURITY` and :kconfig:option:`CONFIG_PSA_CRYPTO` interact with each other.
     :kconfig:option:`CONFIG_NRF_SECURITY` is now promptless and auto-enabled indirectly by :kconfig:option:`CONFIG_PSA_CRYPTO`.
+  * Approach to store keys in the KMU so that AEAD algorithms with non-default (shortened) tag lengths are supported.
 
 * Removed:
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_kmu.c
@@ -32,6 +32,9 @@
 #define CRACEN_KMU_256_BIT_KEY_SIZE	     32u
 #define CRACEN_KMU_384_BIT_KEY_SIZE	     48u
 
+#define CRACEN_KMU_MIN_TAG_SIZE_CCM	     4u /* RFC-3610 */
+#define CRACEN_KMU_MIN_TAG_SIZE_GCM	     4u /* NIST SP800-38D */
+
 /* Reserved slot, used to record whether provisioning is in progress for a set of slots.
  * We only use the metadata field, formatted as follows:
  *      Bits 31-16: Unused
@@ -656,19 +659,35 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 #ifdef PSA_NEED_CRACEN_CHACHA20_POLY1305
 	case METADATA_ALG_CHACHA20_POLY1305:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_CHACHA20);
+		/** There is no need to build an AEAD minimum-tag-length
+		 *  wildcard algorithm for ChaCha20-Poly1305 since it does not
+		 *  support non-standard tag lengths (RFC-8439).
+		 */
 		psa_set_key_algorithm(key_attr, PSA_ALG_CHACHA20_POLY1305);
 		break;
 #endif /* PSA_NEED_CRACEN_CHACHA20_POLY1305 */
 #ifdef PSA_NEED_CRACEN_GCM_AES
 	case METADATA_ALG_AES_GCM:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
-		psa_set_key_algorithm(key_attr, PSA_ALG_GCM);
+
+		/** Building an AEAD minimum-tag-length wildcard algorithm
+		 *  since we do not store non-default tag length to the metadata
+		 *  during key provisioning.
+		 */
+		psa_set_key_algorithm(key_attr, PSA_ALG_AEAD_WITH_AT_LEAST_THIS_LENGTH_TAG(
+						PSA_ALG_GCM, CRACEN_KMU_MIN_TAG_SIZE_GCM));
 		break;
 #endif /* PSA_NEED_CRACEN_GCM_AES */
 #ifdef PSA_NEED_CRACEN_CCM_AES
 	case METADATA_ALG_AES_CCM:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
-		psa_set_key_algorithm(key_attr, PSA_ALG_CCM);
+
+		/** Building an AEAD minimum-tag-length wildcard algorithm
+		 *  since we do not store non-default tag length to the metadata
+		 *  during key provisioning.
+		 */
+		psa_set_key_algorithm(key_attr, PSA_ALG_AEAD_WITH_AT_LEAST_THIS_LENGTH_TAG(
+						PSA_ALG_CCM, CRACEN_KMU_MIN_TAG_SIZE_CCM));
 		break;
 #endif /* PSA_NEED_CRACEN_CCM_AES */
 #ifdef PSA_NEED_CRACEN_ECB_NO_PADDING_AES
@@ -796,6 +815,8 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 						kmu_metadata *metadata)
 {
 	int kmu_slot;
+	psa_algorithm_t key_algorithm;
+
 	memset(metadata, 0, sizeof(*metadata));
 	metadata->metadata_version = 0;
 
@@ -827,7 +848,12 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		return PSA_SUCCESS;
 	}
 
-	switch (psa_get_key_algorithm(key_attr)) {
+	key_algorithm = psa_get_key_algorithm(key_attr);
+	if (PSA_ALG_IS_AEAD(key_algorithm)) {
+		key_algorithm = PSA_ALG_AEAD_WITH_DEFAULT_LENGTH_TAG(key_algorithm);
+	}
+
+	switch (key_algorithm) {
 #ifdef PSA_NEED_CRACEN_AES_KW
 	case PSA_ALG_KW:
 		metadata->algorithm = METADATA_ALG_KW;
@@ -844,7 +870,6 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		}
 		break;
 #endif /* PSA_NEED_CRACEN_AES_KWP */
-
 #ifdef PSA_NEED_CRACEN_STREAM_CIPHER_CHACHA20
 	case PSA_ALG_STREAM_CIPHER:
 		metadata->algorithm = METADATA_ALG_CHACHA20;


### PR DESCRIPTION
 This PR adds changes that allow storing keys for AEAD algorithms with non-default tag length set via `PSA_ALG_AEAD_WITH_SHORTENED_TAG()` to KMU.