### PR TITLE
samples: 802154_phy_test: remove unused rf_uninit teardown

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -368,6 +368,10 @@ nRF5340 samples
 Peripheral samples
 ------------------
 
+* :ref:`802154_phy_test` sample:
+
+  * Removed unused functions from the :file:`rf_proc.c` file and the :file:`rf_proc.h` header file.
+
 * :ref:`radio_test` sample:
 
   * Added:

--- a/samples/peripheral/802154_phy_test/include/rf_proc.h
+++ b/samples/peripheral/802154_phy_test/include/rf_proc.h
@@ -32,14 +32,6 @@
  */
 void rf_init(void);
 
-/** @brief NRF radio driver deinitialization
- *
- *  @param none
- *
- *  @return none
- */
-void rf_uninit(void);
-
 /** @brief Thread function for Radio handling
  *
  *  @param none

--- a/samples/peripheral/802154_phy_test/src/rf_proc.c
+++ b/samples/peripheral/802154_phy_test/src/rf_proc.c
@@ -36,7 +36,6 @@ static struct rf_rx_pkt_s ack_packet;
 static uint8_t temp_tx_pkt[RF_PSDU_MAX_SIZE];
 
 static inline void rf_rx_pool_init(void);
-static void rf_rx_pool_clear(void);
 
 static void rf_tx_finished_fn(struct k_work *work)
 {
@@ -125,14 +124,6 @@ void rf_init(void)
 #if CONFIG_PTT_ANTENNA_DIVERSITY
 	configure_antenna_diversity();
 #endif
-}
-
-void rf_uninit(void)
-{
-	/* free packets and marks them as free */
-	rf_rx_pool_clear();
-	ack_packet = (struct rf_rx_pkt_s){ 0 };
-	nrf_802154_deinit();
 }
 
 #if CONFIG_PTT_ANTENNA_DIVERSITY
@@ -511,18 +502,5 @@ static inline void rf_rx_pool_init(void)
 {
 	for (uint8_t i = 0; i < RF_RX_POOL_N; i++) {
 		rf_rx_pool[i] = (struct rf_rx_pkt_s){ 0 };
-	}
-}
-
-static void rf_rx_pool_clear(void)
-{
-	struct rf_rx_pkt_s *rx_pkt = NULL;
-
-	for (uint8_t i = 0; i < RF_RX_POOL_N; i++) {
-		rx_pkt = &rf_rx_pool[i];
-		if (rx_pkt->data != NULL) {
-			nrf_802154_buffer_free_raw(rx_pkt->rf_buf);
-			rx_pkt->data = NULL;
-		}
 	}
 }


### PR DESCRIPTION
Drop unused `rf_uninit()` from the public `rf_proc` API and delete its implementation, including `nrf_802154_deinit()` and the RX pool drain logic in `rf_rx_pool_clear()`.
Nothing in this sample called rf_uninit(). The helper existed only for that path.