### PR TITLE
net: nrf_provisioning: Replace LTE Link Control with AT Monitor

### DIFF
--- a/doc/nrf/libraries/networking/nrf_provisioning.rst
+++ b/doc/nrf/libraries/networking/nrf_provisioning.rst
@@ -178,7 +178,7 @@ Dependencies
 
 This library uses the following |NCS| libraries:
 
-* :ref:`lte_lc_readme`
+* :ref:`at_monitor_readme`
 * :ref:`modem_info_readme`
 * :ref:`modem_key_mgmt`
 * :ref:`lib_rest_client`

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -484,7 +484,10 @@ Multiprotocol Service Layer libraries
 Libraries for networking
 ------------------------
 
-|no_changes_yet_note|
+* :ref:`lib_nrf_provisioning` library:
+
+  * Removed dependency on the :ref:`lte_lc_readme` library.
+    The :ref:`at_monitor_readme` library is now used for tracking network connectivity status.
 
 Libraries for NFC
 -----------------

--- a/include/net/nrf_provisioning.h
+++ b/include/net/nrf_provisioning.h
@@ -111,8 +111,8 @@ enum nrf_provisioning_event {
 	NRF_PROVISIONING_EVENT_FAILED_WRONG_ROOT_CA,
 
 	/**
-	 * Provisioning process failed because no valid datetime reference is available.
-	 * Ensure the device has access to network time or SNTP.
+	 * Provisioning process failed because no valid modem/network time is available.
+	 * Ensure the modem has acquired network time.
 	 */
 	NRF_PROVISIONING_EVENT_FAILED_NO_VALID_DATETIME,
 

--- a/subsys/net/lib/nrf_provisioning/Kconfig
+++ b/subsys/net/lib/nrf_provisioning/Kconfig
@@ -27,11 +27,11 @@ config NRF_PROVISIONING_SCHEDULED
 	  at a given interval set by CONFIG_NRF_PROVISIONING_INTERVAL_S.
 
 config NRF_PROVISIONING_VALID_DATE_TIME_TIMEOUT_SECONDS
-	int "Time to wait for valid date-time in seconds"
+	int "Time to wait for valid modem time in seconds"
 	default 60
 	help
-	  Time to wait for valid date-time before starting provisioning. The provisioning library
-	  depends on JWT generation, which requires a valid date-time.
+	  Time to wait for valid modem time before starting provisioning. The provisioning library
+	  depends on JWT generation, which requires valid modem/network time.
 
 config NRF_PROVISIONING_MODEM_STATE_WAIT_TIMEOUT_SECONDS
 	int "Modem state wait timeout in seconds"

--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_at.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_at.h
@@ -77,6 +77,15 @@ int nrf_provisioning_at_cmd(void *resp, size_t resp_sz, const char *cmd);
  */
 int nrf_provisioning_at_del_credential(int sec_tag, int type);
 
+/**
+ * @brief Check whether the modem is in offline (flight) mode.
+ *
+ * Queries the modem functional mode through AT+CFUN?
+ *
+ * @returns True if the modem functional mode is offline (CFUN=4), false otherwise.
+ */
+bool nrf_provisioning_at_func_mode_is_offline(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
@@ -19,12 +19,13 @@
 #include <zephyr/sys/reboot.h>
 
 #include <modem/lte_lc.h>
+#include <modem/at_monitor.h>
 #include <modem/modem_key_mgmt.h>
 #include <modem/nrf_modem_lib.h>
 #include <modem/modem_attest_token.h>
+#include <nrf_modem_at.h>
 #include <net/nrf_provisioning.h>
 #include <net/rest_client.h>
-#include <date_time.h>
 
 #include "nrf_provisioning_at.h"
 #include "nrf_provisioning_http.h"
@@ -72,6 +73,7 @@ static void schedule_next_work(unsigned int seconds);
 static void init_work_fn(struct k_work *work);
 static void trigger_reschedule(void);
 static int cert_provision(void);
+static int wait_for_valid_modem_time(int timeout_seconds);
 
 K_WORK_DEFINE(init_work, init_work_fn);
 K_WORK_DELAYABLE_DEFINE(provisioning_work, nrf_provisioning_work);
@@ -96,6 +98,28 @@ static void nrf_provisioning_on_modem_init(int ret, void *ctx)
 	}
 }
 #endif /* CONFIG_NRF_PROVISIONING_WITH_CERT */
+
+NRF_MODEM_LIB_ON_CFUN(nrf_provisioning_cfun_hook, on_modem_cfun, NULL);
+
+static void on_modem_cfun(int mode, void *ctx)
+{
+	ARG_UNUSED(ctx);
+
+	/* Subscribe to +CGEV notifications when the modem enters a connected functional
+	 * mode. +CGEV is required for tracking PDN connectivity state.
+	 */
+	if (mode == LTE_LC_FUNC_MODE_NORMAL || mode == LTE_LC_FUNC_MODE_ACTIVATE_LTE) {
+		int err;
+		struct nrf_provisioning_callback_data event_data = { 0 };
+
+		err = nrf_modem_at_printf("AT+CGEREP=1");
+		if (err) {
+			__ASSERT(false, "Failed to subscribe to +CGEREP=1, err %d", err);
+			event_data.type = NRF_PROVISIONING_EVENT_FATAL_ERROR;
+			callback_local(&event_data);
+		}
+	}
+}
 
 static void schedule_next_work(unsigned int seconds)
 {
@@ -244,9 +268,6 @@ int nrf_provisioning_notify_event_and_wait_for_modem_state(
 				enum nrf_provisioning_event event,
 				nrf_provisioning_event_cb_t callback)
 {
-	int ret;
-	enum lte_lc_func_mode fmode;
-
 	if (callback == NULL) {
 		LOG_ERR("Callback data is NULL");
 		return -EINVAL;
@@ -265,14 +286,8 @@ int nrf_provisioning_notify_event_and_wait_for_modem_state(
 	callback(&event_data);
 
 	for (int i = 0; i < timeout_seconds; i++) {
-		ret = lte_lc_func_mode_get(&fmode);
-		if (ret) {
-			LOG_ERR("Failed to read modem functional mode");
-			return ret;
-		}
-
 		if (event == NRF_PROVISIONING_EVENT_NEED_LTE_DEACTIVATED) {
-			if (fmode == LTE_LC_FUNC_MODE_OFFLINE) {
+			if (nrf_provisioning_at_func_mode_is_offline()) {
 				LOG_DBG("Modem is offline");
 				return 0;
 			}
@@ -329,40 +344,53 @@ static int settings_init(void)
 	return 0;
 }
 
-static void lte_lc_event_handler(const struct lte_lc_evt *const evt)
+static void cgev_handler(const char *notif)
 {
-	switch (evt->type) {
-	case LTE_LC_EVT_PDN:
-		switch (evt->pdn.type) {
-		case LTE_LC_EVT_PDN_ACTIVATED:
-		case LTE_LC_EVT_PDN_RESUMED:
+	struct cgev_mapping {
+		const char *prefix;
+		size_t len;
+		bool connected;
+	} events[] = {
+		{"ME PDN ACT 0",   sizeof("ME PDN ACT 0") - 1,   true},
+		{"ME PDN DEACT 0", sizeof("ME PDN DEACT 0") - 1, false},
+		{"NW PDN DEACT 0", sizeof("NW PDN DEACT 0") - 1, false},
+		{"ME DETACH",      sizeof("ME DETACH") - 1,      false},
+		{"NW DETACH",      sizeof("NW DETACH") - 1,      false},
+	};
 
+	const char *event = strchr(notif, ':');
+
+	if (!event) {
+		return;
+	}
+
+	/* Skip ':' and any leading spaces */
+	event++;
+	while (*event == ' ') {
+		event++;
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(events); i++) {
+		if (strncmp(event, events[i].prefix, events[i].len) != 0) {
+			continue;
+		}
+
+		nw_connected = events[i].connected;
+
+		if (nw_connected) {
 			LOG_DBG("Connected to network");
-			nw_connected = true;
 			if (backoff && IS_ENABLED(CONFIG_NRF_PROVISIONING_SCHEDULED)) {
-				/* If network resumed while waiting, resume immediately */
 				schedule_next_work(0);
 			}
-
-			break;
-		case LTE_LC_EVT_PDN_DEACTIVATED:
-		case LTE_LC_EVT_PDN_NETWORK_DETACH:
-		case LTE_LC_EVT_PDN_SUSPENDED:
-
+		} else {
 			LOG_DBG("Disconnected from network");
-			nw_connected = false;
-
-			break;
-		default:
-			/* Don't care about other PDN events */
-			break;
 		}
-		break;
-	default:
-		/* Don't care about other events */
-		break;
+
+		return;
 	}
 }
+
+AT_MONITOR(nrf_provisioning_cgev, "CGEV", cgev_handler);
 
 int nrf_provisioning_init(nrf_provisioning_event_cb_t callback_handler)
 {
@@ -419,9 +447,6 @@ static void init_work_fn(struct k_work *work)
 		return;
 	}
 
-	/* Setup handler for LTE Link Control events. */
-	lte_lc_register_handler(lte_lc_event_handler);
-
 	if (IS_ENABLED(CONFIG_NRF_PROVISIONING_AUTO_START_ON_INIT)) {
 		LOG_DBG("Starting provisioning on init");
 
@@ -448,10 +473,9 @@ int nrf_provisioning_trigger_manually(void)
  */
 int nrf_provisioning_schedule(void)
 {
-	int ret;
 	int64_t now_s;
 	static time_t retry_s = 1;
-	static time_t deadline_s;
+	static int64_t deadline_s;
 	time_t spread_s;
 	static bool first = true;
 
@@ -473,25 +497,7 @@ int nrf_provisioning_schedule(void)
 		goto out;
 	}
 
-	ret = date_time_now(&now_s);
-	if (ret < 0) {
-		if (ret != -ENODATA) {
-			LOG_ERR("Getting time failed, error: %d", ret);
-			return ret;
-		}
-
-		/* Backoff... */
-		retry_s = retry_s * 2;
-
-		/* ...up to a degree */
-		if (retry_s > CONFIG_NRF_PROVISIONING_INTERVAL_S) {
-			retry_s = CONFIG_NRF_PROVISIONING_INTERVAL_S;
-		}
-
-		goto out;
-	}
-
-	now_s /= 1000; /* date_time_now() is ms */
+	now_s = k_uptime_get() / MSEC_PER_SEC;
 
 	if (now_s > deadline_s || reschedule) {
 		/* Interval set by the server takes precedence */
@@ -528,13 +534,14 @@ static void commit_latest_cmd_id(void)
 	}
 }
 
-static int wait_for_valid_datetime(int timeout_seconds)
+static int wait_for_valid_modem_time(int timeout_seconds)
 {
 	int waited = 0;
+	char time_buf[65];
 
 	while (waited < timeout_seconds) {
-		if (date_time_is_valid()) {
-			LOG_DBG("Valid date time obtained");
+		if (nrf_provisioning_at_time_get(time_buf, sizeof(time_buf)) == 0) {
+			LOG_DBG("Valid modem time obtained");
 			return 0;
 		}
 
@@ -759,9 +766,9 @@ void nrf_provisioning_work(struct k_work *work)
 	event_data.type = NRF_PROVISIONING_EVENT_START;
 	callback_local(&event_data);
 
-	ret = wait_for_valid_datetime(CONFIG_NRF_PROVISIONING_VALID_DATE_TIME_TIMEOUT_SECONDS);
+	ret = wait_for_valid_modem_time(CONFIG_NRF_PROVISIONING_VALID_DATE_TIME_TIMEOUT_SECONDS);
 	if (ret) {
-		LOG_ERR("Failed to get valid date time, err %d", ret);
+		LOG_ERR("Failed to get valid modem time, err %d", ret);
 		event_data.type = NRF_PROVISIONING_EVENT_FAILED_NO_VALID_DATETIME;
 		callback_local(&event_data);
 

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_at.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_at.c
@@ -7,6 +7,7 @@
 #include <zephyr/logging/log.h>
 
 #include <nrf_modem_at.h>
+#include <modem/lte_lc.h>
 
 #include "nrf_provisioning_at.h"
 
@@ -60,4 +61,19 @@ int nrf_provisioning_at_cmd(void *resp, size_t resp_sz, const char *cmd)
 int nrf_provisioning_at_del_credential(int tag, int type)
 {
 	return nrf_modem_at_printf("AT%%CMNG=3,%d,%d", tag, type);
+}
+
+bool nrf_provisioning_at_func_mode_is_offline(void)
+{
+	int err;
+	int mode;
+
+	err = nrf_modem_at_scanf("AT+CFUN?", "+CFUN: %d", &mode);
+	if (err < 0) {
+		LOG_WRN("Failed to retrieve modem functional mode, err %d", err);
+		return false;
+	}
+
+	/* CFUN=4 is offline (flight) mode */
+	return mode == LTE_LC_FUNC_MODE_OFFLINE;
 }

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
@@ -21,7 +21,6 @@
 #include "nrf_provisioning_cbor_encode_types.h"
 #include "nrf_provisioning_internal.h"
 
-#include <modem/lte_lc.h>
 #include <modem/modem_key_mgmt.h>
 #include <nrf_modem_at.h>
 
@@ -499,14 +498,7 @@ int nrf_provisioning_codec_process_commands(void)
 			break;
 		case command_union_at_command_m_c:
 
-			enum lte_lc_func_mode func_mode;
-
-			ret = lte_lc_func_mode_get(&func_mode);
-			if (ret < 0) {
-				goto stop_provisioning;
-			}
-
-			if (func_mode != LTE_LC_FUNC_MODE_OFFLINE) {
+			if (!nrf_provisioning_at_func_mode_is_offline()) {
 				ret = nrf_provisioning_notify_event_and_wait_for_modem_state(
 					CONFIG_NRF_PROVISIONING_MODEM_STATE_WAIT_TIMEOUT_SECONDS,
 					NRF_PROVISIONING_EVENT_NEED_LTE_DEACTIVATED,

--- a/tests/subsys/net/lib/nrf_provisioning/CMakeLists.txt
+++ b/tests/subsys/net/lib/nrf_provisioning/CMakeLists.txt
@@ -15,10 +15,8 @@ set(options
   -DCONFIG_NRF_MODEM_LIB_MEM_DIAG=y
   -DCONFIG_NRF_PROVISIONING_JWT_MAX_VALID_TIME_S=300
   -DCONFIG_MODEM_JWT_MAX_LEN=850
-  -DCONFIG_LTE_LC_PDN_MODULE=y
 )
 
-cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/date_time.h)
 cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/include/modem/lte_lc.h
   FUNC_EXCLUDE ".*(lte_lc_rai_req|lte_lc_rai_param_set)"
   WORD_EXCLUDE "__deprecated"

--- a/tests/subsys/net/lib/nrf_provisioning/src/coap.c
+++ b/tests/subsys/net/lib/nrf_provisioning/src/coap.c
@@ -14,8 +14,6 @@
 #include <time.h>
 #include <ncs_version.h>
 
-#include "cmock_date_time.h"
-#include "cmock_lte_lc.h"
 #include "cmock_modem_key_mgmt.h"
 #include "cmock_modem_info.h"
 #include "cmock_nrf_modem_lib.h"
@@ -810,13 +808,10 @@ void test_provisioning_task_valid(void)
 	__cmock_coap_client_init_IgnoreAndReturn(0);
 	__cmock_modem_info_init_IgnoreAndReturn(0);
 	__cmock_nrf_modem_lib_init_IgnoreAndReturn(0);
-	__cmock_lte_lc_register_handler_Ignore();
-	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_func_mode_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_enable_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_control_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(1);
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(0);
 
 	__cmock_modem_info_get_fw_version_ExpectAnyArgsAndReturn(0);
 	__cmock_modem_info_get_fw_version_ReturnArrayThruPtr_buf(MFW_VER, sizeof(MFW_VER));
@@ -859,13 +854,11 @@ void test_provisioning_commands(void)
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 	__cmock_modem_info_init_IgnoreAndReturn(0);
 	__cmock_nrf_modem_lib_init_IgnoreAndReturn(0);
-	__cmock_lte_lc_register_handler_Ignore();
-	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_func_mode_get_IgnoreAndReturn(0);
+	__cmock_nrf_provisioning_at_func_mode_is_offline_IgnoreAndReturn(true);
 	__cmock_nrf_provisioning_at_cmee_enable_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_control_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(1);
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(0);
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 
 	__cmock_nrf_provisioning_at_cmd_ExpectAnyArgsAndReturn(513);
@@ -915,7 +908,6 @@ void test_coap_rps_bad_request(void)
 
 	struct coap_client_option block2_option = {};
 
-	__cmock_lte_lc_func_mode_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_enable_ExpectAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_control_ExpectAnyArgsAndReturn(0);
 	__cmock_modem_info_get_fw_version_ExpectAnyArgsAndReturn(0);
@@ -953,7 +945,6 @@ void test_coap_rsp_server_error(void)
 
 	struct coap_client_option block2_option = {};
 
-	__cmock_lte_lc_func_mode_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_enable_ExpectAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_control_ExpectAnyArgsAndReturn(0);
 
@@ -992,7 +983,6 @@ void test_coap_rsp_unsupported_code(void)
 
 	struct coap_client_option block2_option = {};
 
-	__cmock_lte_lc_func_mode_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_enable_ExpectAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_control_ExpectAnyArgsAndReturn(0);
 

--- a/tests/subsys/net/lib/nrf_provisioning/src/main.c
+++ b/tests/subsys/net/lib/nrf_provisioning/src/main.c
@@ -20,8 +20,6 @@
 #include <time.h>
 #include <ncs_version.h>
 
-#include "cmock_date_time.h"
-#include "cmock_lte_lc.h"
 #include "cmock_modem_attest_token.h"
 #include "cmock_modem_key_mgmt.h"
 #include "cmock_modem_info.h"
@@ -744,10 +742,10 @@ void test_codec_priv_keygen_valid(void)
 	cdc_ctx.opkt = tx_buff;
 	cdc_ctx.opkt_sz = sizeof(tx_buff);
 
-	__cmock_lte_lc_func_mode_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_enable_ExpectAndReturn(true);
 	__cmock_nrf_provisioning_at_cmee_control_ExpectAnyArgsAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
+	__cmock_nrf_provisioning_at_func_mode_is_offline_IgnoreAndReturn(true);
 
 	__cmock_nrf_provisioning_at_cmd_ExpectAnyArgsAndReturn(513);
 	__cmock_nrf_modem_at_err_ExpectAnyArgsAndReturn(513);
@@ -789,10 +787,10 @@ void test_codec_priv_keygen_rejected_invalid(void)
 	cdc_ctx.opkt = tx_buff;
 	cdc_ctx.opkt_sz = sizeof(tx_buff);
 
-	__cmock_lte_lc_func_mode_get_ExpectAnyArgsAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_enable_ExpectAndReturn(true);
 	__cmock_nrf_provisioning_at_cmee_control_ExpectAnyArgsAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
+	__cmock_nrf_provisioning_at_func_mode_is_offline_IgnoreAndReturn(true);
 
 	char at_resp[] = "";
 
@@ -831,10 +829,10 @@ void test_codec_endorsement_keygen_valid(void)
 	cdc_ctx.opkt = tx_buff;
 	cdc_ctx.opkt_sz = sizeof(tx_buff);
 
-	__cmock_lte_lc_func_mode_get_ExpectAnyArgsAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_enable_ExpectAndReturn(true);
 	__cmock_nrf_provisioning_at_cmee_control_ExpectAnyArgsAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
+	__cmock_nrf_provisioning_at_func_mode_is_offline_IgnoreAndReturn(true);
 
 	char at_resp[] = "";
 
@@ -870,10 +868,10 @@ void test_codec_endorsement_keygen_invalid(void)
 	cdc_ctx.opkt = tx_buff;
 	cdc_ctx.opkt_sz = sizeof(tx_buff);
 
-	__cmock_lte_lc_func_mode_get_ExpectAnyArgsAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_enable_ExpectAndReturn(true);
 	__cmock_nrf_provisioning_at_cmee_control_ExpectAnyArgsAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
+	__cmock_nrf_provisioning_at_func_mode_is_offline_IgnoreAndReturn(true);
 
 	char at_resp[] = "ERROR";
 
@@ -912,7 +910,6 @@ void test_codec_config_store1_valid(void)
 	cdc_ctx.opkt = tx_buff;
 	cdc_ctx.opkt_sz = sizeof(tx_buff);
 
-	__cmock_lte_lc_func_mode_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_enable_ExpectAndReturn(true);
 	__cmock_nrf_provisioning_at_cmee_control_ExpectAnyArgsAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
@@ -989,11 +986,11 @@ void test_codec_modem_unresponsive_invalid(void)
 	cdc_ctx.opkt = NULL;
 	cdc_ctx.opkt_sz = 0;
 
-	__cmock_lte_lc_func_mode_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_at_cmd_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_at_cmee_enable_ExpectAndReturn(true);
 	__cmock_nrf_provisioning_at_cmee_control_ExpectAnyArgsAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
+	__cmock_nrf_provisioning_at_func_mode_is_offline_IgnoreAndReturn(true);
 
 	nrf_provisioning_codec_setup(&cdc_ctx, at_buff, sizeof(at_buff));
 
@@ -1025,7 +1022,7 @@ void test_provisioning_manual_uninitialized_invalid(void)
 void test_provisioning_init_wo_cert_change_valid(void)
 {
 	__cmock_modem_info_init_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(1);
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
 
 	__cmock_settings_subsys_init_ExpectAndReturn(0);
@@ -1043,8 +1040,6 @@ void test_provisioning_init_wo_cert_change_valid(void)
 
 	__cmock_rest_client_request_ExpectAnyArgsAndReturn(0);
 	__cmock_rest_client_request_AddCallback(rest_client_request_auth_hdr_valid);
-
-	__cmock_lte_lc_register_handler_Ignore();
 
 	int ret = nrf_provisioning_init(nrf_provisioning_event_cb);
 
@@ -1071,10 +1066,7 @@ void test_provisioning_task_valid(void)
 	__cmock_settings_register_IgnoreAndReturn(0);
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 	__cmock_modem_info_init_IgnoreAndReturn(0);
-	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_func_mode_get_IgnoreAndReturn(0);
-	__cmock_date_time_now_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(1);
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
 
 	__cmock_rest_client_request_defaults_set_Ignore();
@@ -1110,10 +1102,7 @@ void test_provisioning_task_server_busy_invalid(void)
 	__cmock_settings_register_IgnoreAndReturn(0);
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 	__cmock_modem_info_init_IgnoreAndReturn(0);
-	__cmock_lte_lc_func_mode_set_IgnoreAndReturn(0);
-	__cmock_lte_lc_func_mode_get_IgnoreAndReturn(0);
-	__cmock_date_time_now_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(1);
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
 
 	__cmock_rest_client_request_defaults_set_Ignore();
@@ -1211,7 +1200,7 @@ void test_provisioning_event_failed_device_not_claimed(void)
 	__cmock_settings_register_IgnoreAndReturn(0);
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 	__cmock_modem_info_init_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(1);
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
 	__cmock_modem_attest_token_get_ExpectAnyArgsAndReturn(0);
 	__cmock_modem_attest_token_free_ExpectAnyArgs();
@@ -1249,7 +1238,7 @@ void test_provisioning_event_failed_too_many_commands(void)
 	__cmock_settings_register_IgnoreAndReturn(0);
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 	__cmock_modem_info_init_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(1);
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
 
 	__cmock_rest_client_request_defaults_set_Ignore();
@@ -1285,7 +1274,7 @@ void test_provisioning_event_failed_wrong_root_ca(void)
 	__cmock_settings_register_IgnoreAndReturn(0);
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 	__cmock_modem_info_init_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(1);
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
 
 	__cmock_rest_client_request_defaults_set_Ignore();
@@ -1313,7 +1302,7 @@ void test_provisioning_event_failed_wrong_root_ca(void)
 /*
  * - Test NRF_PROVISIONING_EVENT_FAILED_NO_VALID_DATETIME
  * - Verify that no valid datetime error triggers the correct event
- * - Mock date_time_is_valid to return false to trigger no valid datetime event
+ * - Mock nrf_provisioning_at_time_get to return error to trigger no valid datetime event
  */
 void test_provisioning_event_failed_no_valid_datetime(void)
 {
@@ -1321,7 +1310,7 @@ void test_provisioning_event_failed_no_valid_datetime(void)
 	__cmock_settings_register_IgnoreAndReturn(0);
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 	__cmock_modem_info_init_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(0); /* Return false - no valid datetime */
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(1); /* Return error */
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
 
 	int ret = nrf_provisioning_trigger_manually();
@@ -1346,7 +1335,7 @@ void test_provisioning_event_failed_timeout(void)
 	__cmock_settings_register_IgnoreAndReturn(0);
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 	__cmock_modem_info_init_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(1);
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
 
 	__cmock_rest_client_request_defaults_set_Ignore();
@@ -1382,7 +1371,7 @@ void test_provisioning_event_done(void)
 	__cmock_settings_register_IgnoreAndReturn(0);
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 	__cmock_modem_info_init_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(1);
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
 
 	__cmock_rest_client_request_defaults_set_Ignore();
@@ -1433,16 +1422,11 @@ void test_provisioning_event_lte_deactivation_activation(void)
 	cdc_ctx.opkt = tx_buff;
 	cdc_ctx.opkt_sz = sizeof(tx_buff);
 
-	/* Mock LTE function mode to return NORMAL (online) to trigger deactivation */
-	__cmock_lte_lc_func_mode_get_ExpectAnyArgsAndReturn(0);
-	enum lte_lc_func_mode online_mode = LTE_LC_FUNC_MODE_NORMAL;
-
-	__cmock_lte_lc_func_mode_get_ReturnThruPtr_mode(&online_mode);
-
 	__cmock_nrf_provisioning_at_cmee_enable_ExpectAndReturn(true);
 	__cmock_nrf_provisioning_at_cmee_control_ExpectAnyArgsAndReturn(0);
 
 	/* Mock the LTE deactivation event notification */
+	__cmock_nrf_provisioning_at_func_mode_is_offline_ExpectAndReturn(false);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_ExpectAndReturn(
 		CONFIG_NRF_PROVISIONING_MODEM_STATE_WAIT_TIMEOUT_SECONDS,
 		NRF_PROVISIONING_EVENT_NEED_LTE_DEACTIVATED,
@@ -1487,7 +1471,7 @@ void test_provisioning_event_failed_device_not_claimed_with_token(void)
 	__cmock_settings_register_IgnoreAndReturn(0);
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 	__cmock_modem_info_init_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(1);
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
 
 	__cmock_rest_client_request_defaults_set_Ignore();

--- a/tests/subsys/net/lib/nrf_provisioning/src/scheduled.c
+++ b/tests/subsys/net/lib/nrf_provisioning/src/scheduled.c
@@ -19,7 +19,6 @@
 #include <time.h>
 #include <ncs_version.h>
 
-#include "cmock_date_time.h"
 #include "cmock_lte_lc.h"
 #include "cmock_modem_attest_token.h"
 #include "cmock_modem_key_mgmt.h"
@@ -214,16 +213,9 @@ static int rest_client_request_with_commands_cb(struct rest_client_req_context *
 	return 0; /* Success */
 }
 
-static int time_now(int64_t *unix_time_ms, int cmock_num_calls)
-{
-	*unix_time_ms = (int64_t)time(NULL) * MSEC_PER_SEC;
-	return 0;
-}
-
 void setUp(void)
 {
 	k_sem_reset(&event_received_sem);
-	__cmock_date_time_now_Stub(time_now);
 }
 
 void test_provisioning_init_should_start_provisioning(void)
@@ -235,8 +227,7 @@ void test_provisioning_init_should_start_provisioning(void)
 	__cmock_settings_register_IgnoreAndReturn(0);
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 	__cmock_lte_lc_register_handler_Ignore();
-	__cmock_date_time_now_IgnoreAndReturn(0);
-	__cmock_date_time_is_valid_IgnoreAndReturn(1);
+	__cmock_nrf_provisioning_at_time_get_IgnoreAndReturn(0);
 	__cmock_nrf_provisioning_notify_event_and_wait_for_modem_state_IgnoreAndReturn(0);
 	__cmock_rest_client_request_defaults_set_Ignore();
 	__cmock_modem_info_get_fw_version_IgnoreAndReturn(0);
@@ -366,47 +357,12 @@ void test_provisioning_schedule_valid(void)
 	/* To avoid being entangled to other tests let's assume that the function has
 	 * never been called earlier. If that's not the case let's just ignore the first invocation.
 	 */
-	__cmock_date_time_now_IgnoreAndReturn(0);
 	(void)nrf_provisioning_schedule();
-
-	__cmock_date_time_now_StopIgnore();
-
-	__cmock_date_time_now_AddCallback(time_now);
-	__cmock_date_time_now_ExpectAnyArgsAndReturn(0);
 
 	int ret = nrf_provisioning_schedule();
 
 	/* Can't have exact match due to the spread factor */
 	TEST_ASSERT_GREATER_OR_EQUAL(0, ret);
-	TEST_ASSERT_LESS_OR_EQUAL_INT(
-		CONFIG_NRF_PROVISIONING_INTERVAL_S + CONFIG_NRF_PROVISIONING_SPREAD_S, ret);
-}
-
-/*
- * - Get when next provisioning should be executed when network time is not available
- * - It's not guaranteed that network provides the time information
- * - Call the function and check that the returned interval is within the expected range.
- *   The compile time configuration is used as we are not reading the value from flash.
- *   Internals are configured in a way that it looks like the time information is not
- *   available.
- */
-void test_provisioning_schedule_no_nw_time_valid(void)
-{
-	/* To avoid being entangled to other tests let's assume that the function has
-	 * never been called earlier. If that's not the case let's just ignore the first invocation.
-	 */
-	__cmock_date_time_now_AddCallback(time_now);
-	__cmock_date_time_now_IgnoreAndReturn(0);
-	(void)nrf_provisioning_schedule();
-
-	__cmock_date_time_now_StopIgnore();
-
-	__cmock_date_time_now_ExpectAnyArgsAndReturn(-1);
-
-	int ret = nrf_provisioning_schedule();
-
-	/* Can't have exact match due to the spread factor */
-	TEST_ASSERT_GREATER_THAN_INT(0, ret);
 	TEST_ASSERT_LESS_OR_EQUAL_INT(
 		CONFIG_NRF_PROVISIONING_INTERVAL_S + CONFIG_NRF_PROVISIONING_SPREAD_S, ret);
 }


### PR DESCRIPTION
The LTE Link Control library introduces unnecessary overhead when only network connectivity status is needed.
Replace it with AT Monitor notifications (+CGEV) for tracking modem connection state changes.

Replace date-time with modem time.