### PR TITLE
[Backport v3.3-branch] lib: st25r3911b: Set cs_is_gpio flag in SPI config

### DIFF
--- a/lib/st25r3911b/st25r3911b_spi.c
+++ b/lib/st25r3911b/st25r3911b_spi.c
@@ -40,7 +40,8 @@ static const struct spi_config spi_cfg =  {
 	.slave = DT_REG_ADDR(ST25R3911B_NODE),
 	.cs = {
 		.gpio = SPI_CS_GPIOS_DT_SPEC_GET(ST25R3911B_NODE),
-		.delay = T_NCS_SCLK
+		.delay = T_NCS_SCLK,
+		.cs_is_gpio = true
 	}
 };
 


### PR DESCRIPTION
Backport 64a1cb9f2586829842d63525438a0618dd467c5a from #28026.