### PR TITLE
nrf_security: cracen_sw: Fix in-place ChaCha20-Poly1305 multipart enc…

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_chacha20_poly1305.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_chacha20_poly1305.c
@@ -363,8 +363,6 @@ psa_status_t cracen_sw_chacha20_poly1305_update(cracen_aead_operation_t *operati
 	finalize_ad_padding(operation);
 	operation->ad_finished = true;
 
-	safe_memzero(output, output_size);
-
 	/* Process data with CTR mode encryption/decryption */
 	if (operation->dir == CRACEN_ENCRYPT) {
 		/* Encrypt: apply ChaCha20 keystream, then calc Poly1305 MAC */

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/chachapoly.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/chachapoly.c
@@ -106,6 +106,7 @@ static int lenAlenC_chachapoly(size_t aadsz, size_t datasz, uint8_t *out)
 static int sx_aead_create_chacha20poly1305(struct sxaead *aead_ctx, const struct sxkeyref *key,
 					   const uint8_t *nonce, const uint32_t dir, size_t tagsz)
 {
+	int err;
 
 	if (key->sz != SX_CHACHAPOLY_KEY_SZ) {
 		return SX_ERR_INVALID_KEY_SZ;
@@ -114,6 +115,13 @@ static int sx_aead_create_chacha20poly1305(struct sxaead *aead_ctx, const struct
 	/* ChaCha20Poly1305 doesn't use countermeasures */
 	aead_ctx->has_countermeasures = false;
 	aead_ctx->key = key;
+
+	if (key->prepare_key) {
+		err = key->prepare_key(key->user_data);
+		if (err != SX_OK) {
+			return err;
+		}
+	}
 
 	aead_ctx->cfg = &ba417chachapolycfg;
 
@@ -148,11 +156,21 @@ static int sx_blkcipher_create_chacha20(struct sxblkcipher *cipher_ctx, struct s
 					const uint8_t *counter, const uint8_t *nonce,
 					const uint32_t dir)
 {
+	int err;
+
 	if (key->sz != SX_CHACHAPOLY_KEY_SZ) {
 		return SX_ERR_INVALID_KEY_SZ;
 	}
 
 	cipher_ctx->key = key;
+
+	if (key->prepare_key) {
+		err = key->prepare_key(key->user_data);
+		if (err != SX_OK) {
+			return err;
+		}
+	}
+
 	cipher_ctx->cfg = &ba417chacha20cfg;
 
 	sx_cmdma_newcmd(&cipher_ctx->dma, cipher_ctx->descs, BA417_MODE_CHACHA20 | dir,


### PR DESCRIPTION
…rypt

The zeroing was originally removed in 5b42887a75.
This commit restores the intended behaviour.