### PR TITLE
samples: bluetooth: channel_sounding: reuse common helpers across samples

### DIFF
--- a/samples/bluetooth/channel_sounding/common/cs_samples_common.h
+++ b/samples/bluetooth/channel_sounding/common/cs_samples_common.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef CS_SAMPLES_COMMON_H_
+#define CS_SAMPLES_COMMON_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/bluetooth/conn.h>
+#ifdef CONFIG_BT_SCAN
+#include <bluetooth/scan.h>
+#endif /* CONFIG_BT_SCAN */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Shared connection state for Channel Sounding samples.
+ *
+ * These are defined in `cs_samples_common.c` and reused across the samples.
+ */
+extern struct bt_conn *connection;
+extern struct bt_conn_le_cs_config cs_config;
+extern struct k_sem sem_connected;
+extern struct k_sem sem_security;
+extern struct k_sem sem_cs_security_enabled;
+extern struct k_sem sem_remote_capabilities_obtained;
+extern struct k_sem sem_config_created;
+
+/** @brief Median of @a values (sorted in place); returns NAN if @a count is 0. */
+float common_median_inplace(int count, float *values);
+
+#ifdef CONFIG_BT_SCAN
+/** @brief Scan callback: filter matched (@ref BT_SCAN_CB_INIT). */
+void common_scan_filter_match(struct bt_scan_device_info *device_info,
+			      struct bt_scan_filter_match *filter_match, bool connectable);
+
+/** @brief Scan callback: connection failed; restart passive scan (@ref BT_SCAN_CB_INIT). */
+void common_scan_connecting_error(struct bt_scan_device_info *device_info);
+
+/** @brief Scan callback: connecting (@ref BT_SCAN_CB_INIT). */
+void common_scan_connecting(struct bt_scan_device_info *device_info, struct bt_conn *conn);
+#endif /* CONFIG_BT_SCAN */
+
+/** @brief @c connected handler for Channel Sounding samples. */
+void common_connected_cb(struct bt_conn *conn, uint8_t err);
+
+/** @brief @c disconnected handler for Channel Sounding samples. */
+void common_disconnected_cb(struct bt_conn *conn, uint8_t reason);
+
+/** @brief @c security_changed handler for Channel Sounding samples. */
+void common_security_changed_cb(struct bt_conn *conn, bt_security_t level,
+				enum bt_security_err err);
+
+/** @brief @c le_cs_security_enable_complete handler. */
+void common_cs_security_enable_cb(struct bt_conn *conn, uint8_t status);
+
+/** @brief @c le_cs_read_remote_capabilities_complete handler. */
+void common_remote_capabilities_cb(struct bt_conn *conn, uint8_t status,
+				   struct bt_conn_le_cs_capabilities *params);
+
+/** @brief @c le_cs_config_complete handler. */
+void common_config_create_cb(struct bt_conn *conn, uint8_t status,
+			     struct bt_conn_le_cs_config *config);
+
+/** @brief @c le_cs_procedure_enable_complete handler. */
+void common_procedure_enable_cb(struct bt_conn *conn, uint8_t status,
+				struct bt_conn_le_cs_procedure_enable_complete *params);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CS_SAMPLES_COMMON_H_ */

--- a/samples/bluetooth/channel_sounding/common/src/cs_samples_common.c
+++ b/samples/bluetooth/channel_sounding/common/src/cs_samples_common.c
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ *  @brief Common source file for shared functionality of Channel Sounding samples
+ */
+
+#include <math.h>
+#include <stdlib.h>
+
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/reboot.h>
+
+#include <dk_buttons_and_leds.h>
+
+#if defined(CONFIG_BT_SCAN)
+#include <bluetooth/scan.h>
+#endif /* CONFIG_BT_SCAN */
+
+LOG_MODULE_REGISTER(cs_samples_common, LOG_LEVEL_INF);
+
+#define CON_STATUS_LED DK_LED1
+
+struct bt_conn *connection;
+struct bt_conn_le_cs_config cs_config;
+K_SEM_DEFINE(sem_connected, 0, 1);
+K_SEM_DEFINE(sem_security, 0, 1);
+K_SEM_DEFINE(sem_cs_security_enabled, 0, 1);
+K_SEM_DEFINE(sem_remote_capabilities_obtained, 0, 1);
+K_SEM_DEFINE(sem_config_created, 0, 1);
+
+
+static int float_cmp(const void *a, const void *b)
+{
+	float fa = *(const float *)a;
+	float fb = *(const float *)b;
+
+	return (fa > fb) - (fa < fb);
+}
+
+float common_median_inplace(int count, float *values)
+{
+	if (count == 0) {
+		return NAN;
+	}
+
+	qsort(values, count, sizeof(float), float_cmp);
+
+	if (count % 2 == 0) {
+		return (values[count / 2] + values[count / 2 - 1]) / 2;
+	} else {
+		return values[count / 2];
+	}
+}
+
+
+#if defined(CONFIG_BT_SCAN)
+void common_scan_filter_match(struct bt_scan_device_info *device_info,
+		       struct bt_scan_filter_match *filter_match, bool connectable)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
+
+	LOG_INF("Filters matched. Address: %s connectable: %d", addr, connectable);
+}
+
+void common_scan_connecting_error(struct bt_scan_device_info *device_info)
+{
+	int err;
+
+	LOG_INF("Connecting failed, restarting scanning");
+
+	err = bt_scan_start(BT_SCAN_TYPE_SCAN_PASSIVE);
+	if (err) {
+		LOG_ERR("Failed to restart scanning (err %i)", err);
+		return;
+	}
+}
+
+void common_scan_connecting(struct bt_scan_device_info *device_info, struct bt_conn *conn)
+{
+	LOG_INF("Connecting");
+}
+#endif /* CONFIG_BT_SCAN */
+
+void common_connected_cb(struct bt_conn *conn, uint8_t err)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	LOG_INF("Connected to %s (err 0x%02X)", addr, err);
+
+	if (err) {
+		bt_conn_unref(conn);
+		connection = NULL;
+	} else {
+		connection = bt_conn_ref(conn);
+
+		k_sem_give(&sem_connected);
+
+		dk_set_led_on(CON_STATUS_LED);
+	}
+}
+
+void common_disconnected_cb(struct bt_conn *conn, uint8_t reason)
+{
+	LOG_INF("Disconnected (reason 0x%02X)", reason);
+
+	bt_conn_unref(conn);
+	connection = NULL;
+	dk_set_led_off(CON_STATUS_LED);
+
+	sys_reboot(SYS_REBOOT_COLD);
+}
+
+
+void common_security_changed_cb(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	if (err) {
+		LOG_ERR("Security failed: %s level %u err %d %s", addr, level, err,
+			bt_security_err_to_str(err));
+		return;
+	}
+
+	LOG_INF("Security changed: %s level %u", addr, level);
+	k_sem_give(&sem_security);
+}
+
+void common_cs_security_enable_cb(struct bt_conn *conn, uint8_t status)
+{
+	ARG_UNUSED(conn);
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		LOG_INF("CS security enabled.");
+		k_sem_give(&sem_cs_security_enabled);
+	} else {
+		LOG_WRN("CS security enable failed. (HCI status 0x%02x)", status);
+	}
+}
+
+void common_remote_capabilities_cb(struct bt_conn *conn, uint8_t status,
+				   struct bt_conn_le_cs_capabilities *params)
+{
+	ARG_UNUSED(conn);
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		static const char *const rtt_precision_str[] = {"not supported", "10 ns", "150 ns",
+								"invalid"};
+
+		uint8_t aa_idx = MIN((uint8_t)params->rtt_aa_only_precision, 3U);
+		uint8_t snd_idx = MIN((uint8_t)params->rtt_sounding_precision, 3U);
+		uint8_t rand_idx = MIN((uint8_t)params->rtt_random_payload_precision, 3U);
+
+		LOG_INF("CS capability exchange completed.\n"
+			"Remote CS capabilities:\n"
+			" - num_config_supported: %u\n"
+			" - max_consecutive_procedures_supported: %u\n"
+			" - num_antennas_supported: %u\n"
+			" - max_antenna_paths_supported: %u\n"
+			" - initiator_supported: %s\n"
+			" - reflector_supported: %s\n"
+			" - mode_3_supported: %s\n"
+			" - rtt_aa_only_precision: %s (%u)\n"
+			" - rtt_sounding_precision: %s (%u)\n"
+			" - rtt_random_payload_precision: %s (%u)\n"
+			" - rtt_aa_only_n: %u\n"
+			" - rtt_sounding_n: %u\n"
+			" - rtt_random_payload_n: %u\n"
+			" - phase_based_nadm_sounding_supported: %s\n"
+			" - phase_based_nadm_random_supported: %s\n"
+			" - cs_sync_2m_phy_supported: %s\n"
+			" - cs_sync_2m_2bt_phy_supported: %s\n"
+			" - cs_without_fae_supported: %s\n"
+			" - chsel_alg_3c_supported: %s\n"
+			" - pbr_from_rtt_sounding_seq_supported: %s\n"
+			" - t_ip1_times_supported: 0x%04x\n"
+			" - t_ip2_times_supported: 0x%04x\n"
+			" - t_fcs_times_supported: 0x%04x\n"
+			" - t_pm_times_supported: 0x%04x\n"
+			" - t_sw_time: %u us\n"
+			" - tx_snr_capability: 0x%02x\n"
+			" - t_ip2_ipt_times_supported: 0x%04x\n"
+			" - t_sw_ipt_time_supported: %u us\n",
+			params->num_config_supported, params->max_consecutive_procedures_supported,
+			params->num_antennas_supported, params->max_antenna_paths_supported,
+			params->initiator_supported ? "yes" : "no",
+			params->reflector_supported ? "yes" : "no",
+			params->mode_3_supported ? "yes" : "no", rtt_precision_str[aa_idx],
+			(uint8_t)params->rtt_aa_only_precision, rtt_precision_str[snd_idx],
+			(uint8_t)params->rtt_sounding_precision, rtt_precision_str[rand_idx],
+			(uint8_t)params->rtt_random_payload_precision, params->rtt_aa_only_n,
+			params->rtt_sounding_n, params->rtt_random_payload_n,
+			params->phase_based_nadm_sounding_supported ? "yes" : "no",
+			params->phase_based_nadm_random_supported ? "yes" : "no",
+			params->cs_sync_2m_phy_supported ? "yes" : "no",
+			params->cs_sync_2m_2bt_phy_supported ? "yes" : "no",
+			params->cs_without_fae_supported ? "yes" : "no",
+			params->chsel_alg_3c_supported ? "yes" : "no",
+			params->pbr_from_rtt_sounding_seq_supported ? "yes" : "no",
+			params->t_ip1_times_supported, params->t_ip2_times_supported,
+			params->t_fcs_times_supported, params->t_pm_times_supported,
+			params->t_sw_time, params->tx_snr_capability,
+			params->t_ip2_ipt_times_supported, params->t_sw_ipt_time_supported);
+
+			k_sem_give(&sem_remote_capabilities_obtained);
+	} else {
+		LOG_WRN("CS capability exchange failed. (HCI status 0x%02x)", status);
+	}
+}
+
+void common_config_create_cb(struct bt_conn *conn, uint8_t status,
+			     struct bt_conn_le_cs_config *config)
+{
+	ARG_UNUSED(conn);
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		static const char *const mode_str[5] = {"Unused", "1 (RTT)", "2 (PBR)",
+						       "3 (RTT + PBR)", "Invalid"};
+		static const char *const role_str[3] = {"Initiator", "Reflector", "Invalid"};
+		static const char *const rtt_type_str[8] = {"AA only", "32-bit sounding",
+							    "96-bit sounding", "32-bit random",
+							    "64-bit random", "96-bit random",
+							    "128-bit random", "Invalid"};
+		static const char *const phy_str[4] = {"Invalid", "LE 1M PHY", "LE 2M PHY",
+						       "LE 2M 2BT PHY"};
+		static const char *const chsel_type_str[3] = {"Algorithm #3b", "Algorithm #3c",
+							      "Invalid"};
+		static const char *const ch3c_shape_str[3] = {"Hat shape", "X shape", "Invalid"};
+
+		uint8_t mode_idx = (config->mode > 0 && config->mode < 4) ? config->mode : 4;
+		uint8_t role_idx = MIN(config->role, 2);
+		uint8_t rtt_type_idx = MIN(config->rtt_type, 7);
+		uint8_t phy_idx = (config->cs_sync_phy > 0 && config->cs_sync_phy < 4)
+					  ? config->cs_sync_phy
+					  : 0;
+		uint8_t chsel_type_idx = MIN(config->channel_selection_type, 2);
+		uint8_t ch3c_shape_idx = MIN(config->ch3c_shape, 2);
+
+		LOG_INF("CS config creation complete.\n"
+			" - id: %u\n"
+			" - mode: %s\n"
+			" - min_main_mode_steps: %u\n"
+			" - max_main_mode_steps: %u\n"
+			" - main_mode_repetition: %u\n"
+			" - mode_0_steps: %u\n"
+			" - role: %s\n"
+			" - rtt_type: %s\n"
+			" - cs_sync_phy: %s\n"
+			" - channel_map_repetition: %u\n"
+			" - channel_selection_type: %s\n"
+			" - ch3c_shape: %s\n"
+			" - ch3c_jump: %u\n"
+			" - t_ip1_time_us: %u\n"
+			" - t_ip2_time_us: %u\n"
+			" - t_fcs_time_us: %u\n"
+			" - t_pm_time_us: %u\n"
+			" - channel_map: 0x%08X%08X%04X\n",
+			config->id, mode_str[mode_idx], config->min_main_mode_steps,
+			config->max_main_mode_steps, config->main_mode_repetition,
+			config->mode_0_steps, role_str[role_idx], rtt_type_str[rtt_type_idx],
+			phy_str[phy_idx], config->channel_map_repetition,
+			chsel_type_str[chsel_type_idx], ch3c_shape_str[ch3c_shape_idx],
+			config->ch3c_jump, config->t_ip1_time_us, config->t_ip2_time_us,
+			config->t_fcs_time_us, config->t_pm_time_us,
+			sys_get_le32(&config->channel_map[6]),
+			sys_get_le32(&config->channel_map[2]),
+			sys_get_le16(&config->channel_map[0]));
+
+			cs_config = *config;
+			k_sem_give(&sem_config_created);
+	} else {
+		LOG_WRN("CS config creation failed. (HCI status 0x%02x)", status);
+	}
+}
+
+void common_procedure_enable_cb(
+	struct bt_conn *conn, uint8_t status,
+	struct bt_conn_le_cs_procedure_enable_complete *params)
+{
+	ARG_UNUSED(conn);
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		if (params->state == 1) {
+			LOG_INF("CS procedures enabled:\n"
+				" - config ID: %u\n"
+				" - antenna configuration index: %u\n"
+				" - TX power: %d dbm\n"
+				" - subevent length: %u us\n"
+				" - subevents per event: %u\n"
+				" - subevent interval: %u\n"
+				" - event interval: %u\n"
+				" - procedure interval: %u\n"
+				" - procedure count: %u\n"
+				" - maximum procedure length: %u",
+				params->config_id, params->tone_antenna_config_selection,
+				params->selected_tx_power, params->subevent_len,
+				params->subevents_per_event, params->subevent_interval,
+				params->event_interval, params->procedure_interval,
+				params->procedure_count, params->max_procedure_len);
+		} else {
+			LOG_INF("CS procedures disabled.");
+		}
+	} else {
+		LOG_WRN("CS procedures enable failed. (HCI status 0x%02x)", status);
+	}
+}

--- a/samples/bluetooth/channel_sounding/ipt_initiator/CMakeLists.txt
+++ b/samples/bluetooth/channel_sounding/ipt_initiator/CMakeLists.txt
@@ -10,5 +10,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(channel_sound_ipt_initiator)
 
 # NORDIC SDK APP START
+target_include_directories(app PRIVATE ${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/channel_sounding/common)
+
 target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE ${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/channel_sounding/common/src/cs_samples_common.c)
 # NORDIC SDK APP END

--- a/samples/bluetooth/channel_sounding/ipt_initiator/README.rst
+++ b/samples/bluetooth/channel_sounding/ipt_initiator/README.rst
@@ -133,20 +133,20 @@ After programming the sample to your development kit, you can test it by connect
 #. Wait until the scanner detects the Peripheral.
    In the terminal window, check for information similar to the following::
 
-      *** Booting nRF Connect SDK v3.2.99-d0824283f866 ***
-      *** Using Zephyr OS v4.3.99-2925b3840984 ***
+      *** Booting nRF Connect SDK v3.2.99-4dc52e0d80a6 ***
+      *** Using Zephyr OS v4.4.0-2b3d25313ec3 ***
       I: Starting Channel Sounding IPT Initiator Sample
       I: SoftDevice Controller build revision:
-      I: 36 9c e5 98 e5 71 0a a0 |6....q..
-      I: 2d b9 89 96 6b 15 65 4b |-...k.eK
-      I: d6 e8 4a ac             |..J.
+      I: 10 7f 81 88 e0 eb fc fc |........
+      I: 53 3c 0e d3 0f e7 d0 4f |S<.....O
+      I: 0c 64 24 fc             |.d$.
       I: HW Platform: Nordic Semiconductor (0x0002)
       I: HW Variant: nRF54Lx (0x0005)
-      I: Firmware: Standard Bluetooth controller (0x00) Version 54.58780 Build 175236504
+      I: Firmware: Standard Bluetooth controller (0x00) Version 16.33151 Build 4243316872
       I: HCI transport: SDC
       I: Identity: E6:BA:C9:31:51:DB (random)
-      I: HCI: version 6.2 (0x10) revision 0x30a9, manufacturer 0x0059
-      I: LMP: version 6.2 (0x10) subver 0x30a9
+      I: HCI: version 6.2 (0x10) revision 0x30b8, manufacturer 0x0059
+      I: LMP: version 6.2 (0x10) subver 0x30b8
       I: Filters matched. Address: D2:CE:07:7E:40:79 (random) connectable: 1
       I: Connecting
       I: Connected to D2:CE:07:7E:40:79 (random) (err 0x00)
@@ -214,17 +214,15 @@ After programming the sample to your development kit, you can test it by connect
       - procedure interval: 2
       - procedure count: 0
       - maximum procedure length: 12
-      I: Distance estimates: median: 0.60m, update: 0.60m, time_delta: 0ms
-      I: Distance estimates: median: 0.60m, update: 0.59m, time_delta: 30ms
-      I: Distance estimates: median: 0.59m, update: 0.59m, time_delta: 30ms
-      I: Distance estimates: median: 0.60m, update: 0.60m, time_delta: 30ms
-      I: Distance estimates: median: 0.60m, update: 0.60m, time_delta: 30ms
-      I: Distance estimates: median: 0.60m, update: 0.58m, time_delta: 30ms
-      I: Distance estimates: median: 0.59m, update: 0.59m, time_delta: 30ms
-      I: Distance estimates: median: 0.59m, update: 0.59m, time_delta: 30ms
-      I: Distance estimates: median: 0.59m, update: 0.59m, time_delta: 30ms
-      I: Distance estimates: median: 0.59m, update: 0.59m, time_delta: 30ms
-      I: Distance estimates: median: 0.59m, update: 0.59m, time_delta: 30ms
+      I: Distance estimates: median: 1.34m, update: 1.34m, time_delta: 0ms
+      I: Distance estimates: median: 1.35m, update: 1.35m, time_delta: 30ms
+      I: Distance estimates: median: 1.35m, update: 1.35m, time_delta: 30ms
+      I: Distance estimates: median: 1.35m, update: 1.34m, time_delta: 30ms
+      I: Distance estimates: median: 1.35m, update: 1.35m, time_delta: 30ms
+      I: Distance estimates: median: 1.35m, update: 1.36m, time_delta: 30ms
+      I: Distance estimates: median: 1.35m, update: 1.34m, time_delta: 30ms
+      I: Distance estimates: median: 1.35m, update: 1.34m, time_delta: 30ms
+      I: Distance estimates: median: 1.34m, update: 1.34m, time_delta: 30ms
 
 
 Dependencies

--- a/samples/bluetooth/channel_sounding/ipt_initiator/src/main.c
+++ b/samples/bluetooth/channel_sounding/ipt_initiator/src/main.c
@@ -9,22 +9,24 @@
  */
 
 #include <math.h>
-#include <stdlib.h>
+#include <string.h>
+
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/reboot.h>
-#include <zephyr/bluetooth/cs.h>
 #include <zephyr/bluetooth/conn.h>
+
+#include <zephyr/bluetooth/cs.h>
+
 #include <bluetooth/scan.h>
 #include <bluetooth/cs_de.h>
+
+#include <cs_samples_common.h>
 
 #include <dk_buttons_and_leds.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(app_main, LOG_LEVEL_INF);
 
-#define CON_STATUS_LED	 DK_LED1
 #define CS_CONFIG_ID	 0
 #define NUM_MODE_0_STEPS 3
 #define REFLECTOR_NAME	 "Nordic CS IPT Reflector"
@@ -32,16 +34,8 @@ LOG_MODULE_REGISTER(app_main, LOG_LEVEL_INF);
 #define CHANNEL_INDEX_OFFSET   (2)
 #define MEDIAN_FILTER_SIZE (9)
 
-static K_SEM_DEFINE(sem_remote_capabilities_obtained, 0, 1);
-static K_SEM_DEFINE(sem_config_created, 0, 1);
-static K_SEM_DEFINE(sem_cs_security_enabled, 0, 1);
-static K_SEM_DEFINE(sem_connected, 0, 1);
-static K_SEM_DEFINE(sem_security, 0, 1);
 static K_SEM_DEFINE(sem_subevent_results_parsed, 0, 1);
 static K_SEM_DEFINE(sem_distance_estimate_updated, 1, 1);
-
-static struct bt_conn *connection;
-static struct bt_conn_le_cs_config cs_config;
 
 /* Store local initiator IQs in this union.
  * The size is based on requirements of cs_de_ifft.
@@ -79,29 +73,6 @@ static void store_distance_estimate(float distance)
 	}
 }
 
-static int float_cmp(const void *a, const void *b)
-{
-	float fa = *(const float *)a;
-	float fb = *(const float *)b;
-
-	return (fa > fb) - (fa < fb);
-}
-
-static float median_inplace(int count, float *values)
-{
-	if (count == 0) {
-		return NAN;
-	}
-
-	qsort(values, count, sizeof(float), float_cmp);
-
-	if (count % 2 == 0) {
-		return (values[count / 2] + values[count / 2 - 1]) / 2;
-	} else {
-		return values[count / 2];
-	}
-}
-
 static float get_filtered_distance(void)
 {
 	static float temp_ifft[MEDIAN_FILTER_SIZE];
@@ -114,7 +85,7 @@ static float get_filtered_distance(void)
 		}
 	}
 
-	return median_inplace(num_ifft, temp_ifft);
+	return common_median_inplace(num_ifft, temp_ifft);
 }
 
 static void distance_estimates_update(void)
@@ -240,257 +211,8 @@ static void subevent_result_cb(struct bt_conn *conn, struct bt_conn_le_cs_subeve
 	}
 }
 
-static void security_changed_cb(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	if (err) {
-		LOG_ERR("Security failed: %s level %u err %d %s", addr, level, err,
-			bt_security_err_to_str(err));
-		return;
-	}
-
-	LOG_INF("Security changed: %s level %u", addr, level);
-	k_sem_give(&sem_security);
-}
-
-static void connected_cb(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-	LOG_INF("Connected to %s (err 0x%02X)", addr, err);
-
-	if (err) {
-		bt_conn_unref(conn);
-		connection = NULL;
-	} else {
-		connection = bt_conn_ref(conn);
-
-		k_sem_give(&sem_connected);
-
-		dk_set_led_on(CON_STATUS_LED);
-	}
-}
-
-static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
-{
-	LOG_INF("Disconnected (reason 0x%02X)", reason);
-
-	bt_conn_unref(conn);
-	connection = NULL;
-	dk_set_led_off(CON_STATUS_LED);
-
-	sys_reboot(SYS_REBOOT_COLD);
-}
-
-static void remote_capabilities_cb(struct bt_conn *conn, uint8_t status,
-				   struct bt_conn_le_cs_capabilities *params)
-{
-	ARG_UNUSED(conn);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		static const char *const rtt_precision_str[] = {"not supported", "10 ns", "150 ns",
-								"invalid"};
-
-		uint8_t aa_idx = MIN((uint8_t)params->rtt_aa_only_precision, 3U);
-		uint8_t snd_idx = MIN((uint8_t)params->rtt_sounding_precision, 3U);
-		uint8_t rand_idx = MIN((uint8_t)params->rtt_random_payload_precision, 3U);
-
-		LOG_INF("CS capability exchange completed.\n"
-			"Remote CS capabilities:\n"
-			" - num_config_supported: %u\n"
-			" - max_consecutive_procedures_supported: %u\n"
-			" - num_antennas_supported: %u\n"
-			" - max_antenna_paths_supported: %u\n"
-			" - initiator_supported: %s\n"
-			" - reflector_supported: %s\n"
-			" - mode_3_supported: %s\n"
-			" - rtt_aa_only_precision: %s (%u)\n"
-			" - rtt_sounding_precision: %s (%u)\n"
-			" - rtt_random_payload_precision: %s (%u)\n"
-			" - rtt_aa_only_n: %u\n"
-			" - rtt_sounding_n: %u\n"
-			" - rtt_random_payload_n: %u\n"
-			" - phase_based_nadm_sounding_supported: %s\n"
-			" - phase_based_nadm_random_supported: %s\n"
-			" - cs_sync_2m_phy_supported: %s\n"
-			" - cs_sync_2m_2bt_phy_supported: %s\n"
-			" - cs_without_fae_supported: %s\n"
-			" - chsel_alg_3c_supported: %s\n"
-			" - pbr_from_rtt_sounding_seq_supported: %s\n"
-			" - t_ip1_times_supported: 0x%04x\n"
-			" - t_ip2_times_supported: 0x%04x\n"
-			" - t_fcs_times_supported: 0x%04x\n"
-			" - t_pm_times_supported: 0x%04x\n"
-			" - t_sw_time: %u us\n"
-			" - tx_snr_capability: 0x%02x\n"
-			" - t_ip2_ipt_times_supported: 0x%04x\n"
-			" - t_sw_ipt_time_supported: %u us\n",
-			params->num_config_supported, params->max_consecutive_procedures_supported,
-			params->num_antennas_supported, params->max_antenna_paths_supported,
-			params->initiator_supported ? "yes" : "no",
-			params->reflector_supported ? "yes" : "no",
-			params->mode_3_supported ? "yes" : "no", rtt_precision_str[aa_idx],
-			(uint8_t)params->rtt_aa_only_precision, rtt_precision_str[snd_idx],
-			(uint8_t)params->rtt_sounding_precision, rtt_precision_str[rand_idx],
-			(uint8_t)params->rtt_random_payload_precision, params->rtt_aa_only_n,
-			params->rtt_sounding_n, params->rtt_random_payload_n,
-			params->phase_based_nadm_sounding_supported ? "yes" : "no",
-			params->phase_based_nadm_random_supported ? "yes" : "no",
-			params->cs_sync_2m_phy_supported ? "yes" : "no",
-			params->cs_sync_2m_2bt_phy_supported ? "yes" : "no",
-			params->cs_without_fae_supported ? "yes" : "no",
-			params->chsel_alg_3c_supported ? "yes" : "no",
-			params->pbr_from_rtt_sounding_seq_supported ? "yes" : "no",
-			params->t_ip1_times_supported, params->t_ip2_times_supported,
-			params->t_fcs_times_supported, params->t_pm_times_supported,
-			params->t_sw_time, params->tx_snr_capability,
-			params->t_ip2_ipt_times_supported, params->t_sw_ipt_time_supported);
-
-		k_sem_give(&sem_remote_capabilities_obtained);
-	} else {
-		LOG_WRN("CS capability exchange failed. (HCI status 0x%02x)", status);
-	}
-}
-
-static void config_create_cb(struct bt_conn *conn, uint8_t status,
-			     struct bt_conn_le_cs_config *config)
-{
-	ARG_UNUSED(conn);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		cs_config = *config;
-
-		const char *mode_str[5] = {"Unused", "1 (RTT)", "2 (PBR)", "3 (RTT + PBR)",
-					   "Invalid"};
-		const char *role_str[3] = {"Initiator", "Reflector", "Invalid"};
-		const char *rtt_type_str[8] = {
-			"AA only",	 "32-bit sounding", "96-bit sounding", "32-bit random",
-			"64-bit random", "96-bit random",   "128-bit random",  "Invalid"};
-		const char *phy_str[4] = {"Invalid", "LE 1M PHY", "LE 2M PHY", "LE 2M 2BT PHY"};
-		const char *chsel_type_str[3] = {"Algorithm #3b", "Algorithm #3c", "Invalid"};
-		const char *ch3c_shape_str[3] = {"Hat shape", "X shape", "Invalid"};
-
-		uint8_t mode_idx = config->mode > 0 && config->mode < 4 ? config->mode : 4;
-		uint8_t role_idx = MIN(config->role, 2);
-		uint8_t rtt_type_idx = MIN(config->rtt_type, 7);
-		uint8_t phy_idx = config->cs_sync_phy > 0 && config->cs_sync_phy < 4
-					  ? config->cs_sync_phy
-					  : 0;
-		uint8_t chsel_type_idx = MIN(config->channel_selection_type, 2);
-		uint8_t ch3c_shape_idx = MIN(config->ch3c_shape, 2);
-
-		LOG_INF("CS config creation complete.\n"
-			" - id: %u\n"
-			" - mode: %s\n"
-			" - min_main_mode_steps: %u\n"
-			" - max_main_mode_steps: %u\n"
-			" - main_mode_repetition: %u\n"
-			" - mode_0_steps: %u\n"
-			" - role: %s\n"
-			" - rtt_type: %s\n"
-			" - cs_sync_phy: %s\n"
-			" - channel_map_repetition: %u\n"
-			" - channel_selection_type: %s\n"
-			" - ch3c_shape: %s\n"
-			" - ch3c_jump: %u\n"
-			" - t_ip1_time_us: %u\n"
-			" - t_ip2_time_us: %u\n"
-			" - t_fcs_time_us: %u\n"
-			" - t_pm_time_us: %u\n"
-			" - channel_map: 0x%08X%08X%04X\n",
-			config->id, mode_str[mode_idx], config->min_main_mode_steps,
-			config->max_main_mode_steps, config->main_mode_repetition,
-			config->mode_0_steps, role_str[role_idx], rtt_type_str[rtt_type_idx],
-			phy_str[phy_idx], config->channel_map_repetition,
-			chsel_type_str[chsel_type_idx], ch3c_shape_str[ch3c_shape_idx],
-			config->ch3c_jump, config->t_ip1_time_us, config->t_ip2_time_us,
-			config->t_fcs_time_us, config->t_pm_time_us,
-			sys_get_le32(&config->channel_map[6]),
-			sys_get_le32(&config->channel_map[2]),
-			sys_get_le16(&config->channel_map[0]));
-
-		k_sem_give(&sem_config_created);
-	} else {
-		LOG_WRN("CS config creation failed. (HCI status 0x%02x)", status);
-	}
-}
-
-static void security_enable_cb(struct bt_conn *conn, uint8_t status)
-{
-	ARG_UNUSED(conn);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		LOG_INF("CS security enabled.");
-		k_sem_give(&sem_cs_security_enabled);
-	} else {
-		LOG_WRN("CS security enable failed. (HCI status 0x%02x)", status);
-	}
-}
-
-static void procedure_enable_cb(struct bt_conn *conn, uint8_t status,
-				struct bt_conn_le_cs_procedure_enable_complete *params)
-{
-	ARG_UNUSED(conn);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		if (params->state == 1) {
-			LOG_INF("CS procedures enabled:\n"
-				" - config ID: %u\n"
-				" - antenna configuration index: %u\n"
-				" - TX power: %d dbm\n"
-				" - subevent length: %u us\n"
-				" - subevents per event: %u\n"
-				" - subevent interval: %u\n"
-				" - event interval: %u\n"
-				" - procedure interval: %u\n"
-				" - procedure count: %u\n"
-				" - maximum procedure length: %u",
-				params->config_id, params->tone_antenna_config_selection,
-				params->selected_tx_power, params->subevent_len,
-				params->subevents_per_event, params->subevent_interval,
-				params->event_interval, params->procedure_interval,
-				params->procedure_count, params->max_procedure_len);
-		} else {
-			LOG_INF("CS procedures disabled.");
-		}
-	} else {
-		LOG_WRN("CS procedures enable failed. (HCI status 0x%02x)", status);
-	}
-}
-
-static void scan_filter_match(struct bt_scan_device_info *device_info,
-			      struct bt_scan_filter_match *filter_match, bool connectable)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	(void)bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
-
-	LOG_INF("Filters matched. Address: %s connectable: %d", addr, connectable);
-}
-
-static void scan_connecting_error(struct bt_scan_device_info *device_info)
-{
-	int err;
-
-	LOG_INF("Connecting failed, restarting scanning");
-
-	err = bt_scan_start(BT_SCAN_TYPE_SCAN_PASSIVE);
-	if (err) {
-		LOG_ERR("Failed to restart scanning (err %i)", err);
-		return;
-	}
-}
-
-static void scan_connecting(struct bt_scan_device_info *device_info, struct bt_conn *conn)
-{
-	LOG_INF("Connecting");
-}
-
-BT_SCAN_CB_INIT(scan_cb, scan_filter_match, NULL, scan_connecting_error, scan_connecting);
+BT_SCAN_CB_INIT(scan_cb, common_scan_filter_match, NULL, common_scan_connecting_error,
+		common_scan_connecting);
 
 static int scan_init(struct bt_scan_init_param *p_param)
 {
@@ -516,13 +238,13 @@ static int scan_init(struct bt_scan_init_param *p_param)
 
 
 BT_CONN_CB_DEFINE(conn_cb) = {
-	.connected = connected_cb,
-	.disconnected = disconnected_cb,
-	.security_changed = security_changed_cb,
-	.le_cs_read_remote_capabilities_complete = remote_capabilities_cb,
-	.le_cs_config_complete = config_create_cb,
-	.le_cs_security_enable_complete = security_enable_cb,
-	.le_cs_procedure_enable_complete = procedure_enable_cb,
+	.connected = common_connected_cb,
+	.disconnected = common_disconnected_cb,
+	.security_changed = common_security_changed_cb,
+	.le_cs_read_remote_capabilities_complete = common_remote_capabilities_cb,
+	.le_cs_config_complete = common_config_create_cb,
+	.le_cs_security_enable_complete = common_cs_security_enable_cb,
+	.le_cs_procedure_enable_complete = common_procedure_enable_cb,
 	.le_cs_subevent_data_available = subevent_result_cb,
 };
 

--- a/samples/bluetooth/channel_sounding/ipt_reflector/CMakeLists.txt
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/CMakeLists.txt
@@ -10,5 +10,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(channel_sound_ipt_reflector)
 
 # NORDIC SDK APP START
+target_include_directories(app PRIVATE ${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/channel_sounding/common)
+
 target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE ${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/channel_sounding/common/src/cs_samples_common.c)
 # NORDIC SDK APP END

--- a/samples/bluetooth/channel_sounding/ipt_reflector/README.rst
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/README.rst
@@ -78,22 +78,52 @@ After programming the sample to your development kit, test it together with a de
 #. The reflector starts advertising and the initiator scans for ``Nordic CS IPT Reflector``.
    Once the initiator connects, check the reflector terminal for information similar to the following::
 
-      *** Booting nRF Connect SDK v3.2.99-09f8a95ee5b4 ***
-      *** Using Zephyr OS v4.3.99-2925b3840984 ***
+      *** Booting nRF Connect SDK v3.2.99-4dc52e0d80a6 ***
+      *** Using Zephyr OS v4.4.0-2b3d25313ec3 ***
       I: Starting Channel Sounding IPT Reflector Sample
       I: SoftDevice Controller build revision:
-      I: 36 9c e5 98 e5 71 0a a0 |6....q..
-      I: 2d b9 89 96 6b 15 65 4b |-...k.eK
-      I: d6 e8 4a ac             |..J.
+      I: 10 7f 81 88 e0 eb fc fc |........
+      I: 53 3c 0e d3 0f e7 d0 4f |S<.....O
+      I: 0c 64 24 fc             |.d$.
       I: HW Platform: Nordic Semiconductor (0x0002)
       I: HW Variant: nRF54Lx (0x0005)
-      I: Firmware: Standard Bluetooth controller (0x00) Version 54.58780 Build 175236504
+      I: Firmware: Standard Bluetooth controller (0x00) Version 16.33151 Build 4243316872
       I: HCI transport: SDC
       I: Identity: D2:CE:07:7E:40:79 (random)
-      I: HCI: version 6.2 (0x10) revision 0x30a9, manufacturer 0x0059
-      I: LMP: version 6.2 (0x10) subver 0x30a9
+      I: HCI: version 6.2 (0x10) revision 0x30b8, manufacturer 0x0059
+      I: LMP: version 6.2 (0x10) subver 0x30b8
       I: Connected to E6:BA:C9:31:51:DB (random) (err 0x00)
       I: CS capability exchange completed.
+      Remote CS capabilities:
+      - num_config_supported: 1
+      - max_consecutive_procedures_supported: 0
+      - num_antennas_supported: 1
+      - max_antenna_paths_supported: 1
+      - initiator_supported: yes
+      - reflector_supported: no
+      - mode_3_supported: no
+      - rtt_aa_only_precision: 150 ns (2)
+      - rtt_sounding_precision: not supported (0)
+      - rtt_random_payload_precision: 150 ns (2)
+      - rtt_aa_only_n: 30
+      - rtt_sounding_n: 0
+      - rtt_random_payload_n: 30
+      - phase_based_nadm_sounding_supported: no
+      - phase_based_nadm_random_supported: no
+      - cs_sync_2m_phy_supported: yes
+      - cs_sync_2m_2bt_phy_supported: no
+      - cs_without_fae_supported: yes
+      - chsel_alg_3c_supported: no
+      - pbr_from_rtt_sounding_seq_supported: no
+      - t_ip1_times_supported: 0x007c
+      - t_ip2_times_supported: 0x007e
+      - t_fcs_times_supported: 0x01e0
+      - t_pm_times_supported: 0x0003
+      - t_sw_time: 0 us
+      - tx_snr_capability: 0x00
+      - t_ip2_ipt_times_supported: 0x007e
+      - t_sw_ipt_time_supported: 10 us
+
       I: CS config creation complete.
       - id: 0
       - mode: 2 (PBR)

--- a/samples/bluetooth/channel_sounding/ipt_reflector/src/main.c
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/src/main.c
@@ -8,183 +8,33 @@
  *  @brief Channel Sounding Reflector with Inline PCT Transfer sample
  */
 
-#include <zephyr/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/reboot.h>
+#include <zephyr/bluetooth/cs.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/uuid.h>
-#include <zephyr/bluetooth/cs.h>
+
+#include <cs_samples_common.h>
+
 #include <dk_buttons_and_leds.h>
 
 #include <zephyr/logging/log.h>
+
 LOG_MODULE_REGISTER(app_main, LOG_LEVEL_INF);
-
-#define CON_STATUS_LED DK_LED1
-
-static K_SEM_DEFINE(sem_connected, 0, 1);
-
-static struct bt_conn *connection;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
-static void connected_cb(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-	LOG_INF("Connected to %s (err 0x%02X)", addr, err);
-
-	if (err) {
-		bt_conn_unref(conn);
-		connection = NULL;
-	} else {
-		connection = bt_conn_ref(conn);
-
-		k_sem_give(&sem_connected);
-
-		dk_set_led_on(CON_STATUS_LED);
-	}
-}
-
-static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
-{
-	LOG_INF("Disconnected (reason 0x%02X)", reason);
-
-	bt_conn_unref(conn);
-	connection = NULL;
-
-	dk_set_led_off(CON_STATUS_LED);
-
-	sys_reboot(SYS_REBOOT_COLD);
-}
-
-static void remote_capabilities_cb(struct bt_conn *conn, uint8_t status,
-				   struct bt_conn_le_cs_capabilities *params)
-{
-	ARG_UNUSED(conn);
-	ARG_UNUSED(params);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		LOG_INF("CS capability exchange completed.");
-	} else {
-		LOG_WRN("CS capability exchange failed. (HCI status 0x%02x)", status);
-	}
-}
-
-static void config_create_cb(struct bt_conn *conn, uint8_t status,
-			     struct bt_conn_le_cs_config *config)
-{
-	ARG_UNUSED(conn);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		const char *mode_str[5] = {"Unused", "1 (RTT)", "2 (PBR)", "3 (RTT + PBR)",
-					   "Invalid"};
-		const char *role_str[3] = {"Initiator", "Reflector", "Invalid"};
-		const char *rtt_type_str[8] = {
-			"AA only",	 "32-bit sounding", "96-bit sounding", "32-bit random",
-			"64-bit random", "96-bit random",   "128-bit random",  "Invalid"};
-		const char *phy_str[4] = {"Invalid", "LE 1M PHY", "LE 2M PHY", "LE 2M 2BT PHY"};
-		const char *chsel_type_str[3] = {"Algorithm #3b", "Algorithm #3c", "Invalid"};
-		const char *ch3c_shape_str[3] = {"Hat shape", "X shape", "Invalid"};
-
-		uint8_t mode_idx = config->mode > 0 && config->mode < 4 ? config->mode : 4;
-		uint8_t role_idx = MIN(config->role, 2);
-		uint8_t rtt_type_idx = MIN(config->rtt_type, 7);
-		uint8_t phy_idx = config->cs_sync_phy > 0 && config->cs_sync_phy < 4
-					  ? config->cs_sync_phy
-					  : 0;
-		uint8_t chsel_type_idx = MIN(config->channel_selection_type, 2);
-		uint8_t ch3c_shape_idx = MIN(config->ch3c_shape, 2);
-
-		LOG_INF("CS config creation complete.\n"
-			" - id: %u\n"
-			" - mode: %s\n"
-			" - min_main_mode_steps: %u\n"
-			" - max_main_mode_steps: %u\n"
-			" - main_mode_repetition: %u\n"
-			" - mode_0_steps: %u\n"
-			" - role: %s\n"
-			" - rtt_type: %s\n"
-			" - cs_sync_phy: %s\n"
-			" - channel_map_repetition: %u\n"
-			" - channel_selection_type: %s\n"
-			" - ch3c_shape: %s\n"
-			" - ch3c_jump: %u\n"
-			" - t_ip1_time_us: %u\n"
-			" - t_ip2_time_us: %u\n"
-			" - t_fcs_time_us: %u\n"
-			" - t_pm_time_us: %u\n"
-			" - channel_map: 0x%08X%08X%04X\n",
-			config->id, mode_str[mode_idx], config->min_main_mode_steps,
-			config->max_main_mode_steps, config->main_mode_repetition,
-			config->mode_0_steps, role_str[role_idx], rtt_type_str[rtt_type_idx],
-			phy_str[phy_idx], config->channel_map_repetition,
-			chsel_type_str[chsel_type_idx], ch3c_shape_str[ch3c_shape_idx],
-			config->ch3c_jump, config->t_ip1_time_us, config->t_ip2_time_us,
-			config->t_fcs_time_us, config->t_pm_time_us,
-			sys_get_le32(&config->channel_map[6]),
-			sys_get_le32(&config->channel_map[2]),
-			sys_get_le16(&config->channel_map[0]));
-
-	} else {
-		LOG_WRN("CS config creation failed. (HCI status 0x%02x)", status);
-	}
-}
-
-static void security_enable_cb(struct bt_conn *conn, uint8_t status)
-{
-	ARG_UNUSED(conn);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		LOG_INF("CS security enabled.");
-	} else {
-		LOG_WRN("CS security enable failed. (HCI status 0x%02x)", status);
-	}
-}
-
-static void procedure_enable_cb(struct bt_conn *conn, uint8_t status,
-				struct bt_conn_le_cs_procedure_enable_complete *params)
-{
-	ARG_UNUSED(conn);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		if (params->state == 1) {
-			LOG_INF("CS procedures enabled:\n"
-				" - config ID: %u\n"
-				" - antenna configuration index: %u\n"
-				" - TX power: %d dbm\n"
-				" - subevent length: %u us\n"
-				" - subevents per event: %u\n"
-				" - subevent interval: %u\n"
-				" - event interval: %u\n"
-				" - procedure interval: %u\n"
-				" - procedure count: %u\n"
-				" - maximum procedure length: %u",
-				params->config_id, params->tone_antenna_config_selection,
-				params->selected_tx_power, params->subevent_len,
-				params->subevents_per_event, params->subevent_interval,
-				params->event_interval, params->procedure_interval,
-				params->procedure_count, params->max_procedure_len);
-		} else {
-			LOG_INF("CS procedures disabled.");
-		}
-	} else {
-		LOG_WRN("CS procedures enable failed. (HCI status 0x%02x)", status);
-	}
-}
 
 BT_CONN_CB_DEFINE(conn_cb) = {
-	.connected = connected_cb,
-	.disconnected = disconnected_cb,
-	.le_cs_read_remote_capabilities_complete = remote_capabilities_cb,
-	.le_cs_config_complete = config_create_cb,
-	.le_cs_security_enable_complete = security_enable_cb,
-	.le_cs_procedure_enable_complete = procedure_enable_cb,
+	.connected = common_connected_cb,
+	.disconnected = common_disconnected_cb,
+	.le_cs_read_remote_capabilities_complete = common_remote_capabilities_cb,
+	.le_cs_config_complete = common_config_create_cb,
+	.le_cs_security_enable_complete = common_cs_security_enable_cb,
+	.le_cs_procedure_enable_complete = common_procedure_enable_cb,
 };
 
 int main(void)

--- a/samples/bluetooth/channel_sounding/ras_initiator/CMakeLists.txt
+++ b/samples/bluetooth/channel_sounding/ras_initiator/CMakeLists.txt
@@ -9,9 +9,9 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(channel_sound_ras_initiator)
 
-FILE(GLOB app_sources src/*.c)
 # NORDIC SDK APP START
-target_sources(app PRIVATE
-  ${app_sources}
-)
+target_include_directories(app PRIVATE ${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/channel_sounding/common)
+
+target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE ${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/channel_sounding/common/src/cs_samples_common.c)
 # NORDIC SDK APP END

--- a/samples/bluetooth/channel_sounding/ras_initiator/README.rst
+++ b/samples/bluetooth/channel_sounding/ras_initiator/README.rst
@@ -47,39 +47,93 @@ After programming the sample to your development kit, you can test it by connect
 #. Wait until the scanner detects the Peripheral.
    In the terminal window, check for information similar to the following::
 
+      *** Booting nRF Connect SDK v3.2.99-4dc52e0d80a6 ***
+      *** Using Zephyr OS v4.4.0-2b3d25313ec3 ***
       I: Starting Channel Sounding Initiator Sample
       I: SoftDevice Controller build revision:
-      I: bd 8a c7 d2 9b 7c 24 05 |.....|$.
-      I: d3 20 24 a2 60 b9 62 44 |. $.`.bD
-      I: 1a dc cc 22             |..."
+      I: 10 7f 81 88 e0 eb fc fc |........
+      I: 53 3c 0e d3 0f e7 d0 4f |S<.....O
+      I: 0c 64 24 fc             |.d$.
       I: HW Platform: Nordic Semiconductor (0x0002)
       I: HW Variant: nRF54Lx (0x0005)
-      I: Firmware: Standard Bluetooth controller (0x00) Version 189.51082 Build 612146130
-      I: Identity: XX:XX:XX:XX:XX:XX (random)
-      I: HCI: version 6.0 (0x0e) revision 0x30d5, manufacturer 0x0059
-      I: LMP: version 6.0 (0x0e) subver 0x30d5
-      I: Filters matched. Address: XX:XX:XX:XX:XX:XX (random) connectable: 1
+      I: Firmware: Standard Bluetooth controller (0x00) Version 16.33151 Build 4243316872
+      I: HCI transport: SDC
+      I: Identity: E6:BA:C9:31:51:DB (random)
+      I: HCI: version 6.2 (0x10) revision 0x30b8, manufacturer 0x0059
+      I: LMP: version 6.2 (0x10) subver 0x30b8
+      I: Filters matched. Address: D2:CE:07:7E:40:79 (random) connectable: 1
       I: Connecting
-      I: Connected to XX:XX:XX:XX:XX:XX (random) (err 0x00)
-      I: Security changed: XX:XX:XX:XX:XX:XX (random) level 2
+      I: Connected to D2:CE:07:7E:40:79 (random) (err 0x00)
+      I: Security changed: D2:CE:07:7E:40:79 (random) level 2
       I: MTU exchange success (498)
       I: The discovery procedure succeeded
+      I: Read RAS feature bits: 0x1
       I: CS capability exchange completed.
-      I: CS config creation complete. ID: 0
+      Remote CS capabilities:
+      - num_config_supported: 1
+      - max_consecutive_procedures_supported: 0
+      - num_antennas_supported: 1
+      - max_antenna_paths_supported: 1
+      - initiator_supported: no
+      - reflector_supported: yes
+      - mode_3_supported: no
+      - rtt_aa_only_precision: 150 ns (2)
+      - rtt_sounding_precision: not supported (0)
+      - rtt_random_payload_precision: 150 ns (2)
+      - rtt_aa_only_n: 30
+      - rtt_sounding_n: 0
+      - rtt_random_payload_n: 30
+      - phase_based_nadm_sounding_supported: no
+      - phase_based_nadm_random_supported: no
+      - cs_sync_2m_phy_supported: yes
+      - cs_sync_2m_2bt_phy_supported: no
+      - cs_without_fae_supported: yes
+      - chsel_alg_3c_supported: no
+      - pbr_from_rtt_sounding_seq_supported: no
+      - t_ip1_times_supported: 0x007c
+      - t_ip2_times_supported: 0x007e
+      - t_fcs_times_supported: 0x01e0
+      - t_pm_times_supported: 0x0003
+      - t_sw_time: 0 us
+      - tx_snr_capability: 0x00
+      - t_ip2_ipt_times_supported: 0x0000
+      - t_sw_ipt_time_supported: 0 us
+
+      I: CS config creation complete.
+      - id: 0
+      - mode: Invalid
+      - min_main_mode_steps: 2
+      - max_main_mode_steps: 5
+      - main_mode_repetition: 0
+      - mode_0_steps: 3
+      - role: Initiator
+      - rtt_type: AA only
+      - cs_sync_phy: LE 1M PHY
+      - channel_map_repetition: 1
+      - channel_selection_type: Algorithm #3b
+      - ch3c_shape: Hat shape
+      - ch3c_jump: 2
+      - t_ip1_time_us: 30
+      - t_ip2_time_us: 20
+      - t_fcs_time_us: 60
+      - t_pm_time_us: 10
+      - channel_map: 0x1FFFFFFFFFFFFC7FFFFC
+
       I: CS security enabled.
       I: CS procedures enabled:
-       - config ID: 0
-       - antenna configuration index: 0
-       - TX power: 0 dbm
-       - subevent length: 28198 us
-       - subevents per event: 1
-       - subevent interval: 0
-       - event interval: 2
-       - procedure interval: 10
-       - procedure count: 0
-       - maximum procedure length: 1000
-      I: Distance estimates on antenna path 0: ifft: 1.039173, phase_slope: 1.581897, rtt: 3.075647
-      I: Sleeping for a few seconds...
+      - config ID: 0
+      - antenna configuration index: 0
+      - TX power: 0 dbm
+      - subevent length: 16000 us
+      - subevents per event: 1
+      - subevent interval: 0
+      - event interval: 2
+      - procedure interval: 5
+      - procedure count: 0
+      - maximum procedure length: 128
+      I: Latest distance estimates on antenna path 0: ifft: 1.35, phase_slope: 1.32, rtt: 2.86 meters
+      I: Latest distance estimates on antenna path 0: ifft: 1.35, phase_slope: 1.32, rtt: 2.42 meters
+      I: Latest distance estimates on antenna path 0: ifft: 1.35, phase_slope: 1.32, rtt: 1.98 meter
 
 Dependencies
 ************

--- a/samples/bluetooth/channel_sounding/ras_initiator/src/main.c
+++ b/samples/bluetooth/channel_sounding/ras_initiator/src/main.c
@@ -9,25 +9,26 @@
  */
 
 #include <math.h>
-#include <stdlib.h>
+#include <string.h>
+
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/reboot.h>
-#include <zephyr/bluetooth/cs.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/conn.h>
+
+#include <zephyr/bluetooth/cs.h>
+
 #include <bluetooth/scan.h>
-#include <bluetooth/services/ras.h>
 #include <bluetooth/gatt_dm.h>
 #include <bluetooth/cs_de.h>
+#include <bluetooth/services/ras.h>
+
+#include <cs_samples_common.h>
 
 #include <dk_buttons_and_leds.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(app_main, LOG_LEVEL_INF);
-
-#define CON_STATUS_LED DK_LED1
 
 #define CS_CONFIG_ID 0
 
@@ -55,20 +56,14 @@ BUILD_ASSERT(false, "Invalid ranging mode");
 #define CHANNEL_INDEX_OFFSET (2)
 #define TONE_QI_OK_TONE_COUNT_THRESHOLD (15)
 
-static K_SEM_DEFINE(sem_remote_capabilities_obtained, 0, 1);
-static K_SEM_DEFINE(sem_config_created, 0, 1);
-static K_SEM_DEFINE(sem_cs_security_enabled, 0, 1);
-static K_SEM_DEFINE(sem_connected, 0, 1);
 static K_SEM_DEFINE(sem_discovery_done, 0, 1);
 static K_SEM_DEFINE(sem_mtu_exchange_done, 0, 1);
-static K_SEM_DEFINE(sem_security, 0, 1);
 static K_SEM_DEFINE(sem_ras_features, 0, 1);
 static K_SEM_DEFINE(sem_local_steps, 1, 1);
 static K_SEM_DEFINE(sem_distance_estimate_updated, 0, 1);
 
 static K_MUTEX_DEFINE(distance_estimate_buffer_mutex);
 
-static struct bt_conn *connection;
 NET_BUF_SIMPLE_DEFINE_STATIC(latest_local_steps, LOCAL_PROCEDURE_MEM);
 NET_BUF_SIMPLE_DEFINE_STATIC(latest_peer_steps, BT_RAS_PROCEDURE_MEM);
 static int32_t most_recent_local_ranging_counter = PROCEDURE_COUNTER_NONE;
@@ -82,8 +77,6 @@ struct distance_estimate_buffer {
 };
 
 static struct distance_estimate_buffer distance_estimate_buffers[MAX_AP];
-
-static struct bt_conn_le_cs_config cs_config;
 
 static uint16_t m_n_iqs[CONFIG_BT_RAS_MAX_ANTENNA_PATHS][CS_DE_NUM_CHANNELS];
 static cs_de_report_t m_cs_de_report;
@@ -104,29 +97,6 @@ static void store_distance_estimates_in_buffer(cs_de_dist_estimates_t *p_estimat
 	}
 
 	k_mutex_unlock(&distance_estimate_buffer_mutex);
-}
-
-static int float_cmp(const void *a, const void *b)
-{
-	float fa = *(const float *)a;
-	float fb = *(const float *)b;
-
-	return (fa > fb) - (fa < fb);
-}
-
-static float median_inplace(int count, float *values)
-{
-	if (count == 0) {
-		return NAN;
-	}
-
-	qsort(values, count, sizeof(float), float_cmp);
-
-	if (count % 2 == 0) {
-		return (values[count/2] + values[count/2 - 1]) / 2;
-	} else {
-		return values[count/2];
-	}
 }
 
 static cs_de_dist_estimates_t get_distance(uint8_t ap)
@@ -163,9 +133,9 @@ static cs_de_dist_estimates_t get_distance(uint8_t ap)
 
 	k_mutex_unlock(&distance_estimate_buffer_mutex);
 
-	averaged_result.ifft = median_inplace(num_ifft, temp_ifft);
-	averaged_result.phase_slope = median_inplace(num_phase_slope, temp_phase_slope);
-	averaged_result.rtt = median_inplace(num_rtt, temp_rtt);
+	averaged_result.ifft = common_median_inplace(num_ifft, temp_ifft);
+	averaged_result.phase_slope = common_median_inplace(num_phase_slope, temp_phase_slope);
+	averaged_result.rtt = common_median_inplace(num_rtt, temp_rtt);
 
 	return averaged_result;
 }
@@ -513,178 +483,10 @@ static struct bt_gatt_dm_cb discovery_cb = {
 	.error_found = discovery_error_found_cb,
 };
 
-static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	if (err) {
-		LOG_ERR("Security failed: %s level %u err %d %s", addr, level, err,
-			bt_security_err_to_str(err));
-		return;
-	}
-
-	LOG_INF("Security changed: %s level %u", addr, level);
-	k_sem_give(&sem_security);
-}
-
 static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 {
 	/* Ignore peer parameter preferences. */
 	return false;
-}
-
-static void connected_cb(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-	LOG_INF("Connected to %s (err 0x%02X)", addr, err);
-
-	if (err) {
-		bt_conn_unref(conn);
-		connection = NULL;
-	} else {
-		connection = bt_conn_ref(conn);
-
-		k_sem_give(&sem_connected);
-
-		dk_set_led_on(CON_STATUS_LED);
-	}
-}
-
-static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
-{
-	LOG_INF("Disconnected (reason 0x%02X)", reason);
-
-	bt_conn_unref(conn);
-	connection = NULL;
-	dk_set_led_off(CON_STATUS_LED);
-
-	sys_reboot(SYS_REBOOT_COLD);
-}
-
-static void remote_capabilities_cb(struct bt_conn *conn,
-				   uint8_t status,
-				   struct bt_conn_le_cs_capabilities *params)
-{
-	ARG_UNUSED(conn);
-	ARG_UNUSED(params);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		LOG_INF("CS capability exchange completed.");
-		k_sem_give(&sem_remote_capabilities_obtained);
-	} else {
-		LOG_WRN("CS capability exchange failed. (HCI status 0x%02x)", status);
-	}
-}
-
-static void config_create_cb(struct bt_conn *conn, uint8_t status,
-			     struct bt_conn_le_cs_config *config)
-{
-	ARG_UNUSED(conn);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		cs_config = *config;
-
-		const char *mode_str[5] = {"Unused", "1 (RTT)", "2 (PBR)", "3 (RTT + PBR)",
-					   "Invalid"};
-		const char *role_str[3] = {"Initiator", "Reflector", "Invalid"};
-		const char *rtt_type_str[8] = {
-			"AA only",	 "32-bit sounding", "96-bit sounding", "32-bit random",
-			"64-bit random", "96-bit random",   "128-bit random",  "Invalid"};
-		const char *phy_str[4] = {"Invalid", "LE 1M PHY", "LE 2M PHY", "LE 2M 2BT PHY"};
-		const char *chsel_type_str[3] = {"Algorithm #3b", "Algorithm #3c", "Invalid"};
-		const char *ch3c_shape_str[3] = {"Hat shape", "X shape", "Invalid"};
-
-		uint8_t mode_idx = config->mode > 0 && config->mode < 4 ? config->mode : 4;
-		uint8_t role_idx = MIN(config->role, 2);
-		uint8_t rtt_type_idx = MIN(config->rtt_type, 7);
-		uint8_t phy_idx = config->cs_sync_phy > 0 && config->cs_sync_phy < 4
-					  ? config->cs_sync_phy
-					  : 0;
-		uint8_t chsel_type_idx = MIN(config->channel_selection_type, 2);
-		uint8_t ch3c_shape_idx = MIN(config->ch3c_shape, 2);
-
-		LOG_INF("CS config creation complete.\n"
-			" - id: %u\n"
-			" - mode: %s\n"
-			" - min_main_mode_steps: %u\n"
-			" - max_main_mode_steps: %u\n"
-			" - main_mode_repetition: %u\n"
-			" - mode_0_steps: %u\n"
-			" - role: %s\n"
-			" - rtt_type: %s\n"
-			" - cs_sync_phy: %s\n"
-			" - channel_map_repetition: %u\n"
-			" - channel_selection_type: %s\n"
-			" - ch3c_shape: %s\n"
-			" - ch3c_jump: %u\n"
-			" - t_ip1_time_us: %u\n"
-			" - t_ip2_time_us: %u\n"
-			" - t_fcs_time_us: %u\n"
-			" - t_pm_time_us: %u\n"
-			" - channel_map: 0x%08X%08X%04X\n",
-			config->id, mode_str[mode_idx],
-			config->min_main_mode_steps, config->max_main_mode_steps,
-			config->main_mode_repetition, config->mode_0_steps, role_str[role_idx],
-			rtt_type_str[rtt_type_idx], phy_str[phy_idx],
-			config->channel_map_repetition, chsel_type_str[chsel_type_idx],
-			ch3c_shape_str[ch3c_shape_idx], config->ch3c_jump, config->t_ip1_time_us,
-			config->t_ip2_time_us, config->t_fcs_time_us, config->t_pm_time_us,
-			sys_get_le32(&config->channel_map[6]),
-			sys_get_le32(&config->channel_map[2]),
-			sys_get_le16(&config->channel_map[0]));
-
-		k_sem_give(&sem_config_created);
-	} else {
-		LOG_WRN("CS config creation failed. (HCI status 0x%02x)", status);
-	}
-}
-
-static void security_enable_cb(struct bt_conn *conn, uint8_t status)
-{
-	ARG_UNUSED(conn);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		LOG_INF("CS security enabled.");
-		k_sem_give(&sem_cs_security_enabled);
-	} else {
-		LOG_WRN("CS security enable failed. (HCI status 0x%02x)", status);
-	}
-}
-
-static void procedure_enable_cb(struct bt_conn *conn,
-				uint8_t status,
-				struct bt_conn_le_cs_procedure_enable_complete *params)
-{
-	ARG_UNUSED(conn);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		if (params->state == 1) {
-			LOG_INF("CS procedures enabled:\n"
-				" - config ID: %u\n"
-				" - antenna configuration index: %u\n"
-				" - TX power: %d dbm\n"
-				" - subevent length: %u us\n"
-				" - subevents per event: %u\n"
-				" - subevent interval: %u\n"
-				" - event interval: %u\n"
-				" - procedure interval: %u\n"
-				" - procedure count: %u\n"
-				" - maximum procedure length: %u",
-				params->config_id, params->tone_antenna_config_selection,
-				params->selected_tx_power, params->subevent_len,
-				params->subevents_per_event, params->subevent_interval,
-				params->event_interval, params->procedure_interval,
-				params->procedure_count, params->max_procedure_len);
-		} else {
-			LOG_INF("CS procedures disabled.");
-		}
-	} else {
-		LOG_WRN("CS procedures enable failed. (HCI status 0x%02x)", status);
-	}
 }
 
 void ras_features_read_cb(struct bt_conn *conn, uint32_t feature_bits, int err)
@@ -699,35 +501,8 @@ void ras_features_read_cb(struct bt_conn *conn, uint32_t feature_bits, int err)
 	k_sem_give(&sem_ras_features);
 }
 
-static void scan_filter_match(struct bt_scan_device_info *device_info,
-			      struct bt_scan_filter_match *filter_match, bool connectable)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
-
-	LOG_INF("Filters matched. Address: %s connectable: %d", addr, connectable);
-}
-
-static void scan_connecting_error(struct bt_scan_device_info *device_info)
-{
-	int err;
-
-	LOG_INF("Connecting failed, restarting scanning");
-
-	err = bt_scan_start(BT_SCAN_TYPE_SCAN_PASSIVE);
-	if (err) {
-		LOG_ERR("Failed to restart scanning (err %i)", err);
-		return;
-	}
-}
-
-static void scan_connecting(struct bt_scan_device_info *device_info, struct bt_conn *conn)
-{
-	LOG_INF("Connecting");
-}
-
-BT_SCAN_CB_INIT(scan_cb, scan_filter_match, NULL, scan_connecting_error, scan_connecting);
+BT_SCAN_CB_INIT(scan_cb, common_scan_filter_match, NULL, common_scan_connecting_error,
+		common_scan_connecting);
 
 static int scan_init(struct bt_scan_init_param *p_param)
 {
@@ -752,14 +527,14 @@ static int scan_init(struct bt_scan_init_param *p_param)
 }
 
 BT_CONN_CB_DEFINE(conn_cb) = {
-	.connected = connected_cb,
-	.disconnected = disconnected_cb,
+	.connected = common_connected_cb,
+	.disconnected = common_disconnected_cb,
 	.le_param_req = le_param_req,
-	.security_changed = security_changed,
-	.le_cs_read_remote_capabilities_complete = remote_capabilities_cb,
-	.le_cs_config_complete = config_create_cb,
-	.le_cs_security_enable_complete = security_enable_cb,
-	.le_cs_procedure_enable_complete = procedure_enable_cb,
+	.security_changed = common_security_changed_cb,
+	.le_cs_read_remote_capabilities_complete = common_remote_capabilities_cb,
+	.le_cs_config_complete = common_config_create_cb,
+	.le_cs_security_enable_complete = common_cs_security_enable_cb,
+	.le_cs_procedure_enable_complete = common_procedure_enable_cb,
 	.le_cs_subevent_data_available = subevent_result_cb,
 };
 

--- a/samples/bluetooth/channel_sounding/ras_reflector/CMakeLists.txt
+++ b/samples/bluetooth/channel_sounding/ras_reflector/CMakeLists.txt
@@ -9,7 +9,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(channel_sounding_ras_reflector)
 
 # NORDIC SDK APP START
-target_sources(app PRIVATE
-  src/main.c
-)
+target_include_directories(app PRIVATE ${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/channel_sounding/common)
+
+target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE ${ZEPHYR_NRF_MODULE_DIR}/samples/bluetooth/channel_sounding/common/src/cs_samples_common.c)
 # NORDIC SDK APP END

--- a/samples/bluetooth/channel_sounding/ras_reflector/README.rst
+++ b/samples/bluetooth/channel_sounding/ras_reflector/README.rst
@@ -47,11 +47,85 @@ After programming the sample to your development kit, you can test it by connect
 #. Wait until the advertiser is detected by the Central.
    In the terminal window, check for information similar to the following::
 
-      I: Connected to xx.xx.xx.xx.xx.xx (random) (err 0x00)
+      *** Booting nRF Connect SDK v3.2.99-4dc52e0d80a6 ***
+      *** Using Zephyr OS v4.4.0-2b3d25313ec3 ***
+      I: Starting Channel Sounding Reflector Sample
+      I: SoftDevice Controller build revision:
+      I: 10 7f 81 88 e0 eb fc fc |........
+      I: 53 3c 0e d3 0f e7 d0 4f |S<.....O
+      I: 0c 64 24 fc             |.d$.
+      I: HW Platform: Nordic Semiconductor (0x0002)
+      I: HW Variant: nRF54Lx (0x0005)
+      I: Firmware: Standard Bluetooth controller (0x00) Version 16.33151 Build 4243316872
+      I: HCI transport: SDC
+      I: Identity: D2:CE:07:7E:40:79 (random)
+      I: HCI: version 6.2 (0x10) revision 0x30b8, manufacturer 0x0059
+      I: LMP: version 6.2 (0x10) subver 0x30b8
+      I: Connected to E6:BA:C9:31:51:DB (random) (err 0x00)
       I: CS capability exchange completed.
-      I: CS config creation complete. ID: 0
+      Remote CS capabilities:
+      - num_config_supported: 1
+      - max_consecutive_procedures_supported: 0
+      - num_antennas_supported: 1
+      - max_antenna_paths_supported: 1
+      - initiator_supported: yes
+      - reflector_supported: no
+      - mode_3_supported: no
+      - rtt_aa_only_precision: 150 ns (2)
+      - rtt_sounding_precision: not supported (0)
+      - rtt_random_payload_precision: 150 ns (2)
+      - rtt_aa_only_n: 30
+      - rtt_sounding_n: 0
+      - rtt_random_payload_n: 30
+      - phase_based_nadm_sounding_supported: no
+      - phase_based_nadm_random_supported: no
+      - cs_sync_2m_phy_supported: yes
+      - cs_sync_2m_2bt_phy_supported: no
+      - cs_without_fae_supported: yes
+      - chsel_alg_3c_supported: no
+      - pbr_from_rtt_sounding_seq_supported: no
+      - t_ip1_times_supported: 0x007c
+      - t_ip2_times_supported: 0x007e
+      - t_fcs_times_supported: 0x01e0
+      - t_pm_times_supported: 0x0003
+      - t_sw_time: 0 us
+      - tx_snr_capability: 0x00
+      - t_ip2_ipt_times_supported: 0x0000
+      - t_sw_ipt_time_supported: 0 us
+
+      I: CS config creation complete.
+      - id: 0
+      - mode: Invalid
+      - min_main_mode_steps: 2
+      - max_main_mode_steps: 5
+      - main_mode_repetition: 0
+      - mode_0_steps: 3
+      - role: Reflector
+      - rtt_type: AA only
+      - cs_sync_phy: LE 1M PHY
+      - channel_map_repetition: 1
+      - channel_selection_type: Algorithm #3b
+      - ch3c_shape: Hat shape
+      - ch3c_jump: 0
+      - t_ip1_time_us: 30
+      - t_ip2_time_us: 20
+      - t_fcs_time_us: 60
+      - t_pm_time_us: 10
+      - channel_map: 0x1FFFFFFFFFFFFC7FFFFC
+
       I: CS security enabled.
-      I: CS procedures enabled.
+      I: CS procedures enabled:
+      - config ID: 0
+      - antenna configuration index: 0
+      - TX power: 0 dbm
+      - subevent length: 16000 us
+      - subevents per event: 1
+      - subevent interval: 0
+      - event interval: 2
+      - procedure interval: 5
+      - procedure count: 0
+      - maximum procedure length: 128
+
 
 Building for testing with Android 16 ranging module
 ===================================================

--- a/samples/bluetooth/channel_sounding/ras_reflector/src/main.c
+++ b/samples/bluetooth/channel_sounding/ras_reflector/src/main.c
@@ -8,27 +8,23 @@
  *  @brief Channel Sounding Reflector with Ranging Responder sample
  */
 
-#include <zephyr/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/reboot.h>
+#include <zephyr/bluetooth/cs.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/uuid.h>
-#include <zephyr/bluetooth/cs.h>
-#include <bluetooth/services/ras.h>
 #include <zephyr/settings/settings.h>
+
+#include <bluetooth/services/ras.h>
+
+#include <cs_samples_common.h>
+
 #include <dk_buttons_and_leds.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(app_main, LOG_LEVEL_INF);
 
-#define CON_STATUS_LED DK_LED1
-
-static K_SEM_DEFINE(sem_connected, 0, 1);
 static K_SEM_DEFINE(sem_config, 0, 1);
-
-static struct bt_conn *connection;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -36,162 +32,23 @@ static const struct bt_data ad[] = {
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
-static void connected_cb(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-	LOG_INF("Connected to %s (err 0x%02X)", addr, err);
-
-	if (err) {
-		bt_conn_unref(conn);
-		connection = NULL;
-	} else {
-		connection = bt_conn_ref(conn);
-
-		k_sem_give(&sem_connected);
-
-		dk_set_led_on(CON_STATUS_LED);
-	}
-}
-
-static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
-{
-	LOG_INF("Disconnected (reason 0x%02X)", reason);
-
-	bt_conn_unref(conn);
-	connection = NULL;
-
-	dk_set_led_off(CON_STATUS_LED);
-
-	sys_reboot(SYS_REBOOT_COLD);
-}
-
-static void remote_capabilities_cb(struct bt_conn *conn,
-				   uint8_t status,
-				   struct bt_conn_le_cs_capabilities *params)
-{
-	ARG_UNUSED(conn);
-	ARG_UNUSED(params);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		LOG_INF("CS capability exchange completed.");
-	} else {
-		LOG_WRN("CS capability exchange failed. (HCI status 0x%02x)", status);
-	}
-}
-
 static void config_create_cb(struct bt_conn *conn, uint8_t status,
 			     struct bt_conn_le_cs_config *config)
 {
-	ARG_UNUSED(conn);
+	common_config_create_cb(conn, status, config);
 
 	if (status == BT_HCI_ERR_SUCCESS) {
-		const char *mode_str[5] = {"Unused", "1 (RTT)", "2 (PBR)", "3 (RTT + PBR)",
-					   "Invalid"};
-		const char *role_str[3] = {"Initiator", "Reflector", "Invalid"};
-		const char *rtt_type_str[8] = {
-			"AA only",	 "32-bit sounding", "96-bit sounding", "32-bit random",
-			"64-bit random", "96-bit random",   "128-bit random",  "Invalid"};
-		const char *phy_str[4] = {"Invalid", "LE 1M PHY", "LE 2M PHY", "LE 2M 2BT PHY"};
-		const char *chsel_type_str[3] = {"Algorithm #3b", "Algorithm #3c", "Invalid"};
-		const char *ch3c_shape_str[3] = {"Hat shape", "X shape", "Invalid"};
-
-		uint8_t mode_idx = config->mode > 0 && config->mode < 4 ? config->mode : 4;
-		uint8_t role_idx = MIN(config->role, 2);
-		uint8_t rtt_type_idx = MIN(config->rtt_type, 7);
-		uint8_t phy_idx = config->cs_sync_phy > 0 && config->cs_sync_phy < 4
-					  ? config->cs_sync_phy
-					  : 0;
-		uint8_t chsel_type_idx = MIN(config->channel_selection_type, 2);
-		uint8_t ch3c_shape_idx = MIN(config->ch3c_shape, 2);
-
-		LOG_INF("CS config creation complete.\n"
-			" - id: %u\n"
-			" - mode: %s\n"
-			" - min_main_mode_steps: %u\n"
-			" - max_main_mode_steps: %u\n"
-			" - main_mode_repetition: %u\n"
-			" - mode_0_steps: %u\n"
-			" - role: %s\n"
-			" - rtt_type: %s\n"
-			" - cs_sync_phy: %s\n"
-			" - channel_map_repetition: %u\n"
-			" - channel_selection_type: %s\n"
-			" - ch3c_shape: %s\n"
-			" - ch3c_jump: %u\n"
-			" - t_ip1_time_us: %u\n"
-			" - t_ip2_time_us: %u\n"
-			" - t_fcs_time_us: %u\n"
-			" - t_pm_time_us: %u\n"
-			" - channel_map: 0x%08X%08X%04X\n",
-			config->id, mode_str[mode_idx],
-			config->min_main_mode_steps, config->max_main_mode_steps,
-			config->main_mode_repetition, config->mode_0_steps, role_str[role_idx],
-			rtt_type_str[rtt_type_idx], phy_str[phy_idx],
-			config->channel_map_repetition, chsel_type_str[chsel_type_idx],
-			ch3c_shape_str[ch3c_shape_idx], config->ch3c_jump, config->t_ip1_time_us,
-			config->t_ip2_time_us, config->t_fcs_time_us, config->t_pm_time_us,
-			sys_get_le32(&config->channel_map[6]),
-			sys_get_le32(&config->channel_map[2]),
-			sys_get_le16(&config->channel_map[0]));
-
 		k_sem_give(&sem_config);
-	} else {
-		LOG_WRN("CS config creation failed. (HCI status 0x%02x)", status);
-	}
-}
-
-static void security_enable_cb(struct bt_conn *conn, uint8_t status)
-{
-	ARG_UNUSED(conn);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		LOG_INF("CS security enabled.");
-	} else {
-		LOG_WRN("CS security enable failed. (HCI status 0x%02x)", status);
-	}
-}
-
-static void procedure_enable_cb(struct bt_conn *conn,
-				uint8_t status,
-				struct bt_conn_le_cs_procedure_enable_complete *params)
-{
-	ARG_UNUSED(conn);
-
-	if (status == BT_HCI_ERR_SUCCESS) {
-		if (params->state == 1) {
-			LOG_INF("CS procedures enabled:\n"
-				" - config ID: %u\n"
-				" - antenna configuration index: %u\n"
-				" - TX power: %d dbm\n"
-				" - subevent length: %u us\n"
-				" - subevents per event: %u\n"
-				" - subevent interval: %u\n"
-				" - event interval: %u\n"
-				" - procedure interval: %u\n"
-				" - procedure count: %u\n"
-				" - maximum procedure length: %u",
-				params->config_id, params->tone_antenna_config_selection,
-				params->selected_tx_power, params->subevent_len,
-				params->subevents_per_event, params->subevent_interval,
-				params->event_interval, params->procedure_interval,
-				params->procedure_count, params->max_procedure_len);
-		} else {
-			LOG_INF("CS procedures disabled.");
-		}
-	} else {
-		LOG_WRN("CS procedures enable failed. (HCI status 0x%02x)", status);
 	}
 }
 
 BT_CONN_CB_DEFINE(conn_cb) = {
-	.connected = connected_cb,
-	.disconnected = disconnected_cb,
-	.le_cs_read_remote_capabilities_complete = remote_capabilities_cb,
+	.connected = common_connected_cb,
+	.disconnected = common_disconnected_cb,
+	.le_cs_read_remote_capabilities_complete = common_remote_capabilities_cb,
 	.le_cs_config_complete = config_create_cb,
-	.le_cs_security_enable_complete = security_enable_cb,
-	.le_cs_procedure_enable_complete = procedure_enable_cb,
+	.le_cs_security_enable_complete = common_cs_security_enable_cb,
+	.le_cs_procedure_enable_complete = common_procedure_enable_cb,
 };
 
 int main(void)


### PR DESCRIPTION
Move shared CS sample helpers (connection/scan callbacks, CS event logging, and median utilities) into a common module and update the IPT/RAS initiator and reflector samples to use it. This reduces duplicated code and keeps sample behavior consistent when shared logic is updated.