### PR TITLE
[Backport v3.3-branch] doc: Thingy91X: Remove SIM activation instructions

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_cloud_connecting.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_cloud_connecting.rst
@@ -20,7 +20,7 @@ Once you have an account, activate your SIM card and add the device to your nRF 
 
 .. note::
 
-   The instructions assume you are activating an iBasis SIM card that came with your |DK|.
+   The instructions assume you are activating the iBasis SIM card that came with your device.
 
    If you are using a SIM card from another provider, make sure you activate it through your network operator before adding the device to nRF Cloud.
 
@@ -54,7 +54,7 @@ Activating the SIM card
 
 .. nrf_cloud_activate_sim_start
 
-To activate the iBasis SIM card that comes shipped with the |DK|, complete the following steps in the `nRF Cloud`_ portal.
+To activate the iBasis SIM card that comes shipped with the device, complete the following steps in the `nRF Cloud`_ portal.
 Make sure you are logged in to the portal.
 
 1. Click :guilabel:`SIM Cards` under :guilabel:`Device Management` in the navigation pane on the left.

--- a/doc/nrf/app_dev/device_guides/thingy91x/thingy91x_cloud_connecting.rst
+++ b/doc/nrf/app_dev/device_guides/thingy91x/thingy91x_cloud_connecting.rst
@@ -7,9 +7,10 @@ Connecting the |DK| to nRF Cloud
 
 .. |DK| replace:: Thingy:91x
 
-.. include:: ../nrf91/nrf91_cloud_connecting.rst
-   :start-after: dk_nrf_cloud_start
-   :end-before: dk_nrf_cloud_end
+To transmit data from your |DK| to nRF Cloud, you need an `nRF Cloud`_ account.
+nRF Cloud is Nordic Semiconductor's platform for connecting your IoT devices to the cloud, viewing and analyzing device message data, prototyping ideas that use Nordic Semiconductor's chips, and more.
+
+Once you have an account, add the device to your nRF Cloud account.
 
 Creating an nRF Cloud account
 *****************************
@@ -17,13 +18,6 @@ Creating an nRF Cloud account
 .. include:: ../nrf91/nrf91_cloud_connecting.rst
    :start-after: nrf_cloud_account_start
    :end-before: nrf_cloud_account_end
-
-Activating the SIM card
-***********************
-
-.. include:: ../nrf91/nrf91_cloud_connecting.rst
-   :start-after: nrf_cloud_activate_sim_start
-   :end-before: nrf_cloud_activate_sim_end
 
 Adding the Thingy:91x to nRF Cloud
 **********************************


### PR DESCRIPTION
Backport b6de3df91d3ff7d8fb7701f2133b79aaad8596f2 from #28168.