### PR TITLE
scripts: sbom: Add softdevice .hex file support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -511,7 +511,13 @@ Scripts
 
 This section provides detailed lists of changes by :ref:`script <scripts>`.
 
-|no_changes_yet_note|
+* :ref:`west_sbom` script:
+
+* Added:
+
+  * Licence handling of the LLVM toolchain libraries.
+  * Support for hex only ``softdevice`` sysbuild domains.
+
 
 Integrations
 ============

--- a/scripts/west_commands/sbom/input_build.py
+++ b/scripts/west_commands/sbom/input_build.py
@@ -96,6 +96,19 @@ def get_sysbuild_domains(build_dir: Path) -> list[tuple[str, Path]]:
         raise SbomException(f'No domains detected in "{domains_yaml}".')
     return results
 
+def get_runner_artifact(build_dir: Path) -> Path | None:
+    '''
+    Returns the hex file referenced by zephyr/runners.yaml or None.
+    '''
+    try:
+        runners_yaml = build_dir / 'zephyr' / 'runners.yaml'
+        hex_file = yaml.safe_load(runners_yaml.read_text())['config']['hex_file']
+        artifact = (runners_yaml.parent / hex_file).resolve()
+        return artifact if artifact.is_file() else None
+    except Exception:
+        return None
+
+
 def get_ninja_default_targets(build_dir: Path) -> list[str]:
     '''
     Returns default targets listed in build.ninja.
@@ -703,6 +716,17 @@ class InputBuild:
                 target = target_with_map
 
             if not map_file.exists():
+                # Only fall back to .hex when the user is asking for the default target.
+                # Both "-d build" and "-d build zephyr/zephyr.elf" reach this.
+                if len(targets_with_maps) <= 1 and (
+                    len(targets_with_maps) == 0 or targets_with_maps[0] == DEFAULT_TARGET
+                ):
+                    artifact = get_runner_artifact(self.build_dir)
+                    if artifact is not None:
+                        self.data.inputs.append(f'The "{artifact}" file from the build directory '
+                                    f'"{self.build_dir.resolve()}"')
+                        self.add_file_info(artifact)
+                        return
                 raise SbomException(f'Cannot find map file for "{target_with_map}" '
                                     f'in build directory "{self.build_dir}". '
                                     f'Expected location "{map_file}".')

--- a/scripts/west_commands/sbom/main.py
+++ b/scripts/west_commands/sbom/main.py
@@ -89,6 +89,18 @@ def _target_maps_present(build_dir: Path, targets: list[str]) -> bool:
     return True
 
 
+def _domain_inputs_present(build_dir: Path, targets: list[str]) -> bool:
+    '''
+    Return True if the domain can be analyzed either via map files or
+    via a hex files in runners.yaml.
+    '''
+    if _target_maps_present(build_dir, targets):
+        return True
+    if len(targets) <= 1 and (len(targets) == 0 or targets[0] == input_build.DEFAULT_TARGET):
+        return input_build.get_runner_artifact(build_dir) is not None
+    return False
+
+
 def main():
     '''Main entry function for the script.'''
     try:
@@ -134,10 +146,10 @@ def main():
                 processed_domains = 0
 
                 for domain_name, domain_dir in domains:
-                    if not _target_maps_present(domain_dir, entry[1:]):
+                    if not _domain_inputs_present(domain_dir, entry[1:]):
                         log.wrn(
-                            f'Skipping "{domain_name}" because required map file '
-                            f'missing in "{domain_dir}"'
+                            f'Skipping "{domain_name}" because no map file or hex '
+                            f'was found"{domain_dir}"'
                         )
                         continue
 
@@ -155,7 +167,7 @@ def main():
                     processed_domains += 1
 
                 if processed_domains == 0:
-                    raise SbomException('No sysbuild domains contain map files')
+                    raise SbomException('No sysbuild domains contain map or hex files')
                 return
 
         _run_pipeline()


### PR DESCRIPTION
Add external license support for sysbuild domain that provides only a .hex file. Example: https://github.com/nrfconnect/sdk-nrf-bm/tree/main/components/softdevice