### PR TITLE
manifest: Update TF-m revision to include shared_uart fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 6aafa7b04a2b70bef2543d4d4f19b6b23ee0ae48
+      revision: 471f3b5cde18bb507b7f06a388d503671766a44e
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
Add fix to enable TFM_SHARED_INSTANCE to work correct. Without this the uart would be locked to secure even with the shared instance selected.