### PR TITLE
Set of VPR improvements

### DIFF
--- a/dts/common/nordic/nrf54lv10a.dtsi
+++ b/dts/common/nordic/nrf54lv10a.dtsi
@@ -166,6 +166,7 @@
 				#size-cells = <1>;
 				status = "disabled";
 				enable-secure;
+				hibernation-ram-block = <32>;
 
 				cpuflpr_clic: interrupt-controller@f0000000 {
 					compatible = "nordic,nrf-clic";


### PR DESCRIPTION
All commits from upstream tree. Following improvements:
- Select default VPR sleep mode (hibernation on nrf54l which allows to get low power idle when FLPR is in use)
- Add hibernate mode support to vpr_laucher - vpr launcher enables RAM block used for hibernation (applicable to nrf54l)
- Fix handling of nRF54L errata 16 where event between cpuapp and cpuflpr might be lost.
- Limit scope of errata 16 only to affected SoCs
- ICMSG IPC service - detect when service is open too early