### PR TITLE
manifest: Update Oberon to fix static key slot buffer size

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -141,7 +141,7 @@ manifest:
     - name: oberon-psa-crypto
       path: modules/crypto/oberon-psa-crypto
       repo-path: sdk-oberon-psa-crypto
-      revision: fd1f2aa156d8beb78584dfbaf30df30bf8f6568f
+      revision: fdca9eba5d6fd3fdfdf87196cb4d0d37a5529632
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib


### PR DESCRIPTION
Manifest update to fix the issue with MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE set to 1 when using HMAC algorithm.