### PR TITLE
sysbuild: Fix bootconf not building without Partition Manager

### DIFF
--- a/cmake/sysbuild/bootconf.cmake
+++ b/cmake/sysbuild/bootconf.cmake
@@ -3,35 +3,58 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
+include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/bootloader_dts_utils.cmake)
 
-function(setup_bootconf_data)
-  if(SB_CONFIG_PARTITION_MANAGER)
-    add_custom_target(bootconf_target
-      DEPENDS ${CMAKE_BINARY_DIR}/bootconf.hex
-    )
+set(bootconf_hex ${CMAKE_BINARY_DIR}/bootconf.hex)
+set(bootconf_dependency)
 
-    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/bootconf.hex
-      COMMAND ${Python3_EXECUTABLE}
-        ${ZEPHYR_NRF_MODULE_DIR}/scripts/reglock.py
-        --output ${CMAKE_BINARY_DIR}/bootconf.hex
-        --size $<TARGET_PROPERTY:partition_manager,PM_B0_SIZE>
-        --soc ${SB_CONFIG_SOC}
-      DEPENDS ${APPLICATION_BINARY_DIR}/pm.config
-      VERBATIM
-    )
+if(SB_CONFIG_PARTITION_MANAGER)
+  set(bootconf_size $<TARGET_PROPERTY:partition_manager,PM_B0_SIZE>)
+  set(bootconf_dependency ${APPLICATION_BINARY_DIR}/pm.config)
+else()
+  dt_partition_size(bootconf_size LABEL b0_partition TARGET b0 REQUIRED)
+endif()
 
-    set_property(
-      GLOBAL PROPERTY
-      bootconf_PM_HEX_FILE
-      ${CMAKE_BINARY_DIR}/bootconf.hex
-    )
+# bootconf.hex is only created when there is b0_partition, which
+# indicates that b0 is used.
+if(NOT bootconf_size EQUAL 0)
+  add_custom_command(OUTPUT ${bootconf_hex}
+    COMMAND ${Python3_EXECUTABLE}
+      ${ZEPHYR_NRF_MODULE_DIR}/scripts/reglock.py
+      --output ${bootconf_hex}
+      --size ${bootconf_size}
+      --soc ${SB_CONFIG_SOC}
+    DEPENDS ${bootconf_dependency}
+    VERBATIM
+  )
+else()
+  # Whether we have this CMake invoked or not is controlled by paths in
+  # scripts that invoke; it is expected to be called when Secure Bootloader is
+  # build, which means that the B0 partition for it also exists. If these
+  # expectations are not met and somehow we have this part invoked, this means
+  # that bootconf build has been invoked for something it can not handle.
+  message(FATAL_ERROR "bootconf.hex has nothing to protect."
+    "CMake path that should not have been taken?"
+  )
+endif()
 
-    set_property(
-      GLOBAL PROPERTY
-      bootconf_PM_TARGET
-      bootconf_target
-    )
-  endif()
-endfunction()
+add_custom_target(bootconf_target
+  DEPENDS ${bootconf_hex}
+)
 
-setup_bootconf_data()
+if(SB_CONFIG_PARTITION_MANAGER)
+  set_property(
+    GLOBAL PROPERTY
+    bootconf_PM_HEX_FILE
+    ${bootconf_hex}
+  )
+
+  set_property(
+    GLOBAL PROPERTY
+    bootconf_PM_TARGET
+    bootconf_target
+  )
+else()
+  # Add the bootconf with b0 as bootconf is supposed to protect it.
+  add_dependencies(b0 bootconf_target)
+endif()

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -90,7 +90,7 @@ Developing with nRF70 Series
 Developing with nRF54L Series
 =============================
 
-|no_changes_yet_note|
+* Updated builds without Partition Manager to generate the :file:`bootconf.hex` file when |NSIB| is used as the bootloader.
 
 Developing with nRF54H Series
 =============================

--- a/sysbuild/secureboot.cmake
+++ b/sysbuild/secureboot.cmake
@@ -94,6 +94,10 @@ if(SB_CONFIG_SECURE_BOOT)
 
       include(image_flasher.cmake)
       add_image_flasher(NAME app_provision HEX_FILE "${CMAKE_BINARY_DIR}/app_provision.hex")
+      if(SB_CONFIG_SOC_SERIES_NRF54L)
+        add_image_flasher(NAME bootconf HEX_FILE "${CMAKE_BINARY_DIR}/bootconf.hex")
+        sysbuild_add_dependencies(FLASH bootconf b0)
+      endif()
     endif()
 
     set_target_properties(b0 PROPERTIES


### PR DESCRIPTION
Add building bootconf with non-Partition Manager configurations that use NSIB (B0).