### PR TITLE
sysbuild: Use ERASE_NONE when flashing UICR

### DIFF
--- a/applications/image_flasher/CMakeLists.txt
+++ b/applications/image_flasher/CMakeLists.txt
@@ -19,15 +19,11 @@ add_custom_target(runners_yaml_props_target)
 # Fetch hex file to flash from sysbuild
 zephyr_get(hex_file_to_flash SYSBUILD LOCAL VAR HEX_FILE)
 zephyr_get(base_image SYSBUILD LOCAL VAR IMAGE_FLASHER_SPECIFIC_IMAGE)
+zephyr_get(erase_mode SYSBUILD LOCAL VAR IMAGE_FLASHER_ERASE_MODE)
 
 if(NOT base_image)
   zephyr_get(base_image SYSBUILD GLOBAL VAR IMAGE_FLASHER_DEFAULT_IMAGE)
 endif()
-
-# Set hex_file property to point to the hex file
-set_target_properties(runners_yaml_props_target PROPERTIES
-  hex_file "${hex_file_to_flash}"
-)
 
 # Override the runners.yaml path to use CMAKE_CURRENT_BINARY_DIR/zephyr instead of
 # PROJECT_BINARY_DIR, this ensures runners.yaml is generated at <build>/softdevice/zephyr where
@@ -44,10 +40,21 @@ zephyr_file_copy(${base_image_binary_dir}/edt.pickle ${PROJECT_BINARY_DIR}/edt.p
 )
 import_kconfig(CONFIG_ ${base_image_binary_dir}/.config)
 
+# Allow erase mode to be set so UICR-targeted hex files can be written without a range-erase.
+if(erase_mode)
+  board_runner_args(nrfutil "--erase-mode=${erase_mode}")
+  board_runner_args(nrfjprog "--erase-mode=${erase_mode}")
+endif()
+
 # Manually include board configuration to enable automatic runners.yaml generation
 foreach(dir ${BOARD_DIRECTORIES})
   include(${dir}/board.cmake OPTIONAL)
 endforeach()
+
+# Set hex_file property to point to the hex file
+set_target_properties(runners_yaml_props_target PROPERTIES
+  hex_file "${hex_file_to_flash}"
+)
 
 # Include flash support to automatically generate runners.yaml
 include(${ZEPHYR_BASE}/cmake/flash/CMakeLists.txt)

--- a/sysbuild/image_flasher.cmake
+++ b/sysbuild/image_flasher.cmake
@@ -5,11 +5,11 @@
 #
 
 # Usage:
-#   add_image_flasher(NAME <name> HEX_FILE <hex_file>)
+#   add_image_flasher(NAME <name> HEX_FILE <hex_file> [BASE_IMAGE <image>] [ERASE_MODE <mode>])
 #
 # Adds a sysbuild image which will flash the hex file when `west flash` is invoked.
 function(add_image_flasher)
-  set(single_args NAME HEX_FILE BASE_IMAGE)
+  set(single_args NAME HEX_FILE BASE_IMAGE ERASE_MODE)
   cmake_parse_arguments(args "" "${single_args}" "" ${ARGN})
 
   if(NOT args_NAME)
@@ -24,6 +24,14 @@ function(add_image_flasher)
 
   set(${args_NAME}_HEX_FILE "${args_HEX_FILE}" CACHE FILEPATH "Hex file to flash" FORCE)
   set(IMAGE_FLASHER_DEFAULT_IMAGE ${DEFAULT_IMAGE} CACHE STRING "Default image" FORCE)
+
+  if(args_ERASE_MODE)
+    set(VALID_ERASE_MODES none ranges all)
+    if(NOT args_ERASE_MODE IN_LIST VALID_ERASE_MODES)
+      message(FATAL_ERROR "ERASE_MODE must be one of: none, ranges, all")
+    endif()
+    set(${args_NAME}_IMAGE_FLASHER_ERASE_MODE "${args_ERASE_MODE}" CACHE STRING "Erase mode" FORCE)
+  endif()
 
   ExternalZephyrProject_Add(
     APPLICATION ${args_NAME}

--- a/sysbuild/secureboot.cmake
+++ b/sysbuild/secureboot.cmake
@@ -93,7 +93,7 @@ if(SB_CONFIG_SECURE_BOOT)
       )
 
       include(image_flasher.cmake)
-      add_image_flasher(NAME app_provision HEX_FILE "${CMAKE_BINARY_DIR}/app_provision.hex")
+      add_image_flasher(NAME app_provision HEX_FILE "${CMAKE_BINARY_DIR}/app_provision.hex" ERASE_MODE none)
     endif()
 
     set_target_properties(b0 PROPERTIES


### PR DESCRIPTION
With 91-series, attempting to flash the UICR with
ERASE_RANGES_TOUCHED_BY_FIRMWARE results in
`[jlink] INVALID_DEVICE_FOR_OPERATION (Nrfjlink)`.

Use ERASE_NONE with UICR.

---
(at least) b0 use is a requirement for this.

Error was observed with Serial Modem https://github.com/nrfconnect/ncs-serial-modem/pull/265 with DTS changes on top + changes from https://github.com/nrfconnect/sdk-nrf/pull/27973.

https://github.com/nrfconnect/sdk-nrf/pull/28250/changes allows the *_provision.hex image to be built correctly, but flashing still fails with 9151 DK.