### PR TITLE
applications: nrf5340_audio: Split audio frames into 0.5 ms blocks

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -38,7 +38,7 @@ LOG_MODULE_REGISTER(audio_datapath, CONFIG_AUDIO_DATAPATH_LOG_LEVEL);
  *   - frame: encoded audio packet exchanged with connectivity
  */
 
-#define BLK_PERIOD_US 1000
+#define BLK_PERIOD_US 500
 
 /* Total sample FIFO period in microseconds */
 #define FIFO_CHANNELS_MAX   MAX(CONFIG_AUDIO_INPUT_CHANNELS, CONFIG_AUDIO_OUTPUT_CHANNELS)
@@ -51,7 +51,7 @@ LOG_MODULE_REGISTER(audio_datapath, CONFIG_AUDIO_DATAPATH_LOG_LEVEL);
 #define NUM_BLKS(d) ((d) / BLK_PERIOD_US)
 /* Single audio block size in number of samples */
 /* clang-format off */
-#define BLK_SIZE_SAMPLES(r) (((r)*BLK_PERIOD_US) / 1000000)
+#define BLK_SIZE_SAMPLES(r) (((r)*BLK_PERIOD_US) / USEC_PER_SEC)
 /* clang-format on */
 /* Increment sample FIFO index by one block */
 #define NEXT_IDX(i) (((i) < (FIFO_NUM_BLKS - 1)) ? ((i) + 1) : 0)
@@ -61,6 +61,7 @@ LOG_MODULE_REGISTER(audio_datapath, CONFIG_AUDIO_DATAPATH_LOG_LEVEL);
 #define NUM_BLKS_IN_FRAME	   NUM_BLKS(CONFIG_AUDIO_FRAME_DURATION_US)
 #define BLK_MONO_NUM_SAMPS	   BLK_SIZE_SAMPLES(CONFIG_AUDIO_SAMPLE_RATE_HZ)
 #define BLK_MULTI_CHAN_NUM_SAMPS   (BLK_MONO_NUM_SAMPS * CONFIG_AUDIO_OUTPUT_CHANNELS)
+
 /* Number of octets in a single audio block */
 #define BLK_MONO_SIZE_OCTETS	   (BLK_MONO_NUM_SAMPS * CONFIG_AUDIO_BIT_DEPTH_OCTETS)
 #define BLK_MULTI_CHAN_SIZE_OCTETS (BLK_MULTI_CHAN_NUM_SAMPS * CONFIG_AUDIO_BIT_DEPTH_OCTETS)
@@ -83,7 +84,7 @@ LOG_MODULE_REGISTER(audio_datapath, CONFIG_AUDIO_DATAPATH_LOG_LEVEL);
 #define APLL_FREQ_ADJ(t) (-((t)*1000) / 331)
 /* clang-format on */
 
-#define DRIFT_MEAS_PERIOD_US	   100000
+#define DRIFT_MEAS_PERIOD_US	   150000
 #define DRIFT_ERR_THRESH_LOCK	   16
 #define DRIFT_ERR_THRESH_UNLOCK	   32
 /* To get smaller corrections */
@@ -190,7 +191,7 @@ static int filled_blocks_get(void)
 }
 
 static struct audio_metadata i2s_meta = {.data_coding = PCM,
-					 .data_len_us = 1000,
+					 .data_len_us = BLK_PERIOD_US,
 					 .sample_rate_hz = CONFIG_AUDIO_SAMPLE_RATE_HZ,
 					 .bits_per_sample = CONFIG_AUDIO_BIT_DEPTH_BITS,
 					 .carried_bits_per_sample = CONFIG_AUDIO_BIT_DEPTH_BITS,
@@ -776,7 +777,7 @@ static void audio_datapath_i2s_blk_complete(uint32_t frame_start_ts_us, uint32_t
 		/* Update metadata */
 		struct audio_metadata *meta = net_buf_user_data(i2s_current_frame);
 
-		meta->data_len_us += i2s_meta.data_len_us; /* Each block is 1ms */
+		meta->data_len_us += i2s_meta.data_len_us;
 		meta->bytes_per_location += i2s_meta.bytes_per_location;
 		i2s_blocks_in_current_frame++;
 
@@ -792,7 +793,7 @@ static void audio_datapath_i2s_blk_complete(uint32_t frame_start_ts_us, uint32_t
 				 * queue is ready
 				 */
 				net_buf_remove_mem(i2s_current_frame, BLK_MULTI_CHAN_SIZE_OCTETS);
-				meta->data_len_us -= i2s_meta.data_len_us; /* Each block is 1ms */
+				meta->data_len_us -= i2s_meta.data_len_us;
 				meta->bytes_per_location -= i2s_meta.bytes_per_location;
 				i2s_blocks_in_current_frame--;
 

--- a/applications/nrf5340_audio/src/audio/sw_codec_select.h
+++ b/applications/nrf5340_audio/src/audio/sw_codec_select.h
@@ -25,10 +25,12 @@
 #include "device_location.h"
 
 #if (CONFIG_SW_CODEC_LC3)
-#define LC3_MAX_FRAME_SIZE_MS	10
-#define LC3_ENC_MONO_FRAME_SIZE (CONFIG_LC3_BITRATE_MAX * LC3_MAX_FRAME_SIZE_MS / (8 * 1000))
+#define LC3_MAX_FRAME_SIZE_US	10000
+#define LC3_ENC_MONO_FRAME_SIZE                                                                    \
+	(CONFIG_LC3_BITRATE_MAX * LC3_MAX_FRAME_SIZE_US / (8 * USEC_PER_SEC))
 #define LC3_PCM_NUM_BYTES_MONO                                                                     \
-	(CONFIG_AUDIO_SAMPLE_RATE_HZ * CONFIG_AUDIO_BIT_DEPTH_OCTETS * LC3_MAX_FRAME_SIZE_MS / 1000)
+	(CONFIG_AUDIO_SAMPLE_RATE_HZ * CONFIG_AUDIO_BIT_DEPTH_OCTETS * LC3_MAX_FRAME_SIZE_US /     \
+	 USEC_PER_SEC)
 #define LC3_ENC_TIME_US 3000
 #define LC3_DEC_TIME_US 1500
 #else

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.c
@@ -206,7 +206,7 @@ int le_audio_bitrate_get(const struct bt_audio_codec_cfg *const codec, uint32_t 
 		return ret;
 	}
 
-	int frames_per_sec = 1000000 / dur_us;
+	float frames_per_sec = (float)USEC_PER_SEC / dur_us;
 	uint32_t octets_per_sdu;
 
 	ret = le_audio_octets_per_frame_get(codec, &octets_per_sdu);

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/le_audio.h
@@ -22,7 +22,7 @@
 #include <audio_defines.h>
 
 #define LE_AUDIO_ZBUS_EVENT_WAIT_TIME	  K_MSEC(5)
-#define LE_AUDIO_SDU_SIZE_OCTETS(bitrate, dur_us) (bitrate / (1000000 / dur_us) / 8)
+#define LE_AUDIO_SDU_SIZE_OCTETS(bitrate, dur_us) (bitrate / (USEC_PER_SEC / dur_us) / 8)
 
 #if CONFIG_SAMPLE_RATE_CONVERTER && CONFIG_AUDIO_SAMPLE_RATE_48000_HZ
 #define BT_AUDIO_CODEC_CAPABILIY_FREQ                                                              \

--- a/applications/nrf5340_audio/src/modules/audio_usb.c
+++ b/applications/nrf5340_audio/src/modules/audio_usb.c
@@ -38,8 +38,11 @@ K_MEM_SLAB_DEFINE_STATIC(usb_rx_slab, ROUND_UP(USB_BLOCK_SIZE_MULTI_CHAN, UDC_BU
 static struct k_msgq *audio_q_tx;
 static struct k_msgq *audio_q_rx;
 
+/* USB blocks are 1 ms each, but we split them into 0.5 ms blocks for processing,
+ * hence the dividing by two
+ */
 NET_BUF_POOL_FIXED_DEFINE(pool_in, USB_BLOCKS,
-			  (USB_BLOCK_SIZE_MULTI_CHAN * CONFIG_FIFO_FRAME_SPLIT_NUM),
+			  (USB_BLOCK_SIZE_MULTI_CHAN * CONFIG_FIFO_FRAME_SPLIT_NUM / 2),
 			  sizeof(struct audio_metadata), NULL);
 
 static uint32_t rx_num_overruns;
@@ -167,6 +170,21 @@ static void *get_recv_buf_cb(const struct device *dev, uint8_t terminal, uint16_
 	return buf;
 }
 
+static void half_buf_add(struct net_buf *frame, void *data, uint16_t size,
+			 uint32_t *blocks_in_frame)
+{
+	const uint32_t half_data_len_us = usb_in_meta.data_len_us / 2;
+	const uint32_t half_bytes_per_location = usb_in_meta.bytes_per_location / 2;
+
+	net_buf_add_mem(frame, data, size);
+
+	struct audio_metadata *meta = net_buf_user_data(frame);
+
+	meta->data_len_us += half_data_len_us;
+	meta->bytes_per_location += half_bytes_per_location;
+	(*blocks_in_frame)++;
+}
+
 static void data_recv_cb(const struct device *dev, uint8_t terminal, void *buf, uint16_t size,
 			 void *user_data)
 {
@@ -175,9 +193,11 @@ static void data_recv_cb(const struct device *dev, uint8_t terminal, void *buf, 
 	ARG_UNUSED(user_data);
 
 	int ret;
-	/* Frame accumulation for 10ms frames */
-	static struct net_buf *current_frame;
-	static uint32_t blocks_in_current_frame;
+	/* Frame accumulation */
+	static struct net_buf *frame_current;
+	static struct net_buf *frame_spillover;
+	static uint32_t blocks_in_frame_current;
+	static uint32_t blocks_in_frame_spillover;
 
 	if (unlikely(buf == NULL)) {
 		LOG_ERR("Received NULL buffer");
@@ -185,13 +205,8 @@ static void data_recv_cb(const struct device *dev, uint8_t terminal, void *buf, 
 	}
 
 	/* Fast exit conditions */
-	if (unlikely(size == 0 || !playing_state)) {
-		k_mem_slab_free(&usb_rx_slab, buf);
-		return;
-	}
-
-	/* Terminal check */
-	if (unlikely(!(terminal_headset_out_enabled || terminal_headphones_out_enabled))) {
+	if (unlikely(size == 0 || !playing_state) ||
+	    !(terminal_headset_out_enabled || terminal_headphones_out_enabled)) {
 		k_mem_slab_free(&usb_rx_slab, buf);
 		return;
 	}
@@ -204,52 +219,96 @@ static void data_recv_cb(const struct device *dev, uint8_t terminal, void *buf, 
 	}
 
 	/* Allocate new frame if we don't have one */
-	if (current_frame == NULL) {
-		/* Check space availability */
-		if (unlikely(k_msgq_num_free_get(audio_q_rx) == 0 || pool_in.avail_count == 0)) {
-			goto overrun_cleanup;
+	if (frame_current == NULL) {
+		if (frame_spillover != NULL) {
+			frame_current = frame_spillover;
+			blocks_in_frame_current = blocks_in_frame_spillover;
+			frame_spillover = NULL;
+			blocks_in_frame_spillover = 0;
+		} else {
+			/* Check space availability */
+			if (unlikely(k_msgq_num_free_get(audio_q_rx) == 0 ||
+				     pool_in.avail_count == 0)) {
+				goto overrun_cleanup;
+			}
+
+			frame_current = net_buf_alloc(&pool_in, K_NO_WAIT);
+			if (unlikely(frame_current == NULL)) {
+				LOG_WRN("Out of RX buffers for frame");
+				goto overrun_cleanup;
+			}
+
+			/* Initialize metadata for the first block */
+			struct audio_metadata *meta = net_buf_user_data(frame_current);
+
+			*meta = usb_in_meta;
+			meta->data_len_us = 0;
+			meta->bytes_per_location = 0;
+			blocks_in_frame_current = 0;
+		}
+	}
+
+	/* Check if we are about to spill over, if so: allocate spill_over frame */
+	if ((blocks_in_frame_current + 2) > CONFIG_FIFO_FRAME_SPLIT_NUM) {
+		const size_t half_size = size / 2;
+
+		/* Add half the buffer to current frame */
+		half_buf_add(frame_current, buf, half_size, &blocks_in_frame_current);
+
+		if (frame_spillover != NULL) {
+			LOG_WRN("Previous spillover frame not consumed, dropping it");
+			net_buf_unref(frame_spillover);
+			blocks_in_frame_spillover = 0;
 		}
 
-		current_frame = net_buf_alloc(&pool_in, K_NO_WAIT);
-		if (unlikely(current_frame == NULL)) {
-			LOG_WRN("Out of RX buffers for frame");
+		/* Allocate new frame for spill over data since current frame is full. If allocation
+		 * fails, drop the spill over data to prevent blocking the USB endpoint, but keep
+		 * the current frame to allow it to be sent to the audio system.
+		 */
+		frame_spillover = net_buf_alloc(&pool_in, K_NO_WAIT);
+		if (unlikely(frame_spillover == NULL)) {
+			LOG_WRN("Out of RX buffers for spill over frame");
 			goto overrun_cleanup;
 		}
 
 		/* Initialize metadata for the first block */
-		struct audio_metadata *meta = net_buf_user_data(current_frame);
-		*meta = usb_in_meta;
-		meta->data_len_us = 0;
-		meta->bytes_per_location = 0;
-		blocks_in_current_frame = 0;
+		struct audio_metadata *meta_spill_over = net_buf_user_data(frame_spillover);
+
+		*meta_spill_over = usb_in_meta;
+		meta_spill_over->data_len_us = 0;
+		meta_spill_over->bytes_per_location = 0;
+		blocks_in_frame_spillover = 0;
+
+		/* Add half the buffer to spill over frame */
+		half_buf_add(frame_spillover, (char *)buf + half_size, half_size,
+			     &blocks_in_frame_spillover);
+	} else {
+		/* Add block data directly to current frame */
+		net_buf_add_mem(frame_current, buf, size);
+		/* Update metadata */
+		struct audio_metadata *meta = net_buf_user_data(frame_current);
+
+		/* Accumulate one full 1 ms USB buffer, which counts as two 0.5 ms blocks. */
+		meta->data_len_us += usb_in_meta.data_len_us;
+		meta->bytes_per_location += usb_in_meta.bytes_per_location;
+		blocks_in_frame_current += 2;
 	}
-
-	/* Add block data directly to current frame */
-	net_buf_add_mem(current_frame, buf, size);
-
-	/* Update metadata */
-	struct audio_metadata *meta = net_buf_user_data(current_frame);
-
-	/* Accumulate per-block duration (typically 1 ms) */
-	meta->data_len_us += usb_in_meta.data_len_us;
-	meta->bytes_per_location += usb_in_meta.bytes_per_location;
-	blocks_in_current_frame++;
 
 	/* Release USB buffer */
 	k_mem_slab_free(&usb_rx_slab, buf);
 
 	/* Check if we have a complete frame */
-	if (blocks_in_current_frame >= CONFIG_FIFO_FRAME_SPLIT_NUM) {
+	if (blocks_in_frame_current >= CONFIG_FIFO_FRAME_SPLIT_NUM) {
 		/* Put complete frame into RX queue */
-		ret = k_msgq_put(audio_q_rx, (void *)&current_frame, K_NO_WAIT);
+		ret = k_msgq_put(audio_q_rx, (void *)&frame_current, K_NO_WAIT);
 		if (ret) {
 			LOG_ERR("Failed to store complete frame");
-			net_buf_unref(current_frame);
+			net_buf_unref(frame_current);
 		}
 
 		/* Reset for next frame */
-		current_frame = NULL;
-		blocks_in_current_frame = 0;
+		frame_current = NULL;
+		blocks_in_frame_current = 0;
 	}
 
 	return;

--- a/applications/nrf5340_audio/src/utils/Kconfig
+++ b/applications/nrf5340_audio/src/utils/Kconfig
@@ -12,14 +12,14 @@ menu "FIFO"
 
 config FIFO_FRAME_SPLIT_NUM
 	int "Number of blocks to make up one frame of audio data"
-	default 10
+	default 20
 	help
 	  Easy DMA in I2S requires two buffers to be filled before I2S
 	  transmission will begin. In order to reduce latency, an audio
 	  frame can be split into multiple blocks with this parameter. USB
 	  sends data in 1 ms blocks, so we need the split to match that.
-	  Since we set frame size to 10 ms for USB, 10 is selected as
-	  FRAME_SPLIT_NUM
+	  If we set frame size to 10 ms for USB, 20 is selected as
+	  FIFO_FRAME_SPLIT_NUM
 
 config FIFO_TX_FRAME_COUNT
 	int "Max number of audio frames in TX slab"


### PR DESCRIPTION
-  This commit modifies the audio datapath to split incoming audio frames
    into smaller blocks of 0.5 ms each, allowing better support for other
    frame lengths such as 7.5 ms. The block size is defined as half of the
    USB block size, which is typically 1 ms. This change involves updating
    the metadata to reflect the new block size and adjusting the frame
    accumulation logic accordingly.
    
- OCT-3702