### PR TITLE
doc: H20 misc documentation updates

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_gs.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_gs.rst
@@ -16,7 +16,8 @@ It guides you through the following:
 1. Installing the |NCS| and other required software and tools.
 #. Preparing the nRF54H20 DK for first use:
 
-   a. Programming the nRF54H20 DK's Board Information Configuration Registers (BICR) using the provided binary file.
+   a. Disabling the onboard debugger's USB Mass Storage Device (MSD) feature and forcing UART hardware flow control (HWFC).
+   #. Programming the nRF54H20 DK's Board Information Configuration Registers (BICR) using the provided binary file.
    #. Programming the Secure Domain and System Controller of the nRF54H20 SoC using the provided IronSide SE binaries.
    #. Transitioning the SoC's lifecycle state (LCS) to Root of Trust (RoT).
 
@@ -104,6 +105,83 @@ Install a terminal emulator, such as the `Serial Terminal app`_ (from the nRF Co
 Both of these terminal emulators start the required :ref:`toolchain environment <using_toolchain_environment>`.
 
 .. _ug_nrf54h20_gs_bringup:
+
+.. _ug_nrf54h20_gs_bringup_msd:
+
+.. rst-class:: numbered-step
+
+Bring-up step: Disable onboard J-Link Mass Storage Device (MSD)
+***************************************************************
+
+The onboard debugger enables a USB Mass Storage Device (MSD) by default so you can drag and drop firmware images onto the probe.
+The nRF54H20 DK does not support drag-and-drop programming through MSD, so it is recommended to disable MSD.
+
+You should also force UART hardware flow control (HWFC) on the debugger's virtual serial port to avoid potential race conditions related to HWFC auto-detection.
+
+.. note::
+   You need the `J-Link Software and Documentation Pack`_ installed (included with the |NCS| toolchain).
+
+.. tabs::
+
+   .. tab:: Windows
+
+      To disable MSD and force HWFC:
+
+      #. Connect the nRF54H20 DK to your computer with a USB cable using the **DEBUGGER** port on the DK.
+      #. Run *J-Link Commander*.
+         The configuration window appears.
+      #. From the :guilabel:`Specify Target Device` dropdown menu, select the nRF54H20 device entry that matches your kit and J-Link version.
+
+         For a new DK in lifecycle state (LCS) ``EMPTY``, this is typically ``NRF54H20_SECURE``.
+         After you transition the SoC to Root of Trust (RoT), ``NRF54H20_APP`` is typically used.
+      #. From the :guilabel:`Target Interface & Speed` dropdown menu, select :guilabel:`SWD`.
+      #. After J-Link Commander connects, enter the following commands at the ``J-Link>`` prompt.
+
+         To disable MSD:
+
+         .. code-block:: text
+
+            MSDDisable
+
+         To force HWFC:
+
+         .. code-block:: text
+
+            SetHWFC Force
+
+      #. Power cycle the board using the **POWER** on/off switch on the DK.
+
+   .. tab:: Linux and macOS
+
+      To disable MSD, force HWFC, or both:
+
+      #. Connect the nRF54H20 DK to your computer with a USB cable using the **DEBUGGER** port on the DK.
+      #. Run ``JLinkExe`` to connect to the target.
+         For example, for a new DK in LCS ``EMPTY`` (device name can differ slightly between J-Link releases):
+
+         .. parsed-literal::
+            :class: highlight
+
+            JLinkExe -device NRF54H20_SECURE -if SWD -speed 4000 -autoconnect 1 -SelectEmuBySN <SEGGER_ID>
+
+         Replace ``<SEGGER_ID>`` with the serial number of your onboard J-Link probe (see the sticker on the DK or use ``nrfutil device list``).
+         After RoT transition, you can use ``NRF54H20_APP`` instead of ``NRF54H20_SECURE`` if required for a successful connection.
+      #. At the ``J-Link>`` prompt, run the following commands as needed.
+
+         To disable MSD:
+
+         .. code-block:: text
+
+            MSDDisable
+
+         To force HWFC:
+
+         .. code-block:: text
+
+            SetHWFC Force
+
+      #. Power cycle the board using the **POWER** on/off switch on the DK.
+
 .. _ug_nrf54h20_gs_bringup_bicr:
 .. _ug_nrf54h20_gs_bicr:
 
@@ -119,7 +197,8 @@ To prepare the nRF54H20 DK for its first use, you must manually program the requ
 #. Connect the nRF54H20 DK to your computer using the **DEBUGGER** port on the DK.
 
    .. note::
-      On MacOS, when connecting the DK, you might see a popup with the message ``Disk Not Ejected Properly`` appearing multiple times.
+      On macOS, when connecting the DK, you might see a popup with the message ``Disk Not Ejected Properly`` appearing multiple times.
+      See :ref:`ug_nrf54h20_gs_bringup_msd` to disable MSD on the onboard debugger.
 
 #. List all the connected development kits to see their serial number (matching the one on the DK's sticker)::
 

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_ironside_services.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_ironside_services.rst
@@ -40,7 +40,8 @@ For details about the CPUCONF peripheral, refer to the nRF54H20 SoC datasheet.
 |ISE| provides an update service that allows local domains to trigger the :ref:`update process <ug_nrf54h20_ironside_se_update_architecture>` of |ISE| itself.
 
 The update service requires a release of |ISE| or the |ISE| Recovery image to be programmed within a valid memory range that is accessible by the application core.
-See :file:`nrf_ironside/update.h` for more details on the supported memory range.
+The image must be stored in MRAM11 and cannot reside in MRAM10.
+See :ref:`ug_nrf54h20_ironside_se_update_limitations` and :file:`nrf_ironside/update.h` for details.
 
 After the application has invoked the service, |ISE| will update on the next system reset.
 The update can be verified by checking the listed versions in the :ref:`boot report <ug_nrf54h20_ironside_se_boot_report>` on startup.

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_ironside_update.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_ironside_update.rst
@@ -54,6 +54,17 @@ Performing an update
 .. note::
    You can update the |ISE| only on an nRF54H20 SoC that was initially :ref:`provisioned <ug_nrf54h20_SoC_binaries>` with it.
 
+.. _ug_nrf54h20_ironside_se_update_limitations:
+
+Limitations
+===========
+
+.. important::
+
+   A URoT (|ISE|) update image must be stored in MRAM11.
+   The update cannot be performed with the image placed in MRAM10.
+   See :ref:`ug_nrf54h20_architecture_memory` for the MRAMM10 and MRAMM11 layout.
+
 |ISE| supports being updated in the following ways:
 
 * :ref:`Manual updates <ug_nrf54h20_ironside_se_update_manual>` with a debugger
@@ -163,6 +174,7 @@ Architecture
 ************
 
 The |ISE| update process starts when the application firmware invokes the :ref:`update service <ug_nrf54h20_ironside_se_update_service>` with the address of where the update release package has been written in MRAM.
+The package must lie in MRAMM11 as described in :ref:`ug_nrf54h20_ironside_se_update_limitations`.
 
 .. _ug_nrf54h20_ironside_se_update_architecture_app:
 
@@ -171,7 +183,7 @@ Application procedure
 
 The following describes the process for an |ISE| update from the point of view of the application:
 
-1. The application MRAM is updated with the |ISE| update image.
+1. MRAMM11 is updated with the |ISE| update image (see :ref:`ug_nrf54h20_ironside_se_update_limitations`).
 #. It calls the |ISE| update service with the update image location.
 #. It verifies that the update request is acknowledged.
 #. It triggers a reset.
@@ -195,7 +207,7 @@ The following describes the update process in the |ISE| upon request:
 Once the device comes out of reset, SDROM sees the update metadata and does the following to verify and apply the update:
 
 1. Enables write-protection on the update image and firmware contents.
-#. Checks firmware metadata stored in SICR registers against address range and size constraints.
+#. Checks firmware metadata stored in SICR registers against permitted MRAM region and size constraints.
 #. Verifies update version against current firmware to prevent downgrades.
 #. Computes and validates digest of the public key.
 #. Checks public key is not revoked.

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_pm_optimization.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_pm_optimization.rst
@@ -50,6 +50,11 @@ It schedules the system wake-up from the system-off state in advance of the next
 
 Because the warm-boot latency is compensated by the System Controller, from a local CPU's perspective, the latency when restoring from the local-off state and the system-off state is expected to be the same.
 
+The MRAM auto-powerdown feature (``MRAMC.POWER.AUTOPOWERDOWN``), which the System Controller configures, trades power usage for latency.
+If you run with MRAM auto-powerdown disabled, MRAM stays powered on.
+That improves latency for MRAM-related wake-up and access, at the cost of higher power consumption because the memory is not allowed to power down when idle.
+For more information on how MRAM power state affects wake-up latency, see :ref:`ug_nrf54h20_architecture_pm`.
+
 Latency in local domains
 ------------------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -601,4 +601,8 @@ cJSON
 Documentation
 =============
 
-|no_changes_yet_note|
+* Added:
+
+  * Description of the MRAM auto-powerdown tradeoff in the :ref:`ug_nrf54h20_pm_optimization` documentation page.
+  * MSD disable step in the :ref:`ug_nrf54h20_gs` guide.
+  * MRAM11 Ironside SE update limitations in the :ref:`ug_nrf54h20_ironside_update` and :ref:`ug_nrf54h20_ironside_services` documentation pages.


### PR DESCRIPTION
    Added description of MRAM autopowerdown tradeoff.
    Added MSD disable step in h20 getting started.
    Added MRAM11 Ironside SE update limitations.
