### PR TITLE
subsys: pcd: resolve app address from DTS when PM is disabled

### DIFF
--- a/subsys/pcd/src/pcd.c
+++ b/subsys/pcd/src/pcd.c
@@ -12,6 +12,7 @@
 #ifdef CONFIG_PCD_NET
 #ifdef CONFIG_PCD_READ_NETCORE_APP_VERSION
 #include <fw_info_bare.h>
+#include <zephyr/storage/flash_map.h>
 #endif
 #include <zephyr/storage/stream_flash.h>
 #endif
@@ -91,7 +92,11 @@ int pcd_find_fw_version(void)
 		return -EFAULT;
 	}
 
+#ifdef CONFIG_PARTITION_MANAGER_ENABLED
 	firmware_info = fw_info_find(PM_APP_ADDRESS);
+#else
+	firmware_info = fw_info_find(PARTITION_ADDRESS(s0_partition));
+#endif
 
 	if (firmware_info != NULL) {
 		memcpy((void *)pcd_cmd_p->data, &firmware_info->version, pcd_cmd_p->len);


### PR DESCRIPTION
pcd_find_fw_version() hard-coded fw_info_find(PM_APP_ADDRESS). That symbol is only defined by Partition Manager, so the subsystem failed to link in DTS-based builds.

Fall back to DT_REG_ADDR(DT_NODELABEL(s0_partition)) when PM is off, keeping the PM path unchanged for existing builds.