### PR TITLE
mcuboot: Compatibility setting for usign HMAC-256 with encryption

### DIFF
--- a/cmake/sysbuild/image_signing.cmake
+++ b/cmake/sysbuild/image_signing.cmake
@@ -282,7 +282,9 @@ function(zephyr_mcuboot_tasks)
     # just signed one does not.
     # Only NRF54L gets the HMAC-SHA512, other remain with previously used
     # SHA256.
-    if(CONFIG_SOC_SERIES_NRF54L AND CONFIG_MCUBOOT_BOOTLOADER_SIGNATURE_TYPE_ED25519)
+    if(CONFIG_SOC_SERIES_NRF54L AND CONFIG_MCUBOOT_BOOTLOADER_SIGNATURE_TYPE_ED25519 AND
+      NOT CONFIG_NCS_MCUBOOT_ENCRYPTION_HMAC_SHA256
+    )
       set(imgtool_encrypt_extra_args --hmac-sha 512)
     endif()
   endif()

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -48,6 +48,10 @@ Build and configuration system
 Bootloaders and DFU
 ===================
 
+* Added the hidden :kconfig:option:`CONFIG_NCS_MCUBOOT_ENCRYPTION_HMAC_SHA256` to select HMAC-SHA256 with X25519 for compatibility with existing projects that use it.
+  The option is hidden and requires addition of Kconfig override in your project.
+  This is intentional as HMAC-SHA512 is recommended over HMAC-SHA256.
+
 |no_changes_yet_note|
 
 Developing with nRF91 Series

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -258,4 +258,12 @@ config NCS_IS_VARIANT_IMAGE
 	  This option is set automatically based on devicetree partitions and should not require
 	  manual intervention.
 
+config NCS_MCUBOOT_ENCRYPTION_HMAC_SHA256
+	bool
+	help
+	  Enforce HMAC-SHA256 in image signatures for compatibility with existing MCUboot.
+	  The option allows to override default behaviour for nRF54L series where HMAC-SHA512 is
+	  used. To use the override, add Kconfig entry to your projects Kconfig that sets the
+	  option to true.
+
 endmenu


### PR DESCRIPTION
Allow to use HMAC-256 for encrypted key MAC on nRF54L, instead of the default HMAC-512, for compatibility with bootloaders built with HMAC-256.

Kconfig is intentionally hidden as it should not be selected by user, it is provided for compatibility and requires intentional modifications of user Kconfig.

To use, add to your projects Kconfig:
```
config NCS_MCUBOOT_ENCRYPTION_HMAC_SHA256
        bool
        default y
```
