### PR TITLE
samples: smp_svr: Add bootloader-request nodes to nrf54h20_bt overlays

### DIFF
--- a/samples/dfu/smp_svr/boards/nrf54h20dk_nrf54h20_cpuapp_nrf54h20_bt.overlay
+++ b/samples/dfu/smp_svr/boards/nrf54h20dk_nrf54h20_cpuapp_nrf54h20_bt.overlay
@@ -5,3 +5,22 @@
  */
 
 #include "../dts/nrf54h20dk_nrf54h20_bootchain_bt.dtsi"
+
+&mram1x {
+	partitions {
+		boot_request: partition@0x1c2400 {
+			reg = <0x1c2400 16>;
+		};
+
+		boot_request_backup: partition@1c2410 {
+			reg = <0x1c2410 16>;
+		};
+	};
+};
+
+/ {
+	chosen {
+		nrf,bootloader-request = &boot_request;
+		nrf,bootloader-request-backup = &boot_request_backup;
+	};
+};

--- a/samples/dfu/smp_svr/sysbuild/mcuboot/boards/nrf54h20dk_nrf54h20_cpuapp_nrf54h20_bt.overlay
+++ b/samples/dfu/smp_svr/sysbuild/mcuboot/boards/nrf54h20dk_nrf54h20_cpuapp_nrf54h20_bt.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include "../../../dts/nrf54h20dk_nrf54h20_bootchain_bt.dtsi"
+#include "../../../boards/nrf54h20dk_nrf54h20_cpuapp_nrf54h20_bt.overlay"
 
 / {
 	chosen {


### PR DESCRIPTION
The nrf54h20_bt board overlay and did not contain nrf,bootloader-request. Without that region in the application and MCUboot images, devicetree could not enable bootloader requests;
this led to image confirm touching a statically write-protected slot (Ironside MPC), leading to a bus fault when a confirm attempt was executed.

Ref: NCSDK-38174