### PR TITLE
samples: bluetooth: direct_test_mode: add Set Event Mask HCI command

### DIFF
--- a/samples/bluetooth/direct_test_mode/src/transport/dtm_hci.c
+++ b/samples/bluetooth/direct_test_mode/src/transport/dtm_hci.c
@@ -704,6 +704,12 @@ static int hci_cmd(const struct bt_hci_cmd_hdr *hdr, const uint8_t *data)
 		LOG_INF("Executing HCI LE Test End command.");
 		return hci_test_end();
 
+	case BT_HCI_OP_SET_EVENT_MASK:
+	case BT_HCI_OP_LE_SET_EVENT_MASK:
+		LOG_INF("Tester sets HCI event mask, do nothing");
+		/* Ignore command parameters, and simply return success */
+		return base_cc_evt(cmd, BT_HCI_ERR_SUCCESS);
+
 	default:
 		LOG_ERR("Unknown HCI command opcode: 0x%04x", cmd);
 		base_cc_evt(cmd, BT_HCI_ERR_UNKNOWN_CMD);


### PR DESCRIPTION
It was found that some of the RFPHY testers use
HCI LE Set Event Mask command.
This commit adds dummy handlers of the HCI LE Set Event Mask and HCI Set Event Mask commands with no actual implementation. The handlers simply return success code to the commands to allow proceeding the test implementation.