### PR TITLE
scripts: sbom: Deduplicate symlinks entries

### DIFF
--- a/scripts/west_commands/sbom/external_file_detector.py
+++ b/scripts/west_commands/sbom/external_file_detector.py
@@ -39,6 +39,13 @@ EXTERNAL_FILE_RE = re.compile(
 detected_files = dict()
 dir_search_done = set()
 
+def is_file_check(file: Path) -> bool:
+    try:
+        return file.is_file()
+    except OSError:
+        log.dbg(f'Exception reading file "{file}": {traceback.format_exc()}',
+                level=log.VERBOSE_VERY)
+        return False
 
 def parse_license_file(file: Path):
     try:
@@ -80,7 +87,7 @@ def load_external_globs() -> 'list[tuple[str,set[str]]]':
                 level=log.VERBOSE_VERY)
         return external_globs
     for file in listdir:
-        if (file.is_file() and EXTERNAL_FILE_RE.search(file.name) is not None):
+        if (is_file_check(file) and EXTERNAL_FILE_RE.search(file.name) is not None):
             parsed = parse_license_file(file)
             if parsed is None:
                 continue
@@ -107,7 +114,7 @@ def search_dir(directory: Path):
                 level=log.VERBOSE_VERY)
         listdir = list()
     for file in listdir:
-        if (file.is_file() and EXTERNAL_FILE_RE.search(file.name) is not None):
+        if (is_file_check(file) and EXTERNAL_FILE_RE.search(file.name) is not None):
             parsed = parse_license_file(file)
             if parsed is None:
                 continue

--- a/scripts/west_commands/sbom/input_post_process.py
+++ b/scripts/west_commands/sbom/input_post_process.py
@@ -16,9 +16,13 @@ from data_structure import Data, FileInfo, Package
 def remove_duplicates(data: Data):
     '''Remove duplicated entries in data.files list.'''
     def is_not_visited(file: FileInfo):
-        if file.file_path in visited:
+        try:
+            file_entry = file.file_path.resolve()
+        except OSError:
+            file_entry = file.file_path
+        if file_entry in visited:
             return False
-        visited.add(file.file_path)
+        visited.add(file_entry)
         return True
     visited = set()
     data.files = list(filter(is_not_visited, data.files))


### PR DESCRIPTION
Remove duplicate file entries from the SBOM report under linux run. 
Fix error PermissionError under wsl.