### PR TITLE
tests: drivers: spi: Align spim_mosi_toggles to lm20 CI setups

### DIFF
--- a/tests/drivers/spi/spim_mosi_toggles/boards/nrf54lm20dk_nrf54lm20_common.dtsi
+++ b/tests/drivers/spi/spim_mosi_toggles/boards/nrf54lm20dk_nrf54lm20_common.dtsi
@@ -5,13 +5,13 @@
  */
 
 /* Test requires wire connection:
- *  - SPIM_MOSI with test-gpios -> P2.2 - P1.8.
+ *  - SPIM_MOSI with test-gpios -> P2.8 - P3.3.
  *  - Disable External Memory in NRF Connect for Desktop -> Board Configurator
  */
 
 / {
 	zephyr,user {
-		test-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		test-gpios = <&gpio3 3 GPIO_ACTIVE_LOW>;
 	};
 };
 
@@ -23,7 +23,7 @@
 
 		group2 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 1)>,
-				<NRF_PSEL(SPIM_MOSI, 2, 2)>;
+				<NRF_PSEL(SPIM_MOSI, 2, 8)>;
 			nordic,drive-mode = <NRF_DRIVE_E0E1>;
 		};
 	};
@@ -32,17 +32,17 @@
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 1)>,
 				<NRF_PSEL(SPIM_MISO, 2, 4)>,
-				<NRF_PSEL(SPIM_MOSI, 2, 2)>;
+				<NRF_PSEL(SPIM_MOSI, 2, 8)>;
 			low-power-enable;
 		};
 	};
 };
 
-&gpio1 {
+&gpio2 {
 	status = "okay";
 };
 
-&gpio2 {
+&gpio3 {
 	status = "okay";
 };
 

--- a/tests/drivers/spi/spim_mosi_toggles/testcase.yaml
+++ b/tests/drivers/spi/spim_mosi_toggles/testcase.yaml
@@ -3,11 +3,11 @@ common:
   tags:
     - ci_build
     - ci_tests_drivers_spi
+  harness: console
 
 tests:
 
   drivers.spi.spim_mosi_toggles:
-    harness: console
     harness_config:
       fixture: hpf_mspi_spi_loopback
       type: multi_line
@@ -17,14 +17,24 @@ tests:
         - "Test passed"
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+
+  drivers.spi.spim_mosi_toggles.lm20:
+    harness_config:
+      fixture: spim_mosi_toggles
+      type: multi_line
+      ordered: true
+      regex:
+        - "SPIM MOSI toggling test on"
+        - "Test passed"
+    platform_allow:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     integration_platforms:
-      - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
 
   drivers.spi.spim_mosi_toggles.slow:
-    harness: console
     harness_config:
       fixture: gpio_loopback
       type: multi_line


### PR DESCRIPTION
Test checks MLTPAN-21 observed on fast spi instances.

On LM20, there is only one fast instance spi00.
Its MOSI signal must be on P2.02 or P2.08.
Test requires loopback from spi00.MOSI to GPIOTE pin (P0/P1/P3).

In general, we have three PCA10184 test setups in CI:
- external_flash,
- spi_fast_loopback,
- pca63565 (board with sensors).

P2.08 is connected to P2.07 on external_flash and spi_fast_loopback.

P2.02 is used by external memory on externa_flash.
P2.02 is connected to P2.00 and P2.04 on spi_fast_loopback.

Thus, test must run on setups with pca63565.

Change loopback used in the test from P2.02-P1.08 to P2.08-P3.03.
Define unique fixture spim_mosi_toggles.
Update test setups with the new loopback and extend Twister HW map.