### PR TITLE
Enable testing nrf9251 segl

### DIFF
--- a/samples/zephyr/drivers/watchdog/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/samples/zephyr/drivers/watchdog/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,3 @@
+&wdt010 {
+	status = "okay";
+};

--- a/samples/zephyr/drivers/watchdog/sample.yaml
+++ b/samples/zephyr/drivers/watchdog/sample.yaml
@@ -23,5 +23,6 @@ tests:
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuflpr
+      - nrf9251dk/nrf9251/cpuapp
     integration_platforms:
       - nrf54ls05dk/nrf54ls05b/cpuapp

--- a/tests/drivers/watchdog/wdt_instances/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_instances/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&wdt010 {
+	status = "okay";
+};
+
+&wdt011 {
+	status = "okay";
+};
+
+/* wdt131 is dedicated for cpuppr. */
+
+/* wdt132 is dedicated for cpuflpr. */

--- a/tests/drivers/watchdog/wdt_instances/boards/nrf9251dk_nrf9251_cpuflpr.overlay
+++ b/tests/drivers/watchdog/wdt_instances/boards/nrf9251dk_nrf9251_cpuflpr.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&wdt132 {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_instances/boards/nrf9251dk_nrf9251_cpuppr.overlay
+++ b/tests/drivers/watchdog/wdt_instances/boards/nrf9251dk_nrf9251_cpuppr.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&wdt131 {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_instances/sysbuild/vpr_launcher/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_instances/sysbuild/vpr_launcher/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&wdt131 {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+};
+
+&wdt132 {
+	status = "reserved";
+	interrupt-parent = <&cpuflpr_clic>;
+};

--- a/tests/drivers/watchdog/wdt_instances/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_instances/testcase.yaml
@@ -19,5 +19,8 @@ tests:
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
+      - nrf9251dk/nrf9251/cpuflpr
+      - nrf9251dk/nrf9251/cpuppr
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/drivers/watchdog/wdt_soft_reset/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_soft_reset/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wdt010;
+	};
+};
+
+&wdt010 {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_soft_reset/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_soft_reset/testcase.yaml
@@ -45,6 +45,7 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
+      - nrf9251dk/nrf9251/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
 
@@ -91,5 +92,6 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
+      - nrf9251dk/nrf9251/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/zephyr/drivers/watchdog/wdt_basic_api/boards/nrf9251dk_nrf9251_cpuapp.conf
+++ b/tests/zephyr/drivers/watchdog/wdt_basic_api/boards/nrf9251dk_nrf9251_cpuapp.conf
@@ -1,0 +1,2 @@
+# Disable dcache
+CONFIG_DCACHE=n

--- a/tests/zephyr/drivers/watchdog/wdt_basic_api/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_basic_api/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,3 @@
+watchdog0: &wdt010 {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/zephyr/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -12,5 +12,6 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuflpr
+      - nrf9251dk/nrf9251/cpuapp
     integration_platforms:
       - nrf54ls05dk/nrf54ls05b/cpuapp

--- a/tests/zephyr/drivers/watchdog/wdt_error_cases/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_error_cases/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,15 @@
+&wdt010 {
+	status = "okay";
+};
+
+&wdt011 {
+	status = "disabled";
+};
+
+&wdt131 {
+	status = "disabled";
+};
+
+&wdt132 {
+	status = "disabled";
+};

--- a/tests/zephyr/drivers/watchdog/wdt_error_cases/testcase.yaml
+++ b/tests/zephyr/drivers/watchdog/wdt_error_cases/testcase.yaml
@@ -13,5 +13,6 @@ tests:
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
     integration_platforms:
       - nrf54lv10dk/nrf54lv10a/cpuapp

--- a/tests/zephyr/drivers/watchdog/wdt_variables/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_variables/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&wdt010 {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/watchdog/wdt_variables/boards/nrf9251dk_nrf9251_cpuflpr.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_variables/boards/nrf9251dk_nrf9251_cpuflpr.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wdt132;
+	};
+};
+
+&wdt132 {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/watchdog/wdt_variables/boards/nrf9251dk_nrf9251_cpuppr.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_variables/boards/nrf9251dk_nrf9251_cpuppr.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wdt131;
+	};
+};
+
+&wdt131 {
+	status = "okay";
+};

--- a/tests/zephyr/drivers/watchdog/wdt_variables/sysbuild/vpr_launcher/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/watchdog/wdt_variables/sysbuild/vpr_launcher/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&wdt131 {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+};
+
+&wdt132 {
+	status = "reserved";
+	interrupt-parent = <&cpuflpr_clic>;
+};

--- a/tests/zephyr/drivers/watchdog/wdt_variables/sysbuild/vpr_launcher/prj.conf
+++ b/tests/zephyr/drivers/watchdog/wdt_variables/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/tests/zephyr/drivers/watchdog/wdt_variables/testcase.yaml
+++ b/tests/zephyr/drivers/watchdog/wdt_variables/testcase.yaml
@@ -17,5 +17,8 @@ tests:
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuflpr
+      - nrf9251dk/nrf9251/cpuapp
+      - nrf9251dk/nrf9251/cpuflpr
+      - nrf9251dk/nrf9251/cpuppr
     integration_platforms:
       - nrf54ls05dk/nrf54ls05b/cpuapp


### PR DESCRIPTION
only:
samples/zephyr/drivers/watchdog
tests/drivers/watchdog