### PR TITLE
samples: nfc: writable_ndef_msg: Remove duplicate NVS header

### DIFF
--- a/samples/nfc/writable_ndef_msg/src/ndef_file_m.c
+++ b/samples/nfc/writable_ndef_msg/src/ndef_file_m.c
@@ -16,7 +16,6 @@
 #include <zephyr/kernel.h>
 #include <soc.h>
 #include <zephyr/device.h>
-#include <zephyr/kvss/nvs.h>
 #include <nfc/t4t/ndef_file.h>
 #include <nfc/ndef/uri_msg.h>
 #include <zephyr/storage/flash_map.h>


### PR DESCRIPTION
Remove duplicate unconditional include of <zephyr/kvss/nvs.h> that is already conditionally included based on CONFIG_NVS configuration. Ref: KRKNWK-21807