### PR TITLE
applications: hpf: update nRF7120 GPIO asm for zephyr-sdk 1.0

### DIFF
--- a/applications/hpf/gpio/src/hrt/hrt-nrf7120.s
+++ b/applications/hpf/gpio/src/hrt/hrt-nrf7120.s
@@ -1,6 +1,6 @@
 	.file	"hrt.c"
 	.option nopic
-	.attribute arch, "rv32e1p9_m2p0_c2p0_zicsr2p0"
+	.attribute arch, "rv32e2p0_m2p0_c2p0_zicsr2p0"
 	.attribute unaligned_access, 0
 	.attribute stack_align, 4
 	.text
@@ -77,3 +77,4 @@ hrt_set_masked_bits:
  #NO_APP
 	ret
 	.size	hrt_set_masked_bits, .-hrt_set_masked_bits
+	.section	.note.GNU-stack,"",@progbits


### PR DESCRIPTION
Regenerate the checked-in HPF GPIO HRT assembly for nRF7120 so it matches the assembler metadata emitted by zephyr-sdk 1.0 and passes the golden ASM check in CI.