### PR TITLE
doc: Matter protocols: Adding link to Matter Fundamentals course

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1216,6 +1216,7 @@
 .. _`Power saving techniques`: https://academy.nordicsemi.com/courses/cellular-iot-fundamentals/lessons/lesson-1-cellular-fundamentals/topic/lesson-1-power-saving-techniques/
 .. _`Bluetooth LE Fundamentals course`: https://academy.nordicsemi.com/courses/bluetooth-low-energy-fundamentals/
 .. _`Wi-Fi Fundamentals course`: https://academy.nordicsemi.com/courses/wi-fi-fundamentals/
+.. _`Matter Fundamentals course`: https://academy.nordicsemi.com/courses/matter-fundamentals/
 
 .. _`nRF54L Series Express course`: https://academy.nordicsemi.com/courses/nrf54l-series-express-course/
 

--- a/doc/nrf/protocols/matter/getting_started/index.rst
+++ b/doc/nrf/protocols/matter/getting_started/index.rst
@@ -9,6 +9,8 @@ Getting started with Matter
 
 Read pages in this section and watch the video to start working with Matter using Nordic Semiconductor's SoCs and tools in both the |NCS| and Zephyr.
 
+If you want to go through a hands-on online training to familiarize yourself with Matter development, enroll in the `Matter Fundamentals course`_ in the `Nordic Developer Academy`_.
+
 The following video showcases several aspects of the Matter setup, discussed in detail on the following pages.
 
 .. raw:: html

--- a/doc/nrf/protocols/matter/index.rst
+++ b/doc/nrf/protocols/matter/index.rst
@@ -13,6 +13,8 @@ Matter
 `Matter`_ (formerly Project Connected Home over IP or Project CHIP) is an open-source application layer that aims at creating a unified communication standard across smart home devices, mobile applications, and cloud services.
 It supports a wide range of existing technologies, including Wi-Fi®, Thread, and Bluetooth® LE, and uses IPv6-based transport protocols like TCP and UDP to ensure connectivity between different kinds of networks.
 
+If you want to go through a hands-on online training to familiarize yourself with Matter development, enroll in the `Matter Fundamentals course`_ in the `Nordic Developer Academy`_.
+
 .. matter_intro_end
 
 |NCS| |release| allows you to develop applications with Matter specification version 1.5.0 and `Matter SDK version`_ 1.5.0.0.


### PR DESCRIPTION
Adding links to both the Matter Fundamentals course and DevAcademy in the Matter protocols documentation.

Ref: TECHDOC-4465