### PR TITLE
tests: tfm: add remaining 54L series to regressions tests

### DIFF
--- a/tests/tfm/tfm_regression_test/boards/nrf54lm20dk_nrf54lm20a_cpuapp_ns.conf
+++ b/tests/tfm/tfm_regression_test/boards/nrf54lm20dk_nrf54lm20a_cpuapp_ns.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# The tests need more RAM
+CONFIG_PM_PARTITION_SIZE_TFM_SRAM=0x17000
+
+# Attestation support for nRF54LM20 is not implemented yet
+CONFIG_TFM_PARTITION_INITIAL_ATTESTATION=n
+CONFIG_TFM_NRF_PROVISIONING=n

--- a/tests/tfm/tfm_regression_test/boards/nrf54lm20dk_nrf54lm20a_cpuapp_ns.overlay
+++ b/tests/tfm/tfm_regression_test/boards/nrf54lm20dk_nrf54lm20a_cpuapp_ns.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+&uart30 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	/* Set to disabled in application, since TF-M will be using it. */
+	status = "disabled";
+	hw-flow-control;
+};

--- a/tests/tfm/tfm_regression_test/boards/nrf54lm20dk_nrf54lm20b_cpuapp_ns.conf
+++ b/tests/tfm/tfm_regression_test/boards/nrf54lm20dk_nrf54lm20b_cpuapp_ns.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# The tests need more RAM
+CONFIG_PM_PARTITION_SIZE_TFM_SRAM=0x17000
+
+# Attestation support for nRF54LM20 is not implemented yet
+CONFIG_TFM_PARTITION_INITIAL_ATTESTATION=n
+CONFIG_TFM_NRF_PROVISIONING=n

--- a/tests/tfm/tfm_regression_test/boards/nrf54lm20dk_nrf54lm20b_cpuapp_ns.overlay
+++ b/tests/tfm/tfm_regression_test/boards/nrf54lm20dk_nrf54lm20b_cpuapp_ns.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+&uart30 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	/* Set to disabled in application, since TF-M will be using it. */
+	status = "disabled";
+	hw-flow-control;
+};

--- a/tests/tfm/tfm_regression_test/boards/nrf54lv10dk_nrf54lv10a_cpuapp_ns.conf
+++ b/tests/tfm/tfm_regression_test/boards/nrf54lv10dk_nrf54lv10a_cpuapp_ns.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# The tests need more RAM
+CONFIG_PM_PARTITION_SIZE_TFM_SRAM=0x17000
+
+# Attestation support for nRF54LV10A is not implemented yet
+CONFIG_TFM_PARTITION_INITIAL_ATTESTATION=n
+CONFIG_TFM_NRF_PROVISIONING=n

--- a/tests/tfm/tfm_regression_test/boards/nrf54lv10dk_nrf54lv10a_cpuapp_ns.overlay
+++ b/tests/tfm/tfm_regression_test/boards/nrf54lv10dk_nrf54lv10a_cpuapp_ns.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+&uart20 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	/* Set to disabled in application, since TF-M will be using it. */
+	status = "disabled";
+	hw-flow-control;
+};

--- a/tests/tfm/tfm_regression_test/testcase.yaml
+++ b/tests/tfm/tfm_regression_test/testcase.yaml
@@ -25,6 +25,9 @@ tests:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20a/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf7120dk/nrf7120/cpuapp/ns
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -32,6 +35,9 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20a/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf7120dk/nrf7120/cpuapp/ns
       - nrf9151dk/nrf9151/ns
       - nrf9161dk/nrf9161/ns
@@ -105,9 +111,15 @@ tests:
     timeout: 200
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20a/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf7120dk/nrf7120/cpuapp/ns
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20a/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf7120dk/nrf7120/cpuapp/ns
   tfm.regression_sfn_lvl1:
     sysbuild: true
@@ -122,6 +134,9 @@ tests:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20a/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf7120dk/nrf7120/cpuapp/ns
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -129,6 +144,9 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20a/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf7120dk/nrf7120/cpuapp/ns
       - nrf9151dk/nrf9151/ns
       - nrf9161dk/nrf9161/ns
@@ -144,6 +162,9 @@ tests:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20a/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf7120dk/nrf7120/cpuapp/ns
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -151,6 +172,9 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20a/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf7120dk/nrf7120/cpuapp/ns
       - nrf9151dk/nrf9151/ns
       - nrf9161dk/nrf9161/ns


### PR DESCRIPTION
Add nRF54LM20A, nRF54LM20B and nRF54LV10A to regression tests.