### PR TITLE
[Backport v3.3-branch] nrf_security: cracen: Do not use RandKE on Montomgery curves

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/cmddefs_ecc.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/cmddefs_ecc.c
@@ -14,10 +14,13 @@ static const struct sx_pk_cmd_def CMD_MG_PTMUL = {PK_OP_MG_PTMUL, (1 << OP_SLOT_
 						  (1 << OP_SLOT_PTR_A) | (1 << OP_SLOT_PTR_B),
 						  OP_SLOT_PTR_A,
 #if defined(CONFIG_CRACEN_LITE_ECC_COUNTERMEASURES_EXTENDED)
-						  SX_PK_OP_FLAGS_ECC_CM
+						/* Temporary workaround due to failures when
+						 * running twist curve operations
+						 * NCSDK-38476
+						 */
+						  SX_PK_OP_FLAGS_RANDPROJ
 #endif
 };
-
 const struct sx_pk_cmd_def *const SX_PK_CMD_MONTGOMERY_PTMUL = &CMD_MG_PTMUL;
 
 static const struct sx_pk_cmd_def CMD_ECDSA_VER = {

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/regs_commands.h
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/regs_commands.h
@@ -38,6 +38,9 @@
  */
 #define SX_PK_OP_FLAGS_MOD_CM ((1 << 24) | SX_PK_OP_FLAGS_MOD_RAND_CM)
 
+/* Extra flags to enable projective coordinates randomization */
+ #define SX_PK_OP_FLAGS_RANDPROJ (1 << 25)
+
 /** Extra flags to enable scalar and projective coordinates randomization
  *
  * In BA414ep datasheet, those flags are called RandKE and RandProj.


### PR DESCRIPTION
Backport d59c547f50f2c9fa10f7f3bbfe949711214ddc50 from #28022.