### PR TITLE
samples: cellular: modem_shell: Add support for nRF92

### DIFF
--- a/ext/curl/lib/curl_config.h
+++ b/ext/curl/lib/curl_config.h
@@ -1089,7 +1089,9 @@
 /* #undef USE_WOLFSSL */
 
 /* Version number of package */
+#if !defined(CONFIG_NRF_CURL_INTEGRATION)
 #define VERSION "-"
+#endif
 
 /* Define to 1 to provide own prototypes. */
 /* #undef WANT_IDN_PROTOTYPES */

--- a/ext/curl/lib/easy.c
+++ b/ext/curl/lib/easy.c
@@ -586,7 +586,7 @@ static CURLcode easy_transfer(struct Curl_multi *multi)
   while(!done && !mcode) {
     int still_running = 0;
 
-#if defined(CONFIG_NRF_IPERF3_INTEGRATION)
+#if defined(CONFIG_NRF_CURL_INTEGRATION)
     if (multi->kill_signal != NULL) {
 	    int set, res;
 

--- a/ext/curl/tool/tool_main.c
+++ b/ext/curl/tool/tool_main.c
@@ -34,7 +34,7 @@
 
 #if defined(CONFIG_NRF_CURL_INTEGRATION)
 #if defined (CONFIG_NRF_MODEM_LIB_TRACE)
-/* NRF_IPERF3_INTEGRATION_CHANGE: added */
+/* NRF_CURL_INTEGRATION_CHANGE: added */
 #include <nrf_modem_at.h>
 #endif
 #endif

--- a/ext/curl/tool/tool_operate.c
+++ b/ext/curl/tool/tool_operate.c
@@ -87,7 +87,7 @@
 
 #if defined(CONFIG_NRF_CURL_INTEGRATION)
 #if defined (CONFIG_NRF_MODEM_LIB_TRACE)
-/* NRF_IPERF3_INTEGRATION_CHANGE: added */
+/* NRF_CURL_INTEGRATION_CHANGE: added */
 #include <nrf_modem_at.h>
 #endif
 #endif

--- a/ext/iperf3/iperf_config.h
+++ b/ext/iperf3/iperf_config.h
@@ -127,7 +127,11 @@
 #define STDC_HEADERS 1
 
 /* Version number of package */
+#if !defined(CONFIG_NRF_IPERF3_INTEGRATION)
 #define VERSION "3.9"
 #define IPERF_VERSION VERSION
+#else
+#define IPERF_VERSION "3.9"
+#endif
 /* Define to empty if `const' does not conform to ANSI C. */
 /* #undef const */

--- a/samples/cellular/modem_shell/src/link/link_shell.c
+++ b/samples/cellular/modem_shell/src/link/link_shell.c
@@ -1749,11 +1749,15 @@ static int link_shell_modem(const struct shell *shell, size_t argc, char **argv)
 			break;
 		case LINK_SHELL_OPT_MODEM_SYSTEMOFF:
 			operation_selected = true;
+#if defined(CONFIG_POWEROFF)
 			nrf_modem_at_printf("AT+CFUN=0");
 			nrf_modem_lib_shutdown();
 			printk("Entering SYSTEMOFF in 1 second, wakeup only with reset\n");
 			k_sleep(K_SECONDS(1));
 			sys_poweroff();
+#else
+			mosh_error("Enable CONFIG_POWEROFF for SYSTEMOFF support");
+#endif
 			break;
 
 		case 'h':


### PR DESCRIPTION
Added flagging needed to compile for nRF92.