### PR TITLE
samples: zephyr: net: Add nrf7120dk samples as indirections to zephyr samples

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -701,6 +701,7 @@
 /samples/zephyr/drivers/spi_bitbang/      @nrfconnect/ncs-low-level-test
 /samples/zephyr/drivers/spi_flash/        @nrfconnect/ncs-low-level-test
 /samples/zephyr/drivers/watchdog/         @nrfconnect/ncs-low-level-test
+/samples/zephyr/net/                      @nrfconnect/ncs-bifrost
 /samples/zephyr/sensor/accel_polling/     @nrfconnect/ncs-low-level-test
 /samples/zephyr/sensor/bme680/            @nrfconnect/ncs-low-level-test
 /samples/zephyr/sensor/qdec/              @nrfconnect/ncs-low-level-test

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -702,6 +702,7 @@
 /samples/zephyr/drivers/spi_bitbang/      @nrfconnect/ncs-low-level-test
 /samples/zephyr/drivers/spi_flash/        @nrfconnect/ncs-low-level-test
 /samples/zephyr/drivers/watchdog/         @nrfconnect/ncs-low-level-test
+/samples/zephyr/net/                      @nrfconnect/ncs-bifrost
 /samples/zephyr/sensor/accel_polling/     @nrfconnect/ncs-low-level-test
 /samples/zephyr/sensor/bme680/            @nrfconnect/ncs-low-level-test
 /samples/zephyr/sensor/qdec/              @nrfconnect/ncs-low-level-test

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/system/fmac_event.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/system/fmac_event.c
@@ -370,8 +370,10 @@ static enum nrf_wifi_status umac_event_sys_proc_events(struct nrf_wifi_fmac_dev_
 #endif
 		break;
 	case NRF_WIFI_EVENT_ERROR_STATS: {
+#if WIFI_NRF71_LOG_LEVEL >= NRF_WIFI_LOG_LEVEL_INF
 		struct nrf_wifi_umac_event_error_stats *err_ev =
 			(struct nrf_wifi_umac_event_error_stats *)sys_head;
+#endif
 
 		nrf_wifi_osal_log_info("%s: Error stats event: stats_type=%d status_code=%u",
 				       __func__,

--- a/samples/zephyr/net/dns_resolve/CMakeLists.txt
+++ b/samples/zephyr/net/dns_resolve/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/dns_resolve)
+# Point to original prj.conf (add one more file here if you need overrides) (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/dns_resolve/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(dns_resolve)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/dns_resolve/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/dns_resolve/CMakeLists.txt
+++ b/samples/zephyr/net/dns_resolve/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/dns_resolve")
+# Point to original prj.conf (add one more file here if you need overrides) (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/dns_resolve/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(dns_resolve)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/dns_resolve/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/dns_resolve/Kconfig.sysbuild
+++ b/samples/zephyr/net/dns_resolve/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/dns_resolve/Kconfig.sysbuild"

--- a/samples/zephyr/net/dns_resolve/README.txt
+++ b/samples/zephyr/net/dns_resolve/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/dns_resolve.

--- a/samples/zephyr/net/dns_resolve/sample.yaml
+++ b/samples/zephyr/net/dns_resolve/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: DNS resolver, mDNS and LLMNR responder
+  name: DNS resolver and responder sample application
+tests:
+  nrf.sample.net.dns_resolve.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/dns_resolve/sample.yaml
+++ b/samples/zephyr/net/dns_resolve/sample.yaml
@@ -11,3 +11,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/dns_resolve/sample.yaml
+++ b/samples/zephyr/net/dns_resolve/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: DNS resolver, mDNS and LLMNR responder
+  name: DNS resolver and responder sample application
+tests:
+  nrf.extended.sample.net.dns_resolve.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/ipv4_autoconf/CMakeLists.txt
+++ b/samples/zephyr/net/ipv4_autoconf/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/ipv4_autoconf")
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/ipv4_autoconf/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(ipv4_autoconf)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/ipv4_autoconf/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/ipv4_autoconf/CMakeLists.txt
+++ b/samples/zephyr/net/ipv4_autoconf/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/ipv4_autoconf)
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/ipv4_autoconf/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(ipv4_autoconf)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/ipv4_autoconf/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/ipv4_autoconf/Kconfig.sysbuild
+++ b/samples/zephyr/net/ipv4_autoconf/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/ipv4_autoconf/Kconfig.sysbuild"

--- a/samples/zephyr/net/ipv4_autoconf/README.txt
+++ b/samples/zephyr/net/ipv4_autoconf/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/ipv4_autoconf.

--- a/samples/zephyr/net/ipv4_autoconf/sample.yaml
+++ b/samples/zephyr/net/ipv4_autoconf/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: Test IPv4 autoconf functionality
+  name: IPv4 autoconf sample app
+tests:
+  nrf.sample.net.ipv4_autoconf.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/ipv4_autoconf/sample.yaml
+++ b/samples/zephyr/net/ipv4_autoconf/sample.yaml
@@ -11,3 +11,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/ipv4_autoconf/sample.yaml
+++ b/samples/zephyr/net/ipv4_autoconf/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: Test IPv4 autoconf functionality
+  name: IPv4 autoconf sample app
+tests:
+  nrf.extended.sample.net.ipv4_autoconf.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/mdns_responder/CMakeLists.txt
+++ b/samples/zephyr/net/mdns_responder/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/mdns_responder)
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/mdns_responder/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(mdns_responder)
+
+target_sources(app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/mdns_responder/src/main.c
+  ${ZEPHYR_BASE}/samples/net/mdns_responder/src/service.c
+)
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/mdns_responder/CMakeLists.txt
+++ b/samples/zephyr/net/mdns_responder/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/mdns_responder")
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/mdns_responder/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(mdns_responder)
+
+target_sources(app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/mdns_responder/src/main.c
+  ${ZEPHYR_BASE}/samples/net/mdns_responder/src/service.c
+)
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/mdns_responder/Kconfig
+++ b/samples/zephyr/net/mdns_responder/Kconfig
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Source the original Zephyr sample Kconfig directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/mdns_responder/Kconfig"

--- a/samples/zephyr/net/mdns_responder/Kconfig.sysbuild
+++ b/samples/zephyr/net/mdns_responder/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/mdns_responder/Kconfig.sysbuild"

--- a/samples/zephyr/net/mdns_responder/README.txt
+++ b/samples/zephyr/net/mdns_responder/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/mdns_responder.

--- a/samples/zephyr/net/mdns_responder/sample.yaml
+++ b/samples/zephyr/net/mdns_responder/sample.yaml
@@ -1,0 +1,12 @@
+sample:
+  name: mDNS responder
+tests:
+  nrf.sample.net.mdns_responder.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/mdns_responder/sample.yaml
+++ b/samples/zephyr/net/mdns_responder/sample.yaml
@@ -10,3 +10,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/mdns_responder/sample.yaml
+++ b/samples/zephyr/net/mdns_responder/sample.yaml
@@ -1,0 +1,12 @@
+sample:
+  name: mDNS responder
+tests:
+  nrf.extended.sample.net.mdns_responder.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/mqtt_publisher/CMakeLists.txt
+++ b/samples/zephyr/net/mqtt_publisher/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/mqtt_publisher)
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/mqtt_publisher/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(mqtt_publisher)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/mqtt_publisher/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/mqtt_publisher/CMakeLists.txt
+++ b/samples/zephyr/net/mqtt_publisher/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/mqtt_publisher")
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/mqtt_publisher/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(mqtt_publisher)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/mqtt_publisher/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/mqtt_publisher/Kconfig
+++ b/samples/zephyr/net/mqtt_publisher/Kconfig
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Source the original Zephyr sample Kconfig directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/mqtt_publisher/Kconfig"

--- a/samples/zephyr/net/mqtt_publisher/Kconfig.sysbuild
+++ b/samples/zephyr/net/mqtt_publisher/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/mqtt_publisher/Kconfig.sysbuild"

--- a/samples/zephyr/net/mqtt_publisher/README.txt
+++ b/samples/zephyr/net/mqtt_publisher/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/mqtt_publisher.

--- a/samples/zephyr/net/mqtt_publisher/sample.yaml
+++ b/samples/zephyr/net/mqtt_publisher/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: MQTT publisher sample application
+  name: MQTT publisher
+tests:
+  nrf.extended.sample.net.mqtt_publisher.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/mqtt_publisher/sample.yaml
+++ b/samples/zephyr/net/mqtt_publisher/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: MQTT publisher sample application
+  name: MQTT publisher
+tests:
+  nrf.sample.net.mqtt_publisher.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/mqtt_publisher/sample.yaml
+++ b/samples/zephyr/net/mqtt_publisher/sample.yaml
@@ -11,3 +11,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/mqtt_sn_publisher/CMakeLists.txt
+++ b/samples/zephyr/net/mqtt_sn_publisher/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/mqtt_sn_publisher")
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/mqtt_sn_publisher/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(mqtt_sn_publisher)
+
+target_sources(app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/mqtt_sn_publisher/src/main.c
+  ${ZEPHYR_BASE}/samples/net/mqtt_sn_publisher/src/udp.c
+)
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/mqtt_sn_publisher/CMakeLists.txt
+++ b/samples/zephyr/net/mqtt_sn_publisher/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/mqtt_sn_publisher)
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/mqtt_sn_publisher/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(mqtt_sn_publisher)
+
+target_sources(app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/mqtt_sn_publisher/src/main.c
+  ${ZEPHYR_BASE}/samples/net/mqtt_sn_publisher/src/udp.c
+)
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/mqtt_sn_publisher/Kconfig
+++ b/samples/zephyr/net/mqtt_sn_publisher/Kconfig
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Source the original Zephyr sample Kconfig directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/mqtt_sn_publisher/Kconfig"

--- a/samples/zephyr/net/mqtt_sn_publisher/Kconfig.sysbuild
+++ b/samples/zephyr/net/mqtt_sn_publisher/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/mqtt_sn_publisher/Kconfig.sysbuild"

--- a/samples/zephyr/net/mqtt_sn_publisher/README.txt
+++ b/samples/zephyr/net/mqtt_sn_publisher/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/mqtt_sn_publisher.

--- a/samples/zephyr/net/mqtt_sn_publisher/sample.yaml
+++ b/samples/zephyr/net/mqtt_sn_publisher/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: MQTT-SN publisher sample application
+  name: MQTT-SN publisher
+tests:
+  nrf.extended.sample.net.mqtt_sn_publisher.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/mqtt_sn_publisher/sample.yaml
+++ b/samples/zephyr/net/mqtt_sn_publisher/sample.yaml
@@ -11,3 +11,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/mqtt_sn_publisher/sample.yaml
+++ b/samples/zephyr/net/mqtt_sn_publisher/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: MQTT-SN publisher sample application
+  name: MQTT-SN publisher
+tests:
+  nrf.sample.net.mqtt_sn_publisher.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/coap_server/CMakeLists.txt
+++ b/samples/zephyr/net/sockets/coap_server/CMakeLists.txt
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/sockets/coap_server)
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/sockets/coap_server/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(coap_server)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/sockets/coap_server/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)
+
+zephyr_linker_sources(DATA_SECTIONS
+  ${ZEPHYR_BASE}/samples/net/sockets/coap_server/sections-ram.ld
+)
+zephyr_iterable_section(
+  NAME coap_resource_coap_server
+  GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT}
+)
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)
+
+set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+
+foreach(inc_file
+  ca.der
+  server.der
+  server_privkey.der
+  coaps-server-cert.der
+  coaps-server-key.der
+)
+  generate_inc_file_for_target(
+    app
+    ${ZEPHYR_BASE}/samples/net/sockets/coap_server/src/certs/${inc_file}
+    ${gen_dir}/${inc_file}.inc
+  )
+endforeach()

--- a/samples/zephyr/net/sockets/coap_server/CMakeLists.txt
+++ b/samples/zephyr/net/sockets/coap_server/CMakeLists.txt
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/sockets/coap_server")
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/sockets/coap_server/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(coap_server)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/sockets/coap_server/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)
+
+zephyr_linker_sources(DATA_SECTIONS
+  ${ZEPHYR_BASE}/samples/net/sockets/coap_server/sections-ram.ld
+)
+zephyr_iterable_section(
+  NAME coap_resource_coap_server
+  GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT}
+)
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)
+
+set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+
+foreach(inc_file
+  ca.der
+  server.der
+  server_privkey.der
+  coaps-server-cert.der
+  coaps-server-key.der
+)
+  generate_inc_file_for_target(
+    app
+    ${ZEPHYR_BASE}/samples/net/sockets/coap_server/src/certs/${inc_file}
+    ${gen_dir}/${inc_file}.inc
+  )
+endforeach()

--- a/samples/zephyr/net/sockets/coap_server/Kconfig
+++ b/samples/zephyr/net/sockets/coap_server/Kconfig
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Source the original Zephyr sample Kconfig directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/sockets/coap_server/Kconfig"

--- a/samples/zephyr/net/sockets/coap_server/Kconfig.sysbuild
+++ b/samples/zephyr/net/sockets/coap_server/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/sockets/coap_server/Kconfig.sysbuild"

--- a/samples/zephyr/net/sockets/coap_server/README.txt
+++ b/samples/zephyr/net/sockets/coap_server/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/sockets/coap_server.

--- a/samples/zephyr/net/sockets/coap_server/sample.yaml
+++ b/samples/zephyr/net/sockets/coap_server/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: BSD Sockets API CoAP server example
+  name: socket_coap_server
+tests:
+  nrf.sample.net.sockets.coap_server.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/coap_server/sample.yaml
+++ b/samples/zephyr/net/sockets/coap_server/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: BSD Sockets API CoAP server example
+  name: socket_coap_server
+tests:
+  nrf.extended.sample.net.sockets.coap_server.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/coap_server/sample.yaml
+++ b/samples/zephyr/net/sockets/coap_server/sample.yaml
@@ -11,3 +11,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/echo_async/CMakeLists.txt
+++ b/samples/zephyr/net/sockets/echo_async/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/sockets/echo_async")
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/sockets/echo_async/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sockets_echo_async)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/sockets/echo_async/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/sockets/echo_async/CMakeLists.txt
+++ b/samples/zephyr/net/sockets/echo_async/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/sockets/echo_async)
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/sockets/echo_async/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sockets_echo_async)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/sockets/echo_async/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/sockets/echo_async/Kconfig.sysbuild
+++ b/samples/zephyr/net/sockets/echo_async/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/sockets/echo_async/Kconfig.sysbuild"

--- a/samples/zephyr/net/sockets/echo_async/README.txt
+++ b/samples/zephyr/net/sockets/echo_async/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/sockets/echo_async.

--- a/samples/zephyr/net/sockets/echo_async/sample.yaml
+++ b/samples/zephyr/net/sockets/echo_async/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: BSD Sockets API TCP echo server sample using non-blocking sockets
+  name: socket_echo_async
+tests:
+  nrf.sample.net.sockets.echo_async.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/echo_async/sample.yaml
+++ b/samples/zephyr/net/sockets/echo_async/sample.yaml
@@ -11,3 +11,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/echo_async/sample.yaml
+++ b/samples/zephyr/net/sockets/echo_async/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: BSD Sockets API TCP echo server sample using non-blocking sockets
+  name: socket_echo_async
+tests:
+  nrf.extended.sample.net.sockets.echo_async.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/echo_client/CMakeLists.txt
+++ b/samples/zephyr/net/sockets/echo_client/CMakeLists.txt
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/sockets/echo_client")
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/sockets/echo_client/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sockets_echo_client)
+
+target_sources(app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_client/src/echo-client.c
+)
+target_sources_ifdef(CONFIG_NET_UDP app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_client/src/udp.c
+)
+target_sources_ifdef(CONFIG_NET_TCP app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_client/src/tcp.c
+)
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)
+
+set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+
+generate_inc_file_for_target(
+  app
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_client/src/echo-apps-cert.der
+  ${gen_dir}/echo-apps-cert.der.inc
+)

--- a/samples/zephyr/net/sockets/echo_client/CMakeLists.txt
+++ b/samples/zephyr/net/sockets/echo_client/CMakeLists.txt
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/sockets/echo_client)
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/sockets/echo_client/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sockets_echo_client)
+
+target_sources(app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_client/src/echo-client.c
+)
+target_sources_ifdef(CONFIG_NET_UDP app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_client/src/udp.c
+)
+target_sources_ifdef(CONFIG_NET_TCP app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_client/src/tcp.c
+)
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)
+
+set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+
+generate_inc_file_for_target(
+  app
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_client/src/echo-apps-cert.der
+  ${gen_dir}/echo-apps-cert.der.inc
+)

--- a/samples/zephyr/net/sockets/echo_client/Kconfig
+++ b/samples/zephyr/net/sockets/echo_client/Kconfig
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Source the original Zephyr sample Kconfig directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/sockets/echo_client/Kconfig"

--- a/samples/zephyr/net/sockets/echo_client/Kconfig.sysbuild
+++ b/samples/zephyr/net/sockets/echo_client/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/sockets/echo_client/Kconfig.sysbuild"

--- a/samples/zephyr/net/sockets/echo_client/README.txt
+++ b/samples/zephyr/net/sockets/echo_client/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/sockets/echo_client.

--- a/samples/zephyr/net/sockets/echo_client/sample.yaml
+++ b/samples/zephyr/net/sockets/echo_client/sample.yaml
@@ -11,3 +11,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/echo_client/sample.yaml
+++ b/samples/zephyr/net/sockets/echo_client/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: Test network sockets using a client/server sample
+  name: Socket Echo Client
+tests:
+  nrf.sample.net.sockets.echo_client.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/echo_client/sample.yaml
+++ b/samples/zephyr/net/sockets/echo_client/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: Test network sockets using a client/server sample
+  name: Socket Echo Client
+tests:
+  nrf.extended.sample.net.sockets.echo_client.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/echo_server/CMakeLists.txt
+++ b/samples/zephyr/net/sockets/echo_server/CMakeLists.txt
@@ -1,0 +1,79 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/sockets/echo_server)
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/sockets/echo_server/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sockets_echo_server)
+
+target_sources(app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/echo-server.c
+)
+target_sources_ifdef(CONFIG_NET_UDP app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/udp.c
+)
+target_sources_ifdef(CONFIG_NET_TCP app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/tcp.c
+)
+
+if(CONFIG_USB_DEVICE_STACK_NEXT)
+  target_sources(app PRIVATE
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/usb.c
+  )
+  include(${ZEPHYR_BASE}/samples/subsys/usb/common/common.cmake)
+endif()
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)
+
+set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+
+foreach(inc_file
+  ca.der
+  server.der
+  server_privkey.der
+  echo-apps-cert.der
+  echo-apps-key.der
+)
+  generate_inc_file_for_target(
+    app
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/${inc_file}
+    ${gen_dir}/${inc_file}.inc
+  )
+endforeach()
+
+if(CONFIG_NET_SAMPLE_WEBSOCKET_CONSOLE)
+  zephyr_linker_sources(SECTIONS
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/ws_console/sections-rom.ld
+  )
+  target_sources(app PRIVATE
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/ws_console/ws.c
+  )
+  generate_inc_file_for_target(app
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/ws_console/index.html
+    ${gen_dir}/index.html.gz.inc --gzip
+  )
+  generate_inc_file_for_target(app
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/ws_console/style.css
+    ${gen_dir}/style.css.gz.inc --gzip
+  )
+  generate_inc_file_for_target(app
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/ws_console/favicon-16x16.png
+    ${gen_dir}/favicon-16x16.png.gz.inc --gzip
+  )
+endif()
+if(CONFIG_NET_SAMPLE_HTTPS_SERVICE)
+  zephyr_linker_section_ifdef(CONFIG_NET_SAMPLE_WEBSOCKET_CONSOLE NAME
+    http_resource_desc_wss_console_service
+    KVMA RAM_REGION GROUP RODATA_REGION
+  )
+endif()
+zephyr_linker_section_ifdef(CONFIG_NET_SAMPLE_WEBSOCKET_CONSOLE NAME
+  http_resource_desc_ws_console_service
+  KVMA RAM_REGION GROUP RODATA_REGION
+)

--- a/samples/zephyr/net/sockets/echo_server/CMakeLists.txt
+++ b/samples/zephyr/net/sockets/echo_server/CMakeLists.txt
@@ -1,0 +1,79 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/sockets/echo_server")
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/sockets/echo_server/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sockets_echo_server)
+
+target_sources(app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/echo-server.c
+)
+target_sources_ifdef(CONFIG_NET_UDP app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/udp.c
+)
+target_sources_ifdef(CONFIG_NET_TCP app PRIVATE
+  ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/tcp.c
+)
+
+if(CONFIG_USB_DEVICE_STACK_NEXT)
+  target_sources(app PRIVATE
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/usb.c
+  )
+  include(${ZEPHYR_BASE}/samples/subsys/usb/common/common.cmake)
+endif()
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)
+
+set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+
+foreach(inc_file
+  ca.der
+  server.der
+  server_privkey.der
+  echo-apps-cert.der
+  echo-apps-key.der
+)
+  generate_inc_file_for_target(
+    app
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/${inc_file}
+    ${gen_dir}/${inc_file}.inc
+  )
+endforeach()
+
+if(CONFIG_NET_SAMPLE_WEBSOCKET_CONSOLE)
+  zephyr_linker_sources(SECTIONS
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/ws_console/sections-rom.ld
+  )
+  target_sources(app PRIVATE
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/ws_console/ws.c
+  )
+  generate_inc_file_for_target(app
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/ws_console/index.html
+    ${gen_dir}/index.html.gz.inc --gzip
+  )
+  generate_inc_file_for_target(app
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/ws_console/style.css
+    ${gen_dir}/style.css.gz.inc --gzip
+  )
+  generate_inc_file_for_target(app
+    ${ZEPHYR_BASE}/samples/net/sockets/echo_server/src/ws_console/favicon-16x16.png
+    ${gen_dir}/favicon-16x16.png.gz.inc --gzip
+  )
+endif()
+if(CONFIG_NET_SAMPLE_HTTPS_SERVICE)
+  zephyr_linker_section_ifdef(CONFIG_NET_SAMPLE_WEBSOCKET_CONSOLE NAME
+    http_resource_desc_wss_console_service
+    KVMA RAM_REGION GROUP RODATA_REGION
+  )
+endif()
+zephyr_linker_section_ifdef(CONFIG_NET_SAMPLE_WEBSOCKET_CONSOLE NAME
+  http_resource_desc_ws_console_service
+  KVMA RAM_REGION GROUP RODATA_REGION
+)

--- a/samples/zephyr/net/sockets/echo_server/Kconfig
+++ b/samples/zephyr/net/sockets/echo_server/Kconfig
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Source the original Zephyr sample Kconfig directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/sockets/echo_server/Kconfig"

--- a/samples/zephyr/net/sockets/echo_server/Kconfig.sysbuild
+++ b/samples/zephyr/net/sockets/echo_server/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/sockets/echo_server/Kconfig.sysbuild"

--- a/samples/zephyr/net/sockets/echo_server/README.txt
+++ b/samples/zephyr/net/sockets/echo_server/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/sockets/echo_server.

--- a/samples/zephyr/net/sockets/echo_server/sample.yaml
+++ b/samples/zephyr/net/sockets/echo_server/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: Test network sockets using a client/server sample
+  name: Socket Echo Server
+tests:
+  nrf.extended.sample.net.sockets.echo_server.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/echo_server/sample.yaml
+++ b/samples/zephyr/net/sockets/echo_server/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: Test network sockets using a client/server sample
+  name: Socket Echo Server
+tests:
+  nrf.sample.net.sockets.echo_server.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/echo_server/sample.yaml
+++ b/samples/zephyr/net/sockets/echo_server/sample.yaml
@@ -11,3 +11,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/http_get/CMakeLists.txt
+++ b/samples/zephyr/net/sockets/http_get/CMakeLists.txt
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/sockets/http_get)
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/sockets/http_get/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(http_get)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/sockets/http_get/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)
+
+set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+
+generate_inc_file_for_target(
+  app
+  ${ZEPHYR_BASE}/samples/net/sockets/http_get/src/globalsign_r1.der
+  ${gen_dir}/globalsign_r1.der.inc
+)

--- a/samples/zephyr/net/sockets/http_get/CMakeLists.txt
+++ b/samples/zephyr/net/sockets/http_get/CMakeLists.txt
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/sockets/http_get")
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/sockets/http_get/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(http_get)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/sockets/http_get/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)
+
+set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+
+generate_inc_file_for_target(
+  app
+  ${ZEPHYR_BASE}/samples/net/sockets/http_get/src/globalsign_r1.der
+  ${gen_dir}/globalsign_r1.der.inc
+)

--- a/samples/zephyr/net/sockets/http_get/Kconfig
+++ b/samples/zephyr/net/sockets/http_get/Kconfig
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Source the original Zephyr sample Kconfig directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/sockets/http_get/Kconfig"

--- a/samples/zephyr/net/sockets/http_get/Kconfig.sysbuild
+++ b/samples/zephyr/net/sockets/http_get/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/sockets/http_get/Kconfig.sysbuild"

--- a/samples/zephyr/net/sockets/http_get/README.txt
+++ b/samples/zephyr/net/sockets/http_get/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/sockets/http_get.

--- a/samples/zephyr/net/sockets/http_get/sample.yaml
+++ b/samples/zephyr/net/sockets/http_get/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: BSD Sockets API HTTP GET example
+  name: socket_http_get
+tests:
+  nrf.extended.sample.net.sockets.http_get.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/http_get/sample.yaml
+++ b/samples/zephyr/net/sockets/http_get/sample.yaml
@@ -11,3 +11,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/http_get/sample.yaml
+++ b/samples/zephyr/net/sockets/http_get/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: BSD Sockets API HTTP GET example
+  name: socket_http_get
+tests:
+  nrf.sample.net.sockets.http_get.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/sntp_client/CMakeLists.txt
+++ b/samples/zephyr/net/sockets/sntp_client/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/sockets/sntp_client")
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/sockets/sntp_client/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sntp_client)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/sockets/sntp_client/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/sockets/sntp_client/CMakeLists.txt
+++ b/samples/zephyr/net/sockets/sntp_client/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/sockets/sntp_client)
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/sockets/sntp_client/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sntp_client)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/sockets/sntp_client/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/sockets/sntp_client/Kconfig
+++ b/samples/zephyr/net/sockets/sntp_client/Kconfig
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Source the original Zephyr sample Kconfig directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/sockets/sntp_client/Kconfig"

--- a/samples/zephyr/net/sockets/sntp_client/Kconfig.sysbuild
+++ b/samples/zephyr/net/sockets/sntp_client/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/sockets/sntp_client/Kconfig.sysbuild"

--- a/samples/zephyr/net/sockets/sntp_client/README.txt
+++ b/samples/zephyr/net/sockets/sntp_client/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/sockets/sntp_client.

--- a/samples/zephyr/net/sockets/sntp_client/sample.yaml
+++ b/samples/zephyr/net/sockets/sntp_client/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: SNTP client sample
+  name: sntp_client
+tests:
+  nrf.extended.sample.net.sockets.sntp_client.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/sntp_client/sample.yaml
+++ b/samples/zephyr/net/sockets/sntp_client/sample.yaml
@@ -11,3 +11,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/sockets/sntp_client/sample.yaml
+++ b/samples/zephyr/net/sockets/sntp_client/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: SNTP client sample
+  name: sntp_client
+tests:
+  nrf.sample.net.sockets.sntp_client.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/syslog_net/CMakeLists.txt
+++ b/samples/zephyr/net/syslog_net/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/syslog_net")
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/syslog_net/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(syslog_net)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/syslog_net/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/syslog_net/CMakeLists.txt
+++ b/samples/zephyr/net/syslog_net/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/syslog_net)
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/syslog_net/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(syslog_net)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/syslog_net/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/syslog_net/Kconfig
+++ b/samples/zephyr/net/syslog_net/Kconfig
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Source the original Zephyr sample Kconfig directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/syslog_net/Kconfig"

--- a/samples/zephyr/net/syslog_net/Kconfig.sysbuild
+++ b/samples/zephyr/net/syslog_net/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/syslog_net/Kconfig.sysbuild"

--- a/samples/zephyr/net/syslog_net/README.txt
+++ b/samples/zephyr/net/syslog_net/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/syslog_net.

--- a/samples/zephyr/net/syslog_net/sample.yaml
+++ b/samples/zephyr/net/syslog_net/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: syslog network backend
+  name: syslog_net
+tests:
+  nrf.sample.net.syslog.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/syslog_net/sample.yaml
+++ b/samples/zephyr/net/syslog_net/sample.yaml
@@ -11,3 +11,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/syslog_net/sample.yaml
+++ b/samples/zephyr/net/syslog_net/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: syslog network backend
+  name: syslog_net
+tests:
+  nrf.extended.sample.net.syslog.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/telnet/CMakeLists.txt
+++ b/samples/zephyr/net/telnet/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR $ENV{ZEPHYR_BASE}/samples/net/telnet)
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE $ENV{ZEPHYR_BASE}/samples/net/telnet/prj.conf)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(telnet)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/telnet/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/telnet/CMakeLists.txt
+++ b/samples/zephyr/net/telnet/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+# Board/shield and overlay lookup in original directory
+set(APPLICATION_CONFIG_DIR "\${ZEPHYR_BASE}/samples/net/telnet")
+# Point to original prj.conf (add one more file here if you need overrides)
+set(CONF_FILE "\${ZEPHYR_BASE}/samples/net/telnet/prj.conf")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(telnet)
+
+FILE(GLOB app_sources ${ZEPHYR_BASE}/samples/net/telnet/src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/zephyr/net/telnet/Kconfig.sysbuild
+++ b/samples/zephyr/net/telnet/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Source the original Zephyr sample Kconfig.sysbuild directly to avoid duplication.
+source "${ZEPHYR_BASE}/samples/net/telnet/Kconfig.sysbuild"

--- a/samples/zephyr/net/telnet/README.txt
+++ b/samples/zephyr/net/telnet/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/net/telnet.

--- a/samples/zephyr/net/telnet/sample.yaml
+++ b/samples/zephyr/net/telnet/sample.yaml
@@ -1,0 +1,12 @@
+sample:
+  name: Telnet Server
+tests:
+  nrf.extended.sample.net.telnet.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/telnet/sample.yaml
+++ b/samples/zephyr/net/telnet/sample.yaml
@@ -1,0 +1,12 @@
+sample:
+  name: Telnet Server
+tests:
+  nrf.sample.net.telnet.wifi.nrf71dk:
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    extra_args:
+      - SNIPPET=wifi-ipv4
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp

--- a/samples/zephyr/net/telnet/sample.yaml
+++ b/samples/zephyr/net/telnet/sample.yaml
@@ -10,3 +10,5 @@ tests:
       - SNIPPET=wifi-ipv4
     platform_allow:
       - nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -103,6 +103,19 @@ ci_samples_net: &ci_net
     - nrf/modules/cjson/
     - nrf/modules/trusted-firmware-m/
     - nrf/samples/net/
+    - nrf/samples/zephyr/net/dns_resolve/
+    - nrf/samples/zephyr/net/ipv4_autoconf/
+    - nrf/samples/zephyr/net/mdns_responder/
+    - nrf/samples/zephyr/net/mqtt_publisher/
+    - nrf/samples/zephyr/net/mqtt_sn_publisher/
+    - nrf/samples/zephyr/net/sockets/coap_server/
+    - nrf/samples/zephyr/net/sockets/echo_async/
+    - nrf/samples/zephyr/net/sockets/echo_client/
+    - nrf/samples/zephyr/net/sockets/echo_server/
+    - nrf/samples/zephyr/net/sockets/http_get/
+    - nrf/samples/zephyr/net/sockets/sntp_client/
+    - nrf/samples/zephyr/net/syslog_net/
+    - nrf/samples/zephyr/net/telnet/
     - nrf/subsys/dfu/
     - nrf/subsys/fw_info/
     - nrf/subsys/net/

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -102,6 +102,19 @@ ci_samples_net: &ci_net
     - nrf/modules/cjson/
     - nrf/modules/trusted-firmware-m/
     - nrf/samples/net/
+    - nrf/samples/zephyr/net/dns_resolve/
+    - nrf/samples/zephyr/net/ipv4_autoconf/
+    - nrf/samples/zephyr/net/mdns_responder/
+    - nrf/samples/zephyr/net/mqtt_publisher/
+    - nrf/samples/zephyr/net/mqtt_sn_publisher/
+    - nrf/samples/zephyr/net/sockets/coap_server/
+    - nrf/samples/zephyr/net/sockets/echo_async/
+    - nrf/samples/zephyr/net/sockets/echo_client/
+    - nrf/samples/zephyr/net/sockets/echo_server/
+    - nrf/samples/zephyr/net/sockets/http_get/
+    - nrf/samples/zephyr/net/sockets/sntp_client/
+    - nrf/samples/zephyr/net/syslog_net/
+    - nrf/samples/zephyr/net/telnet/
     - nrf/subsys/dfu/
     - nrf/subsys/fw_info/
     - nrf/subsys/net/


### PR DESCRIPTION
This PR adds new samples under `samples/zephyr/net` pointing at original zephyr samples.
Given that we are not upstreaming the nrf7120 Wifi drivers, we need these samples to live in NCS, and we do it as indirection so as to avoid code duplication.

Not tests on hardware yet. The tests I did:
* All samples build with snippet `wifi-ipv4` for nrf7002dk/nrf5340 and yield the same .hex as when build from the original folder
* All samples build with snippet `wifi-ipv4` for nrf7120dk/7120

JIRA: NCSDK-38926 NCSDK-38721 NCSDK-38720 NCSDK-38715 NCSDK-38722 NCSDK-38723 NCSDK-38724 NCSDK-38716 NCSDK-38717 NCSDK-38718 NCSDK-38719 NCSDK-38727 NCSDK-38726 NCSDK-38728