### PR TITLE
tests: subsys: bootloader: b0_lock_rwx: add lm20b for b0.w

### DIFF
--- a/tests/subsys/bootloader/b0_lock_rwx/testcase.yaml
+++ b/tests/subsys/bootloader/b0_lock_rwx/testcase.yaml
@@ -9,6 +9,7 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp


### PR DESCRIPTION
Missing configuration.