### PR TITLE
codeowners: remove duplicated line

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -539,7 +539,6 @@
 /samples/sensor/bh1749/                   @nrfconnect/ncs-cia
 /samples/sensor/bme68x_iaq/               @nrfconnect/ncs-cia
 /samples/nrf5340/empty_app_core/          @nrfconnect/ncs-si-muffin
-/samples/nrf5340/extxip_smp_svr/          @nrfconnect/ncs-eris
 /samples/nrf54h20/empty_app_core/         @nrfconnect/ncs-aurora
 /samples/nrf54h20/idle_relocated_tcm/     @nrfconnect/ncs-si-muffin
 /samples/nrf54h20/radio_loader/           @nrfconnect/ncs-si-muffin


### PR DESCRIPTION
Removed line which was added twice (lines 537 and 542 ware the same)