### PR TITLE
Fw info invalidate test

### DIFF
--- a/tests/subsys/fw_info/src/main.c
+++ b/tests/subsys/fw_info/src/main.c
@@ -95,6 +95,56 @@ ZTEST(test_fw_info, test_fw_info_invalidated)
 	zassert_equal(0, ret, "flash_write_failed %d", ret);
 }
 
+ZTEST(test_fw_info, test_fw_info_invalidate)
+{
+	/* We will write fw_info, valid, two pages from the beginning of partitions;
+	 * next fw_info_invalidate is called and we will check if invalidation was
+	 * done ok.
+	 */
+	const struct fw_info *target = (const struct fw_info *)(TEST_ADDRESS + ERASE_PAGE_SIZE * 2);
+	uint8_t intermediate[(sizeof(dummy_s1) + MAX_SUPPORTED_WBS - 1) & ~(MAX_SUPPORTED_WBS - 1)];
+	struct fw_info re_read_fw_info;
+	uint32_t wbs = flash_get_write_block_size(flash_dev);
+	const uint32_t zero = 0;
+	int ret;
+
+	/* Write a dummy upgrade to S1 */
+#ifndef NO_ERASE_NEEDED
+	ret = flash_erase(flash_dev, (off_t)target, ERASE_PAGE_SIZE);
+	zassert_equal(0, ret, "flash_erase failed %d", ret);
+#endif
+	memset(intermediate, 0, sizeof(intermediate));
+	memcpy(intermediate, &dummy_s1, sizeof(dummy_s1));
+	ret = flash_write(flash_dev, (off_t)target, intermediate,
+					(sizeof(dummy_s1) + wbs - 1) & ~(wbs - 1));
+	zassert_equal(0, ret, "flash_write failed %d", ret);
+	zassert_equal(CONFIG_FW_INFO_VALID_VAL, target->valid, "wrong valid value");
+
+	/* Now we should have the fw_info invalidated */
+	fw_info_invalidate(target);
+	/* Check the valid field against the valid literal */
+	zassert_not_equal(CONFIG_FW_INFO_VALID_VAL, target->valid,
+		"expected target to be invalidated 0x%x", target->valid);
+
+	/* We will read the entire fw_info to re_read_fw_info for comparison,
+	 * then .valid field will be set to CONFIG_FW_INFO_VALID_VAL, and the
+	 * intermediate buffer will be compared against dummy_s1. The comparison
+	 * should indicate no difference, as the only field that was supposed to
+	 * be touched by invalidation has been reset in intermediate buffer
+	 */
+	zassert_ok(flash_read(flash_dev, (uint32_t)target, &re_read_fw_info, sizeof(struct fw_info)),
+		"reading fw_info failed");
+
+	re_read_fw_info.valid = CONFIG_FW_INFO_VALID_VAL;
+
+	zassert_ok(memcmp(&dummy_s1, &re_read_fw_info, sizeof(struct fw_info)),
+		"modification spilled out of .valid");
+
+	/* Reset flash so test will enter the fw_info setup path on next run */
+	ret = flash_write(flash_dev, (off_t)target, &zero, sizeof(zero));
+	zassert_equal(0, ret, "flash_write_failed %d", ret);
+}
+
 
 ZTEST(test_fw_info, test_fw_info_find)
 {

--- a/tests/subsys/fw_info/src/main.c
+++ b/tests/subsys/fw_info/src/main.c
@@ -9,53 +9,89 @@
 #include <fw_info.h>
 #include <pm_config.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/storage/flash_map.h>
 #include <zephyr/sys/reboot.h>
 #include <zephyr/devicetree.h>
 
-#define S1_ADDRESS PM_S1_ADDRESS
-#define S1_SIZE 0x8000
+#define PARTITION	s1_image
+#define TEST_ADDRESS	FIXED_PARTITION_ADDRESS(PARTITION)
+#define TEST_SIZE	FIXED_PARTITION_SIZE(PARTITION)
+#define TEST_DEV	FIXED_PARTITION_DEVICE(PARTITION)
 
+/* Assumptions for test supported environment */
+#define MAX_SUPPORTED_WBS 16
+#define ERASE_PAGE_SIZE 0x1000
+
+/* Address is used as offset with flash device writes and to access
+ * structures via processor address space. Assumption was that they
+ * are the same.
+ */
+BUILD_ASSERT(TEST_ADDRESS == FIXED_PARTITION_OFFSET(PARTITION));
+
+/* Assumption: The test is only run on the internal SoC NVM, so we can
+ * figure out need to erase before write on SoC series only.
+ */
+#if defined(CONFIG_SOC_NRF54L15)
+#define NO_ERASE_NEEDED
+#elif defined(CONFIG_SOC_SERIES_NRF52) || defined(CONFIG_SOC_SERIES_NRF53) ||\
+	defined(CONFIG_SOC_SERIES_NRF91)
+/* Nothing */
+#else
+#error Test needs alignment to the platform
+#endif
 
 /* signature check of this will fail, causing .valid to be overwritten. */
 const struct fw_info dummy_s1 = {
 	.magic = {FIRMWARE_INFO_MAGIC},
-	.address = S1_ADDRESS,
-	.size = S1_SIZE,
+	.address = TEST_ADDRESS,
+	.size = TEST_SIZE,
 	.version = 0xFF,
 	.valid = CONFIG_FW_INFO_VALID_VAL,
 };
 
 static uint8_t fw_info_find_buf[0x1000 + sizeof(dummy_s1)];
+static const struct device *flash_dev = TEST_DEV;
 
 
-ZTEST(test_fw_info, test_fw_info_invalidate)
+ZTEST(test_fw_info, test_fw_info_invalidated)
 {
-	const struct fw_info *target = (const struct fw_info *)(S1_ADDRESS);
+	const struct fw_info *target = (const struct fw_info *)(TEST_ADDRESS);
 	const uint32_t zero = 0;
+	uint8_t intermediate[(sizeof(dummy_s1) + MAX_SUPPORTED_WBS - 1) & ~(MAX_SUPPORTED_WBS - 1)];
 	int ret;
 
-	const struct device *flash_dev = DEVICE_DT_GET(DT_NODELABEL(PM_S0_DEV));
-
 	/* Write a dummy upgrade to S1 */
-	if (!fw_info_check(S1_ADDRESS)) {
-		ret = flash_erase(flash_dev, S1_ADDRESS, 0x1000);
+	if (!fw_info_check((uint32_t)target)) {
+		uint32_t wbs = flash_get_write_block_size(flash_dev);
+
+		TC_PRINT("#### Writing dummy fw_info of s1 ####\n");
+
+#ifndef NO_ERASE_NEEDED
+		ret = flash_erase(flash_dev, (off_t)target, ERASE_PAGE_SIZE);
 		zassert_equal(0, ret, "flash_erase failed %d", ret);
-		ret = flash_write(flash_dev, S1_ADDRESS, &dummy_s1,
-					sizeof(dummy_s1));
+#endif
+		memset(intermediate, 0, sizeof(intermediate));
+		memcpy(intermediate, &dummy_s1, sizeof(dummy_s1));
+		ret = flash_write(flash_dev, (off_t)target, intermediate,
+					(sizeof(dummy_s1) + wbs - 1) & ~(wbs - 1));
 		zassert_equal(0, ret, "flash_write failed %d", ret);
+
 		zassert_equal(CONFIG_FW_INFO_VALID_VAL, target->valid,
 				"wrong valid value");
+
+		TC_PRINT("#### REBOOTING ####\n\n");
 		sys_reboot(0);
 	}
 
-	/* Dummy upgrade should have been invalidated during reboot. */
-	zassert_equal(S1_ADDRESS, (uint32_t)target,
-		"wrong info address 0x%x", (uint32_t)target);
-	zassert_equal(CONFIG_FW_INFO_VALID_VAL & 0xFFFF0000, target->valid,
-		"wrong valid value 0x%x", target->valid);
+	/* The s1 fw_info has been faked and boot should detect this, prior to
+	 * booting the test, and invalidate the fw_info, which means t should
+	 * be set to value different from CONFIG_FW_INFO_VALID_VAL.
+	 */
+	zassert_not_equal(CONFIG_FW_INFO_VALID_VAL, target->valid,
+		"expected target to be invalidated 0x%x", target->valid);
 
-	/* Reset flash so test can be run again. */
-	ret = flash_write(flash_dev, S1_ADDRESS, &zero,	sizeof(zero));
+	/* Reset flash so test will enter the fw_info setup path on next run */
+	ret = flash_write(flash_dev, (off_t)target, &zero, sizeof(zero));
 	zassert_equal(0, ret, "flash_write_failed %d", ret);
 }
 
@@ -75,4 +111,20 @@ ZTEST(test_fw_info, test_fw_info_find)
 	}
 }
 
-ZTEST_SUITE(test_fw_info, NULL, NULL, NULL, NULL, NULL);
+static void *test_fw_info_setup(void)
+{
+	uint32_t wbs = flash_get_write_block_size(flash_dev);
+
+	/* Test may have not been tuned for a new platform with given write block size */
+	zassert_true(wbs <= MAX_SUPPORTED_WBS, "Write block not yet supported within test");
+#ifndef NO_ERASE_NEEDED
+	/* Check if erase-block-size is supported */
+	struct flash_pages_info page;
+	zassert_ok(flash_get_page_info_by_offs(flash_dev, 0, &page));
+	zassert_equal(page.size, ERASE_PAGE_SIZE);
+#endif
+
+	return NULL;
+}
+
+ZTEST_SUITE(test_fw_info, NULL, test_fw_info_setup, NULL, NULL, NULL);


### PR DESCRIPTION
Build
```
west build': west build  -p -d builds/nrf54l15dk/fw_info_pm -b nrf54l15dk/nrf54l15/cpuapp -T fw_info.core nrf/tests/subsys/fw_info/  -Db0_CONFIG_LTO=n -DSB_CONFIG_SECURE_BOOT_GENERATE_DEFAULT_KMU_KEYFILE=y`
```
test
```
 west flash  --erase --recover -d builds/nrf54l15dk/fw_info_pm/
```