### PR TITLE
subsys: bluetooth: controller: rename num_antennas_supported to num_a…

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -1253,7 +1253,7 @@ static int configure_memory_usage(void)
 
 #if defined(CONFIG_BT_CTLR_SDC_CS_COUNT)
 	cfg.cs_cfg.max_antenna_paths_supported = CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS;
-	cfg.cs_cfg.num_antennas_supported = CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS;
+	cfg.cs_cfg.num_antennae_supported = CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS;
 
 	required_memory = sdc_cfg_set(SDC_DEFAULT_RESOURCE_CFG_TAG,
 									SDC_CFG_TYPE_CS_CFG,


### PR DESCRIPTION
…ntennae_supported

In the official BLE Spec v6.3 some of event parameters are renamed, and num_antennae_supported is one of them.