### PR TITLE
[Backport v3.3-branch] doc: Update the OS Support table for the 3.3.0 release

### DIFF
--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -336,11 +336,11 @@ For firmware OS support, see :ref:`the table at the top of the page <supported_O
     - Not supported
   * - `Linux - Ubuntu 24.04 LTS`_
     - Not supported
-    - Tier 2
+    - Tier 1
     - Not supported
   * - `Linux - Ubuntu 22.04 LTS`_
     - Not supported
-    - Tier 1
+    - Tier 2
     - Not supported
   * - `Linux - Ubuntu 20.04 LTS`_
     - Not supported


### PR DESCRIPTION
Backport 89d434743cbb058c95b03f8b0307f4bc8a93ea6b from #28150.