### PR TITLE
doc: tfm: Add docs for platfrom memory services

### DIFF
--- a/doc/nrf/libraries/security/tfm/tfm_ioctl_api.rst
+++ b/doc/nrf/libraries/security/tfm/tfm_ioctl_api.rst
@@ -33,7 +33,10 @@ Read service
 ============
 
 The TF-M IOTCL read service allows the NSPE to access memory areas within the SPE that would otherwise be inaccessible to it.
-The allowed memory areas are defined by the :file:`tfm_platform_user_memory_ranges.h` file.
+For a memory location to be accessible, it must be within the allowed memory areas defined by the :file:`tfm_platform_user_memory_ranges.h` file.
+
+.. caution::
+   Adding locations to the allowed memory areas for reading might lead to major security consequences if the NSPE has access to sensitive data or code in the SPE.
 
 The service is used by the :c:func:`tfm_platform_mem_read` function.
 For example, you can use the service to read the OTP value from UICR registers:
@@ -56,6 +59,48 @@ For example, you can use the service to read the OTP value from UICR registers:
     }
 
 See the :ref:`tfm_hello_world` sample for example usage.
+
+Write service
+=============
+
+The TF-M IOTCL write service allows the NSPE to write words of memory to the SPE.
+
+For a memory location to be writable, it must be within the allowed memory areas defined by the :file:`tfm_platform_user_memory_ranges.h` file.
+
+The allowed areas for writing are described by the :c:struct:`tfm_write32_service_address` structure that contains the following fields:
+
+.. code-block:: c
+
+    struct tfm_write32_service_address {
+        uint32_t addr; /* Mandatory field with the address to write to. */
+        uint32_t mask; /* Mandatory field with the bitmask of the bits to write. */
+        const uint32_t *allowed_values; /* Optional field with the allowed values to write. If NULL, any value is allowed. */
+        const uint32_t allowed_values_array_size; /* Optional field with the size of the allowed values array. Must be 0 if allowed_values is NULL. */
+    };
+
+.. caution::
+   Adding locations to the allowed memory areas for writing might lead to major security consequences if the NSPE has access to sensitive data or code in the SPE.
+
+The service is used by the :c:func:`tfm_platform_mem_write32` function.
+For example, you can use the service to write a value to a memory location in the SPE:
+
+.. code-block:: c
+
+    #include <tfm_ioctl_api.h>
+
+    void write_memory_value(void) {
+        uint32_t *addr = (uint32_t *)0x20000000; /* Randomly picked address for demonstration purposes only */
+        uint32_t value_to_write = 0x80;
+        uint32_t mask = 0xFF;
+        int err;
+        enum tfm_platform_err_t plt_err;
+
+        plt_err = tfm_platform_mem_write32(addr, value_to_write, mask, &err);
+        if (plt_err != TFM_PLATFORM_ERR_SUCCESS || err != 0) {
+            /* Handle error */
+        }
+
+    }
 
 Prerequisites
 *************

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -1135,6 +1135,10 @@ cJSON
 Documentation
 =============
 
-* Added a section in :ref:`ug_nrf54h20_pm_optimization` about optimizing power on the nRF54H20 SoC by relocating the radio core firmware to TCM.
+* Added:
+
+  * A section in :ref:`ug_nrf54h20_pm_optimization` about optimizing power on the nRF54H20 SoC by relocating the radio core firmware to TCM.
+  * A section in the :ref:`lib_tfm_ioctl_api` page about using the TF-M IOCTL API to perform secure memory writes from NSPE.
+
 * Updated the :ref:`emds_readme` library documentation to use static device tree partitions instead of the Partition Manager.
 * Removed references to JITP in different areas of the documentation.

--- a/doc/nrf/security/tfm/tfm_services.rst
+++ b/doc/nrf/security/tfm/tfm_services.rst
@@ -32,6 +32,12 @@ The platform service also exposes the following |NCS| specific APIs for the non-
     /* Check if S0 is the active B1 slot. */
     int tfm_platform_s0_active(uint32_t s0_address, uint32_t s1_address, bool *s0_active);
 
+    /* Writes a word to the secure memory as long as the address permissions allow it. */
+    enum tfm_platform_err_t tfm_platform_mem_write32(uint32_t addr, uint32_t value, uint32_t mask, uint32_t *result);
+
+    /* Reads data from the secure memory as long as the address range permissions allow it. */
+    enum tfm_platform_err_t tfm_platform_mem_read(void *destination, uint32_t addr, size_t len, uint32_t *result);
+
 See :ref:`lib_tfm_ioctl_api` for more information about APIs available for the non-secure application.
 
 For more information about the general features of the TF-M Platform partition, see `TF-M Platform`_.


### PR DESCRIPTION
Add documentation for the TFM platform memory write service and improve the documentation for the TFM platform memory read service.

Ref: NCSDK-31184