### PR TITLE
nfc: lib: reset NFCT frame delay max on field lost

### DIFF
--- a/subsys/nfc/lib/platform.c
+++ b/subsys/nfc/lib/platform.c
@@ -255,6 +255,13 @@ void nfc_platform_event_handler(nrfx_nfct_evt_t const *event)
 		__ASSERT_NO_MSG(err >= 0);
 		break;
 	case NRFX_NFCT_EVT_FIELD_LOST:
+		/* Workaround: Ensure the FRAMEDELAYMAX register is set to default value when
+		 * field is lost. This avoids violating protocol timing, which can lead readers
+		 * to reject the NFC tag's response.
+		 */
+		if (!(NRF_ERRATA_DYNAMIC_CHECK(52, 218) && NRF_ERRATA_DYNAMIC_CHECK(53, 71))) {
+			nrf_nfct_frame_delay_max_set(NRF_NFCT, NRF_NFCT_FAME_DELAY_MAX_DEFAULT);
+		}
 		LOG_DBG("Field lost");
 
 #if IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF)


### PR DESCRIPTION
This PR contains workaround for upcoming NCS release for known issue https://nordicsemi.atlassian.net/browse/KRKNWK-21640:
Restore NFCT max frame delay (FRAMEDELAYMAX) to the default when the RF field is removed, so a shortened delay does not persist and corrupt frame timing for the next session (readers may then reject tag responses).

The  `nrf_nfct_frame_delay_max_set(NRF_NFCT, NRF_NFCT_FAME_DELAY_MAX_DEFAULT);` should be placed in NFC driver, however this requires nrfxlib release. For near relese it is impossible to do that, so the another solution is placed the function directly in the `platform.c` file.
Follow up ticket https://nordicsemi.atlassian.net/browse/NRFX-9423 - after implementation the fix in the driver, this workaround will be removed.