### PR TITLE
Add support for high performance framework

### DIFF
--- a/applications/hpf/gpio/README.rst
+++ b/applications/hpf/gpio/README.rst
@@ -10,7 +10,7 @@ High-Performance Framework GPIO
 
 .. caution::
 
-   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15, nRF54LM20A, and nRF54LV10A devices.
+   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15, nRF54LM20A, nRF54LV10A, and nRF7120 devices.
 
 This application demonstrates how to write a :ref:`High-Performance Framework (HPF) <hpf_index>` application implementing a simple peripheral.
 The application implements a subset of the Zephyr GPIO API.
@@ -54,7 +54,7 @@ Building and running
 To build and run the application, you must include code for both the application core and FLPR core.
 The process involves building the :zephyr:code-sample:`blinky` sample with the appropriate sysbuild configuration.
 
-For example, to build with icmsg backend, run the following commands:
+For example, to build with icmsg backend, run the following commands (replace ``<build_target>`` with target board, such as ``nrf54l15dk/nrf54l15/cpuapp`` or ``nrf7120dk/nrf7120/cpuapp``):
 
 .. code-block:: console
 

--- a/applications/hpf/gpio/boards/nrf7120dk_nrf7120_cpuflpr.overlay
+++ b/applications/hpf/gpio/boards/nrf7120dk_nrf7120_cpuflpr.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuflpr_vevif_rx {
+	status = "okay";
+	interrupts = <16 NRF_DEFAULT_IRQ_PRIORITY>;
+	nordic,tasks = <1>;
+	nordic,tasks-mask = <0x00010000>;
+};
+
+&cpuflpr_vevif_tx {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "disabled";
+};
+
+&gpio1 {
+	status = "disabled";
+};
+
+&gpio2 {
+	status = "disabled";
+};
+
+&gpiote20 {
+	status = "disabled";
+};
+
+&gpiote30 {
+	status = "disabled";
+};
+
+&grtc {
+	status = "disabled";
+};
+
+&uart20 {
+	status = "disabled";
+};
+
+&uart30 {
+	status = "okay";
+};
+
+&pwm20 {
+	status = "disabled";
+};

--- a/applications/hpf/gpio/sample.yaml
+++ b/applications/hpf/gpio/sample.yaml
@@ -11,6 +11,7 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuflpr
       - nrf54lm20dk/nrf54lm20a/cpuflpr
+      - nrf7120dk/nrf7120/cpuflpr
     tags:
       - ci_build
       - sysbuild
@@ -25,6 +26,7 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuflpr
       - nrf54lm20dk/nrf54lm20a/cpuflpr
+      - nrf7120dk/nrf7120/cpuflpr
     tags:
       - ci_build
       - sysbuild
@@ -39,6 +41,7 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuflpr
       - nrf54lm20dk/nrf54lm20a/cpuflpr
+      - nrf7120dk/nrf7120/cpuflpr
     tags:
       - ci_build
       - sysbuild

--- a/applications/hpf/gpio/src/hrt/hrt-nrf7120.s
+++ b/applications/hpf/gpio/src/hrt/hrt-nrf7120.s
@@ -1,0 +1,79 @@
+	.file	"hrt.c"
+	.option nopic
+	.attribute arch, "rv32e1p9_m2p0_c2p0_zicsr2p0"
+	.attribute unaligned_access, 0
+	.attribute stack_align, 4
+	.text
+	.section	.text.hrt_set_bits,"ax",@progbits
+	.align	1
+	.globl	hrt_set_bits
+	.type	hrt_set_bits, @function
+hrt_set_bits:
+ #APP
+	csrr a4, 3008
+ #NO_APP
+	lui	a5,%hi(irq_arg)
+	lhu	a5,%lo(irq_arg)(a5)
+	or	a5,a5,a4
+	slli	a5,a5,16
+	srli	a5,a5,16
+ #APP
+	csrw 3008, a5
+ #NO_APP
+	ret
+	.size	hrt_set_bits, .-hrt_set_bits
+	.section	.text.hrt_clear_bits,"ax",@progbits
+	.align	1
+	.globl	hrt_clear_bits
+	.type	hrt_clear_bits, @function
+hrt_clear_bits:
+ #APP
+	csrr a4, 3008
+ #NO_APP
+	lui	a5,%hi(irq_arg)
+	lhu	a5,%lo(irq_arg)(a5)
+	not	a5,a5
+	and	a5,a5,a4
+	slli	a5,a5,16
+	srli	a5,a5,16
+ #APP
+	csrw 3008, a5
+ #NO_APP
+	ret
+	.size	hrt_clear_bits, .-hrt_clear_bits
+	.section	.text.hrt_toggle_bits,"ax",@progbits
+	.align	1
+	.globl	hrt_toggle_bits
+	.type	hrt_toggle_bits, @function
+hrt_toggle_bits:
+	lui	a5,%hi(irq_arg)
+	lhu	a5,%lo(irq_arg)(a5)
+ #APP
+	csrw 3024, a5
+ #NO_APP
+	ret
+	.size	hrt_toggle_bits, .-hrt_toggle_bits
+	.section	.text.hrt_set_masked_bits,"ax",@progbits
+	.align	1
+	.globl	hrt_set_masked_bits
+	.type	hrt_set_masked_bits, @function
+hrt_set_masked_bits:
+ #APP
+	csrr a2, 3008
+ #NO_APP
+	lui	a3,%hi(irq_arg)
+	lhu	a5,%lo(irq_arg)(a3)
+	lui	a4,%hi(irq_arg2)
+	lhu	a4,%lo(irq_arg2)(a4)
+	lhu	a3,%lo(irq_arg)(a3)
+	not	a5,a5
+	and	a5,a5,a2
+	and	a4,a4,a3
+	or	a5,a5,a4
+	slli	a5,a5,16
+	srli	a5,a5,16
+ #APP
+	csrw 3008, a5
+ #NO_APP
+	ret
+	.size	hrt_set_masked_bits, .-hrt_set_masked_bits

--- a/applications/hpf/gpio/src/main.c
+++ b/applications/hpf/gpio/src/main.c
@@ -60,6 +60,25 @@ static const uint8_t pin_to_vio_map[] = {
 #define VIO_PORT 1
 #define VIO_PIN_OFFSET 15
 
+#elif defined(CONFIG_SOC_NRF7120)
+static const uint8_t pin_to_vio_map[] = {
+	6,  /* Physical pin 0 */
+	7,  /* Physical pin 1 */
+	8,  /* Physical pin 2 */
+	9,  /* Physical pin 3 */
+	10, /* Physical pin 4 */
+	11, /* Physical pin 5 */
+	0,  /* Physical pin 6 */
+	1,  /* Physical pin 7 */
+	2,  /* Physical pin 8 */
+	3,  /* Physical pin 9 */
+	4,  /* Physical pin 10 */
+	5,  /* Physical pin 11 */
+};
+
+#define VIO_PORT 2
+#define VIO_PIN_OFFSET 0
+
 #else
 #error "Unsupported target"
 #endif
@@ -150,6 +169,19 @@ static int gpio_hpf_pin_configure(uint8_t port, uint16_t pin, uint32_t flags)
 		return -EINVAL;
 	}
 
+	nrf_gpio_pin_dir_t dir =
+		(flags & GPIO_OUTPUT) ? NRF_GPIO_PIN_DIR_OUTPUT : NRF_GPIO_PIN_DIR_INPUT;
+	nrf_gpio_pin_input_t input =
+		(flags & GPIO_INPUT) ? NRF_GPIO_PIN_INPUT_CONNECT : NRF_GPIO_PIN_INPUT_DISCONNECT;
+
+	nrfy_gpio_reconfigure(abs_pin, &dir, &input, &pull, &drive, NULL);
+
+	nrfy_gpio_pin_control_select(abs_pin, NRF_GPIO_PIN_SEL_VPR);
+
+	if (dir == NRF_GPIO_PIN_DIR_OUTPUT) {
+		nrf_vpr_csr_vio_dir_set(nrf_vpr_csr_vio_dir_get() | (BIT(pin_vio_index)));
+	}
+
 	if (flags & GPIO_OUTPUT_INIT_HIGH) {
 		uint16_t outs = nrf_vpr_csr_vio_out_get();
 
@@ -159,23 +191,6 @@ static int gpio_hpf_pin_configure(uint8_t port, uint16_t pin, uint32_t flags)
 
 		nrf_vpr_csr_vio_out_set(outs & ~(BIT(pin_vio_index)));
 	}
-
-	nrf_gpio_pin_dir_t dir =
-		(flags & GPIO_OUTPUT) ? NRF_GPIO_PIN_DIR_OUTPUT : NRF_GPIO_PIN_DIR_INPUT;
-	nrf_gpio_pin_input_t input =
-		(flags & GPIO_INPUT) ? NRF_GPIO_PIN_INPUT_CONNECT : NRF_GPIO_PIN_INPUT_DISCONNECT;
-
-	/* Reconfigure the GPIO pin with the specified pull-up/pull-down configuration and drive
-	 * strength.
-	 */
-	nrfy_gpio_reconfigure(abs_pin, &dir, &input, &pull, &drive, NULL);
-
-	if (dir == NRF_GPIO_PIN_DIR_OUTPUT) {
-		nrf_vpr_csr_vio_dir_set(nrf_vpr_csr_vio_dir_get() | (BIT(pin_vio_index)));
-	}
-
-	/* Take control of the pin */
-	nrfy_gpio_pin_control_select(abs_pin, NRF_GPIO_PIN_SEL_VPR);
 
 	return 0;
 }

--- a/applications/hpf/hpf.rst
+++ b/applications/hpf/hpf.rst
@@ -5,7 +5,7 @@ High-Performance Framework
 
 .. caution::
 
-   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15, nRF54LM20, and nRF54LV10A devices.
+   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15, nRF54LM20, nRF54LV10A, and nRF7120 devices.
 
 High-Performance Framework, is a framework designed to facilitate the creation and integration of :ref:`peripheral emulations using coprocessors <coprocessors_index>`.
 The following applications are created using HPF:

--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -338,3 +338,7 @@
 .. nrf7120dk_nrf7120_cpuapp_ns
 
 | nRF7120 DK |   | nrf7120dk | ``nrf7120dk/nrf7120/cpuapp/ns`` |
+
+.. nrf7120dk_nrf7120_cpuflpr
+
+| nRF7120 DK |   | nrf7120dk | ``nrf7120dk/nrf7120/cpuflpr`` |

--- a/samples/zephyr/basic/blinky/boards/nrf7120dk_nrf7120_cpuapp_hpf_gpio.overlay
+++ b/samples/zephyr/basic/blinky/boards/nrf7120dk_nrf7120_cpuapp_hpf_gpio.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&led0 {
+	gpios = <&hpf_gpio 9 GPIO_ACTIVE_HIGH>;
+};

--- a/samples/zephyr/basic/blinky/sample.yaml
+++ b/samples/zephyr/basic/blinky/sample.yaml
@@ -14,7 +14,6 @@ common:
     regex:
       - "LED state: ON"
       - "LED state: OFF"
-
 tests:
   nrf.extended.sample.basic.blinky:
     platform_allow:
@@ -35,6 +34,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
@@ -50,6 +50,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
@@ -65,6 +66,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:

--- a/snippets/hpf/gpio/icbmsg/snippet.yml
+++ b/snippets/hpf/gpio/icbmsg/snippet.yml
@@ -39,3 +39,11 @@ boards:
     append:
       EXTRA_CONF_FILE: flpr.conf
       EXTRA_DTC_OVERLAY_FILE: soc/nrf54lv10a_cpuflpr.overlay
+  /.*/nrf7120/cpuapp/:
+    append:
+      EXTRA_CONF_FILE: app.conf
+      EXTRA_DTC_OVERLAY_FILE: soc/nrf7120_cpuapp.overlay
+  /.*/nrf7120/cpuflpr/:
+    append:
+      EXTRA_CONF_FILE: flpr.conf
+      EXTRA_DTC_OVERLAY_FILE: soc/nrf7120_cpuflpr.overlay

--- a/snippets/hpf/gpio/icbmsg/soc/nrf7120_cpuapp.overlay
+++ b/snippets/hpf/gpio/icbmsg/soc/nrf7120_cpuapp.overlay
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../hpf-gpio-app.overlay"
+
+/ {
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			sram_rx: memory@20080000 {
+				reg = <0x20080000 0x0800>;
+			};
+
+			sram_tx: memory@20080800 {
+				reg = <0x20080800 0x0800>;
+			};
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icbmsg";
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			tx-blocks = <16>;
+			rx-blocks = <18>;
+			mboxes = <&cpuapp_vevif_rx 20>, <&cpuapp_vevif_tx 16>;
+			mbox-names = "rx", "tx";
+			status = "okay";
+		};
+	};
+};
+
+&ram03_sram {
+	cpuflpr_sram_code_data: sram@0 {
+		compatible = "mmio-sram";
+		reg = <0x0 DT_SIZE_K(116)>;
+		status = "reserved";
+	};
+};
+
+&cpuapp_mram {
+	reg = <0x0 DT_SIZE_K(3960)>;
+
+	cpuflpr_code_partition: mram@3de000 {
+		compatible = "mmio-mram";
+		reg = <0x3de000 DT_SIZE_K(116)>;
+	};
+};
+
+&cpuflpr_vpr {
+	execution-memory = <&cpuflpr_sram_code_data>;
+	source-memory = <&cpuflpr_code_partition>;
+};
+
+&gpio2 {
+	status = "disabled";
+};
+
+&cpuapp_vevif_rx {
+	status = "okay";
+};
+
+&cpuapp_vevif_tx {
+	status = "okay";
+};
+
+&hpf_gpio {
+	status = "okay";
+	ngpios = <12>;
+	port = <2>;
+};

--- a/snippets/hpf/gpio/icbmsg/soc/nrf7120_cpuflpr.overlay
+++ b/snippets/hpf/gpio/icbmsg/soc/nrf7120_cpuflpr.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			sram_tx: memory@20080000 {
+				reg = <0x20080000 0x0800>;
+			};
+
+			sram_rx: memory@20080800 {
+				reg = <0x20080800 0x0800>;
+			};
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icbmsg";
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			tx-blocks = <18>;
+			rx-blocks = <16>;
+			mboxes = <&cpuflpr_vevif_rx 16>, <&cpuflpr_vevif_tx 20>;
+			mbox-names = "rx", "tx";
+			status = "okay";
+		};
+	};
+};

--- a/snippets/hpf/gpio/icmsg/snippet.yml
+++ b/snippets/hpf/gpio/icmsg/snippet.yml
@@ -39,3 +39,11 @@ boards:
     append:
       EXTRA_CONF_FILE: flpr.conf
       EXTRA_DTC_OVERLAY_FILE: soc/nrf54lv10a_cpuflpr.overlay
+  /.*/nrf7120/cpuapp/:
+    append:
+      EXTRA_CONF_FILE: app.conf
+      EXTRA_DTC_OVERLAY_FILE: soc/nrf7120_cpuapp.overlay
+  /.*/nrf7120/cpuflpr/:
+    append:
+      EXTRA_CONF_FILE: flpr.conf
+      EXTRA_DTC_OVERLAY_FILE: soc/nrf7120_cpuflpr.overlay

--- a/snippets/hpf/gpio/icmsg/soc/nrf7120_cpuapp.overlay
+++ b/snippets/hpf/gpio/icmsg/soc/nrf7120_cpuapp.overlay
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../hpf-gpio-app.overlay"
+
+/ {
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			sram_rx: memory@20080000 {
+				reg = <0x20080000 0x0800>;
+			};
+
+			sram_tx: memory@20080800 {
+				reg = <0x20080800 0x0800>;
+			};
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			mboxes = <&cpuapp_vevif_rx 20>, <&cpuapp_vevif_tx 16>;
+			mbox-names = "rx", "tx";
+			status = "okay";
+		};
+	};
+};
+
+&ram03_sram {
+	cpuflpr_sram_code_data: sram@0 {
+		compatible = "mmio-sram";
+		reg = <0x0 DT_SIZE_K(116)>;
+		status = "reserved";
+	};
+};
+
+&cpuapp_mram {
+	reg = <0x0 DT_SIZE_K(3960)>;
+
+	cpuflpr_code_partition: mram@3de000 {
+		compatible = "mmio-mram";
+		reg = <0x3de000 DT_SIZE_K(116)>;
+	};
+};
+
+&cpuflpr_vpr {
+	execution-memory = <&cpuflpr_sram_code_data>;
+	source-memory = <&cpuflpr_code_partition>;
+};
+
+&gpio2 {
+	status = "disabled";
+};
+
+&cpuapp_vevif_rx {
+	status = "okay";
+};
+
+&cpuapp_vevif_tx {
+	status = "okay";
+};
+
+&hpf_gpio {
+	status = "okay";
+	ngpios = <12>;
+	port = <2>;
+};

--- a/snippets/hpf/gpio/icmsg/soc/nrf7120_cpuflpr.overlay
+++ b/snippets/hpf/gpio/icmsg/soc/nrf7120_cpuflpr.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			sram_tx: memory@20080000 {
+				reg = <0x20080000 0x0800>;
+			};
+
+			sram_rx: memory@20080800 {
+				reg = <0x20080800 0x0800>;
+			};
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			mboxes = <&cpuflpr_vevif_rx 16>, <&cpuflpr_vevif_tx 20>;
+			mbox-names = "rx", "tx";
+			status = "okay";
+		};
+	};
+};

--- a/snippets/hpf/gpio/mbox/snippet.yml
+++ b/snippets/hpf/gpio/mbox/snippet.yml
@@ -39,3 +39,11 @@ boards:
     append:
       EXTRA_CONF_FILE: flpr.conf
       EXTRA_DTC_OVERLAY_FILE: soc/nrf54lv10a_cpuflpr.overlay
+  /.*/nrf7120/cpuapp/:
+    append:
+      EXTRA_CONF_FILE: app.conf
+      EXTRA_DTC_OVERLAY_FILE: soc/nrf7120_cpuapp.overlay
+  /.*/nrf7120/cpuflpr/:
+    append:
+      EXTRA_CONF_FILE: flpr.conf
+      EXTRA_DTC_OVERLAY_FILE: soc/nrf7120_cpuflpr.overlay

--- a/snippets/hpf/gpio/mbox/soc/nrf7120_cpuapp.overlay
+++ b/snippets/hpf/gpio/mbox/soc/nrf7120_cpuapp.overlay
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../hpf-gpio-app.overlay"
+
+/ {
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			sram_rx: memory@20080000 {
+				reg = <0x20080000 0x0800>;
+			};
+
+			sram_tx: memory@20080800 {
+				reg = <0x20080800 0x0800>;
+			};
+		};
+	};
+
+	mbox_consumer {
+		compatible = "vnd,mbox-consumer";
+		mboxes = <&cpuapp_vevif_rx 20>, <&cpuapp_vevif_tx 16>;
+		mbox-names = "rx", "tx";
+	};
+};
+
+&ram03_sram {
+	cpuflpr_sram_code_data: sram@0 {
+		compatible = "mmio-sram";
+		reg = <0x0 DT_SIZE_K(116)>;
+		status = "reserved";
+	};
+};
+
+&cpuapp_mram {
+	reg = <0x0 DT_SIZE_K(3960)>;
+
+	cpuflpr_code_partition: mram@3de000 {
+		compatible = "mmio-mram";
+		reg = <0x3de000 DT_SIZE_K(116)>;
+	};
+};
+
+&cpuflpr_vpr {
+	execution-memory = <&cpuflpr_sram_code_data>;
+	source-memory = <&cpuflpr_code_partition>;
+};
+
+&gpio2 {
+	status = "disabled";
+};
+
+&cpuapp_vevif_rx {
+	status = "okay";
+};
+
+&cpuapp_vevif_tx {
+	status = "okay";
+};
+
+&hpf_gpio {
+	status = "okay";
+	ngpios = <12>;
+	port = <2>;
+};

--- a/snippets/hpf/gpio/mbox/soc/nrf7120_cpuflpr.overlay
+++ b/snippets/hpf/gpio/mbox/soc/nrf7120_cpuflpr.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			sram_tx: memory@20080000 {
+				reg = <0x20080000 0x0800>;
+			};
+
+			sram_rx: memory@20080800 {
+				reg = <0x20080800 0x0800>;
+			};
+		};
+	};
+
+	mbox_consumer: mbox_consumer {
+		compatible = "vnd,mbox-consumer";
+		mboxes = <&cpuflpr_vevif_rx 16>, <&cpuflpr_vevif_tx 20>;
+		mbox-names = "rx", "tx";
+	};
+};

--- a/tests/drivers/gpio/hpf_gpio_basic_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/gpio/hpf_gpio_basic_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires GPIO loopback between P2.00 and P1.01. */
+
+/ {
+	resources {
+		compatible = "test-hpf-gpio";
+		out-gpios = <&hpf_gpio 0 GPIO_ACTIVE_HIGH>;
+		in-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpiote20 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/hpf_gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/hpf_gpio_basic_api/testcase.yaml
@@ -13,6 +13,7 @@ common:
     - nrf54lm20dk/nrf54lm20a/cpuapp
     - nrf54lm20dk/nrf54lm20b/cpuapp
     - nrf54lv10dk/nrf54lv10a/cpuapp
+    - nrf7120dk/nrf7120/cpuapp
   integration_platforms:
     - nrf54l15dk/nrf54l15/cpuapp
   sysbuild: true

--- a/tests/drivers/gpio/hpf_gpio_more_loops/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/gpio/hpf_gpio_more_loops/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/* Test requires GPIO loopback between P2.09 and P1.01. */
+/* Test requires GPIO loopback between P2.00 and P1.01. */
 
 / {
 	/* Test requirements:
@@ -15,7 +15,7 @@
 	 * All outputs must be on the same device.
 	 */
 	zephyr,user {
-		out-gpios = <&hpf_gpio 9 GPIO_ACTIVE_HIGH>;
+		out-gpios = <&hpf_gpio 0 GPIO_ACTIVE_HIGH>;
 		in-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/tests/drivers/gpio/hpf_gpio_more_loops/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/gpio/hpf_gpio_more_loops/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires GPIO loopback between P2.09 and P1.01. */
+
+/ {
+	/* Test requirements:
+	 * out-gpios[0] wire connected with in-gpios[0],
+	 * out-gpios[1] wire connected with in-gpios[1],
+	 * etc.
+	 * Output-input GPIO pair must have identical active level flag.
+	 * All outputs must be on the same device.
+	 */
+	zephyr,user {
+		out-gpios = <&hpf_gpio 9 GPIO_ACTIVE_HIGH>;
+		in-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpiote20 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/hpf_gpio_more_loops/testcase.yaml
+++ b/tests/drivers/gpio/hpf_gpio_more_loops/testcase.yaml
@@ -68,3 +68,31 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
     integration_platforms:
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+
+  drivers.hpf.gpio.many_loops.7120.icmsg:
+    extra_args: SB_CONFIG_HPF_GPIO_BACKEND_ICMSG=y
+    harness_config:
+      fixture: gpio_loopback
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp
+
+  drivers.hpf.gpio.many_loops.7120.icbmsg:
+    extra_args: SB_CONFIG_HPF_GPIO_BACKEND_ICBMSG=y
+    harness_config:
+      fixture: gpio_loopback
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp
+
+  drivers.hpf.gpio.many_loops.7120.mbox:
+    extra_args: SB_CONFIG_HPF_GPIO_BACKEND_MBOX=y
+    harness_config:
+      fixture: gpio_loopback
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp


### PR DESCRIPTION
This PR adds High-Performance Framework (HPF) GPIO support for the nRF7120 device, including the HPF application, blinky sample, and loopback tests.