### PR TITLE
boards: nrf54ls05dk: use dedicated JLink device

### DIFF
--- a/boards/nordic/nrf54ls05dk/board.cmake
+++ b/boards/nordic/nrf54ls05dk/board.cmake
@@ -1,8 +1,10 @@
 # Copyright (c) 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-if(CONFIG_SOC_NRF54LS05A_CPUAPP OR CONFIG_SOC_NRF54LS05B_CPUAPP)
-  board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+if(CONFIG_SOC_NRF54LS05A_CPUAPP)
+  board_runner_args(jlink "--device=NRF54LS05A_M33" "--speed=4000")
+elseif(CONFIG_SOC_NRF54LS05B_CPUAPP)
+  board_runner_args(jlink "--device=NRF54LS05B_M33" "--speed=4000")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)

--- a/boards/nordic/nrf54lv10dk/nrf54lv10dk_nrf54lv10a_cpuflpr.dts
+++ b/boards/nordic/nrf54lv10dk/nrf54lv10dk_nrf54lv10a_cpuflpr.dts
@@ -9,7 +9,7 @@
 #include "nrf54lv10dk_nrf54lv10a-common.dtsi"
 
 / {
-	model = "Nordic nRF54Lv10 DK nRF54Lv10a FLPR MCU";
+	model = "Nordic nRF54LV10 DK nRF54LV10A FLPR MCU";
 	compatible = "nordic,nrf54lv10dk_nrf54lv10a-cpuflpr";
 
 	chosen {

--- a/boards/nordic/nrf54lv10dk/nrf54lv10dk_nrf54lv10a_cpuflpr_0_7_0.yaml
+++ b/boards/nordic/nrf54lv10dk/nrf54lv10dk_nrf54lv10a_cpuflpr_0_7_0.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
 identifier: nrf54lv10dk@0.7.0/nrf54lv10a/cpuflpr
-name: nRF54LV10-DK-nRF54LV10a-Fast-Lightweight-Peripheral-Processor (rev. 0.7.0)
+name: nRF54LV10-DK-nRF54LV10A-Fast-Lightweight-Peripheral-Processor (rev. 0.7.0)
 type: mcu
 arch: riscv
 toolchain:


### PR DESCRIPTION
JLink now supports nRF54LS05. Use dedicated device.