### PR TITLE
rpc: add event reset function to the rpc os layer

### DIFF
--- a/subsys/nrf_rpc/include/nrf_rpc_os.h
+++ b/subsys/nrf_rpc/include/nrf_rpc_os.h
@@ -69,6 +69,11 @@ static inline int nrf_rpc_os_event_wait(struct nrf_rpc_os_event *event, int time
 	return 0;
 }
 
+static inline void nrf_rpc_os_event_reset(struct nrf_rpc_os_event *event)
+{
+	k_sem_reset(&event->sem);
+}
+
 static inline int nrf_rpc_os_mutex_init(struct nrf_rpc_os_mutex *mutex)
 {
 	return k_mutex_init(&mutex->mutex);

--- a/west.yml
+++ b/west.yml
@@ -145,7 +145,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 529012899ffb2aa8ef69cbbb315eaf2848737aca
+      revision: pull/2068/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Added the nrf_rpc_os_event_reset function implementation. This is needed to fix an issue with running out of buffers if OpenThread is running on the rpc server.