### PR TITLE
changelog: mention that 4 MCUboot images can be write protected

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -68,7 +68,9 @@ Developing with nRF54L Series
 Developing with nRF54H Series
 =============================
 
-|no_changes_yet_note|
+* Updated:
+
+   * MCUboot to support MRAM write protection for up to four images.
 
 Developing with nRF53 Series
 ============================


### PR DESCRIPTION
Add a note to the changelog that up to four images can be write protected on 54H.
See #27980.