### PR TITLE
[Backport v3.3-branch] fix: nrf54lm20dk matter-diagnostic-logs SRAM memory region overlap

### DIFF
--- a/snippets/matter/matter-diagnostic-logs/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/snippets/matter/matter-diagnostic-logs/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -4,9 +4,9 @@
  */
 
 / {
-	cpuapp_sram@2007df40 {
+	cpuapp_sram@2007db40 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x2007df40 0x20c0>;
+		reg = <0x2007db40 0x20c0>;
 		zephyr,memory-region = "DiagnosticLogMem";
 		status = "okay";
 
@@ -48,5 +48,5 @@
 
 /* Reduce cpuapp_sram usage by 8384 B to account for non-init area */
 &cpuapp_sram {
-	reg = <0x20000000 0x7df40>;
+	reg = <0x20000000 0x7db40>;
 };

--- a/snippets/matter/matter-diagnostic-logs/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/snippets/matter/matter-diagnostic-logs/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -4,9 +4,9 @@
  */
 
 / {
-	cpuapp_sram@2007df40 {
+	cpuapp_sram@2007db40 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x2007df40 0x20c0>;
+		reg = <0x2007db40 0x20c0>;
 		zephyr,memory-region = "DiagnosticLogMem";
 		status = "okay";
 
@@ -48,5 +48,5 @@
 
 /* Reduce cpuapp_sram usage by 8384 B to account for non-init area */
 &cpuapp_sram {
-	reg = <0x20000000 0x7df40>;
+	reg = <0x20000000 0x7db40>;
 };


### PR DESCRIPTION
Backport 64da6d66a478d602c1b64375c5acc5776563d713 from #27996.