### PR TITLE
Show of  fix  for NCSDK-38824

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -4520,6 +4520,9 @@ NCSDK-38824: Bluetooth LE SMP MCUmgr image erase request causes NMP timeout and 
 
   **Affected plafforms:** nRF54L Series devices
 
+  **Workaround:** To fix the issue, update the ``sdk-nrf`` repository by cherry-picking the commits with the following hash: ``9d348796552294e48e12084032a607bd339a6b65``.
+    The patch sets the value of the :kconfig:option:`CONFIG_FLASH_FILL_BUFFER_SIZ`` kconfig option to ``256`` and speeds up the emulated erase operations on RRAM.
+
 .. rst-class:: v3-2-0
 
 NCSDK-36692: In a single slot DFU, the firmware loader image can be erased using the ``SMP erase slot`` command issued in the firmware loader application


### PR DESCRIPTION
flash RRAM driver (zephyr\drivers\flash\soc_flash_nrf_rram.c) has emulated erase built-in

It is not used when call flash_flatten API, flash_util.c chose  z_impl_flash_fill() instead.

This imply degradation of performance when erasing. Especially when CONFIG_FLASH_FILL_BUFFER_SIZE< ( CONFIG_NRF_RRAM_WRITE_BUFFER_SIZE*16).

covers patching by https://github.com/nrfconnect/sdk-nrf/pull/28582