### PR TITLE
[collab-nrf9251] manifest: update sdk-zephyr for NFCT pins as GPIOs on nRF92

### DIFF
--- a/soc/nordic/nrf92/soc.c
+++ b/soc/nordic/nrf92/soc.c
@@ -19,6 +19,7 @@
 #include <hal/nrf_lrcconf.h>
 #include <hal/nrf_spu.h>
 #include <hal/nrf_memconf.h>
+#include <hal/nrf_nfct.h>
 #include <lib/nrfx_coredep.h>
 #include <soc_lrcconf.h>
 #include <haltium_power.h>
@@ -95,6 +96,13 @@ void soc_early_init_hook(void)
 
 	err = dmm_init();
 	__ASSERT_NO_MSG(err == 0);
+
+	if (((IS_ENABLED(CONFIG_SOC_NRF9220_CPUAPP) &&
+	      DT_NODE_HAS_STATUS(DT_NODELABEL(nfct), disabled)) ||
+	     DT_NODE_HAS_STATUS(DT_NODELABEL(nfct), reserved)) &&
+	    DT_PROP_OR(DT_NODELABEL(nfct), nfct_pins_as_gpios, 0)) {
+		nrf_nfct_pad_config_enable_set(NRF_NFCT, false);
+	}
 }
 
 void arch_busy_wait(uint32_t time_us)

--- a/tests/drivers/gpio/gpio_nfct/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_nfct/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -12,11 +12,11 @@
 		compatible = "gpio-leds";
 
 		out_gpios: out_gpios {
-			gpios = <&gpio2 8 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
 		};
 
 		in_gpios: in_gpios {
-			gpios = <&gpio2 9 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };
@@ -31,6 +31,6 @@
 	owned-channels = <7>;
 };
 
-&gpio2 {
+&gpio1 {
 	status = "okay";
 };


### PR DESCRIPTION
Updated sdk-zephyr contains a fix for configuring NFCT pins as standard GPIOs on nRF92 Series SoCs.