### PR TITLE
Partition manager thread

### DIFF
--- a/dts/samples/openthread/nrf54l15_cpuapp_ns_partitions.dtsi
+++ b/dts/samples/openthread/nrf54l15_cpuapp_ns_partitions.dtsi
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Match DTS-only partitioning to the Partition Manager split. */
+&sram0_s {
+	reg = <0x0 0x13000>;
+	ranges = <0x0 0x0 0x13000>;
+};
+
+&sram0_ns {
+	reg = <0x13000 0x2d000>;
+	ranges = <0x0 0x13000 0x2d000>;
+};
+
+&slot0_partition {
+	reg = <0x00000000 0x40000>;
+};
+
+&tfm_ps_partition {
+	reg = <0x00046000 0x4000>;
+};
+
+&tfm_its_partition {
+	reg = <0x00040000 0x4000>;
+};
+
+&tfm_otp_partition {
+	reg = <0x00044000 0x2000>;
+};
+
+&slot0_ns_partition {
+	reg = <0x0004a000 0x12b000>;
+};
+
+&storage_partition {
+	reg = <0x00175000 0x8000>;
+};

--- a/samples/openthread/cli/Kconfig.sysbuild
+++ b/samples/openthread/cli/Kconfig.sysbuild
@@ -4,9 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Do not use partition manager on nRF52840 dongle.
 config PARTITION_MANAGER
-	default n if BOARD_NRF52840DONGLE_NRF52840
+	default n
 
 config NRF_DEFAULT_IPC_RADIO
 	default y if SOC_SERIES_NRF53

--- a/samples/openthread/cli/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
+++ b/samples/openthread/cli/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
@@ -4,12 +4,4 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-// restore full RRAM and SRAM space - by default some parts are dedicated to FLPR
-&cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1524)>;
-};
-
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(256)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
-};
+#include <samples/openthread/nrf54l15_cpuapp_ns_partitions.dtsi>

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -236,7 +236,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
     extra_args:
-      - cli_SNIPPET="ot-logging;ot-zephyr-l2;zperf"
+      - cli_SNIPPET="ot-ci;ot-logging;ot-zephyr-l2;zperf"
       - EXTRA_CONF_FILE="extra_conf/l2_logging.conf;extra_conf/multiprotocol.conf"
       - FILE_SUFFIX=ble
     integration_platforms:

--- a/samples/openthread/coap_client/Kconfig.sysbuild
+++ b/samples/openthread/coap_client/Kconfig.sysbuild
@@ -6,5 +6,8 @@
 
 source "share/sysbuild/Kconfig"
 
+config PARTITION_MANAGER
+	default n
+
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/openthread/coap_server/Kconfig.sysbuild
+++ b/samples/openthread/coap_server/Kconfig.sysbuild
@@ -6,6 +6,9 @@
 
 source "share/sysbuild/Kconfig"
 
+config PARTITION_MANAGER
+	default n
+
 config NRF_DEFAULT_IPC_RADIO
 	default y
 

--- a/samples/openthread/coprocessor/Kconfig.sysbuild
+++ b/samples/openthread/coprocessor/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/openthread/coprocessor/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
+++ b/samples/openthread/coprocessor/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <samples/openthread/nrf54l15_cpuapp_ns_partitions.dtsi>
+
 &uart20 {
 	current-speed = <1000000>;
 	status = "okay";
@@ -13,14 +15,4 @@
 	chosen {
 		zephyr,ot-uart = &uart20;
 	};
-};
-
-// restore full RRAM and SRAM space - by default some parts are dedicated to FLPR
-&cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1524)>;
-};
-
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(256)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };


### PR DESCRIPTION
* Set `PARTITION_MANAGER` default to `n` in all OpenThread sample
`Kconfig.sysbuild` files to consistently turn off sysbuild
Partition Manager for these samples.

* Change align the configraution and should stabilize the CI tests.

test_thread: PR-1561

