### PR TITLE
[Backport v3.3-branch] bluetooth: hci: add support for CS capabilities v2 commands

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -635,8 +635,10 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_cs_create_config = 1;
 	cmds->hci_le_cs_remove_config = 1;
 	cmds->hci_le_cs_read_local_supported_capabilities = 1;
+	cmds->hci_le_cs_read_local_supported_capabilities_v2 = 1;
 	cmds->hci_le_cs_read_remote_supported_capabilities = 1;
 	cmds->hci_le_cs_write_cached_remote_supported_capabilities = 1;
+	cmds->hci_le_cs_write_cached_remote_supported_capabilities_v2 = 1;
 #if defined(CONFIG_BT_CTLR_CHANNEL_SOUNDING_TEST)
 	cmds->hci_le_cs_test = 1;
 	cmds->hci_le_cs_test_end = 1;
@@ -1501,6 +1503,16 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 							(void *)event_out_params);
 	case SDC_HCI_OPCODE_CMD_LE_CS_PROCEDURE_ENABLE:
 		return sdc_hci_cmd_le_cs_procedure_enable((void *)cmd_params);
+	case SDC_HCI_OPCODE_CMD_LE_CS_READ_LOCAL_SUPPORTED_CAPABILITIES_V2:
+		*param_length_out +=
+			sizeof(sdc_hci_cmd_le_cs_read_local_supported_capabilities_v2_return_t);
+		return sdc_hci_cmd_le_cs_read_local_supported_capabilities_v2(
+			(void *)event_out_params);
+	case SDC_HCI_OPCODE_CMD_LE_CS_WRITE_CACHED_REMOTE_SUPPORTED_CAPABILITIES_V2:
+		*param_length_out += sizeof(
+			sdc_hci_cmd_le_cs_write_cached_remote_supported_capabilities_v2_return_t);
+		return sdc_hci_cmd_le_cs_write_cached_remote_supported_capabilities_v2(
+			(void *)cmd_params, (void *)event_out_params);
 #if defined(CONFIG_BT_CTLR_CHANNEL_SOUNDING_TEST)
 	case SDC_HCI_OPCODE_CMD_LE_CS_TEST:
 		return sdc_hci_cmd_le_cs_test((void *)cmd_params);


### PR DESCRIPTION
Backport 7a1d5ee310175bc47ccf439be603e921d45dc989 from #28355.