### PR TITLE
tests: drivers: i2s_latency: add nRF54LM20 support

### DIFF
--- a/tests/drivers/i2s/i2s_latency/boards/nrf54lm20dk_nrf54lm20_common.dtsi
+++ b/tests/drivers/i2s/i2s_latency/boards/nrf54lm20dk_nrf54lm20_common.dtsi
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		tst-timer = &timer21;
+	};
+};
+
+&pinctrl {
+	tdm_default_alt: tdm_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TDM_SCK_M, 1, 23)>,
+				<NRF_PSEL(TDM_FSYNC_M, 1, 14)>,
+				<NRF_PSEL(TDM_SDOUT, 1, 30)>,
+				<NRF_PSEL(TDM_SDIN, 1, 31)>;
+		};
+	};
+};
+
+i2s_dut: &tdm {
+	status = "okay";
+	pinctrl-0 = <&tdm_default_alt>;
+	pinctrl-names = "default";
+};
+
+&timer21 {
+	status = "okay";
+};

--- a/tests/drivers/i2s/i2s_latency/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/i2s/i2s_latency/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54lm20dk_nrf54lm20_common.dtsi"

--- a/tests/drivers/i2s/i2s_latency/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/i2s/i2s_latency/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54lm20dk_nrf54lm20_common.dtsi"

--- a/tests/drivers/i2s/i2s_latency/testcase.yaml
+++ b/tests/drivers/i2s/i2s_latency/testcase.yaml
@@ -9,6 +9,8 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf7120dk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
@@ -22,6 +24,8 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf7120dk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
@@ -34,6 +38,8 @@ tests:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf7120dk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Added overlays and platform allow for nRF54LM20.