### PR TITLE
tests: subsys: bootloader: backward_compatibility: add ci tag

### DIFF
--- a/tests/subsys/bootloader/backward_compatibility/v3.2/compressed_update/mcuboot_update/testcase.yaml
+++ b/tests/subsys/bootloader/backward_compatibility/v3.2/compressed_update/mcuboot_update/testcase.yaml
@@ -3,6 +3,7 @@ common:
   build_only: true
   tags:
     - mcuboot
+    - ci_tests_subsys_bootloader
 
 # Application name changed back to "mcuboot_update"
 # Partition Manager re-enabled

--- a/tests/subsys/bootloader/backward_compatibility/v3.2/dfu_multi_image/testcase.yaml
+++ b/tests/subsys/bootloader/backward_compatibility/v3.2/dfu_multi_image/testcase.yaml
@@ -3,6 +3,7 @@ common:
   build_only: true
   tags:
     - mcuboot
+    - ci_tests_subsys_bootloader
 
 # Reduced code size for mcuboot for nRF54H20
 # Incompatibility introduced in commit ae3449e

--- a/tests/subsys/bootloader/backward_compatibility/v3.2/smp_svr/testcase.yaml
+++ b/tests/subsys/bootloader/backward_compatibility/v3.2/smp_svr/testcase.yaml
@@ -3,6 +3,7 @@ common:
   build_only: true
   tags:
     - mcumgr
+    - ci_tests_subsys_bootloader
 
 # nrf54h20dk direct_xip_withrevert:
 #   In v3.3 the merged-slot Direct XIP bootchain assigns a different UUID-CID


### PR DESCRIPTION
Missing ci tag ci_tests_subsys_bootloader.