### PR TITLE
Nrf91 Documentation update for using devicetree partitions.

### DIFF
--- a/doc/nrf/libraries/bin/lwm2m_carrier/requirements.rst
+++ b/doc/nrf/libraries/bin/lwm2m_carrier/requirements.rst
@@ -51,8 +51,8 @@ Following are some of the requirements and limitations of the application while 
   Out-of-band FOTA updates are done by the :ref:`lib_downloader`.
   Although the certificates are updated as part of the |NCS| releases, you must check the requirements from your carrier to know which certificates are applicable.
 
-* The LwM2M carrier library uses the following NVS record key range: ``0xCA00`` to ``0xCAFF``.
-  This range must not be used by the application.
+* The LwM2M carrier library requires a :ref:`zephyr:nvs_api` partition to be chosen as ``lwm2m_carrier`` in the devicetree.
+  To mark this partition as non-secure in TF-M it needs to be (part of) a partition called ``storage_partition``.
 
 .. _lwm2m_carrier_dependent:
 

--- a/doc/nrf/libraries/modem/nrf_modem_lib/index.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib/index.rst
@@ -4,7 +4,7 @@ Modem library integration layer
 ###############################
 
 The Modem library integration layer handles the integration of the Modem library into |NCS|.
-The integration layer is constituted by the library wrapper and functionalities like socket offloading, OS abstraction, memory reservation by the Partition manager, handling modem traces, and diagnostics.
+The integration layer is constituted by the library wrapper and functionalities like socket offloading, OS abstraction, memory reservation by the Partition manager or devicetree, handling modem traces, and diagnostics.
 
 .. toctree::
    :maxdepth: 1
@@ -14,6 +14,7 @@ The integration layer is constituted by the library wrapper and functionalities 
    nrf_modem_lib_wrapper
    nrf_modem_lib_socket_offloading
    nrf_modem_lib_os_abstraction
+   nrf_modem_lib_dt_integration
    nrf_modem_lib_pm_integration
    nrf_modem_lib_lte_net_if
    nrf_modem_lib_trace

--- a/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_dt_integration.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_dt_integration.rst
@@ -1,0 +1,56 @@
+.. _devicetree_integration:
+
+Devicetree integration
+######################
+
+The :ref:`nrfxlib:nrf_modem`, which runs on the application core, shares a region of RAM memory with the modem core.
+During the initialization, the Modem library accepts the boundaries of this region of RAM and configures the communication with the modem core accordingly.
+
+However, it is the responsibility of the application to reserve that RAM during linking so that this memory area is not used for other purposes and remains dedicated for use by the Modem library.
+
+The size and location of the shared memory can be defined in devicetree by creating the following RAM sections:
+
+* ``sram0_ns_modem``:
+
+  This section contains all the subsections needed for communicating with the modem.
+  You must place it in a specific area of RAM depending on the device (see the :ref:`following table <modem_shmem_variations>`).
+
+  * ``cpuapp_cpucell_ipc_shm_ctrl``:
+
+    This section is used for control messages.
+    It has a minimum size depending on the modem firmware (see the :ref:`following table <modem_shmem_variations>`).
+
+  * ``cpuapp_cpucell_ipc_shm_heap``:
+
+    This section is used for data sent from the Modem library to the modem.
+    The heap implementation used has an overhead of up to 128 bytes.
+    Adjust the size of this region so it is 128 bytes larger than the largest allocation you expect to happen in your application (such as the longest AT command or the largest payload passed to :c:func:`nrf_send`).
+
+  * ``cpucell_cpuapp_ipc_shm_heap``:
+
+    This section is used for data sent from the modem to the Modem library.
+
+  * ``cpucell_cpuapp_ipc_shm_trace``:
+
+    This section is used for modem tracing.
+    It is optional and only needs to be added when modem tracing is enabled.
+
+* ``sram0_ns_app``:
+
+  This section is used as the application memory.
+  The size of this section will be assigned to ``CONFIG_SRAM_SIZE`` in kB, so this section must be 1024-byte aligned.
+
+.. _modem_shmem_variations:
+
+.. table:: Control region size and shared memory location
+
+  +---------------+--------------+-----------------------+---------------------+------------------------+
+  | Device series | Variant      | Firmware              | Control region size | Shared memory location |
+  +---------------+--------------+-----------------------+---------------------+------------------------+
+  | nRF91         | DECT NR+     | * mfw_nr+_nrf91x1     | 1832 bytes          | first 128 kB of RAM    |
+  |               |              | * mfw_nr+-phy_nrf91x1 |                     |                        |
+  |               +--------------+-----------------------+---------------------+                        |
+  |               | Cellular     | * mfw_nrf9160         | 1256 bytes          |                        |
+  |               |              | * mfw_nrf91x1         |                     |                        |
+  |               |              | * mfw_nrf9151-ntn     |                     |                        |
+  +---------------+--------------+-----------------------+---------------------+------------------------+


### PR DESCRIPTION
Update documentation for using devicetree partitions instead of partition manager for:
- Modem Library
- LwM2M Carrier library 