### PR TITLE
scripts/docker: Handle `read` fail

### DIFF
--- a/scripts/docker/interactive-setup.sh
+++ b/scripts/docker/interactive-setup.sh
@@ -7,12 +7,18 @@ if [ ! -f /jlink/license_processed ] && [ ! -f /usr/bin/JLinkExe ] ; then
     cat '/jlink/license.txt'
     printf '\n'
     while true; do
-      read -p "Do you accept these Terms of Use (y/n)? " yn
-      case $yn in
-          [Yy]* ) export ACCEPT_JLINK_LICENSE=1; break;;
-          [Nn]* ) export ACCEPT_JLINK_LICENSE=0; break;;
-          * ) echo "Invalid input. Please use y/n";;
-      esac
+      if read -p "Do you accept these Terms of Use (y/n)? " yn ; then
+        case $yn in
+            [Yy]* ) export ACCEPT_JLINK_LICENSE=1; break;;
+            [Nn]* ) export ACCEPT_JLINK_LICENSE=0; break;;
+            * ) echo "Invalid input. Please use y/n";;
+        esac
+      else
+        echo "Failed to read answer, assuming no."
+        echo "To install manually, run:"
+        echo "    env ACCEPT_JLINK_LICENSE=1 /jlink/install.sh"
+        break
+      fi
     done
   fi
   if [[ "${ACCEPT_JLINK_LICENSE}" == "1" ]]; then

--- a/scripts/docker/interactive-setup.sh
+++ b/scripts/docker/interactive-setup.sh
@@ -17,6 +17,7 @@ if [ ! -f /jlink/license_processed ] && [ ! -f /usr/bin/JLinkExe ] ; then
         echo "Failed to read answer, assuming no."
         echo "To install manually, run:"
         echo "    env ACCEPT_JLINK_LICENSE=1 /jlink/install.sh"
+        export ACCEPT_JLINK_LICENSE=0
         break
       fi
     done


### PR DESCRIPTION
The `read` built-in command can fail (return non-zero) under the following circumstances:

- end-of-file is encountered
- read times out (in which case the status is greater than 128)
- a variable assignment error (such as assigning to a readonly variable) occurs
- or an invalid file descriptor is supplied as the argument to `-u`.

We're not using time-outs or special file descriptors, and none of the variables here are read-only, however we will yield non-zero status if EOF is hit (because maybe `stdin` is piped from `/dev/null`).

In cases where it fails, we provide the user a command they can run to manually trigger the install should JLink tools be necessary.

This fixes an issue on Bitbucket Pipelines, where the environment there confuses the script into thinking the session is interactive but `stdin` is not readable.  (Bitbucket Pipelines does _not_ provide the ability to set the `ACCEPT_JLINK_LICENSE` variable.)

(I'm not sure what they're doing, tried to reproduce the behaviour with `docker run` but got nowhere.)

The behaviour without this patch is the "interactive" set-up script goes into an infinite loop trying to read a `y` or `n` from `stdin` and failing:

<img width="1710" height="1242" alt="Screenshot of pipelines showing an infinite loop" src="https://github.com/user-attachments/assets/be2e46b4-5e9b-457c-82a9-f21da45b65d0" />

Using this update to the script, it is possible to use the nRF Connect SDK container in Bitbucket pipelines like so:

```yaml
        build:
        - step:
            name: 'Build the firmware'
            # The following is a monkey-patched version of the official
            # sdk-nrf-toolchain:v3.2.4 container, built via the following Dockerfile:
            #
            # FROM ghcr.io/nrfconnect/sdk-nrf-toolchain:v3.2.4
            # COPY --chmod=0555 interactive-setup.sh /opt/.bashrc
            #
            image: docker.io/sjlongland/sdk-nrf-toolchain:v3.2.4
            script:
            # Initialise the `west` workspace
            - . /opt/toolchain-env.sh
            - west init -l
            - west update
            # Do a build
            - west build -p always -b my_board app
            artifacts:
              upload:
                 - name: Firmware Image (Intel hex)
                   type: shared
                   paths:
                   - build/merged.hex
```