### PR TITLE
Applications: Audio: Removed defines

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
@@ -824,7 +824,8 @@ int broadcast_source_enable(struct broadcast_source_big const *const broadcast_p
 	}
 
 	if (!initialized) {
-		ret = bt_le_audio_tx_init(bt_le_audio_tx);
+		/* A broadcast source is the Bluetooth central device */
+		ret = bt_le_audio_tx_init(bt_le_audio_tx, true);
 		if (ret != 0) {
 			LOG_ERR("Failed to initialize LE Audio TX: %d", ret);
 			return ret;

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
@@ -470,17 +470,15 @@ static int tx_controller_sync_and_correct(struct bt_le_audio_tx_ctx *ctx,
 			LOG_DBG("TX clock corrected by (%lld us). Early", ctx->corr_diff_us);
 			ctx->ts_ctlr_esti_us_valid = false;
 		} else {
-			if (CONFIG_AUDIO_DEV == HEADSET) {
-				LOG_DBG("TX clock has been drift adjusted by (%lld us)",
-					ctx->corr_diff_us);
-				ctx->ts_ctlr_esti_us_valid = true;
-			}
-
-			if (CONFIG_AUDIO_DEV == GATEWAY) {
+			if (ctx->is_ble_clock_master) {
 				/* The gateway is the Bluetooth central. This shall not happen */
 				LOG_ERR("TX clock has been drift adjusted by (%lld us)",
 					ctx->corr_diff_us);
 				ctx->ts_ctlr_esti_us_valid = false;
+			} else {
+				LOG_DBG("TX clock has been drift adjusted by (%lld us)",
+					ctx->corr_diff_us);
+				ctx->ts_ctlr_esti_us_valid = true;
 			}
 		}
 
@@ -658,7 +656,7 @@ int bt_le_audio_tx_stream_sent(struct bt_le_audio_tx_ctx *ctx, struct stream_ind
 	return 0;
 }
 
-int bt_le_audio_tx_init(struct bt_le_audio_tx_ctx *ctx)
+int bt_le_audio_tx_init(struct bt_le_audio_tx_ctx *ctx, bool is_clock_master)
 {
 	if (ctx == NULL || ctx->iso_tx_pool == NULL) {
 		return -EINVAL;
@@ -669,6 +667,7 @@ int bt_le_audio_tx_init(struct bt_le_audio_tx_ctx *ctx)
 	(void)memset(ctx, 0, sizeof(*ctx));
 
 	ctx->iso_tx_pool = tmp;
+	ctx->is_ble_clock_master = is_clock_master;
 
 	for (int i = 0; i < GROUP_MAX; i++) {
 		for (int j = 0; j < SUBGROUP_MAX; j++) {

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.h
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.h
@@ -82,6 +82,8 @@ struct bt_le_audio_tx_ctx {
 	bool ts_last_us_valid;
 	/* Should the data in the next function call be flushed */
 	bool flush_next;
+	/* This device is Bluetooth clock master (central/unicast client or broadcast source) */
+	bool is_ble_clock_master;
 };
 
 #define BT_LE_AUDIO_TX_DEFINE(name)                                                                \
@@ -144,11 +146,14 @@ int bt_le_audio_tx_stream_sent(struct bt_le_audio_tx_ctx *ctx, struct stream_ind
  * @brief	Initializes the TX path for ISO transmission.
  *
  * @param[in]	ctx		Pointer to TX context.
+ * @param[in]	is_clock_master	Set to true if this device is a Bluetooth central,
+ *				(Unicast client) or Broadcast source,
+ *				false = peripheral (unicast server) or Broadcast sink.
  *
  * @retval	-EINVAL		@p ctx is NULL or required configuration is missing.
  * @retval	0		Success.
  */
-int bt_le_audio_tx_init(struct bt_le_audio_tx_ctx *ctx);
+int bt_le_audio_tx_init(struct bt_le_audio_tx_ctx *ctx, bool is_clock_master);
 
 /**
  * @}

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -1967,7 +1967,8 @@ int unicast_client_enable(uint8_t cig_index, le_audio_receive_cb recv_cb)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_TX)) {
-		ret = bt_le_audio_tx_init(bt_le_audio_tx);
+		/* A unicast client is the Bluetooth central device */
+		ret = bt_le_audio_tx_init(bt_le_audio_tx, true);
 		if (ret) {
 			LOG_ERR("Failed to initialize LE Audio TX: %d", ret);
 			srv_store_unlock();

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_server.c
@@ -817,7 +817,8 @@ int unicast_server_enable(le_audio_receive_cb recv_cb, enum bt_audio_location lo
 	}
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_TX)) {
-		ret = bt_le_audio_tx_init(bt_le_audio_tx);
+		/* A unicast server is the Bluetooth peripheral device */
+		ret = bt_le_audio_tx_init(bt_le_audio_tx, false);
 		if (ret) {
 			LOG_ERR("Failed to initialize LE Audio TX: %d", ret);
 			return ret;

--- a/samples/bluetooth/nrf_auraconfig/sample.yaml
+++ b/samples/bluetooth/nrf_auraconfig/sample.yaml
@@ -13,6 +13,8 @@ common:
     - sysbuild
     - bluetooth
     - ci_samples_bluetooth
+    - ci_applications_nrf5340_audio
+    - ci_tests_nrf5340_audio
 tests:
   sample.bluetooth.nrf_auraconfig.build:
     extra_args: []

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -48,12 +48,6 @@
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-38898"
 
 - scenarios:
-    - sample.bluetooth.nrf_auraconfig.build
-  platforms:
-    - nrf5340_audio_dk/nrf5340/cpuapp
-  comment: "https://nordicsemi.atlassian.net/browse/OCT-3708"
-
-- scenarios:
     - sample.bluetooth.mesh_dfu_distributor
     - sample.bluetooth.mesh_dfu_distributor.dfu_ext_flash
     - sample.bluetooth.mesh_dfu_distributor.settings_ext_flash

--- a/tests/nrf5340_audio/bt_le_audio_tx/CMakeLists.txt
+++ b/tests/nrf5340_audio/bt_le_audio_tx/CMakeLists.txt
@@ -27,8 +27,3 @@ target_include_directories(app PRIVATE
   ${ZEPHYR_NRF_MODULE_DIR}/tests/nrf5340_audio/fakes/
   ${ZEPHYR_NRF_MODULE_DIR}/include
 )
-
-target_compile_options(app PRIVATE
-  -DHEADSET=1
-  -DGATEWAY=2
-)

--- a/tests/nrf5340_audio/bt_le_audio_tx/Kconfig
+++ b/tests/nrf5340_audio/bt_le_audio_tx/Kconfig
@@ -1,7 +1,3 @@
-config AUDIO_DEV
-	int
-	default 1
-
 config LC3_BITRATE_MIN
 	int
 	default 32000

--- a/tests/nrf5340_audio/bt_le_audio_tx/src/main.c
+++ b/tests/nrf5340_audio/bt_le_audio_tx/src/main.c
@@ -470,7 +470,7 @@ ZTEST(audio_tx, test_bad_parameters_tx_init)
 	/* Verifies argument validation for NULL input pointers. */
 	int ret;
 
-	ret = bt_le_audio_tx_init(NULL);
+	ret = bt_le_audio_tx_init(NULL, true);
 	zassert_equal(-EINVAL, ret, "ret %d", ret);
 }
 
@@ -565,7 +565,10 @@ static void before_fn(void *f)
 	audio_sync_timer_capture_fake.return_val = 0;
 
 	FFF_RESET_HISTORY();
-	zassert_equal(0, bt_le_audio_tx_init(audio_tx_ctx));
+	/* Initialize the TX context as a Bluetooth central device
+	 * At current time, this only impacts print options.
+	 */
+	zassert_equal(0, bt_le_audio_tx_init(audio_tx_ctx, true));
 }
 
 ZTEST_SUITE(audio_tx, NULL, NULL, before_fn, NULL, NULL);


### PR DESCRIPTION
The use of HEADSET, GATEWAY, and AUDIO_DEV defines have been removed from le_audio_tx.
This caused a build issue with auraconfig, which don't use these. Tests updated, and quarantine removed.

OCT-3708