### PR TITLE
applications: hpf: update asm files after zephyr-sdk upgrade

### DIFF
--- a/applications/hpf/gpio/src/hrt/hrt-nrf54l15.s
+++ b/applications/hpf/gpio/src/hrt/hrt-nrf54l15.s
@@ -1,6 +1,6 @@
 	.file	"hrt.c"
 	.option nopic
-	.attribute arch, "rv32e1p9_m2p0_c2p0_zicsr2p0"
+	.attribute arch, "rv32e2p0_m2p0_c2p0_zicsr2p0"
 	.attribute unaligned_access, 0
 	.attribute stack_align, 4
 	.text
@@ -77,3 +77,4 @@ hrt_set_masked_bits:
  #NO_APP
 	ret
 	.size	hrt_set_masked_bits, .-hrt_set_masked_bits
+	.section	.note.GNU-stack,"",@progbits

--- a/applications/hpf/gpio/src/hrt/hrt-nrf54lm20a.s
+++ b/applications/hpf/gpio/src/hrt/hrt-nrf54lm20a.s
@@ -1,6 +1,6 @@
 	.file	"hrt.c"
 	.option nopic
-	.attribute arch, "rv32e1p9_m2p0_c2p0_zicsr2p0"
+	.attribute arch, "rv32e2p0_m2p0_c2p0_zicsr2p0"
 	.attribute unaligned_access, 0
 	.attribute stack_align, 4
 	.text
@@ -77,3 +77,4 @@ hrt_set_masked_bits:
  #NO_APP
 	ret
 	.size	hrt_set_masked_bits, .-hrt_set_masked_bits
+	.section	.note.GNU-stack,"",@progbits

--- a/applications/hpf/gpio/src/hrt/hrt-nrf54lm20b.s
+++ b/applications/hpf/gpio/src/hrt/hrt-nrf54lm20b.s
@@ -1,6 +1,6 @@
 	.file	"hrt.c"
 	.option nopic
-	.attribute arch, "rv32e1p9_m2p0_c2p0_zicsr2p0"
+	.attribute arch, "rv32e2p0_m2p0_c2p0_zicsr2p0"
 	.attribute unaligned_access, 0
 	.attribute stack_align, 4
 	.text
@@ -77,3 +77,4 @@ hrt_set_masked_bits:
  #NO_APP
 	ret
 	.size	hrt_set_masked_bits, .-hrt_set_masked_bits
+	.section	.note.GNU-stack,"",@progbits

--- a/applications/hpf/gpio/src/hrt/hrt-nrf54lv10a.s
+++ b/applications/hpf/gpio/src/hrt/hrt-nrf54lv10a.s
@@ -1,6 +1,6 @@
 	.file	"hrt.c"
 	.option nopic
-	.attribute arch, "rv32e1p9_m2p0_c2p0_zicsr2p0"
+	.attribute arch, "rv32e2p0_m2p0_c2p0_zicsr2p0"
 	.attribute unaligned_access, 0
 	.attribute stack_align, 4
 	.text
@@ -77,3 +77,4 @@ hrt_set_masked_bits:
  #NO_APP
 	ret
 	.size	hrt_set_masked_bits, .-hrt_set_masked_bits
+	.section	.note.GNU-stack,"",@progbits

--- a/applications/hpf/mspi/src/hrt/hrt-nrf54l15.s
+++ b/applications/hpf/mspi/src/hrt/hrt-nrf54l15.s
@@ -1,6 +1,6 @@
 	.file	"hrt.c"
 	.option nopic
-	.attribute arch, "rv32e1p9_m2p0_c2p0_zicsr2p0"
+	.attribute arch, "rv32e2p0_m2p0_c2p0_zicsr2p0"
 	.attribute unaligned_access, 0
 	.attribute stack_align, 4
 	.text
@@ -9,32 +9,33 @@
 	.type	hrt_tx, @function
 hrt_tx:
 	lw	a5,4(a0)
-	addi	sp,sp,-16
-	sw	s0,12(sp)
-	sw	s1,8(sp)
-	sw	a2,0(sp)
+	addi	sp,sp,-20
+	sw	s0,16(sp)
+	sw	s1,12(sp)
+	sw	a2,4(sp)
 	beq	a5,zero,.L1
 	li	a4,32
 	div	a4,a4,a1
-	lui	t2,%hi(xfer_shift_ctrl)
-	addi	a2,t2,%lo(xfer_shift_ctrl)
-	lbu	s1,2(a2)
-	lbu	a5,1(a2)
+	lui	t1,%hi(xfer_shift_ctrl)
+	addi	a2,t1,%lo(xfer_shift_ctrl)
+	lbu	a5,2(a2)
 	sb	a1,2(a2)
+	li	t0,3145728
+	sw	a5,0(sp)
+	lbu	a5,1(a2)
 	lbu	a2,3(a2)
-	li	t1,3145728
 	slli	a5,a5,8
 	slli	a2,a2,20
-	and	a2,a2,t1
+	and	a2,a2,t0
 	andi	a5,a5,1792
 	or	a5,a5,a2
-	li	t1,126976
+	li	t0,126976
 	slli	a2,a1,12
-	and	a2,a2,t1
+	and	a2,a2,t0
 	or	a5,a5,a2
 	addi	a4,a4,-1
 	andi	a4,a4,0xff
-	sb	a4,%lo(xfer_shift_ctrl)(t2)
+	sb	a4,%lo(xfer_shift_ctrl)(t1)
 	andi	a4,a4,63
 	or	a5,a5,a4
  #APP
@@ -44,22 +45,21 @@ hrt_tx:
 	slli	a5,a1,16
 	and	a5,a5,a4
 	ori	a5,a5,4
-	sw	a5,4(sp)
-	li	t1,0
-	addi	t0,t2,%lo(xfer_shift_ctrl)
+	li	a2,0
+	li	t2,1
+	sw	a5,8(sp)
 .L3:
 	lw	a5,4(a0)
-	bltu	t1,a5,.L14
+	bltu	a2,a5,.L14
 .L1:
-	lw	s0,12(sp)
-	lw	s1,8(sp)
-	addi	sp,sp,16
+	lw	s0,16(sp)
+	lw	s1,12(sp)
+	addi	sp,sp,20
 	jr	ra
 .L14:
 	lw	a5,4(a0)
-	li	a4,1
-	sub	a5,a5,t1
-	beq	a5,a4,.L4
+	sub	a5,a5,a2
+	beq	a5,t2,.L4
 	li	a4,2
 	beq	a5,a4,.L5
 .L6:
@@ -67,59 +67,59 @@ hrt_tx:
 	li	a5,0
 	beq	a4,zero,.L7
 	lw	a5,0(a0)
-	slli	a4,t1,2
+	slli	a4,a2,2
 	add	a5,a5,a4
 	lw	a5,0(a5)
 	j	.L7
 .L4:
-	lbu	a2,1(t0)
-	lbu	a5,2(t0)
-	li	s0,126976
-	slli	a2,a2,8
-	slli	a5,a5,12
-	and	a5,a5,s0
-	andi	a2,a2,1792
-	or	a2,a2,a5
-	lbu	a4,8(a0)
-	lbu	a5,3(t0)
+	addi	s0,t1,%lo(xfer_shift_ctrl)
+	lbu	t0,1(s0)
+	lbu	a4,2(s0)
+	li	s1,126976
+	slli	t0,t0,8
+	slli	a4,a4,12
+	andi	t0,t0,1792
+	and	a4,a4,s1
+	or	a4,t0,a4
+	lbu	a5,8(a0)
+	lbu	t0,3(s0)
 	li	s0,3145728
-	addi	a4,a4,-1
-	slli	a5,a5,20
-	andi	a4,a4,0xff
-	and	a5,a5,s0
-	sb	a4,%lo(xfer_shift_ctrl)(t2)
-	or	a5,a2,a5
-	andi	a4,a4,63
-	or	a5,a5,a4
+	addi	a5,a5,-1
+	slli	t0,t0,20
+	andi	a5,a5,0xff
+	and	t0,t0,s0
+	sb	a5,%lo(xfer_shift_ctrl)(t1)
+	or	t0,a4,t0
+	andi	a5,a5,63
+	or	t0,t0,a5
  #APP
-	csrw 3019, a5
+	csrw 3019, t0
  #NO_APP
 	lw	a5,12(a0)
 .L7:
-	beq	a1,s1,.L8
+	lw	a4,0(sp)
+	beq	a1,a4,.L8
 .L9:
  #APP
 	csrr a4, 3022
  #NO_APP
 	andi	a4,a4,0xff
 	bne	a4,zero,.L9
-	lw	a4,4(sp)
+	lw	a4,8(sp)
  #APP
 	csrw 3043, a4
  #NO_APP
-	mv	s1,a1
 .L8:
 	lbu	a4,16(a0)
-	andi	a2,a4,0xff
+	andi	t0,a4,0xff
 	beq	a4,zero,.L10
-	li	a4,1
-	bne	a2,a4,.L11
+	bne	t0,t2,.L11
  #APP
 	csrw 3017, a5
  #NO_APP
 .L11:
-	bne	t1,zero,.L12
-	lw	a5,0(sp)
+	bne	a2,zero,.L12
+	lw	a5,4(sp)
 	lbu	a5,0(a5)
 	bne	a5,zero,.L12
 	mv	a5,a3
@@ -131,34 +131,35 @@ hrt_tx:
  #APP
 	csrw 2005, a3
  #NO_APP
-	lw	a5,0(sp)
-	li	a4,1
-	sb	a4,0(a5)
+	lw	a5,4(sp)
+	sb	t2,0(a5)
 .L12:
-	addi	t1,t1,1
+	addi	a2,a2,1
+	sw	a1,0(sp)
 	j	.L3
 .L5:
-	lbu	a2,1(t0)
-	lbu	a5,2(t0)
-	li	s0,126976
-	slli	a2,a2,8
-	slli	a5,a5,12
-	and	a5,a5,s0
-	andi	a2,a2,1792
-	or	a2,a2,a5
-	lbu	a4,9(a0)
-	lbu	a5,3(t0)
+	addi	s0,t1,%lo(xfer_shift_ctrl)
+	lbu	t0,1(s0)
+	lbu	a4,2(s0)
+	li	s1,126976
+	slli	t0,t0,8
+	slli	a4,a4,12
+	andi	t0,t0,1792
+	and	a4,a4,s1
+	or	a4,t0,a4
+	lbu	a5,9(a0)
+	lbu	t0,3(s0)
 	li	s0,3145728
-	addi	a4,a4,-1
-	slli	a5,a5,20
-	andi	a4,a4,0xff
-	and	a5,a5,s0
-	sb	a4,%lo(xfer_shift_ctrl)(t2)
-	or	a5,a2,a5
-	andi	a4,a4,63
-	or	a5,a5,a4
+	addi	a5,a5,-1
+	slli	t0,t0,20
+	andi	a5,a5,0xff
+	and	t0,t0,s0
+	sb	a5,%lo(xfer_shift_ctrl)(t1)
+	or	t0,a4,t0
+	andi	a5,a5,63
+	or	t0,t0,a5
  #APP
-	csrw 3019, a5
+	csrw 3019, t0
  #NO_APP
 	j	.L6
 .L10:
@@ -194,18 +195,22 @@ hrt_write:
 	bne	a5,a3,.L21
 	li	a5,3
 .L22:
-	li	a4,1
-	beq	a5,a4,.L23
-	li	a4,3
-	beq	a5,a4,.L24
-	li	a3,0
-	bne	a5,zero,.L25
-	lbu	a3,80(s0)
-.L43:
-	andi	a3,a3,0xff
-.L25:
-	lui	a4,%hi(xfer_shift_ctrl+2)
-	sb	a3,%lo(xfer_shift_ctrl+2)(a4)
+	lbu	a4,83(s0)
+	j	.L42
+.L20:
+	andi	a4,a5,0xff
+	li	a3,1
+	beq	a4,a3,.L23
+	li	a3,3
+	beq	a4,a3,.L22
+	bne	a4,zero,.L36
+	lbu	a4,80(s0)
+.L42:
+	andi	a4,a4,0xff
+	mv	a3,a4
+.L24:
+	lui	a2,%hi(xfer_shift_ctrl+2)
+	sb	a4,%lo(xfer_shift_ctrl+2)(a2)
  #APP
 	csrw 2000, 2
  #NO_APP
@@ -234,38 +239,36 @@ hrt_write:
 	li	a2,1
 	add	a5,s0,a5
 	lw	a4,4(a5)
-	beq	a4,a2,.L26
+	beq	a4,a2,.L25
 	li	a2,2
-	beq	a4,a2,.L27
+	beq	a4,a2,.L26
 	li	a5,32
 	div	a5,a5,a3
-	j	.L44
-.L20:
-	andi	a5,a5,0xff
-	j	.L22
+	j	.L43
 .L23:
-	lbu	a3,81(s0)
-	j	.L43
-.L24:
-	lbu	a3,83(s0)
-	j	.L43
-.L26:
+	lbu	a4,81(s0)
+	j	.L42
+.L36:
+	li	a4,0
+	li	a3,0
+	j	.L24
+.L25:
 	lbu	a5,8(a5)
-.L44:
+.L43:
  #APP
 	csrw 3022, a5
  #NO_APP
-	lbu	a5,88(s0)
-	lbu	a4,86(s0)
-	bne	a5,zero,.L30
+	lbu	a4,88(s0)
 	li	a5,1
+	bne	a4,zero,.L29
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrc 3008, a5
  #NO_APP
-.L31:
+.L30:
  #APP
 	csrr s1, 3008
  #NO_APP
@@ -290,30 +293,30 @@ hrt_write:
 	addi	a0,s0,60
 	call	hrt_tx
 	lbu	a5,92(s0)
-	bne	a5,zero,.L32
+	bne	a5,zero,.L31
 	li	a5,4096
 	addi	a5,a5,1
  #APP
 	csrw 3019, a5
  #NO_APP
-	li	a4,131072
-	slli	a5,s1,1
-	addi	a4,a4,-2
-	and	a5,a5,a4
+	li	a5,131072
+	addi	a5,a5,-2
+	slli	s1,s1,1
+	and	s1,s1,a5
  #APP
-	csrw 3012, a5
+	csrw 3012, s1
 	csrw 2000, 0
  #NO_APP
-.L33:
+.L32:
  #APP
 	csrw 2005, 0
  #NO_APP
 	lbu	a5,87(s0)
 	bne	a5,zero,.L19
-	lbu	a5,88(s0)
-	lbu	a4,86(s0)
-	bne	a5,zero,.L36
+	lbu	a4,88(s0)
 	li	a5,1
+	bne	a4,zero,.L35
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
@@ -326,24 +329,24 @@ hrt_write:
 	lw	s1,4(sp)
 	addi	sp,sp,16
 	jr	ra
-.L27:
+.L26:
 	lbu	a5,9(a5)
-	j	.L44
-.L30:
-	li	a5,1
+	j	.L43
+.L29:
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrs 3008, a5
  #NO_APP
-	j	.L31
-.L32:
+	j	.L30
+.L31:
  #APP
 	csrr a5, 3022
  #NO_APP
 	andi	a5,a5,0xff
-	bne	a5,zero,.L32
+	bne	a5,zero,.L31
  #APP
 	csrw 2000, 0
  #NO_APP
@@ -354,21 +357,21 @@ hrt_write:
  #NO_APP
 	lbu	a4,92(s0)
 	li	a5,1
-	bne	a4,a5,.L34
+	bne	a4,a5,.L33
  #APP
-	csrc 3008, 1
+	csrc 3008, a5
  #NO_APP
-	j	.L33
-.L34:
+	j	.L32
+.L33:
 	lbu	a4,92(s0)
 	li	a5,3
-	bne	a4,a5,.L33
+	bne	a4,a5,.L32
  #APP
 	csrs 3008, 1
  #NO_APP
-	j	.L33
-.L36:
-	li	a5,1
+	j	.L32
+.L35:
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
@@ -402,34 +405,34 @@ hrt_read:
 	andi	t1,t1,0xff
 	addi	s1,s1,-1
 	andi	s1,s1,0xff
-	bne	a0,a2,.L46
+	bne	a0,a2,.L45
 	lbu	a2,68(s0)
 	addi	a2,a2,-1
 	andi	a2,a2,0xff
 	sb	a2,68(s0)
-.L46:
-	lbu	a2,88(s0)
-	lbu	a0,86(s0)
-	bne	a2,zero,.L47
+.L45:
+	lbu	a0,88(s0)
 	li	a2,1
+	bne	a0,zero,.L46
+	lbu	a0,86(s0)
 	sll	a2,a2,a0
 	slli	a2,a2,16
 	srli	a2,a2,16
  #APP
 	csrc 3008, a2
  #NO_APP
-.L48:
+.L47:
  #APP
 	csrr a2, 3008
  #NO_APP
 	lw	a0,4(s0)
 	sw	a2,0(sp)
-	bne	a0,zero,.L49
+	bne	a0,zero,.L48
 	lw	a0,24(s0)
-	bne	a0,zero,.L49
+	bne	a0,zero,.L48
 	lw	a0,44(s0)
-	beq	a0,zero,.L50
-.L49:
+	beq	a0,zero,.L49
+.L48:
 	sw	zero,64(s0)
 	li	a0,1
 	sb	a0,87(s0)
@@ -445,17 +448,17 @@ hrt_read:
 	lw	a4,12(sp)
 	lw	a3,8(sp)
 	lw	a5,4(sp)
-.L50:
+.L49:
 	sw	a4,64(s0)
 	sb	t1,87(s0)
 	lbu	t0,83(s0)
 	li	t1,1
 	li	a0,4
-	bleu	t0,t1,.L51
+	bleu	t0,t1,.L50
 	lbu	t1,83(s0)
-	beq	t1,a0,.L79
+	beq	t1,a0,.L80
 	li	a0,6
-.L51:
+.L50:
  #APP
 	csrr t1, 3009
  #NO_APP
@@ -516,18 +519,18 @@ hrt_read:
 	csrw 3019, a0
 	csrw 3017, 0
  #NO_APP
-	li	a0,1
-	bne	a4,a0,.L52
-	lbu	t0,68(s0)
+	li	t1,1
 	li	a0,2
-	bne	t0,a0,.L53
+	bne	a4,t1,.L51
+	lbu	t1,68(s0)
+	bne	t1,a0,.L52
 	lhu	a4,84(s0)
 	li	a1,65536
 	or	a4,a4,a1
  #APP
 	csrw 2002, a4
  #NO_APP
-.L54:
+.L53:
  #APP
 	csrr a1, 2005
 	csrr a4, 2005
@@ -536,7 +539,7 @@ hrt_read:
 	slli	a4,a4,16
 	srli	a1,a1,16
 	srli	a4,a4,16
-	bne	a1,a4,.L54
+	bne	a1,a4,.L53
 	lw	a4,0(sp)
 	slli	a2,a4,24
  #APP
@@ -546,9 +549,9 @@ hrt_read:
  #NO_APP
 	lbu	a2,83(s0)
 	li	a3,8
-	bne	a2,a3,.L55
+	bne	a2,a3,.L54
 	srli	a4,a4,16
-.L92:
+.L95:
 	sw	a4,72(s0)
  #APP
 	csrw 2000, 0
@@ -560,51 +563,72 @@ hrt_read:
 	csrw 3019, s1
  #NO_APP
 	lbu	a5,87(s0)
-	bne	a5,zero,.L45
-	lbu	a5,88(s0)
-	lbu	a4,86(s0)
-	bne	a5,zero,.L77
+	bne	a5,zero,.L44
+	lbu	a4,88(s0)
 	li	a5,1
+	bne	a4,zero,.L78
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrs 3008, a5
  #NO_APP
-.L45:
+.L44:
 	lw	ra,32(sp)
 	lw	s0,28(sp)
 	lw	s1,24(sp)
 	addi	sp,sp,36
 	jr	ra
-.L47:
-	li	a2,1
+.L46:
+	lbu	a0,86(s0)
 	sll	a2,a2,a0
 	slli	a2,a2,16
 	srli	a2,a2,16
  #APP
 	csrs 3008, a2
  #NO_APP
-	j	.L48
-.L79:
+	j	.L47
+.L80:
 	li	a0,30
-	j	.L51
-.L55:
+	j	.L50
+.L54:
 	srli	a4,a4,24
+	j	.L95
+.L51:
+	bne	a4,a0,.L88
+	lbu	a0,69(s0)
 	j	.L92
 .L52:
-	li	a0,2
-	bne	a4,a0,.L87
-	lbu	a0,69(s0)
-	addi	a0,a0,-3
+	lbu	a0,68(s0)
+.L92:
+	addi	a0,a0,-1
+	addi	a0,a0,-2
 	andi	a0,a0,63
+	li	t1,2097152
 	or	a0,a0,a5
+	addi	t1,t1,1024
 	or	a0,a0,t1
  #APP
 	csrw 3019, a0
  #NO_APP
+	li	t1,1
+	addi	a0,a4,-1
+	beq	a0,t1,.L60
+	li	t1,2
+	beq	a0,t1,.L61
+	lbu	a0,83(s0)
+	li	s1,32
+	div	s1,s1,a0
+	j	.L93
+.L88:
+	lbu	t1,83(s0)
+	li	a0,32
+	div	a0,a0,t1
+	j	.L92
+.L60:
 	lbu	s1,68(s0)
-.L90:
+.L93:
 	lhu	a0,84(s0)
 	li	t1,65536
 	addi	s1,s1,-1
@@ -626,9 +650,9 @@ hrt_read:
 	addi	a4,a4,-2
 	li	t0,2
 	li	t2,32
-.L63:
-	bne	a4,a2,.L68
-.L69:
+.L64:
+	bne	a4,a2,.L69
+.L70:
  #APP
 	csrr a1, 2005
 	csrr a4, 2005
@@ -637,7 +661,7 @@ hrt_read:
 	slli	a4,a4,16
 	srli	a1,a1,16
 	srli	a4,a4,16
-	bne	a1,a4,.L69
+	bne	a1,a4,.L70
 	lw	a4,0(sp)
 	slli	a2,a4,24
  #APP
@@ -646,7 +670,7 @@ hrt_read:
  #NO_APP
 	lbu	a3,92(s0)
 	li	a4,3
-	bne	a3,a4,.L70
+	bne	a3,a4,.L71
  #APP
 	fence iorw,iorw
 	csrr a3, 3018
@@ -654,7 +678,7 @@ hrt_read:
  #NO_APP
 	lhu	a2,84(s0)
 	li	a4,35
-	bleu	a2,a4,.L71
+	bleu	a2,a4,.L72
  #APP
 	csrw 2000, 0
  #NO_APP
@@ -665,23 +689,23 @@ hrt_read:
  #APP
 	csrw 2005, a4
  #NO_APP
-.L71:
+.L72:
 	li	a4,65536
 	addi	a4,a4,-1
-.L72:
+.L73:
  #APP
 	csrr a2, 3010
  #NO_APP
 	slli	a2,a2,16
 	srli	a2,a2,16
-	beq	a2,a4,.L72
+	beq	a2,a4,.L73
 	lhu	a2,84(s0)
 	li	a4,35
-	bleu	a2,a4,.L73
+	bleu	a2,a4,.L74
  #APP
 	csrw 2010, 0
  #NO_APP
-.L73:
+.L74:
  #APP
 	csrr a2, 3010
  #NO_APP
@@ -690,28 +714,29 @@ hrt_read:
  #APP
 	csrs 3008, 1
  #NO_APP
-	lbu	a1,83(s0)
-	li	a4,4
-	beq	a1,a4,.L80
-	li	t1,2
-	li	t0,4
-.L74:
-	slli	a1,a3,24
+	lbu	a4,83(s0)
+	li	a1,4
+	li	t0,2
+	bne	a4,a1,.L75
+	li	t0,1
+	li	a1,30
+.L75:
+	slli	a0,a3,24
 	srli	a4,a3,24
-	or	a4,a4,a1
-	li	a1,65536
-	srli	a0,a3,8
-	addi	a1,a1,-256
-	and	a0,a0,a1
-	lbu	t2,83(s0)
 	or	a4,a4,a0
+	li	a0,65536
+	srli	t1,a3,8
+	addi	a0,a0,-256
+	and	t1,t1,a0
+	lbu	t2,83(s0)
+	or	a4,a4,t1
 	slli	a3,a3,8
-	li	a0,16711680
-	and	a3,a3,a0
+	li	t1,16711680
+	and	a3,a3,t1
 	or	a4,a4,a3
-	and	a2,a2,t0
+	and	a2,a2,a1
 	lbu	a3,68(s0)
-	sra	a2,a2,t1
+	sra	a2,a2,t0
 	sll	a4,a4,t2
 	or	a4,a4,a2
 	lbu	a2,83(s0)
@@ -724,55 +749,25 @@ hrt_read:
 	srli	a3,a4,24
 	or	a3,a3,a2
 	srli	a2,a4,8
-	and	a2,a2,a1
+	and	a2,a2,a0
 	slli	a4,a4,8
 	or	a3,a3,a2
-	and	a4,a4,a0
+	and	a4,a4,t1
 	or	a4,a3,a4
-	j	.L92
-.L53:
-	lbu	a0,68(s0)
-	addi	a0,a0,-3
-	andi	a0,a0,63
-	or	a0,a0,a5
-	or	a0,a0,t1
- #APP
-	csrw 3019, a0
- #NO_APP
-	li	a0,0
-.L60:
-	li	t1,2
-	bne	a0,t1,.L62
+	j	.L95
+.L61:
 	lbu	s1,69(s0)
-	j	.L90
-.L87:
-	lbu	t0,83(s0)
-	li	a0,32
-	div	a0,a0,t0
-	addi	a0,a0,-3
-	andi	a0,a0,63
-	or	a0,a0,a5
-	or	a0,a0,t1
- #APP
-	csrw 3019, a0
- #NO_APP
-	addi	a0,a4,-1
-	j	.L60
-.L62:
-	lbu	a0,83(s0)
-	li	s1,32
-	div	s1,s1,a0
-	j	.L90
-.L68:
+	j	.L93
+.L69:
 	li	a0,1
-	beq	a4,a0,.L64
-	beq	a4,t0,.L65
+	beq	a4,a0,.L65
+	beq	a4,t0,.L66
 	lbu	s1,83(s0)
 	div	s1,t2,s1
-	j	.L91
-.L64:
+	j	.L94
+.L65:
 	lbu	s1,68(s0)
-.L91:
+.L94:
 	addi	s1,s1,-1
 	andi	s1,s1,0xff
  #APP
@@ -787,15 +782,11 @@ hrt_read:
  #NO_APP
 	addi	a1,a1,4
 	addi	a4,a4,-1
-	j	.L63
-.L65:
+	j	.L64
+.L66:
 	lbu	s1,69(s0)
-	j	.L91
-.L80:
-	li	t1,1
-	li	t0,30
-	j	.L74
-.L70:
+	j	.L94
+.L71:
  #APP
 	csrr a4, 3018
  #NO_APP
@@ -805,16 +796,16 @@ hrt_read:
 	li	a3,32
 	sub	a3,a3,a2
 	srl	a4,a4,a3
-	j	.L92
-.L77:
-	li	a5,1
+	j	.L95
+.L78:
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrc 3008, a5
  #NO_APP
-	j	.L45
+	j	.L44
 	.size	hrt_read, .-hrt_read
 	.section	.sdata.xfer_shift_ctrl,"aw"
 	.align	2
@@ -825,3 +816,4 @@ xfer_shift_ctrl:
 	.byte	4
 	.byte	1
 	.byte	0
+	.section	.note.GNU-stack,"",@progbits

--- a/applications/hpf/mspi/src/hrt/hrt-nrf54lm20a.s
+++ b/applications/hpf/mspi/src/hrt/hrt-nrf54lm20a.s
@@ -1,6 +1,6 @@
 	.file	"hrt.c"
 	.option nopic
-	.attribute arch, "rv32e1p9_m2p0_c2p0_zicsr2p0"
+	.attribute arch, "rv32e2p0_m2p0_c2p0_zicsr2p0"
 	.attribute unaligned_access, 0
 	.attribute stack_align, 4
 	.text
@@ -9,32 +9,33 @@
 	.type	hrt_tx, @function
 hrt_tx:
 	lw	a5,4(a0)
-	addi	sp,sp,-16
-	sw	s0,12(sp)
-	sw	s1,8(sp)
-	sw	a2,0(sp)
+	addi	sp,sp,-20
+	sw	s0,16(sp)
+	sw	s1,12(sp)
+	sw	a2,4(sp)
 	beq	a5,zero,.L1
 	li	a4,32
 	div	a4,a4,a1
-	lui	t2,%hi(xfer_shift_ctrl)
-	addi	a2,t2,%lo(xfer_shift_ctrl)
-	lbu	s1,2(a2)
-	lbu	a5,1(a2)
+	lui	t1,%hi(xfer_shift_ctrl)
+	addi	a2,t1,%lo(xfer_shift_ctrl)
+	lbu	a5,2(a2)
 	sb	a1,2(a2)
+	li	t0,3145728
+	sw	a5,0(sp)
+	lbu	a5,1(a2)
 	lbu	a2,3(a2)
-	li	t1,3145728
 	slli	a5,a5,8
 	slli	a2,a2,20
-	and	a2,a2,t1
+	and	a2,a2,t0
 	andi	a5,a5,1792
 	or	a5,a5,a2
-	li	t1,126976
+	li	t0,126976
 	slli	a2,a1,12
-	and	a2,a2,t1
+	and	a2,a2,t0
 	or	a5,a5,a2
 	addi	a4,a4,-1
 	andi	a4,a4,0xff
-	sb	a4,%lo(xfer_shift_ctrl)(t2)
+	sb	a4,%lo(xfer_shift_ctrl)(t1)
 	andi	a4,a4,63
 	or	a5,a5,a4
  #APP
@@ -44,22 +45,21 @@ hrt_tx:
 	slli	a5,a1,16
 	and	a5,a5,a4
 	ori	a5,a5,4
-	sw	a5,4(sp)
-	li	t1,0
-	addi	t0,t2,%lo(xfer_shift_ctrl)
+	li	a2,0
+	li	t2,1
+	sw	a5,8(sp)
 .L3:
 	lw	a5,4(a0)
-	bltu	t1,a5,.L14
+	bltu	a2,a5,.L14
 .L1:
-	lw	s0,12(sp)
-	lw	s1,8(sp)
-	addi	sp,sp,16
+	lw	s0,16(sp)
+	lw	s1,12(sp)
+	addi	sp,sp,20
 	jr	ra
 .L14:
 	lw	a5,4(a0)
-	li	a4,1
-	sub	a5,a5,t1
-	beq	a5,a4,.L4
+	sub	a5,a5,a2
+	beq	a5,t2,.L4
 	li	a4,2
 	beq	a5,a4,.L5
 .L6:
@@ -67,59 +67,59 @@ hrt_tx:
 	li	a5,0
 	beq	a4,zero,.L7
 	lw	a5,0(a0)
-	slli	a4,t1,2
+	slli	a4,a2,2
 	add	a5,a5,a4
 	lw	a5,0(a5)
 	j	.L7
 .L4:
-	lbu	a2,1(t0)
-	lbu	a5,2(t0)
-	li	s0,126976
-	slli	a2,a2,8
-	slli	a5,a5,12
-	and	a5,a5,s0
-	andi	a2,a2,1792
-	or	a2,a2,a5
-	lbu	a4,8(a0)
-	lbu	a5,3(t0)
+	addi	s0,t1,%lo(xfer_shift_ctrl)
+	lbu	t0,1(s0)
+	lbu	a4,2(s0)
+	li	s1,126976
+	slli	t0,t0,8
+	slli	a4,a4,12
+	andi	t0,t0,1792
+	and	a4,a4,s1
+	or	a4,t0,a4
+	lbu	a5,8(a0)
+	lbu	t0,3(s0)
 	li	s0,3145728
-	addi	a4,a4,-1
-	slli	a5,a5,20
-	andi	a4,a4,0xff
-	and	a5,a5,s0
-	sb	a4,%lo(xfer_shift_ctrl)(t2)
-	or	a5,a2,a5
-	andi	a4,a4,63
-	or	a5,a5,a4
+	addi	a5,a5,-1
+	slli	t0,t0,20
+	andi	a5,a5,0xff
+	and	t0,t0,s0
+	sb	a5,%lo(xfer_shift_ctrl)(t1)
+	or	t0,a4,t0
+	andi	a5,a5,63
+	or	t0,t0,a5
  #APP
-	csrw 3019, a5
+	csrw 3019, t0
  #NO_APP
 	lw	a5,12(a0)
 .L7:
-	beq	a1,s1,.L8
+	lw	a4,0(sp)
+	beq	a1,a4,.L8
 .L9:
  #APP
 	csrr a4, 3022
  #NO_APP
 	andi	a4,a4,0xff
 	bne	a4,zero,.L9
-	lw	a4,4(sp)
+	lw	a4,8(sp)
  #APP
 	csrw 3043, a4
  #NO_APP
-	mv	s1,a1
 .L8:
 	lbu	a4,16(a0)
-	andi	a2,a4,0xff
+	andi	t0,a4,0xff
 	beq	a4,zero,.L10
-	li	a4,1
-	bne	a2,a4,.L11
+	bne	t0,t2,.L11
  #APP
 	csrw 3017, a5
  #NO_APP
 .L11:
-	bne	t1,zero,.L12
-	lw	a5,0(sp)
+	bne	a2,zero,.L12
+	lw	a5,4(sp)
 	lbu	a5,0(a5)
 	bne	a5,zero,.L12
 	mv	a5,a3
@@ -131,34 +131,35 @@ hrt_tx:
  #APP
 	csrw 2005, a3
  #NO_APP
-	lw	a5,0(sp)
-	li	a4,1
-	sb	a4,0(a5)
+	lw	a5,4(sp)
+	sb	t2,0(a5)
 .L12:
-	addi	t1,t1,1
+	addi	a2,a2,1
+	sw	a1,0(sp)
 	j	.L3
 .L5:
-	lbu	a2,1(t0)
-	lbu	a5,2(t0)
-	li	s0,126976
-	slli	a2,a2,8
-	slli	a5,a5,12
-	and	a5,a5,s0
-	andi	a2,a2,1792
-	or	a2,a2,a5
-	lbu	a4,9(a0)
-	lbu	a5,3(t0)
+	addi	s0,t1,%lo(xfer_shift_ctrl)
+	lbu	t0,1(s0)
+	lbu	a4,2(s0)
+	li	s1,126976
+	slli	t0,t0,8
+	slli	a4,a4,12
+	andi	t0,t0,1792
+	and	a4,a4,s1
+	or	a4,t0,a4
+	lbu	a5,9(a0)
+	lbu	t0,3(s0)
 	li	s0,3145728
-	addi	a4,a4,-1
-	slli	a5,a5,20
-	andi	a4,a4,0xff
-	and	a5,a5,s0
-	sb	a4,%lo(xfer_shift_ctrl)(t2)
-	or	a5,a2,a5
-	andi	a4,a4,63
-	or	a5,a5,a4
+	addi	a5,a5,-1
+	slli	t0,t0,20
+	andi	a5,a5,0xff
+	and	t0,t0,s0
+	sb	a5,%lo(xfer_shift_ctrl)(t1)
+	or	t0,a4,t0
+	andi	a5,a5,63
+	or	t0,t0,a5
  #APP
-	csrw 3019, a5
+	csrw 3019, t0
  #NO_APP
 	j	.L6
 .L10:
@@ -194,18 +195,22 @@ hrt_write:
 	bne	a5,a3,.L21
 	li	a5,3
 .L22:
-	li	a4,1
-	beq	a5,a4,.L23
-	li	a4,3
-	beq	a5,a4,.L24
-	li	a3,0
-	bne	a5,zero,.L25
-	lbu	a3,80(s0)
-.L43:
-	andi	a3,a3,0xff
-.L25:
-	lui	a4,%hi(xfer_shift_ctrl+2)
-	sb	a3,%lo(xfer_shift_ctrl+2)(a4)
+	lbu	a4,83(s0)
+	j	.L42
+.L20:
+	andi	a4,a5,0xff
+	li	a3,1
+	beq	a4,a3,.L23
+	li	a3,3
+	beq	a4,a3,.L22
+	bne	a4,zero,.L36
+	lbu	a4,80(s0)
+.L42:
+	andi	a4,a4,0xff
+	mv	a3,a4
+.L24:
+	lui	a2,%hi(xfer_shift_ctrl+2)
+	sb	a4,%lo(xfer_shift_ctrl+2)(a2)
  #APP
 	csrw 2000, 2
  #NO_APP
@@ -234,38 +239,36 @@ hrt_write:
 	li	a2,1
 	add	a5,s0,a5
 	lw	a4,4(a5)
-	beq	a4,a2,.L26
+	beq	a4,a2,.L25
 	li	a2,2
-	beq	a4,a2,.L27
+	beq	a4,a2,.L26
 	li	a5,32
 	div	a5,a5,a3
-	j	.L44
-.L20:
-	andi	a5,a5,0xff
-	j	.L22
+	j	.L43
 .L23:
-	lbu	a3,81(s0)
-	j	.L43
-.L24:
-	lbu	a3,83(s0)
-	j	.L43
-.L26:
+	lbu	a4,81(s0)
+	j	.L42
+.L36:
+	li	a4,0
+	li	a3,0
+	j	.L24
+.L25:
 	lbu	a5,8(a5)
-.L44:
+.L43:
  #APP
 	csrw 3022, a5
  #NO_APP
-	lbu	a5,88(s0)
-	lbu	a4,86(s0)
-	bne	a5,zero,.L30
+	lbu	a4,88(s0)
 	li	a5,1
+	bne	a4,zero,.L29
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrc 3008, a5
  #NO_APP
-.L31:
+.L30:
  #APP
 	csrr s1, 3008
  #NO_APP
@@ -290,30 +293,30 @@ hrt_write:
 	addi	a0,s0,60
 	call	hrt_tx
 	lbu	a5,92(s0)
-	bne	a5,zero,.L32
+	bne	a5,zero,.L31
 	li	a5,4096
 	addi	a5,a5,1
  #APP
 	csrw 3019, a5
  #NO_APP
-	li	a4,131072
-	slli	a5,s1,1
-	addi	a4,a4,-2
-	and	a5,a5,a4
+	li	a5,131072
+	addi	a5,a5,-2
+	slli	s1,s1,1
+	and	s1,s1,a5
  #APP
-	csrw 3012, a5
+	csrw 3012, s1
 	csrw 2000, 0
  #NO_APP
-.L33:
+.L32:
  #APP
 	csrw 2005, 0
  #NO_APP
 	lbu	a5,87(s0)
 	bne	a5,zero,.L19
-	lbu	a5,88(s0)
-	lbu	a4,86(s0)
-	bne	a5,zero,.L36
+	lbu	a4,88(s0)
 	li	a5,1
+	bne	a4,zero,.L35
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
@@ -326,24 +329,24 @@ hrt_write:
 	lw	s1,4(sp)
 	addi	sp,sp,16
 	jr	ra
-.L27:
+.L26:
 	lbu	a5,9(a5)
-	j	.L44
-.L30:
-	li	a5,1
+	j	.L43
+.L29:
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrs 3008, a5
  #NO_APP
-	j	.L31
-.L32:
+	j	.L30
+.L31:
  #APP
 	csrr a5, 3022
  #NO_APP
 	andi	a5,a5,0xff
-	bne	a5,zero,.L32
+	bne	a5,zero,.L31
  #APP
 	csrw 2000, 0
  #NO_APP
@@ -354,21 +357,21 @@ hrt_write:
  #NO_APP
 	lbu	a4,92(s0)
 	li	a5,1
-	bne	a4,a5,.L34
+	bne	a4,a5,.L33
  #APP
-	csrc 3008, 1
+	csrc 3008, a5
  #NO_APP
-	j	.L33
-.L34:
+	j	.L32
+.L33:
 	lbu	a4,92(s0)
 	li	a5,3
-	bne	a4,a5,.L33
+	bne	a4,a5,.L32
  #APP
 	csrs 3008, 1
  #NO_APP
-	j	.L33
-.L36:
-	li	a5,1
+	j	.L32
+.L35:
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
@@ -392,30 +395,30 @@ hrt_read:
 	lw	s1,64(a0)
 	lbu	a3,87(a0)
 	lw	a2,60(a0)
-	lbu	a5,88(a0)
-	lbu	a1,86(a0)
+	lbu	a1,88(a0)
 	mv	s0,a0
 	andi	a4,a4,0xff
 	andi	a3,a3,0xff
-	bne	a5,zero,.L46
 	li	a5,1
+	bne	a1,zero,.L45
+	lbu	a1,86(a0)
 	sll	a5,a5,a1
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrc 3008, a5
  #NO_APP
-.L47:
+.L46:
  #APP
 	csrr a5, 3008
  #NO_APP
 	lw	a5,4(s0)
-	bne	a5,zero,.L48
+	bne	a5,zero,.L47
 	lw	a5,24(s0)
-	bne	a5,zero,.L48
+	bne	a5,zero,.L47
 	lw	a5,44(s0)
-	beq	a5,zero,.L49
-.L48:
+	beq	a5,zero,.L48
+.L47:
 	sw	zero,64(s0)
 	li	a5,1
 	sb	a5,87(s0)
@@ -427,7 +430,7 @@ hrt_read:
 	lw	a2,8(sp)
 	lw	a3,4(sp)
 	lw	a4,0(sp)
-.L49:
+.L48:
 	sw	s1,64(s0)
 	sb	a3,87(s0)
  #APP
@@ -437,11 +440,11 @@ hrt_read:
 	lbu	a1,83(s0)
 	li	a3,1
 	li	a5,4
-	bleu	a1,a3,.L50
+	bleu	a1,a3,.L49
 	lbu	a3,83(s0)
-	beq	a3,a5,.L70
+	beq	a3,a5,.L69
 	li	a5,6
-.L50:
+.L49:
  #APP
 	csrr a3, 3009
  #NO_APP
@@ -464,28 +467,28 @@ hrt_read:
 	csrw 3043, a5
  #NO_APP
 	li	a5,1
-	beq	s1,a5,.L51
+	beq	s1,a5,.L50
 	li	a5,2
-	beq	s1,a5,.L52
+	beq	s1,a5,.L51
 	lbu	a3,83(s0)
 	li	a5,32
 	div	a5,a5,a3
-	j	.L81
-.L46:
-	li	a5,1
+	j	.L80
+.L45:
+	lbu	a1,86(a0)
 	sll	a5,a5,a1
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrs 3008, a5
  #NO_APP
-	j	.L47
-.L70:
+	j	.L46
+.L69:
 	li	a5,30
-	j	.L50
-.L51:
+	j	.L49
+.L50:
 	lbu	a5,68(s0)
-.L81:
+.L80:
 	addi	a5,a5,-1
 	andi	a5,a5,255
  #APP
@@ -535,45 +538,45 @@ hrt_read:
 	addi	a3,s1,-1
 	li	a0,2
 	li	t1,32
-.L55:
-	bne	a3,zero,.L60
+.L54:
+	bne	a3,zero,.L59
  #APP
 	csrw 3023, 0
  #NO_APP
-.L61:
+.L60:
  #APP
 	csrr a5, 3021
  #NO_APP
 	andi	a5,a5,0xff
-	bne	a5,zero,.L61
+	bne	a5,zero,.L60
  #APP
 	csrw 2010, 0
  #NO_APP
 	lbu	a5,92(s0)
-	beq	a5,zero,.L62
+	beq	a5,zero,.L61
 	lbu	a3,92(s0)
 	li	a5,2
-	bne	a3,a5,.L63
-.L62:
+	bne	a3,a5,.L62
+.L61:
  #APP
 	csrw 2010, 0
  #NO_APP
-.L63:
+.L62:
  #APP
 	csrw 2000, 0
 	csrw 2001, 0
 	csrr a5, 3018
  #NO_APP
 	li	a3,1
-	bne	s1,a3,.L64
+	bne	s1,a3,.L63
 	lbu	a2,68(s0)
 	li	a3,2
-	bne	a2,a3,.L64
+	bne	a2,a3,.L63
 	lbu	a2,83(s0)
 	li	a3,8
-	bne	a2,a3,.L65
+	bne	a2,a3,.L64
 	srli	a5,a5,16
-.L83:
+.L82:
 	sw	a5,72(s0)
  #APP
 	csrw 2010, 0
@@ -582,35 +585,35 @@ hrt_read:
 	csrw 3011, 0
  #NO_APP
 	lbu	a5,87(s0)
-	bne	a5,zero,.L45
-	lbu	a5,88(s0)
-	lbu	a4,86(s0)
-	bne	a5,zero,.L68
+	bne	a5,zero,.L44
+	lbu	a4,88(s0)
 	li	a5,1
+	bne	a4,zero,.L67
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrs 3008, a5
  #NO_APP
-.L45:
+.L44:
 	lw	ra,20(sp)
 	lw	s0,16(sp)
 	lw	s1,12(sp)
 	addi	sp,sp,24
 	jr	ra
-.L52:
+.L51:
 	lbu	a5,69(s0)
-	j	.L81
-.L60:
-	beq	a3,a1,.L56
-	beq	a3,a0,.L57
+	j	.L80
+.L59:
+	beq	a3,a1,.L55
+	beq	a3,a0,.L56
 	lbu	a5,83(s0)
 	div	a5,t1,a5
-	j	.L82
-.L56:
+	j	.L81
+.L55:
 	lbu	a5,68(s0)
-.L82:
+.L81:
 	addi	a5,a5,-1
 	andi	a5,a5,255
  #APP
@@ -620,30 +623,30 @@ hrt_read:
 	sw	a5,0(a2)
 	addi	a3,a3,-1
 	addi	a2,a2,4
-	j	.L55
-.L57:
+	j	.L54
+.L56:
 	lbu	a5,69(s0)
-	j	.L82
-.L65:
-	srli	a5,a5,24
-	j	.L83
+	j	.L81
 .L64:
+	srli	a5,a5,24
+	j	.L82
+.L63:
 	lbu	a2,68(s0)
 	lbu	a3,83(s0)
 	mul	a2,a2,a3
 	li	a3,32
 	sub	a3,a3,a2
 	srl	a5,a5,a3
-	j	.L83
-.L68:
-	li	a5,1
+	j	.L82
+.L67:
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrc 3008, a5
  #NO_APP
-	j	.L45
+	j	.L44
 	.size	hrt_read, .-hrt_read
 	.section	.sdata.xfer_shift_ctrl,"aw"
 	.align	2
@@ -654,3 +657,4 @@ xfer_shift_ctrl:
 	.byte	4
 	.byte	1
 	.byte	0
+	.section	.note.GNU-stack,"",@progbits

--- a/applications/hpf/mspi/src/hrt/hrt-nrf54lm20b.s
+++ b/applications/hpf/mspi/src/hrt/hrt-nrf54lm20b.s
@@ -1,6 +1,6 @@
 	.file	"hrt.c"
 	.option nopic
-	.attribute arch, "rv32e1p9_m2p0_c2p0_zicsr2p0"
+	.attribute arch, "rv32e2p0_m2p0_c2p0_zicsr2p0"
 	.attribute unaligned_access, 0
 	.attribute stack_align, 4
 	.text
@@ -9,32 +9,33 @@
 	.type	hrt_tx, @function
 hrt_tx:
 	lw	a5,4(a0)
-	addi	sp,sp,-16
-	sw	s0,12(sp)
-	sw	s1,8(sp)
-	sw	a2,0(sp)
+	addi	sp,sp,-20
+	sw	s0,16(sp)
+	sw	s1,12(sp)
+	sw	a2,4(sp)
 	beq	a5,zero,.L1
 	li	a4,32
 	div	a4,a4,a1
-	lui	t2,%hi(xfer_shift_ctrl)
-	addi	a2,t2,%lo(xfer_shift_ctrl)
-	lbu	s1,2(a2)
-	lbu	a5,1(a2)
+	lui	t1,%hi(xfer_shift_ctrl)
+	addi	a2,t1,%lo(xfer_shift_ctrl)
+	lbu	a5,2(a2)
 	sb	a1,2(a2)
+	li	t0,3145728
+	sw	a5,0(sp)
+	lbu	a5,1(a2)
 	lbu	a2,3(a2)
-	li	t1,3145728
 	slli	a5,a5,8
 	slli	a2,a2,20
-	and	a2,a2,t1
+	and	a2,a2,t0
 	andi	a5,a5,1792
 	or	a5,a5,a2
-	li	t1,126976
+	li	t0,126976
 	slli	a2,a1,12
-	and	a2,a2,t1
+	and	a2,a2,t0
 	or	a5,a5,a2
 	addi	a4,a4,-1
 	andi	a4,a4,0xff
-	sb	a4,%lo(xfer_shift_ctrl)(t2)
+	sb	a4,%lo(xfer_shift_ctrl)(t1)
 	andi	a4,a4,63
 	or	a5,a5,a4
  #APP
@@ -44,22 +45,21 @@ hrt_tx:
 	slli	a5,a1,16
 	and	a5,a5,a4
 	ori	a5,a5,4
-	sw	a5,4(sp)
-	li	t1,0
-	addi	t0,t2,%lo(xfer_shift_ctrl)
+	li	a2,0
+	li	t2,1
+	sw	a5,8(sp)
 .L3:
 	lw	a5,4(a0)
-	bltu	t1,a5,.L14
+	bltu	a2,a5,.L14
 .L1:
-	lw	s0,12(sp)
-	lw	s1,8(sp)
-	addi	sp,sp,16
+	lw	s0,16(sp)
+	lw	s1,12(sp)
+	addi	sp,sp,20
 	jr	ra
 .L14:
 	lw	a5,4(a0)
-	li	a4,1
-	sub	a5,a5,t1
-	beq	a5,a4,.L4
+	sub	a5,a5,a2
+	beq	a5,t2,.L4
 	li	a4,2
 	beq	a5,a4,.L5
 .L6:
@@ -67,59 +67,59 @@ hrt_tx:
 	li	a5,0
 	beq	a4,zero,.L7
 	lw	a5,0(a0)
-	slli	a4,t1,2
+	slli	a4,a2,2
 	add	a5,a5,a4
 	lw	a5,0(a5)
 	j	.L7
 .L4:
-	lbu	a2,1(t0)
-	lbu	a5,2(t0)
-	li	s0,126976
-	slli	a2,a2,8
-	slli	a5,a5,12
-	and	a5,a5,s0
-	andi	a2,a2,1792
-	or	a2,a2,a5
-	lbu	a4,8(a0)
-	lbu	a5,3(t0)
+	addi	s0,t1,%lo(xfer_shift_ctrl)
+	lbu	t0,1(s0)
+	lbu	a4,2(s0)
+	li	s1,126976
+	slli	t0,t0,8
+	slli	a4,a4,12
+	andi	t0,t0,1792
+	and	a4,a4,s1
+	or	a4,t0,a4
+	lbu	a5,8(a0)
+	lbu	t0,3(s0)
 	li	s0,3145728
-	addi	a4,a4,-1
-	slli	a5,a5,20
-	andi	a4,a4,0xff
-	and	a5,a5,s0
-	sb	a4,%lo(xfer_shift_ctrl)(t2)
-	or	a5,a2,a5
-	andi	a4,a4,63
-	or	a5,a5,a4
+	addi	a5,a5,-1
+	slli	t0,t0,20
+	andi	a5,a5,0xff
+	and	t0,t0,s0
+	sb	a5,%lo(xfer_shift_ctrl)(t1)
+	or	t0,a4,t0
+	andi	a5,a5,63
+	or	t0,t0,a5
  #APP
-	csrw 3019, a5
+	csrw 3019, t0
  #NO_APP
 	lw	a5,12(a0)
 .L7:
-	beq	a1,s1,.L8
+	lw	a4,0(sp)
+	beq	a1,a4,.L8
 .L9:
  #APP
 	csrr a4, 3022
  #NO_APP
 	andi	a4,a4,0xff
 	bne	a4,zero,.L9
-	lw	a4,4(sp)
+	lw	a4,8(sp)
  #APP
 	csrw 3043, a4
  #NO_APP
-	mv	s1,a1
 .L8:
 	lbu	a4,16(a0)
-	andi	a2,a4,0xff
+	andi	t0,a4,0xff
 	beq	a4,zero,.L10
-	li	a4,1
-	bne	a2,a4,.L11
+	bne	t0,t2,.L11
  #APP
 	csrw 3017, a5
  #NO_APP
 .L11:
-	bne	t1,zero,.L12
-	lw	a5,0(sp)
+	bne	a2,zero,.L12
+	lw	a5,4(sp)
 	lbu	a5,0(a5)
 	bne	a5,zero,.L12
 	mv	a5,a3
@@ -131,34 +131,35 @@ hrt_tx:
  #APP
 	csrw 2005, a3
  #NO_APP
-	lw	a5,0(sp)
-	li	a4,1
-	sb	a4,0(a5)
+	lw	a5,4(sp)
+	sb	t2,0(a5)
 .L12:
-	addi	t1,t1,1
+	addi	a2,a2,1
+	sw	a1,0(sp)
 	j	.L3
 .L5:
-	lbu	a2,1(t0)
-	lbu	a5,2(t0)
-	li	s0,126976
-	slli	a2,a2,8
-	slli	a5,a5,12
-	and	a5,a5,s0
-	andi	a2,a2,1792
-	or	a2,a2,a5
-	lbu	a4,9(a0)
-	lbu	a5,3(t0)
+	addi	s0,t1,%lo(xfer_shift_ctrl)
+	lbu	t0,1(s0)
+	lbu	a4,2(s0)
+	li	s1,126976
+	slli	t0,t0,8
+	slli	a4,a4,12
+	andi	t0,t0,1792
+	and	a4,a4,s1
+	or	a4,t0,a4
+	lbu	a5,9(a0)
+	lbu	t0,3(s0)
 	li	s0,3145728
-	addi	a4,a4,-1
-	slli	a5,a5,20
-	andi	a4,a4,0xff
-	and	a5,a5,s0
-	sb	a4,%lo(xfer_shift_ctrl)(t2)
-	or	a5,a2,a5
-	andi	a4,a4,63
-	or	a5,a5,a4
+	addi	a5,a5,-1
+	slli	t0,t0,20
+	andi	a5,a5,0xff
+	and	t0,t0,s0
+	sb	a5,%lo(xfer_shift_ctrl)(t1)
+	or	t0,a4,t0
+	andi	a5,a5,63
+	or	t0,t0,a5
  #APP
-	csrw 3019, a5
+	csrw 3019, t0
  #NO_APP
 	j	.L6
 .L10:
@@ -194,18 +195,22 @@ hrt_write:
 	bne	a5,a3,.L21
 	li	a5,3
 .L22:
-	li	a4,1
-	beq	a5,a4,.L23
-	li	a4,3
-	beq	a5,a4,.L24
-	li	a3,0
-	bne	a5,zero,.L25
-	lbu	a3,80(s0)
-.L43:
-	andi	a3,a3,0xff
-.L25:
-	lui	a4,%hi(xfer_shift_ctrl+2)
-	sb	a3,%lo(xfer_shift_ctrl+2)(a4)
+	lbu	a4,83(s0)
+	j	.L42
+.L20:
+	andi	a4,a5,0xff
+	li	a3,1
+	beq	a4,a3,.L23
+	li	a3,3
+	beq	a4,a3,.L22
+	bne	a4,zero,.L36
+	lbu	a4,80(s0)
+.L42:
+	andi	a4,a4,0xff
+	mv	a3,a4
+.L24:
+	lui	a2,%hi(xfer_shift_ctrl+2)
+	sb	a4,%lo(xfer_shift_ctrl+2)(a2)
  #APP
 	csrw 2000, 2
  #NO_APP
@@ -234,38 +239,36 @@ hrt_write:
 	li	a2,1
 	add	a5,s0,a5
 	lw	a4,4(a5)
-	beq	a4,a2,.L26
+	beq	a4,a2,.L25
 	li	a2,2
-	beq	a4,a2,.L27
+	beq	a4,a2,.L26
 	li	a5,32
 	div	a5,a5,a3
-	j	.L44
-.L20:
-	andi	a5,a5,0xff
-	j	.L22
+	j	.L43
 .L23:
-	lbu	a3,81(s0)
-	j	.L43
-.L24:
-	lbu	a3,83(s0)
-	j	.L43
-.L26:
+	lbu	a4,81(s0)
+	j	.L42
+.L36:
+	li	a4,0
+	li	a3,0
+	j	.L24
+.L25:
 	lbu	a5,8(a5)
-.L44:
+.L43:
  #APP
 	csrw 3022, a5
  #NO_APP
-	lbu	a5,88(s0)
-	lbu	a4,86(s0)
-	bne	a5,zero,.L30
+	lbu	a4,88(s0)
 	li	a5,1
+	bne	a4,zero,.L29
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrc 3008, a5
  #NO_APP
-.L31:
+.L30:
  #APP
 	csrr s1, 3008
  #NO_APP
@@ -290,30 +293,30 @@ hrt_write:
 	addi	a0,s0,60
 	call	hrt_tx
 	lbu	a5,92(s0)
-	bne	a5,zero,.L32
+	bne	a5,zero,.L31
 	li	a5,4096
 	addi	a5,a5,1
  #APP
 	csrw 3019, a5
  #NO_APP
-	li	a4,131072
-	slli	a5,s1,1
-	addi	a4,a4,-2
-	and	a5,a5,a4
+	li	a5,131072
+	addi	a5,a5,-2
+	slli	s1,s1,1
+	and	s1,s1,a5
  #APP
-	csrw 3012, a5
+	csrw 3012, s1
 	csrw 2000, 0
  #NO_APP
-.L33:
+.L32:
  #APP
 	csrw 2005, 0
  #NO_APP
 	lbu	a5,87(s0)
 	bne	a5,zero,.L19
-	lbu	a5,88(s0)
-	lbu	a4,86(s0)
-	bne	a5,zero,.L36
+	lbu	a4,88(s0)
 	li	a5,1
+	bne	a4,zero,.L35
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
@@ -326,24 +329,24 @@ hrt_write:
 	lw	s1,4(sp)
 	addi	sp,sp,16
 	jr	ra
-.L27:
+.L26:
 	lbu	a5,9(a5)
-	j	.L44
-.L30:
-	li	a5,1
+	j	.L43
+.L29:
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrs 3008, a5
  #NO_APP
-	j	.L31
-.L32:
+	j	.L30
+.L31:
  #APP
 	csrr a5, 3022
  #NO_APP
 	andi	a5,a5,0xff
-	bne	a5,zero,.L32
+	bne	a5,zero,.L31
  #APP
 	csrw 2000, 0
  #NO_APP
@@ -354,21 +357,21 @@ hrt_write:
  #NO_APP
 	lbu	a4,92(s0)
 	li	a5,1
-	bne	a4,a5,.L34
+	bne	a4,a5,.L33
  #APP
-	csrc 3008, 1
+	csrc 3008, a5
  #NO_APP
-	j	.L33
-.L34:
+	j	.L32
+.L33:
 	lbu	a4,92(s0)
 	li	a5,3
-	bne	a4,a5,.L33
+	bne	a4,a5,.L32
  #APP
 	csrs 3008, 1
  #NO_APP
-	j	.L33
-.L36:
-	li	a5,1
+	j	.L32
+.L35:
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
@@ -392,30 +395,30 @@ hrt_read:
 	lw	s1,64(a0)
 	lbu	a3,87(a0)
 	lw	a2,60(a0)
-	lbu	a5,88(a0)
-	lbu	a1,86(a0)
+	lbu	a1,88(a0)
 	mv	s0,a0
 	andi	a4,a4,0xff
 	andi	a3,a3,0xff
-	bne	a5,zero,.L46
 	li	a5,1
+	bne	a1,zero,.L45
+	lbu	a1,86(a0)
 	sll	a5,a5,a1
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrc 3008, a5
  #NO_APP
-.L47:
+.L46:
  #APP
 	csrr a5, 3008
  #NO_APP
 	lw	a5,4(s0)
-	bne	a5,zero,.L48
+	bne	a5,zero,.L47
 	lw	a5,24(s0)
-	bne	a5,zero,.L48
+	bne	a5,zero,.L47
 	lw	a5,44(s0)
-	beq	a5,zero,.L49
-.L48:
+	beq	a5,zero,.L48
+.L47:
 	sw	zero,64(s0)
 	li	a5,1
 	sb	a5,87(s0)
@@ -427,7 +430,7 @@ hrt_read:
 	lw	a2,8(sp)
 	lw	a3,4(sp)
 	lw	a4,0(sp)
-.L49:
+.L48:
 	sw	s1,64(s0)
 	sb	a3,87(s0)
  #APP
@@ -437,11 +440,11 @@ hrt_read:
 	lbu	a1,83(s0)
 	li	a3,1
 	li	a5,4
-	bleu	a1,a3,.L50
+	bleu	a1,a3,.L49
 	lbu	a3,83(s0)
-	beq	a3,a5,.L70
+	beq	a3,a5,.L69
 	li	a5,6
-.L50:
+.L49:
  #APP
 	csrr a3, 3009
  #NO_APP
@@ -464,28 +467,28 @@ hrt_read:
 	csrw 3043, a5
  #NO_APP
 	li	a5,1
-	beq	s1,a5,.L51
+	beq	s1,a5,.L50
 	li	a5,2
-	beq	s1,a5,.L52
+	beq	s1,a5,.L51
 	lbu	a3,83(s0)
 	li	a5,32
 	div	a5,a5,a3
-	j	.L81
-.L46:
-	li	a5,1
+	j	.L80
+.L45:
+	lbu	a1,86(a0)
 	sll	a5,a5,a1
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrs 3008, a5
  #NO_APP
-	j	.L47
-.L70:
+	j	.L46
+.L69:
 	li	a5,30
-	j	.L50
-.L51:
+	j	.L49
+.L50:
 	lbu	a5,68(s0)
-.L81:
+.L80:
 	addi	a5,a5,-1
 	andi	a5,a5,255
  #APP
@@ -535,45 +538,45 @@ hrt_read:
 	addi	a3,s1,-1
 	li	a0,2
 	li	t1,32
-.L55:
-	bne	a3,zero,.L60
+.L54:
+	bne	a3,zero,.L59
  #APP
 	csrw 3023, 0
  #NO_APP
-.L61:
+.L60:
  #APP
 	csrr a5, 3021
  #NO_APP
 	andi	a5,a5,0xff
-	bne	a5,zero,.L61
+	bne	a5,zero,.L60
  #APP
 	csrw 2010, 0
  #NO_APP
 	lbu	a5,92(s0)
-	beq	a5,zero,.L62
+	beq	a5,zero,.L61
 	lbu	a3,92(s0)
 	li	a5,2
-	bne	a3,a5,.L63
-.L62:
+	bne	a3,a5,.L62
+.L61:
  #APP
 	csrw 2010, 0
  #NO_APP
-.L63:
+.L62:
  #APP
 	csrw 2000, 0
 	csrw 2001, 0
 	csrr a5, 3018
  #NO_APP
 	li	a3,1
-	bne	s1,a3,.L64
+	bne	s1,a3,.L63
 	lbu	a2,68(s0)
 	li	a3,2
-	bne	a2,a3,.L64
+	bne	a2,a3,.L63
 	lbu	a2,83(s0)
 	li	a3,8
-	bne	a2,a3,.L65
+	bne	a2,a3,.L64
 	srli	a5,a5,16
-.L83:
+.L82:
 	sw	a5,72(s0)
  #APP
 	csrw 2010, 0
@@ -582,35 +585,35 @@ hrt_read:
 	csrw 3011, 0
  #NO_APP
 	lbu	a5,87(s0)
-	bne	a5,zero,.L45
-	lbu	a5,88(s0)
-	lbu	a4,86(s0)
-	bne	a5,zero,.L68
+	bne	a5,zero,.L44
+	lbu	a4,88(s0)
 	li	a5,1
+	bne	a4,zero,.L67
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrs 3008, a5
  #NO_APP
-.L45:
+.L44:
 	lw	ra,20(sp)
 	lw	s0,16(sp)
 	lw	s1,12(sp)
 	addi	sp,sp,24
 	jr	ra
-.L52:
+.L51:
 	lbu	a5,69(s0)
-	j	.L81
-.L60:
-	beq	a3,a1,.L56
-	beq	a3,a0,.L57
+	j	.L80
+.L59:
+	beq	a3,a1,.L55
+	beq	a3,a0,.L56
 	lbu	a5,83(s0)
 	div	a5,t1,a5
-	j	.L82
-.L56:
+	j	.L81
+.L55:
 	lbu	a5,68(s0)
-.L82:
+.L81:
 	addi	a5,a5,-1
 	andi	a5,a5,255
  #APP
@@ -620,30 +623,30 @@ hrt_read:
 	sw	a5,0(a2)
 	addi	a3,a3,-1
 	addi	a2,a2,4
-	j	.L55
-.L57:
+	j	.L54
+.L56:
 	lbu	a5,69(s0)
-	j	.L82
-.L65:
-	srli	a5,a5,24
-	j	.L83
+	j	.L81
 .L64:
+	srli	a5,a5,24
+	j	.L82
+.L63:
 	lbu	a2,68(s0)
 	lbu	a3,83(s0)
 	mul	a2,a2,a3
 	li	a3,32
 	sub	a3,a3,a2
 	srl	a5,a5,a3
-	j	.L83
-.L68:
-	li	a5,1
+	j	.L82
+.L67:
+	lbu	a4,86(s0)
 	sll	a5,a5,a4
 	slli	a5,a5,16
 	srli	a5,a5,16
  #APP
 	csrc 3008, a5
  #NO_APP
-	j	.L45
+	j	.L44
 	.size	hrt_read, .-hrt_read
 	.section	.sdata.xfer_shift_ctrl,"aw"
 	.align	2
@@ -654,3 +657,4 @@ xfer_shift_ctrl:
 	.byte	4
 	.byte	1
 	.byte	0
+	.section	.note.GNU-stack,"",@progbits


### PR DESCRIPTION
Upgrading the zephyr-SDK version to 1.0.1 requires updating the assembler files.