### PR TITLE
doc: deprecate hardware model migration guide

### DIFF
--- a/doc/nrf/app_dev/board_names.rst
+++ b/doc/nrf/app_dev/board_names.rst
@@ -67,7 +67,6 @@ While the board name is always present, other elements, such as the board revisi
 
 .. note::
     This board name scheme was introduced in the |NCS| before the v2.7.0 release following changes in Zephyr v3.6.0.
-    Read :ref:`hwmv1_to_v2_migration`, Zephyr's :ref:`zephyr:hw_model_v2`, and refer to the `conversion example Pull Request`_ in Zephyr upstream if you have to port a board to the new model.
 
 .. _app_boards_names_zephyr:
 

--- a/doc/nrf/app_dev/bootloaders_dfu/qspi_xip_split_image.rst
+++ b/doc/nrf/app_dev/bootloaders_dfu/qspi_xip_split_image.rst
@@ -27,7 +27,7 @@ Requirements
 
 To use this feature, meet the following requirements:
 
-* Board based on nRF52840 or nRF5340, with file structure compatible with :ref:`Hardware model v2 (HWMv2) <hwmv1_to_v2_migration>`
+* Board based on nRF52840 or nRF5340, with file structure compatible with Hardware model v2 (HWMv2)
 * External QSPI flash chip with supported commands connected to QSPI pins
 * QSPI flash chip in always-on mode (meaning, no DPM or low-power modes)
 * :doc:`MCUboot configuration <mcuboot:design>` in the Swap using move mode (``MCUBOOT_SWAP_USING_MOVE``), the Upgrade only mode (``MCUBOOT_OVERWRITE_ONLY``), or in the direct-XIP mode

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_nRF54H20_cs_to_2_7.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_nRF54H20_cs_to_2_7.rst
@@ -29,8 +29,4 @@ See the following documents, based on the version you are migrating from.
    nRF54H20_migration_2.7/migration_guide_2.6.99-cs2_to_2_7_environment
    nRF54H20_migration_2.7/migration_guide_2.6.99-cs2_to_2.7_application
 
-
-Consult also the following pages about *Hardware model v2* and *Sysbuild*:
-
-* :ref:`hwmv1_to_v2_migration`
-* :ref:`child_parent_to_sysbuild_migration`
+Consult also the :ref:`child_parent_to_sysbuild_migration` page about *Sysbuild*.

--- a/doc/nrf/releases_and_maturity/migration/migration_hwmv2.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_hwmv2.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _hwmv1_to_v2_migration:
 
 Migrating to the current hardware model
@@ -6,6 +8,9 @@ Migrating to the current hardware model
 .. contents::
    :local:
    :depth: 2
+
+.. note::
+   This migration guide is deprecated and will be removed in the future |NCS| release.
 
 The *hardware model* refers to how SoCs and boards are named, defined, and used.
 Starting with |NCS| version 2.7.0, this model has been completely updated.

--- a/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/migration_guide_2.4.99-cs3_to_2.7_application.rst
+++ b/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/migration_guide_2.4.99-cs3_to_2.7_application.rst
@@ -24,8 +24,7 @@ Sysbuild
   For more information, see the :ref:`Migrating to sysbuild <child_parent_to_sysbuild_migration>` user guide.
 
 Hardware Model v2
-  A new hardware model was recently introduced in the |NCS|.
-  For more information, see :ref:`hwmv1_to_v2_migration`.
+  The hardware model was introduced in the |NCS| v2.7.0.
 
 DTS changes
   The layout of DTS files and the names of DTS nodes related to the updated board names have been updated, which also affects overlay files from applications and samples.
@@ -82,8 +81,7 @@ General
      For more information, see the :ref:`Migrating to sysbuild <child_parent_to_sysbuild_migration>` user guide.
 
    * Hardware Model v2
-     A new hardware model was recently introduced in the |NCS|.
-     For more information, see :ref:`hwmv1_to_v2_migration`.
+     The hardware model was introduced in the |NCS| v2.7.0.
 
 Applications using the :file:`dfu_application.zip` file
 -------------------------------------------------------

--- a/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/migration_guide_2.6.99-cs2_to_2.7_application.rst
+++ b/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/migration_guide_2.6.99-cs2_to_2.7_application.rst
@@ -25,8 +25,7 @@ Sysbuild
   For more information, see the :ref:`Migrating to sysbuild <child_parent_to_sysbuild_migration>` user guide.
 
 Hardware Model v2
-  A new hardware model was recently introduced in the |NCS|.
-  For more information, see :ref:`hwmv1_to_v2_migration`.
+  The hardware model was introduced in the |NCS| v2.7.0.
 
 nRF54H20 SoC binaries
   A new version (v0.5.0) of the nRF54H20 SoC binaries was released.
@@ -57,8 +56,7 @@ General
      For more information, see the :ref:`Migrating to sysbuild <child_parent_to_sysbuild_migration>` user guide.
 
    * Hardware Model v2
-     A new hardware model was recently introduced in the |NCS|.
-     For more information, see :ref:`hwmv1_to_v2_migration`.
+     The hardware model was introduced in the |NCS| v2.7.0.
 
 Applications using the :file:`dfu_application.zip` file
 -------------------------------------------------------

--- a/doc/nrf/releases_and_maturity/migration_guides.rst
+++ b/doc/nrf/releases_and_maturity/migration_guides.rst
@@ -44,4 +44,3 @@ Migration notes are also provided for major functionality updates.
    :caption: General migration guides
 
    migration/migration_sysbuild
-   migration/migration_hwmv2


### PR DESCRIPTION
deprecating the hardware model migration guide.
The conversion script is no longer there.
It's no longer relevant.

Requested by @carlescufi 