### PR TITLE
samples: bluetooth: add nRF54LS05A to LBS and UART sample yaml

### DIFF
--- a/samples/benchmarks/coremark/boards/nrf54ls05dk_nrf54ls05a_cpuapp.conf
+++ b/samples/benchmarks/coremark/boards/nrf54ls05dk_nrf54ls05a_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_COREMARK_ITERATIONS=4000
+
+CONFIG_LOG_MODE_IMMEDIATE=y

--- a/samples/benchmarks/coremark/sample.yaml
+++ b/samples/benchmarks/coremark/sample.yaml
@@ -4,11 +4,18 @@ sample:
     CoreMark benchmark that measures the CPU efficiency performing different algorithms
     like state machine, CRC calculation, matrix manipulation and list processing (find
     and sort).
+
+common:
+  sysbuild: true
+  build_only: true
+  tags:
+    - ci_build
+    - sysbuild
+    - ci_samples_benchmarks
+
 tests:
   sample.benchmark.coremark:
-    sysbuild: true
-    build_only: true
-    platform_allow:
+    platform_allow: &coremark_platforms
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -19,9 +26,9 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -32,27 +39,10 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
-    tags:
-      - ci_build
-      - sysbuild
-      - ci_samples_benchmarks
+
   sample.benchmark.coremark.flash_and_run:
-    sysbuild: true
     build_only: false
-    platform_allow:
-      - nrf52833dk/nrf52833
-      - nrf52840dk/nrf52840
-      - nrf52dk/nrf52832
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l05/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+    platform_allow: *coremark_platforms
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -65,10 +55,6 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
-    tags:
-      - ci_build
-      - sysbuild
-      - ci_samples_benchmarks
     harness: console
     harness_config:
       ordered: false
@@ -77,17 +63,14 @@ tests:
         - "Correct operation validated."
       type: multi_line
     extra_args: FILE_SUFFIX=flash_and_run
+
   sample.benchmark.coremark.flash_and_run.nrf7120:
-    sysbuild: true
     build_only: false
+    platform_exclude: *coremark_platforms
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
     integration_platforms:
       - nrf7120dk/nrf7120/cpuapp
-    tags:
-      - ci_build
-      - sysbuild
-      - ci_samples_benchmarks
     harness: console
     harness_config:
       ordered: false
@@ -97,81 +80,24 @@ tests:
       type: multi_line
     timeout: 180
     extra_args: FILE_SUFFIX=flash_and_run
+
   sample.benchmark.coremark.heap_memory:
-    sysbuild: true
-    build_only: true
-    platform_allow:
-      - nrf52833dk/nrf52833
-      - nrf52840dk/nrf52840
-      - nrf52dk/nrf52832
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l05/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+    platform_allow: *coremark_platforms
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
-    tags:
-      - ci_build
-      - sysbuild
-      - ci_samples_benchmarks
     extra_args: FILE_SUFFIX=heap_memory
+
   sample.benchmark.coremark.static_memory:
-    sysbuild: true
-    build_only: true
-    platform_allow:
-      - nrf52833dk/nrf52833
-      - nrf52840dk/nrf52840
-      - nrf52dk/nrf52832
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l05/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+    platform_allow: *coremark_platforms
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
-    tags:
-      - ci_build
-      - sysbuild
-      - ci_samples_benchmarks
     extra_args: FILE_SUFFIX=static_memory
+
   sample.benchmark.coremark.multiple_threads:
-    sysbuild: true
-    build_only: true
-    platform_allow:
-      - nrf52833dk/nrf52833
-      - nrf52840dk/nrf52840
-      - nrf52dk/nrf52832
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l05/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+    platform_allow: *coremark_platforms
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
-    tags:
-      - ci_build
-      - sysbuild
-      - ci_samples_benchmarks
     extra_args: FILE_SUFFIX=multiple_threads

--- a/samples/benchmarks/coremark/sample.yaml
+++ b/samples/benchmarks/coremark/sample.yaml
@@ -20,6 +20,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
@@ -29,6 +30,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     tags:
       - ci_build
@@ -49,6 +51,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
@@ -60,6 +63,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     tags:
       - ci_build
@@ -108,9 +112,11 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     tags:
       - ci_build
@@ -132,9 +138,11 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     tags:
       - ci_build
@@ -156,9 +164,11 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     tags:
       - ci_build

--- a/samples/benchmarks/coremark/sample.yaml
+++ b/samples/benchmarks/coremark/sample.yaml
@@ -29,32 +29,13 @@ tests:
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+    integration_platforms: *coremark_platforms
 
   sample.benchmark.coremark.flash_and_run:
     build_only: false
     platform_allow: *coremark_platforms
     integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l05/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
     harness: console
     harness_config:
       ordered: false
@@ -85,19 +66,19 @@ tests:
     platform_allow: *coremark_platforms
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args: FILE_SUFFIX=heap_memory
 
   sample.benchmark.coremark.static_memory:
     platform_allow: *coremark_platforms
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args: FILE_SUFFIX=static_memory
 
   sample.benchmark.coremark.multiple_threads:
     platform_allow: *coremark_platforms
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args: FILE_SUFFIX=multiple_threads

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -1,20 +1,26 @@
 sample:
   description: Bluetooth Low Energy LED Button service sample
   name: Bluetooth LE LED Button service
+
 common:
+  sysbuild: true
+  build_only: true
   tags:
     - bluetooth
     - ci_build
     - sysbuild
     - ci_samples_bluetooth
+
 tests:
   sample.bluetooth.peripheral_lbs:
-    sysbuild: true
-    integration_platforms:
+    build_only: false
+    platform_allow: &peripheral_lbs_platforms
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
       - thingy53/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -25,18 +31,14 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
-      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
-    platform_allow:
+    integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - nrf5340dk/nrf5340/cpuapp/ns
       - thingy53/nrf5340/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
@@ -58,63 +60,28 @@ tests:
         - "Bluetooth initialized"
         - "Advertising successfully started"
     timeout: 15
+
   sample.bluetooth.peripheral_lbs_minimal:
-    sysbuild: true
-    build_only: true
-    extra_args: FILE_SUFFIX=minimal
-    integration_platforms:
-      - nrf52dk/nrf52805
-      - nrf52840dk/nrf52811
     platform_allow:
       - nrf52dk/nrf52805
       - nrf52dk/nrf52810
       - nrf52840dk/nrf52811
       - nrf52833dk/nrf52820
+    integration_platforms:
+      - nrf52dk/nrf52805
+      - nrf52840dk/nrf52811
+      - nrf54ls05dk/nrf54ls05a/cpuapp
+    extra_args: FILE_SUFFIX=minimal
+
   sample.bluetooth.peripheral_lbs_no_security:
-    sysbuild: true
-    build_only: true
+    platform_allow: *peripheral_lbs_platforms
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args: CONFIG_BT_LBS_SECURITY_ENABLED=n
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - thingy53/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp/ns
-      - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp/ns
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
-    platform_allow:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf5340dk/nrf5340/cpuapp/ns
-      - thingy53/nrf5340/cpuapp
-      - thingy53/nrf5340/cpuapp/ns
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp/ns
-      - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp/ns
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+
   sample.bluetooth.peripheral_lbs_bt_ota_dfu:
-    sysbuild: true
     build_only: true
-    integration_platforms:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
@@ -122,36 +89,36 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
+    integration_platforms:
+      - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
     extra_configs:
       - CONFIG_BOOTLOADER_MCUBOOT=y
       - CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
+
   sample.bluetooth.peripheral_lbs_bt_ota_dfu.direct_xip:
-    sysbuild: true
     build_only: true
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
+    integration_platforms:
+      - nrf52840dk/nrf52840
     extra_args: mcuboot_CONFIG_BOOT_DIRECT_XIP=y
     extra_configs:
       - CONFIG_BOOTLOADER_MCUBOOT=y
       - CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
       - CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP=y
+
   sample.bluetooth.peripheral_lbs_bt_ota_dfu.direct_xip.revert:
-    sysbuild: true
     build_only: true
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
+    integration_platforms:
+      - nrf52840dk/nrf52840
     extra_args:
       - mcuboot_CONFIG_BOOT_DIRECT_XIP=y
       - mcuboot_CONFIG_BOOT_DIRECT_XIP_REVERT=y
@@ -159,10 +126,10 @@ tests:
       - CONFIG_BOOTLOADER_MCUBOOT=y
       - CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
       - CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT=y
+
   sample.bluetooth.peripheral_lbs.llvm:
     toolchain_allow: llvm
-    sysbuild: true
-    integration_platforms:
+    platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54lm20dk/nrf54lm20a/cpuapp
@@ -172,7 +139,7 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
-    platform_allow:
+    integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54lm20dk/nrf54lm20a/cpuapp
@@ -186,16 +153,13 @@ tests:
       - bluetooth
       - ci_build
       - sysbuild
+
   sample.bluetooth.peripheral_lbs.l15_tag:
-    sysbuild: true
+    platform_exclude: *peripheral_lbs_platforms
     integration_platforms:
       - nrf54l15tag/nrf54l15/cpuapp
     platform_allow:
       - nrf54l15tag/nrf54l15/cpuapp
-    tags:
-      - bluetooth
-      - ci_build
-      - sysbuild
     extra_configs:
       - CONFIG_NCS_SAMPLE_MCUMGR_BT_OTA_DFU=y
       - CONFIG_LOG_BACKEND_UART=n

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -26,6 +26,7 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
@@ -34,6 +35,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - thingy53/nrf5340/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -45,6 +47,7 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     harness: console
     harness_config:
@@ -83,6 +86,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
@@ -100,6 +104,7 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
   sample.bluetooth.peripheral_lbs_bt_ota_dfu:
     sysbuild: true
@@ -108,12 +113,14 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     extra_configs:
       - CONFIG_BOOTLOADER_MCUBOOT=y
@@ -123,9 +130,11 @@ tests:
     build_only: true
     integration_platforms:
       - nrf52840dk/nrf52840
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     extra_args: mcuboot_CONFIG_BOOT_DIRECT_XIP=y
     extra_configs:
@@ -137,9 +146,11 @@ tests:
     build_only: true
     integration_platforms:
       - nrf52840dk/nrf52840
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     extra_args:
       - mcuboot_CONFIG_BOOT_DIRECT_XIP=y
@@ -159,6 +170,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
@@ -168,6 +180,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     tags:
       - bluetooth

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -33,24 +33,7 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
-    integration_platforms:
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - thingy53/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l05/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp/ns
-      - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp/ns
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+    integration_platforms: *peripheral_lbs_platforms
     harness: console
     harness_config:
       type: multi_line
@@ -67,6 +50,7 @@ tests:
       - nrf52dk/nrf52810
       - nrf52840dk/nrf52811
       - nrf52833dk/nrf52820
+      - nrf54ls05dk/nrf54ls05a/cpuapp
     integration_platforms:
       - nrf52dk/nrf52805
       - nrf52840dk/nrf52811
@@ -87,8 +71,6 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
@@ -101,8 +83,6 @@ tests:
     build_only: true
     platform_allow:
       - nrf52840dk/nrf52840
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: mcuboot_CONFIG_BOOT_DIRECT_XIP=y
@@ -115,8 +95,6 @@ tests:
     build_only: true
     platform_allow:
       - nrf52840dk/nrf52840
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args:
@@ -155,7 +133,6 @@ tests:
       - sysbuild
 
   sample.bluetooth.peripheral_lbs.l15_tag:
-    platform_exclude: *peripheral_lbs_platforms
     integration_platforms:
       - nrf54l15tag/nrf54l15/cpuapp
     platform_allow:

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -1,16 +1,20 @@
 sample:
   description: Bluetooth Low Energy UART service sample
   name: Bluetooth LE UART service
+
 common:
+  sysbuild: true
+  build_only: true
   tags:
     - bluetooth
     - ci_build
     - sysbuild
     - ci_samples_bluetooth
+
 tests:
   sample.bluetooth.peripheral_uart:
-    sysbuild: true
-    platform_allow:
+    build_only: false
+    platform_allow: &peripheral_uart_platforms
       - nrf52dk/nrf52832
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
@@ -43,50 +47,36 @@ tests:
       regex:
         - "Starting Nordic UART service sample"
     timeout: 15
+
   sample.bluetooth.peripheral_uart_cdc:
-    sysbuild: true
-    build_only: true
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52833dk/nrf52833
+    integration_platforms:
+      - nrf52840dk/nrf52840
     extra_args:
       - OVERLAY_CONFIG=prj_cdc.conf
       - DTC_OVERLAY_FILE="usb.overlay"
-    integration_platforms:
-      - nrf52840dk/nrf52840
-    platform_allow:
-      - nrf52840dk/nrf52840
-      - nrf52833dk/nrf52833
+
   sample.bluetooth.peripheral_uart_minimal:
-    sysbuild: true
-    build_only: true
-    extra_args: FILE_SUFFIX=minimal
-    integration_platforms:
-      - nrf52833dk/nrf52820
     platform_allow:
       - nrf52833dk/nrf52820
+    extra_args: FILE_SUFFIX=minimal
+
   sample.bluetooth.peripheral_uart_ble_rpc:
-    sysbuild: true
-    build_only: true
+    platform_exclude:
+      - nrf52840dk/nrf52840
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
       - SNIPPET=nordic-bt-rpc
       - FILE_SUFFIX=bt_rpc
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
-    platform_allow:
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
+
   sample.bluetooth.peripheral_uart.security_disabled:
-    sysbuild: true
-    build_only: true
-    platform_allow:
-      - nrf52dk/nrf52832
-      - nrf52833dk/nrf52833
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf5340dk/nrf5340/cpuapp/ns
-      - thingy53/nrf5340/cpuapp
-      - thingy53/nrf5340/cpuapp/ns
-      - nrf21540dk/nrf52840
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+    platform_allow: *peripheral_uart_platforms
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_configs:

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -22,6 +22,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
@@ -33,6 +34,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpurad
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     harness: console
     harness_config:
@@ -83,6 +85,7 @@ tests:
       - thingy53/nrf5340/cpuapp
       - thingy53/nrf5340/cpuapp/ns
       - nrf21540dk/nrf52840
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -36,10 +36,7 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-    integration_platforms:
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+    integration_platforms: *peripheral_uart_platforms
     harness: console
     harness_config:
       type: multi_line
@@ -60,6 +57,9 @@ tests:
 
   sample.bluetooth.peripheral_uart_minimal:
     platform_allow:
+      - nrf52833dk/nrf52820
+      - nrf54ls05dk/nrf54ls05a/cpuapp
+    integration_platforms:
       - nrf52833dk/nrf52820
     extra_args: FILE_SUFFIX=minimal
 

--- a/soc/nordic/nrf54l/Kconfig.soc
+++ b/soc/nordic/nrf54l/Kconfig.soc
@@ -46,5 +46,6 @@ config SOC_NRF54LV10A_CPUFLPR
 	  NRF54LV10A CPUFLPR
 
 config SOC
+	default "nrf54ls05a" if SOC_NRF54LS05A
 	default "nrf54ls05b" if SOC_NRF54LS05B
 	default "nrf54lv10a" if SOC_NRF54LV10A


### PR DESCRIPTION
Include nrf54ls05dk/nrf54ls05a/cpuapp in integration_platforms and platform_allow for peripheral_lbs and peripheral_uart Twister configs, alongside existing nRF54LS05B entries.