### PR TITLE
tests: subsys: west: fix west warning

### DIFF
--- a/tests/subsys/west_debug/pytest/test_west_debug.py
+++ b/tests/subsys/west_debug/pytest/test_west_debug.py
@@ -59,7 +59,7 @@ def west_tester(dut: DeviceAdapter, main_command: str, input_data: str, expected
     gdb_port = find_free_port()
     cmd = (
         f"west {main_command}"
-        f" -d {BUILD_DIR} --skip-rebuild --"
+        f" -d {BUILD_DIR} --no-rebuild --"
         f" --dev-id {SEGGER_ID}"
         f" --gdb-port {gdb_port}"
         f" --domain west_debug"

--- a/tests/subsys/west_flash/pytest/test_west_flash.py
+++ b/tests/subsys/west_flash/pytest/test_west_flash.py
@@ -98,7 +98,7 @@ def test_west_flash(dut: DeviceAdapter):
     ### Check that west -v flash -r jlink works
     cmd = (
         "west -v flash -r jlink"
-        f" -d {BUILD_DIR} --skip-rebuild --"
+        f" -d {BUILD_DIR} --no-rebuild --"
         f" --dev-id {SEGGER_ID}"
         f" --gdb-port {gdb_port}"
     )


### PR DESCRIPTION
--skip-rebuild is deprecated. Please use --no-rebuild instead