### PR TITLE
TF-M minimal no heap 3.3 backport

### DIFF
--- a/subsys/nrf_security/cmake/extensions.cmake
+++ b/subsys/nrf_security/cmake/extensions.cmake
@@ -12,6 +12,8 @@ macro(kconfig_check_and_set_base_val base val)
   if(CONFIG_${base})
     nrf_security_debug("Setting ${base} to ${val}")
     set(${base} ${val})
+  else()
+    unset(${base})
   endif()
 endmacro()
 

--- a/subsys/nrf_security/cmake/generate_configs.cmake
+++ b/subsys/nrf_security/cmake/generate_configs.cmake
@@ -90,6 +90,7 @@ macro(generate_mbedcrypto_library_configs)
     kconfig_backup_current_config(CONFIG_MBEDTLS_THREADING_C)
     kconfig_backup_current_config(CONFIG_MBEDTLS_THREADING_ALT)
     kconfig_backup_current_config(CONFIG_MBEDTLS_MEMORY_BUFFER_ALLOC_C)
+    kconfig_backup_current_config(CONFIG_MBEDTLS_SSL_CONTEXT_SERIALIZATION)
 
     nrf_security_debug("=========== Checkpoint: backup ===============")
 
@@ -120,6 +121,11 @@ macro(generate_mbedcrypto_library_configs)
       if(CONFIG_TFM_PROFILE_TYPE_MINIMAL)
         set(CONFIG_MBEDTLS_MEMORY_BUFFER_ALLOC_C False)
       endif()
+      # CONFIG_MBEDTLS_SSL_CONTEXT_SERIALIZATION must be set to false because it is not used
+      # in the library build in TF-M and there is a check_config.h test that will fail if this
+      # is enabled but not some of the prerequisites. Functionally TF-M does not rely on this
+      # config or any TLS APIs. NS image still must be able to enable and use this feature
+      set(CONFIG_MBEDTLS_SSL_CONTEXT_SERIALIZATION False)
     endif()
 
     # Generate MBEDCRYPTO_CONFIG_FILE
@@ -144,6 +150,7 @@ macro(generate_mbedcrypto_library_configs)
     kconfig_restore_backup_config(CONFIG_MBEDTLS_THREADING_C)
     kconfig_restore_backup_config(CONFIG_MBEDTLS_THREADING_ALT)
     kconfig_restore_backup_config(CONFIG_MBEDTLS_MEMORY_BUFFER_ALLOC_C)
+    kconfig_restore_backup_config(CONFIG_MBEDTLS_SSL_CONTEXT_SERIALIZATION)
 
     nrf_security_debug("=========== End psa_crypto_library_config ===============")
   endif()

--- a/subsys/nrf_security/cmake/generate_configs.cmake
+++ b/subsys/nrf_security/cmake/generate_configs.cmake
@@ -89,7 +89,7 @@ macro(generate_mbedcrypto_library_configs)
     kconfig_backup_current_config(CONFIG_MBEDTLS_PLATFORM_PRINTF_ALT)
     kconfig_backup_current_config(CONFIG_MBEDTLS_THREADING_C)
     kconfig_backup_current_config(CONFIG_MBEDTLS_THREADING_ALT)
-
+    kconfig_backup_current_config(CONFIG_MBEDTLS_MEMORY_BUFFER_ALLOC_C)
 
     nrf_security_debug("=========== Checkpoint: backup ===============")
 
@@ -115,6 +115,11 @@ macro(generate_mbedcrypto_library_configs)
       # Disable threading for the PSA interface used in TF-M build (NS and S image)
       set(CONFIG_MBEDTLS_THREADING_C False)
       set(CONFIG_MBEDTLS_THREADING_ALT False)
+      # Disable heap when using CONFIG_TFM_PROFILE_TYPE_MINIMAL to ensure that the build size
+      # is underneath 32 KB
+      if(CONFIG_TFM_PROFILE_TYPE_MINIMAL)
+        set(CONFIG_MBEDTLS_MEMORY_BUFFER_ALLOC_C False)
+      endif()
     endif()
 
     # Generate MBEDCRYPTO_CONFIG_FILE
@@ -138,6 +143,7 @@ macro(generate_mbedcrypto_library_configs)
     kconfig_restore_backup_config(CONFIG_MBEDTLS_PLATFORM_PRINTF_ALT)
     kconfig_restore_backup_config(CONFIG_MBEDTLS_THREADING_C)
     kconfig_restore_backup_config(CONFIG_MBEDTLS_THREADING_ALT)
+    kconfig_restore_backup_config(CONFIG_MBEDTLS_MEMORY_BUFFER_ALLOC_C)
 
     nrf_security_debug("=========== End psa_crypto_library_config ===============")
   endif()

--- a/subsys/nrf_security/cmake/generate_configs.cmake
+++ b/subsys/nrf_security/cmake/generate_configs.cmake
@@ -104,7 +104,8 @@ macro(generate_mbedcrypto_library_configs)
 
     # Handle configurations required by library build inside TF-M (NS world doesn't use psa_crypto_library_config)
     if(CONFIG_BUILD_WITH_TFM)
-      set(MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER True)
+      # CONFIG_MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER must be set for the library build in TF-M
+      set(CONFIG_MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER True)
       # CONFIG_MBEDTLS_PSA_CRYPTO_SPM must be set for the library build in TF-M
       set(CONFIG_MBEDTLS_PSA_CRYPTO_SPM True)
       # CONFIG_MBEDTLS_USE_PSA_CRYPTO must be unset for library build in TF-M

--- a/west.yml
+++ b/west.yml
@@ -148,7 +148,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 4c7af57cce2516893ee8dafd99ea54ae5107ca5c
+      revision: 4f72bf583e71503965aed78f819474f25ce45a81
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
The backport was not started by itself

Ref: https://github.com/nrfconnect/sdk-nrf/pull/27691