### PR TITLE
net: otperf: fixed unused return value warning

### DIFF
--- a/subsys/net/openthread/otperf/otperf_udp_receiver.c
+++ b/subsys/net/openthread/otperf/otperf_udp_receiver.c
@@ -249,8 +249,12 @@ static void udp_receiver_cleanup(void)
 	otInstance *instance = openthread_get_default_instance();
 
 	openthread_mutex_lock();
-	otUdpClose(instance, &current_socket);
+	otError error = otUdpClose(instance, &current_socket);
 	openthread_mutex_unlock();
+
+	if (error != OT_ERROR_NONE) {
+		LOG_ERR("Cannot close UDP Socket: %d", error);
+	}
 
 	udp_server_running = false;
 	udp_session_cb = NULL;
@@ -311,8 +315,12 @@ static int otperf_udp_receiver_init(otInstance *instance)
 		LOG_ERR("Cannot bind IPv6 UDP port %d: %d", bindAddr.mPort, error);
 
 		openthread_mutex_lock();
-		otUdpClose(instance, &current_socket);
+		error = otUdpClose(instance, &current_socket);
 		openthread_mutex_unlock();
+
+		if (error != OT_ERROR_NONE) {
+			LOG_ERR("Cannot close UDP Socket: %d", error);
+		}
 
 		return -EIO;
 	}

--- a/subsys/net/openthread/otperf/otperf_udp_uploader.c
+++ b/subsys/net/openthread/otperf/otperf_udp_uploader.c
@@ -305,8 +305,12 @@ int otperf_udp_upload(const struct otperf_upload_params *param, struct otperf_re
 	ret = udp_upload(&sock, param, result, extra_results);
 
 	openthread_mutex_lock();
-	otUdpClose(instance, &sock);
+	otError error = otUdpClose(instance, &sock);
 	openthread_mutex_unlock();
+
+	if (error != OT_ERROR_NONE) {
+		LOG_ERR("Cannot close UDP Socket: %d", error);
+	}
 
 	return ret;
 }


### PR DESCRIPTION
The return value of otUdpClose is no longer ignored