### PR TITLE
Nrf profiler timestamp

### DIFF
--- a/doc/nrf/libraries/others/nrf_profiler.rst
+++ b/doc/nrf/libraries/others/nrf_profiler.rst
@@ -25,6 +25,12 @@ Configuration
 
 Since Application Event Manager events are converted to nRF Profiler events by the :ref:`app_event_manager_profiler_tracer`, you can configure the nRF Profiler to profile custom events or Application Event Manager events, or both.
 
+.. note::
+   Starting from |NCS| v3.4.0, the nRF Profiler library introduces a modified string layout for the Info RTT channel to support the nRF54L Series SoCs.
+   The library now provides also system configuration data, such as :kconfig:option:`CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC`, within specific markers to allow the host tools to perform accurate time unit conversions for nRF54L Series SoCs.
+   This modification breaks the backward compatibility with older host scripts.
+   To ensure proper behavior, use both the library and host tools from the same |NCS| release.
+
 Configuring for use with custom events
 ======================================
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -638,6 +638,10 @@ This section provides detailed lists of changes by :ref:`script <scripts>`.
   * Support for hex only ``softdevice`` sysbuild domains.
   * Updated the SPDX License List database to version 3.28.0.
 
+* :ref:`nrf_profiler_script` script:
+
+  * Fixed the ``ms_per_timestamp_tick`` parameter (defined in the :file: `rtt_nordic_config.py`) to accurately align with the system clock's frequency of the nRF52, nRF53, and nRF91 Series SoCs.
+
 Integrations
 ============
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -650,6 +650,8 @@ This section provides detailed lists of changes by :ref:`script <scripts>`.
 
 * :ref:`nrf_profiler_script` script:
 
+  * Updated the scripts to use hardware clock information from SoC to enable accurate conversion from hardware clock cycles to seconds.
+    Refactored the parser to support the new RTT communication layout, including the handling of ``<ev_info_...>`` and ``<sys_config_...>`` data markers.
   * Fixed the ``ms_per_timestamp_tick`` parameter (defined in the :file: `rtt_nordic_config.py`) to accurately align with the system clock's frequency of the nRF52, nRF53, and nRF91 Series SoCs.
 
 Integrations

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -613,7 +613,17 @@ nRF RPC libraries
 Other libraries
 ---------------
 
-|no_changes_yet_note|
+* :ref:`nrf_profiler` library:
+
+  * Added sending :kconfig:option:`CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC` through the info RTT channel as part of the system description.
+    This enables support for the nRF54L Series SoCs (:kconfig:option:`CONFIG_SOC_SERIES_NRF54L`) by providing accurate hardware clock information to the profiler host tools.
+    The hardware clock frequency varies between different SoCs, and the host tools require this information to correctly interpret the received timestamps.
+    This change breaks the backward compatibility between the library and host tools due to modifications in the info RTT channel string layout.
+    The nRF Profiler event descriptions are now sent within the ``<ev_info_start>`` and ``<ev_info_stop>`` markers.
+    System configuration details are now sent within the ``<sys_config_start>`` and ``<sys_config_stop>`` markers.
+    The system configuration details are formatted as a list of key-value data, for example, ``key1,value1``.
+    Subsequent entries are separated by newlines.
+    The value returned by the :c:func:`sys_clock_hw_cycles_per_sec` function is sent using the ``sys_clock_hw_cycles_per_sec`` key.
 
 Shell libraries
 ---------------

--- a/scripts/nrf_profiler/README.rst
+++ b/scripts/nrf_profiler/README.rst
@@ -18,6 +18,12 @@ The collected profiling data is stored as local files and can be processed later
 Other scripts are used for visualizing, processing, and analyzing the data or calculating statistics.
 These scripts rely on locally stored files created earlier.
 
+.. note::
+   Since the |NCS| v3.4.0 release, host scripts have been updated to support the nRF54L Series SoC.
+   To achieve this, the hardware clock frequency (:kconfig:option:`CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC`) is now sent from the SoC to the host tools over the existing Info RTT channel.
+   This change breaks backward compatibility between the :ref:`nrf_profiler` library and host tools due to modifications in the Info RTT channel string layout.
+   Ensure that you use the updated version of the scripts together with the corresponding library version.
+
 Requirements
 ************
 

--- a/scripts/nrf_profiler/model_creator.py
+++ b/scripts/nrf_profiler/model_creator.py
@@ -63,6 +63,8 @@ class ModelCreator:
         self.bufs = list()
         self.bcnt = 0
 
+        self.sec_per_timestamp_tick = self.config['ms_per_timestamp_tick'] / 1000
+
         self.logger = logging.getLogger('model_creator')
         self.logger_console = logging.StreamHandler()
         self.logger.setLevel(log_lvl)
@@ -112,8 +114,49 @@ class ModelCreator:
     def _timestamp_from_ticks(self, clock_ticks):
         ts_ticks_aggregated = self.timestamp_overflows * self.config['timestamp_raw_max']
         ts_ticks_aggregated += clock_ticks
-        ts_s = ts_ticks_aggregated * self.config['ms_per_timestamp_tick'] / 1000
+        ts_s = ts_ticks_aggregated * self.sec_per_timestamp_tick
         return ts_s
+
+    def decode_by_markers(self, data, start_marker, stop_marker):
+        ev_start_idx = data.find(start_marker)
+        ev_stop_idx = data.find(stop_marker)
+        ret_tab = ""
+
+        if ((ev_start_idx != -1) and (ev_stop_idx != -1) and (ev_start_idx <= ev_stop_idx)):
+            start_pos = ev_start_idx + len(start_marker)
+            #The newline character (\n) is always at the end - skip it - decrease last index by 1
+            if data[ev_stop_idx - 1] == '\n':
+                ev_stop_idx -= 1
+            ret_tab = data[start_pos:ev_stop_idx]
+        return ret_tab
+
+    def sys_config_decode_to_dict(self, data):
+
+        def sys_clock_hw_cycles_per_sec_decode(data):
+            temp_data = int(data, 10)
+            if temp_data <= 0:
+                raise ValueError(f"Incorrect value: {temp_data}. Value is expected to be bigger than 0.")
+            return temp_data
+
+        DECODE_MAP = {
+            "sys_clock_hw_cycles_per_sec":  sys_clock_hw_cycles_per_sec_decode
+        }
+        ret_dict = {}
+        items = data.strip().splitlines()
+
+        for item in items:
+            parts = item.split(',')
+            if len(parts) != 2:
+                continue
+            key, value = parts[0], parts[1]
+            try:
+                decoder = DECODE_MAP[key]
+                ret_dict[key] = decoder(value)
+            except KeyError:
+                self.logger.error(f"Unsupported parameter '{key}'")
+            except (TypeError, ValueError) as err:
+                self.logger.error(f"Received error: '{err}'")
+        return ret_dict
 
     def transmit_all_events_descriptions(self):
         while True:
@@ -128,8 +171,27 @@ class ModelCreator:
                     continue
                 self.logger.error(f"Receiving error: {err}. Exiting")
                 sys.exit()
-        desc_buf = bytes.decode()
-        f = StringIO(desc_buf)
+
+        ev_start_tag = '<ev_info_start>\n'
+        ev_stop_tag = '<ev_info_stop>\n'
+        sys_cfg_start_tag = '<sys_config_start>\n'
+        sys_cfg_stop_tag = '<sys_config_stop>\n'
+        sys_clock_hw_cycles_per_sec_tag = 'sys_clock_hw_cycles_per_sec'
+
+        in_data = bytes.decode()
+        ev_info = self.decode_by_markers(in_data, ev_start_tag, ev_stop_tag)
+        sys_config = self.decode_by_markers(in_data, sys_cfg_start_tag, sys_cfg_stop_tag)
+        sys_dict = self.sys_config_decode_to_dict(sys_config)
+
+        sys_clock_hw_cycles_per_sec = sys_dict.get(sys_clock_hw_cycles_per_sec_tag)
+        if sys_clock_hw_cycles_per_sec is not None:
+            self.sec_per_timestamp_tick = 1 / sys_clock_hw_cycles_per_sec
+        else:
+            self.logger.error(f"Value for key {sys_clock_hw_cycles_per_sec_tag} cannot be used or "
+                              f"key {sys_clock_hw_cycles_per_sec_tag} is not provided at all.")
+            sys.exit()
+
+        f = StringIO(ev_info)
         reader = csv.reader(f, delimiter=',')
         for row in reader:
             # Empty field is sent after last event description

--- a/scripts/nrf_profiler/rtt_nordic_config.py
+++ b/scripts/nrf_profiler/rtt_nordic_config.py
@@ -12,7 +12,7 @@ RttNordicConfig = {
     'rtt_down_channel_names': {
         'Nordic nrf_profiler command': 'command',
     },
-    'ms_per_timestamp_tick': 0.03125,
+    'ms_per_timestamp_tick': 1000/32768,
     'byteorder': 'little',
     'reset_on_start': True,
     'connection_timeout': -1,

--- a/subsys/nrf_profiler/profiler_nordic.c
+++ b/subsys/nrf_profiler/profiler_nordic.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <zephyr/kernel_structs.h>
+#include <zephyr/sys/time_units.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/kernel.h>
@@ -92,16 +93,23 @@ static int send_info_data(const char *data, size_t data_len)
 	return 0;
 }
 
-static void send_system_description(void)
+static int send_system_description(void)
 {
+	int err;
 	/* Memory barrier to make sure that data is visible
 	 * before being accessed
 	 */
 	uint8_t ne = nrf_profiler_num_events;
+	static const char * const ev_info_start = "<ev_info_start>\n";
+	static const char * const ev_info_stop = "<ev_info_stop>\n";
+	static const char end_line = '\n';
 
 	__DMB();
-	char end_line = '\n';
-	int err = 0;
+
+	err = send_info_data(ev_info_start, strlen(ev_info_start));
+	if (err) {
+		return err;
+	}
 
 	for (size_t t = 0; ((t < ne) && !err); t++) {
 		err = send_info_data(descr[t], strlen(descr[t]));
@@ -109,17 +117,60 @@ static void send_system_description(void)
 			err = send_info_data(&end_line, 1);
 		}
 	}
-	if (!err) {
-		(void)send_info_data(&end_line, 1);
+	if (err) {
+		return err;
 	}
+
+	err = send_info_data(ev_info_stop, strlen(ev_info_stop));
+
+	return err;
+}
+
+static int send_system_configuration(void)
+{
+	char sys_clock_buf[13];
+	int temp_val;
+	int err;
+	static const char * const sys_config_start = "<sys_config_start>\n";
+	static const char * const sys_config_stop = "<sys_config_stop>\n";
+	static const char * const sys_clock_param_name = "sys_clock_hw_cycles_per_sec";
+
+	temp_val = snprintf(sys_clock_buf,
+						sizeof(sys_clock_buf),
+						",%" PRIu32 "\n",
+						sys_clock_hw_cycles_per_sec());
+	if ((temp_val < 0) || ((size_t)temp_val >= sizeof(sys_clock_buf))) {
+		return -ENOMEM;
+	}
+
+	err = send_info_data(sys_config_start, strlen(sys_config_start));
+	if (err) {
+		return err;
+	}
+
+	err = send_info_data(sys_clock_param_name, strlen(sys_clock_param_name));
+	if (err) {
+		return err;
+	}
+
+	err = send_info_data(sys_clock_buf, strlen(sys_clock_buf));
+	if (err) {
+		return err;
+	}
+
+	err = send_info_data(sys_config_stop, strlen(sys_config_stop));
+
+	return err;
 }
 
 static void nrf_profiler_nordic_thread_fn(void)
 {
-	while (atomic_get(&nrf_profiler_state) != STATE_TERMINATED) {
-		uint8_t read_data;
-		enum nordic_command command;
+	int ret_err;
+	uint8_t read_data;
+	enum nordic_command command;
+	static const char end_line = '\n';
 
+	while (atomic_get(&nrf_profiler_state) != STATE_TERMINATED) {
 		if (SEGGER_RTT_Read(
 		     CONFIG_NRF_PROFILER_NORDIC_RTT_CHANNEL_COMMANDS,
 		     &read_data, sizeof(read_data))) {
@@ -132,10 +183,16 @@ static void nrf_profiler_nordic_thread_fn(void)
 				atomic_cas(&nrf_profiler_state, STATE_ACTIVE, STATE_INACTIVE);
 				break;
 			case NORDIC_COMMAND_INFO:
-				send_system_description();
+				ret_err = send_system_description();
+				if (ret_err) {
+					break;
+				}
+				ret_err = send_system_configuration();
+				if (!ret_err) {
+					(void)send_info_data(&end_line, 1);
+				}
 				break;
 			default:
-				__ASSERT_NO_MSG(false);
 				break;
 			}
 		}


### PR DESCRIPTION
This PR introduces changes to the info RTT channel string format to support more granular system configuration data.

SoC side: Implemented a new string format using dedicated markers (<ev_info_...> and <sys_config_...Custom>) to separate event descriptions from system configuration.

Host tools side: Updated the nRF Profiler scripts to handle the new RTT layout and implement logic for parsing the system hardware clock frequency.

Jira: NCSDK-30089