### PR TITLE
[Backport v3.3-branch]: manifest: mcuboot: Fix uuid + extflash

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: ncs-v3.3.0-rc1
+      revision: pull/638/head
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
This updates the manifest to the backport of the MCUBoot bugfix.