### PR TITLE
snippets: nrf93m1dk: Add snippet for enabling modem-bypass in nRF93M1DK

### DIFF
--- a/snippets/nrf93m1dk-modem-bypass/nrf93m1dk_modem_bypas.conf
+++ b/snippets/nrf93m1dk-modem-bypass/nrf93m1dk_modem_bypas.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_REGULATOR_FIXED_INIT_PRIORITY=95

--- a/snippets/nrf93m1dk-modem-bypass/nrf93m1dk_modem_bypas.overlay
+++ b/snippets/nrf93m1dk-modem-bypass/nrf93m1dk_modem_bypas.overlay
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This overlay is used to enable the nRF93M1DK in a modem-bypass mode where
+ * modem is powered on a boot and UART switch is controlled to route the
+ * modem's main UART to the VCOM1 port on the on-board debugger.
+ */
+
+
+/*
+ * UART routing switch:
+ * control IO have a pull-down resistor that defaults to bypass mode, so delete the control GPIO
+ */
+/delete-node/ &modem_uart_switch;
+
+/*
+ * Enable the modem, so the power-domain is enabled
+ */
+&modem {
+	status = "okay";
+};
+
+
+/*
+ * Activate POWERKEY:
+ * Driver powerkey on boot, so the modem boots when DC power is enabled
+ */
+&gpio1 {
+	/* Remove the default powerkey config so I can redefine it */
+	/delete-node/ modem-powerkey;
+
+	modem_powerkey_on {
+		gpio-hog;
+		gpios = <13 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+};
+
+
+/*
+ * Modem DCDC control:
+ * When board boots, wait 500ms before enabling the power for modem.
+ * Then wait another 500ms while the powerkey is active to trigger modem boot up.
+ */
+&modem_dcdc {
+	off-on-delay-us = <500000>;
+	startup-delay-us = <500000>;
+};
+
+
+/*
+ * Release powerkey:
+ * After modem is booted up, release the powerkey.
+ */
+/ {
+	/* Dummy regulator that switch powerkey off,
+	 * This runs after gpio-hog switched the powerkey-on and power-domain enabled the DC power.
+	 * The powerdomain driver have startup-delay that is enough for the powerkey.
+	 * This depends on CONFIG_REGULATOR_FIXED_INIT_PRIORITY being higher than
+	 * CONFIG_POWER_DOMAIN_GPIO_INIT_PRIORITY.
+	 */
+	modem_powerkey_off: modem_powerkey_off {
+		compatible = "regulator-fixed";
+		status = "okay";
+		regulator-name = "modem_powerkey";
+		enable-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+		regulator-boot-off;
+	};
+};

--- a/snippets/nrf93m1dk-modem-bypass/snippet.yml
+++ b/snippets/nrf93m1dk-modem-bypass/snippet.yml
@@ -1,0 +1,7 @@
+name: nrf93m1dk-modem-bypass
+
+boards:
+  /nrf93m1dk.*/nrf54l15/cpuapp.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: nrf93m1dk_modem_bypas.overlay
+      EXTRA_CONF_FILE: nrf93m1dk_modem_bypas.conf


### PR DESCRIPTION
Add snippet for configuring nRF93M1DK board into modem-bypass mode. This mode can be used for testing the modem from PC host.

Main UART of modem is routed to VCOM1 of the USB debug IC. Modem is powered when board boots up.

This snippet, and everything nRF93M1DK related, depends on board support, which is still open.
PR is in https://github.com/nrfconnect/sdk-nrf/pull/28518

So this is Do-Not-Merge, until the nRF93M1DK board files are in `sdk-zephyr`

Opening as a draft, so the review can start. I need opinions if this way for booting up the mode is acceptable.

Allows building sample applications with
```
west build -b nrf93m1dk/nrf54l15/cpuapp -p -S nrf93m1dk-modem-bypass
```
