### PR TITLE
[Backport v3.3-branch] applications: nrf5340_audio: Only enable I2S RX if encoder has started

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -738,7 +738,7 @@ static void audio_datapath_i2s_blk_complete(uint32_t frame_start_ts_us, uint32_t
 	static uint32_t num_overruns;
 	static uint32_t num_overruns_last_printed;
 
-	if (IS_ENABLED(CONFIG_STREAM_BIDIRECTIONAL) || (CONFIG_AUDIO_DEV == GATEWAY)) {
+	if (audio_system_encoder_is_started()) {
 		if (unlikely(rx_buf_released == NULL)) {
 			ERR_CHK_MSG(-ENOMEM, "No RX data available");
 		}

--- a/applications/nrf5340_audio/src/audio/audio_system.c
+++ b/applications/nrf5340_audio/src/audio/audio_system.c
@@ -231,6 +231,15 @@ void audio_system_encoder_stop(void)
 	k_poll_signal_reset(&encoder_sig);
 }
 
+bool audio_system_encoder_is_started(void)
+{
+	int set, res;
+
+	k_poll_signal_check(&encoder_sig, &set, &res);
+
+	return (set == 0 ? false : true);
+}
+
 int audio_system_encode_test_tone_set(uint32_t freq)
 {
 	int ret;

--- a/applications/nrf5340_audio/src/audio/audio_system.h
+++ b/applications/nrf5340_audio/src/audio/audio_system.h
@@ -39,6 +39,13 @@ void audio_system_encoder_start(void);
 void audio_system_encoder_stop(void);
 
 /**
+ * @brief	Check if the encoder thread is currently enabled to execute.
+ *
+ * @return	true if encoder thread is enabled, false otherwise.
+ */
+bool audio_system_encoder_is_started(void);
+
+/**
  * @brief	Toggle a test tone on and off.
  *
  * @note	A stream must already be running to use this feature.

--- a/applications/nrf5340_audio/unicast_server/overlay-unicast_server.conf
+++ b/applications/nrf5340_audio/unicast_server/overlay-unicast_server.conf
@@ -49,3 +49,7 @@ CONFIG_MBEDTLS_HEAP_SIZE=2048
 CONFIG_BT_AUDIO_CONCURRENT_RX_STREAMS_MAX=2
 CONFIG_AUDIO_DECODE_CHANNELS_MAX=2
 CONFIG_AUDIO_SOURCE_I2S=y
+
+# Always enable bidirectional stream support on the server.
+# The client may not support it, but the server should be able to handle it if the client does.
+CONFIG_STREAM_BIDIRECTIONAL=y


### PR DESCRIPTION
Backport ac3c41544535a49da2af9de0db92b0e00e911537 from #28019.