### PR TITLE
bluetooth: fast_pair: fix Additional Data write length validation

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -469,7 +469,9 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
-|no_changes_yet_note|
+* :ref:`bt_fast_pair_readme` library:
+
+  * Fixed missing ATT write length validation in the GATT write handler for the Fast Pair Additional Data characteristic, used by the experimental Personalized Name extension (:kconfig:option:`CONFIG_BT_FAST_PAIR_PN`).
 
 Common Application Framework
 ----------------------------

--- a/subsys/bluetooth/fast_pair/fp_gatt_service.c
+++ b/subsys/bluetooth/fast_pair/fp_gatt_service.c
@@ -784,9 +784,13 @@ static ssize_t write_additional_data(struct bt_conn *conn,
 {
 	/* The only expected Additional Data write is with Personalized Name. fp_keys module will
 	 * return an error if it receives Personalized Name store request in inappropriate state.
+	 *
+	 * The decoded payload is at most FP_STORAGE_PN_BUF_LEN - 1 bytes (the maximum
+	 * Personalized Name length), with one extra byte reserved for the NULL terminator
+	 * appended below.
 	 */
-	size_t data_len = len - FP_CRYPTO_ADDITIONAL_DATA_HEADER_LEN;
-	uint8_t decoded_data[data_len + sizeof(char)];
+	uint8_t decoded_data[FP_STORAGE_PN_BUF_LEN];
+	size_t data_len;
 	int err = 0;
 	ssize_t res = len;
 
@@ -807,6 +811,25 @@ static ssize_t write_additional_data(struct bt_conn *conn,
 		goto finish;
 	}
 
+	/* Validate the ATT write length before any arithmetic on it: a value below the
+	 * header length would underflow the unsigned data_len computation below, and a value
+	 * above the buffer capacity would overflow the decoded_data buffer.
+	 */
+	if (len <= FP_CRYPTO_ADDITIONAL_DATA_HEADER_LEN) {
+		LOG_WRN("Invalid length: len=%" PRIu16 " (Additional Data)", len);
+		res = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+		goto finish;
+	}
+
+	if (len > FP_CRYPTO_ADDITIONAL_DATA_HEADER_LEN + sizeof(decoded_data) - 1) {
+		LOG_WRN("Length exceeds buffer capacity: len=%" PRIu16 " (Additional Data)", len);
+		LOG_WRN("Align the CONFIG_BT_FAST_PAIR_STORAGE_PN_LEN_MAX Kconfig to support "
+			"longer Personalized Name");
+		res = BT_GATT_ERR(BT_ATT_ERR_INSUFFICIENT_RESOURCES);
+		goto finish;
+	}
+
+	/* Decode the encrypted field in the Additional Data payload. */
 	err = fp_keys_additional_data_decode(conn, decoded_data, buf, len);
 	if (err) {
 		LOG_WRN("Decrypt failed: err=%d (Additional Data)", err);
@@ -815,6 +838,7 @@ static ssize_t write_additional_data(struct bt_conn *conn,
 	}
 
 	/* Received data is assumed to be a Personalized Name string. Terminate the string. */
+	data_len = len - FP_CRYPTO_ADDITIONAL_DATA_HEADER_LEN;
 	decoded_data[data_len] = '\0';
 
 	LOG_DBG("Received following Personalized Name: %s (Additional Data)", decoded_data);


### PR DESCRIPTION
## Summary

Fixes the `write_additional_data()` GATT callback in `subsys/bluetooth/fast_pair/fp_gatt_service.c` for the Fast Pair Additional Data characteristic, which is exposed by the experimental Personalized Name extension (`CONFIG_BT_FAST_PAIR_PN`).

Previously, the callback computed `data_len = len - FP_CRYPTO_ADDITIONAL_DATA_HEADER_LEN` and used the result as the size of a stack-allocated VLA without first validating that the ATT write payload length (`len`) is at least equal to the header length. A short write would underflow the unsigned subtraction, and a long write could exceed the available stack budget.

Changes in this PR:

- Replaced the variable-length array with a fixed-size buffer of `FP_STORAGE_PN_BUF_LEN` bytes, sized to the worst-case Personalized Name plus the NULL terminator.
- Added explicit length validation before any arithmetic on `len`:
  - Writes shorter than or equal to the Additional Data header length are rejected with `BT_ATT_ERR_INVALID_ATTRIBUTE_LEN`.
  - Writes that would not fit in the decoded data buffer are rejected with `BT_ATT_ERR_INSUFFICIENT_RESOURCES`, including a warning that points to the `CONFIG_BT_FAST_PAIR_STORAGE_PN_LEN_MAX` Kconfig option for longer Personalized Name support.
- Added a corresponding entry under the `Bluetooth libraries and services` section of `release-notes-changelog.rst`.

Ref: NCSDK-39121

## Test plan

- [x] Run the existing Fast Pair unit tests under `tests/subsys/bluetooth/fast_pair/`.
- [x] Build and flash the `fast_pair_input_device` sample (which selects `CONFIG_BT_FAST_PAIR_PN`) and verify nominal Personalized Name read/write over the Additional Data characteristic still works.
- [x] Exercise the new error paths from a connected peer:
  - ATT write with `len < 16` returns `BT_ATT_ERR_INVALID_ATTRIBUTE_LEN`.
  - ATT write with `len > FP_CRYPTO_ADDITIONAL_DATA_HEADER_LEN + FP_STORAGE_PN_BUF_LEN - 1` returns `BT_ATT_ERR_INSUFFICIENT_RESOURCES` and the warning log fires.
- [x] Confirm the changelog entry renders correctly in the rendered HTML docs.