### PR TITLE
mgmt/mcumgr/grp/img_mgmt: ensure erase speed on RRAM

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -29,3 +29,12 @@ config MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_IMAGE
 endif # MCUMGR_GRP_IMG_NRF
 
 endmenu
+
+if MCUMGR_GRP_IMG && SOC_FLASH_NRF_RRAM
+
+# Ensure that flash_flatten is done in chunks that are large enough for keeping speed performance on RRAM devices
+# Perfectly, this value should be set to the value of (NRF_RRAM_WRITE_BUFFER_SIZE * 16).
+configdefault FLASH_FILL_BUFFER_SIZE
+	default 256
+
+endif # MCUMGR_GRP_IMG && SOC_FLASH_NRF_RRAM


### PR DESCRIPTION
Patch is for mitigating lower mcumgr image erase speed performance on RRAM devices.

On RRAM devices image erase is emulated by writing of 0xFF (flash_flatten() API call).
Ensure that this is done in chunks which are
in size of configured RRAMC buffer, so speed will be not worse than while writing.

ref.: NCSDK-38824, NCSDK-39113