### PR TITLE
quarantine: Add test configurations at NCS and sdk-zephyr

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -95,3 +95,15 @@
   platforms:
     - nrf52840dk/nrf52840
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39216"
+
+- scenarios:
+    - sample.bluetooth.central_uart
+  platforms:
+    - nrf54lm20dongle/nrf54lm20b/cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39225"
+
+- scenarios:
+    - nrf.extended.sample.basic.blinky
+  platforms:
+    - nrf54lm20dongle/nrf54lm20b/cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39226"

--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -253,6 +253,13 @@
     - native_sim/native
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39122"
 
+- scenarios:
+    - sample.edk.app
+    - sample.llext.shell
+  platforms:
+    - nrf9160dk/nrf9160/ns
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39227"
+
 # ---------------------------------   Won't fix section -----------------------------------
 
 - scenarios:


### PR DESCRIPTION
Test configurations are added to quarantines due to build failures.