### PR TITLE
manifest: Updated sdk-zephyr with HIDS UUID-s

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: e88cd523ff4b9d7484dc875048a0f2f14dbf99f2
+      revision: pull/4036/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit updates the sdk-zephyr revision to
bring in the newest changes containing new Bluetooth UUID-s for HID SCI