### PR TITLE
samples: zephyr: boards: nordic: Run clock_control on nrf9251dk

### DIFF
--- a/samples/zephyr/boards/nordic/clock_control/CMakeLists.txt
+++ b/samples/zephyr/boards/nordic/clock_control/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(nrf_clock_control)
+
+target_sources(app PRIVATE ${ZEPHYR_BASE}/samples/boards/nordic/clock_control/src/main.c)

--- a/samples/zephyr/boards/nordic/clock_control/Kconfig
+++ b/samples/zephyr/boards/nordic/clock_control/Kconfig
@@ -1,0 +1,1 @@
+source "samples/boards/nordic/clock_control/Kconfig"

--- a/samples/zephyr/boards/nordic/clock_control/README.txt
+++ b/samples/zephyr/boards/nordic/clock_control/README.txt
@@ -1,0 +1,3 @@
+This sample extends the same-named Zephyr sample to verify it with Nordic development kits.
+
+Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/boards/nordic/clock_control.

--- a/samples/zephyr/boards/nordic/clock_control/configs/uart133.conf
+++ b/samples/zephyr/boards/nordic/clock_control/configs/uart133.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_CLOCK_CONTROL=y
+
+CONFIG_SAMPLE_CLOCK_ACCURACY_PPM=30

--- a/samples/zephyr/boards/nordic/clock_control/configs/uart133.overlay
+++ b/samples/zephyr/boards/nordic/clock_control/configs/uart133.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		sample-device = &uart133;
+	};
+};
+
+&uart133 {
+	status = "okay";
+	memory-regions = <&cpuapp_dma_region>;
+};
+
+&fll16m {
+	status = "okay";
+};

--- a/samples/zephyr/boards/nordic/clock_control/prj.conf
+++ b/samples/zephyr/boards/nordic/clock_control/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/samples/zephyr/boards/nordic/clock_control/sample.yaml
+++ b/samples/zephyr/boards/nordic/clock_control/sample.yaml
@@ -1,0 +1,61 @@
+sample:
+  name: Clock control sample
+common:
+  tags:
+    - ci_samples_zephyr_boards_nordic_clock_control
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "clock spec request released"
+tests:
+  nrf.extended.sample.boards.nrf.clock_control.fll16m:
+    platform_allow:
+      - nrf9251dk/nrf9251/cpuapp
+    extra_args:
+      - CONF_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/fll16m.conf"
+      - DTC_OVERLAY_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/fll16m.overlay"
+  nrf.extended.sample.boards.nrf.clock_control.lfclk:
+    platform_allow:
+      - nrf9251dk/nrf9251/cpuapp
+    extra_args:
+      - CONF_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/lfclk.conf"
+      - DTC_OVERLAY_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/lfclk.overlay"
+  nrf.extended.sample.boards.nrf.clock_control.uart133:
+    platform_allow:
+      - nrf9251dk/nrf9251/cpuapp
+    extra_args:
+      - CONF_FILE="configs/uart133.conf"
+      - DTC_OVERLAY_FILE="configs/uart133.overlay"
+  nrf.extended.sample.boards.nrf.clock_control.uart135:
+    depends_on:
+      - future_target
+    extra_args:
+      - CONF_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/uart135.conf"
+      - DTC_OVERLAY_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/uart135.overlay"
+  nrf.extended.sample.boards.nrf.clock_control.cpuapp_hsfll:
+    platform_allow:
+      - nrf9251dk/nrf9251/cpuapp
+    extra_args:
+      - CONF_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/cpuapp_hsfll.conf"
+      - DTC_OVERLAY_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/cpuapp_hsfll.overlay"
+  nrf.extended.sample.boards.nrf.clock_control.global_hsfll:
+    platform_allow:
+      - nrf9251dk/nrf9251/cpuapp
+    extra_args:
+      - CONF_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/global_hsfll.conf"
+      - DTC_OVERLAY_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/global_hsfll.overlay"
+  nrf.extended.sample.boards.nrf.clock_control.global_hsfll.req_low_freq_n:
+    platform_allow:
+      - nrf9251dk/nrf9251/cpuapp
+    extra_configs:
+      - CONFIG_CLOCK_CONTROL_NRF_HSFLL_GLOBAL_REQ_LOW_FREQ=n
+    extra_args:
+      - CONF_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/global_hsfll.conf"
+      - DTC_OVERLAY_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/global_hsfll.overlay"
+  nrf.extended.sample.boards.nrf.clock_control.audiopll:
+    platform_allow:
+      - nrf9251dk/nrf9251/cpuapp
+    extra_args:
+      - CONF_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/audiopll.conf"
+      - DTC_OVERLAY_FILE="${ZEPHYR_BASE}/samples/boards/nordic/clock_control/configs/audiopll.overlay"

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -1746,6 +1746,11 @@ ci_samples_zephyr_drivers_mbox:
     - nrf/samples/zephyr/drivers/mbox/
     - zephyr/samples/drivers/mbox/
 
+ci_samples_zephyr_boards_nordic_clock_control:
+  files:
+    - nrf/samples/zephyr/boards/nordic/clock_control/
+    - zephyr/samples/boards/nordic/clock_control/
+
 ci_samples_zephyr_boards_nordic_nrf_sys_event:
   files:
     - nrf/samples/zephyr/boards/nordic/nrf_sys_event/


### PR DESCRIPTION
Copy the clock_control sample from sdk-zephyr to sdk-nrf and enable it on nrf9251dk target.