### PR TITLE
bluetooth: controller: add HCI VS command tx carrier freq

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -1755,6 +1755,11 @@ static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out
 		return sdc_hci_cmd_vs_enable_periodic_adv_event_counter_reports(
 		(sdc_hci_cmd_vs_enable_periodic_adv_event_counter_reports_t const *)cmd_params);
 #endif
+#if defined(CONFIG_BT_CTLR_DTM_HCI)
+	case SDC_HCI_OPCODE_CMD_VS_TRANSMITTER_CARRIER_TEST:
+		return sdc_hci_cmd_vs_transmitter_carrier_test(
+		(sdc_hci_cmd_vs_transmitter_carrier_test_t const *)cmd_params);
+#endif
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;
 	}

--- a/west.yml
+++ b/west.yml
@@ -145,7 +145,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 332808f18c01d7a418105274e2526f0dc05e111b
+      revision: 2a68c0583801dfb6b2da76b450bdd45e479117c0
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
@@ -183,7 +183,7 @@ manifest:
       # Only for internal Nordic development
       repo-path: dragoon.git
       remote: dragoon
-      revision: 107f8188e0ebfcfc533c0ed30fe7d04f0c6424fc
+      revision: e720db1c0540269136da7dc0ec470d531e4cfa6a
       groups:
         - dragoon
     - name: cjson


### PR DESCRIPTION
1. added support of HCI VS command to start constant
carrier. The command can be used as an addtion to
standard BLE DTM commands, and requires two
non-default configs to be enabled:
- CONFIG_BT_CTLR_DTM_HCI
- CONFIG_BT_HCI_VS

The command implementation is added to SDC in DRGN-28500

2. Updated nrfxlib to bring the command implementation