### PR TITLE
doc: release-notes-changelog: Update Zephyr SHA after upmerge

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -576,21 +576,21 @@ Zephyr
 
 .. NOTE TO MAINTAINERS: All the Zephyr commits in the below git commands must be handled specially after each upmerge and each nRF Connect SDK release.
 
-The Zephyr fork in |NCS| (``sdk-zephyr``) contains all commits from the upstream Zephyr repository up to and including ``93b5f19f994b9a9376985299c1427a1630f6950e``, with some |NCS| specific additions.
+The Zephyr fork in |NCS| (``sdk-zephyr``) contains all commits from the upstream Zephyr repository up to and including ``684c9e8f32e4373a21098559f748f06915f950c9``, with some |NCS| specific additions.
 
 For the list of upstream Zephyr commits (not including cherry-picked commits) incorporated into |NCS| since the most recent release, run the following command from the :file:`ncs/zephyr` repository (after running ``west update``):
 
 .. code-block:: none
 
-   git log --oneline 93b5f19f99 ^911b3da139
+   git log --oneline 684c9e8f32 ^911b3da139
 
 For the list of |NCS| specific commits, including commits cherry-picked from upstream, run:
 
 .. code-block:: none
 
-   git log --oneline manifest-rev ^93b5f19f99
+   git log --oneline manifest-rev ^684c9e8f32
 
-The current |NCS| main branch is based on revision ``93b5f19f99`` of Zephyr.
+The current |NCS| main branch is based on revision ``684c9e8f32`` of Zephyr.
 
 .. note::
    For possible breaking changes and changes between the latest Zephyr release and the current Zephyr version, refer to the :ref:`Zephyr release notes <zephyr_release_notes>`.


### PR DESCRIPTION
Update Zephyr SHA in release notes after upmerging the sdk-zephyr repository up to 684c9e8f32e4373a21098559f748f06915f950c9 (v4.4.0).