### PR TITLE
modules: memfault: Default FW version prefix to app version if available

### DIFF
--- a/modules/memfault-firmware-sdk/Kconfig
+++ b/modules/memfault-firmware-sdk/Kconfig
@@ -118,6 +118,7 @@ endchoice
 config MEMFAULT_NCS_FW_VERSION_PREFIX
 	string "Firmware version prefix"
 	depends on MEMFAULT_NCS_FW_VERSION_AUTO
+	default "$(APP_VERSION_STRING)+" if "$(VERSION_MAJOR)" != ""
 	default "0.0.1+"
 	help
 	  Prefix to use in front of automatically generated build version string.


### PR DESCRIPTION
set default `CONFIG_MEMFAULT_NCS_FW_VERSION_PREFIX` to be pulled from the `VERSION` file if it is available.