### PR TITLE
tests: drivers: mspi: trap_handler: fix missing regex

### DIFF
--- a/tests/drivers/mspi/trap_handler/testcase.yaml
+++ b/tests/drivers/mspi/trap_handler/testcase.yaml
@@ -14,6 +14,9 @@ tests:
   drivers.mspi.hpf_trap_handler.l15:
     harness_config:
       fixture: external_flash
+      type: one_line
+      regex:
+        - ">>> HPF APP FATAL ERROR"
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:


### PR DESCRIPTION
Once harness_config is overwriten, all its parts needs to be copied.