### PR TITLE
applications: nrf_desktop: Disable fprotect in MCUboot for nRF54LS05

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54ls05dk_nrf54ls05b_cpuapp/images/mcuboot/prj_release.conf
+++ b/applications/nrf_desktop/configuration/nrf54ls05dk_nrf54ls05b_cpuapp/images/mcuboot/prj_release.conf
@@ -14,7 +14,9 @@ CONFIG_BOOT_BOOTSTRAP=n
 CONFIG_BOOT_VERSION_CMP_USE_BUILD_NUMBER=y
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
+# Temporarily disable fprotect to workaround `fprotect_area` API call failure.
+# The `fprotect_area` failure leads to application boot failures.
+CONFIG_FPROTECT=n
 
 CONFIG_RESET_ON_FATAL_ERROR=y
 

--- a/applications/nrf_desktop/configuration/nrf54ls05dk_nrf54ls05b_cpuapp/images/mcuboot/prj_release_keyboard.conf
+++ b/applications/nrf_desktop/configuration/nrf54ls05dk_nrf54ls05b_cpuapp/images/mcuboot/prj_release_keyboard.conf
@@ -14,7 +14,9 @@ CONFIG_BOOT_BOOTSTRAP=n
 CONFIG_BOOT_VERSION_CMP_USE_BUILD_NUMBER=y
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
+# Temporarily disable fprotect to workaround `fprotect_area` API call failure.
+# The `fprotect_area` failure leads to application boot failures.
+CONFIG_FPROTECT=n
 
 CONFIG_RESET_ON_FATAL_ERROR=y
 


### PR DESCRIPTION
Temporarily disable fprotect to workaround `fprotect_area` API call failure. The `fprotect_area` failure leads to application boot failures.

Jira: NCSDK-38834