### PR TITLE
modules: trusted-firmware-m: Update provisioning for non-pm

### DIFF
--- a/modules/trusted-firmware-m/tfm_boards/common/nrf_provisioning.c
+++ b/modules/trusted-firmware-m/tfm_boards/common/nrf_provisioning.c
@@ -16,7 +16,9 @@
 #include "nrf_provisioning.h"
 #include <identity_key.h>
 #include <tfm_spm_log.h>
+#if defined(CONFIG_PARTITION_MANAGER_ENABLED)
 #include <pm_config.h>
+#endif
 #if defined(NRF53_SERIES) && (defined(PM_CPUNET_APP_ADDRESS) || defined(CONFIG_TFM_HAS_B0N))
 #include <dfu/pcd_common.h>
 #include <spu.h>
@@ -138,7 +140,7 @@ enum tfm_plat_err_t tfm_plat_provisioning_perform(void)
 		return TFM_PLAT_ERR_SYSTEM_ERR;
 	}
 
-#if defined(NRF53_SERIES) && defined(PM_CPUNET_APP_ADDRESS)
+#if defined(NRF53_SERIES) && (defined(PM_CPUNET_APP_ADDRESS) || defined(CONFIG_TFM_HAS_B0N))
 	/* Disable network core debug in here */
 	if (disable_netcore_debug() != TFM_PLAT_ERR_SUCCESS) {
 		return TFM_PLAT_ERR_SYSTEM_ERR;


### PR DESCRIPTION
nrf_provisioning.c unconditionally included <pm_config.h> and gated the network-core debug-lock path on PM_CPUNET_APP_ADDRESS, both of which prevented the file from compiling when CONFIG_PARTITION_MANAGER is disabled on nRF5340.