### PR TITLE
applications: nrf_desktop: Migrate mcuboot_smp layout to DTS

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/app_mcuboot_smp.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/app_mcuboot_smp.overlay
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include "memory_map_mcuboot_smp.dtsi"
 #include "app_common.dtsi"
 
 / {

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/app_mcuboot_smp.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/app_mcuboot_smp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../memory_map_mcuboot_smp.dtsi"
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/memory_map_mcuboot_smp.dtsi
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/memory_map_mcuboot_smp.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&flash0 {
+	/delete-node/ partitions;
+
+	partitions {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(48)>;
+		};
+
+		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0xc000 DT_SIZE_K(484)>;
+		};
+
+		slot1_partition: partition@85000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
+			reg = <0x85000 DT_SIZE_K(484)>;
+		};
+
+		storage_partition: partition@fe000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0xfe000 DT_SIZE_K(8)>;
+		};
+	};
+};

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/sysbuild_mcuboot_smp.conf
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/sysbuild_mcuboot_smp.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2024-2026 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -8,3 +8,5 @@
 SB_CONFIG_BOOTLOADER_MCUBOOT=y
 SB_CONFIG_BOOT_SIGNATURE_TYPE_RSA=y
 SB_CONFIG_BOOT_SIGNATURE_KEY_FILE="\${APPLICATION_CONFIG_DIR}/images/mcuboot/mcuboot_private.pem"
+
+SB_CONFIG_PARTITION_MANAGER=n

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/app_mcuboot_smp.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/app_mcuboot_smp.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "memory_map_mcuboot_smp.dtsi"
+#include "app_common.dtsi"

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/images/mcuboot/app_mcuboot_smp.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/images/mcuboot/app_mcuboot_smp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../memory_map_mcuboot_smp.dtsi"
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/memory_map_mcuboot_smp.dtsi
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/memory_map_mcuboot_smp.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&flash0 {
+	/delete-node/ partitions;
+
+	partitions {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(24)>;
+		};
+
+		slot0_partition: partition@6000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x6000 DT_SIZE_K(496)>;
+		};
+
+		slot1_partition: partition@82000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
+			reg = <0x82000 DT_SIZE_K(496)>;
+		};
+
+		storage_partition: partition@fe000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0xfe000 DT_SIZE_K(8)>;
+		};
+	};
+};

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/sysbuild_mcuboot_smp.conf
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/sysbuild_mcuboot_smp.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2024-2026 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -8,3 +8,5 @@
 SB_CONFIG_BOOTLOADER_MCUBOOT=y
 SB_CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256=y
 SB_CONFIG_BOOT_SIGNATURE_KEY_FILE="\${APPLICATION_CONFIG_DIR}/images/mcuboot/mcuboot_private.pem"
+
+SB_CONFIG_PARTITION_MANAGER=n


### PR DESCRIPTION
Migrate the mcuboot smp flash layout used by the mcuboot_smp from the Partition Manager to DTS on the following boards:
* nrf52840dk/nrf52840
* nrf52840gmouse/nrf52840