### PR TITLE
mcuboot: Support 4 images with MPCCONF write protection 

### DIFF
--- a/samples/nrf54h20/idle_relocated_tcm/common/memory_map_split_slot.dtsi
+++ b/samples/nrf54h20/idle_relocated_tcm/common/memory_map_split_slot.dtsi
@@ -36,7 +36,7 @@
 		/* Image 0, slot 0 (primary slot) - Application code for cpuapp core. */
 		slot0_partition: cpuapp_slot0_partition: partition@40000 {
 			compatible = "zephyr,mapped-partition";
-			reg = <0x40000 DT_SIZE_K(326)>;
+			reg = <0x40000 DT_SIZE_K(328)>;
 		};
 
 		/* Image 2, slot 0 (primary slot) - radio loader code for cpurad core. */
@@ -72,7 +72,7 @@
 		/* Image 0, slot 1 (secondary slot) - Application code for cpuapp core. */
 		slot1_partition: cpuapp_slot1_partition: partition@100000 {
 			compatible = "zephyr,mapped-partition";
-			reg = <0x100000 DT_SIZE_K(326)>;
+			reg = <0x100000 DT_SIZE_K(328)>;
 		};
 
 		/* Image 2, slot 1 (secondary slot) - radio loader code for cpurad core. */

--- a/samples/nrf54h20/idle_relocated_tcm/testcase.yaml
+++ b/samples/nrf54h20/idle_relocated_tcm/testcase.yaml
@@ -43,6 +43,5 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
       - FILE_SUFFIX=split_slot
-      # Does not currently set SB_CONFIG_NCS_MCUBOOT_MPCCONF_STATIC_WRITE_PROTECTION=y since only
-      # two images per slot are supported when using that feature.
       - SB_CONFIG_NCS_MCUBOOT_LOAD_PERIPHCONF=y
+      - SB_CONFIG_NCS_MCUBOOT_MPCCONF_STATIC_WRITE_PROTECTION=y

--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -310,7 +310,7 @@ config NCS_MCUBOOT_MPCCONF_STATIC_WRITE_PROTECTION
 	  UICR generator image and placed into the mpcconf_partition area.
 
 	  Using this feature introduces some limitations on the partition layout.
-	  The write protection scheme does not support more than two images per slot.
+	  The write protection scheme does not support more than four images.
 	  Additionally, if the UICR.SECURESTORAGE partition is enabled, it must be placed at
 	  the end of the MRAM area.
 

--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 8230615892bd06e59d3e6af7e423c6f74a4645ef
+      revision: c10ab348f397ed0ff42f7bb9fb55b0071903eda9
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Pull in support for up to 4 images with the MPCCONF write protection, and adjust users of this feature accordingly.