### PR TITLE
CI ONLY. DONT REVIEW: Testing alternative tfm dts interface

### DIFF
--- a/boards/nordic/thingy91/thingy91_nrf9160_partition.dtsi
+++ b/boards/nordic/thingy91/thingy91_nrf9160_partition.dtsi
@@ -83,4 +83,19 @@
 	};
 };
 
+/ {
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>,
+				  <&slot1_s_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>,
+				  <&slot1_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};
+
 #include <common/nordic/nrf91_partition_sram.dtsi>

--- a/boards/nordic/thingy91x/thingy91x_nrf9151_partition.dtsi
+++ b/boards/nordic/thingy91x/thingy91x_nrf9151_partition.dtsi
@@ -108,4 +108,19 @@
 	};
 };
 
+/ {
+	/* Only the internal-flash slot is described here; slot1, fmfu_storage
+	 * and storage live on external flash and are outside TF-M's purview.
+	 */
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+	};
+};
+
 #include <common/nordic/nrf91_partition_sram.dtsi>

--- a/cmake/sysbuild/image_signing.cmake
+++ b/cmake/sysbuild/image_signing.cmake
@@ -60,7 +60,10 @@ function(zephyr_mcuboot_tasks)
 
   # Fetch devicetree details for flash and slot information
   dt_chosen(flash_node PROPERTY "zephyr,flash")
-  dt_nodelabel(slot0_flash NODELABEL "slot0_partition" REQUIRED)
+  dt_nodelabel(slot0_flash NODELABEL "slot0_partition")
+  if(NOT slot0_flash)
+    dt_nodelabel(slot0_flash NODELABEL "slot0_s_partition" REQUIRED)
+  endif()
   dt_reg_size(slot_size PATH "${slot0_flash}" REQUIRED)
   dt_prop(write_block_size PATH "${flash_node}" PROPERTY "write-block-size")
 

--- a/cmake/sysbuild/image_signing_extra.cmake
+++ b/cmake/sysbuild/image_signing_extra.cmake
@@ -74,7 +74,10 @@ endif()
 
 # Fetch devicetree details for flash and slot information
 dt_chosen(flash_node TARGET ${DEFAULT_IMAGE} PROPERTY "zephyr,flash")
-dt_nodelabel(slot0_flash TARGET ${DEFAULT_IMAGE} NODELABEL "slot0_partition" REQUIRED)
+dt_nodelabel(slot0_flash TARGET ${DEFAULT_IMAGE} NODELABEL "slot0_partition")
+if(NOT slot0_flash)
+  dt_nodelabel(slot0_flash TARGET ${DEFAULT_IMAGE} NODELABEL "slot0_s_partition" REQUIRED)
+endif()
 dt_prop(slot_size TARGET ${DEFAULT_IMAGE} PATH "${slot0_flash}" PROPERTY "reg" INDEX 1 REQUIRED)
 dt_prop(write_block_size TARGET ${DEFAULT_IMAGE} PATH "${flash_node}" PROPERTY "write-block-size")
 

--- a/cmake/sysbuild/image_signing_installer.cmake
+++ b/cmake/sysbuild/image_signing_installer.cmake
@@ -64,7 +64,10 @@ dt_chosen(flash_node TARGET ${installer_image} PROPERTY "zephyr,flash")
 dt_prop(write_block_size TARGET ${installer_image} PATH "${flash_node}" PROPERTY
   "write-block-size"
 )
-dt_nodelabel(slot0_path TARGET ${installer_image} NODELABEL "slot0_partition" REQUIRED)
+dt_nodelabel(slot0_path TARGET ${installer_image} NODELABEL "slot0_partition")
+if(NOT slot0_path)
+  dt_nodelabel(slot0_path TARGET ${installer_image} NODELABEL "slot0_s_partition" REQUIRED)
+endif()
 dt_partition_addr(slot0_addr PATH "${slot0_path}" TARGET ${installer_image} REQUIRED)
 dt_reg_size(slot0_size TARGET ${installer_image} PATH ${slot0_path})
 

--- a/cmake/sysbuild/image_signing_nrf700x.cmake
+++ b/cmake/sysbuild/image_signing_nrf700x.cmake
@@ -30,7 +30,10 @@ function(nrf7x_signing_tasks input output_hex output_bin dependencies)
 
   # Fetch devicetree details for flash and slot information
   dt_chosen(flash_node TARGET ${DEFAULT_IMAGE} PROPERTY "zephyr,flash")
-  dt_nodelabel(slot0_flash TARGET ${DEFAULT_IMAGE} NODELABEL "slot0_partition" REQUIRED)
+  dt_nodelabel(slot0_flash TARGET ${DEFAULT_IMAGE} NODELABEL "slot0_partition")
+  if(NOT slot0_flash)
+    dt_nodelabel(slot0_flash TARGET ${DEFAULT_IMAGE} NODELABEL "slot0_s_partition" REQUIRED)
+  endif()
   dt_prop(slot_size TARGET ${DEFAULT_IMAGE} PATH "${slot0_flash}" PROPERTY "reg" INDEX 1 REQUIRED)
   dt_prop(write_block_size TARGET ${DEFAULT_IMAGE} PATH "${flash_node}" PROPERTY "write-block-size")
 

--- a/cmake/sysbuild/image_signing_split.cmake
+++ b/cmake/sysbuild/image_signing_split.cmake
@@ -85,7 +85,10 @@ function(zephyr_mcuboot_tasks)
 
   # Fetch devicetree details for flash and slot information
   dt_chosen(flash_node PROPERTY "zephyr,flash")
-  dt_nodelabel(slot0_flash NODELABEL "slot0_partition" REQUIRED)
+  dt_nodelabel(slot0_flash NODELABEL "slot0_partition")
+  if(NOT slot0_flash)
+    dt_nodelabel(slot0_flash NODELABEL "slot0_s_partition" REQUIRED)
+  endif()
   dt_prop(slot_size PATH "${slot0_flash}" PROPERTY "reg" INDEX 1 REQUIRED)
   dt_prop(write_block_size PATH "${flash_node}" PROPERTY "write-block-size")
 

--- a/dts/common/nordic/nrf54lv10a_cpuapp_ns_partition.dtsi
+++ b/dts/common/nordic/nrf54lv10a_cpuapp_ns_partition.dtsi
@@ -91,3 +91,19 @@
 		};
 	};
 };
+
+/ {
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/dts/common/nordic/nrf54lv10a_cpuapp_ns_partition.dtsi
+++ b/dts/common/nordic/nrf54lv10a_cpuapp_ns_partition.dtsi
@@ -36,6 +36,10 @@
 
 &cpuapp_rram {
 	partitions {
+<<<<<<< HEAD
+=======
+		ranges;
+>>>>>>> b608bba27b (dts: nordic: nrf54lv10a: Migrate to zephyr,mapped-partition)
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges;
@@ -46,7 +50,11 @@
 		 * header flash_layout.h of the relevant platform. Any updates in the layout
 		 * need to happen both in the flash_layout.h and in this file at the same time.
 		 */
+<<<<<<< HEAD
 		slot0_partition: partition@0 {
+=======
+		slot0_s_partition: partition@0 {
+>>>>>>> b608bba27b (dts: nordic: nrf54lv10a: Migrate to zephyr,mapped-partition)
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000000 DT_SIZE_K(384)>;

--- a/dts/samples/matter/nrf54l15_cpuapp_tfm_application_partitions.dtsi
+++ b/dts/samples/matter/nrf54l15_cpuapp_tfm_application_partitions.dtsi
@@ -27,8 +27,8 @@
 	};
 };
 
-/* Cleanup the default partitioning for Application and TF-M */
-
+/delete-node/ &slot0_s_partition;
+/delete-node/ &storage_partition;
 /delete-node/ &slot0_ns_partition;
 /delete-node/ &tfm_its_partition;
 /delete-node/ &tfm_otp_partition;

--- a/dts/samples/openthread/nrf54l15_cpuapp_ns_partitions.dtsi
+++ b/dts/samples/openthread/nrf54l15_cpuapp_ns_partitions.dtsi
@@ -15,7 +15,7 @@
 	ranges = <0x0 0x13000 0x2d000>;
 };
 
-&slot0_partition {
+&slot0_s_partition {
 	reg = <0x00000000 0x40000>;
 };
 

--- a/modules/trusted-firmware-m/tfm_boards/CMakeLists.txt
+++ b/modules/trusted-firmware-m/tfm_boards/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(platform_s
   $<$<OR:$<BOOL:${TFM_PARTITION_INITIAL_ATTESTATION}>,$<BOOL:${NRF_PROVISIONING}>>:${CMAKE_CURRENT_SOURCE_DIR}/common/attest_hal.c>
   $<$<OR:$<BOOL:${TFM_PARTITION_INITIAL_ATTESTATION}>,$<BOOL:${NRF_PROVISIONING}>>:${ZEPHYR_NRF_MODULE_DIR}/subsys/bootloader/bl_storage/bl_storage.c>
   common/assert.c
+  partition/partition_check.c
   $<$<NOT:$<BOOL:${PLATFORM_DEFAULT_OTP}>>:${CMAKE_CURRENT_SOURCE_DIR}/common/dummy_otp.c>
   $<$<NOT:$<BOOL:${PLATFORM_DEFAULT_SYSTEM_RESET_HALT}>>:${CMAKE_CURRENT_SOURCE_DIR}/common/tfm_hal_reset_halt.c>
 )

--- a/modules/trusted-firmware-m/tfm_boards/common/tfm_hal_platform.c
+++ b/modules/trusted-firmware-m/tfm_boards/common/tfm_hal_platform.c
@@ -28,6 +28,7 @@
 #include "config_tfm.h"
 #include "exception_info.h"
 #include "tfm_arch.h"
+#include "partition_check.h"
 
 #if defined(NRF_LOG_MEMORY_PROTECTION_SAU_MPC)
 #include <log_memory_protection.h>
@@ -127,6 +128,9 @@ static void log_pin_security_configuration(void)
 enum tfm_hal_status_t tfm_hal_platform_init(void)
 {
 	enum tfm_hal_status_t status;
+
+	/* Verify the TrustZone partition layout declared in devicetree. */
+	tfm_tz_partition_check();
 
 	status = tfm_hal_platform_common_init();
 	if (status != TFM_HAL_SUCCESS) {

--- a/modules/trusted-firmware-m/tfm_boards/ns/CMakeLists.txt
+++ b/modules/trusted-firmware-m/tfm_boards/ns/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(platform_ns STATIC)
 set(partition_includes
     ${TFM_BOARDS_NRF_DIR}/partition
     ${CMAKE_BINARY_DIR}/../zephyr/include/generated
+    ${ZEPHYR_BASE}/include
 )
 
 set(board_includes

--- a/modules/trusted-firmware-m/tfm_boards/partition/flash_layout.h
+++ b/modules/trusted-firmware-m/tfm_boards/partition/flash_layout.h
@@ -64,6 +64,18 @@
 	IF_ENABLED(TFM_DT_PROP_EXISTS(node_id, data_partitions),                                   \
 		   (TFM_DT_FOREACH_PROP_ELEM(node_id, data_partitions,                              \
 					     TFM_DT_PROP_ELEM_REG_SIZE)))
+
+/* TF-M derives the TrustZone-M flash layout from two devicetree
+ * descriptor nodes ("nordic,tz-secure" / "nordic,tz-nonsecure") that
+ * point at the board's existing "zephyr,mapped-partition" leaves via
+ * code-partitions / data-partitions phandle lists.
+ */
+#if !defined(DT_COMPAT_HAS_OKAY_nordic_tz_secure)
+#error "TF-M cannot derive the secure flash layout: the board's NS partition dtsi is missing a 'nordic,tz-secure' descriptor."
+#endif
+#if !defined(DT_COMPAT_HAS_OKAY_nordic_tz_nonsecure)
+#error "TF-M cannot derive the non-secure flash layout: the board's NS partition dtsi is missing a 'nordic,tz-nonsecure' descriptor."
+#endif
 #endif
 
 /* This header file is included from linker scatter file as well, where only a

--- a/modules/trusted-firmware-m/tfm_boards/partition/flash_layout.h
+++ b/modules/trusted-firmware-m/tfm_boards/partition/flash_layout.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -12,26 +12,58 @@
 #if defined(CONFIG_PARTITION_MANAGER_ENABLED)
 #include <pm_config.h>
 #else
-/*
- * When not using Partition Manager, get partition info from devicetree.
- * We can't use <zephyr/devicetree.h> directly because this header is included
- * from linker scripts, and devicetree.h includes C headers that are not valid
- * in linker script context. Instead, we include only the generated devicetree
- * defines and provide minimal DT macros for extracting partition information.
+/* This header is included from linker scripts, which can't see the C
+ * constructs in <zephyr/devicetree.h>. Pull in the generated header
+ * directly and provide a minimal linker-safe DT macro set below.
+ * TFM_DT_ prefix avoids clashes with <zephyr/devicetree.h> when this
+ * header is reached via C code.
  */
 #include <zephyr/devicetree_generated.h>
+#include <zephyr/sys/util_macro.h>
 
-/*
- * Minimal devicetree macros for linker script compatibility.
- * These use TFM_DT_ prefix to avoid conflicts with <zephyr/devicetree.h>
- * which may be included via other headers in C code context.
- */
-#define TFM_DT_CAT(a, b) a ## b
-#define TFM_DT_CAT4(a, b, c, d) a ## b ## c ## d
-#define TFM_DT_NODELABEL(label) TFM_DT_CAT(DT_N_NODELABEL_, label)
-#define TFM_DT_REG_ADDR(node_id) TFM_DT_CAT4(node_id, _REG_IDX_, 0, _VAL_ADDRESS)
-#define TFM_DT_REG_SIZE(node_id) TFM_DT_CAT4(node_id, _REG_IDX_, 0, _VAL_SIZE)
+#define TFM_DT_CAT(a, b)              a##b
+#define TFM_DT_CAT4(a, b, c, d)       a##b##c##d
+#define TFM_DT_CAT6(a, b, c, d, e, f) a##b##c##d##e##f
+
+#define TFM_DT_NODELABEL(label)     TFM_DT_CAT(DT_N_NODELABEL_, label)
+#define TFM_DT_CHOSEN(name)         TFM_DT_CAT(DT_CHOSEN_, name)
+#define TFM_DT_INST(inst, compat)   TFM_DT_CAT4(DT_N_INST_, inst, _, compat)
+#define TFM_DT_REG_ADDR(node_id)    TFM_DT_CAT4(node_id, _REG_IDX_, 0, _VAL_ADDRESS)
+#define TFM_DT_REG_SIZE(node_id)    TFM_DT_CAT4(node_id, _REG_IDX_, 0, _VAL_SIZE)
 #define TFM_DT_NODE_EXISTS(node_id) TFM_DT_CAT(node_id, _EXISTS)
+
+/* Resolve element idx of phandle-list property prop on node_id to a node id. */
+#define TFM_DT_PHANDLE_BY_IDX(node_id, prop, idx)                                                  \
+	TFM_DT_CAT6(node_id, _P_, prop, _IDX_, idx, _PH)
+
+/* Iterate fn(node_id, prop, idx) over each element of a phandle-list property.
+ * Pastes against the DT_N_<node>_P_<prop>_FOREACH_PROP_ELEM tokens that
+ * gen_defines emits per phandle-list property.
+ */
+#define TFM_DT_FOREACH_PROP_ELEM(node_id, prop, fn)                                                \
+	TFM_DT_CAT4(node_id, _P_, prop, _FOREACH_PROP_ELEM)(fn)
+
+/* "Does node_id have property prop set?" Pastes to 1 when set, to an
+ * undefined identifier (treated as 0 by #if and IF_ENABLED) otherwise.
+ */
+#define TFM_DT_PROP_EXISTS(node_id, prop) TFM_DT_CAT4(node_id, _P_, prop, _EXISTS)
+
+/* Sum-fold helper: produces "+<size of partition referenced at idx>" for
+ * one element of a phandle-list property. Plugged into TFM_DT_FOREACH_PROP_ELEM.
+ */
+#define TFM_DT_PROP_ELEM_REG_SIZE(node_id, prop, idx)                                              \
+	+TFM_DT_REG_SIZE(TFM_DT_PHANDLE_BY_IDX(node_id, prop, idx))
+
+/* Sum over one descriptor node's code-partitions / data-partitions.
+ * data-partitions is optional; the IF_ENABLED gate expands to nothing
+ * on nodes that omit it.
+ */
+#define TFM_DT_NODE_SUM_CODE(node_id)                                                              \
+	TFM_DT_FOREACH_PROP_ELEM(node_id, code_partitions, TFM_DT_PROP_ELEM_REG_SIZE)
+#define TFM_DT_NODE_SUM_DATA(node_id)                                                              \
+	IF_ENABLED(TFM_DT_PROP_EXISTS(node_id, data_partitions),                                   \
+		   (TFM_DT_FOREACH_PROP_ELEM(node_id, data_partitions,                              \
+					     TFM_DT_PROP_ELEM_REG_SIZE)))
 #endif
 
 /* This header file is included from linker scatter file as well, where only a
@@ -48,24 +80,45 @@
 #error "CONFIG_FLASH_SIZE not defined"
 #endif
 
-/* Size of a Secure and of a Non-secure image */
+/* Size of a single Secure / Non-Secure image slot (drives SECURE_IMAGE_MAX_SIZE).
+ *
+ * Picks code-partitions[0] of the first okay "nordic,tz-{secure,nonsecure}"
+ * descriptor. partition_check.c enforces (BUILD_ASSERT) that all
+ * code-partitions entries across all descriptor instances are equal-sized,
+ * so picking the first is sufficient.
+ */
 #if defined(CONFIG_PARTITION_MANAGER_ENABLED)
 #define FLASH_S_PARTITION_SIZE	(PM_TFM_SECURE_SIZE)
 #define FLASH_NS_PARTITION_SIZE (PM_TFM_NONSECURE_SIZE)
 #else
-#if TFM_DT_NODE_EXISTS(TFM_DT_NODELABEL(slot0_s_partition))
-/* When slot0_partition is the combined MCUboot slot, use slot0_s_partition
- * for the size of the secure-only sub-partition.
- */
-#define FLASH_S_PARTITION_SIZE	TFM_DT_REG_SIZE(TFM_DT_NODELABEL(slot0_s_partition))
-#else
-#define FLASH_S_PARTITION_SIZE	TFM_DT_REG_SIZE(TFM_DT_NODELABEL(slot0_partition))
-#endif
-#define FLASH_NS_PARTITION_SIZE TFM_DT_REG_SIZE(TFM_DT_NODELABEL(slot0_ns_partition))
+#define FLASH_S_PARTITION_SIZE                                                                     \
+	TFM_DT_REG_SIZE(TFM_DT_PHANDLE_BY_IDX(TFM_DT_INST(0, nordic_tz_secure), code_partitions, 0))
+#define FLASH_NS_PARTITION_SIZE                                                                    \
+	TFM_DT_REG_SIZE(                                                                           \
+		TFM_DT_PHANDLE_BY_IDX(TFM_DT_INST(0, nordic_tz_nonsecure), code_partitions, 0))
 #endif
 #define FLASH_MAX_PARTITION_SIZE                                                                   \
 	((FLASH_S_PARTITION_SIZE > FLASH_NS_PARTITION_SIZE) ? FLASH_S_PARTITION_SIZE               \
 							    : FLASH_NS_PARTITION_SIZE)
+
+/* Total flash footprint per security state: sum of all code-partitions and
+ * data-partitions reg sizes across every okay "nordic,tz-{secure,nonsecure}"
+ * descriptor. DTS-only; in PM builds the partition layout comes from
+ * pm_static.yml and these macros are not emitted.
+ */
+#if !defined(CONFIG_PARTITION_MANAGER_ENABLED)
+#if defined(DT_COMPAT_HAS_OKAY_nordic_tz_secure)
+#define FLASH_SECURE_TOTAL_SIZE                                                                    \
+	(0UL DT_FOREACH_OKAY_nordic_tz_secure(TFM_DT_NODE_SUM_CODE)                                \
+		 DT_FOREACH_OKAY_nordic_tz_secure(TFM_DT_NODE_SUM_DATA))
+#endif
+
+#if defined(DT_COMPAT_HAS_OKAY_nordic_tz_nonsecure)
+#define FLASH_NONSECURE_TOTAL_SIZE                                                                 \
+	(0UL DT_FOREACH_OKAY_nordic_tz_nonsecure(TFM_DT_NODE_SUM_CODE)                             \
+		 DT_FOREACH_OKAY_nordic_tz_nonsecure(TFM_DT_NODE_SUM_DATA))
+#endif
+#endif /* !CONFIG_PARTITION_MANAGER_ENABLED */
 
 /* Sector size of the embedded flash hardware (erase/program).
  * Flash memory program/erase operations have a page granularity.
@@ -110,64 +163,68 @@
  */
 #define MCUBOOT_STATUS_MAX_ENTRIES (0)
 
-/* Protected Storage (PS) partition */
+/* Protected Storage / ITS / OTP / Non-Secure storage.
+ *
+ * Non-PM builds resolve these by node label; the labels below are part
+ * of the public contract and any dtsi wiring up these TF-M services
+ * must use them. The data-partitions arrays only feed the aggregate
+ * FLASH_*_TOTAL_SIZE numbers and partition_check.c's contiguity check;
+ * they don't identify which entry is which service.
+ */
 #if defined(CONFIG_PARTITION_MANAGER_ENABLED)
 #ifdef PM_TFM_PS_ADDRESS
 #define FLASH_PS_AREA_OFFSET (PM_TFM_PS_ADDRESS)
 #define FLASH_PS_AREA_SIZE   (PM_TFM_PS_SIZE)
 #endif
-#else
-#if TFM_DT_NODE_EXISTS(TFM_DT_NODELABEL(tfm_ps_partition))
+#elif TFM_DT_NODE_EXISTS(TFM_DT_NODELABEL(tfm_ps_partition))
 #define FLASH_PS_AREA_OFFSET TFM_DT_REG_ADDR(TFM_DT_NODELABEL(tfm_ps_partition))
 #define FLASH_PS_AREA_SIZE   TFM_DT_REG_SIZE(TFM_DT_NODELABEL(tfm_ps_partition))
 #endif
-#endif /* CONFIG_PARTITION_MANAGER_ENABLED */
 
-/* Internal Trusted Storage (ITS) Service definitions */
 #if defined(CONFIG_PARTITION_MANAGER_ENABLED)
 #ifdef PM_TFM_ITS_ADDRESS
 #define FLASH_ITS_AREA_OFFSET (PM_TFM_ITS_ADDRESS)
 #define FLASH_ITS_AREA_SIZE   (PM_TFM_ITS_SIZE)
 #endif
-#else
-#if TFM_DT_NODE_EXISTS(TFM_DT_NODELABEL(tfm_its_partition))
+#elif TFM_DT_NODE_EXISTS(TFM_DT_NODELABEL(tfm_its_partition))
 #define FLASH_ITS_AREA_OFFSET TFM_DT_REG_ADDR(TFM_DT_NODELABEL(tfm_its_partition))
 #define FLASH_ITS_AREA_SIZE   TFM_DT_REG_SIZE(TFM_DT_NODELABEL(tfm_its_partition))
 #endif
-#endif /* CONFIG_PARTITION_MANAGER_ENABLED */
 
-/* OTP / NV counters partition */
 #define FLASH_OTP_NV_COUNTERS_SECTOR_SIZE (FLASH_AREA_IMAGE_SECTOR_SIZE)
 #if defined(CONFIG_PARTITION_MANAGER_ENABLED)
 #ifdef PM_TFM_OTP_NV_COUNTERS_ADDRESS
 #define FLASH_OTP_NV_COUNTERS_AREA_OFFSET (PM_TFM_OTP_NV_COUNTERS_ADDRESS)
 #define FLASH_OTP_NV_COUNTERS_AREA_SIZE	  (PM_TFM_OTP_NV_COUNTERS_SIZE)
 #endif
-#else
-#if TFM_DT_NODE_EXISTS(TFM_DT_NODELABEL(tfm_otp_partition))
+#elif TFM_DT_NODE_EXISTS(TFM_DT_NODELABEL(tfm_otp_partition))
 #define FLASH_OTP_NV_COUNTERS_AREA_OFFSET TFM_DT_REG_ADDR(TFM_DT_NODELABEL(tfm_otp_partition))
 #define FLASH_OTP_NV_COUNTERS_AREA_SIZE	  TFM_DT_REG_SIZE(TFM_DT_NODELABEL(tfm_otp_partition))
 #endif
-#endif /* CONFIG_PARTITION_MANAGER_ENABLED */
 
-/* Non-secure storage region */
 #if defined(CONFIG_PARTITION_MANAGER_ENABLED)
 #if defined(PM_NONSECURE_STORAGE_ADDRESS)
 #define NRF_FLASH_NS_STORAGE_AREA_OFFSET (PM_NONSECURE_STORAGE_ADDRESS)
 #define NRF_FLASH_NS_STORAGE_AREA_SIZE	 (PM_NONSECURE_STORAGE_SIZE)
 #endif
-#else
-#if TFM_DT_NODE_EXISTS(TFM_DT_NODELABEL(storage_partition))
+#elif TFM_DT_NODE_EXISTS(TFM_DT_NODELABEL(storage_partition))
 #define NRF_FLASH_NS_STORAGE_AREA_OFFSET TFM_DT_REG_ADDR(TFM_DT_NODELABEL(storage_partition))
 #define NRF_FLASH_NS_STORAGE_AREA_SIZE	 TFM_DT_REG_SIZE(TFM_DT_NODELABEL(storage_partition))
 #endif
-#endif /* CONFIG_PARTITION_MANAGER_ENABLED */
 
-/* Offset and size definition in flash area used by assemble.py */
+/* Non-Secure starts at the end of the entire Secure footprint (code +
+ * data), not just past the code slot. When FLASH_SECURE_TOTAL_SIZE is
+ * available use it directly; otherwise fall back to "just past the code
+ * slot", which is only correct when there are no secure data partitions.
+ */
 #define SECURE_IMAGE_OFFSET   (0x0)
 #define SECURE_IMAGE_MAX_SIZE FLASH_S_PARTITION_SIZE
 
-#define NON_SECURE_IMAGE_OFFSET	  (SECURE_IMAGE_OFFSET + SECURE_IMAGE_MAX_SIZE)
+#if defined(FLASH_SECURE_TOTAL_SIZE)
+#define NON_SECURE_IMAGE_OFFSET (SECURE_IMAGE_OFFSET + FLASH_SECURE_TOTAL_SIZE)
+#else
+#define NON_SECURE_IMAGE_OFFSET (SECURE_IMAGE_OFFSET + SECURE_IMAGE_MAX_SIZE)
+#endif
 #define NON_SECURE_IMAGE_MAX_SIZE FLASH_NS_PARTITION_SIZE
 
 /*

--- a/modules/trusted-firmware-m/tfm_boards/partition/partition_check.c
+++ b/modules/trusted-firmware-m/tfm_boards/partition/partition_check.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Validity checks for the TrustZone partition layout declared in devicetree.
+ *
+ * Lives in a .c file (not flash_layout.h) because the header is also pulled
+ * in by linker scripts, which can't expand BUILD_ASSERT or the full
+ * <zephyr/devicetree.h> macro set.
+ *
+ * Skipped under the Partition Manager where pm_static.yml is the source of
+ * truth and FLASH_*_PARTITION_SIZE may legitimately diverge from DTS.
+ *
+ * Both nordic,tz-{secure,nonsecure} descriptors are guaranteed to exist in
+ * any non-PM build that reaches this file: flash_layout.h #errors otherwise.
+ */
+
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+#include <stdint.h>
+
+#include "flash_layout.h"
+
+#if !defined(CONFIG_PARTITION_MANAGER_ENABLED)
+
+struct tfm_tz_part {
+	uint32_t start;
+	uint32_t end;
+};
+
+struct tfm_tz_summary {
+	uint32_t min_start;
+	uint32_t max_end;
+	uint32_t sum_size;
+};
+
+#define TFM_TZ_PART_FROM_PH(node_id, prop, idx)                                                    \
+	{                                                                                          \
+		.start = DT_REG_ADDR(DT_PHANDLE_BY_IDX(node_id, prop, idx)),                       \
+		.end = DT_REG_ADDR(DT_PHANDLE_BY_IDX(node_id, prop, idx)) +                        \
+		       DT_REG_SIZE(DT_PHANDLE_BY_IDX(node_id, prop, idx)),                         \
+	},
+
+/* data-partitions is optional. */
+#define TFM_TZ_PARTS_FROM_NODE(node_id)                                                            \
+	DT_FOREACH_PROP_ELEM(node_id, code_partitions, TFM_TZ_PART_FROM_PH)                        \
+	IF_ENABLED(DT_NODE_HAS_PROP(node_id, data_partitions),                                     \
+		   (DT_FOREACH_PROP_ELEM(node_id, data_partitions, TFM_TZ_PART_FROM_PH)))
+
+/* Emits "(size == ref) &&" per element which is chained with a trailing 1 below to
+ * fold into a single boolean for BUILD_ASSERT.
+ */
+#define TFM_TZ_SIZE_EQ(node_id, prop, idx, ref_size)                                               \
+	(DT_REG_SIZE(DT_PHANDLE_BY_IDX(node_id, prop, idx)) == (ref_size)) &&
+
+#define TFM_TZ_CODE_SIZES_EQ(node_id, ref_size)                                                    \
+	DT_FOREACH_PROP_ELEM_VARGS(node_id, code_partitions, TFM_TZ_SIZE_EQ, ref_size)
+
+static const struct tfm_tz_part tfm_tz_secure_parts[] = {
+	DT_FOREACH_STATUS_OKAY(nordic_tz_secure, TFM_TZ_PARTS_FROM_NODE)
+};
+
+static const struct tfm_tz_part tfm_tz_nonsecure_parts[] = {
+	DT_FOREACH_STATUS_OKAY(nordic_tz_nonsecure, TFM_TZ_PARTS_FROM_NODE)
+};
+
+BUILD_ASSERT(
+	(DT_FOREACH_STATUS_OKAY_VARGS(nordic_tz_secure, TFM_TZ_CODE_SIZES_EQ,
+				      FLASH_S_PARTITION_SIZE) 1),
+	"All entries of nordic,tz-secure code-partitions must have equal reg size "
+	"(single-slot size; multi-slot layouts must match across all instances)");
+
+BUILD_ASSERT(
+	(DT_FOREACH_STATUS_OKAY_VARGS(nordic_tz_nonsecure, TFM_TZ_CODE_SIZES_EQ,
+				      FLASH_NS_PARTITION_SIZE) 1),
+	"All entries of nordic,tz-nonsecure code-partitions must have equal reg size "
+	"(single-slot size; multi-slot layouts must match across all instances)");
+
+/* Total fit isn't implied by the runtime contiguity check: a contiguous
+ * block can still overflow the flash device.
+ */
+#if defined(FLASH_SECURE_TOTAL_SIZE) && defined(FLASH_NONSECURE_TOTAL_SIZE)
+BUILD_ASSERT((SECURE_IMAGE_OFFSET + FLASH_SECURE_TOTAL_SIZE + FLASH_NONSECURE_TOTAL_SIZE) <=
+		     FLASH_TOTAL_SIZE,
+	     "TrustZone partitions extend past the end of the flash device");
+#endif
+
+static inline struct tfm_tz_summary tfm_tz_summarize(const struct tfm_tz_part *parts, size_t n)
+{
+	struct tfm_tz_summary s = { .min_start = UINT32_MAX, .max_end = 0, .sum_size = 0 };
+
+	for (size_t i = 0; i < n; i++) {
+		if (parts[i].start < s.min_start) {
+			s.min_start = parts[i].start;
+		}
+		if (parts[i].end > s.max_end) {
+			s.max_end = parts[i].end;
+		}
+		s.sum_size += parts[i].end - parts[i].start;
+	}
+	return s;
+}
+
+void tfm_tz_partition_check(void)
+{
+	const struct tfm_tz_summary secure =
+		tfm_tz_summarize(tfm_tz_secure_parts, ARRAY_SIZE(tfm_tz_secure_parts));
+	const struct tfm_tz_summary nonsecure =
+		tfm_tz_summarize(tfm_tz_nonsecure_parts, ARRAY_SIZE(tfm_tz_nonsecure_parts));
+
+	__ASSERT(secure.sum_size == (secure.max_end - secure.min_start),
+		 "Secure TrustZone partitions (code + data) are not contiguous");
+	__ASSERT(secure.min_start == SECURE_IMAGE_OFFSET,
+		 "Secure partitions must start at SECURE_IMAGE_OFFSET (0x0)");
+	__ASSERT(secure.sum_size == FLASH_SECURE_TOTAL_SIZE,
+		 "FLASH_SECURE_TOTAL_SIZE macro does not match runtime sum");
+
+	__ASSERT(nonsecure.sum_size == (nonsecure.max_end - nonsecure.min_start),
+		 "Non-Secure TrustZone partitions (code + data) are not contiguous");
+	__ASSERT(nonsecure.sum_size == FLASH_NONSECURE_TOTAL_SIZE,
+		 "FLASH_NONSECURE_TOTAL_SIZE macro does not match runtime sum");
+
+	__ASSERT(nonsecure.min_start == secure.max_end,
+		 "Non-Secure partitions must begin exactly where Secure partitions end");
+}
+
+#else /* CONFIG_PARTITION_MANAGER_ENABLED */
+
+void tfm_tz_partition_check(void)
+{
+}
+
+#endif /* !CONFIG_PARTITION_MANAGER_ENABLED */

--- a/modules/trusted-firmware-m/tfm_boards/partition/partition_check.h
+++ b/modules/trusted-firmware-m/tfm_boards/partition/partition_check.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef __TFM_TZ_PARTITION_CHECK_H__
+#define __TFM_TZ_PARTITION_CHECK_H__
+
+/**
+ * Runtime sanity check for the TrustZone partition layout.
+ *
+ * Verifies that the {code,data}-partitions referenced via every okay
+ * "nordic,tz-{secure,nonsecure}" descriptor form a single contiguous
+ * block per security state, that secure starts at SECURE_IMAGE_OFFSET,
+ * and that non-secure begins exactly where secure ends.
+ *
+ * Call once from platform init. Compile-time invariants on the same
+ * layout (equal slot sizes, total flash fit) are enforced via
+ * BUILD_ASSERT in partition_check.c.
+ */
+void tfm_tz_partition_check(void);
+
+#endif /* __TFM_TZ_PARTITION_CHECK_H__ */

--- a/modules/trusted-firmware-m/tfm_boards/partition/region_defs.h
+++ b/modules/trusted-firmware-m/tfm_boards/partition/region_defs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -35,38 +35,41 @@
 #endif /* NRF_NS_SECONDARY */
 #define NS_IMAGE_PRIMARY_PARTITION_OFFSET (PM_TFM_NONSECURE_ADDRESS)
 #else
-/* DTS-based partition offsets. */
+/* DTS-based partition offsets. code-partitions[0] is the primary slot;
+ * code-partitions[1], when present, is the secondary slot.
+ */
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET                                                           \
+	TFM_DT_REG_ADDR(TFM_DT_PHANDLE_BY_IDX(TFM_DT_INST(0, nordic_tz_secure), code_partitions, 0))
 #ifdef NRF_NS_SECONDARY
-#define S_IMAGE_PRIMARY_PARTITION_OFFSET   TFM_DT_REG_ADDR(TFM_DT_NODELABEL(slot0_partition))
-#define S_IMAGE_SECONDARY_PARTITION_OFFSET TFM_DT_REG_ADDR(TFM_DT_NODELABEL(slot1_partition))
-#else
-#define S_IMAGE_PRIMARY_PARTITION_OFFSET   TFM_DT_REG_ADDR(TFM_DT_NODELABEL(slot0_partition))
-#endif /* NRF_NS_SECONDARY */
-#define NS_IMAGE_PRIMARY_PARTITION_OFFSET TFM_DT_REG_ADDR(TFM_DT_NODELABEL(slot0_ns_partition))
+#define S_IMAGE_SECONDARY_PARTITION_OFFSET                                                         \
+	TFM_DT_REG_ADDR(TFM_DT_PHANDLE_BY_IDX(TFM_DT_INST(0, nordic_tz_secure), code_partitions, 1))
+#endif
+
+#define NS_IMAGE_PRIMARY_PARTITION_OFFSET                                                          \
+	TFM_DT_REG_ADDR(                                                                           \
+		TFM_DT_PHANDLE_BY_IDX(TFM_DT_INST(0, nordic_tz_nonsecure), code_partitions, 0))
 #endif /* CONFIG_PARTITION_MANAGER_ENABLED */
 #else
 #error "Execute from secondary partition is not supported!"
 #endif /* !defined(LINK_TO_SECONDARY_PARTITION) */
 
-/* Secure regions */
+/* Secure code lives after the MCUboot header. TFM_MCUBOOT_OFFSET is the
+ * MCUboot header size (CONFIG_TFM_MCUBOOT_HEADER_SIZE, 0 on non-MCUboot
+ * builds): it is added to the slot start and subtracted from the slot
+ * size to skip over the header.
+ */
 #if defined(CONFIG_PARTITION_MANAGER_ENABLED)
 #define S_CODE_START (PM_TFM_OFFSET)
 #define S_CODE_SIZE  (PM_TFM_SIZE)
-#elif TFM_DT_NODE_EXISTS(TFM_DT_NODELABEL(slot0_s_partition))
-/* When slot0_partition is the combined MCUboot slot containing sub-partitions,
- * use slot0_s_partition for the secure-only size and start address.
- * BL2_HEADER_SIZE (= CONFIG_ROM_START_OFFSET, 0x200 with MCUboot) skips the
- * MCUboot header at the start of the combined slot. BL2_HEADER_SIZE is also
- * used by target_cfg.c to locate the NS vector table, keeping both in sync.
- * This is a bit of a hack to get around handing the offset manually in TF-m.
- */
-#define S_CODE_START (TFM_DT_REG_ADDR(TFM_DT_NODELABEL(slot0_s_partition)) + \
-		      TFM_MCUBOOT_OFFSET)
-#define S_CODE_SIZE  (TFM_DT_REG_SIZE(TFM_DT_NODELABEL(slot0_s_partition)) - \
-		      TFM_MCUBOOT_OFFSET)
 #else
-#define S_CODE_START TFM_DT_REG_ADDR(TFM_DT_NODELABEL(slot0_partition))
-#define S_CODE_SIZE  TFM_DT_REG_SIZE(TFM_DT_NODELABEL(slot0_partition))
+#define S_CODE_START                                                                               \
+	(TFM_DT_REG_ADDR(                                                                          \
+		 TFM_DT_PHANDLE_BY_IDX(TFM_DT_INST(0, nordic_tz_secure), code_partitions, 0)) +    \
+	 TFM_MCUBOOT_OFFSET)
+#define S_CODE_SIZE                                                                                \
+	(TFM_DT_REG_SIZE(                                                                          \
+		 TFM_DT_PHANDLE_BY_IDX(TFM_DT_INST(0, nordic_tz_secure), code_partitions, 0)) -    \
+	 TFM_MCUBOOT_OFFSET)
 #endif
 #define S_CODE_LIMIT (S_CODE_START + S_CODE_SIZE - 1)
 
@@ -123,13 +126,20 @@
 
 #endif /* CONFIG_CPU_HAS_NRF_IDAU */
 
-/* Non-secure regions */
+/* Non-Secure code. Unlike S_CODE_*, no MCUboot header offset is
+ * applied here: the MCUboot header sits at the start of the secure
+ * slot and is already accounted for by S_CODE_START.
+ */
 #if defined(CONFIG_PARTITION_MANAGER_ENABLED)
 #define NS_CODE_START (PM_APP_OFFSET)
 #define NS_CODE_SIZE  (PM_APP_SIZE)
 #else
-#define NS_CODE_START TFM_DT_REG_ADDR(TFM_DT_NODELABEL(slot0_ns_partition))
-#define NS_CODE_SIZE  TFM_DT_REG_SIZE(TFM_DT_NODELABEL(slot0_ns_partition))
+#define NS_CODE_START                                                                              \
+	TFM_DT_REG_ADDR(                                                                           \
+		TFM_DT_PHANDLE_BY_IDX(TFM_DT_INST(0, nordic_tz_nonsecure), code_partitions, 0))
+#define NS_CODE_SIZE                                                                               \
+	TFM_DT_REG_SIZE(                                                                           \
+		TFM_DT_PHANDLE_BY_IDX(TFM_DT_INST(0, nordic_tz_nonsecure), code_partitions, 0))
 #endif
 #define NS_CODE_LIMIT (NS_CODE_START + NS_CODE_SIZE - 1)
 

--- a/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -36,3 +36,18 @@
 		};
 	};
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+	};
+};

--- a/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp_ns_dfu.overlay
+++ b/samples/bluetooth/mesh/light/boards/nrf5340dk_nrf5340_cpuapp_ns_dfu.overlay
@@ -58,3 +58,20 @@
 		};
 	};
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>,
+				  <&slot1_s_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>,
+				  <&slot1_ns_partition>;
+	};
+};

--- a/samples/bluetooth/mesh/light_ctrl/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/mesh/light_ctrl/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -37,6 +37,21 @@
 	};
 };
 
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+	};
+};
+
 &pwm0 {
 	status = "okay";
 	pinctrl-0 = <&pwm0_default_alt>;

--- a/samples/bluetooth/mesh/light_ctrl/boards/nrf5340dk_nrf5340_cpuapp_ns_emds.overlay
+++ b/samples/bluetooth/mesh/light_ctrl/boards/nrf5340dk_nrf5340_cpuapp_ns_emds.overlay
@@ -107,6 +107,25 @@
 	};
 };
 
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};
+
 &pwm0 {
 	status = "okay";
 	pinctrl-0 = <&pwm0_default_alt>;

--- a/samples/bluetooth/mesh/light_dimmer/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/mesh/light_dimmer/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -36,3 +36,18 @@
 		};
 	};
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+	};
+};

--- a/samples/bluetooth/mesh/light_switch/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/mesh/light_switch/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -36,3 +36,18 @@
 		};
 	};
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+	};
+};

--- a/samples/bluetooth/mesh/silvair_enocean/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/mesh/silvair_enocean/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -36,3 +36,18 @@
 		};
 	};
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+	};
+};

--- a/samples/cellular/at_client/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/samples/cellular/at_client/boards/nrf9151dk_nrf9151_ns.overlay
@@ -7,3 +7,19 @@
 #include <samples/cellular/nrf91_no_bootloader_partitions.dtsi>
 
 #include <samples/cellular/nrf91_sram_partitions.dtsi>
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/cellular/at_client/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/samples/cellular/at_client/boards/nrf9160dk_nrf9160_ns.overlay
@@ -7,3 +7,20 @@
 #include <samples/cellular/nrf91_no_bootloader_partitions.dtsi>
 
 #include <samples/cellular/nrf91_sram_partitions.dtsi>
+
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/cellular/at_client/boards/nrf9161dk_nrf9161_ns.overlay
+++ b/samples/cellular/at_client/boards/nrf9161dk_nrf9161_ns.overlay
@@ -7,3 +7,20 @@
 #include <samples/cellular/nrf91_no_bootloader_partitions.dtsi>
 
 #include <samples/cellular/nrf91_sram_partitions.dtsi>
+
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/tests/tfm/tfm_psa_test/CMakeLists.txt
+++ b/tests/tfm/tfm_psa_test/CMakeLists.txt
@@ -119,6 +119,7 @@ ExternalProject_Add(tfm_psa_arch_test_app
                 -DT_COSE_PATH=${CONFIG_TFM_T_COSE_PATH}
                 -DCMAKE_BUILD_TYPE=${tfm_ns_CMAKE_BUILD_TYPE}
                 -DTEST_PSA_API=${TEST_PSA_API}
+                -DZEPHYR_BASE=${ZEPHYR_BASE}
                 -DZEPHYR_NRF_MODULE_DIR=${ZEPHYR_NRF_MODULE_DIR}
                 -DTFM_BOARDS_NRF_DIR=${TFM_BOARDS_NRF_DIR}
                 -DNRF_CONFIG_CPU_FREQ_MHZ=${CONFIG_TFM_CPU_FREQ_MHZ}

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 7e13730f40a0717e56dd2f5b92e6d4fbeacd60cb
+      revision: pull/4063/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Proposed alternative way of interfacing dts with TF-m. 
This also includes an updated partition check that enforces some partitioning rules and throw useful errors at the users to help make partitioning work easier. 