### PR TITLE
Applicatations: nrf5340_audio: Location check fix

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
@@ -538,7 +538,8 @@ int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *co
 		/* May happen if we are trying to send N streams, but N-X locations are available */
 		LOG_DBG("Number of locations (%u) more than number of streams (%u)", num_loc,
 			num_tx);
-	} else if (num_loc < num_tx) {
+	} else if ((num_loc < num_tx) && (num_loc != 1U)) {
+		/* If num_loc = 1, the same stream is sent to all locations */
 		LOG_ERR("Number of locations (%u) less than number of streams (%u)", num_loc,
 			num_tx);
 		return -EINVAL;


### PR DESCRIPTION
Missed a check for the case where num_loc = 1,
which is a valid configuration where the same stream is sent to all locations.

OCT-3716