### PR TITLE
nrf_security: cracen_trng: Update to deactivate trng after use

### DIFF
--- a/subsys/nrf_security/src/drivers/nrf_oberon/cracen_trng/cracen_trng.c
+++ b/subsys/nrf_security/src/drivers/nrf_oberon/cracen_trng/cracen_trng.c
@@ -50,5 +50,7 @@ psa_status_t cracen_trng_get_entropy(uint32_t flags, size_t *estimate_bits,
 
 	*estimate_bits = PSA_BYTES_TO_BITS(request_len);
 
+	nrfx_cracen_uninit();
+
 	return PSA_SUCCESS;
 }


### PR DESCRIPTION
Add nrfx_cracen_uninit after operation is completed.