### PR TITLE
[Backport v3.3-branch] doc: Tag file updates for the 3.3.0 release

### DIFF
--- a/doc/_zoomin/ncs.tags.yml
+++ b/doc/_zoomin/ncs.tags.yml
@@ -11,13 +11,14 @@ mapping_topics:
   - nrf/index.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series", "nrf52-series",
                      "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91", "thingy91x", "nrf9161",
                      "nrf9151", "nrf9131", "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10",
-                     "nrf54lm20", "nrf54lv10a", "nrf54ls05b", "nrf5340", "thingy53", "nrf52840",
-                     "nrf52833", "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805",
-                     "nrf21540", "npm1100", "npm1300", "npm2100", "npm6001"]
+                     "nrf54lm20a", "nrf54lm20b", "nrf54lv10a", "nrf54ls05a", "nrf54ls05b",
+                     "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820",
+                     "nrf52811", "nrf52810", "nrf52805", "nrf21540", "npm1100", "npm1300",
+                     "npm2100", "npm6001"]
   - nrf/gsg_guides.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                           "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91",
                           "thingy91x", "nrf9161", "nrf9151", "nrf9131", "nrf54h20", "nrf54l15",
-                          "nrf54l05", "nrf54l10", "nrf54lm20", "nrf54lm20b", "nrf54lv10a",
+                          "nrf54l05", "nrf54l10", "nrf54lm20a", "nrf54lm20b", "nrf54lv10a",
                           "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820",
                           "nrf52811", "nrf52810", "nrf52805", "nrf21540", "npm1100", "npm1300",
                           "npm2100", "npm6001", "development-kits", "prototyping-platforms",
@@ -25,49 +26,52 @@ mapping_topics:
   - nrf/installation.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                             "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91",
                             "thingy91x", "nrf9161", "nrf9151", "nrf9131", "nrf54h20", "nrf54l15",
-                            "nrf54l05", "nrf54l10", "nrf54lm20", "nrf54lv10a", "nrf54ls05b",
-                            "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820",
-                            "nrf52811", "nrf52810", "nrf52805", "nrf21540", "npm1100", "npm1300",
-                            "npm2100", "npm6001"]
+                            "nrf54l05", "nrf54l10", "nrf54lm20a", "nrf54lm20b", "nrf54lv10a",
+                            "nrf54ls05a", "nrf54ls05b", "nrf5340", "thingy53", "nrf52840",
+                            "nrf52833", "nrf52832", "nrf52820", "nrf52811", "nrf52810",
+                            "nrf52805", "nrf21540", "npm1100", "npm1300", "npm2100", "npm6001"]
   - nrf/installation/*.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                               "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160",
                               "thingy91", "thingy91x", "nrf9161", "nrf9151", "nrf9131", "nrf54h20",
-                              "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20", "nrf54lv10a",
-                              "nrf54ls05b", "nrf5340", "thingy53", "nrf52840", "nrf52833",
-                              "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805",
-                              "nrf21540", "npm1100", "npm1300", "npm2100", "npm6001"]
+                              "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20a", "nrf54lm20b",
+                              "nrf54lv10a", "nrf54ls05a", "nrf54ls05b", "nrf5340", "thingy53",
+                              "nrf52840", "nrf52833", "nrf52832", "nrf52820", "nrf52811",
+                              "nrf52810", "nrf52805", "nrf21540", "npm1100", "npm1300",
+                              "npm2100", "npm6001"]
   - nrf/app_dev.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                        "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91",
                        "thingy91x", "nrf9161", "nrf9151", "nrf9131", "nrf54h20", "nrf54l15",
-                       "nrf54l05", "nrf54l10", "nrf54lm20", "nrf54lv10a", "nrf54ls05b", "nrf5340",
-                       "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820", "nrf52811",
-                       "nrf52810", "nrf52805", "nrf21540", "npm1100", "npm1300", "npm2100",
-                       "npm6001"]
+                       "nrf54l05", "nrf54l10", "nrf54lm20a", "nrf54lm20b", "nrf54lv10a",
+                       "nrf54ls05a", "nrf54ls05b", "nrf5340", "thingy53", "nrf52840", "nrf52833",
+                       "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805", "nrf21540",
+                       "npm1100", "npm1300", "npm2100", "npm6001"]
   - nrf/app_dev/create_application.html: ["nrf91-series", "nrf70-series", "nrf54-series",
                                           "nrf53-series", "nrf52-series", "nrf7002", "nrf7001",
                                           "nrf7000", "nrf9160", "thingy91", "thingy91x", "nrf9161",
                                           "nrf9151", "nrf9131", "nrf54h20", "nrf54l15", "nrf54l05",
-                                          "nrf54l10", "nrf54lm20", "nrf54lv10a", "nrf54ls05b",
-                                          "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832",
-                                          "nrf52820", "nrf52811", "nrf52810", "nrf52805",
-                                          "nrf21540", "npm1100", "npm1300", "npm2100", "npm6001",
+                                          "nrf54l10", "nrf54lm20a", "nrf54lm20b", "nrf54lv10a",
+                                          "nrf54ls05a", "nrf54ls05b", "nrf5340", "thingy53",
+                                          "nrf52840", "nrf52833", "nrf52832", "nrf52820",
+                                          "nrf52811", "nrf52810", "nrf52805", "nrf21540",
+                                          "npm1100", "npm1300", "npm2100", "npm6001",
                                           "applications", "nrf-connect-vsc"]
   - nrf/app_dev/board_names.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                                    "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160",
                                    "thingy91", "thingy91x", "nrf9161", "nrf9151", "nrf9131",
-                                   "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20",
-                                   "nrf54lv10a", "nrf54ls05b", "nrf5340", "thingy53", "nrf52840",
-                                   "nrf52833", "nrf52832", "nrf52820", "nrf52811", "nrf52810",
-                                   "nrf52805", "nrf21540", "npm1100", "npm1300", "npm2100",
-                                   "npm6001"]
+                                   "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20a",
+                                   "nrf54lm20b", "nrf54lv10a", "nrf54ls05a", "nrf54ls05b",
+                                   "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832",
+                                   "nrf52820", "nrf52811", "nrf52810", "nrf52805", "nrf21540",
+                                   "npm1100", "npm1300", "npm2100", "npm6001"]
   - nrf/app_dev/config_and_build/*.html: ["nrf91-series", "nrf70-series", "nrf54-series",
                                           "nrf53-series", "nrf52-series", "nrf7002", "nrf7001",
                                           "nrf7000", "nrf9160", "thingy91", "thingy91x", "nrf9161",
                                           "nrf9151", "nrf9131", "nrf54h20", "nrf54l15", "nrf54l05",
-                                          "nrf54l10", "nrf54lm20", "nrf54lv10a", "nrf54ls05b",
-                                          "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832",
-                                          "nrf52820", "nrf52811", "nrf52810", "nrf52805",
-                                          "nrf21540", "npm1100", "npm1300", "npm2100", "npm6001"]
+                                          "nrf54l10", "nrf54lm20a", "nrf54lm20b", "nrf54lv10a",
+                                          "nrf54ls05a", "nrf54ls05b", "nrf5340", "thingy53",
+                                          "nrf52840", "nrf52833", "nrf52832", "nrf52820",
+                                          "nrf52811", "nrf52810", "nrf52805", "nrf21540",
+                                          "npm1100", "npm1300", "npm2100", "npm6001"]
   - nrf/app_dev/config_and_build/config_and_build_system.html: ["applications", "samples",
                                                                 "kconfig"]
   - nrf/app_dev/config_and_build/cmake/index.html: ["applications", "samples", "kconfig",
@@ -88,41 +92,45 @@ mapping_topics:
                                                            "prototyping-platforms"]
   - nrf/app_dev/programming.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                                    "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160",
-                                   "thingy91", "thingy91x", "nrf9161", "nnrf9151", "nrf9131",
-                                   "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20",
-                                   "nrf54lv10a", "nrf54ls05b", "nrf5340", "thingy53", "nrf52840",
-                                   "nrf52833", "nrf52832", "nrf52820", "nrf52811", "nrf52810",
-                                   "nrf52805", "nrf21540", "npm1100", "npm1300", "npm2100",
-                                   "npm6001", "applications", "samples", "development-kits",
-                                   "evaluation-kits", "prototyping-platforms"]
+                                   "thingy91", "thingy91x", "nrf9161", "nrf9151", "nrf9131",
+                                   "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20a",
+                                   "nrf54lm20b", "nrf54lv10a", "nrf54ls05a", "nrf54ls05b",
+                                   "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832",
+                                   "nrf52820", "nrf52811", "nrf52810", "nrf52805", "nrf21540",
+                                   "npm1100", "npm1300", "npm2100", "npm6001", "applications",
+                                   "samples", "development-kits", "evaluation-kits",
+                                   "prototyping-platforms"]
   - nrf/app_dev/companion_components.html: ["nrf91-series", "nrf70-series", "nrf54-series",
                                             "nrf53-series", "nrf52-series", "nrf7002", "nrf7001",
                                             "nrf7000", "nrf9160", "thingy91", "thingy91x",
-                                            "nrf9161", "nnrf9151", "nrf9131", "nrf54h20",
-                                            "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20",
-                                            "nrf54lv10a", "nrf54ls05b", "nrf5340", "thingy53",
-                                            "nrf52840", "nrf52833", "nrf52832", "nrf52820",
-                                            "nrf52811", "nrf52810", "nrf52805", "nrf21540",
-                                            "npm1100", "npm1300", "npm2100", "npm6001",
-                                            "applications", "samples", "development-kits",
-                                            "evaluation-kits", "prototyping-platforms"]
+                                            "nrf9161", "nrf9151", "nrf9131", "nrf54h20",
+                                            "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20a",
+                                            "nrf54lm20b", "nrf54lv10a", "nrf54ls05a", "nrf54ls05b",
+                                            "nrf5340", "thingy53", "nrf52840", "nrf52833",
+                                            "nrf52832", "nrf52820", "nrf52811", "nrf52810",
+                                            "nrf52805", "nrf21540", "npm1100", "npm1300", "npm2100",
+                                            "npm6001", "applications", "samples",
+                                            "development-kits", "evaluation-kits",
+                                            "prototyping-platforms"]
   - nrf/app_dev/bootloaders_dfu/index.html: ["nrf91-series", "nrf70-series", "nrf54-series",
                                              "nrf53-series", "nrf52-series", "nrf7002", "nrf7001",
                                              "nrf7000", "nrf9160", "thingy91", "thingy91x",
                                              "nrf9161", "nrf9151", "nrf9131", "nrf54h20",
-                                             "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20",
-                                             "nrf54lv10a", "nrf54ls05b", "nrf5340", "thingy53",
-                                             "nrf52840", "nrf52833", "nrf52832", "nrf52820",
-                                             "nrf52811", "nrf52810", "nrf52805", "nrf21540",
-                                             "npm1100", "npm1300", "npm2100", "npm6001"]
+                                             "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20a",
+                                             "nrf54lm20b", "nrf54lv10a", "nrf54ls05a", "nrf54ls05b",
+                                             "nrf5340", "thingy53", "nrf52840", "nrf52833",
+                                             "nrf52832", "nrf52820", "nrf52811", "nrf52810",
+                                             "nrf52805", "nrf21540", "npm1100", "npm1300",
+                                             "npm2100", "npm6001"]
   - nrf/app_dev/bootloaders_dfu/mcuboot_nsib/*.html: ["nrf91-series", "nrf70-series",
                                                       "nrf54-series", "nrf53-series",
                                                       "nrf52-series", "nrf7002", "nrf7001",
                                                       "nrf7000", "nrf9160", "thingy91", "thingy91x",
                                                       "nrf9161", "nrf9151", "nrf9131", "nrf54h20",
                                                       "nrf54l15", "nrf54l05", "nrf54l10",
-                                                      "nrf54lm20", "nrf54lv10a", "nrf54ls05b",
-                                                      "nrf5340", "thingy53", "nrf52840", "nrf52833",
+                                                      "nrf54lm20a", "nrf54lm20b", "nrf54lv10a",
+                                                      "nrf54ls05a", "nrf54ls05b", "nrf5340",
+                                                      "thingy53", "nrf52840", "nrf52833",
                                                       "nrf52832", "nrf52820", "nrf52811",
                                                       "nrf52810", "nrf52805", "nrf21540", "npm1100",
                                                       "npm1300", "npm2100", "npm6001",
@@ -135,8 +143,9 @@ mapping_topics:
                                                             "nrf7000", "nrf9160", "thingy91",
                                                             "thingy91x", "nrf9161", "nrf9151",
                                                             "nrf9131", "nrf54h20", "nrf54l15",
-                                                            "nrf54l05", "nrf54l10", "nrf54lm20",
-                                                            "nrf54lv10a", "nrf54ls05b", "nrf5340",
+                                                            "nrf54l05", "nrf54l10", "nrf54lm20a",
+                                                            "nrf54lm20b", "nrf54lv10a",
+                                                            "nrf54ls05a", "nrf54ls05b", "nrf5340",
                                                             "thingy53", "nrf52840", "nrf52833",
                                                             "nrf52832", "nrf52820", "nrf52811",
                                                             "nrf52810", "nrf52805", "nrf21540",
@@ -149,7 +158,8 @@ mapping_topics:
                                                                  "thingy91", "thingy91x", "nrf9161",
                                                                  "nrf9151", "nrf9131", "nrf54h20",
                                                                  "nrf54l15", "nrf54l05", "nrf54l10",
-                                                                 "nrf54lm20", "nrf54lv10a",
+                                                                 "nrf54lm20a", "nrf54lm20b",
+                                                                 "nrf54lv10a", "nrf54ls05a",
                                                                  "nrf54ls05b", "nrf5340",
                                                                  "thingy53", "nrf52840", "nrf52833",
                                                                  "nrf52832", "nrf52820", "nrf52811",
@@ -162,13 +172,13 @@ mapping_topics:
                                                           "nrf7000", "nrf9160", "thingy91",
                                                           "thingy91x", "nrf9161", "nrf9151",
                                                           "nrf9131", "nrf54h20", "nrf54l15",
-                                                          "nrf54l05", "nrf54l10", "nrf54lm20",
-                                                          "nrf54lv10a", "nrf54ls05b", "nrf5340",
-                                                          "thingy53", "nrf52840", "nrf52833",
-                                                          "nrf52832", "nrf52820", "nrf52811",
-                                                          "nrf52810", "nrf52805", "nrf21540",
-                                                          "npm1100", "npm1300", "npm2100",
-                                                          "npm6001"]
+                                                          "nrf54l05", "nrf54l10", "nrf54lm20a",
+                                                          "nrf54lm20b", "nrf54lv10a", "nrf54ls05a",
+                                                          "nrf54ls05b", "nrf5340", "thingy53",
+                                                          "nrf52840", "nrf52833", "nrf52832",
+                                                          "nrf52820", "nrf52811", "nrf52810",
+                                                          "nrf52805", "nrf21540", "npm1100",
+                                                          "npm1300", "npm2100", "npm6001"]
   - nrf/app_dev/device_guides/nrf91/index.html: ["nrf9160", "nrf9161", "thingy91", "thingy91x",
                                                  "nrf9151", "nrf9131", "development-kits",
                                                  "dect-nr+", "prototyping-platforms"]
@@ -210,9 +220,9 @@ mapping_topics:
   - nrf/app_dev/device_guides/nrf70/index.html: ["evaluation-kits"]
   - nrf/app_dev/device_guides/nrf70/nrf7002ek_dev_guide.html: ["evaluation-kits"]
   - nrf/app_dev/device_guides/nrf70/constrained.html: ["kconfig"]
-  - nrf/app_dev/device_guides/nrf54l/*.html: ["nrf54-series", "nrf54l15", "nrf54l10", "nrf54lm20",
-                                              "nrf54lv10a", "nrf54ls05b", "nrf54l05",
-                                              "development-kits"]
+  - nrf/app_dev/device_guides/nrf54l/*.html: ["nrf54-series", "nrf54l15", "nrf54l10", "nrf54lm20a",
+                                              "nrf54lm20b", "nrf54lv10a", "nrf54ls05a",
+                                              "nrf54ls05b", "nrf54l05", "development-kits"]
   - nrf/app_dev/device_guides/nrf54h/*.html: ["nrf54-series", "nrf54h20", "development-kits"]
   - nrf/app_dev/device_guides/nrf53/index.html: ["nrf5340", "thingy53", "development-kits",
                                                  "prototyping-platforms"]
@@ -224,8 +234,8 @@ mapping_topics:
   - nrf/app_dev/device_guides/nrf53/fota_update_nrf5340.html: ["nrf5340", "development-kits"]
   - nrf/app_dev/device_guides/nrf53/simultaneous_multi_image_dfu_nrf5340.html: ["nrf5340",
                                                                                 "development-kits"]
-  - /nrf/app_dev/device_guides/nrf53/serial_recovery.html: ["nrf5340", "development-kits"]
-  - /nrf/app_dev/device_guides/nrf53/logging_nrf5340.html: ["nrf5340", "development-kits"]
+  - nrf/app_dev/device_guides/nrf53/serial_recovery.html: ["nrf5340", "development-kits"]
+  - nrf/app_dev/device_guides/nrf53/logging_nrf5340.html: ["nrf5340", "development-kits"]
   - nrf/app_dev/device_guides/nrf53/qspi_xip_guide_nrf5340.html: ["nrf5340", "development-kits"]
   - nrf/app_dev/device_guides/thingy53/*.html: ["thingy53", "prototyping-platforms", "nrf53-series"]
   - nrf/app_dev/device_guides/nrf52/*.html: ["nrf52-series", "development-kits", "nrf52840",
@@ -241,25 +251,29 @@ mapping_topics:
   - nrf/app_dev/device_guides/pmic/npm2100.html: ["npm2100"]
   - nrf/app_dev/device_guides/fem/*.html: ["fem", "evaluation-kits", "development-kits"]
   - nrf/app_dev/device_guides/fem/21540ek_dev_guide.html: ["nrf21540"]
+  - nrf/app_dev/device_guides/kmu_guides/*.html: ["nrf54-series", "nrf54l15", "nrf54l10",
+                                                  "nrf54lm20a", "nrf54lm20b", "nrf54lv10a",
+                                                  "nrf54ls05a", "nrf54ls05b", "nrf54l05",
+                                                  "nrf54h20", "development-kits"]
   - nrf/app_dev/device_guides/wifi_coex.html: ["kconfig", "ble", "nrf70-series", "nrf7002",
                                                "nrf7001", "nrf7000", "wifi"]
   - nrf/app_dev/device_guides/custom/*.html: ["development-kits"]
   - nrf/test_and_optimize.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                                  "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160",
                                  "thingy91", "thingy91x", "nrf9161", "nrf9151", "nrf9131",
-                                 "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20",
-                                 "nrf54lv10a", "nrf54ls05b", "nrf5340", "thingy53", "nrf52840",
-                                 "nrf52833", "nrf52832", "nrf52820", "nrf52811", "nrf52810",
-                                 "nrf52805", "nrf21540", "npm1100", "npm1300", "npm2100",
-                                 "npm6001", "applications", "samples"]
+                                 "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20a",
+                                 "nrf54lm20b", "nrf54lv10a", "nrf54ls05a", "nrf54ls05b", "nrf5340",
+                                 "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820",
+                                 "nrf52811", "nrf52810", "nrf52805", "nrf21540", "npm1100",
+                                 "npm1300", "npm2100", "npm6001", "applications", "samples"]
   - nrf/test_and_optimize/*.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                                    "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160",
                                    "thingy91", "thingy91x", "nrf9161", "nrf9151", "nrf9131",
-                                   "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20",
-                                   "nrf54lv10a", "nrf54ls05b", "nrf5340", "thingy53", "nrf52840",
-                                   "nrf52833", "nrf52832", "nrf52820", "nrf52811", "nrf52810",
-                                   "nrf52805", "nrf21540", "npm1100", "npm1300", "npm2100",
-                                   "npm6001"]
+                                   "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20a",
+                                   "nrf54lm20b", "nrf54lv10a", "nrf54ls05a", "nrf54ls05b",
+                                   "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832",
+                                   "nrf52820", "nrf52811", "nrf52810", "nrf52805", "nrf21540",
+                                   "npm1100", "npm1300", "npm2100", "npm6001"]
   - nrf/test_and_optimize/optimizing/*.html: ["applications", "protocols"]
   - nrf/test_and_optimize/optimizing/memory.html: ["kconfig", "ble", "blemesh",
                                                    "gazell", "matter", "nfc", "thread", "zigbee",
@@ -270,32 +284,35 @@ mapping_topics:
                                                       "nrf54-series", "nrf53-series",
                                                       "nrf52-series", "nrf7002", "nrf7001",
                                                       "nrf7000", "nrf54l15", "nrf54l05",
-                                                      "nrf54l10", "nrf54lm20", "nrf54lv10a",
-                                                      "nrf54ls05b", "nrf5340", "thingy53",
-                                                      "nrf52840", "nrf52833", "nrf52832",
-                                                      "nrf52820", "nrf52811", "nrf52810",
-                                                      "nrf52805", "nrf9160", "matter",
+                                                      "nrf54l10", "nrf54lm20a", "nrf54lm20b",
+                                                      "nrf54lv10a", "nrf54ls05a", "nrf54ls05b",
+                                                      "nrf5340", "thingy53", "nrf52840", "nrf52833",
+                                                      "nrf52832", "nrf52820", "nrf52811",
+                                                      "nrf52810", "nrf52805", "nrf9160", "matter",
                                                       "thread", "lte", "wifi"]
   - nrf/security.html: ["kconfig"]
   - nrf/security/*.html: ["kconfig"]
   - nrf/security/crypto/*.html: ["nrf91-series", "nrf54-series", "nrf53-series",
                                  "nrf52-series", "nrf9160", "nrf9161", "nrf9151", "nrf9131",
-                                 "nrf54h20", "nrf54l15", "nrf54l10", "nrf54lm20", "nrf54lv10a",
-                                 "nrf54l05", "nrf5340", "nrf52840", "nrf52833", "nrf52832",
-                                 "kconfig"]
+                                 "nrf54h20", "nrf54l15", "nrf54l10", "nrf54lm20a", "nrf54lm20b",
+                                 "nrf54lv10a", "nrf54l05", "nrf5340", "nrf52840", "nrf52833",
+                                 "nrf52832", "kconfig"]
   - nrf/security/tfm/*.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                               "nrf9160", "nrf9161", "nrf9151", "nrf9131", "nrf7002",
-                              "nrf54l15", "nrf54l10", "nrf54lm20", "nrf54lv10a", "nrf54ls05b",
-                              "nrf5340", "thingy91", "thingy91x", "thingy53", "kconfig"]
+                              "nrf54l15", "nrf54l10", "nrf54lm20a", "nrf54lm20b", "nrf54lv10a",
+                              "nrf54ls05a", "nrf54ls05b", "nrf5340", "thingy91", "thingy91x",
+                              "thingy53", "kconfig"]
   - nrf/security/ap_protect.html: ["nrf91-series", "nrf54-series", "nrf53-series",
                                    "nrf52-series", "nrf9160", "nrf9161", "nrf9151", "nrf9131",
-                                   "nrf54h20", "nrf54l15", "nrf54lm20", "nrf54lv10a", "nrf54ls05b",
-                                   "nrf5340", "nrf52840", "nrf52833", "nrf52832", "nrf52820",
-                                   "nrf52811", "nrf52810", "nrf52805", "kconfig"]
+                                   "nrf54h20", "nrf54l15", "nrf54lm20a", "nrf54lm20b", "nrf54lv10a",
+                                   "nrf54ls05a", "nrf54ls05b", "nrf5340", "nrf52840", "nrf52833",
+                                   "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805",
+                                   "kconfig"]
   - nrf/security/secure_storage.html: ["nrf91-series", "nrf54-series", "nrf53-series",
                                        "nrf52-series", "nrf9160", "nrf9161", "nrf9151", "nrf9131",
-                                       "nrf54l15", "nrf54l10", "nrf54lm20", "nrf54lv10a",
-                                       "nrf5340", "nrf52840", "nrf52833", "nrf52832", "kconfig"]
+                                       "nrf54l15", "nrf54l10", "nrf54lm20a", "nrf54lm20b",
+                                       "nrf54lv10a", "nrf5340", "nrf52840", "nrf52833", "nrf52832",
+                                       "kconfig"]
   - nrf/protocols/*.html: ["protocols"]
   - nrf/protocols.html: ["sidewalk", "ble", "blemesh", "esb", "gazell", "matter", "multiprotocol",
                          "nfc", "thread", "zigbee", "wifi", "dect-nr+", "protocols"]
@@ -330,17 +347,18 @@ mapping_topics:
   - nrf/protocols/thread/sed_ssed.html: ["kconfig"]
   - nrf/protocols/thread/certification.html: ["certifications"]
   - nrf/protocols/wifi/*.html: ["wifi", "nrf70-series", "nrf7002", "nrf7001", "nrf7000"]
-  - nrfprotocols/wifi/wifi_certification.html: ["certifications"]
+  - nrf/protocols/wifi/wifi_certification.html: ["certifications"]
   - nrf/protocols/wifi/regulatory_certification/index.html: ["certifications"]
   - nrf/protocols/zigbee/index.html: ["zigbee"]
   - nrf/protocols/wifi/station_mode/powersave.html: ["power-profiler-kit"]
   - nrf/applications.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                             "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91",
                             "thingy91x", "nrf9161", "nrf9151", "nrf54h20", "nrf54l15", "nrf54l05",
-                            "nrf54l10", "nrf54lm20", "nrf54lv10a", "nrf54ls05b", "nrf5340",
-                            "thingy53", "nrf52840", "nrf52833", "nrf52832", "nrf52820", "nrf52811",
-                            "nrf52810", "nrf52805", "nrf21540", "npm1100", "npm1300", "npm2100",
-                            "npm6001", "kconfig", "development-kits", "prototyping-platforms"]
+                            "nrf54l10", "nrf54lm20a", "nrf54lm20b", "nrf54lv10a", "nrf54ls05a",
+                            "nrf54ls05b", "nrf5340", "thingy53", "nrf52840", "nrf52833",
+                            "nrf52832", "nrf52820", "nrf52811", "nrf52810", "nrf52805", "nrf21540",
+                            "npm1100", "npm1300", "npm2100", "npm6001", "kconfig",
+                            "development-kits", "prototyping-platforms"]
   - nrf/applications/*.html: ["applications", "kconfig"]
   - nrf/applications/connectivity_bridge/README.html: ["lte"]
   - nrf/applications/matter_bridge/*.html: ["matter", "wifi"]
@@ -351,8 +369,9 @@ mapping_topics:
   - nrf/samples.html: ["nrf91-series", "nrf70-series", "nrf54-series", "nrf53-series",
                        "nrf52-series", "nrf7002", "nrf7001", "nrf7000", "nrf9160", "thingy91",
                        "thingy91x", "nrf9161", "nrf9151", "nrf54h20", "nrf54l15", "nrf54l05",
-                       "nrf54l10", "nrf54lm20", "nrf54lv10a", "nrf54ls05b", "nrf5340", "thingy53",
-                       "nrf52840", "nrf52833", "nrf52832", "nrf52820", "nrf52811", "nrf52810",
+                       "nrf54l10", "nrf54lm20a", "nrf54lm20b", "nrf54lv10a", "nrf54ls05a",
+                       "nrf54ls05b", "nrf5340", "thingy53", "nrf52840", "nrf52833", "nrf52832",
+                       "nrf52820", "nrf52811", "nrf52810",
                        "nrf52805", "nrf21540", "npm1100", "npm1300", "npm2100", "npm6001",
                        "development-kits", "prototyping-platforms", "kconfig"]
   - nrf/samples/*.html: ["samples", "kconfig"]
@@ -393,8 +412,9 @@ mapping_topics:
   - nrf/libraries/bin/lwm2m_carrier/certification.html: ["certification"]
   - nrf/libraries/bluetooth/*.html: ["ble", "nrf52-series", "nrf52840", "nrf52833", "nrf52832",
                                      "nrf52820", "nrf52811", "nrf52810", "nrf52805", "nrf54-series",
-                                     "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20",
-                                     "nrf54lv10a", "nrf54ls05b", "development-kits"]
+                                     "nrf54h20", "nrf54l15", "nrf54l05", "nrf54l10", "nrf54lm20a",
+                                     "nrf54lm20b", "nrf54lv10a", "nrf54ls05a", "nrf54ls05b",
+                                     "development-kits"]
   - nrf/libraries/bluetooth/mesh.html: ["blemesh"]
   - nrf/libraries/bluetooth/mesh/*.html: ["blemesh"]
   - nrf/libraries/gazell/*.html: ["gazell"]
@@ -409,8 +429,8 @@ mapping_topics:
   - nrf/libraries/networking/nrf_cloud_pgps.html: ["nrf-cloud"]
   - nrf/libraries/networking/nrf_cloud_rest.html: ["nrf-cloud"]
   - nrf/libraries/networking/nrf_provisioning.html: ["at-commands"]
-  - nrf/libraries/networking/softap_wifi_provision: ["wifi", "nrf70-series", "nrf7002", "nrf7001",
-                                                     "nrf7000"]
+  - nrf/libraries/networking/softap_wifi_provision.html: ["wifi", "nrf70-series", "nrf7002",
+                                                          "nrf7001", "nrf7000"]
   - nrf/libraries/networking/lwm2m_client_utils.html: ["lte"]
   - nrf/libraries/networking/lwm2m_location_assistance.html: ["lte"]
   - nrf/libraries/networking/wifi_credentials.html: ["wifi", "nrf70-series", "nrf7002", "nrf7001",
@@ -418,7 +438,8 @@ mapping_topics:
   - nrf/libraries/networking/wifi_mgmt_ext.html: ["wifi", "nrf70-series", "nrf7002", "nrf7001",
                                                   "nrf7000"]
   - nrf/libraries/networking/ot_rpc.html: ["thread"]
-  - nrf/libraries/networking/wifi_ready: ["wifi", "nrf70-series", "nrf7002", "nrf7001", "nrf7000"]
+  - nrf/libraries/networking/wifi_ready.html: ["wifi", "nrf70-series", "nrf7002", "nrf7001",
+                                               "nrf7000"]
   - nrf/libraries/nfc/*.html: ["nfc"]
   - nrf/libraries/others/adp536x.html: ["pmic"]
   - nrf/libraries/others/contin_array.html: ["nrf5340"]
@@ -446,7 +467,7 @@ mapping_topics:
   - nrfxlib/nrf_modem/*.html: ["nrf91-series", "nrf9160", "nrf9161", "nrf9151", "lte", "dect-nr+"]
   - nrfxlib/nrf_modem/doc/at_interface.html: ["at-commands"]
   - nrfxlib/nrf_802154/README.html: ["nrf52-series", "nrf54-series", "nrf54l15", "nrf54l05",
-                                     "nrf54l10", "nrf54lm20", "nrf52840", "nrf52833",
+                                     "nrf54l10", "nrf54lm20a", "nrf54lm20b", "nrf52840", "nrf52833",
                                      "nrf5340"]
   - nrfxlib/nrf_802154/*.html: ["multiprotocol"]
   - nrfxlib/nrf_fuel_gauge/*.html: ["pmic", "npm1100", "npm1300", "npm2100", "npm6001",


### PR DESCRIPTION
Backport 910c88192ef51595eb8591f3c0707cfa86280bc5 from #28104.