### PR TITLE
applications: nrf_audio: Fixes to TX timestamp handling

### DIFF
--- a/applications/nrf_audio/src/audio/le_audio_rx.c
+++ b/applications/nrf_audio/src/audio/le_audio_rx.c
@@ -22,10 +22,8 @@
 LOG_MODULE_REGISTER(le_audio_rx, CONFIG_LE_AUDIO_RX_LOG_LEVEL);
 
 struct rx_stats {
-	uint32_t recv_cnt;
-	uint32_t good_frame_cnt;
-	uint32_t bad_frame_cnt;
-	bool prev_bad_data;
+	uint64_t good_frame_cnt;
+	uint64_t bad_or_empty_frame_cnt;
 };
 
 static bool initialized;
@@ -109,33 +107,37 @@ void le_audio_rx_data_handler(struct net_buf *audio_frame_rx, struct audio_metad
 	static uint32_t num_overruns;
 	static uint32_t num_thrown;
 
+	__ASSERT_NO_MSG(audio_frame_rx != NULL);
+	__ASSERT_NO_MSG(meta != NULL);
+
 	if (!initialized) {
 		ERR_CHK_MSG(-EPERM, "Data received but le_audio_rx is not initialized");
 	}
 
-	rx_stats[location_index].recv_cnt++;
-
 	if (meta->bad_data) {
-		rx_stats[location_index].bad_frame_cnt++;
+		rx_stats[location_index].bad_or_empty_frame_cnt++;
 	} else {
 		rx_stats[location_index].good_frame_cnt++;
 	}
 
-	if ((rx_stats[location_index].recv_cnt % 100) == 0 && rx_stats[location_index].recv_cnt) {
+	uint64_t total_frames = rx_stats[location_index].good_frame_cnt +
+				rx_stats[location_index].bad_or_empty_frame_cnt;
+	double bad_frame_percentage =
+		(total_frames > 0) ? (((double)rx_stats[location_index].bad_or_empty_frame_cnt /
+				       total_frames) *
+				      100)
+				   : 0.0;
+
+	if ((total_frames % 100) == 0 && (total_frames != 0)) {
 		/* NOTE: The string below is used by the Nordic CI system */
-		LOG_DBG("ISO RX SDUs: Loc: %d Total: %d Bad: %d", location_index,
-			rx_stats[location_index].recv_cnt, rx_stats[location_index].bad_frame_cnt);
+		LOG_DBG("ISO RX SDUs: Loc: %u Total: %llu Bad: %llu", location_index, total_frames,
+			rx_stats[location_index].bad_or_empty_frame_cnt);
 	}
 
-	if (meta->bad_data && !rx_stats[location_index].prev_bad_data) {
-		LOG_INF_RATELIMIT_RATE(1000,
-				       "Bad or 0 SDU: Loc: %u Total: %u Bad: %u. (Prints "
-				       "good->bad transition)",
-				       location_index, rx_stats[location_index].recv_cnt,
-				       rx_stats[location_index].bad_frame_cnt);
-	}
-
-	rx_stats[location_index].prev_bad_data = meta->bad_data;
+	LOG_DBG_RATELIMIT_RATE(
+		10000, "Bad or 0 SDU: Loc: %u Total: %llu Empty/bad: %llu (%2.3f %%)",
+		location_index, total_frames, rx_stats[location_index].bad_or_empty_frame_cnt,
+		bad_frame_percentage);
 
 	if (stream_state_get() != STATE_STREAMING) {
 		/* Throw away data */
@@ -264,6 +266,10 @@ check_send:
  */
 static void audio_datapath_thread(void *dummy1, void *dummy2, void *dummy3)
 {
+	ARG_UNUSED(dummy1);
+	ARG_UNUSED(dummy2);
+	ARG_UNUSED(dummy3);
+
 	int ret;
 	struct net_buf *audio_frame = NULL;
 

--- a/applications/nrf_audio/src/bluetooth/bt_stream/bt_le_audio_tx/Kconfig
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/bt_le_audio_tx/Kconfig
@@ -9,6 +9,7 @@ config NRF_AUDIO_TX_TGT_LEAD_TIME_US
 	  Used to make sure that the data is sent to controller just in time for the next SDU,
 	  which can help with reducing the overall latency and power consumption.
 	  Setting this too low may lead to flushed data, and too high will increase latency.
+	  Must be higher than HCI_ISO_TX_SDU_ARRIVAL_MARGIN_US + plus a margin depending on SoC.
 
 config NRF_AUDIO_TX_LEAD_TIME_DEVIATION_US
 	int

--- a/applications/nrf_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
@@ -12,6 +12,7 @@
 #include <../subsys/bluetooth/audio/bap_stream.h>
 #include <bluetooth/hci_vs_sdc.h>
 #include <audio_defines.h>
+#include <sdc_hci.h>
 
 #include "zbus_common.h"
 #include "audio_sync_timer.h"
@@ -23,6 +24,17 @@ ZBUS_CHAN_DEFINE(sdu_ref_chan, struct sdu_ref_msg, NULL, NULL, ZBUS_OBSERVERS_EM
 		 ZBUS_MSG_INIT(0));
 
 #define HANDLE_INVALID 0xFFFF
+
+#define TX_MARGIN_MIN_US CONFIG_NRF_AUDIO_TX_TGT_LEAD_TIME_US
+#if (TX_MARGIN_MIN_US <= HCI_ISO_TX_SDU_ARRIVAL_MARGIN_US)
+#error "TX_MARGIN_MIN_US must be higher than HCI_ISO_TX_SDU_ARRIVAL_MARGIN_US"
+#endif
+
+/* The maximum time allowed before an SDU is flushed.
+ * The common_interval is added to this value.
+ * Must be higher than TX_MARGIN_MIN_US
+ */
+#define TX_MARGIN_MAX_US 4700
 
 /* Maximum allowed time deviation for calling tx_send.
  * E.g. 0.2 = 20 % deviation from the common interval
@@ -64,11 +76,12 @@ ZBUS_CHAN_DEFINE(sdu_ref_chan, struct sdu_ref_msg, NULL, NULL, ZBUS_OBSERVERS_EM
  * @return		0 if successful, error otherwise.
  */
 static int iso_stream_send(uint8_t const *const data, size_t size, struct bt_cap_stream *cap_stream,
-			   struct bt_le_audio_tx_ctx *ctx, struct tx_inf *tx_info, uint32_t ts_tx,
-			   bool send_ts_tx)
+			   struct bt_le_audio_tx_ctx *ctx, struct tx_inf *tx_info)
 {
 	int ret;
 	struct net_buf *buf;
+
+	bool send_ts_tx = ctx->ts_ctlr_esti_us_valid;
 
 	/* net_buf_alloc allocates buffers for APP->NET transfer over HCI RPMsg,
 	 * but when these buffers are released it is not guaranteed that the
@@ -88,6 +101,7 @@ static int iso_stream_send(uint8_t const *const data, size_t size, struct bt_cap
 				(void *)&cap_stream->bap_stream);
 			tx_info->hci_wrn_printed = true;
 		}
+
 		return -ENOMEM;
 	}
 
@@ -106,7 +120,7 @@ static int iso_stream_send(uint8_t const *const data, size_t size, struct bt_cap
 	atomic_inc(&tx_info->iso_tx_pool_alloc);
 
 	if (send_ts_tx) {
-		ret = bt_cap_stream_send_ts(cap_stream, buf, 0U, ts_tx);
+		ret = bt_cap_stream_send_ts(cap_stream, buf, 0U, ctx->ts_ctlr_esti_us);
 	} else {
 		ret = bt_cap_stream_send(cap_stream, buf, 0U);
 	}
@@ -119,6 +133,12 @@ static int iso_stream_send(uint8_t const *const data, size_t size, struct bt_cap
 		net_buf_unref(buf);
 		(void)atomic_dec(&tx_info->iso_tx_pool_alloc);
 		return ret;
+	} else {
+		if (ctx->last_data_status == STATUS_NOT_SET && send_ts_tx) {
+			ctx->last_data_status = STATUS_SENT_WITH_TS;
+		} else if (ctx->last_data_status == STATUS_NOT_SET && !send_ts_tx) {
+			ctx->last_data_status = STATUS_SENT_WITHOUT_TS;
+		}
 	}
 
 	return 0;
@@ -253,6 +273,7 @@ static int tx_precheck(struct le_audio_tx_info const *const tx, uint8_t num_tx,
 			LOG_ERR("Not all channels have the same ISO interval");
 			return -EINVAL;
 		}
+
 		*common_interval_us = bap_stream->qos->interval;
 	}
 
@@ -349,8 +370,7 @@ static uint8_t tx_streams_send(struct bt_le_audio_tx_ctx *ctx,
 		/* Check if same audio is sent to all locations */
 		if (num_loc == 1U) {
 			ret = iso_stream_send(audio_frame->data, data_size_pr_stream,
-					      tx[i].cap_stream, ctx, tx_info, ctx->ts_ctlr_esti_us,
-					      ctx->ts_ctlr_esti_us_valid);
+					      tx[i].cap_stream, ctx, tx_info);
 		} else {
 			if (unlikely(tx[i].audio_location >= num_loc)) {
 				LOG_ERR("audio_location (%u) out of bounds (num_loc: %u) for "
@@ -362,8 +382,7 @@ static uint8_t tx_streams_send(struct bt_le_audio_tx_ctx *ctx,
 
 			ret = iso_stream_send(audio_frame->data +
 						      (tx[i].audio_location * data_size_pr_stream),
-					      data_size_pr_stream, tx[i].cap_stream, ctx, tx_info,
-					      ctx->ts_ctlr_esti_us, ctx->ts_ctlr_esti_us_valid);
+					      data_size_pr_stream, tx[i].cap_stream, ctx, tx_info);
 		}
 
 		if (ret != 0) {
@@ -381,25 +400,6 @@ static uint8_t tx_streams_send(struct bt_le_audio_tx_ctx *ctx,
 	return sent_streams;
 }
 
-static int tx_ts_prepare(struct bt_le_audio_tx_ctx *ctx, uint32_t common_interval_us)
-{
-	/* Increment the tx timestamp with the interval.
-	 * Designed for overflow.
-	 * If this TX function is called too fast or slow, the estimate will deteriorate more
-	 * quickly.
-	 */
-	ctx->ts_ctlr_esti_us += common_interval_us;
-	if (ctx->flush_next) {
-		LOG_DBG("Flushed %u us of audio data to maintain timestamp sync with controller",
-			common_interval_us);
-		ctx->flush_next = false;
-		ctx->ts_ctlr_esti_us_valid = false;
-		return -ECANCELED;
-	}
-
-	return 0;
-}
-
 static int tx_controller_sync_and_correct(struct bt_le_audio_tx_ctx *ctx,
 					  const struct bt_bap_stream *last_successful_bap_stream,
 					  uint32_t common_interval_us, uint32_t ts_now_us,
@@ -407,86 +407,102 @@ static int tx_controller_sync_and_correct(struct bt_le_audio_tx_ctx *ctx,
 {
 	int ret;
 	uint32_t ts_ctlr_real_us = 0U;
+	bool sync_required = false;
 
-	ctx->corr_diff_us = 0U;
+	int64_t corr_diff_us = 0U;
 
-	/* If the timestamp is not valid or it has been more than TX_TS_RESYNC_US since the last
-	 * timestamp, we re-acquire a timestamp from the controller.
-	 */
-	if (!ctx->ts_ctlr_esti_us_valid ||
-	    ((uint32_t)(ctx->ts_ctlr_esti_us - ctx->ts_ctlr_real_us_last) >= TX_TS_RESYNC_US) ||
-	    ((uint32_t)(ts_now_us - ctx->ts_last_us) >= TX_TS_RESYNC_US)) {
-
-		ret = controller_ts_tx_get(last_successful_bap_stream, &ts_ctlr_real_us, tx_info);
-		if (ret != 0) {
-			LOG_ERR("Failed to get timestamp after sending: %d", ret);
-			return ret;
-		}
-
-		ctx->corr_diff_us = (int64_t)ts_ctlr_real_us - (int64_t)ctx->ts_ctlr_esti_us;
-		LOG_DBG_RATELIMIT_RATE(1000U, "TX clock correction: %lld us real %u esti %u",
-				       ctx->corr_diff_us, ts_ctlr_real_us, ctx->ts_ctlr_esti_us);
-
-		if ((uint32_t)(ts_now_us - ctx->ts_last_correction) < TX_TS_RESYNC_US) {
-			ctx->subsequent_rapid_corrections++;
-		} else {
-			ctx->subsequent_rapid_corrections = 0U;
-		}
-
-		if (ctx->subsequent_rapid_corrections > SUBSEQUENT_RAPID_CORRECTIONS_LIMIT) {
-			LOG_ERR_RATELIMIT_RATE(1000U, "%d subsequent time corrections",
-					       ctx->subsequent_rapid_corrections);
-		}
-
-		/* There are several options which can occur at this point:
-		 *
-		 * - corr_diff_us == 0: The estimate is correct, no correction needed.
-		 *
-		 * - corr_diff_us >> 0: Data was given to this module too slow/late.
-		 * Hence, the controller schedules sending for the next ISO
-		 * interval. An empty packet will be sent on air.
-		 *
-		 * - corr_diff_us << 0: Data was given to this module too fast/early.
-		 *
-		 * - corr_diff_us > or < 0: This means that the estimate has gotten a small
-		 * correction. As a central/gateway/unicast client/broadcast source, the
-		 * clocks shall be running in lockstep and this should never happen. As a
-		 * peripheral/headset/unicast server/broadcast sink, this will occur to
-		 * correct for drift.
-		 */
-
-		const int64_t half_common_interval_us = (int64_t)common_interval_us / 2;
-
-		if (ctx->corr_diff_us == 0) {
-			/* No correction needed, the estimate is correct. */
-			LOG_DBG("TX clock no adjustment needed (%lld us)", ctx->corr_diff_us);
-			ctx->ts_ctlr_esti_us_valid = true;
-		} else if (ctx->corr_diff_us > half_common_interval_us) {
-			LOG_DBG("TX clock corrected by (%lld us). Late: Empty packet(s) on air",
-				ctx->corr_diff_us);
-			ctx->ts_ctlr_esti_us_valid = false;
-			*status = -ETIMEDOUT;
-		} else if (ctx->corr_diff_us < -half_common_interval_us) {
-			LOG_DBG("TX clock corrected by (%lld us). Early", ctx->corr_diff_us);
-			ctx->ts_ctlr_esti_us_valid = false;
-		} else {
-			if (ctx->is_ble_clock_master) {
-				/* The gateway is the Bluetooth central. This shall not happen */
-				LOG_ERR("TX clock has been drift adjusted by (%lld us)",
-					ctx->corr_diff_us);
-				ctx->ts_ctlr_esti_us_valid = false;
-			} else {
-				LOG_DBG("TX clock has been drift adjusted by (%lld us)",
-					ctx->corr_diff_us);
-				ctx->ts_ctlr_esti_us_valid = true;
-			}
-		}
-
-		ctx->ts_ctlr_real_us_last = ts_ctlr_real_us;
-		/* Update the estimate to the real (most current) value */
-		ctx->ts_ctlr_esti_us = ts_ctlr_real_us;
-		ctx->ts_last_correction = ts_now_us;
+	/* Timestamp is invalid: send with no timestamp and re-sync */
+	if (!ctx->ts_ctlr_esti_us_valid) {
+		sync_required = true;
 	}
+
+	/* Time since last correction over limit: send with no timestamp and re-sync.
+	 * This is required on the headset/peripheral/broadcast sink side to compensate
+	 * for clock drift compared to the gateway/central/broadcast source.
+	 */
+	if ((uint32_t)(ctx->ts_ctlr_esti_us - ctx->ts_ctlr_real_us_last) >= TX_TS_RESYNC_US) {
+		sync_required = true;
+	}
+
+	/* Same as above. Checks against current time. */
+	if ((uint32_t)(ts_now_us - ctx->ts_last_us) >= TX_TS_RESYNC_US) {
+		sync_required = true;
+	}
+
+	if (!sync_required) {
+		return 0;
+	}
+
+	ret = controller_ts_tx_get(last_successful_bap_stream, &ts_ctlr_real_us, tx_info);
+	if (ret != 0) {
+		LOG_ERR("Failed to get timestamp after sending: %d", ret);
+		return ret;
+	}
+
+	corr_diff_us = (int64_t)ts_ctlr_real_us - (int64_t)ctx->ts_ctlr_esti_us;
+
+	if ((uint32_t)(ts_now_us - ctx->ts_last_correction) < TX_TS_RESYNC_US) {
+		ctx->subsequent_rapid_corrections++;
+	} else {
+		ctx->subsequent_rapid_corrections = 0U;
+	}
+
+	if (ctx->subsequent_rapid_corrections > SUBSEQUENT_RAPID_CORRECTIONS_LIMIT) {
+		LOG_ERR_RATELIMIT_RATE(1000U, "%d subsequent time corrections",
+				       ctx->subsequent_rapid_corrections);
+	}
+
+	/* There are several options which can occur at this point:
+	 *
+	 * - corr_diff_us == 0: The estimate is correct, no correction needed.
+	 *
+	 * - corr_diff_us >> 0: Data was given to this module too slow/late.
+	 * Hence, the controller schedules sending for the next ISO
+	 * interval. An empty packet will be sent on air.
+	 *
+	 * - corr_diff_us << 0: Data was given to this module too fast/early.
+	 *
+	 * - corr_diff_us > or < 0: This means that the estimate has gotten a small
+	 * correction. As a central/gateway/unicast client/broadcast source, the
+	 * clocks shall be running in lockstep and this should never happen. As a
+	 * peripheral/headset/unicast server/broadcast sink, this will occur to
+	 * correct for drift.
+	 */
+
+	const int64_t half_common_interval_us = (int64_t)common_interval_us / 2;
+
+	if (corr_diff_us == 0) {
+		/* No correction needed, the estimate is correct. */
+		LOG_DBG_RATELIMIT("TX clock no adj (%lld us)", corr_diff_us);
+		ctx->ts_ctlr_esti_us_valid = true;
+
+	} else if (corr_diff_us > half_common_interval_us) {
+		LOG_DBG("TX clock corrected by (%lld us). Late: Empty packet(s) on air",
+			corr_diff_us);
+
+		ctx->ts_ctlr_esti_us_valid = false;
+		*status = -ETIMEDOUT;
+
+	} else if (corr_diff_us < -half_common_interval_us) {
+		LOG_DBG("TX clock corrected by (%lld us). Early", corr_diff_us);
+		ctx->ts_ctlr_esti_us_valid = false;
+	} else {
+		/* Ts corrected by some small factor*/
+		if (ctx->is_ble_clock_master) {
+			/* The gateway is the Bluetooth central. This shall not happen */
+			LOG_ERR("TX clock has been drift adjusted by (%lld us)", corr_diff_us);
+			ctx->ts_ctlr_esti_us_valid = false;
+		} else {
+			LOG_DBG("TX clock has been drift adjusted by (%lld us)", corr_diff_us);
+			ctx->ts_ctlr_esti_us_valid = true;
+		}
+	}
+
+	ctx->corr_diff_us = corr_diff_us;
+	ctx->ts_ctlr_real_us_last = ts_ctlr_real_us;
+	/* Update the estimate to the real (most current) value */
+	ctx->ts_ctlr_esti_us = ts_ctlr_real_us;
+	ctx->ts_last_correction = ts_now_us;
 
 	return 0;
 }
@@ -504,9 +520,6 @@ static void tx_publish_sdu_ref_and_finalize(struct bt_le_audio_tx_ctx *ctx, uint
 	if (ret != 0) {
 		LOG_WRN("Failed to publish timestamp: %d", ret);
 	}
-
-	ctx->ts_last_us = ts_now_us;
-	ctx->ts_last_us_valid = true;
 }
 
 int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *const audio_frame,
@@ -519,6 +532,8 @@ int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *co
 	if (unlikely(ctx == NULL || tx == NULL || num_tx == 0U || audio_frame == NULL)) {
 		return -EINVAL;
 	}
+
+	ctx->last_data_status = STATUS_NOT_SET;
 
 	ret = tx_entries_validate(tx, num_tx);
 	if (ret != 0) {
@@ -581,16 +596,61 @@ int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *co
 		return -EINVAL;
 	}
 
-	ret = tx_ts_prepare(ctx, common_interval_us);
-	if (ret != 0) {
-		return ret;
-	}
-
-	LOG_DBG_RATELIMIT_RATE(1000, "tx %d valid %d", num_tx, ctx->ts_ctlr_esti_us_valid);
-
 	uint32_t ts_now_us = audio_sync_timer_capture();
 
 	tx_call_interval_check(ctx, ts_now_us, common_interval_us);
+
+	ctx->ts_last_us = ts_now_us;
+	ctx->ts_last_us_valid = true;
+	ctx->ts_ctlr_esti_us += common_interval_us;
+
+	if (ctx->ts_ctlr_esti_us_valid) {
+
+		/* A large positive time diff:
+		 *	Too fast/too much data -> Throw
+		 * A small positive time diff or negative:
+		 *	Too slow/not enough data -> Skip SDU
+		 */
+		int32_t time_diff_us = (int32_t)(ctx->ts_ctlr_esti_us - ts_now_us);
+
+		LOG_DBG_RATELIMIT_RATE(1000, "Time diff to controller timestamp: %d us",
+				       time_diff_us);
+
+		/* The time diffs below will be too large at times if the audio source is not
+		 * synced to the BLE master clock. This will be the case for syncronous USB, where
+		 * the USB host (often a PC) will provide data slightly faster or slower than the
+		 * BLE master clock. I2S or asynchronous USB will not have this issue.
+		 */
+
+		if (time_diff_us < TX_MARGIN_MIN_US) {
+			/* If the diff is below the margin:
+			 *	Data provided too slow. Increase TS by
+			 *	an extra interval, get one empty SDU on air per location.
+			 */
+			LOG_INF("Data provided too slow. May happen for sync USB. time_diff_us:"
+				" %d(not in range : %u - %u) ",
+				time_diff_us, TX_MARGIN_MAX_US + common_interval_us,
+				TX_MARGIN_MIN_US);
+
+			ctx->ts_ctlr_esti_us += common_interval_us;
+			ctx->last_data_status = STATUS_UNDERRUN_EMPTY_SDU_ON_AIR;
+
+		} else if (time_diff_us > (TX_MARGIN_MAX_US + common_interval_us)) {
+
+			/* Data provided too fast. Will need to flush this data */
+			LOG_INF("Data provided too fast. May happen for sync USB. time_diff_us: "
+				" %d (not in range: %u - %u)",
+				time_diff_us, TX_MARGIN_MAX_US + common_interval_us,
+				TX_MARGIN_MIN_US);
+
+			ctx->last_data_status = STATUS_OVERRUN_FLUSHED;
+			return -ECANCELED;
+		}
+
+		/* If ts_ctlr_esti_us_valid is false, this means we shall send with no timestamp.
+		 * This can lead to tx_sync_get returning a timestamp which is +1 or +2 intervals.
+		 */
+	}
 
 	sent_streams = tx_streams_send(ctx, audio_frame, tx, num_tx, num_loc, data_size_pr_stream,
 				       &last_successful_bap_stream, &tx_info);
@@ -608,21 +668,11 @@ int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *co
 		return -EIO;
 	}
 
-	/* Get the current (wall clock) time */
-	ts_now_us = audio_sync_timer_capture();
-
 	ret = tx_controller_sync_and_correct(ctx, last_successful_bap_stream, common_interval_us,
 					     ts_now_us, tx_info, &status);
+
 	if (ret != 0) {
 		return ret;
-	}
-
-	if ((int32_t)(ts_now_us - ctx->ts_ctlr_esti_us) > 0) {
-		LOG_WRN("Curr time ahead of ctlr time. Flush %u us of data. "
-			"Now: %u us, ctlr: %u us",
-			common_interval_us, ts_now_us, ctx->ts_ctlr_esti_us);
-		ctx->flush_next = true;
-		ctx->ts_ctlr_esti_us_valid = false;
 	}
 
 	tx_publish_sdu_ref_and_finalize(ctx, ts_now_us);

--- a/applications/nrf_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.h
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.h
@@ -55,6 +55,14 @@ struct bt_le_audio_tx_ctx;
 
 #define TX_BUF_NUM (GROUP_MAX * SUBGROUP_MAX * TX_STREAMS_MAX * HCI_ISO_BUF_PER_CHAN)
 
+enum bt_le_audio_tx_last_data_status {
+	STATUS_NOT_SET = 0,		  /* Initial status */
+	STATUS_SENT_WITH_TS,		  /* Data sent with timestamp */
+	STATUS_SENT_WITHOUT_TS,		  /* Data sent without timestamp */
+	STATUS_OVERRUN_FLUSHED,		  /* Data overrun, flushed */
+	STATUS_UNDERRUN_EMPTY_SDU_ON_AIR, /* Data underrun, empty SDU on air */
+};
+
 struct tx_inf {
 	uint16_t iso_conn_handle;
 	struct bt_iso_tx_info iso_tx;
@@ -80,10 +88,10 @@ struct bt_le_audio_tx_ctx {
 	/* The previous "now" timestamp and validity */
 	uint32_t ts_last_us;
 	bool ts_last_us_valid;
-	/* Should the data in the next function call be flushed */
-	bool flush_next;
 	/* This device is Bluetooth clock master (central/unicast client or broadcast source) */
 	bool is_ble_clock_master;
+	/* Status of the last submitted data */
+	enum bt_le_audio_tx_last_data_status last_data_status;
 };
 
 #define BT_LE_AUDIO_TX_DEFINE(name)                                                                \
@@ -124,9 +132,9 @@ int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *co
  * @param[in]	ctx		Pointer to TX context.
  * @param[in]	stream_idx	Stream index.
  *
+ * @retval	0		Success.
  * @retval	-EINVAL		ctx is NULL or the module has not been initialized.
  * @retval      -ESPIPE		stream_idx is out of bounds.
- * @retval	0		Success.
  */
 int bt_le_audio_tx_stream_started(struct bt_le_audio_tx_ctx *ctx, struct stream_index stream_idx);
 
@@ -136,9 +144,9 @@ int bt_le_audio_tx_stream_started(struct bt_le_audio_tx_ctx *ctx, struct stream_
  * @param[in]	ctx		Pointer to TX context.
  * @param[in]	stream_idx	Stream index.
  *
+ * @retval	0		Success.
  * @retval	-EINVAL		ctx is NULL or the module has not been initialized.
  * @retval      -ESPIPE		stream_idx is out of bounds.
- * @retval	0		Success.
  */
 int bt_le_audio_tx_stream_sent(struct bt_le_audio_tx_ctx *ctx, struct stream_index stream_idx);
 
@@ -150,8 +158,8 @@ int bt_le_audio_tx_stream_sent(struct bt_le_audio_tx_ctx *ctx, struct stream_ind
  *				(Unicast client) or Broadcast source,
  *				false = peripheral (unicast server) or Broadcast sink.
  *
- * @retval	-EINVAL		@p ctx is NULL or required configuration is missing.
  * @retval	0		Success.
+ * @retval	-EINVAL		@p ctx is NULL or required configuration is missing.
  */
 int bt_le_audio_tx_init(struct bt_le_audio_tx_ctx *ctx, bool is_clock_master);
 

--- a/applications/nrf_audio/src/bluetooth/bt_stream/le_audio.c
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/le_audio.c
@@ -55,6 +55,8 @@ int le_audio_metadata_populate(struct audio_metadata *meta, const struct bt_bap_
 		return -EINVAL;
 	}
 
+	/* A valid packet will always have a valid timestamp from the Softdevice Controller*/
+
 	if (!(info->flags & BT_ISO_FLAGS_VALID) ||
 	    audio_frame->len != bt_audio_codec_cfg_get_octets_per_frame(stream->codec_cfg)) {
 		meta->bad_data = meta->locations;

--- a/applications/nrf_audio/src/modules/audio_usb.c
+++ b/applications/nrf_audio/src/modules/audio_usb.c
@@ -11,6 +11,7 @@
 #include <zephyr/usb/class/usbd_uac2.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/net_buf.h>
+#include <string.h>
 #include <audio_defines.h>
 
 #include "macros_common.h"
@@ -86,6 +87,8 @@ static void terminal_update_cb(const struct device *dev, uint8_t terminal, bool 
 		LOG_WRN("Unknown terminal ID: %d", terminal);
 		return;
 	}
+
+	LOG_DBG("Terminal %d %s", terminal, enabled ? "enabled" : "disabled");
 }
 
 static void usb_send_cb(const struct device *dev, void *user_data)

--- a/tests/nrf_audio/bt_le_audio_tx/CMakeLists.txt
+++ b/tests/nrf_audio/bt_le_audio_tx/CMakeLists.txt
@@ -26,4 +26,5 @@ target_include_directories(app PRIVATE
   ${ZEPHYR_NRF_MODULE_DIR}/applications/nrf_audio/include
   ${ZEPHYR_NRF_MODULE_DIR}/tests/nrf_audio/fakes/
   ${ZEPHYR_NRF_MODULE_DIR}/include
+  ${ZEPHYR_NRFXLIB_MODULE_DIR}/softdevice_controller/include
 )

--- a/tests/nrf_audio/bt_le_audio_tx/Kconfig
+++ b/tests/nrf_audio/bt_le_audio_tx/Kconfig
@@ -1,3 +1,7 @@
+config NRF_AUDIO_TX_TGT_LEAD_TIME_US
+	int
+	default 3000
+
 config LC3_BITRATE_MIN
 	int
 	default 32000

--- a/tests/nrf_audio/bt_le_audio_tx/src/main.c
+++ b/tests/nrf_audio/bt_le_audio_tx/src/main.c
@@ -99,21 +99,26 @@ BT_LE_AUDIO_TX_DEFINE(audio_tx_ctx);
 	meta->locations = 0x07;                                                                    \
 	static const uint8_t chan_to_send = 3U;
 
-static void internals_verify(int64_t corr_diff_us, bool ts_ctlr_esti_valid,
-			     uint32_t ts_ctlr_esti_us, bool flush_next)
+static void internals_verify_impl(int64_t corr_diff_us, bool ts_ctlr_esti_valid,
+				  uint32_t ts_ctlr_esti_us,
+				  enum bt_le_audio_tx_last_data_status last_data_status, int line)
 {
 	struct bt_le_audio_tx_ctx *ctx = (struct bt_le_audio_tx_ctx *)audio_tx_ctx;
 
-	zassert_equal(ctx->corr_diff_us, corr_diff_us, "corr_diff_us %lld expected %lld",
-		      ctx->corr_diff_us, corr_diff_us);
+	zassert_equal(ctx->corr_diff_us, corr_diff_us, "corr_diff_us %lld expected %lld, line: %d",
+		      ctx->corr_diff_us, corr_diff_us, line);
 	zassert_equal(ctx->ts_ctlr_esti_us_valid, ts_ctlr_esti_valid,
-		      "ts_ctlr_esti_valid %d expected %d", ctx->ts_ctlr_esti_us_valid,
-		      ts_ctlr_esti_valid);
-	zassert_equal(ctx->ts_ctlr_esti_us, ts_ctlr_esti_us, "ts_ctlr_esti_us %u expected %u",
-		      ctx->ts_ctlr_esti_us, ts_ctlr_esti_us);
-	zassert_equal(ctx->flush_next, flush_next, "flush_next %d expected %d", ctx->flush_next,
-		      flush_next);
+		      "ts_ctlr_esti_valid %d expected %d, line: %d", ctx->ts_ctlr_esti_us_valid,
+		      ts_ctlr_esti_valid, line);
+	zassert_equal(ctx->ts_ctlr_esti_us, ts_ctlr_esti_us,
+		      "ts_ctlr_esti_us %u expected %u, line: %d", ctx->ts_ctlr_esti_us,
+		      ts_ctlr_esti_us, line);
+	zassert_equal(ctx->last_data_status, last_data_status,
+		      "last_data_status %d expected %d, line: %d", ctx->last_data_status,
+		      last_data_status, line);
 }
+
+#define internals_verify(...) internals_verify_impl(__VA_ARGS__, __LINE__)
 
 static void call_tx_sent(struct le_audio_tx_info *tx, uint8_t num_streams)
 {
@@ -146,7 +151,7 @@ ZTEST(audio_tx, test_tx_send_basic_1_stream)
 	zassert_equal(1U, zbus_chan_pub_fake.call_count);
 
 	call_tx_sent(tx, 1U);
-	internals_verify(0, true, 10000U, false);
+	internals_verify(0, true, 10000U, STATUS_SENT_WITHOUT_TS);
 
 	net_buf_unref(dummy_audio_frame);
 }
@@ -170,7 +175,7 @@ ZTEST(audio_tx, test_tx_send_basic_2_streams)
 	zassert_equal(1U, zbus_chan_pub_fake.call_count);
 
 	call_tx_sent(tx, 2U);
-	internals_verify(0, true, 10000U, false);
+	internals_verify(0, true, 10000U, STATUS_SENT_WITHOUT_TS);
 
 	net_buf_unref(dummy_audio_frame);
 }
@@ -194,7 +199,7 @@ ZTEST(audio_tx, test_tx_send_basic_3_streams)
 	zassert_equal(1U, zbus_chan_pub_fake.call_count);
 
 	call_tx_sent(tx, 3U);
-	internals_verify(0, true, 10000U, false);
+	internals_verify(0, true, 10000U, STATUS_SENT_WITHOUT_TS);
 
 	net_buf_unref(dummy_audio_frame);
 }
@@ -207,86 +212,25 @@ ZTEST(audio_tx, test_tx_send_bad_parameters)
 
 	ret = bt_le_audio_tx_send(NULL, dummy_audio_frame, tx, chan_to_send);
 	zassert_equal(-EINVAL, ret, "ret %d", ret);
+	internals_verify(0, false, 0, STATUS_NOT_SET);
 
 	ret = bt_le_audio_tx_send(audio_tx_ctx, NULL, tx, chan_to_send);
 	zassert_equal(-EINVAL, ret, "ret %d", ret);
+	internals_verify(0, false, 0, STATUS_NOT_SET);
 
 	ret = bt_le_audio_tx_send(audio_tx_ctx, dummy_audio_frame, NULL, chan_to_send);
 	zassert_equal(-EINVAL, ret, "ret %d", ret);
+	internals_verify(0, false, 0, STATUS_NOT_SET);
 
 	ret = bt_le_audio_tx_send(audio_tx_ctx, dummy_audio_frame, tx, 5);
 	zassert_equal(-EINVAL, ret, "ret %d", ret);
+	internals_verify(0, false, 0, STATUS_NOT_SET);
 
 	ret = bt_le_audio_tx_send(audio_tx_ctx, dummy_audio_frame, tx, 0);
 	zassert_equal(-EINVAL, ret, "ret %d", ret);
+	internals_verify(0, false, 0, STATUS_NOT_SET);
 
 	call_tx_sent(tx, chan_to_send);
-
-	net_buf_unref(dummy_audio_frame);
-}
-
-ZTEST(audio_tx, test_tx_send_too_late)
-{
-	int ret;
-
-	TEST_SETUP_2_STREAMS;
-
-	audio_sync_timer_capture_fake.return_val = UINT32_MAX - 20500U;
-	hci_vs_sdc_iso_read_tx_timestamp_fake.return_val = UINT32_MAX - 20000U;
-
-	/* Data is submitted way too late */
-	ret = bt_le_audio_tx_send(audio_tx_ctx, dummy_audio_frame, tx, chan_to_send);
-	zassert_equal(-ETIMEDOUT, ret, "ret %d", ret);
-	zassert_equal(2U, bt_cap_stream_send_fake.call_count, "%d",
-		      bt_cap_stream_send_fake.call_count);
-	zassert_equal(0U, bt_cap_stream_send_ts_fake.call_count);
-
-	zassert_equal(1U, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
-	zassert_equal(1U, zbus_chan_pub_fake.call_count);
-	call_tx_sent(tx, chan_to_send);
-	internals_verify(UINT32_MAX - 30000U, false, UINT32_MAX - 20000U, false);
-
-	audio_sync_timer_capture_fake.return_val = UINT32_MAX - 10500U;
-	hci_vs_sdc_iso_read_tx_timestamp_fake.return_val = UINT32_MAX - 10000U;
-
-	ret = bt_le_audio_tx_send(audio_tx_ctx, dummy_audio_frame, tx, chan_to_send);
-	zassert_equal(0, ret, "ret %d", ret);
-	zassert_equal(4U, bt_cap_stream_send_fake.call_count, "%d",
-		      bt_cap_stream_send_fake.call_count);
-	zassert_equal(0U, bt_cap_stream_send_ts_fake.call_count);
-
-	zassert_equal(2U, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
-	zassert_equal(2U, zbus_chan_pub_fake.call_count);
-	call_tx_sent(tx, chan_to_send);
-	internals_verify(0, true, UINT32_MAX - 10000U, false);
-
-	audio_sync_timer_capture_fake.return_val = UINT32_MAX - 500U;
-	hci_vs_sdc_iso_read_tx_timestamp_fake.return_val = UINT32_MAX - 0U;
-
-	ret = bt_le_audio_tx_send(audio_tx_ctx, dummy_audio_frame, tx, chan_to_send);
-	zassert_equal(0, ret, "ret %d", ret);
-	zassert_equal(4U, bt_cap_stream_send_fake.call_count, "%d",
-		      bt_cap_stream_send_fake.call_count);
-	zassert_equal(2U, bt_cap_stream_send_ts_fake.call_count);
-
-	zassert_equal(2U, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
-	zassert_equal(3U, zbus_chan_pub_fake.call_count);
-	call_tx_sent(tx, chan_to_send);
-	internals_verify(0, true, UINT32_MAX - 0U, false);
-
-	audio_sync_timer_capture_fake.return_val = UINT32_MAX + 9500U;
-	hci_vs_sdc_iso_read_tx_timestamp_fake.return_val = UINT32_MAX + 10000U;
-
-	ret = bt_le_audio_tx_send(audio_tx_ctx, dummy_audio_frame, tx, chan_to_send);
-	zassert_equal(0, ret, "ret %d", ret);
-	zassert_equal(4U, bt_cap_stream_send_fake.call_count, "%d",
-		      bt_cap_stream_send_fake.call_count);
-	zassert_equal(4U, bt_cap_stream_send_ts_fake.call_count);
-
-	zassert_equal(2U, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
-	zassert_equal(4U, zbus_chan_pub_fake.call_count);
-	call_tx_sent(tx, chan_to_send);
-	internals_verify(0, true, UINT32_MAX + 10000U, false);
 
 	net_buf_unref(dummy_audio_frame);
 }
@@ -304,8 +248,8 @@ ZTEST(audio_tx, test_tx_send_many)
 	const uint32_t NUM_ITER = 430000U;
 	uint32_t read_tx_ts_calls = 0U;
 
-	for (uint32_t i = 0U; i < NUM_ITER; i++) {
-		if (i % 100U == 0U) {
+	for (uint32_t i = 0; i < NUM_ITER; i++) {
+		if (i % 100 == 0) {
 			read_tx_ts_calls++;
 		}
 
@@ -328,7 +272,11 @@ ZTEST(audio_tx, test_tx_send_many)
 		zassert_equal(read_tx_ts_calls, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
 		zassert_equal(i + 1U, zbus_chan_pub_fake.call_count);
 		call_tx_sent(tx, chan_to_send);
-		internals_verify(0U, true, (i + 1U) * 10000U, false);
+		if (i == 0) {
+			internals_verify(0, true, (i + 1U) * 10000U, STATUS_SENT_WITHOUT_TS);
+		} else {
+			internals_verify(0, true, (i + 1U) * 10000U, STATUS_SENT_WITH_TS);
+		}
 	}
 
 	net_buf_unref(dummy_audio_frame);
@@ -353,7 +301,7 @@ ZTEST(audio_tx, test_tx_test_api_call_too_slow)
 	zassert_equal(1, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
 	zassert_equal(1, zbus_chan_pub_fake.call_count);
 	call_tx_sent(tx, chan_to_send);
-	internals_verify(0, true, 10000U, false);
+	internals_verify(0, true, 10000U, STATUS_SENT_WITHOUT_TS);
 
 	/* Simulate that we called too late */
 	audio_sync_timer_capture_fake.return_val = 13000U;
@@ -368,7 +316,7 @@ ZTEST(audio_tx, test_tx_test_api_call_too_slow)
 	zassert_equal(2, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
 	zassert_equal(2, zbus_chan_pub_fake.call_count);
 	call_tx_sent(tx, chan_to_send);
-	internals_verify(0, true, 20000U, false);
+	internals_verify(0, true, 20000U, STATUS_SENT_WITHOUT_TS);
 }
 
 ZTEST(audio_tx, test_tx_test_api_call_too_fast)
@@ -390,7 +338,7 @@ ZTEST(audio_tx, test_tx_test_api_call_too_fast)
 	zassert_equal(1, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
 	zassert_equal(1, zbus_chan_pub_fake.call_count);
 	call_tx_sent(tx, chan_to_send);
-	internals_verify(0, true, 10000U, false);
+	internals_verify(0, true, 10000U, STATUS_SENT_WITHOUT_TS);
 
 	/* Simulate that we called too fast */
 	audio_sync_timer_capture_fake.return_val = 7000U;
@@ -405,7 +353,7 @@ ZTEST(audio_tx, test_tx_test_api_call_too_fast)
 	zassert_equal(2, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
 	zassert_equal(2, zbus_chan_pub_fake.call_count);
 	call_tx_sent(tx, chan_to_send);
-	internals_verify(0, true, 20000U, false);
+	internals_verify(0, true, 20000U, STATUS_SENT_WITHOUT_TS);
 }
 
 /* Test for what happens when the controller returns drifted timestamps*/
@@ -420,7 +368,7 @@ ZTEST(audio_tx, test_tx_send_send_too_fast)
 	TEST_SETUP_2_STREAMS;
 
 	audio_sync_timer_capture_fake.return_val = 10000U;
-	hci_vs_sdc_iso_read_tx_timestamp_fake.return_val = 5000U;
+	hci_vs_sdc_iso_read_tx_timestamp_fake.return_val = 10000U;
 
 	ret = bt_le_audio_tx_send(audio_tx_ctx, dummy_audio_frame, tx, chan_to_send);
 	zassert_equal(0, ret, "ret %d", ret);
@@ -431,11 +379,62 @@ ZTEST(audio_tx, test_tx_send_send_too_fast)
 	zassert_equal(1U, zbus_chan_pub_fake.call_count);
 
 	call_tx_sent(tx, chan_to_send);
-	internals_verify(-5000, false, 5000U, true);
+	internals_verify(0, true, 10000U, STATUS_SENT_WITHOUT_TS);
 
-	/* Call send again immediately, should trigger flush */
+	audio_sync_timer_capture_fake.return_val = 20000U;
+	/* Inject that the controller timestamp estimate is ahead */
+	audio_tx_ctx->ts_ctlr_esti_us = 25500;
+
 	ret = bt_le_audio_tx_send(audio_tx_ctx, dummy_audio_frame, tx, chan_to_send);
 	zassert_equal(-ECANCELED, ret, "ret %d", ret);
+	zassert_equal(2U, bt_cap_stream_send_fake.call_count);
+	zassert_equal(0U, bt_cap_stream_send_ts_fake.call_count);
+
+	zassert_equal(1U, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
+	zassert_equal(1, zbus_chan_pub_fake.call_count);
+
+	call_tx_sent(tx, chan_to_send);
+	internals_verify(0, true, 35500, STATUS_OVERRUN_FLUSHED);
+
+	net_buf_unref(dummy_audio_frame);
+}
+
+ZTEST(audio_tx, test_tx_send_too_slow)
+{
+	int ret;
+
+	TEST_SETUP_2_STREAMS;
+
+	audio_sync_timer_capture_fake.return_val = 10000U;
+	hci_vs_sdc_iso_read_tx_timestamp_fake.return_val = 10000U;
+
+	ret = bt_le_audio_tx_send(audio_tx_ctx, dummy_audio_frame, tx, chan_to_send);
+	zassert_equal(0, ret, "ret %d", ret);
+	zassert_equal(2U, bt_cap_stream_send_fake.call_count);
+	zassert_equal(0U, bt_cap_stream_send_ts_fake.call_count);
+
+	zassert_equal(1U, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
+	zassert_equal(1U, zbus_chan_pub_fake.call_count);
+
+	call_tx_sent(tx, chan_to_send);
+	internals_verify(0, true, 10000U, STATUS_SENT_WITHOUT_TS);
+
+	audio_sync_timer_capture_fake.return_val = 20000U;
+	/* Inject that the controller timestamp estimate is ahead */
+	hci_vs_sdc_iso_read_tx_timestamp_fake.return_val = 11000U;
+	audio_tx_ctx->ts_ctlr_esti_us = 11000;
+
+	ret = bt_le_audio_tx_send(audio_tx_ctx, dummy_audio_frame, tx, chan_to_send);
+	zassert_equal(0, ret, "ret %d", ret);
+	zassert_equal(2, bt_cap_stream_send_fake.call_count);
+	zassert_equal(2, bt_cap_stream_send_ts_fake.call_count);
+
+	zassert_equal(1, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
+	zassert_equal(2, zbus_chan_pub_fake.call_count);
+
+	call_tx_sent(tx, chan_to_send);
+	/*  The timestamp is increased by two intervals to get NULL SDU on air */
+	internals_verify(0, true, 31000, STATUS_UNDERRUN_EMPTY_SDU_ON_AIR);
 
 	net_buf_unref(dummy_audio_frame);
 }
@@ -460,7 +459,7 @@ ZTEST(audio_tx, test_tx_send_send_uncommon_channels)
 	zassert_equal(1U, zbus_chan_pub_fake.call_count);
 
 	call_tx_sent(tx, 2U);
-	internals_verify(0, true, 10000U, false);
+	internals_verify(0, true, 10000U, STATUS_SENT_WITHOUT_TS);
 
 	net_buf_unref(dummy_audio_frame);
 }


### PR DESCRIPTION
 Fixes an issue where too many SDUs were lost when using an
    unsynchronized audio source (such as async USB).
    Reworked timestamp handling to be more robust and added better logging.
    
    OCT-3710