### PR TITLE
[Backport v3.3-branch] samples: ipc_service: Add separate .conf file for cpuppr scenario

### DIFF
--- a/samples/ipc/ipc_service/boards/nrf54h20dk_nrf54h20_cpuapp_cpuppr.conf
+++ b/samples/ipc/ipc_service/boards/nrf54h20dk_nrf54h20_cpuapp_cpuppr.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_APP_IPC_SERVICE_SEND_INTERVAL=900


### PR DESCRIPTION
Backport a43f56baaeacc155ec2af58c06e781d4cbc775a4 from #27659.

Ref. NCSDK-38026