### PR TITLE
[Backport v3.3-branch] samples: bluetooth: peripheral_power_profiling: fix expected log

### DIFF
--- a/samples/bluetooth/peripheral_power_profiling/sample.yaml
+++ b/samples/bluetooth/peripheral_power_profiling/sample.yaml
@@ -242,9 +242,7 @@ tests:
       ordered: true
       regex:
         - "Starting Bluetooth Power Profiling sample"
-        - |
-          ".*(Power-on reset|Application soft reset detected|Reset from pin-reset|"
-          "System reset from different reason).*"
+        - "Reset from pin-reset"
     timeout: 30
     tags:
       - twister


### PR DESCRIPTION
Backport 5ea28b462f874e106668b78144e27217d993aead from #28018.