### PR TITLE
samples: bluetooth: peripheral_power_profiling: fix expected log

### DIFF
--- a/samples/bluetooth/peripheral_power_profiling/sample.yaml
+++ b/samples/bluetooth/peripheral_power_profiling/sample.yaml
@@ -267,9 +267,7 @@ tests:
       ordered: true
       regex:
         - "Starting Bluetooth Power Profiling sample"
-        - |
-          ".*(Power-on reset|Application soft reset detected|Reset from pin-reset|"
-          "System reset from different reason).*"
+        - "Reset from pin-reset"
     timeout: 30
 
   sample.bluetooth.peripheral_power_profiling.llvm:


### PR DESCRIPTION
At CI, where this regex is used, there is always pin reset, as by default this is last action after west flash. Other console output would be an error.

Beside that, twister seems to not handle properly multiline regex definition and that one was failing to match.