### PR TITLE
samples: alarm: Disable PM 

### DIFF
--- a/samples/zephyr/drivers/counter/alarm/Kconfig.sysbuild
+++ b/samples/zephyr/drivers/counter/alarm/Kconfig.sysbuild
@@ -5,6 +5,6 @@
 #
 
 config PARTITION_MANAGER
-	default n if SOC_NRF54LV10A_ENGA
+	default n
 
 source "share/sysbuild/Kconfig"


### PR DESCRIPTION
It was reported that this sample had issues booting in certain configurations. It affected the nRF54LM20 with TF-M enabled. The reason for the failure was
that the non-secure RAM partition was not following the alignment requirements for the MPC. Instead of updating the Partition manager partitions in this
sample we can just disable it so that the device
tree partitions are being used, these are configured correctly.

Ref: NCSDK-38913