### PR TITLE
samples: dfu_multi_image: Fix partitions

### DIFF
--- a/samples/dfu/dfu_multi_image/sysbuild/nrf54h20dk_nrf54h20_memory_map.dtsi
+++ b/samples/dfu/dfu_multi_image/sysbuild/nrf54h20dk_nrf54h20_memory_map.dtsi
@@ -29,28 +29,28 @@
 		};
 
 		cpurad_slot0_partition: partition@77000 {
-			reg = <0x77000 DT_SIZE_K(216)>;
+			reg = <0x77000 DT_SIZE_K(212)>;
 		};
 
-		cpuapp_slot1_partition: partition@ad000 {
-			reg = <0xad000 DT_SIZE_K(212)>;
+		cpuapp_slot1_partition: partition@ac000 {
+			reg = <0xac000 DT_SIZE_K(212)>;
 		};
 
-		cpurad_slot1_partition: partition@e2000 {
-			reg = <0xe2000 DT_SIZE_K(216)>;
+		cpurad_slot1_partition: partition@e1000 {
+			reg = <0xe1000 DT_SIZE_K(212)>;
 		};
 
-		cpuppr_code_partition: partition@118000 {
-			reg = <0x118000 DT_SIZE_K(64)>;
+		cpuppr_code_partition: partition@116000 {
+			reg = <0x116000 DT_SIZE_K(64)>;
 		};
 
-		cpuflpr_code_partition: partition@128000 {
-			reg = <0x128000 DT_SIZE_K(48)>;
+		cpuflpr_code_partition: partition@126000 {
+			reg = <0x126000 DT_SIZE_K(48)>;
 		};
 
-		dfu_multi_image_helper_partition: partition@134000 {
+		dfu_multi_image_helper_partition: partition@132000 {
 			label = "helper";
-			reg = <0x134000 DT_SIZE_K(448)>;
+			reg = <0x132000 DT_SIZE_K(456)>;
 		};
 	};
 };


### PR DESCRIPTION
Align radio partition size with the application partition size. Currently the CONFIG_BOOT_MAX_IMG_SECTORS_AUTO functionality does not support cases, in which the radio FW is larger than the application FW.

Ref: NCSDK-38844

Regression introduced by: https://github.com/nrfconnect/sdk-nrf/pull/28014 merged only into the v3.3-branch.