### PR TITLE
samples: radio_test: add PRBS-9 channel sequence shuffle shell commands

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -343,14 +343,11 @@ Peripheral samples
 
   * Added:
 
-    * ``start_tx_sweep_with_sleep`` shell command.
-        It allows for running a TX sweep with silent periods between each frequency.
-    * ``start_tx_sweep_with_sleep_modulated`` shell command.
-        It allows for running a modulated TX sweep with silent periods between each frequency.
-    * ``set_channel_sequence`` shell command.
-        It allows for setting a custom channel sequence for the ``start_tx_sweep_with_sleep`` and ``start_tx_sweep_with_sleep_modulated`` commands.
-    * ``print_channel_sequence`` shell command.
-        It prints the currently configured channel sequence.
+    * ``start_tx_sweep_with_sleep`` shell command that allows for running a TX sweep with silent periods between each frequency.
+    * ``start_tx_sweep_with_sleep_modulated`` shell command that allows for running a modulated TX sweep with silent periods between each frequency.
+    * ``set_channel_sequence`` shell command that allows for setting a custom channel sequence for the ``start_tx_sweep_with_sleep`` and ``start_tx_sweep_with_sleep_modulated`` commands.
+    * ``print_channel_sequence`` shell command that prints the currently configured channel sequence.
+    * ``set_channel_sequence_hopping_mode`` shell command that allows for setting the hopping mode for the channel sequence.
     * Support for pin debugging of radio events on nRF54L Series devices.
 
 PMIC samples

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -111,6 +111,10 @@ User interface
    * - set_channel_sequence
      - <sequence of up to 80 channels>
      - Set a custom channel sequence for the start_tx_with_sleep command
+   * - set_channel_sequence_hopping_mode
+     - <hopping_mode>
+     - Set the hopping mode for the channel sequence.
+       Sequential (default order) | random <seed>
    * - start_channel
      - <channel>
      - Start channel for the sweep or the channel for the constant carrier (in MHz, as difference from 2400 MHz).

--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -749,6 +749,7 @@ static int cmd_set_channel_sequence(const struct shell *shell, size_t argc,
 	if (sequence_length > 80) {
 		shell_error(shell, "Too many channels in array, %i is larger than 80",
 			    sequence_length);
+		return -EINVAL;
 	}
 
 	for (uint8_t i = 0; i < sequence_length; i++) {
@@ -764,7 +765,7 @@ static int cmd_set_channel_sequence(const struct shell *shell, size_t argc,
 
 	struct radio_test_channel_sequence *channel_sequence = radio_test_channel_sequence_get();
 
-	channel_sequence->sequence_length = sequence_length;
+	channel_sequence->length = sequence_length;
 	for (uint8_t i = 0; i < sequence_length; i++) {
 		uint8_t channel = atoi(argv[i + 1]);
 
@@ -773,14 +774,65 @@ static int cmd_set_channel_sequence(const struct shell *shell, size_t argc,
 	return 0;
 }
 
+static int cmd_sequential(const struct shell *shell, size_t argc,
+			      char **argv)
+{
+	(void)argc;
+	(void)argv;
+
+	struct radio_test_channel_sequence *seq = radio_test_channel_sequence_get();
+
+	seq->hopping_mode = CHANNEL_HOP_SEQUENTIAL;
+	shell_print(shell, "Channel hopping: sequential (default order)");
+
+	return 0;
+}
+
+static int cmd_random(const struct shell *shell, size_t argc,
+			      char **argv)
+{
+	struct radio_test_channel_sequence *seq = radio_test_channel_sequence_get();
+
+	seq->hopping_mode = CHANNEL_HOP_RANDOM_FISHER_YATES;
+
+	if (argc >= 2) {
+		seq->shuffled.seed = (uint32_t)atoi(argv[1]);
+	}
+
+	memcpy(seq->shuffled.sequence, seq->sequence_array, seq->length);
+
+	srand((unsigned int)seq->shuffled.seed);
+	shuffle_channel_sequence();
+
+	shell_print(shell, "Channel hopping: random (seed %u)", seq->shuffled.seed);
+	return 0;
+}
+
+static int cmd_set_channel_sequence_hopping_mode(const struct shell *shell, size_t argc,
+							 char **argv)
+{
+	if (argc == 1) {
+		shell_help(shell);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	if (argc > 2) {
+		shell_error(shell, "%s: bad parameters count", argv[0]);
+		return -EINVAL;
+	}
+
+	shell_error(shell, "Unknown argument: %s", argv[1]);
+	return -EINVAL;
+}
+
 static int cmd_print_channel_sequence(const struct shell *shell, size_t argc, char **argv)
 {
 	struct radio_test_channel_sequence *channel_sequence = radio_test_channel_sequence_get();
 
-	shell_print(shell, "Channel Sequence length: %i", channel_sequence->sequence_length);
+	shell_print(shell, "Channel Sequence length: %i", channel_sequence->length);
 	shell_fprintf_normal(shell, "Channel Sequence: [%i", channel_sequence->sequence_array[0]);
 
-	for (uint8_t i = 1; i < channel_sequence->sequence_length; i++) {
+	for (uint8_t i = 1; i < channel_sequence->length; i++) {
 		shell_fprintf_normal(shell, ", %i", channel_sequence->sequence_array[i]);
 	}
 
@@ -1631,6 +1683,16 @@ SHELL_CMD_REGISTER(total_output_power, NULL,
 		  cmd_total_output_power_set);
 #endif /* CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC */
 
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_set_channel_sequence_hopping_mode,
+	SHELL_CMD(sequential, NULL,
+		  "Set the channel sequence hopping mode to sequential",
+		  cmd_sequential),
+	SHELL_CMD(random, NULL,
+		  "Set the channel sequence hopping mode to random with <seed>",
+		  cmd_random),
+	SHELL_SUBCMD_SET_END
+);
+
 SHELL_CMD_REGISTER(transmit_pattern,
 		   &sub_transmit_pattern,
 		   "Set the transmission pattern",
@@ -1651,6 +1713,9 @@ SHELL_CMD_REGISTER(set_channel_sequence, NULL,
 		   "Set a custom channel sequence for TX "
 		   "<sequence_of_up_to_80_channels>",
 		   cmd_set_channel_sequence);
+SHELL_CMD_REGISTER(set_channel_sequence_hopping_mode, &sub_set_channel_sequence_hopping_mode,
+		   "TX hop: sequential (default order) | random <seed>",
+		   cmd_set_channel_sequence_hopping_mode);
 SHELL_CMD_REGISTER(print_channel_sequence, NULL,
 		   "Print the custom channel sequence for TX.",
 		   cmd_print_channel_sequence);

--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -7,6 +7,7 @@
 #include "radio_test.h"
 
 #include <string.h>
+#include <stdlib.h>
 #include <inttypes.h>
 
 #if !(defined(CONFIG_SOC_SERIES_NRF54H) || defined(CONFIG_SOC_SERIES_NRF54L))
@@ -123,17 +124,69 @@ static uint32_t rx_packet_cnt;
 /* Radio current channel (frequency). */
 static uint8_t current_channel;
 
-/* Modulated TX sweep with sleep: sequential index into channel_array. */
-static uint8_t mod_tx_sweep_ch_idx;
+#define DEFAULT_CHANNEL_VALUES						\
+	4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,				\
+	17, 18, 19, 20, 21, 22, 23, 24, 28, 29, 30, 31, 32, 33,		\
+	34, 35, 36, 37, 38, 39, 40, 41,					\
+	42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,		\
+	56, 57, 58, 59, 60, 61, 62, 63,					\
+	64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78
+
+#define DEFAULT_CHANNEL_SEQUENCE	{DEFAULT_CHANNEL_VALUES}
+
+#define DEFAULT_CHANNEL_COUNT							\
+	((uint8_t)(sizeof((uint8_t[]){ DEFAULT_CHANNEL_VALUES }) / sizeof(uint8_t)))
 
 /* Radio TX Sweep with sleep channel array */
 static struct radio_test_channel_sequence channel_sequence = {
-	.sequence_length = 72,
-	.sequence_array = {4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
-	17, 18, 19, 20, 21, 22, 23, 24, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
-	42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
-	64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78}
+	.length = DEFAULT_CHANNEL_COUNT,
+	.sequence_array = DEFAULT_CHANNEL_SEQUENCE,
+	.hopping_mode = CHANNEL_HOP_SEQUENTIAL,
+	.shuffled = {
+		.seed = 1,
+	}
 };
+
+static const uint8_t *active_channel_sequence(void)
+{
+	if (channel_sequence.hopping_mode == CHANNEL_HOP_RANDOM_FISHER_YATES) {
+		return channel_sequence.shuffled.sequence;
+	}
+	return channel_sequence.sequence_array;
+}
+
+/**
+ * @brief Random index in [0, n - 1] using rand() (n is exclusive upper bound).
+ */
+static uint8_t shuffle_rand_index(uint8_t n)
+{
+	if (n <= 1) {
+		return 0;
+	}
+
+	return (uint8_t)((uint32_t)rand() % (uint32_t)n);
+}
+
+/**
+ * @brief Shuffle hop order on shuffled.sequence (Fisher–Yates) using C library rand().
+ *
+ *
+ */
+void shuffle_channel_sequence(void)
+{
+	if (channel_sequence.length <= 1) {
+		return;
+	}
+
+	/* Fisher-Yates shuffle */
+	for (uint8_t i = channel_sequence.length - 1; i > 0; i--) {
+		uint8_t j = shuffle_rand_index(i + 1);
+		uint8_t tmp = channel_sequence.shuffled.sequence[i];
+
+		channel_sequence.shuffled.sequence[i] = channel_sequence.shuffled.sequence[j];
+		channel_sequence.shuffled.sequence[j] = tmp;
+	}
+}
 
 /* Timer used for channel sweeps and tx with duty cycle. */
 static nrfx_timer_t timer =
@@ -1124,7 +1177,7 @@ static void tx_sweep_with_sleep_modulated_timer_setup(const struct radio_test_co
 
 static void radio_tx_sweep_with_sleep_modulated(const struct radio_test_config *cfg)
 {
-	mod_tx_sweep_ch_idx = 0;
+	channel_sequence.current_index = 0;
 
 	nrfx_timer_disable(&timer);
 	tx_sweep_with_sleep_modulated_timer_setup(cfg);
@@ -1132,7 +1185,7 @@ static void radio_tx_sweep_with_sleep_modulated(const struct radio_test_config *
 	sweep_processing = true;
 	radio_modulated_tx_carrier(cfg->mode,
 				   cfg->params.tx_sweep_with_sleep_modulated.txpower,
-				   channel_sequence.sequence_array[mod_tx_sweep_ch_idx],
+				   active_channel_sequence()[channel_sequence.current_index],
 				   cfg->params.tx_sweep_with_sleep_modulated.pattern,
 				   0);
 	sweep_processing = false;
@@ -1350,11 +1403,11 @@ static void timer_handler(nrf_timer_event_t event_type, void *context)
 			radio_unmodulated_tx_carrier_radio_setup(
 				NRF_RADIO_MODE_BLE_1MBIT,
 				config->params.tx_sweep_with_sleep.txpower,
-				channel_sequence.sequence_array[current_channel], false);
+				active_channel_sequence()[current_channel], false);
 
 			/* set up next channel */
 			channel_start = 0;
-			channel_end = channel_sequence.sequence_length - 1;
+			channel_end = channel_sequence.length - 1;
 		} else if (config->type == TX_SWEEP_WITH_SLEEP_MODULATED) {
 
 			nrf_radio_task_trigger(NRF_RADIO, NRF_RADIO_TASK_DISABLE);
@@ -1363,17 +1416,18 @@ static void timer_handler(nrf_timer_event_t event_type, void *context)
 			}
 			nrf_radio_event_clear(NRF_RADIO, NRF_RADIO_EVENT_DISABLED);
 			nrf_radio_event_clear(NRF_RADIO, NRF_RADIO_EVENT_READY);
-			mod_tx_sweep_ch_idx++;
+			channel_sequence.current_index =
+				(channel_sequence.current_index + 1) % channel_sequence.length;
 
-			if (mod_tx_sweep_ch_idx >
-				  channel_sequence.sequence_length - 1) {
-				mod_tx_sweep_ch_idx = 0;
+			if (channel_sequence.hopping_mode == CHANNEL_HOP_RANDOM_FISHER_YATES &&
+				channel_sequence.current_index == 0) {
+				shuffle_channel_sequence();
 			}
 
 			nrf_radio_event_clear(NRF_RADIO, RADIO_TEST_EVENT_END);
 			radio_channel_set(
 				config->mode,
-				channel_sequence.sequence_array[mod_tx_sweep_ch_idx]);
+				active_channel_sequence()[channel_sequence.current_index]);
 		} else {
 			printk("Unexpected test type: %d\n", config->type);
 			return;
@@ -1384,6 +1438,11 @@ static void timer_handler(nrf_timer_event_t event_type, void *context)
 		current_channel++;
 		if (current_channel > channel_end) {
 			current_channel = channel_start;
+
+			if (channel_sequence.hopping_mode == CHANNEL_HOP_RANDOM_FISHER_YATES &&
+			    config->type == TX_SWEEP_WITH_SLEEP) {
+				shuffle_channel_sequence();
+			}
 		}
 #if NRF_ERRATA_STATIC_CHECK(54H, 216)
 	} else if (event_type == NRF_TIMER_EVENT_COMPARE7) { /* HMPAN-216 errata */

--- a/samples/peripheral/radio_test/src/radio_test.h
+++ b/samples/peripheral/radio_test/src/radio_test.h
@@ -228,13 +228,41 @@ struct radio_rx_stats {
 	uint32_t packet_cnt;
 };
 
-/**@brief Configurable channel sequence for TX with sleep. */
+/**
+ * @brief How the TX sweep walks the configured channel list.
+ *
+ * Sequential: index order. Random: list order is shuffled before use.
+ */
+typedef enum {
+	CHANNEL_HOP_SEQUENTIAL,
+	CHANNEL_HOP_RANDOM_FISHER_YATES,
+} channel_hopping_mode_t;
+
+/**
+ * @brief Configurable channel sequence.
+ *
+ * sequence_array holds the configured channel order (never permuted here).
+ * When hopping_mode is CHANNEL_HOP_RANDOM_FISHER_YATES,
+ * the sweep uses shuffled.sequence, a Fisher–Yates permutation of sequence_array.
+ */
 struct radio_test_channel_sequence {
 	/** Length of configurable channel sequence. */
-	uint8_t sequence_length;
+	uint8_t length;
 
-	/** Configurable channel sequence contents. */
+	/** Configured channel sequence (canonical order). */
 	uint8_t sequence_array[80];
+
+	/* Index of the next channel in the sequence. */
+	uint8_t current_index;
+
+	/** Channel hopping mode. */
+	channel_hopping_mode_t hopping_mode;
+
+	/** Shuffled channel sequence. */
+	struct {
+		uint32_t seed;
+		uint8_t sequence[80];
+	} shuffled;
 };
 
 /**
@@ -281,5 +309,11 @@ void toggle_dcdc_state(uint8_t dcdc_state);
  * @return Pointer to the static channel_sequence in the radio_test
  */
 struct radio_test_channel_sequence *radio_test_channel_sequence_get(void);
+
+/**
+ * @brief Shuffle channel sequence using Fisher–Yates shuffling algorithm.
+ * Randomness provided by standard library rand().
+ */
+void shuffle_channel_sequence(void);
 
 #endif /* RADIO_TEST_H_ */


### PR DESCRIPTION
Add two new shell commands:
* shuffle_channel_sequence <seed> - PRBS-9–driven Fisher–Yates shuffle of the configurable TX sweep channel list.
The first shuffle copies the current order to a snapshot used by restore.

* restore_default_channel_sequence - restores the channel list from that snapshot (default order before the first shuffle).