### PR TITLE
nrf_security: CRACEN: Fix possible nullpointer reference

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/silexpk/include/silexpk/cmddefs/modmath.h
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/include/silexpk/cmddefs/modmath.h
@@ -53,6 +53,9 @@ extern const struct sx_pk_cmd_def *const SX_PK_CMD_MULT;
 /** Clear memory **/
 extern const struct sx_pk_cmd_def *const SX_PK_CMD_CLEAR_MEMORY;
 
+/** Init command */
+extern const struct sx_pk_cmd_def *const SX_PK_CMD_NONE;
+
 /** @} */
 
 /** Input slots for ::SX_PK_CMD_ODD_MOD_INV & ::SX_PK_CMD_ODD_MOD_REDUCE

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -248,7 +248,7 @@ void sx_pk_acquire_hw(sx_pk_req *req)
 	req->cryptoram = silex_pk_engine.instance.cryptoram;
 	req->slot_sz = silex_pk_engine.instance.slot_sz;
 	req->cnx = &silex_pk_engine;
-	req->cnx->cmd = NULL;
+	req->cnx->cmd = SX_PK_CMD_NONE;
 	req->ik_mode = 0;
 
 	cracen_acquire();
@@ -288,15 +288,15 @@ void *sx_pk_get_user_context(sx_pk_req *req)
 
 void sx_pk_release_req(sx_pk_req *req)
 {
-	nrf_cracen_int_disable(NRF_CRACEN, NRF_CRACEN_INT_PKE_IKG_MASK);
-
 	if (!IS_ENABLED(CONFIG_CRACEN_HW_VERSION_BASE)) {
 		/* Clear PK data memory */
 		(void)sx_pk_clear_memory(req);
 	}
 
+	nrf_cracen_int_disable(NRF_CRACEN, NRF_CRACEN_INT_PKE_IKG_MASK);
+
 	cracen_release();
-	req->cnx->cmd = NULL;
+	req->cnx->cmd = SX_PK_CMD_NONE;
 	req->userctxt = NULL;
 	nrf_security_mutex_unlock(cracen_mutex_asymmetric);
 }

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/cmddefs_modmath.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/cmddefs_modmath.c
@@ -150,3 +150,6 @@ const struct sx_pk_cmd_def *const SX_PK_CMD_CHECK_XY = &CMD_CHECK_XY;
 static const struct sx_pk_cmd_def CMD_CLEAR_MEMORY = {
 	PK_OP_CLEAR_MEMORY, 0, 0, OP_SLOT_DEFAULT_PTRS};
 const struct sx_pk_cmd_def *const SX_PK_CMD_CLEAR_MEMORY = &CMD_CLEAR_MEMORY;
+
+static const struct sx_pk_cmd_def CMD_NONE = {0};
+const struct sx_pk_cmd_def *const SX_PK_CMD_NONE = &CMD_NONE;


### PR DESCRIPTION
Add CMD_NONE to PK commands to avoid null pointer reference during init.