### PR TITLE
lib: nrf_cloud: Fix P-GPS prediction handling

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -511,6 +511,16 @@ Libraries for networking
   As part of the migration to *nRF Cloud powered by Memfault*, the nRF Cloud Alerts feature is now redundant.
   Memfault's Trace Events feature replaces the Alerts feature, as it provides equivalent functionality for event reporting, and it also adds enhanced debugging capabilities that were not available with Alerts.
 
+* :ref:`lib_nrf_cloud_pgps` library:
+
+  * Updated the range for the :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_NUM_PREDICTIONS` and :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD` Kconfig options to values supported by nRF Cloud.
+
+  * Fixed:
+
+    * An issue that caused predictions to be stored into incorrect index in flash, leading to an error when the affected predictions were used.
+    * An issue where the library tried to use predictions that had not yet been flushed to flash, leading to a prediction validation error.
+    * An issue where the library kept trying to use corrupted predictions.
+
 Libraries for NFC
 -----------------
 

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_pgps
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_pgps
@@ -27,8 +27,8 @@ config NRF_CLOUD_PGPS_REQUEST_UPON_INIT
 
 config NRF_CLOUD_PGPS_NUM_PREDICTIONS
 	int "Desired number of predictions"
-	range 2 42
-	default 42
+	range 2 40
+	default 40
 	help
 	  This value, together with the prediction period, determines the
 	  overall timespan that the GPS predictions will cover. The
@@ -37,7 +37,7 @@ config NRF_CLOUD_PGPS_NUM_PREDICTIONS
 
 config NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD
 	int "Number of predictions remaining before fetching more"
-	range 0 40
+	range 0 38
 	default 0
 	help
 	  When set to 0, no attempt will be made to update the prediction

--- a/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_pgps.c
+++ b/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_pgps.c
@@ -632,6 +632,14 @@ int nrf_cloud_pgps_find_prediction(struct nrf_cloud_pgps_prediction **prediction
 		return -ETIMEUNKNOWN;
 	} else if (cur_gps_sec > end_sec) {
 		if ((cur_gps_sec - end_sec) > PGPS_MARGIN_SEC) {
+			if (nrf_cloud_pgps_loading()) {
+				/* A download is already in progress; the old predictions
+				 * being expired is expected. Do not reset state or
+				 * loading_in_progress.
+				 */
+				LOG_INF("Loading in progress; ignoring expired old predictions");
+				return -ELOADING;
+			}
 			index.cur_pnum = 0xff;
 			state = PGPS_EXPIRED;
 			loading_in_progress = false; /* make sure we request it */
@@ -659,7 +667,28 @@ int nrf_cloud_pgps_find_prediction(struct nrf_cloud_pgps_prediction **prediction
 			start_expiration_timer(pnum, cur_gps_sec);
 			return pnum;
 		}
-		return err;
+
+		/* The selected prediction failed validation. If we are not loading
+		 * new data, the stored predictions are corrupt or stale. Mark them as
+		 * expired so that a fresh download is triggered.
+		 */
+		if (!nrf_cloud_pgps_loading()) {
+			LOG_ERR("Prediction num:%u invalid; discarding all P-GPS data", pnum);
+			index.cur_pnum = 0xff;
+			state = PGPS_EXPIRED;
+			loading_in_progress = false;
+			return err;
+		}
+
+		/* During loading, the prediction pointer is set but the flash page may
+		 * not be flushed yet: stream_flash only commits a page when its buffer
+		 * is full (two 2048-byte predictions share one 4096-byte flash page).
+		 * The page will be flushed once the following prediction is stored, so
+		 * signal the caller to retry rather than treating this as an error.
+		 */
+		LOG_WRN("Prediction num:%u not yet readable; waiting for flash flush", pnum);
+		*prediction = NULL;
+		return -ELOADING;
 	}
 	if (nrf_cloud_pgps_loading()) {
 		LOG_WRN("Prediction num:%u not loaded yet", pnum);


### PR DESCRIPTION
Fixed a bug which caused predictions to be stored into incorrect index in flash, leading to an error when the affected predictions were tried to be used, because the selected prediction did not contain the expected time range.

Fixed a bug where the device kept trying to use corrupted predictions. If corruption is detected, all data is now discarded and a new download is triggered.

Fixed a bug where the library tried to use predictions which had not yet been flushed to flash, leading to a prediction validation error.

Changed the maximum value of `CONFIG_NRF_CLOUD_PGPS_NUM_PREDICTIONS` from 42 to 40 and `CONFIG_NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD` from 40 to 38. The reason for this change is, that the nRF Cloud does not always have 42 valid predictions available.