### PR TITLE
manifest: Update tf-m revision to include secure uart fix.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -149,7 +149,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 3a4c9e4f95daed17461d92c805aa415783d49bd0
+      revision: eb5d3e5379201431d740b3bc164267c8049ef790
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
Pull in the fix that selects TFM_PERIPHERAL_STD_UART based on NRF_SECURE_UART_INSTANCE, which is needed to build TF-M for nRF54LV10a where the secure UART instance is UARTE20.