### PR TITLE
samples: cellular: modem_shell: Add nRF9251 DK support

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os_rpc.c
+++ b/lib/nrf_modem_lib/nrf_modem_os_rpc.c
@@ -130,10 +130,10 @@ int nrf_modem_os_rpc_cellcore_boot(void)
 	uint8_t *msg = (uint8_t *)&params;
 	size_t msg_size = sizeof(params);
 
-	/* Don't wait as this is not yet supported. */
 	bool cpu_wait = false;
 
-	return ironside_se_cpuconf(NRF_PROCESSOR_CELLCORE, NULL, cpu_wait, msg, msg_size);
+	/* TODO: Replace hardcoded value when a define is available. */
+	return ironside_se_cpuconf(4, NULL, cpu_wait, msg, msg_size);
 #else
 	/* Without IronSide SE, cellcore is booted by the SDFW. */
 	return 0;

--- a/samples/cellular/modem_shell/boards/nrf9251dk_nrf9251_cpuapp.conf
+++ b/samples/cellular/modem_shell/boards/nrf9251dk_nrf9251_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# FOTA not yet supported
+CONFIG_MOSH_FOTA=n
+CONFIG_FOTA_DOWNLOAD=n

--- a/samples/cellular/modem_shell/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/samples/cellular/modem_shell/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &cpuapp_boot_partition;
+/delete-node/ &cpuapp_slot0_partition;
+/delete-node/ &cpuapp_slot1_partition;
+/delete-node/ &cpuppr_code_partition;
+/delete-node/ &cpuflpr_code_partition;
+/delete-node/ &storage_partition;
+/delete-node/ &periphconf_partition;
+/delete-node/ &secure_storage_partition;
+
+&cpuppr_vpr {
+	status = "disabled";
+	/delete-property/ source-memory;
+	/delete-property/ execution-memory;
+};
+
+&cpuflpr_vpr {
+	status = "disabled";
+	/delete-property/ source-memory;
+	/delete-property/ execution-memory;
+};
+
+&mram1x {
+	partitions {
+		cpuapp_boot_partition: partition@312000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x312000 DT_SIZE_K(64)>;
+		};
+
+		cpuapp_slot0_partition: partition@322000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x322000 DT_SIZE_K(888)>;
+		};
+
+		storage_partition: partition@400000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x400000 DT_SIZE_K(40)>;
+		};
+
+		periphconf_partition: partition@40a000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x40a000 DT_SIZE_K(8)>;
+		};
+
+		secure_storage_partition: partition@40c000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x40c000 DT_SIZE_K(8)>;
+			ranges = <0x0 0x40c000 0x2000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cpuapp_crypto_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				reg = <0x0 DT_SIZE_K(4)>;
+			};
+
+			cpuapp_its_partition: partition@1000 {
+				compatible = "zephyr,mapped-partition";
+				reg = <0x1000 DT_SIZE_K(4)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Added board overlays for the nRF9251 DK to modem_shell.

Hardcoded the cellcore processor ID in nrf_modem_lib for now, because there's no define available in the MDK or IronSide SE API.