### PR TITLE
Fix nrf modem lib tests

### DIFF
--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -34,7 +34,8 @@ config HEAP_MEM_POOL_ADD_SIZE_NRF9X_SOCKETS_GETADDRINFO
 
 config NRF_MODEM_LIB_SHMEM_CTRL_SIZE
 	hex
-	default NRF_MODEM_SHMEM_CTRL_SIZE
+	default NRF_MODEM_SHMEM_CTRL_SIZE if NRF_MODEM
+	default 0
 	help
 	  Size of the shared memory area used for control structures.
 	  This is a constant for a given library build, and is exported

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -1009,6 +1009,7 @@ ci_tests_lib_nrf_modem_lib:
     - nrf/lib/nrf_modem_lib/
     - nrf/tests/lib/nrf_modem_lib/
     - nrf/tests/mocks/nrf_modem_at/
+    - nrfxlib/nrf_modem/
     - zephyr/subsys/net/
 
 ci_tests_lib_edge_impulse:


### PR DESCRIPTION
Fix failures not caught by the CI when merging https://github.com/nrfconnect/sdk-nrfxlib/pull/2100.
Also update CI tags to ensure this won't happen again.