### PR TITLE
samples: ipc_service: Add separate .conf file for cpuppr scenario

### DIFF
--- a/samples/ipc/ipc_service/boards/nrf54h20dk_nrf54h20_cpuapp_cpuppr.conf
+++ b/samples/ipc/ipc_service/boards/nrf54h20dk_nrf54h20_cpuapp_cpuppr.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=900


### PR DESCRIPTION
This is a follow-up to commit a879edd0ba3a1743257635f1b1c162d862fb8c79.

It is undesirable to enable the Radio core in this sample when the PPR is used as the remote side. Thus, the default .conf file should not be used in such case.