### PR TITLE
samples: bluetooth: memset CS config to 0 before setting values

### DIFF
--- a/samples/bluetooth/channel_sounding/ras_initiator/src/main.c
+++ b/samples/bluetooth/channel_sounding/ras_initiator/src/main.c
@@ -765,6 +765,7 @@ BT_CONN_CB_DEFINE(conn_cb) = {
 
 static void cs_config_get(struct bt_le_cs_create_config_params *config_params)
 {
+	memset(config_params, 0, sizeof(struct bt_le_cs_create_config_params));
 	config_params->id = CS_CONFIG_ID;
 	config_params->mode = CS_CONFIG_MODE;
 	config_params->min_main_mode_steps = 2;


### PR DESCRIPTION
In the ras_initiator.

To guarantee that the configuration is initialized as expected memset it to 0 before setting the individual values.