### PR TITLE
samples: dfu: Add support for nRFLM20b for usb_mcumgr

### DIFF
--- a/samples/dfu/fw_loader/usb_mcumgr/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/samples/dfu/fw_loader/usb_mcumgr/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1940)>;
+
+	partitions {
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(24)>;
+		};
+
+		slot0_partition: partition@6000 {
+			label = "image-0";
+			reg = <0x6000 DT_SIZE_K(1784)>;
+		};
+
+		slot1_partition: partition@1c4000 {
+			label = "image-1";
+			reg = <0x1c4000 DT_SIZE_K(116)>;
+		};
+
+		storage_partition: partition@1e1000 {
+			label = "storage";
+			reg = <0x1e1000 DT_SIZE_K(16)>;
+		};
+	};
+};
+
+#include "../app.overlay"

--- a/samples/dfu/fw_loader/usb_mcumgr/sample.yaml
+++ b/samples/dfu/fw_loader/usb_mcumgr/sample.yaml
@@ -9,5 +9,7 @@ tests:
       - ci_samples_dfu
     platform_allow:
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     integration_platforms:
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp

--- a/samples/dfu/single_slot/sample.yaml
+++ b/samples/dfu/single_slot/sample.yaml
@@ -36,10 +36,12 @@ tests:
       - ci_samples_dfu
     platform_allow:
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     integration_platforms:
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     extra_args:
-      - DFILE_SUFFIX=usb
+      - FILE_SUFFIX=usb
   sample.dfu.single_slot.fw_loader_update.nrf54l15:
     extra_args:
       - SB_CONFIG_FIRMWARE_LOADER_UPDATE=y


### PR DESCRIPTION
Added nrf54lm20dk/nrf54lm20b/cpuapp support for the usb_mcumgr FW loader as well as for the USB single slot sample configuration.