### PR TITLE
bluetooth: controller: Use new SDC Channel Sounding support APIs

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -944,13 +944,23 @@ static void configure_supported_features(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_SDC_CS_ROLE_INITIATOR_ONLY) ||
-		IS_ENABLED(CONFIG_BT_CTLR_SDC_CS_ROLE_BOTH)) {
-		sdc_support_channel_sounding_initiator_role();
+	    IS_ENABLED(CONFIG_BT_CTLR_SDC_CS_ROLE_BOTH)) {
+		if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+			sdc_support_channel_sounding_initiator_role_central();
+		}
+		if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
+			sdc_support_channel_sounding_initiator_role_peripheral();
+		}
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_SDC_CS_ROLE_REFLECTOR_ONLY) ||
-		IS_ENABLED(CONFIG_BT_CTLR_SDC_CS_ROLE_BOTH)) {
-		sdc_support_channel_sounding_reflector_role();
+	    IS_ENABLED(CONFIG_BT_CTLR_SDC_CS_ROLE_BOTH)) {
+		if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+			sdc_support_channel_sounding_reflector_role_central();
+		}
+		if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
+			sdc_support_channel_sounding_reflector_role_peripheral();
+		}
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_SDC_LE_POWER_CLASS_1)) {

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -66,7 +66,9 @@ static bool command_generates_command_complete_event(uint16_t hci_opcode)
 	case SDC_HCI_OPCODE_CMD_LE_SUBRATE_REQUEST:
 #if defined(CONFIG_BT_CTLR_CHANNEL_SOUNDING)
 	case SDC_HCI_OPCODE_CMD_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES:
+#if defined(CONFIG_BT_CENTRAL)
 	case SDC_HCI_OPCODE_CMD_LE_CS_SECURITY_ENABLE:
+#endif /* CONFIG_BT_CENTRAL */
 	case SDC_HCI_OPCODE_CMD_LE_CS_READ_REMOTE_FAE_TABLE:
 	case SDC_HCI_OPCODE_CMD_LE_CS_CREATE_CONFIG:
 	case SDC_HCI_OPCODE_CMD_LE_CS_REMOVE_CONFIG:
@@ -641,7 +643,9 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_cs_test = 1;
 	cmds->hci_le_cs_test_end = 1;
 #endif /* CONFIG_BT_CTLR_CHANNEL_SOUNDING_TEST */
+#if defined(CONFIG_BT_CENTRAL)
 	cmds->hci_le_cs_security_enable = 1;
+#endif /* CONFIG_BT_CENTRAL */
 	cmds->hci_le_cs_set_default_settings = 1;
 	cmds->hci_le_cs_set_channel_classification = 1;
 	cmds->hci_le_cs_set_procedure_parameters = 1;
@@ -1476,8 +1480,10 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 			sdc_hci_cmd_le_cs_write_cached_remote_supported_capabilities_return_t);
 		return sdc_hci_cmd_le_cs_write_cached_remote_supported_capabilities(
 			(void *)cmd_params, (void *)event_out_params);
+#if defined(CONFIG_BT_CENTRAL)
 	case SDC_HCI_OPCODE_CMD_LE_CS_SECURITY_ENABLE:
 		return sdc_hci_cmd_le_cs_security_enable((void *)cmd_params);
+#endif /* CONFIG_BT_CENTRAL */
 	case SDC_HCI_OPCODE_CMD_LE_CS_SET_DEFAULT_SETTINGS:
 		*param_length_out += sizeof(sdc_hci_cmd_le_cs_set_default_settings_return_t);
 		return sdc_hci_cmd_le_cs_set_default_settings((void *)cmd_params,


### PR DESCRIPTION
- These APIs allow for more granular linker GC of unused code if the application only uses one link role, resulting in a lower NVM usage.
- Remove linking sdc_hci_cmd_le_cs_security_enable from the peripheral role to reduce NVM usage, this command is only valid for the central.