### PR TITLE
[Backport v3.3-branch] applications: nrf5340_audio: error differentiation

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -1218,8 +1218,12 @@ static void unicast_discovery_complete_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	if (err || csis_inst == NULL) {
+	if (err) {
 		LOG_WRN("Got err: %d from conn: %p", err, (void *)conn);
+		msg.set_size = 0;
+		msg.sirk = NULL;
+	} else if (csis_inst == NULL) {
+		LOG_WRN("csis_inst is NULL from conn: %p", (void *)conn);
 		msg.set_size = 0;
 		msg.sirk = NULL;
 	} else {


### PR DESCRIPTION
Backport c987544fca5263018d6d713d9cd55f31b3e0f7eb from #27976.