### PR TITLE
P2p sample redefinition error

### DIFF
--- a/samples/wifi/p2p/src/p2p_go.c
+++ b/samples/wifi/p2p/src/p2p_go.c
@@ -146,30 +146,6 @@ static int wifi_p2p_group_add(void)
 	return 0;
 }
 
-static int wifi_p2p_wps_pin(void)
-{
-	struct wifi_wps_config_params params = {0};
-	struct net_if *iface = net_if_get_first_wifi();
-
-	if (!iface) {
-		LOG_ERR("Failed to get Wi-Fi interface");
-		return -1;
-	}
-
-	params.oper = WIFI_WPS_PIN_GET;
-
-	if (net_mgmt(NET_REQUEST_WIFI_WPS_CONFIG, iface, &params, sizeof(params))) {
-		LOG_WRN("Start wps pin connection failed");
-		return -1;
-	}
-
-	if (params.oper == WIFI_WPS_PIN_GET) {
-		LOG_INF("WPS PIN is: %s", params.pin);
-	}
-
-	return 0;
-}
-
 #ifdef CONFIG_SAMPLE_P2P_CONNECTION_METHOD_PIN
 static int wifi_p2p_wps_pin(void)
 {
@@ -264,11 +240,6 @@ int p2p_go_run(void)
 	net_mgmt_callback_init();
 
 	ret = wifi_p2p_group_add();
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = wifi_p2p_wps_pin();
 	if (ret < 0) {
 		return ret;
 	}


### PR DESCRIPTION
The WPS PIN API was defined twice. Remove the duplicate definition.