### PR TITLE
mpsl: Remove unsupported CONSTLAT request and release APIs

### DIFF
--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -598,24 +598,6 @@ int32_t mpsl_lib_uninit(void)
 }
 
 #if defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
-void mpsl_constlat_request_callback(void)
-{
-#if defined(CONFIG_NRFX_POWER)
-	nrfx_power_constlat_mode_request();
-#else
-	nrf_power_task_trigger(NRF_POWER, NRF_POWER_TASK_CONSTLAT);
-#endif
-}
-
-void mpsl_lowpower_request_callback(void)
-{
-#if defined(CONFIG_NRFX_POWER)
-	nrfx_power_constlat_mode_free();
-#else
-	nrf_power_task_trigger(NRF_POWER, NRF_POWER_TASK_LOWPWR);
-#endif
-}
-
 void mpsl_low_latency_acquire_callback(void)
 {
 #if IS_ENABLED(CONFIG_SOC_SERIES_NRF54L)


### PR DESCRIPTION
The APIs mpsl_constlat_request_callback() and mpsl_lowpower_request- _callback() were replaced by mpsl_low_latency_acquire_callback() and mpsl_low_latency_release_callback().

The commit removes the usupported APIs.