### PR TITLE
manifest: update sdk-zephyr with PERIPHCONF validation script fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ae78dcc4cdfd35af54f88b3de4db10726dfeb08a
+      revision: pull/3961/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a minor bugfix that corrects the error output from this script when there are multiple inputs.