### PR TITLE
[Backport v3.3-branch] Radio test coded phy rx disable between packets

### DIFF
--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -807,6 +807,21 @@ static int cmd_rx_start(const struct shell *shell, size_t argc, char **argv)
 	memset(&test_config, 0, sizeof(test_config));
 	test_config.type = RX;
 	test_config.mode = config.mode;
+
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
+	if (config.mode == NRF_RADIO_MODE_BLE_LR125KBIT ||
+	    config.mode == NRF_RADIO_MODE_BLE_LR500KBIT) {
+		shell_warn(
+			shell,
+			"Warning:\n Due to required post-processing in the receiver,"
+			" only every second packet sent by a device\n"
+			" running the start_tx_modulated_carrier command"
+			" with the configured data rate: %s can be received. Starting RX anyway.",
+			config.mode == NRF_RADIO_MODE_BLE_LR125KBIT ? "ble_lr125kbit"
+								    : "ble_lr500kbit");
+	}
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
+
 	test_config.params.rx.channel = config.channel_start;
 	test_config.params.rx.pattern = config.tx_pattern;
 #if CONFIG_FEM

--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -960,9 +960,20 @@ static void radio_rx(uint8_t mode, uint8_t channel, enum transmit_pattern patter
 
 	radio_mode_set(NRF_RADIO, mode);
 
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
+	if ((mode == NRF_RADIO_MODE_BLE_LR125KBIT) || (mode == NRF_RADIO_MODE_BLE_LR500KBIT)) {
+		nrf_radio_shorts_enable(NRF_RADIO, NRF_RADIO_SHORT_READY_START_MASK |
+							   RADIO_TEST_SHORT_END_DISABLE_MASK |
+							   NRF_RADIO_SHORT_DISABLED_RXEN_MASK);
+	} else {
+		nrf_radio_shorts_enable(NRF_RADIO, NRF_RADIO_SHORT_READY_START_MASK |
+							   NRF_RADIO_SHORT_END_START_MASK);
+	}
+#else
 	nrf_radio_shorts_enable(NRF_RADIO,
-				NRF_RADIO_SHORT_READY_START_MASK |
-				NRF_RADIO_SHORT_END_START_MASK);
+				NRF_RADIO_SHORT_READY_START_MASK | NRF_RADIO_SHORT_END_START_MASK);
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
+
 	nrf_radio_packetptr_set(NRF_RADIO, rx_packet);
 
 	radio_config(mode, pattern);


### PR DESCRIPTION
Backport 9145ec24581b64f9a52ef22d36269db28bdba292 from #28131.