### PR TITLE
samples: cellular: Fix printing of GPS coordinates in nrf_cloud_multi_service

### DIFF
--- a/samples/cellular/nrf_cloud_multi_service/src/application.c
+++ b/samples/cellular/nrf_cloud_multi_service/src/application.c
@@ -188,7 +188,7 @@ static int send_gnss(const struct location_event_data * const loc_gnss)
  */
 static void on_location_update(const struct location_event_data * const location_data)
 {
-	LOG_INF("Location Updated: %.06f N %.06f W, accuracy: %.01f m, Method: %s",
+	LOG_INF("Location Updated: lat: %.06f, lon: %.06f, accuracy: %.01f m, Method: %s",
 		location_data->location.latitude,
 		location_data->location.longitude,
 		(double)location_data->location.accuracy,


### PR DESCRIPTION
The current log line shows wrong coordinates, for example the Stockholm office prints as 59.339759 N 18.013012 W which is incorrect; the correct location being 59.339759 N 18.013012 E (because positive longitude means "east"). Standard notation (ISO-6709) is to use either direction letters or integer sign; not both combined.

This PR aligns the format to what we have in other samples: signed values rather than direction letters.