### PR TITLE
tests: drivers: spi_controller_peripheral: use NFCT pins for loopback

### DIFF
--- a/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf9251dk_nrf9251_common.dtsi
+++ b/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf9251dk_nrf9251_common.dtsi
@@ -8,7 +8,7 @@
  * SCK:  P1.00 - P1.01
  * MISO: P1.04 - P1.11
  * MOSI: P2.03 - P2.09
- * CS:   P2.01 - P2.02
+ * CS:   P1.09 - P1.09 (connected with antena)
  */
 
 &pinctrl {
@@ -34,7 +34,7 @@
 			psels = <NRF_PSEL(SPIS_SCK, 1, 1)>,
 				<NRF_PSEL(SPIS_MISO, 1, 11)>,
 				<NRF_PSEL(SPIS_MOSI, 2, 9)>,
-				<NRF_PSEL(SPIS_CSN, 2, 2)>;
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
 		};
 	};
 
@@ -43,19 +43,23 @@
 			psels = <NRF_PSEL(SPIS_SCK, 1, 1)>,
 				<NRF_PSEL(SPIS_MISO, 1, 11)>,
 				<NRF_PSEL(SPIS_MOSI, 2, 9)>,
-				<NRF_PSEL(SPIS_CSN, 2, 2)>;
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
 			low-power-enable;
 		};
 	};
 };
 
-&gpio2 {
+&gpio1 {
 	status = "okay";
 };
 
 &gpiote130 {
 	status = "okay";
 	owned-channels = <7>;
+};
+
+&uicr {
+	nfct-pins-as-gpios;
 };
 
 &spi130 {
@@ -65,7 +69,7 @@
 	pinctrl-1 = <&spi130_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
-	cs-gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 	zephyr,pm-device-runtime-auto;
 
 	dut_spi_dt: test-spi-dev@0 {


### PR DESCRIPTION
Now that NFCT pins can be used for other peripherals, use them in SPI test to avoid overlap with CLK pins.

This does not fix all cases as anomaly support is still needed.