### PR TITLE
tests: tfm: tfm_psa_test: align with integration quarnatine

### DIFF
--- a/scripts/quarantine_integration.yaml
+++ b/scripts/quarantine_integration.yaml
@@ -111,13 +111,6 @@
   comment: "Configurations excluded to limit resources usage in integration builds"
 
 - scenarios:
-    - tfm.psa_test_initial_attestation_lvl1
-    - tfm.psa_test_storage_lvl1
-  platforms:
-    - nrf9160dk@0.14.0/nrf9160/ns
-  comment: "Configurations excluded to limit resources usage in integration builds"
-
-- scenarios:
     - lib.fprotect.sys_init_fprotect
     - drivers.fprotect.positive
     - drivers.fprotect.negative

--- a/tests/tfm/tfm_psa_test/testcase.yaml
+++ b/tests/tfm/tfm_psa_test/testcase.yaml
@@ -12,8 +12,6 @@ common:
     - nrf9161dk/nrf9161/ns
   integration_platforms:
     - nrf9151dk/nrf9151/ns
-    - nrf9160dk/nrf9160/ns
-    - nrf9161dk/nrf9161/ns
   harness: console
   harness_config:
     type: multi_line


### PR DESCRIPTION
Remove from int platform what is already in integration quarnatine. Plus remove 9161 as similar to nrf9151,
similar like at https://github.com/nrfconnect/sdk-nrf/pull/26515.