### PR TITLE
bluetooth: hids: Fix bt_hogp_rep_unsubscribe issue

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -507,6 +507,10 @@ Bluetooth libraries and services
 
   * Fixed missing ATT write length validation in the GATT write handler for the Fast Pair Additional Data characteristic, used by the experimental Personalized Name extension (:kconfig:option:`CONFIG_BT_FAST_PAIR_PN`).
 
+* :ref:`hogp_readme` library:
+
+  * Fixed an issue where the :c:func:`bt_hogp_rep_unsubscribe` function did not clear the notification callback, which prevented the :c:func:`bt_hogp_rep_subscribe` function from succeeding after unsubscribing.
+
 Common Application Framework
 ----------------------------
 

--- a/include/bluetooth/services/hogp.h
+++ b/include/bluetooth/services/hogp.h
@@ -38,7 +38,8 @@ struct bt_hogp_rep_info;
  * @param hogp   HOGP object.
  * @param rep    Report object.
  * @param err    ATT error code.
- * @param data   Pointer to the received data.
+ * @param data   Pointer to the received data or NULL to indicate
+ *               that the subscription has been cleared.
  *
  * @retval BT_GATT_ITER_STOP     Stop notification.
  * @retval BT_GATT_ITER_CONTINUE Continue notification.
@@ -406,6 +407,11 @@ int bt_hogp_rep_subscribe(struct bt_hogp *hogp,
 
 /**
  * @brief Remove the subscription for a selected report.
+ *
+ * When the subscription has been cleared the callback function
+ * will be called with data set to NULL.
+ * This will happen both on successful unsubscription as well as
+ * on CCC write error.
  *
  * @param hogp   HOGP object.
  * @param rep    Report object.

--- a/subsys/bluetooth/services/hogp.c
+++ b/subsys/bluetooth/services/hogp.c
@@ -1014,6 +1014,7 @@ static uint8_t rep_notify_process(struct bt_conn *conn,
 			       const void *data, uint16_t length)
 {
 	struct bt_hogp_rep_info *rep;
+	uint8_t err = 0;
 
 	rep = CONTAINER_OF(params,
 			   struct bt_hogp_rep_info,
@@ -1026,6 +1027,7 @@ static uint8_t rep_notify_process(struct bt_conn *conn,
 		LOG_WRN("Data size too big, truncating");
 		length = UINT8_MAX;
 	}
+
 	/* Zephyr uses the callback with data set to NULL to inform about the
 	 * subscription removal. Do not update the report size in that case.
 	 */
@@ -1033,7 +1035,18 @@ static uint8_t rep_notify_process(struct bt_conn *conn,
 		rep->size = (uint8_t)length;
 	}
 
-	return rep->notify_cb(rep->hogp, rep, 0, data);
+
+	err = rep->notify_cb(rep->hogp, rep, 0, data);
+
+	if (data == NULL) {
+		/* Zephyr uses the callback with data set to NULL to inform about the
+		 * subscription removal.
+		 * The notification callback can be safely cleared.
+		 */
+		rep->notify_cb = NULL;
+	}
+
+	return err;
 }
 
 int bt_hogp_rep_subscribe(struct bt_hogp *hogp,


### PR DESCRIPTION
The bt_hogp_rep_unsubscribe did not reset the rep->notify_cb, while bt_hogp_rep_subscribe returned an error if
notify_cb was not null. Thus, it would be impossible to subscribe again to the report notification after unsubscribing.

This commit fixes this.