### PR TITLE
nrf_security: CRACEN: Clean up includes and naming

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/silexpk/silexpk.cmake
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/silexpk.cmake
@@ -25,9 +25,8 @@ list(APPEND cracen_driver_sources
   ${CMAKE_CURRENT_LIST_DIR}/target/hw/ba414/cmddefs_ecjpake.c
 )
 
-# We need internal.h to be on path
 list(APPEND cracen_driver_include_dirs
-  ${CMAKE_CURRENT_LIST_DIR}/target/baremetal_ba414e_with_ik
+  ${CMAKE_CURRENT_LIST_DIR}/target
   ${CMAKE_CURRENT_LIST_DIR}/include
 )
 

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/src/blind.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/src/blind.c
@@ -8,7 +8,7 @@
 #include <silexpk/blinding.h>
 #include <cracen/statuscodes.h>
 #include <cracen/prng_pool.h>
-#include "internal.h"
+#include <baremetal_ba414e_with_ik/internal.h>
 
 int sx_pk_get_blinding_factor(sx_pk_blind_factor *bld_factor)
 {

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -19,7 +19,7 @@
 #include <silexpk/blinding.h>
 #include <cracen/interrupts.h>
 #include <cracen/statuscodes.h>
-#include "internal.h"
+#include <baremetal_ba414e_with_ik/internal.h>
 
 #include <hal/nrf_cracen.h>
 #include <cracen/hardware.h>

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/ec_curves.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/ec_curves.c
@@ -7,7 +7,7 @@
  #include <zephyr/kernel.h>
 #include <silexpk/ec_curves.h>
 #include "../../../src/regs_curves.h"
-#include "../../target/hw/ba414/regs_commands.h"
+#include "regs_commands.h"
 #include <silexpk/core.h>
 #include <string.h>
 #include <zephyr/sys/util.h>

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/pkhardware_ba414e.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/pkhardware_ba414e.c
@@ -13,7 +13,7 @@
 
 #include <silexpk/core.h>
 #include "regs_addr.h"
-#include <internal.h>
+#include <baremetal_ba414e_with_ik/internal.h>
 #include "op_slots.h"
 #include "regs_commands.h"
 #include "pkhardware_ba414e.h"

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ik/ikhardware.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ik/ikhardware.c
@@ -7,7 +7,7 @@
 #include <cracen/membarriers.h>
 
 #include "ikhardware.h"
-#include <internal.h>
+#include <baremetal_ba414e_with_ik/internal.h>
 #include "../ba414/op_slots.h"
 #include "../ik/regs_commands.h"
 #include "../ba414/regs_addr.h"

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ik/ikhardware.h
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ik/ikhardware.h
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 #include <silexpk/core.h>
-#include <internal.h>
+#include <baremetal_ba414e_with_ik/internal.h>
 #include <silexpk/ik.h>
 
 /** Get status for IK operation */


### PR DESCRIPTION
Switch to <baremetal_ba414e_with_ik/internal.h> and move the include dir up to target/ to provide the namespace. Fix an incorrect relative path for regs_commands.h in ec_curves.c.