### PR TITLE
[Backport v3.3-branch] scripts: pm_to_dts: Fix missing f-string

### DIFF
--- a/scripts/pm_to_dts.py
+++ b/scripts/pm_to_dts.py
@@ -489,8 +489,8 @@ def main():
             if tfm_enabled and mcuboot_enabled and area[0] == 'slot0_ns_partition':
                 indent = '\t\t'
                 subpartition_offset = 0
-                f.write('{indent}};\n')
-                print('{indent}};')
+                f.write(f'{indent}}};\n')
+                print(f'{indent}}};')
 
             output_count += 1
 


### PR DESCRIPTION
Backport 47b99136cd66d7e831cef42762691cb6d42cdc31 from #28201.