### PR TITLE
doc: ap_protect: add flow figures & clarify USE_UICR

### DIFF
--- a/doc/nrf/security/ap_protect.rst
+++ b/doc/nrf/security/ap_protect.rst
@@ -62,6 +62,9 @@ Flow for AP-Protect controlled by hardware
 
 This flow applies to the nRF9160 and older HW build codes of nRF52 Series devices.
 
+.. figure:: images/ap_protect_hw_flow.svg
+   :alt: AP-Protect controlled by hardware
+
 Enabling AP-Protect controlled by hardware
 ------------------------------------------
 
@@ -109,6 +112,9 @@ Flow for AP-Protect controlled by hardware and software
 =======================================================
 
 This flow applies to nRF53, nRF54L, nRF91x1, and newer HW build codes of nRF52 Series devices.
+
+.. figure:: images/ap_protect_hwsw_flow.svg
+   :alt: AP-Protect controlled by hardware and software
 
 Disabling AP-Protect controlled by hardware and software
 --------------------------------------------------------
@@ -168,6 +174,9 @@ Flow for Secure AP-Protect
 
 This flow applies to TrustZone-enabled devices (nRF5340, most nRF54L Series devices, nRF91 Series devices, with nRF9160 being an exception) when Secure AP-Protect is enabled.
 Such devices use :ref:`Trusted Firmware-M (TF-M) <ug_tfm>` and :ref:`security by separation <app_boards_spe_nspe>`, where a Secure Processing Environment (SPE) is isolated from the Non-Secure Processing Environment (NSPE).
+
+.. figure:: images/ap_protect_secure_flow.svg
+   :alt: Secure AP-Protect
 
 While AP-Protect blocks access to all CPU registers and memories, Secure AP-Protect limits the CPU access to the NSPE side only.
 This allows debugging of the NSPE, while the SPE debugging is blocked.
@@ -365,7 +374,7 @@ nRF91 Series
            - Description
          * - Enabled
            - :kconfig:option:`CONFIG_NRF_APPROTECT_LOCK`
-           - | With this Kconfig option set, the MDK locks AP-Protect in ``SystemInit()`` at every boot.
+           - | With this Kconfig option selected, the MDK locks AP-Protect in ``SystemInit()`` at every boot.
              | It also prevents CPU from disabling AP-Protect in software.
              | UICR is not modified by this Kconfig option.
              |
@@ -373,7 +382,7 @@ nRF91 Series
              | You can set this option manually for each image or use sysbuild's :kconfig:option:`SB_CONFIG_APPROTECT_LOCK` Kconfig option to set it for all images at once.
          * - Authenticated
            - :kconfig:option:`CONFIG_NRF_APPROTECT_USER_HANDLING`
-           - | With this Kconfig option set, AP-Protect is left enabled and it is up to the user-space code to handle unlocking the device if needed.
+           - | With this Kconfig option selected, AP-Protect is left enabled and it is up to the user-space code to handle unlocking the device if needed.
              | Reopening the AHB-AP must be configured in firmware and it must be preceded by a handshake operation over UART, CTRL-AP Mailboxes, or some other communication channel.
              |
              | You can use this Kconfig option for example to implement the authenticated debug and lock. See the SoC or SiP hardware documentation for more information.
@@ -382,10 +391,9 @@ nRF91 Series
              | You can set this option manually for each image or use sysbuild's :kconfig:option:`SB_CONFIG_APPROTECT_USER_HANDLING` Kconfig option to set it for all images at once.
          * - Disabled
            - :kconfig:option:`CONFIG_NRF_APPROTECT_USE_UICR`
-           - | This option is set to ``y`` by default in the |NCS|.
-             | You can start debugging the firmware without additional steps needed.
+           - | This option is selected by default in the |NCS| for this device.
              |
-             | With this Kconfig option set, AP-Protect follows the UICR register. If UICR is open (``UICR.APPROTECT`` disabled), AP-Protect is disabled.
+             | With this Kconfig option selected, AP-Protect follows the UICR register. If UICR is open (``UICR.APPROTECT`` disabled), AP-Protect is disabled.
 
 
       .. list-table:: nRF91x1 Secure AP-Protect software configuration options in the |NCS|
@@ -398,23 +406,22 @@ nRF91 Series
            - Description
          * - Enabled
            - :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_LOCK`
-           - | With this Kconfig option set, the MDK locks Secure AP-Protect in ``SystemInit()`` at every boot.
+           - | With this Kconfig option selected, the MDK locks Secure AP-Protect in ``SystemInit()`` at every boot.
              |
              | For multi-image boot, this option needs to be set in *the first image* (like a secure bootloader). Otherwise, the software Secure AP-Protect will be opened for subsequent images.
              | You can set this option manually for each image or use sysbuild's :kconfig:option:`SB_CONFIG_SECURE_APPROTECT_LOCK` Kconfig option to set it for all images at once.
          * - Authenticated
            - :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING`
-           - | With this Kconfig option set, Secure AP-Protect is left enabled and you can handle its state at a later stage.
+           - | With this Kconfig option selected, Secure AP-Protect is left enabled and you can handle its state at a later stage.
              | You can use this option for example to implement the authenticated debug and lock. See the SoC or SiP hardware documentation for more information.
              |
              | For multi-image boot, this option needs to be set for *all images*. The default value is to open the device. This allows the debugger to be attached to the device.
              | You can set this option manually for each image or use sysbuild's :kconfig:option:`SB_CONFIG_SECURE_APPROTECT_USER_HANDLING` Kconfig option to set it for all images at once.
          * - Disabled
            - :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_USE_UICR`
-           - | This option is set to ``y`` by default in the |NCS|.
-             | You can start debugging the SPE without additional steps needed.
+           - | This option is selected by default in the |NCS| for this device.
              |
-             | With this Kconfig option set, Secure AP-Protect follows the UICR register. If UICR is open (``UICR.SECUREAPPROTECT`` disabled), Secure AP-Protect is disabled.
+             | With this Kconfig option selected, Secure AP-Protect follows the UICR register. If UICR is open (``UICR.SECUREAPPROTECT`` disabled), Secure AP-Protect is disabled.
 
       **Enabling AP-Protect:**
 
@@ -456,7 +463,7 @@ nRF91 Series
       **Keeping AP-Protect disabled after hard reset:**
 
       If you want to keep the AP-Protect disabled after hard reset, configure and program firmware that writes ``SwDisable`` to ``APPROTECT.DISABLE`` during boot.
-      In the |NCS|, :kconfig:option:`CONFIG_NRF_APPROTECT_USE_UICR`  handles the unlock for AP-Protect on the software side.
+      In the |NCS|, :kconfig:option:`CONFIG_NRF_APPROTECT_USE_UICR` handles the unlock for AP-Protect on the software side.
 
       **Keeping Secure AP-Protect disabled after hard reset:**
 
@@ -576,7 +583,7 @@ nRF54L Series
            - Description
          * - Enabled
            - :kconfig:option:`CONFIG_NRF_APPROTECT_LOCK`
-           - | With this Kconfig option set, the MDK locks AP-Protect in ``SystemInit()`` at every boot.
+           - | With this Kconfig option selected, the MDK locks AP-Protect in ``SystemInit()`` at every boot.
              | It also prevents CPU from disabling AP-Protect in software.
              | UICR is not modified by this Kconfig option.
              |
@@ -584,7 +591,7 @@ nRF54L Series
              | You can set this option manually for each image or use sysbuild's :kconfig:option:`SB_CONFIG_APPROTECT_LOCK` Kconfig option to set it for all images at once.
          * - Authenticated
            - :kconfig:option:`CONFIG_NRF_APPROTECT_USER_HANDLING`
-           - | With this Kconfig option set, AP-Protect is left enabled and it is up to the user-space code to handle unlocking the device if needed.
+           - | With this Kconfig option selected, AP-Protect is left enabled and it is up to the user-space code to handle unlocking the device if needed.
              | Reopening the AHB-AP must be configured in firmware and it must be preceded by a handshake operation over UART, CTRL-AP Mailboxes, or some other communication channel.
              |
              | You can use this Kconfig option for example to implement the authenticated debug and lock. See the SoC or SiP hardware documentation for more information.
@@ -593,8 +600,9 @@ nRF54L Series
              | You can set this option manually for each image or use sysbuild's :kconfig:option:`SB_CONFIG_APPROTECT_USER_HANDLING` Kconfig option to set it for all images at once.
          * - Disabled
            - :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE`
-           - | This option is set to ``y`` by default in the |NCS|.
-             | You can start debugging the firmware without additional steps needed.
+           - | This option is selected by default in the |NCS| for this device.
+             |
+             | With this Kconfig option selected, the AP-Protect mechanism is disabled and you can start debugging the firmware.
 
       .. nrf54l15_approtect_tab_kconfigs_standard_end
 
@@ -610,21 +618,22 @@ nRF54L Series
            - Description
          * - Enabled
            - :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_LOCK`
-           - | With this Kconfig option set, the MDK locks Secure AP-Protect in ``SystemInit()`` at every boot.
+           - | With this Kconfig option selected, the MDK locks Secure AP-Protect in ``SystemInit()`` at every boot.
              |
              | For multi-image boot, this option needs to be set in *the first image* (like a secure bootloader). Otherwise, the software Secure AP-Protect will be opened for subsequent images.
              | You can set this option manually for each image or use sysbuild's :kconfig:option:`SB_CONFIG_SECURE_APPROTECT_LOCK` Kconfig option to set it for all images at once.
          * - Authenticated
            - :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING`
-           - | With this Kconfig option set, Secure AP-Protect is left enabled and it is up to the user-space code to handle unlocking the device if needed.
+           - | With this Kconfig option selected, Secure AP-Protect is left enabled and it is up to the user-space code to handle unlocking the device if needed.
              | You can use this option for example to implement the authenticated debug and lock. See the SoC or SiP hardware documentation for more information.
              |
              | For multi-image boot, this option needs to be set for *all images*. The default value is to open the device. This allows the debugger to be attached to the device.
              | You can set this option manually for each image or use sysbuild's :kconfig:option:`SB_CONFIG_SECURE_APPROTECT_USER_HANDLING` Kconfig option to set it for all images at once.
          * - Disabled
            - :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_DISABLE`
-           - | This option is set to ``y`` by default in the |NCS|.
-             | You can start debugging the SPE without additional steps needed.
+           - | This option is selected by default in the |NCS| for this device.
+             |
+             | With this Kconfig option selected, the Secure AP-Protect mechanism is disabled and you can start debugging the SPE.
 
       .. nrf54l15_approtect_tab_kconfigs_secure_end
 
@@ -976,7 +985,7 @@ nRF53 Series
            - Description
          * - Enabled
            - :kconfig:option:`CONFIG_NRF_APPROTECT_LOCK`
-           - | With this Kconfig option set, the MDK locks AP-Protect in ``SystemInit()`` at every boot.
+           - | With this Kconfig option selected, the MDK locks AP-Protect in ``SystemInit()`` at every boot.
              | It also prevents CPU from disabling AP-Protect in software.
              | UICR is not modified by this Kconfig option.
              |
@@ -984,7 +993,7 @@ nRF53 Series
              | You can set this option manually for each image or use sysbuild's :kconfig:option:`SB_CONFIG_APPROTECT_LOCK` Kconfig option to set it for all images at once.
          * - Authenticated
            - :kconfig:option:`CONFIG_NRF_APPROTECT_USER_HANDLING`
-           - | With this Kconfig option set, AP-Protect is left enabled and it is up to the user-space code to handle unlocking the device if needed.
+           - | With this Kconfig option selected, AP-Protect is left enabled and it is up to the user-space code to handle unlocking the device if needed.
              | Reopening the AHB-AP must be configured in firmware and it must be preceded by a handshake operation over UART, CTRL-AP Mailboxes, or some other communication channel.
              |
              | You can use this Kconfig option for example to implement the authenticated debug and lock. See the SoC or SiP hardware documentation for more information.
@@ -993,10 +1002,9 @@ nRF53 Series
              | You can set this option manually for each image or use sysbuild's :kconfig:option:`SB_CONFIG_APPROTECT_USER_HANDLING` Kconfig option to set it for all images at once.
          * - Disabled
            - :kconfig:option:`CONFIG_NRF_APPROTECT_USE_UICR`
-           - | This option is set to ``y`` by default in the |NCS|.
-             | You can start debugging the firmware without additional steps needed.
+           - | This option is selected by default in the |NCS| for this device.
              |
-             | With this Kconfig option set, AP-Protect follows the UICR register. If UICR is open (``UICR.APPROTECT`` disabled), AP-Protect is disabled.
+             | With this Kconfig option selected, AP-Protect follows the UICR register. If UICR is open (``UICR.APPROTECT`` disabled), AP-Protect is disabled.
 
       The following Kconfig options configure Secure AP-Protect on the nRF5340 in the |NCS| when you are using TF-M:
 
@@ -1010,22 +1018,21 @@ nRF53 Series
            - Description
          * - Enabled
            - :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_LOCK`
-           - | With this Kconfig option set, the MDK locks Secure AP-Protect in ``SystemInit()`` at every boot.
+           - | With this Kconfig option selected, the MDK locks Secure AP-Protect in ``SystemInit()`` at every boot.
              |
              | For multi-image boot, this option needs to be set in *the first image* (like a secure bootloader). Otherwise, the software Secure AP-Protect will be opened for subsequent images.
              | You can set this option manually for each image or use sysbuild's :kconfig:option:`SB_CONFIG_SECURE_APPROTECT_LOCK` Kconfig option to set it for all images at once.
          * - Authenticated
            - :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING`
-           - | With this Kconfig option set, Secure AP-Protect is left enabled and it is up to the user-space code to handle unlocking the device if needed, for example for authenticated debugging of the SPE.
+           - | With this Kconfig option selected, Secure AP-Protect is left enabled and it is up to the user-space code to handle unlocking the device if needed, for example for authenticated debugging of the SPE.
              |
              | For multi-image boot, this option needs to be set for *all images*. The default value is to open the device. This allows the debugger to be attached to the device.
              | You can set this option manually for each image or use sysbuild's :kconfig:option:`SB_CONFIG_SECURE_APPROTECT_USER_HANDLING` Kconfig option to set it for all images at once.
          * - Disabled
            - :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_USE_UICR`
-           - | This option is set to ``y`` by default in the |NCS|.
-             | You can start debugging the SPE without additional steps needed.
+           - | This option is selected by default in the |NCS| for this device.
              |
-             | With this Kconfig option set, Secure AP-Protect follows the UICR register. If UICR is open (``UICR.SECUREAPPROTECT`` disabled), Secure AP-Protect is disabled.
+             | With this Kconfig option selected, Secure AP-Protect follows the UICR register. If UICR is open (``UICR.SECUREAPPROTECT`` disabled), Secure AP-Protect is disabled.
 
       **Enabling AP-Protect on the hardware side:**
 
@@ -1142,16 +1149,15 @@ nRF52 Series
            - Applicability
          * - Enabled
            - :kconfig:option:`CONFIG_NRF_APPROTECT_LOCK`
-           - | With this Kconfig option set, the MDK locks AP-Protect in ``SystemInit()`` at every boot.
+           - | With this Kconfig option selected, the MDK locks AP-Protect in ``SystemInit()`` at every boot.
              | It also prevents CPU from disabling AP-Protect in software.
              | UICR is not modified by this Kconfig option.
            - Only HW build codes supporting AP-Protect controlled by hardware and software
          * - Disabled
            - :kconfig:option:`CONFIG_NRF_APPROTECT_USE_UICR`
-           - | This option is set to ``y`` by default in the |NCS|.
-             | You can start debugging the firmware without additional steps needed.
+           - | This option is selected by default in the |NCS| for this device.
              |
-             | With this Kconfig option set, AP-Protect follows the UICR register. If UICR is open (``UICR.APPROTECT`` disabled), AP-Protect is disabled.
+             | With this Kconfig option selected, AP-Protect follows the UICR register. If UICR is open (``UICR.APPROTECT`` disabled), AP-Protect is disabled.
            - All HW build codes
 
       **Enabling AP-Protect on the hardware side:**

--- a/doc/nrf/security/images/ap_protect_hw_flow.svg
+++ b/doc/nrf/security/images/ap_protect_hw_flow.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="620px" height="225px" viewBox="0 0 620 225" xml:space="preserve">
+	<style type="text/css">
+	<![CDATA[
+		.s-dark  { fill: #0033a0; }
+		.s-mid   { fill: #0077c8; }
+		.t-head  { fill: #ffffff; font-family: Arial, sans-serif; font-size: 14px; font-weight: bold; }
+		.t-sub   { fill: #ffffff; font-family: Arial, sans-serif; font-size: 12px; }
+		.t-note  { fill: #ffffff; font-family: Arial, sans-serif; font-size: 11px; font-style: italic; }
+		.a-solid { stroke: #008bab; stroke-width: 1.5; fill: none; }
+		.a-head  { fill: #008bab; }
+		.lbl     { fill: #333f48; font-family: Arial, sans-serif; font-size: 11px; }
+		.title   { fill: #333f48; font-family: Arial, sans-serif; font-size: 14px; font-weight: bold; }
+	]]>
+	</style>
+	<defs>
+		<marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+			<polygon points="0 0, 8 3, 0 6" class="a-head"/>
+		</marker>
+	</defs>
+
+	<text x="310" y="27" class="title" text-anchor="middle">AP-Protect controlled by hardware</text>
+
+	<ellipse cx="155" cy="125" rx="130" ry="42" class="s-mid"/>
+	<text x="155" y="112" class="t-head" text-anchor="middle">Disabled</text>
+	<text x="155" y="127" class="t-sub"  text-anchor="middle">Debug open</text>
+	<text x="155" y="141" class="t-note" text-anchor="middle">(default)</text>
+
+	<ellipse cx="465" cy="125" rx="130" ry="42" class="s-dark"/>
+	<text x="465" y="119" class="t-head" text-anchor="middle">Enabled</text>
+	<text x="465" y="135" class="t-sub"  text-anchor="middle">Debug blocked</text>
+
+	<path d="M 239,93 Q 310,36 381,93" class="a-solid" marker-end="url(#arr)"/>
+	<text x="310" y="50" class="lbl" text-anchor="middle">Write Enabled to UICR.APPROTECT + Any reset</text>
+
+	<path d="M 381,157 Q 310,214 239,157" class="a-solid" marker-end="url(#arr)"/>
+	<text x="310" y="202" class="lbl" text-anchor="middle">ERASEALL through CTRL-AP</text>
+	<text x="310" y="216" class="lbl" text-anchor="middle">(erases flash, RAM, and UICR)</text>
+</svg>

--- a/doc/nrf/security/images/ap_protect_hwsw_flow.svg
+++ b/doc/nrf/security/images/ap_protect_hwsw_flow.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="900px" height="250px" viewBox="0 29 900 250" xml:space="preserve">
+	<style type="text/css">
+	<![CDATA[
+		.s-dark  { fill: #0033a0; }
+		.s-mid   { fill: #0077c8; }
+		.s-light { fill: #00a9ce; }
+		.t-head  { fill: #ffffff; font-family: Arial, sans-serif; font-size: 13px; font-weight: bold; }
+		.t-sub   { fill: #ffffff; font-family: Arial, sans-serif; font-size: 11px; }
+		.t-note  { fill: #ffffff; font-family: Arial, sans-serif; font-size: 10px; font-style: italic; }
+		.a-solid { stroke: #008bab; stroke-width: 1.5; fill: none; }
+		.a-dash  { stroke: #008bab; stroke-width: 1.5; fill: none; stroke-dasharray: 6,4; }
+		.a-head  { fill: #008bab; }
+		.lbl     { fill: #333f48; font-family: Arial, sans-serif; font-size: 11px; }
+		.title   { fill: #333f48; font-family: Arial, sans-serif; font-size: 14px; font-weight: bold; }
+	]]>
+	</style>
+	<defs>
+		<marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+			<polygon points="0 0, 8 3, 0 6" class="a-head"/>
+		</marker>
+		<marker id="arr-dash" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+			<polygon points="0 0, 8 3, 0 6" class="a-head"/>
+		</marker>
+	</defs>
+
+	<text x="450" y="53" class="title" text-anchor="middle">AP-Protect controlled by hardware and software</text>
+
+	<ellipse cx="130" cy="160" rx="110" ry="40" class="s-dark"/>
+	<text x="130" y="149" class="t-head" text-anchor="middle">Enabled</text>
+	<text x="130" y="163" class="t-sub"  text-anchor="middle">Debug blocked</text>
+	<text x="130" y="176" class="t-note" text-anchor="middle">(default)</text>
+
+	<ellipse cx="450" cy="160" rx="150" ry="40" class="s-mid"/>
+	<text x="450" y="151" class="t-head" text-anchor="middle">Temporarily disabled</text>
+	<text x="450" y="165" class="t-sub"  text-anchor="middle">Debug open</text>
+	<text x="450" y="178" class="t-note" text-anchor="middle">(re-enables on reset)</text>
+
+	<ellipse cx="770" cy="160" rx="110" ry="40" class="s-light"/>
+	<text x="770" y="153" class="t-head" text-anchor="middle">Permanently disabled</text>
+	<text x="770" y="168" class="t-sub"  text-anchor="middle">Debug open after reset</text>
+
+	<path d="M 234,147 Q 271,90 308,147" class="a-solid" marker-end="url(#arr)"/>
+	<text x="271" y="96" class="lbl" text-anchor="middle">ERASEALL through CTRL-AP</text>
+
+	<path d="M 308,173 Q 271,228 234,173" class="a-dash" marker-end="url(#arr-dash)"/>
+	<text x="271" y="179" class="lbl" text-anchor="middle">Any reset</text>
+
+	<path d="M 592,147 Q 629,90 666,147" class="a-solid" marker-end="url(#arr)"/>
+	<text x="629" y="90" class="lbl" text-anchor="middle">Configure UICR.APPROTECT</text>
+	<text x="629" y="103" class="lbl" text-anchor="middle">+ Configure Kconfig and flash firmware</text>
+
+	<path d="M 770,200 Q 450,258 130,200" class="a-solid" marker-end="url(#arr)"/>
+	<text x="450" y="258" class="lbl" text-anchor="middle">Write Enabled to UICR.APPROTECT + Any reset</text>
+</svg>

--- a/doc/nrf/security/images/ap_protect_secure_flow.svg
+++ b/doc/nrf/security/images/ap_protect_secure_flow.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="970px" height="289px" viewBox="10 15 970 289" xml:space="preserve">
+	<style type="text/css">
+	<![CDATA[
+		.pad    { fill: #b0bec5; }
+		.open   { fill: #0077c8; }
+		.open-light { fill: #00a9ce; }
+		.closed { fill: #0033a0; }
+		.divln  { stroke: #ffffff; stroke-width: 1.5; fill: none; }
+		.t-head { fill: #ffffff; font-family: Arial, sans-serif; font-size: 12px; font-weight: bold; }
+		.t-sub  { fill: #ffffff; font-family: Arial, sans-serif; font-size: 11px; }
+		.t-note { fill: #ffffff; font-family: Arial, sans-serif; font-size: 10px; font-style: italic; }
+		.s-lbl  { fill: #333f48; font-family: Arial, sans-serif; font-size: 13px; font-weight: bold; }
+		.a-solid{ stroke: #008bab; stroke-width: 1.5; fill: none; }
+		.a-dash { stroke: #008bab; stroke-width: 1.5; fill: none; stroke-dasharray: 6,4; }
+		.a-head { fill: #008bab; }
+		.lbl    { fill: #333f48; font-family: Arial, sans-serif; font-size: 11px; }
+		.lbl-i  { fill: #333f48; font-family: Arial, sans-serif; font-size: 10px; font-style: italic; }
+		.title  { fill: #333f48; font-family: Arial, sans-serif; font-size: 14px; font-weight: bold; }
+	]]>
+	</style>
+	<defs>
+		<clipPath id="lh1"><rect x="0"   y="104" width="155" height="120"/></clipPath>
+		<clipPath id="rh1"><rect x="155" y="104" width="200" height="120"/></clipPath>
+		<clipPath id="lh2"><rect x="0"   y="104" width="490" height="120"/></clipPath>
+		<clipPath id="rh2"><rect x="490" y="104" width="200" height="120"/></clipPath>
+		<clipPath id="lh3"><rect x="0"   y="104" width="835" height="120"/></clipPath>
+		<clipPath id="rh3"><rect x="835" y="104" width="200" height="120"/></clipPath>
+		<linearGradient id="spe-debug-gradient" gradientUnits="userSpaceOnUse"
+		                x1="490" y1="127" x2="578" y2="215">
+			<stop offset="0%" stop-color="#0077c8"/>
+			<stop offset="100%" stop-color="#00a9ce"/>
+		</linearGradient>
+		<marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+			<polygon points="0 0, 8 3, 0 6" class="a-head"/>
+		</marker>
+		<marker id="arr-dash" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+			<polygon points="0 0, 8 3, 0 6" class="a-head"/>
+		</marker>
+	</defs>
+
+	<text x="490" y="35" class="title" text-anchor="middle">Secure AP-Protect</text>
+	<text x="490" y="48" class="lbl-i" text-anchor="middle">Initial state depends on device UICR and Kconfig defaults (see configuration tables below)</text>
+
+	<!-- State 1: NSPE open (Debug open), SPE closed (Debug blocked) -->
+	<ellipse cx="155" cy="169" rx="130" ry="47" class="pad"/>
+	<ellipse cx="155" cy="169" rx="125" ry="42" class="open"   clip-path="url(#lh1)"/>
+	<ellipse cx="155" cy="169" rx="125" ry="42" class="closed" clip-path="url(#rh1)"/>
+	<line x1="155" y1="122" x2="155" y2="216" class="divln"/>
+	<text x="155" y="103" class="s-lbl"  text-anchor="middle">AP-Protect disabled</text>
+	<text x="155" y="117" class="s-lbl"  text-anchor="middle">Secure AP-Protect enabled</text>
+	<text x="93"  y="162" class="t-head" text-anchor="middle">NSPE</text>
+	<text x="93"  y="176" class="t-sub"  text-anchor="middle">Debug open</text>
+	<text x="217" y="162" class="t-head" text-anchor="middle">SPE</text>
+	<text x="217" y="176" class="t-sub"  text-anchor="middle">Debug blocked</text>
+
+	<!-- State 2: NSPE open (Debug open), SPE open (Debug open) -->
+	<ellipse cx="490" cy="169" rx="130" ry="47" class="pad"/>
+	<ellipse cx="490" cy="169" rx="125" ry="42" class="open" clip-path="url(#lh2)"/>
+	<ellipse cx="490" cy="169" rx="125" ry="42" fill="url(#spe-debug-gradient)" clip-path="url(#rh2)"/>
+	<line x1="490" y1="122" x2="490" y2="216" class="divln"/>
+	<text x="490" y="103" class="s-lbl"  text-anchor="middle">AP-Protect disabled</text>
+	<text x="490" y="117" class="s-lbl"  text-anchor="middle">Secure AP-Protect disabled</text>
+	<text x="420" y="162" class="t-head" text-anchor="middle">NSPE</text>
+	<text x="420" y="176" class="t-sub"  text-anchor="middle">Debug open</text>
+	<text x="545" y="155" class="t-head" text-anchor="middle">SPE</text>
+	<text x="545" y="169" class="t-sub"  text-anchor="middle">Debug open</text>
+	<text x="545" y="182" class="t-note" text-anchor="middle">(temporarily</text>
+	<text x="545" y="194" class="t-note" text-anchor="middle">or permanently)</text>
+
+	<!-- State 3: AP/Secure AP disabled, both debug blocked -->
+	<ellipse cx="835" cy="169" rx="130" ry="47" class="pad"/>
+	<ellipse cx="835" cy="169" rx="125" ry="42" class="closed" clip-path="url(#lh3)"/>
+	<ellipse cx="835" cy="169" rx="125" ry="42" class="closed" clip-path="url(#rh3)"/>
+	<line x1="835" y1="122" x2="835" y2="216" class="divln"/>
+	<text x="835" y="103" class="s-lbl"  text-anchor="middle">AP-Protect enabled</text>
+	<text x="835" y="117" class="s-lbl"  text-anchor="middle">Secure AP-Protect enabled</text>
+	<text x="770" y="162" class="t-head" text-anchor="middle">NSPE</text>
+	<text x="770" y="176" class="t-sub"  text-anchor="middle">Debug blocked</text>
+	<text x="900" y="162" class="t-head" text-anchor="middle">SPE</text>
+	<text x="900" y="176" class="t-sub"  text-anchor="middle">Debug blocked</text>
+
+	<!-- A1: State 1 to State 2 -->
+	<path d="M 280,156 Q 322,99 365,156" class="a-solid" marker-end="url(#arr)"/>
+	<text x="322" y="79" class="lbl" text-anchor="middle">ERASEALL through CTRL-AP</text>
+	<text x="322" y="92" class="lbl" text-anchor="middle">+ Configure UICR to allow debugging</text>
+	<text x="322" y="105" class="lbl" text-anchor="middle">(device specific)</text>
+
+	<!-- A2: State 2 to State 1 (dashed, any reset) -->
+	<path d="M 365,182 Q 322,236 280,182" class="a-dash" marker-end="url(#arr-dash)"/>
+	<text x="322" y="192" class="lbl" text-anchor="middle">Any reset</text>
+	<text x="322" y="225" class="lbl-i" text-anchor="middle">(When SPE open</text>
+	<text x="322" y="238" class="lbl-i" text-anchor="middle">temporarily)</text>
+
+	<!-- A3: State 2 to State 3 -->
+	<path d="M 615,156 Q 662,99 710,156" class="a-solid" marker-end="url(#arr)"/>
+	<text x="662" y="79" class="lbl" text-anchor="middle">Configure UICR to disallow debugging</text>
+	<text x="662" y="92" class="lbl" text-anchor="middle">(device specific)</text>
+	<text x="662" y="105" class="lbl" text-anchor="middle">+ Any reset</text>
+
+	<!-- A4: State 3 to State 1 (big arc below all states) -->
+	<path d="M 835,216 Q 495,303 155,216" class="a-solid" marker-end="url(#arr)"/>
+	<text x="495" y="278" class="lbl" text-anchor="middle">Configure UICR to allow NSPE and disallow SPE debugging (device specific)</text>
+	<text x="495" y="291" class="lbl" text-anchor="middle">+ Any reset</text>
+</svg>


### PR DESCRIPTION
Added figures that illustrate AP-Protect flows.
Clarified Kconfig description for USE_UICR.
NCSDK-38220.