### PR TITLE
net: dect: l2_dect: ft: fix: handle re-association 

### DIFF
--- a/drivers/dect/dect_mdm/dect_mdm.c
+++ b/drivers/dect/dect_mdm/dect_mdm.c
@@ -193,6 +193,7 @@ dect_mdm_child_association_list_add(uint32_t target_long_rd_id)
 	/* Return existing item if already in list */
 	ass_list_item = dect_mdm_child_association_list_item_get(target_long_rd_id);
 	if (ass_list_item != NULL) {
+		LOG_DBG("Re-association with child_long_rd_id %u", target_long_rd_id);
 		return ass_list_item;
 	}
 

--- a/drivers/dect/dect_mdm/dect_mdm_rx.c
+++ b/drivers/dect/dect_mdm/dect_mdm_rx.c
@@ -27,7 +27,7 @@
 LOG_MODULE_DECLARE(dect_mdm, CONFIG_DECT_MDM_LOG_LEVEL);
 
 K_MSGQ_DEFINE(dect_mdm_rx_th_op_event_msgq, sizeof(struct dect_mdm_common_op_event_msgq_item),
-	      10, 4);
+	      CONFIG_DECT_MDM_NRF_RX_MSGQ_SIZE, 4);
 
 #define DECT_MDM_RX_THREAD_STACK_SIZE CONFIG_DECT_MDM_NRF_RX_THREAD_STACK_SIZE
 #define DECT_MDM_RX_THREAD_PRIORITY   5

--- a/subsys/net/l2_dect/dect_net_l2.c
+++ b/subsys/net/l2_dect/dect_net_l2.c
@@ -735,6 +735,16 @@ void dect_net_l2_child_association_created(struct net_if *iface, uint32_t child_
 		child_long_rd_id);
 
 	k_mutex_lock(&associations_mutex, K_FOREVER);
+
+	/* Search for existing association */
+	for (int i = 0; i < ARRAY_SIZE(child_associations); i++) {
+		if (child_associations[i].in_use &&
+			child_associations[i].target_long_rd_id == child_long_rd_id) {
+			LOG_INF("Re-association with child_long_rd_id %u", child_long_rd_id);
+			k_mutex_unlock(&associations_mutex);
+			goto send_event;
+		}
+	}
 	for (int i = 0; i < ARRAY_SIZE(child_associations); i++) {
 		if (!child_associations[i].in_use) {
 			child_associations[i].in_use = true;
@@ -754,6 +764,8 @@ void dect_net_l2_child_association_created(struct net_if *iface, uint32_t child_
 	/* Do external calls outside of mutex to avoid lock ordering issues */
 	dect_net_l2_ipv6_addressing_child_added_handle(
 		assoc, iface, child_long_rd_id, first_child);
+
+send_event:
 	dect_mgmt_child_association_created_evt(iface, child_long_rd_id);
 
 	/* Put the carrier on if this was the first association */

--- a/subsys/net/l2_dect/dect_net_l2_ipv6.c
+++ b/subsys/net/l2_dect/dect_net_l2_ipv6.c
@@ -48,8 +48,10 @@ static void dect_net_l2_ipv6_util_global_nbr_add(
 			/* global: add a parent as a neighbor to dect iface */
 			if (!net_ipv6_nbr_add(iface, &nbr_addr, net_if_get_link_addr(iface), false,
 					      NET_IPV6_NBR_STATE_REACHABLE)) {
-				LOG_ERR("(%s): cannot add parents global addr as nbr to dect iface",
-					(__func__));
+				LOG_ERR("(%s): cannot add global addr (%s) as nbr to dect iface "
+					"(sink long RD ID %u, nbr long RD ID %u)",
+					(__func__), net_sprint_ipv6_addr(&nbr_addr),
+					sink_long_rd_id, nbr_long_rd_id);
 			} else {
 				*nbr_global_addr_was_set = true;
 				*nbr_global_ipv6_addr_out = nbr_addr;
@@ -85,7 +87,7 @@ static void dect_net_l2_ipv6_util_nbr_add(
 		/* local: add a parent as a neighbor to dect iface */
 		if (!net_ipv6_nbr_add(iface, &nbr_addr, net_if_get_link_addr(iface), false,
 				      NET_IPV6_NBR_STATE_REACHABLE)) {
-			LOG_ERR("(%s): cannot add parents local addr (%s) as nbr to dect iface",
+			LOG_ERR("(%s): cannot add local addr (%s) as nbr to dect iface",
 				(__func__), net_sprint_ipv6_addr(&nbr_addr));
 		} else {
 			*nbr_local_addr_was_set = true;
@@ -96,8 +98,8 @@ static void dect_net_l2_ipv6_util_nbr_add(
 				net_sprint_ll_addr(net_if_get_link_addr(iface)->addr, 8), iface);
 		}
 	} else {
-		LOG_ERR("(%s): cannot create parents local addr as nbr to dect iface",
-			(__func__));
+		LOG_ERR("(%s): cannot create local addr as nbr to dect iface for long RD ID %u",
+			(__func__), nbr_long_rd_id);
 	}
 	dect_net_l2_ipv6_util_global_nbr_add(
 		iface, ipv6_prefix_cfg, sink_long_rd_id, nbr_long_rd_id,


### PR DESCRIPTION
Handle re-association for child associations and assure that no duplicates are added into L2 association list.
Jira: DECT-1356

Additionally: taking existing CONFIG_DECT_MDM_NRF_RX_MSGQ_SIZE into use.