### PR TITLE
boards: nrf9251: add DMA region property to ADC node

### DIFF
--- a/boards/nordic/nrf9251dk/nrf9251dk_nrf9251_cpuapp.dts
+++ b/boards/nordic/nrf9251dk/nrf9251dk_nrf9251_cpuapp.dts
@@ -166,6 +166,11 @@
 	memory-regions = <&cpuapp_dma_region>;
 };
 
+&adc {
+	status = "okay";
+	memory-regions = <&cpuapp_dma_region>;
+};
+
 &coresight {
 	pinctrl-0 = <&tpiu_default>;
 	pinctrl-names = "default";


### PR DESCRIPTION
Aligning to how it is defined for nRF54H20.