### PR TITLE
soc: nordic: Enable TAMPC configuration for LV10

### DIFF
--- a/soc/nordic/nrf54l/CMakeLists.txt
+++ b/soc/nordic/nrf54l/CMakeLists.txt
@@ -21,7 +21,6 @@ add_subdirectory(${ZEPHYR_BASE}/soc/nordic/common ${CMAKE_BINARY_DIR}/common)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LS05B NRF54LS05B_XXAA)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LS05B_CPUAPP NRF_APPLICATION)
 
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LV10A NRF_SKIP_TAMPC_SETUP)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LV10A NRF54LV10A_XXAA)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LV10A_CPUAPP  NRF_APPLICATION)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LV10A_CPUFLPR NRF_FLPR)


### PR DESCRIPTION
It enables configuration of the TAMPC peripheral to open debug port at LV10.