### PR TITLE
samples: radio_test: Support finite packet count in duty cycle TX

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -367,6 +367,9 @@ Peripheral samples
     * ``set_channel_sequence_hopping_mode`` shell command that allows for setting the hopping mode for the channel sequence.
     * Support for pin debugging of radio events on nRF54L Series devices.
 
+  * Updated the ``start_duty_cycle_modulated_tx`` command to accept an optional argument specifying the number of packets to transmit.
+    If no additional argument is provided, the command works as before.
+
 PMIC samples
 ------------
 

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -81,7 +81,7 @@ User interface
    :header-rows: 1
 
    * - Command
-     - Argument
+     - Arguments
      - Description
    * - cancel
      -
@@ -120,7 +120,11 @@ User interface
      - Start channel for the sweep or the channel for the constant carrier (in MHz, as difference from 2400 MHz).
    * - start_duty_cycle_modulated_tx
      - <duty_cycle>
+
+       <packet_num> (optional)
      - Duty cycle as a percentage (two decimal digits, ranging from 01 to 90).
+
+       Number of packets to transmit (default is 0, which means continuous TX).
    * - start_rx
      - <packet_num>
      - Start RX (continuous RX mode is used if no argument is provided).

--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -254,6 +254,12 @@ static void tx_modulated_carrier_end(void)
 	printk("The modulated TX has finished\n");
 }
 
+static void tx_modulated_carrier_duty_cycle_end(void)
+{
+	printk("The modulated TX duty cycle has finished\n");
+}
+
+
 static void rx_end(void)
 {
 	uint32_t recv_pkt, req_pkt;
@@ -328,13 +334,14 @@ static int cmd_duty_cycle_set(const struct shell *shell, size_t argc,
 			      char **argv)
 {
 	uint32_t duty_cycle;
+	uint32_t packets_num = 0;
 
 	if (argc == 1) {
 		shell_help(shell);
 		return SHELL_CMD_HELP_PRINTED;
 	}
 
-	if (argc > 2) {
+	if (argc > 3) {
 		shell_error(shell, "%s: bad parameters count.", argv[0]);
 		return -EINVAL;
 	}
@@ -346,13 +353,21 @@ static int cmd_duty_cycle_set(const struct shell *shell, size_t argc,
 		return -EINVAL;
 	}
 
+	memset(&test_config, 0, sizeof(test_config));
+
+	if (argc == 3) {
+		packets_num = atoi(argv[2]);
+		if (packets_num > 0) {
+			test_config.params.modulated_tx_duty_cycle.cb =
+				tx_modulated_carrier_duty_cycle_end;
+		}
+	}
+
 	config.duty_cycle = duty_cycle;
 
 #if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	ieee_channel_check(shell, config.channel_start);
 #endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
-
-	memset(&test_config, 0, sizeof(test_config));
 	test_config.type = MODULATED_TX_DUTY_CYCLE;
 	test_config.mode = config.mode;
 	test_config.params.modulated_tx_duty_cycle.txpower = config.txpower;
@@ -361,6 +376,7 @@ static int cmd_duty_cycle_set(const struct shell *shell, size_t argc,
 		config.channel_start;
 	test_config.params.modulated_tx_duty_cycle.duty_cycle =
 		config.duty_cycle;
+	test_config.params.modulated_tx_duty_cycle.packets_num = packets_num;
 #if CONFIG_FEM
 	test_config.fem = config.fem;
 #endif /* CONFIG_FEM */
@@ -1699,7 +1715,7 @@ SHELL_CMD_REGISTER(transmit_pattern,
 		   cmd_transmit_pattern_set);
 SHELL_CMD_REGISTER(start_duty_cycle_modulated_tx, NULL,
 		   "Duty cycle in percent (two decimal digits, between 01 and "
-		   "90) <duty_cycle>", cmd_duty_cycle_set);
+		   "90) <duty_cycle> Optional <num_packets> to send", cmd_duty_cycle_set);
 SHELL_CMD_REGISTER(parameters_print, NULL,
 		   "Print current delay, channel and so on",
 		   cmd_print);

--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -1099,6 +1099,7 @@ static void radio_modulated_tx_carrier_duty_cycle(uint8_t mode, int8_t txpower,
 						  enum transmit_pattern pattern,
 						  uint32_t duty_cycle)
 {
+	tx_packet_cnt = 0;
 	/* Lookup table with time per byte in each radio MODE
 	 * Mapped per NRF_RADIO->MODE available on nRF5-series devices
 	 */
@@ -1491,6 +1492,10 @@ void on_radio_end(const struct radio_test_config *config)
 		config->params.modulated_tx.cb();
 	} else if (cancel_request) {
 		cancel();
+	} else if (config->type == MODULATED_TX_DUTY_CYCLE &&
+		tx_packet_cnt == config->params.modulated_tx_duty_cycle.packets_num) {
+		cancel();
+		config->params.modulated_tx_duty_cycle.cb();
 	} else if (config->type == MODULATED_TX ||
 			   config->type == TX_SWEEP_WITH_SLEEP_MODULATED) {
 		nrf_radio_task_trigger(NRF_RADIO, NRF_RADIO_TASK_START);

--- a/samples/peripheral/radio_test/src/radio_test.h
+++ b/samples/peripheral/radio_test/src/radio_test.h
@@ -178,6 +178,15 @@ struct radio_test_config {
 
 			/** Duty cycle. */
 			uint32_t duty_cycle;
+
+			/**
+			 * Number of packets to transmit.
+			 * Set to zero for continuous mode.
+			 */
+			uint32_t packets_num;
+
+			/** Callback to indicate that TX is finished. */
+			void (*cb)(void);
 		} modulated_tx_duty_cycle;
 
 		struct {


### PR DESCRIPTION
Add an optional <num_packets> argument to start_duty_cycle_modulated_tx so the duty cycle modulated TX can stop after a given number of packets instead of running continuously. When the count is reached, the test cancels and invokes a new completion callback. A value of zero keeps the existing continuous behavior.