### PR TITLE
lib: st25r3911b: Set cs_is_gpio flag in SPI config

### DIFF
--- a/lib/st25r3911b/st25r3911b_spi.c
+++ b/lib/st25r3911b/st25r3911b_spi.c
@@ -40,7 +40,8 @@ static const struct spi_config spi_cfg =  {
 	.slave = DT_REG_ADDR(ST25R3911B_NODE),
 	.cs = {
 		.gpio = SPI_CS_GPIOS_DT_SPEC_GET(ST25R3911B_NODE),
-		.delay = T_NCS_SCLK
+		.delay = T_NCS_SCLK,
+		.cs_is_gpio = true
 	}
 };
 


### PR DESCRIPTION
## Summary

Zephyr SPI API change (commit `a60f93d742a`, *spi.h: Get CS delay parameters from DT*) added a `cs_is_gpio` boolean to `spi_cs_control`. The `spi_cs_is_gpio()` helper now checks this flag instead of the legacy `gpio.port != NULL` check.

The `st25r3911b_spi.c` driver hand-initialises `spi_config` without setting `cs_is_gpio`, so `spi_cs_is_gpio()` returns `false` and `spi_context_cs_control()` never asserts the CS GPIO. With CS permanently de-asserted all SPI transactions are invisible to the chip, preventing oscillator startup and causing `nfc_poller_init()` to fail with `-ENXIO` (-6).

Fix: set `.cs_is_gpio = true` in the `spi_cfg` initializer.

Fixes KRKNWK-21750.

## Test plan

- [x] Build `samples/bluetooth/central_nfc_pairing` for `nrf52840dk/nrf52840` — succeeds
- [x] Flash and observe that `Oscillator start failed` / `NFC Poller initialization error: -6` are gone

Made with [Cursor](https://cursor.com)