### PR TITLE
lib: fprotect: fix RRAMC region default value for nRF54LS05

### DIFF
--- a/lib/fprotect/fprotect_rram.c
+++ b/lib/fprotect/fprotect_rram.c
@@ -11,7 +11,7 @@
 #include <nrfx.h>
 #include <hal/nrf_rramc.h>
 
-#define RRAMC_REGION_FOR_FPROTECT_DEFAULT_VALUE 0x0000000f
+#define RRAMC_REGION_FOR_FPROTECT_DEFAULT_VALUE NRF_RRAMC_REGION_CONFIG_PERM_MASK
 #define RRAMC_REGION_FOR_FPROTECT 4
 #define RRAMC_REGION_FOR_COMBINED_REGIONS_FPROTECT 3
 /* symbols temporarily defined here, since PM can't handle different


### PR DESCRIPTION
## Summary

- Fix `fprotect_area()` returning `-ENOSPC` on cold boot for nRF54LS05 (and other SoCs without the SECURE permission bit in RRAMC).
- The hardcoded unconfigured-region default `0x0000000f` includes the SECURE bit (bit 3), which does not exist on nRF54LS05 where the actual reset value is `0x00000007`. This caused the region to appear already configured.
- Replace the constant with the HAL-provided `NRF_RRAMC_REGION_CONFIG_PERM_MASK`, which evaluates correctly for each SoC variant.

## Test plan

- [x] Build and flash the Fast Pair Locator Tag sample for `nrf54ls05dk/nrf54ls05b/cpuapp` with `-DFILE_SUFFIX=release` (MCUboot enabled).
- [x] Verify MCUboot boots successfully without spinning in the `fprotect_area` error loop.
- [x] Verify no regression on `nrf54l15dk/nrf54l15/cpuapp` (SECURE bit present, mask evaluates to `0x0F`).