### PR TITLE
doc: nrf: releases: migration: 3.4: Add SRAM migration notes

### DIFF
--- a/doc/nrf/releases_and_maturity/migration/migration_guide_3.4.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_3.4.rst
@@ -62,6 +62,18 @@ The following changes are recommended for your application to work optimally aft
 Build and configuration system
 ==============================
 
+* The Kconfig options :kconfig:option:`CONFIG_SRAM_SIZE` and :kconfig:option:`CONFIG_SRAM_BASE_ADDRESS` have been deprecated.
+  Use the devicetree ``zephyr.sram`` chosen node to specify which RAM node is used.
+  If you adjust either option manually, :kconfig:option:`CONFIG_SRAM_DEPRECATED_KCONFIG_SET` is set to indicate the deprecation.
+  However, applications will continue to build and work with this notice.
+  For the majority of cases, you should not change these values as they default to the values of the ``zephyr,sram`` chosen node.
+  If the code references these Kconfig options, you should update them.
+  No deprecation warning will be emitted when these values are referenced due to the Kconfig define generation process.
+
+  .. note::
+     This is listed in the recommended changes for this |NCS| release.
+     In the next |NCS| release, this will be a required change.
+
 Nordic SoC platform symbols (Haltium / Lumos)
 ---------------------------------------------
 


### PR DESCRIPTION
Adds notes on the change to Kconfigs to use dts