### PR TITLE
[Backport v3.3-branch] manifest: Update TF-m revision to include shar…

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -148,7 +148,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: ncs-v3.3.0-rc1
+      revision: 4c7af57cce2516893ee8dafd99ea54ae5107ca5c
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
…ed_uart fix

Add fix to enable TFM_SHARED_INSTANCE to work correct. Without this the uart would be locked to secure even with the shared instance selected.

Manual backport of [28085]( https://github.com/nrfconnect/sdk-nrf/pull/28085)