### PR TITLE
samples: bluetooth: add channel sounding IPT initiator and reflector

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -448,8 +448,7 @@
 /samples/bluetooth/central_nfc_pairing/   @nrfconnect/ncs-blenders
 /samples/bluetooth/central_smp_client/    @nrfconnect/ncs-eris
 /samples/bluetooth/central_uart/          @nrfconnect/ncs-blenders
-/samples/bluetooth/channel_sounding/ras_initiator/ @nrfconnect/ncs-dragoon
-/samples/bluetooth/channel_sounding/ras_reflector/ @nrfconnect/ncs-dragoon
+/samples/bluetooth/channel_sounding/      @nrfconnect/ncs-dragoon
 /samples/bluetooth/conn_time_sync/        @nrfconnect/ncs-dragoon
 /samples/bluetooth/direction_finding_central/ @nrfconnect/ncs-dragoon
 /samples/bluetooth/direction_finding_connectionless_rx/ @nrfconnect/ncs-dragoon
@@ -589,6 +588,8 @@
 /samples/bluetooth/central_uart/*.rst     @nrfconnect/ncs-blenders-doc
 /samples/bluetooth/channel_sounding/ras_initiator/*.rst @nrfconnect/ncs-dragoon-doc
 /samples/bluetooth/channel_sounding/ras_reflector/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/channel_sounding/ipt_initiator/*.rst @nrfconnect/ncs-dragoon-doc
+/samples/bluetooth/channel_sounding/ipt_reflector/*.rst @nrfconnect/ncs-dragoon-doc
 /samples/bluetooth/conn_time_sync/*.rst   @nrfconnect/ncs-dragoon-doc
 /samples/bluetooth/direction_finding_central/*.rst @nrfconnect/ncs-dragoon-doc
 /samples/bluetooth/direction_finding_connectionless_rx/*.rst @nrfconnect/ncs-dragoon-doc

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -260,7 +260,9 @@ This section provides detailed lists of changes by :ref:`sample <samples>`.
 Bluetooth samples
 -----------------
 
-|no_changes_yet_note|
+* Added:
+
+  * The :ref:`channel_sounding_ipt_initiator` and :ref:`channel_sounding_ipt_reflector` samples to demonstrate how to use the Bluetooth Channel Sounding (CS) Inline Phase Correction Term Transfer (IPT) feature.
 
 Bluetooth Mesh samples
 ----------------------

--- a/samples/bluetooth/channel_sounding/ipt_initiator/CMakeLists.txt
+++ b/samples/bluetooth/channel_sounding/ipt_initiator/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(channel_sound_ipt_initiator)
+
+# NORDIC SDK APP START
+target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END

--- a/samples/bluetooth/channel_sounding/ipt_initiator/README.rst
+++ b/samples/bluetooth/channel_sounding/ipt_initiator/README.rst
@@ -1,0 +1,251 @@
+.. _channel_sounding_ipt_initiator:
+
+Bluetooth: Channel Sounding Initiator with Inline PCT Transfer
+##############################################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+This sample demonstrates how to use the Bluetooth® Channel Sounding (CS) Inline Phase Correction Term Transfer (IPT) feature as a CS initiator, to achieve fast and efficient distance estimation.
+
+
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-sample-yaml::
+
+You can use any combination of supported development kits in your test setup.
+
+The sample also requires a device running a Channel Sounding Reflector with CS IPT support to connect to, such as the :ref:`channel_sounding_ipt_reflector` sample.
+
+Overview
+********
+
+The sample acts as a Bluetooth Low Energy Central and Channel Sounding initiator.
+After startup, the sample performs the following steps:
+
+1. Scans for a reflector advertising the name ``Nordic CS IPT Reflector``.
+#. Connects to the reflector.
+#. Encrypts the ACL link.
+#. Reads the remote supported features.
+#. Performs the required CS setup over the ACL:
+
+   a. CS default settings
+   #. CS capability exchange
+   #. CS configuration creation with CS IPT enabled
+   #. CS security enable
+   #. CS procedures enable
+
+#. Continuously receives CS subevent result events from the controller, computes a distance estimate for each completed procedure using :c:func:`cs_de_ifft`, and logs the estimate and sliding window median over the serial port together with the time delta since the previous estimate.
+
+Unlike the :ref:`channel_sounding_ras_initiator` sample, this sample does not act as a GATT Ranging Requestor client and does not fetch peer ranging data over GATT.
+The initiator computes distance estimates entirely from its own CS subevent result events, without ever receiving the reflector's raw measurements over the ACL.
+
+.. channel_sounding_ipt_initiator_cs_ipt_start
+
+How CS IPT works
+================
+
+.. channel_sounding_ipt_initiator_cs_ipt_works_start
+
+CS IPT exploits the symmetry of CS Phase-Based Ranging (PBR) tones.
+PBR tones are exchanged in mode 2 steps and in the PBR portion of mode 3 steps, and CS IPT is applicable to both.
+During a PBR tone exchange the initiator and the reflector each transmit a continuous-wave tone on the same frequency, back-to-back.
+With CS IPT enabled, the reflector adjusts the phase of the tone it transmits to the initiator to match the phase of the tone it just received from the initiator on the same frequency.
+
+As a result, the phase that the initiator measures on the received tone already contains the sum of the following  components:
+
+* The phase measured by the reflector on the initiator's tone.
+* The phase accumulated on the return trip from the reflector to the initiator.
+
+With CS IPT, the initiator therefore has everything it needs to compute a distance estimate from its local subevent data alone, and the reflector's phase measurements do not have to be relayed back over the ACL.
+
+This sample only uses mode 2 steps, but the CS IPT feature also applies to the PBR tones within mode 3 steps.
+
+.. note::
+   The CS IPT feature only works for distance estimating using PBR.
+   So if you want an RTT measurement from a mode 3 step you still need to use Ranging Service, or an equivalent, to relay the RTT measurement back from the peer device over the ACL.
+
+.. channel_sounding_ipt_initiator_cs_ipt_works_end
+
+Benefits of CS IPT
+==================
+
+.. channel_sounding_ipt_initiator_cs_ipt_benefits_start
+
+Compared to using the Ranging Service (RAS) to transfer ranging data, CS IPT provides the following benefits:
+
+* Reduced setup time for Channel Sounding, since no GATT Ranging Service discovery or subscription is required before distance estimates can be produced.
+* Higher achievable update rate for distance estimates based on CS procedures, because the reflector's measurement data is already encoded in the tones the initiator receives and does not need a separate GATT transfer.
+* Reduced latency between the measurements being taken during a CS procedure and the distance estimate being computed, because the reflector's measurement data is already encoded in the tones the initiator receives.
+* Lower power consumption and reduced memory usage on both devices, since the reflector's measurement data does not have to be buffered on the reflector, sent over the ACL, or reassembled on the initiator.
+
+.. channel_sounding_ipt_initiator_cs_ipt_benefits_end
+
+Drawbacks of CS IPT
+===================
+
+.. channel_sounding_ipt_initiator_cs_ipt_drawbacks_start
+
+Compared to using RAS, CS IPT has the following drawbacks:
+
+* Reduced security level.
+  This sample only runs CS mode 2 steps, so it cannot provide the same level of protection against ranging attacks as a RAS-based setup that combines mode 1 (RTT) and mode 2 (PBR) steps.
+
+.. channel_sounding_ipt_initiator_cs_ipt_drawbacks_end
+.. channel_sounding_ipt_initiator_cs_ipt_end
+
+Limitations
+===========
+
+To keep the sample minimal, it has the following limitations:
+
+* Multi-antenna configurations are not supported.
+  The sample is configured for a single antenna path (``CONFIG_BT_CS_DE_MAX_NUM_ANTENNA_PATHS=1``).
+* Distance estimation only uses the IFFT-based estimator (:c:func:`cs_de_ifft`).
+* Only basic post-processing is applied to the distance estimates in the form of a sliding-window median filter.
+* Tones are not filtered out based on the Tone Quality Indicator (TQI).
+  All reported tones are fed into the distance estimator.
+
+User interface
+**************
+
+The sample does not require user input and scans for a device advertising with the name ``Nordic CS IPT Reflector``.
+The first LED on the development kit will be lit when a connection has been established.
+
+Building and running
+********************
+
+.. |sample path| replace:: :file:`samples/bluetooth/channel_sounding/ipt_initiator`
+
+.. include:: /includes/build_and_run.txt
+
+Testing
+=======
+
+After programming the sample to your development kit, you can test it by connecting to another device programmed with a Channel Sounding Reflector role with CS IPT support, such as the :ref:`channel_sounding_ipt_reflector` sample:
+
+1. |connect_terminal_specific|
+#. Reset both kits.
+#. Wait until the scanner detects the Peripheral.
+   In the terminal window, check for information similar to the following::
+
+      *** Booting nRF Connect SDK v3.2.99-d0824283f866 ***
+      *** Using Zephyr OS v4.3.99-2925b3840984 ***
+      I: Starting Channel Sounding IPT Initiator Sample
+      I: SoftDevice Controller build revision:
+      I: 36 9c e5 98 e5 71 0a a0 |6....q..
+      I: 2d b9 89 96 6b 15 65 4b |-...k.eK
+      I: d6 e8 4a ac             |..J.
+      I: HW Platform: Nordic Semiconductor (0x0002)
+      I: HW Variant: nRF54Lx (0x0005)
+      I: Firmware: Standard Bluetooth controller (0x00) Version 54.58780 Build 175236504
+      I: HCI transport: SDC
+      I: Identity: E6:BA:C9:31:51:DB (random)
+      I: HCI: version 6.2 (0x10) revision 0x30a9, manufacturer 0x0059
+      I: LMP: version 6.2 (0x10) subver 0x30a9
+      I: Filters matched. Address: D2:CE:07:7E:40:79 (random) connectable: 1
+      I: Connecting
+      I: Connected to D2:CE:07:7E:40:79 (random) (err 0x00)
+      I: Security changed: D2:CE:07:7E:40:79 (random) level 2
+      I: CS capability exchange completed.
+      Remote CS capabilities:
+      - num_config_supported: 1
+      - max_consecutive_procedures_supported: 0
+      - num_antennas_supported: 1
+      - max_antenna_paths_supported: 1
+      - initiator_supported: no
+      - reflector_supported: yes
+      - mode_3_supported: no
+      - rtt_aa_only_precision: 150 ns (2)
+      - rtt_sounding_precision: not supported (0)
+      - rtt_random_payload_precision: 150 ns (2)
+      - rtt_aa_only_n: 30
+      - rtt_sounding_n: 0
+      - rtt_random_payload_n: 30
+      - phase_based_nadm_sounding_supported: no
+      - phase_based_nadm_random_supported: no
+      - cs_sync_2m_phy_supported: yes
+      - cs_sync_2m_2bt_phy_supported: no
+      - cs_without_fae_supported: yes
+      - chsel_alg_3c_supported: no
+      - pbr_from_rtt_sounding_seq_supported: no
+      - t_ip1_times_supported: 0x007c
+      - t_ip2_times_supported: 0x007e
+      - t_fcs_times_supported: 0x01e0
+      - t_pm_times_supported: 0x0003
+      - t_sw_time: 0 us
+      - tx_snr_capability: 0x00
+      - t_ip2_ipt_times_supported: 0x007e
+      - t_sw_ipt_time_supported: 10 us
+
+      I: CS config creation complete.
+      - id: 0
+      - mode: 2 (PBR)
+      - min_main_mode_steps: 0
+      - max_main_mode_steps: 0
+      - main_mode_repetition: 0
+      - mode_0_steps: 3
+      - role: Initiator
+      - rtt_type: AA only
+      - cs_sync_phy: LE 1M PHY
+      - channel_map_repetition: 1
+      - channel_selection_type: Algorithm #3b
+      - ch3c_shape: Hat shape
+      - ch3c_jump: 2
+      - t_ip1_time_us: 30
+      - t_ip2_time_us: 20
+      - t_fcs_time_us: 60
+      - t_pm_time_us: 10
+      - channel_map: 0x1FFFFFFFFFFFFC7FFFFC
+
+      I: CS security enabled.
+      I: CS procedures enabled:
+      - config ID: 0
+      - antenna configuration index: 0
+      - TX power: 0 dbm
+      - subevent length: 7500 us
+      - subevents per event: 1
+      - subevent interval: 0
+      - event interval: 3
+      - procedure interval: 2
+      - procedure count: 0
+      - maximum procedure length: 12
+      I: Distance estimates: median: 0.60m, update: 0.60m, time_delta: 0ms
+      I: Distance estimates: median: 0.60m, update: 0.59m, time_delta: 30ms
+      I: Distance estimates: median: 0.59m, update: 0.59m, time_delta: 30ms
+      I: Distance estimates: median: 0.60m, update: 0.60m, time_delta: 30ms
+      I: Distance estimates: median: 0.60m, update: 0.60m, time_delta: 30ms
+      I: Distance estimates: median: 0.60m, update: 0.58m, time_delta: 30ms
+      I: Distance estimates: median: 0.59m, update: 0.59m, time_delta: 30ms
+      I: Distance estimates: median: 0.59m, update: 0.59m, time_delta: 30ms
+      I: Distance estimates: median: 0.59m, update: 0.59m, time_delta: 30ms
+      I: Distance estimates: median: 0.59m, update: 0.59m, time_delta: 30ms
+      I: Distance estimates: median: 0.59m, update: 0.59m, time_delta: 30ms
+
+
+Dependencies
+************
+
+This sample uses the following |NCS| libraries:
+
+* :ref:`dk_buttons_and_leds_readme`
+* :file:`include/bluetooth/cs_de.h`
+* :file:`include/bluetooth/scan.h`
+
+This sample uses the following Zephyr libraries:
+
+* :file:`include/sys/printk.h`
+* :file:`include/zephyr/types.h`
+* :ref:`zephyr:kernel_api`:
+
+  * :file:`include/kernel.h`
+
+* :ref:`zephyr:bluetooth_api`:
+
+* :file:`include/bluetooth/bluetooth.h`
+* :file:`include/bluetooth/conn.h`
+* :file:`include/bluetooth/cs.h`

--- a/samples/bluetooth/channel_sounding/ipt_initiator/prj.conf
+++ b/samples/bluetooth/channel_sounding/ipt_initiator/prj.conf
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NCS_SAMPLES_DEFAULTS=y
+CONFIG_DK_LIBRARY=y
+
+CONFIG_BT=y
+CONFIG_BT_SMP=y
+CONFIG_BT_CENTRAL=y
+CONFIG_BT_MAX_CONN=1
+CONFIG_BT_BONDABLE=n
+
+CONFIG_BT_CHANNEL_SOUNDING=y
+
+CONFIG_BT_SCAN=y
+CONFIG_BT_SCAN_FILTER_ENABLE=y
+CONFIG_BT_SCAN_NAME_CNT=1
+
+# This reduces RAM usage. Additional RAM is needed to support optional
+# features such as mode 3 or multiantenna. Change or remove these if
+# using those features
+CONFIG_BT_CS_DE_MAX_NUM_ANTENNA_PATHS=1
+CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS=1
+CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS=1
+CONFIG_BT_CTLR_SDC_CS_STEP_MODE3=n
+CONFIG_BT_CTLR_SDC_CS_ROLE_INITIATOR_ONLY=y
+
+# This is required for CS Enhancements
+CONFIG_BT_CTLR_EXTENDED_FEAT_SET=y
+
+# Disabling the CS Test command reduces flash usage
+CONFIG_BT_CTLR_CHANNEL_SOUNDING_TEST=n
+
+# This allows CS and ACL to use different PHYs
+CONFIG_BT_TRANSMIT_POWER_CONTROL=y
+
+# This improves the performance of floating-point operations
+CONFIG_FPU=y
+CONFIG_FPU_SHARING=y
+
+CONFIG_CBPRINTF_FP_SUPPORT=y
+
+CONFIG_BT_CS_DE=y
+CONFIG_BT_CS_DE_1024_NFFT=y

--- a/samples/bluetooth/channel_sounding/ipt_initiator/sample.yaml
+++ b/samples/bluetooth/channel_sounding/ipt_initiator/sample.yaml
@@ -1,0 +1,22 @@
+sample:
+  description: Bluetooth Low Energy Channel Sounding Initiator with Inline PCT Transfer
+  name: Bluetooth LE Channel Sounding Initiator with IPT
+tests:
+  sample.bluetooth.channel_sounding_ipt_initiator:
+    sysbuild: true
+    build_only: true
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
+      - ci_samples_bluetooth

--- a/samples/bluetooth/channel_sounding/ipt_initiator/src/main.c
+++ b/samples/bluetooth/channel_sounding/ipt_initiator/src/main.c
@@ -1,0 +1,677 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ *  @brief Channel Sounding Initiator with Inline PCT Transfer sample
+ */
+
+#include <math.h>
+#include <stdlib.h>
+#include <zephyr/kernel.h>
+#include <zephyr/types.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/bluetooth/cs.h>
+#include <zephyr/bluetooth/conn.h>
+#include <bluetooth/scan.h>
+#include <bluetooth/cs_de.h>
+
+#include <dk_buttons_and_leds.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(app_main, LOG_LEVEL_INF);
+
+#define CON_STATUS_LED	 DK_LED1
+#define CS_CONFIG_ID	 0
+#define NUM_MODE_0_STEPS 3
+#define REFLECTOR_NAME	 "Nordic CS IPT Reflector"
+
+#define CHANNEL_INDEX_OFFSET   (2)
+#define MEDIAN_FILTER_SIZE (9)
+
+static K_SEM_DEFINE(sem_remote_capabilities_obtained, 0, 1);
+static K_SEM_DEFINE(sem_config_created, 0, 1);
+static K_SEM_DEFINE(sem_cs_security_enabled, 0, 1);
+static K_SEM_DEFINE(sem_connected, 0, 1);
+static K_SEM_DEFINE(sem_security, 0, 1);
+static K_SEM_DEFINE(sem_subevent_results_parsed, 0, 1);
+static K_SEM_DEFINE(sem_distance_estimate_updated, 1, 1);
+
+static struct bt_conn *connection;
+static struct bt_conn_le_cs_config cs_config;
+
+/* Store local initiator IQs in this union.
+ * The size is based on requirements of cs_de_ifft.
+ * The scratch memory is used for the ifft operation.
+ */
+static union {
+	struct {
+		float i;
+		float q;
+	} values[CS_DE_NUM_CHANNELS];
+	float scratch_mem[2 * CONFIG_BT_CS_DE_NFFT_SIZE];
+} iq;
+
+/* --- Sliding-window median filter for distance tracking ---
+ *
+ * Keeps the most recent MEDIAN_FILTER_SIZE distance measurements in a
+ * circular buffer and reports the median of the valid (finite) samples.
+ */
+struct distance_estimate_buffer {
+	float estimates[MEDIAN_FILTER_SIZE];
+	uint8_t num_valid;
+	uint8_t index;
+};
+
+static struct distance_estimate_buffer distance_estimate_buffer;
+
+static void store_distance_estimate(float distance)
+{
+	distance_estimate_buffer.estimates[distance_estimate_buffer.index] = distance;
+	distance_estimate_buffer.index =
+		(distance_estimate_buffer.index + 1) % MEDIAN_FILTER_SIZE;
+
+	if (distance_estimate_buffer.num_valid < MEDIAN_FILTER_SIZE) {
+		distance_estimate_buffer.num_valid++;
+	}
+}
+
+static int float_cmp(const void *a, const void *b)
+{
+	float fa = *(const float *)a;
+	float fb = *(const float *)b;
+
+	return (fa > fb) - (fa < fb);
+}
+
+static float median_inplace(int count, float *values)
+{
+	if (count == 0) {
+		return NAN;
+	}
+
+	qsort(values, count, sizeof(float), float_cmp);
+
+	if (count % 2 == 0) {
+		return (values[count / 2] + values[count / 2 - 1]) / 2;
+	} else {
+		return values[count / 2];
+	}
+}
+
+static float get_filtered_distance(void)
+{
+	static float temp_ifft[MEDIAN_FILTER_SIZE];
+	uint8_t num_ifft = 0;
+
+	for (uint8_t i = 0; i < distance_estimate_buffer.num_valid; i++) {
+		if (isfinite(distance_estimate_buffer.estimates[i])) {
+			temp_ifft[num_ifft] = distance_estimate_buffer.estimates[i];
+			num_ifft++;
+		}
+	}
+
+	return median_inplace(num_ifft, temp_ifft);
+}
+
+static void distance_estimates_update(void)
+{
+	for (uint8_t i = 0; i < CS_DE_NUM_CHANNELS; i++) {
+		LOG_DBG("iq[%d]: %.1f + j * %.1f", i, (double)iq.values[i].i,
+			(double)iq.values[i].q);
+	}
+
+	float distance_ifft = cs_de_ifft(iq.scratch_mem);
+
+	if (isfinite(distance_ifft)) {
+		static int64_t prev_ts = -1;
+
+		int64_t now = k_uptime_get();
+		int64_t delta = 0;
+
+		if (prev_ts != -1) {
+			delta = now - prev_ts;
+		}
+		prev_ts = now;
+
+		store_distance_estimate(distance_ifft);
+
+		float distance_median = get_filtered_distance();
+
+		LOG_INF("Distance estimates: median: %.2fm, update: %.2fm, time_delta: %lldms",
+			(double)distance_median, (double)distance_ifft, delta);
+	}
+	k_sem_give(&sem_distance_estimate_updated);
+}
+
+static void pcts_parse(uint8_t channel_index,
+		       struct bt_hci_le_cs_step_data_tone_info *local_tone_info)
+{
+	struct bt_le_cs_iq_sample local_iq =
+		bt_le_cs_parse_pct(local_tone_info[0].phase_correction_term);
+
+	iq.values[channel_index - CHANNEL_INDEX_OFFSET].i = local_iq.i;
+	iq.values[channel_index - CHANNEL_INDEX_OFFSET].q = local_iq.q;
+}
+
+static void subevent_steps_parse(struct bt_conn_le_cs_subevent_result *result)
+{
+	for (uint8_t i = 0; i < result->header.num_steps_reported; i++) {
+		if (result->step_data_buf->len < 3) {
+			LOG_WRN("Local step data appears malformed.");
+			return;
+		}
+		struct bt_le_cs_subevent_step local_step = {0};
+
+		local_step.mode = net_buf_simple_pull_u8(result->step_data_buf);
+		local_step.channel = net_buf_simple_pull_u8(result->step_data_buf);
+		local_step.data_len = net_buf_simple_pull_u8(result->step_data_buf);
+
+		if (local_step.data_len == 0) {
+			LOG_WRN("Encountered zero-length step data.");
+			return;
+		}
+		if (local_step.data_len > result->step_data_buf->len) {
+			LOG_WRN("Local step data appears malformed.");
+			return;
+		}
+
+		local_step.data = result->step_data_buf->data;
+
+		if (local_step.mode == BT_HCI_OP_LE_CS_MAIN_MODE_2) {
+			struct bt_hci_le_cs_step_data_mode_2 *local_step_data =
+				(struct bt_hci_le_cs_step_data_mode_2 *)local_step.data;
+			pcts_parse(local_step.channel, local_step_data->tone_info);
+		}
+
+		net_buf_simple_pull(result->step_data_buf, local_step.data_len);
+	}
+}
+
+static void subevent_result_cb(struct bt_conn *conn, struct bt_conn_le_cs_subevent_result *result)
+{
+	static int64_t prev_ts = -1;
+	static uint32_t prev_procedure_counter = UINT16_MAX + 1;
+
+	int64_t now = k_uptime_get();
+	int64_t delta = 0;
+
+	if (prev_ts != -1) {
+		delta = now - prev_ts;
+	}
+	prev_ts = now;
+
+	LOG_DBG("Subevent result callback for procedure counter %u procedure done status "
+		"%u subevent done status %u, number of steps reported %u, time delta since "
+		"last call: %lld ms",
+		result->header.procedure_counter, result->header.procedure_done_status,
+		result->header.subevent_done_status, result->header.num_steps_reported, delta);
+
+	const bool cs_aborted = (result->header.procedure_abort_reason !=
+				 BT_HCI_LE_CS_PROCEDURE_ABORT_REASON_NO_ABORT) ||
+				(result->header.subevent_abort_reason !=
+				 BT_HCI_LE_CS_SUBEVENT_ABORT_REASON_NO_ABORT);
+
+	if (cs_aborted) {
+		LOG_DBG("CS aborted. "
+			"Procedure counter: %u, procedure abort reason: %u, subevent abort reason: "
+			"%u",
+			result->header.procedure_counter, result->header.procedure_abort_reason,
+			result->header.subevent_abort_reason);
+		return;
+	}
+
+	if (result->header.procedure_counter != prev_procedure_counter) {
+		k_sem_take(&sem_distance_estimate_updated, K_FOREVER);
+		memset(iq.scratch_mem, 0, sizeof(iq.scratch_mem));
+	}
+	prev_procedure_counter = result->header.procedure_counter;
+
+	subevent_steps_parse(result);
+
+	/* This means all the steps from the procedure have been parsed and distance estimation can
+	 * run.
+	 */
+	if (result->header.procedure_done_status == BT_CONN_LE_CS_PROCEDURE_COMPLETE) {
+		k_sem_give(&sem_subevent_results_parsed);
+	}
+}
+
+static void security_changed_cb(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	if (err) {
+		LOG_ERR("Security failed: %s level %u err %d %s", addr, level, err,
+			bt_security_err_to_str(err));
+		return;
+	}
+
+	LOG_INF("Security changed: %s level %u", addr, level);
+	k_sem_give(&sem_security);
+}
+
+static void connected_cb(struct bt_conn *conn, uint8_t err)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	LOG_INF("Connected to %s (err 0x%02X)", addr, err);
+
+	if (err) {
+		bt_conn_unref(conn);
+		connection = NULL;
+	} else {
+		connection = bt_conn_ref(conn);
+
+		k_sem_give(&sem_connected);
+
+		dk_set_led_on(CON_STATUS_LED);
+	}
+}
+
+static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
+{
+	LOG_INF("Disconnected (reason 0x%02X)", reason);
+
+	bt_conn_unref(conn);
+	connection = NULL;
+	dk_set_led_off(CON_STATUS_LED);
+
+	sys_reboot(SYS_REBOOT_COLD);
+}
+
+static void remote_capabilities_cb(struct bt_conn *conn, uint8_t status,
+				   struct bt_conn_le_cs_capabilities *params)
+{
+	ARG_UNUSED(conn);
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		static const char *const rtt_precision_str[] = {"not supported", "10 ns", "150 ns",
+								"invalid"};
+
+		uint8_t aa_idx = MIN((uint8_t)params->rtt_aa_only_precision, 3U);
+		uint8_t snd_idx = MIN((uint8_t)params->rtt_sounding_precision, 3U);
+		uint8_t rand_idx = MIN((uint8_t)params->rtt_random_payload_precision, 3U);
+
+		LOG_INF("CS capability exchange completed.\n"
+			"Remote CS capabilities:\n"
+			" - num_config_supported: %u\n"
+			" - max_consecutive_procedures_supported: %u\n"
+			" - num_antennas_supported: %u\n"
+			" - max_antenna_paths_supported: %u\n"
+			" - initiator_supported: %s\n"
+			" - reflector_supported: %s\n"
+			" - mode_3_supported: %s\n"
+			" - rtt_aa_only_precision: %s (%u)\n"
+			" - rtt_sounding_precision: %s (%u)\n"
+			" - rtt_random_payload_precision: %s (%u)\n"
+			" - rtt_aa_only_n: %u\n"
+			" - rtt_sounding_n: %u\n"
+			" - rtt_random_payload_n: %u\n"
+			" - phase_based_nadm_sounding_supported: %s\n"
+			" - phase_based_nadm_random_supported: %s\n"
+			" - cs_sync_2m_phy_supported: %s\n"
+			" - cs_sync_2m_2bt_phy_supported: %s\n"
+			" - cs_without_fae_supported: %s\n"
+			" - chsel_alg_3c_supported: %s\n"
+			" - pbr_from_rtt_sounding_seq_supported: %s\n"
+			" - t_ip1_times_supported: 0x%04x\n"
+			" - t_ip2_times_supported: 0x%04x\n"
+			" - t_fcs_times_supported: 0x%04x\n"
+			" - t_pm_times_supported: 0x%04x\n"
+			" - t_sw_time: %u us\n"
+			" - tx_snr_capability: 0x%02x\n"
+			" - t_ip2_ipt_times_supported: 0x%04x\n"
+			" - t_sw_ipt_time_supported: %u us\n",
+			params->num_config_supported, params->max_consecutive_procedures_supported,
+			params->num_antennas_supported, params->max_antenna_paths_supported,
+			params->initiator_supported ? "yes" : "no",
+			params->reflector_supported ? "yes" : "no",
+			params->mode_3_supported ? "yes" : "no", rtt_precision_str[aa_idx],
+			(uint8_t)params->rtt_aa_only_precision, rtt_precision_str[snd_idx],
+			(uint8_t)params->rtt_sounding_precision, rtt_precision_str[rand_idx],
+			(uint8_t)params->rtt_random_payload_precision, params->rtt_aa_only_n,
+			params->rtt_sounding_n, params->rtt_random_payload_n,
+			params->phase_based_nadm_sounding_supported ? "yes" : "no",
+			params->phase_based_nadm_random_supported ? "yes" : "no",
+			params->cs_sync_2m_phy_supported ? "yes" : "no",
+			params->cs_sync_2m_2bt_phy_supported ? "yes" : "no",
+			params->cs_without_fae_supported ? "yes" : "no",
+			params->chsel_alg_3c_supported ? "yes" : "no",
+			params->pbr_from_rtt_sounding_seq_supported ? "yes" : "no",
+			params->t_ip1_times_supported, params->t_ip2_times_supported,
+			params->t_fcs_times_supported, params->t_pm_times_supported,
+			params->t_sw_time, params->tx_snr_capability,
+			params->t_ip2_ipt_times_supported, params->t_sw_ipt_time_supported);
+
+		k_sem_give(&sem_remote_capabilities_obtained);
+	} else {
+		LOG_WRN("CS capability exchange failed. (HCI status 0x%02x)", status);
+	}
+}
+
+static void config_create_cb(struct bt_conn *conn, uint8_t status,
+			     struct bt_conn_le_cs_config *config)
+{
+	ARG_UNUSED(conn);
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		cs_config = *config;
+
+		const char *mode_str[5] = {"Unused", "1 (RTT)", "2 (PBR)", "3 (RTT + PBR)",
+					   "Invalid"};
+		const char *role_str[3] = {"Initiator", "Reflector", "Invalid"};
+		const char *rtt_type_str[8] = {
+			"AA only",	 "32-bit sounding", "96-bit sounding", "32-bit random",
+			"64-bit random", "96-bit random",   "128-bit random",  "Invalid"};
+		const char *phy_str[4] = {"Invalid", "LE 1M PHY", "LE 2M PHY", "LE 2M 2BT PHY"};
+		const char *chsel_type_str[3] = {"Algorithm #3b", "Algorithm #3c", "Invalid"};
+		const char *ch3c_shape_str[3] = {"Hat shape", "X shape", "Invalid"};
+
+		uint8_t mode_idx = config->mode > 0 && config->mode < 4 ? config->mode : 4;
+		uint8_t role_idx = MIN(config->role, 2);
+		uint8_t rtt_type_idx = MIN(config->rtt_type, 7);
+		uint8_t phy_idx = config->cs_sync_phy > 0 && config->cs_sync_phy < 4
+					  ? config->cs_sync_phy
+					  : 0;
+		uint8_t chsel_type_idx = MIN(config->channel_selection_type, 2);
+		uint8_t ch3c_shape_idx = MIN(config->ch3c_shape, 2);
+
+		LOG_INF("CS config creation complete.\n"
+			" - id: %u\n"
+			" - mode: %s\n"
+			" - min_main_mode_steps: %u\n"
+			" - max_main_mode_steps: %u\n"
+			" - main_mode_repetition: %u\n"
+			" - mode_0_steps: %u\n"
+			" - role: %s\n"
+			" - rtt_type: %s\n"
+			" - cs_sync_phy: %s\n"
+			" - channel_map_repetition: %u\n"
+			" - channel_selection_type: %s\n"
+			" - ch3c_shape: %s\n"
+			" - ch3c_jump: %u\n"
+			" - t_ip1_time_us: %u\n"
+			" - t_ip2_time_us: %u\n"
+			" - t_fcs_time_us: %u\n"
+			" - t_pm_time_us: %u\n"
+			" - channel_map: 0x%08X%08X%04X\n",
+			config->id, mode_str[mode_idx], config->min_main_mode_steps,
+			config->max_main_mode_steps, config->main_mode_repetition,
+			config->mode_0_steps, role_str[role_idx], rtt_type_str[rtt_type_idx],
+			phy_str[phy_idx], config->channel_map_repetition,
+			chsel_type_str[chsel_type_idx], ch3c_shape_str[ch3c_shape_idx],
+			config->ch3c_jump, config->t_ip1_time_us, config->t_ip2_time_us,
+			config->t_fcs_time_us, config->t_pm_time_us,
+			sys_get_le32(&config->channel_map[6]),
+			sys_get_le32(&config->channel_map[2]),
+			sys_get_le16(&config->channel_map[0]));
+
+		k_sem_give(&sem_config_created);
+	} else {
+		LOG_WRN("CS config creation failed. (HCI status 0x%02x)", status);
+	}
+}
+
+static void security_enable_cb(struct bt_conn *conn, uint8_t status)
+{
+	ARG_UNUSED(conn);
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		LOG_INF("CS security enabled.");
+		k_sem_give(&sem_cs_security_enabled);
+	} else {
+		LOG_WRN("CS security enable failed. (HCI status 0x%02x)", status);
+	}
+}
+
+static void procedure_enable_cb(struct bt_conn *conn, uint8_t status,
+				struct bt_conn_le_cs_procedure_enable_complete *params)
+{
+	ARG_UNUSED(conn);
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		if (params->state == 1) {
+			LOG_INF("CS procedures enabled:\n"
+				" - config ID: %u\n"
+				" - antenna configuration index: %u\n"
+				" - TX power: %d dbm\n"
+				" - subevent length: %u us\n"
+				" - subevents per event: %u\n"
+				" - subevent interval: %u\n"
+				" - event interval: %u\n"
+				" - procedure interval: %u\n"
+				" - procedure count: %u\n"
+				" - maximum procedure length: %u",
+				params->config_id, params->tone_antenna_config_selection,
+				params->selected_tx_power, params->subevent_len,
+				params->subevents_per_event, params->subevent_interval,
+				params->event_interval, params->procedure_interval,
+				params->procedure_count, params->max_procedure_len);
+		} else {
+			LOG_INF("CS procedures disabled.");
+		}
+	} else {
+		LOG_WRN("CS procedures enable failed. (HCI status 0x%02x)", status);
+	}
+}
+
+static void scan_filter_match(struct bt_scan_device_info *device_info,
+			      struct bt_scan_filter_match *filter_match, bool connectable)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	(void)bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
+
+	LOG_INF("Filters matched. Address: %s connectable: %d", addr, connectable);
+}
+
+static void scan_connecting_error(struct bt_scan_device_info *device_info)
+{
+	int err;
+
+	LOG_INF("Connecting failed, restarting scanning");
+
+	err = bt_scan_start(BT_SCAN_TYPE_SCAN_PASSIVE);
+	if (err) {
+		LOG_ERR("Failed to restart scanning (err %i)", err);
+		return;
+	}
+}
+
+static void scan_connecting(struct bt_scan_device_info *device_info, struct bt_conn *conn)
+{
+	LOG_INF("Connecting");
+}
+
+BT_SCAN_CB_INIT(scan_cb, scan_filter_match, NULL, scan_connecting_error, scan_connecting);
+
+static int scan_init(struct bt_scan_init_param *p_param)
+{
+	int err;
+
+	bt_scan_init(p_param);
+	bt_scan_cb_register(&scan_cb);
+
+	err = bt_scan_filter_add(BT_SCAN_FILTER_TYPE_NAME, REFLECTOR_NAME);
+	if (err) {
+		LOG_ERR("Scanning filters cannot be set (err %d)", err);
+		return err;
+	}
+
+	err = bt_scan_filter_enable(BT_SCAN_NAME_FILTER, false);
+	if (err) {
+		LOG_ERR("Filters cannot be turned on (err %d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+
+BT_CONN_CB_DEFINE(conn_cb) = {
+	.connected = connected_cb,
+	.disconnected = disconnected_cb,
+	.security_changed = security_changed_cb,
+	.le_cs_read_remote_capabilities_complete = remote_capabilities_cb,
+	.le_cs_config_complete = config_create_cb,
+	.le_cs_security_enable_complete = security_enable_cb,
+	.le_cs_procedure_enable_complete = procedure_enable_cb,
+	.le_cs_subevent_data_available = subevent_result_cb,
+};
+
+static void cs_config_get(struct bt_le_cs_create_config_params *config_params)
+{
+	config_params->id = CS_CONFIG_ID;
+	config_params->mode = BT_CONN_LE_CS_MAIN_MODE_2_NO_SUB_MODE;
+	config_params->min_main_mode_steps = 2;
+	config_params->max_main_mode_steps = 5;
+	config_params->main_mode_repetition = 0;
+	config_params->mode_0_steps = NUM_MODE_0_STEPS;
+	config_params->role = BT_CONN_LE_CS_ROLE_INITIATOR;
+	config_params->rtt_type = BT_CONN_LE_CS_RTT_TYPE_AA_ONLY;
+	config_params->cs_sync_phy = BT_CONN_LE_CS_SYNC_1M_PHY;
+	config_params->channel_map_repetition = 1;
+	config_params->channel_selection_type = BT_CONN_LE_CS_CHSEL_TYPE_3B;
+	config_params->ch3c_shape = BT_CONN_LE_CS_CH3C_SHAPE_HAT;
+	config_params->ch3c_jump = 2;
+	/* Enable inline PCT transfer. */
+	config_params->cs_enhancements_1 = 1;
+}
+
+int main(void)
+{
+	int err;
+
+	LOG_INF("Starting Channel Sounding IPT Initiator Sample");
+
+	dk_leds_init();
+
+	err = bt_enable(NULL);
+	if (err) {
+		LOG_ERR("Bluetooth init failed (err %d)", err);
+		return 0;
+	}
+
+	struct bt_scan_init_param scan_params = {
+		.scan_param = NULL,
+		.conn_param = BT_LE_CONN_PARAM(6, 6, 0, BT_GAP_MS_TO_CONN_TIMEOUT(4000)),
+		.connect_if_match = 1};
+
+	err = scan_init(&scan_params);
+	if (err) {
+		LOG_ERR("Scan init failed (err %d)", err);
+		return 0;
+	}
+
+	err = bt_scan_start(BT_SCAN_TYPE_SCAN_PASSIVE);
+	if (err) {
+		LOG_ERR("Scanning failed to start (err %i)", err);
+		return 0;
+	}
+
+	k_sem_take(&sem_connected, K_FOREVER);
+
+	err = bt_conn_set_security(connection, BT_SECURITY_L2);
+	if (err) {
+		LOG_ERR("Failed to encrypt connection (err %d)", err);
+		return 0;
+	}
+	k_sem_take(&sem_security, K_FOREVER);
+
+	const struct bt_le_cs_set_default_settings_param default_settings = {
+		.enable_initiator_role = true,
+		.enable_reflector_role = false,
+		.cs_sync_antenna_selection = BT_LE_CS_ANTENNA_SELECTION_OPT_REPETITIVE,
+		.max_tx_power = BT_HCI_OP_LE_CS_MAX_MAX_TX_POWER,
+	};
+
+	err = bt_le_cs_set_default_settings(connection, &default_settings);
+	if (err) {
+		LOG_ERR("Failed to configure default CS settings (err %d)", err);
+		return 0;
+	}
+
+	err = bt_le_cs_read_remote_supported_capabilities(connection);
+	if (err) {
+		LOG_ERR("Failed to exchange CS capabilities (err %d)", err);
+		return 0;
+	}
+
+	k_sem_take(&sem_remote_capabilities_obtained, K_FOREVER);
+
+	struct bt_le_cs_create_config_params config_params;
+
+	cs_config_get(&config_params);
+
+	bt_le_cs_set_valid_chmap_bits(config_params.channel_map);
+
+	err = bt_le_cs_create_config(connection, &config_params,
+				     BT_LE_CS_CREATE_CONFIG_CONTEXT_LOCAL_AND_REMOTE);
+	if (err) {
+		LOG_ERR("Failed to create CS config (err %d)", err);
+		return 0;
+	}
+	k_sem_take(&sem_config_created, K_FOREVER);
+
+	err = bt_le_cs_security_enable(connection);
+	if (err) {
+		LOG_ERR("Failed to start CS Security (err %d)", err);
+		return 0;
+	}
+
+	k_sem_take(&sem_cs_security_enabled, K_FOREVER);
+
+	/* scale factor of conn_interval units to proc_interval units is 1.25/0.625 = 2 */
+	const uint16_t acl_interval_in_proc_interval_units =
+		scan_params.conn_param->interval_max * 2;
+	uint16_t desired_procedure_interval = 2;
+	uint16_t desired_max_procedure_length =
+		acl_interval_in_proc_interval_units * (desired_procedure_interval - 1);
+
+	const struct bt_le_cs_set_procedure_parameters_param procedure_params = {
+		.config_id = CS_CONFIG_ID,
+		.max_procedure_len = desired_max_procedure_length,
+		.min_procedure_interval = desired_procedure_interval,
+		.max_procedure_interval = desired_procedure_interval,
+		.max_procedure_count = 0,
+		.min_subevent_len = 11000,
+		.max_subevent_len = 11000,
+		.tone_antenna_config_selection = BT_LE_CS_TONE_ANTENNA_CONFIGURATION_A1_B1,
+		.phy = BT_LE_CS_PROCEDURE_PHY_2M,
+		.tx_power_delta = 0x80,
+		.preferred_peer_antenna = BT_LE_CS_PROCEDURE_PREFERRED_PEER_ANTENNA_1,
+		.snr_control_initiator = BT_LE_CS_SNR_CONTROL_NOT_USED,
+		.snr_control_reflector = BT_LE_CS_SNR_CONTROL_NOT_USED,
+	};
+
+	err = bt_le_cs_set_procedure_parameters(connection, &procedure_params);
+	if (err) {
+		LOG_ERR("Failed to set procedure parameters (err %d)", err);
+		return 0;
+	}
+
+	struct bt_le_cs_procedure_enable_param params = {
+		.config_id = CS_CONFIG_ID,
+		.enable = 1,
+	};
+
+	err = bt_le_cs_procedure_enable(connection, &params);
+	if (err) {
+		LOG_ERR("Failed to enable CS procedures (err %d)", err);
+		return 0;
+	}
+
+	while (true) {
+		k_sem_take(&sem_subevent_results_parsed, K_FOREVER);
+		distance_estimates_update();
+	}
+
+	return 0;
+}

--- a/samples/bluetooth/channel_sounding/ipt_reflector/CMakeLists.txt
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(channel_sound_ipt_reflector)
+
+# NORDIC SDK APP START
+target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END

--- a/samples/bluetooth/channel_sounding/ipt_reflector/README.rst
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/README.rst
@@ -1,0 +1,154 @@
+.. _channel_sounding_ipt_reflector:
+
+Bluetooth: Channel Sounding Reflector with Inline PCT Transfer
+##############################################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+This sample demonstrates how to use the Bluetooth® Channel Sounding (CS) Inline Phase Correction Term Transfer (IPT) feature as a CS reflector, to achieve fast and efficient distance estimation.
+
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-sample-yaml::
+
+The sample also requires a device running the :ref:`channel_sounding_ipt_initiator` sample.
+
+Overview
+********
+
+The sample acts as a Bluetooth Low Energy Peripheral and Channel Sounding reflector.
+After startup, it performs the following steps:
+
+1. Starts connectable advertising using its name (``Nordic CS IPT Reflector``), which the :ref:`channel_sounding_ipt_initiator` sample scans for.
+#. Waits for a central device to connect.
+#. Configures the CS default settings to enable the reflector role.
+#. The connected central device performs the rest of the CS setup.
+   The central device is responsible for enabling CS IPT in the CS configuration.
+#. Participates in the continuous CS procedures started by the central device.
+
+The sample does not expose any ranging data to the initiator over GATT.
+Instead, its contribution to the measurement is encoded directly in the phase of the tones it transmits as a CS reflector using the CS IPT feature during the CS procedures.
+
+How CS IPT works
+================
+
+.. include:: ../ipt_initiator/README.rst
+   :start-after: channel_sounding_ipt_initiator_cs_ipt_works_start
+   :end-before: channel_sounding_ipt_initiator_cs_ipt_works_end
+
+Benefits of CS IPT
+==================
+
+.. include:: ../ipt_initiator/README.rst
+   :start-after: .. channel_sounding_ipt_initiator_cs_ipt_benefits_start
+   :end-before: .. channel_sounding_ipt_initiator_cs_ipt_benefits_end
+
+Drawbacks of CS IPT
+===================
+
+.. include:: ../ipt_initiator/README.rst
+   :start-after: channel_sounding_ipt_initiator_cs_ipt_drawbacks_start
+   :end-before: channel_sounding_ipt_initiator_cs_ipt_drawbacks_end
+
+User interface
+**************
+
+The sample does not require user input.
+The first LED on the development kit will be lit when a connection has been established.
+
+Building and running
+********************
+
+.. |sample path| replace:: :file:`samples/bluetooth/channel_sounding/ipt_reflector`
+
+.. include:: /includes/build_and_run.txt
+
+Testing
+=======
+
+After programming the sample to your development kit, test it together with a device programmed with the :ref:`channel_sounding_ipt_initiator` sample.
+
+1. |connect_terminal_specific|
+#. Reset both kits.
+#. The reflector starts advertising and the initiator scans for ``Nordic CS IPT Reflector``.
+   Once the initiator connects, check the reflector terminal for information similar to the following::
+
+      *** Booting nRF Connect SDK v3.2.99-09f8a95ee5b4 ***
+      *** Using Zephyr OS v4.3.99-2925b3840984 ***
+      I: Starting Channel Sounding IPT Reflector Sample
+      I: SoftDevice Controller build revision:
+      I: 36 9c e5 98 e5 71 0a a0 |6....q..
+      I: 2d b9 89 96 6b 15 65 4b |-...k.eK
+      I: d6 e8 4a ac             |..J.
+      I: HW Platform: Nordic Semiconductor (0x0002)
+      I: HW Variant: nRF54Lx (0x0005)
+      I: Firmware: Standard Bluetooth controller (0x00) Version 54.58780 Build 175236504
+      I: HCI transport: SDC
+      I: Identity: D2:CE:07:7E:40:79 (random)
+      I: HCI: version 6.2 (0x10) revision 0x30a9, manufacturer 0x0059
+      I: LMP: version 6.2 (0x10) subver 0x30a9
+      I: Connected to E6:BA:C9:31:51:DB (random) (err 0x00)
+      I: CS capability exchange completed.
+      I: CS config creation complete.
+      - id: 0
+      - mode: 2 (PBR)
+      - min_main_mode_steps: 0
+      - max_main_mode_steps: 0
+      - main_mode_repetition: 0
+      - mode_0_steps: 3
+      - role: Reflector
+      - rtt_type: AA only
+      - cs_sync_phy: LE 1M PHY
+      - channel_map_repetition: 1
+      - channel_selection_type: Algorithm #3b
+      - ch3c_shape: Hat shape
+      - ch3c_jump: 0
+      - t_ip1_time_us: 30
+      - t_ip2_time_us: 20
+      - t_fcs_time_us: 60
+      - t_pm_time_us: 10
+      - channel_map: 0x1FFFFFFFFFFFFC7FFFFC
+
+      I: CS security enabled.
+      I: CS procedures enabled:
+      - config ID: 0
+      - antenna configuration index: 0
+      - TX power: 0 dbm
+      - subevent length: 7500 us
+      - subevents per event: 1
+      - subevent interval: 0
+      - event interval: 3
+      - procedure interval: 2
+      - procedure count: 0
+      - maximum procedure length: 12
+
+
+Dependencies
+************
+
+This sample uses the following |NCS| libraries:
+
+* :ref:`dk_buttons_and_leds_readme`
+
+This sample uses the following Zephyr libraries:
+
+* :ref:`zephyr:logging_api`:
+
+  * :file:`include/logging/log.h`
+
+* :file:`include/zephyr/types.h`
+* :ref:`zephyr:kernel_api`:
+
+  * :file:`include/kernel.h`
+
+* :ref:`zephyr:bluetooth_api`:
+
+* :file:`include/bluetooth/bluetooth.h`
+* :file:`include/bluetooth/conn.h`
+* :file:`include/bluetooth/uuid.h`
+* :file:`include/bluetooth/cs.h`

--- a/samples/bluetooth/channel_sounding/ipt_reflector/prj.conf
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/prj.conf
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NCS_SAMPLES_DEFAULTS=y
+CONFIG_DK_LIBRARY=y
+
+CONFIG_BT=y
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_SMP=y
+CONFIG_BT_DEVICE_NAME="Nordic CS IPT Reflector"
+CONFIG_BT_MAX_CONN=1
+CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=n
+CONFIG_BT_BONDABLE=n
+
+CONFIG_BT_CTLR_PHY_2M=y
+
+# This reduces RAM usage. Additional RAM is needed to support optional
+# features such as mode 3 or multiantenna. Change or remove these if
+# using those features
+CONFIG_BT_CS_DE_MAX_NUM_ANTENNA_PATHS=1
+CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS=1
+CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS=1
+CONFIG_BT_CTLR_SDC_CS_STEP_MODE3=n
+CONFIG_BT_CTLR_SDC_CS_ROLE_REFLECTOR_ONLY=y
+
+# Disabling the CS Test command reduces flash usage
+CONFIG_BT_CTLR_CHANNEL_SOUNDING_TEST=n
+
+# This allows CS and ACL to use different PHYs
+CONFIG_BT_TRANSMIT_POWER_CONTROL=y
+
+# This is required for CS Enhancements
+CONFIG_BT_CTLR_EXTENDED_FEAT_SET=y
+
+# Let the initiating device control the PHY updates
+CONFIG_BT_AUTO_PHY_UPDATE=n
+
+CONFIG_BT_CHANNEL_SOUNDING=y

--- a/samples/bluetooth/channel_sounding/ipt_reflector/sample.yaml
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/sample.yaml
@@ -1,0 +1,22 @@
+sample:
+  description: Bluetooth Low Energy Channel Sounding Reflector with Inline PCT Transfer
+  name: Bluetooth LE Channel Sounding Reflector with IPT
+tests:
+  sample.bluetooth.channel_sounding_ipt_reflector:
+    sysbuild: true
+    build_only: true
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
+    tags:
+      - bluetooth
+      - ci_build
+      - sysbuild
+      - ci_samples_bluetooth

--- a/samples/bluetooth/channel_sounding/ipt_reflector/src/main.c
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/src/main.c
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ *  @brief Channel Sounding Reflector with Inline PCT Transfer sample
+ */
+
+#include <zephyr/types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/cs.h>
+#include <dk_buttons_and_leds.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(app_main, LOG_LEVEL_INF);
+
+#define CON_STATUS_LED DK_LED1
+
+static K_SEM_DEFINE(sem_connected, 0, 1);
+
+static struct bt_conn *connection;
+
+static const struct bt_data ad[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
+static void connected_cb(struct bt_conn *conn, uint8_t err)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	LOG_INF("Connected to %s (err 0x%02X)", addr, err);
+
+	if (err) {
+		bt_conn_unref(conn);
+		connection = NULL;
+	} else {
+		connection = bt_conn_ref(conn);
+
+		k_sem_give(&sem_connected);
+
+		dk_set_led_on(CON_STATUS_LED);
+	}
+}
+
+static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
+{
+	LOG_INF("Disconnected (reason 0x%02X)", reason);
+
+	bt_conn_unref(conn);
+	connection = NULL;
+
+	dk_set_led_off(CON_STATUS_LED);
+
+	sys_reboot(SYS_REBOOT_COLD);
+}
+
+static void remote_capabilities_cb(struct bt_conn *conn, uint8_t status,
+				   struct bt_conn_le_cs_capabilities *params)
+{
+	ARG_UNUSED(conn);
+	ARG_UNUSED(params);
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		LOG_INF("CS capability exchange completed.");
+	} else {
+		LOG_WRN("CS capability exchange failed. (HCI status 0x%02x)", status);
+	}
+}
+
+static void config_create_cb(struct bt_conn *conn, uint8_t status,
+			     struct bt_conn_le_cs_config *config)
+{
+	ARG_UNUSED(conn);
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		const char *mode_str[5] = {"Unused", "1 (RTT)", "2 (PBR)", "3 (RTT + PBR)",
+					   "Invalid"};
+		const char *role_str[3] = {"Initiator", "Reflector", "Invalid"};
+		const char *rtt_type_str[8] = {
+			"AA only",	 "32-bit sounding", "96-bit sounding", "32-bit random",
+			"64-bit random", "96-bit random",   "128-bit random",  "Invalid"};
+		const char *phy_str[4] = {"Invalid", "LE 1M PHY", "LE 2M PHY", "LE 2M 2BT PHY"};
+		const char *chsel_type_str[3] = {"Algorithm #3b", "Algorithm #3c", "Invalid"};
+		const char *ch3c_shape_str[3] = {"Hat shape", "X shape", "Invalid"};
+
+		uint8_t mode_idx = config->mode > 0 && config->mode < 4 ? config->mode : 4;
+		uint8_t role_idx = MIN(config->role, 2);
+		uint8_t rtt_type_idx = MIN(config->rtt_type, 7);
+		uint8_t phy_idx = config->cs_sync_phy > 0 && config->cs_sync_phy < 4
+					  ? config->cs_sync_phy
+					  : 0;
+		uint8_t chsel_type_idx = MIN(config->channel_selection_type, 2);
+		uint8_t ch3c_shape_idx = MIN(config->ch3c_shape, 2);
+
+		LOG_INF("CS config creation complete.\n"
+			" - id: %u\n"
+			" - mode: %s\n"
+			" - min_main_mode_steps: %u\n"
+			" - max_main_mode_steps: %u\n"
+			" - main_mode_repetition: %u\n"
+			" - mode_0_steps: %u\n"
+			" - role: %s\n"
+			" - rtt_type: %s\n"
+			" - cs_sync_phy: %s\n"
+			" - channel_map_repetition: %u\n"
+			" - channel_selection_type: %s\n"
+			" - ch3c_shape: %s\n"
+			" - ch3c_jump: %u\n"
+			" - t_ip1_time_us: %u\n"
+			" - t_ip2_time_us: %u\n"
+			" - t_fcs_time_us: %u\n"
+			" - t_pm_time_us: %u\n"
+			" - channel_map: 0x%08X%08X%04X\n",
+			config->id, mode_str[mode_idx], config->min_main_mode_steps,
+			config->max_main_mode_steps, config->main_mode_repetition,
+			config->mode_0_steps, role_str[role_idx], rtt_type_str[rtt_type_idx],
+			phy_str[phy_idx], config->channel_map_repetition,
+			chsel_type_str[chsel_type_idx], ch3c_shape_str[ch3c_shape_idx],
+			config->ch3c_jump, config->t_ip1_time_us, config->t_ip2_time_us,
+			config->t_fcs_time_us, config->t_pm_time_us,
+			sys_get_le32(&config->channel_map[6]),
+			sys_get_le32(&config->channel_map[2]),
+			sys_get_le16(&config->channel_map[0]));
+
+	} else {
+		LOG_WRN("CS config creation failed. (HCI status 0x%02x)", status);
+	}
+}
+
+static void security_enable_cb(struct bt_conn *conn, uint8_t status)
+{
+	ARG_UNUSED(conn);
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		LOG_INF("CS security enabled.");
+	} else {
+		LOG_WRN("CS security enable failed. (HCI status 0x%02x)", status);
+	}
+}
+
+static void procedure_enable_cb(struct bt_conn *conn, uint8_t status,
+				struct bt_conn_le_cs_procedure_enable_complete *params)
+{
+	ARG_UNUSED(conn);
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		if (params->state == 1) {
+			LOG_INF("CS procedures enabled:\n"
+				" - config ID: %u\n"
+				" - antenna configuration index: %u\n"
+				" - TX power: %d dbm\n"
+				" - subevent length: %u us\n"
+				" - subevents per event: %u\n"
+				" - subevent interval: %u\n"
+				" - event interval: %u\n"
+				" - procedure interval: %u\n"
+				" - procedure count: %u\n"
+				" - maximum procedure length: %u",
+				params->config_id, params->tone_antenna_config_selection,
+				params->selected_tx_power, params->subevent_len,
+				params->subevents_per_event, params->subevent_interval,
+				params->event_interval, params->procedure_interval,
+				params->procedure_count, params->max_procedure_len);
+		} else {
+			LOG_INF("CS procedures disabled.");
+		}
+	} else {
+		LOG_WRN("CS procedures enable failed. (HCI status 0x%02x)", status);
+	}
+}
+
+BT_CONN_CB_DEFINE(conn_cb) = {
+	.connected = connected_cb,
+	.disconnected = disconnected_cb,
+	.le_cs_read_remote_capabilities_complete = remote_capabilities_cb,
+	.le_cs_config_complete = config_create_cb,
+	.le_cs_security_enable_complete = security_enable_cb,
+	.le_cs_procedure_enable_complete = procedure_enable_cb,
+};
+
+int main(void)
+{
+	int err;
+
+	LOG_INF("Starting Channel Sounding IPT Reflector Sample");
+
+	dk_leds_init();
+
+	err = bt_enable(NULL);
+	if (err) {
+		LOG_ERR("Bluetooth init failed (err %d)", err);
+		return 0;
+	}
+
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		LOG_ERR("Advertising failed to start (err %d)", err);
+		return 0;
+	}
+
+	k_sem_take(&sem_connected, K_FOREVER);
+
+	const struct bt_le_cs_set_default_settings_param default_settings = {
+		.enable_initiator_role = false,
+		.enable_reflector_role = true,
+		.cs_sync_antenna_selection = BT_LE_CS_ANTENNA_SELECTION_OPT_REPETITIVE,
+		.max_tx_power = BT_HCI_OP_LE_CS_MAX_MAX_TX_POWER,
+	};
+
+	err = bt_le_cs_set_default_settings(connection, &default_settings);
+	if (err) {
+		LOG_ERR("Failed to configure default CS settings (err %d)", err);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Add two new Channel Sounding samples, ipt_initiator and ipt_reflector,
that demonstrate the Inline Phase Correction Term (PCT) Transfer (IPT)
feature. In IPT, the reflector transmits each mode 2 tone with its
phase adjusted by the phase of the tone it just received from the
initiator on the same frequency. The initiator's received phase on
that tone therefore already encodes the reflector's received phase,
so the reflector's measurement data does not need to be relayed back
over the ACL through the GATT Ranging Service (RAS). This is unlike
the existing ras_initiator / ras_reflector pair, where the reflector
subevent data is transferred over RAS before a distance estimate can
be computed.

Compared to a RAS-based setup, this reduces CS setup time, enables a
higher achievable update rate for distance estimates, and saves power
and memory on both devices since the peer measurement data no longer
has to be buffered and relayed over GATT. The trade-off is a reduced
security level, since the samples only run CS mode 2 (PBR) steps.

The ipt_initiator sample:

- Configures the CS initiator role and runs CS procedures using
  mode 2 steps.
- Parses the local step data, extracts the IQ samples from the PCTs,
  and computes a distance estimate per procedure using cs_de_ifft().
- Applies a sliding-window median filter over the recent estimates
  and logs the filtered and raw values.

The ipt_reflector sample advertises as "Nordic CS IPT Reflector",
enables the CS reflector role, and waits for the initiator to drive
the CS procedures. It is derived from ras_reflector with the
RAS-specific code removed.

Current limitations of the initiator sample: single antenna path
only, cs_de_ifft() is the only distance estimator, filtering is a
basic median filter, and tones are not filtered using the Tone
Quality Indicator.

Also add CODEOWNERS entries for the two new sample directories,
update the release notes, and make a minor adjustment in
subsys/bluetooth/controller/hci_internal.c required for IPT.

Desk-tested on an nrf54l15dk pair by running the two samples together
and observing filtered distance estimates in the initiator log.
Regression tests for the IPT samples are planned in internal CI.