### PR TITLE
samples: bluetooth: fast_pair: align partition overlays with pm_to_dts

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -279,6 +279,9 @@ Bluetooth Mesh samples
 Bluetooth Fast Pair samples
 ---------------------------
 
+* Updated the DTS overlays of the Fast Pair samples to use the new ``zephyr,mapped-partition`` compatible property for each partition node.
+  The change aligns the board target overlays with the layout produced by the Partition Manager-to-DTS helper script (:file:`scripts/pm_to_dts.py`).
+
 * Removed the remaining ``nrf54h20dk/nrf54h20/cpuapp`` board target configurations from the following samples:
 
   * :ref:`fast_pair_locator_tag`

--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
@@ -5,9 +5,6 @@
  */
 
 &cpuapp_rram {
-	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
-	reg = <0x0 DT_SIZE_K(500)>;
-
 	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 

--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -5,9 +5,6 @@
  */
 
 &cpuapp_rram {
-	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
-	reg = <0x0 DT_SIZE_K(1012)>;
-
 	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 

--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -5,9 +5,6 @@
  */
 
 &cpuapp_rram {
-	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
-	reg = <0x0 DT_SIZE_K(1524)>;
-
 	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 

--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -5,9 +5,6 @@
  */
 
 &cpuapp_rram {
-	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
-	reg = <0x0 DT_SIZE_K(2036)>;
-
 	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 

--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -5,9 +5,6 @@
  */
 
 &cpuapp_rram {
-	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
-	reg = <0x0 DT_SIZE_K(2036)>;
-
 	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 

--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -12,20 +12,23 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0 DT_SIZE_K(2012)>;
 		};
 
 		bt_fast_pair_partition: partition@1f7000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x1f7000 DT_SIZE_K(4)>;
 		};
 
 		storage_partition: partition@1f8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1f8000 DT_SIZE_K(20)>;
 		};

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
@@ -5,9 +5,6 @@
  */
 
 &cpuapp_rram {
-	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
-	reg = <0x0 DT_SIZE_K(500)>;
-
 	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15dk_nrf54l05_cpuapp_release.overlay
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15dk_nrf54l05_cpuapp_release.overlay
@@ -5,9 +5,6 @@
  */
 
 &cpuapp_rram {
-	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
-	reg = <0x0 DT_SIZE_K(500)>;
-
 	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -5,9 +5,6 @@
  */
 
 &cpuapp_rram {
-	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
-	reg = <0x0 DT_SIZE_K(1012)>;
-
 	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -5,9 +5,6 @@
  */
 
 &cpuapp_rram {
-	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
-	reg = <0x0 DT_SIZE_K(1524)>;
-
 	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
@@ -56,34 +56,39 @@
 	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
 	reg = <0x0 DT_SIZE_K(1524)>;
 
+	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(28)>;
 		};
 
 		slot0_partition: partition@7000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x7000 DT_SIZE_K(736)>;
 		};
 
 		slot1_partition: partition@bf000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xbf000 DT_SIZE_K(736)>;
 		};
 
 		bt_fast_pair_partition: partition@177000 {
-			label = "bt_fast_pair";
+			compatible = "zephyr,mapped-partition";
 			reg = <0x177000 DT_SIZE_K(4)>;
 		};
 
 		storage_partition: partition@178000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x178000 DT_SIZE_K(20)>;
 		};

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
@@ -53,9 +53,6 @@
 };
 
 &cpuapp_rram {
-	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
-	reg = <0x0 DT_SIZE_K(1524)>;
-
 	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -5,9 +5,6 @@
  */
 
 &cpuapp_rram {
-	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
-	reg = <0x0 DT_SIZE_K(2036)>;
-
 	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -12,30 +12,35 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(20)>;
 		};
 
 		slot0_partition: partition@5000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x5000 DT_SIZE_K(996)>;
 		};
 
 		slot1_partition: partition@fe000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xfe000 DT_SIZE_K(996)>;
 		};
 
 		bt_fast_pair_partition: partition@1f7000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x1f7000 DT_SIZE_K(4)>;
 		};
 
 		storage_partition: partition@1f8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1f8000 DT_SIZE_K(20)>;
 		};

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -5,9 +5,6 @@
  */
 
 &cpuapp_rram {
-	/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
-	reg = <0x0 DT_SIZE_K(2036)>;
-
 	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
@@ -5,23 +5,27 @@
  */
 
 &cpuapp_rram {
+	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0 DT_SIZE_K(492)>;
 		};
 
 		bt_fast_pair_partition: partition@7b000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x7b000 DT_SIZE_K(4)>;
 		};
 
 		storage_partition: partition@7c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7c000 DT_SIZE_K(12)>;
 		};

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54ls05dk_nrf54ls05b_cpuapp_release.overlay
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54ls05dk_nrf54ls05b_cpuapp_release.overlay
@@ -5,33 +5,39 @@
  */
 
 &cpuapp_rram {
+	/* Redefine the "partitions" DTS node. */
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(20)>;
 		};
 
 		slot0_partition: partition@5000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x5000 DT_SIZE_K(236)>;
 		};
 
 		slot1_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x40000 DT_SIZE_K(236)>;
 		};
 
 		bt_fast_pair_partition: partition@7b000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x7b000 DT_SIZE_K(4)>;
 		};
 
 		storage_partition: partition@7c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7c000 DT_SIZE_K(12)>;
 		};


### PR DESCRIPTION
## Summary

Updated the devicetree partition overlays of the Fast Pair Locator Tag and Input Device samples to use the new `zephyr,mapped-partition` compatible. This aligns the affected overlays with the layout produced by the Partition Manager-to-DTS helper script (`scripts/pm_to_dts.py`) and matches the convention already used by the rest of the Fast Pair overlays.

For each updated overlay:

- Replaced the `fixed-partitions` compatible on the `partitions` container with the `ranges;` property required by the mapped-partition binding (the `#address-cells` and `#size-cells` properties were preserved).
- Added the `zephyr,mapped-partition` compatible to every partition node.
- Aligned the surrounding boilerplate (the `delete-node` directive and comment) with the rest of the overlays where it was missing.

Additionally, for the locator_tag `nrf54l15tag/nrf54l15/cpuapp` overlay, dropped the leftover `label = "bt_fast_pair"` from the `bt_fast_pair_partition` node so that the partition is referenced through its node label only, which matches every other Fast Pair overlay.

This change aligns the remaining board target overlays that were not aligned in [`f6ace89`](https://github.com/nrfconnect/sdk-nrf/commit/f6ace89fa0939417bf13ac82ac50d288d1ed90ed). A changelog entry under the *Bluetooth Fast Pair samples* section describes the migration.

Affected board target overlays:

- `input_device`: `nrf54lm20dk/nrf54lm20b/cpuapp`.
- `locator_tag`: `nrf54l15tag/nrf54l15/cpuapp`, `nrf54lm20dk/nrf54lm20b/cpuapp`, and `nrf54ls05dk/nrf54ls05b/cpuapp` (default and release).

The nRF53 board target overlays (`nrf5340dk/nrf5340/cpuapp` and `thingy53/nrf5340/cpuapp`) are not part of this PR. Their migration from Partition Manager to DTS is tracked separately and will land in dedicated PRs.

Ref: [NCSDK-39184](https://nordicsemi.atlassian.net/browse/NCSDK-39184)

## Test plan

- [x] `west build` (sysbuild) for `samples/bluetooth/fast_pair/locator_tag` on:
  - `nrf54l15tag/nrf54l15/cpuapp`
  - `nrf54lm20dk/nrf54lm20b/cpuapp`
  - `nrf54ls05dk/nrf54ls05b/cpuapp` (default and `FILE_SUFFIX=release`)
- [x] `west build` (sysbuild) for `samples/bluetooth/fast_pair/input_device` on:
  - `nrf54lm20dk/nrf54lm20b/cpuapp`
- [x] CI `ci_samples_bluetooth` Twister run.


[NCSDK-39184]: https://nordicsemi.atlassian.net/browse/NCSDK-39184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ