### PR TITLE
nrf_security: Forbid multiple ways to invalitate PROT_RAM slots

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -63,7 +63,11 @@ Developing with nRF70 Series
 Developing with nRF54L Series
 =============================
 
-|no_changes_yet_note|
+* Added:
+
+  * The :kconfig:option:`CONFIG_SB_CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS` sysbuild Kconfig option to populate the Key Management Unit (KMU) slots for invalidation of the CRACEN-protected RAM using nrfutil.
+    This option requires ``nrfutil device`` version 2.15.4 or later to work.
+    When enabled, the :kconfig:option:`CONFIG_CRACEN_PROVISION_PROT_RAM_INV_SLOTS_ON_INIT` and :kconfig:option:`CONFIG_CRACEN_PROVISION_PROT_RAM_INV_SLOTS_WITH_IMPORT` Kconfig options become unavailable, as they implement the same feature through alternative provisioning paths.
 
 Developing with nRF54H Series
 =============================

--- a/subsys/nrf_security/src/drivers/cracen/Kconfig
+++ b/subsys/nrf_security/src/drivers/cracen/Kconfig
@@ -74,6 +74,18 @@ config CRACEN_LIB_KMU
 	help
 	  The CRACEN KMU library.
 
+config CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS
+	bool "Provision protected RAM invalidation slots with nrfutil (informative only, do not change)"
+	help
+	  This option indicates that the protected RAM invalidation slots are provisioned
+	  using nrfutil. When enabled, the manual provisioning options below are hidden because
+	  provisioning is expected to be handled through sysbuild/nrfutil instead.
+	  This option is controlled by the KMU_INVALIDATE_PROTECTED_RAM_SLOTS sysbuild
+	  configuration option, so enable it in your sysbuild
+	  configuration rather than setting this symbol manually.
+
+if !CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS
+
 config CRACEN_PROVISION_PROT_RAM_INV_SLOTS_ON_INIT
 	bool "Provision protected RAM invalidation slots on boot"
 	depends on CRACEN_LIB_KMU
@@ -95,6 +107,8 @@ config CRACEN_PROVISION_PROT_RAM_INV_SLOTS_WITH_IMPORT
 	  populate the slots.
 	  This is meant to be used by a provisioning image that runs once before the application
 	  image is flashed. This is not meant to be used by user applications.
+
+endif # CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS
 
 config CRACEN_IKG
 	bool "CRACEN IKG"

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -1016,6 +1016,19 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
     set_config_bool(mcuboot CONFIG_NCS_MCUBOOT_MPCCONF_STATIC_WRITE_PROTECTION y)
     set_config_bool(mcuboot CONFIG_NRF_MPCCONF_API_IN_RAM y)
   endif()
+
+  if(SB_CONFIG_CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS)
+    foreach(image ${PRE_CMAKE_IMAGES})
+      set_config_bool(${image} CONFIG_CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS y)
+    endforeach()
+
+    include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/nrf54l_prot_ram_inv_slots.cmake)
+  else()
+    foreach(image ${PRE_CMAKE_IMAGES})
+      set_config_bool(${image} CONFIG_CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS n)
+    endforeach()
+  endif()
+
 endfunction(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
 
 function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_image_cmake)
@@ -1083,10 +1096,6 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
         OUTPUT_FILE ${CMAKE_BINARY_DIR}/${SB_CONFIG_MATTER_OTA_IMAGE_FILE_NAME}
       )
     endif()
-  endif()
-
-  if(SB_CONFIG_KMU_INVALIDATE_PROTECTED_RAM_SLOTS)
-    include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/nrf54l_prot_ram_inv_slots.cmake)
   endif()
 
   if(SB_CONFIG_WIFI_PATCHES_EXT_FLASH_STORE)

--- a/sysbuild/Kconfig.kmu_prot_ram_inv
+++ b/sysbuild/Kconfig.kmu_prot_ram_inv
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-config KMU_INVALIDATE_PROTECTED_RAM_SLOTS
+config CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS
 	bool "Populates the KMU slots for invalidation of the protected RAM using nrfutil"
 	depends on SOC_SERIES_NRF54L && !(SOC_NRF54LS05A || SOC_NRF54LS05B)
 	help


### PR DESCRIPTION
This makes sure that when SB_CONFIG_KMU_INVALIDATE_PROTECTED_RAM_SLOTS is enabled none of the other options meant to do the same thing are enabled:
CRACEN_PROVISION_PROT_RAM_INV_SLOTS_ON_INIT
CRACEN_PROVISION_PROT_RAM_INV_SLOTS_WITH_IMPORT

This is done to avoid misconfigurations.

In order to do that I had to create a separate helper symbol since the sysbuild symbol cannot be directly added as a dependency in the application image build.

Also I moved the sysbuild logic in the pre_cmake section because in post_cmake it is too late to set Kconfig options, they are already parsed at that point.