### PR TITLE
samples: bluetooth: mesh: Add new Kconfig to enable/disable SMP adv

### DIFF
--- a/samples/bluetooth/mesh/common/Kconfig
+++ b/samples/bluetooth/mesh/common/Kconfig
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config NCS_SAMPLE_MESH_COMMON_SMP_BT_DEDICATED_ADV_SET
+	bool "When enabled, create a separate BT ID and advertising set broadcasting SMP DFU availability"
+	depends on MCUMGR_TRANSPORT_BT
+	default n if BT_SMP
+	default y

--- a/samples/bluetooth/mesh/common/smp_bt.c
+++ b/samples/bluetooth/mesh/common/smp_bt.c
@@ -5,7 +5,9 @@
  */
 
 #include <zephyr/init.h>
+#include <zephyr/sys/printk.h>
 
+#if IS_ENABLED(CONFIG_NCS_SAMPLE_MESH_COMMON_SMP_BT_DEDICATED_ADV_SET)
 /* .. include_startingpoint_mesh_smp_dfu_rst_1 */
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
@@ -146,30 +148,40 @@ int smp_service_adv_init(void)
 	return err;
 }
 /* .. include_endpoint_mesh_smp_dfu_rst_1 */
+#endif /* CONFIG_NCS_SAMPLE_MESH_COMMON_SMP_BT_DEDICATED_ADV_SET */
 
 int smp_dfu_init(void)
 {
-	if (IS_ENABLED(CONFIG_MCUMGR_TRANSPORT_BT_PERM_RW_AUTHEN) &&
-	    IS_ENABLED(CONFIG_BT_MESH_LE_PAIR_RESP)) {
-		int err;
+	int err = 0;
 
-		err = smp_bt_auth_init();
-		if (err) {
-			printk("Can't enable authentication for SMP (err: %d)\n", err);
-			return err;
-		}
-	} else {
-		printk("Authentication for SMP over BLE is disabled\n");
+#if IS_ENABLED(CONFIG_MCUMGR_TRANSPORT_BT_PERM_RW_AUTHEN) && \
+	IS_ENABLED(CONFIG_BT_MESH_LE_PAIR_RESP)
+
+	err = smp_bt_auth_init();
+	if (err) {
+		printk("Can't enable authentication for SMP (err: %d)\n", err);
+		return err;
 	}
+#else
+	printk("Authentication for SMP over BLE is not enabled\n");
+#endif /* CONFIG_MCUMGR_TRANSPORT_BT_PERM_RW_AUTHEN && CONFIG_BT_MESH_LE_PAIR_RESP */
 
+#if IS_ENABLED(CONFIG_NCS_SAMPLE_MESH_COMMON_SMP_BT_DEDICATED_ADV_SET)
 /* .. include_startingpoint_mesh_smp_dfu_rst_2 */
 	bt_conn_cb_register(&conn_callbacks);
 
 	/**
-	 * Since Bluetooth Mesh utilizes the advertiser as the main channel of
-	 * communication, a secondary advertising set is necessary to broadcast
-	 * the SMP service.
-	 */
-	return smp_service_adv_init();
+	* Since Bluetooth Mesh utilizes the advertiser as the main channel of
+	* communication, a secondary advertising set is necessary to broadcast
+	* the SMP service.
+	*/
+	err = smp_service_adv_init();
+	if (err) {
+		printk("Starting advertising of SMP service failed (err %d)\n", err);
+		return err;
+	}
 /* .. include_endpoint_mesh_smp_dfu_rst_2 */
+#endif /* CONFIG_NCS_SAMPLE_MESH_COMMON_SMP_BT_DEDICATED_ADV_SET */
+
+	return err;
 }

--- a/samples/bluetooth/mesh/dfu/distributor/Kconfig
+++ b/samples/bluetooth/mesh/dfu/distributor/Kconfig
@@ -1,0 +1,3 @@
+source "Kconfig.zephyr"
+
+rsource "../../common/Kconfig"

--- a/samples/bluetooth/mesh/dfu/distributor/Kconfig
+++ b/samples/bluetooth/mesh/dfu/distributor/Kconfig
@@ -1,3 +1,3 @@
 source "Kconfig.zephyr"
 
-rsource "../../common/Kconfig"
+source "${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/mesh/common/Kconfig"

--- a/samples/bluetooth/mesh/dfu/target/Kconfig
+++ b/samples/bluetooth/mesh/dfu/target/Kconfig
@@ -1,0 +1,3 @@
+source "Kconfig.zephyr"
+
+rsource "../../common/Kconfig"

--- a/samples/bluetooth/mesh/dfu/target/Kconfig
+++ b/samples/bluetooth/mesh/dfu/target/Kconfig
@@ -1,3 +1,3 @@
 source "Kconfig.zephyr"
 
-rsource "../../common/Kconfig"
+source "${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/mesh/common/Kconfig"

--- a/samples/bluetooth/mesh/light/Kconfig
+++ b/samples/bluetooth/mesh/light/Kconfig
@@ -1,0 +1,3 @@
+source "Kconfig.zephyr"
+
+rsource "../common/Kconfig"

--- a/samples/bluetooth/mesh/light/Kconfig
+++ b/samples/bluetooth/mesh/light/Kconfig
@@ -1,3 +1,3 @@
 source "Kconfig.zephyr"
 
-rsource "../common/Kconfig"
+source "${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/mesh/common/Kconfig"


### PR DESCRIPTION
Add a CONFIG_NCS_SAMPLE_MESH_COMMON_SMP_BT_ADV_SET_ENABLED to control whether a separate advertising set will be created to broadcast SMP Service availability. 

Having a second Bluetooth Identity with its own connectable advertising set can cause issue with bonding.