### PR TITLE
tests: Do NOT use gpiote130 channel 0 on nrf9251dk

### DIFF
--- a/tests/drivers/spi/spi_latency/boards/nrf9251dk_nrf9251_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_latency/boards/nrf9251dk_nrf9251_cpuapp_fast.overlay
@@ -16,7 +16,6 @@
 
 &gpiote130 {
 	status = "okay";
-	owned-channels = <0>;
 };
 
 &pinctrl {

--- a/tests/zephyr/drivers/gpio/gpio_basic_api/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/gpio/gpio_basic_api/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -13,5 +13,5 @@
 
 &gpiote130 {
 	status = "okay";
-	owned-channels = <0 1>;
+	owned-channels = <1 2>;
 };


### PR DESCRIPTION
GPIOTE130 channel0 is currently allocated to the CELLCORE. Do not use this channel in test overlays.