### PR TITLE
bluetooth: rpc: disable GAP SVC on BT RPC client

### DIFF
--- a/subsys/bluetooth/rpc/Kconfig
+++ b/subsys/bluetooth/rpc/Kconfig
@@ -64,6 +64,10 @@ source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
 if BT_RPC_CLIENT
 
+# GAP service is present on HOST, forwarding it via RPC would create a duplicate service.
+configdefault BT_GAP_SVC
+	default n
+
 config HEAP_MEM_POOL_SIZE
 	default 4096
 


### PR DESCRIPTION
During `bt_enable()` the RPC client sends all its static GATT services to the HOST via `bt_rpc_gatt_init()`. The HOST then has two Generic Access services: its own static one and the copy forwarded from the APP core. The `gatt_gap_svc_validate()` checks if there is one GAP service. With two services present it returns `-EINVAL`, causing `bt_enable()` to fail with error -22.

Fix this by overriding `CONFIG_BT_GAP_SVC` to `n` for BT_RPC_CLIENT.