### PR TITLE
[collab-nrf9251] manifest: update nrfx branch for nRF9251 testing purposes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -121,7 +121,7 @@ manifest:
       remote: zephyrproject
       path: modules/hal/nor
     - name: nrfx
-      revision: master
+      revision: deploy-bsd
       path: modules/hal/nor/nrfx
     - name: wfa-qt-control-app
       repo-path: sdk-wi-fiquicktrack-controlappc


### PR DESCRIPTION
Use nrfx 4.3.0 release branch.

The same branch as in https://github.com/zephyrproject-rtos/hal_nordic/pull/360