### PR TITLE
tests: bootloader: b0_lock_rwx: nrf54lm20

### DIFF
--- a/tests/subsys/bootloader/b0_lock_rwx/testcase.yaml
+++ b/tests/subsys/bootloader/b0_lock_rwx/testcase.yaml
@@ -6,9 +6,12 @@ common:
 
 tests:
   b0.w:
-    platform_allow: nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
   b0.rwx:
     extra_args:
       - b0_CONFIG_SB_DISABLE_SELF_RWX=y


### PR DESCRIPTION
adds nrf54lm20a and nrf54lm20b to 'w' tests