### PR TITLE
scripts: ci: tags: fix ci_tests_zephyr_kernel_timer_timer_behavior

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -1864,7 +1864,7 @@ ci_tests_zephyr_drivers_clock_control:
 ci_tests_zephyr_kernel_timer_timer_behavior:
   files:
     - nrf/tests/zephyr/kernel/timer/timer_behavior/
-    - tests/zephyr/kernel/timer/timer_behavior/
+    - zephyr/tests/kernel/timer/timer_behavior/
 
 ci_tests_zephyr_boards_nrf_i2c:
   files:


### PR DESCRIPTION
Fix wrong path.