### PR TITLE
drivers: serial: lpuart: default enable from DT

### DIFF
--- a/drivers/serial/Kconfig.nrf_sw_lpuart
+++ b/drivers/serial/Kconfig.nrf_sw_lpuart
@@ -5,9 +5,11 @@
 
 config NRF_SW_LPUART
 	bool "Low Power UART using REQ/RDY lines"
+	depends on DT_HAS_NORDIC_NRF_SW_LPUART_ENABLED
 	select GPIO
 	select UART_ASYNC_API
 	select RING_BUFFER
+	default y
 	help
 	  Low power UART implements UART API and extends standard UART
 	  communication with 2 pins protocol for receiver wake up and flow control.


### PR DESCRIPTION
Enable the LP UART driver by default if it exists and is enabled in devicetree. This matches the behaviour of the majority of other drivers.