### PR TITLE
applications: machine_learning: Fix nRF54H20 partition addresses

### DIFF
--- a/applications/machine_learning/configuration/nrf54h20dk_nrf54h20_cpuapp/app.overlay
+++ b/applications/machine_learning/configuration/nrf54h20dk_nrf54h20_cpuapp/app.overlay
@@ -67,10 +67,12 @@ ipc1: &cpuapp_cpuppr_ipc {
 &mram1x {
 	partitions {
 		slot0_partition: cpuapp_slot0_partition: partition@30000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x30000 0x82000>;
 		};
 
 		cpurad_slot0_partition: partition@b2000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0xb2000 0x32000>;
 		};
 	};


### PR DESCRIPTION
This fix corrects the missing "compatible" in the cpuapp DTS overlay resulting in correct address calculation which fixes BUSFAULT in the nRF54H20 post-kernel hook.