### PR TITLE
tests: zephyr: drivers: spi: spi_loopback: Fix nrf9251/cpuppr overlay

### DIFF
--- a/boards/nordic/nrf9251dk/nrf9251dk_nrf9251_common.dtsi
+++ b/boards/nordic/nrf9251dk/nrf9251dk_nrf9251_common.dtsi
@@ -52,12 +52,4 @@
 			label = "LED3";
 		};
 	};
-
-	pwmleds {
-		compatible = "pwm-leds";
-
-		pwm_led0: pwm_led_0 {
-			pwms = <&pwm130 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
-		};
-	};
 };

--- a/boards/nordic/nrf9251dk/nrf9251dk_nrf9251_cpuapp.dts
+++ b/boards/nordic/nrf9251dk/nrf9251dk_nrf9251_cpuapp.dts
@@ -46,6 +46,14 @@
 		compatible = "zephyr,psa-crypto-rng";
 		status = "okay";
 	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm130 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
 };
 
 &gpio0 {

--- a/tests/zephyr/drivers/spi/spi_loopback/boards/nrf9251dk_nrf9251_common.dtsi
+++ b/tests/zephyr/drivers/spi/spi_loopback/boards/nrf9251dk_nrf9251_common.dtsi
@@ -59,6 +59,10 @@
 	status = "okay";
 };
 
+&gpio2 {
+	status = "okay";
+};
+
 &gpiote130 {
 	status = "okay";
 };

--- a/tests/zephyr/drivers/uart/uart_async_dual/boards/nrf9251dk_nrf9251_cpuppr.overlay
+++ b/tests/zephyr/drivers/uart/uart_async_dual/boards/nrf9251dk_nrf9251_cpuppr.overlay
@@ -6,6 +6,6 @@
 
 #include "nrf9251dk_nrf9251_common.dtsi"
 
-&timer137 {
+&timer133 {
 	interrupts = <435 (NRF_DEFAULT_IRQ_PRIORITY + 1)>;
 };


### PR DESCRIPTION
Fix overlay for the test.
On cpuppr all GPIO nodes are disabled by default.
Thus, if test uses some GPIO port it must be enabled in an overlay.