### PR TITLE
samples: matter: Fix missing zephyr log include

### DIFF
--- a/samples/matter/common/src/app/matter_init.cpp
+++ b/samples/matter/common/src/app/matter_init.cpp
@@ -63,6 +63,8 @@
 #include <platform/nrfconnect/ExternalFlashManager.h>
 #include <setup_payload/OnboardingCodesUtil.h>
 
+#include <zephyr/logging/log.h>
+
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
 using namespace ::chip::DeviceLayer;


### PR DESCRIPTION
The <zephyr/logging/log.h> include was missing in the Matter init file.