### PR TITLE
net: lib: nrf_cloud: mqtt: Fix integer underflow in topic prefix parsing

### DIFF
--- a/subsys/net/lib/nrf_cloud/mqtt/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/mqtt/src/nrf_cloud_transport.c
@@ -277,29 +277,39 @@ int nct_tenant_id_get(char *cur_tenant, const int cur_tenant_len)
 
 void nct_set_topic_prefix(const char *topic_prefix)
 {
-	char *end_of_stage = strchr(topic_prefix, '/');
-	int len;
+	const char *end_of_stage = strchr(topic_prefix, '/');
+	size_t total_len;
+	size_t stage_len;
+	size_t tenant_len;
 
-	if (end_of_stage) {
-		len = end_of_stage - topic_prefix;
-		if (len >= sizeof(stage)) {
-			LOG_WRN("Truncating copy of stage string length "
-				"from %d to %zd",
-				len, sizeof(stage));
-			len = sizeof(stage) - 1;
-		}
-		memcpy(stage, topic_prefix, len);
-		stage[len] = '\0';
-		len = strlen(topic_prefix) - len - 2; /* skip both / */
-		if (len >= sizeof(tenant)) {
-			LOG_WRN("Truncating copy of tenant id string length "
-				"from %d to %zd",
-				len, sizeof(tenant));
-			len = sizeof(tenant) - 1;
-		}
-		memcpy(tenant, end_of_stage + 1, len);
-		tenant[len] = '\0';
+	if (!end_of_stage) {
+		return;
 	}
+
+	total_len = strlen(topic_prefix);
+	stage_len = (size_t)(end_of_stage - topic_prefix);
+
+	if (total_len < stage_len + 2) {
+		LOG_ERR("Malformed topic prefix");
+		return;
+	}
+
+	if (stage_len >= sizeof(stage)) {
+		LOG_WRN("Truncating copy of stage string length from %zu to %zu",
+			stage_len, sizeof(stage) - 1);
+		stage_len = sizeof(stage) - 1;
+	}
+	memcpy(stage, topic_prefix, stage_len);
+	stage[stage_len] = '\0';
+
+	tenant_len = total_len - stage_len - 2;
+	if (tenant_len >= sizeof(tenant)) {
+		LOG_WRN("Truncating copy of tenant id string length from %zu to %zu",
+			tenant_len, sizeof(tenant) - 1);
+		tenant_len = sizeof(tenant) - 1;
+	}
+	memcpy(tenant, end_of_stage + 1, tenant_len);
+	tenant[tenant_len] = '\0';
 }
 
 static int allocate_and_format_topic(struct mqtt_utf8 *const topic,


### PR DESCRIPTION
Fixed a signed integer underflow in nct_set_topic_prefix() where a
malformed topic prefix (e.g. "stage/" with no tenant segment) caused
len to compute as -1. Due to implicit signed-to-unsigned conversion,
the bounds check was bypassed and memcpy copied 63 bytes of memory
beyond the end of the input string into the tenant[] buffer.

Fixed by using size_t for all length variables and validating that
the topic prefix contains a non-empty tenant segment before computing
tenant_len.

Ref: SI-539

Signed-off-by: Noah Pendleton <noah.pendleton@nordicsemi.no>
