### PR TITLE
mcuboot: Add S2RAM early hooks

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -496,7 +496,7 @@ The code for integrating MCUboot into |NCS| is located in the :file:`ncs/nrf/mod
 
 The following list summarizes both the main changes inherited from upstream MCUboot and the main changes applied to the |NCS| specific additions:
 
-|no_changes_yet_note|
+* Fixed an issue where MCUboot could not recover after resuming from suspend-to-RAM when manifest-based updates were enabled on nRF54H20 devices.
 
 Zephyr
 ======

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: ncs-v3.2.4
+      revision: cac2b4255f65b1d19f510d58baba39a2cc004073
       path: bootloader/mcuboot
     - name: qcbor
       url: https://github.com/laurencelundblade/QCBOR


### PR DESCRIPTION
Add missing SoC early hooks, required for the S2RAM functionality to work if manifest-based updates are enabled.

Ref: NCSIDB-1870