### PR TITLE
smaples/nrf5340/extxip_smp_svr: fix TF-M partitioning

### DIFF
--- a/samples/nrf5340/extxip_smp_svr/pm_static_nrf5340dk_nrf5340_cpuapp_ns.yml
+++ b/samples/nrf5340/extxip_smp_svr/pm_static_nrf5340dk_nrf5340_cpuapp_ns.yml
@@ -150,6 +150,12 @@ settings_storage:
   end_address: 0x100000
   region: flash_primary
   size: 0x10000
+nonsecure_storage:
+  address: 0xf0000
+  end_address: 0x100000
+  region: flash_primary
+  size: 0x10000
+  span: [settings_storage]
 sram_primary:
   address: 0x20010000
   end_address: 0x20070000

--- a/samples/nrf5340/extxip_smp_svr/pm_static_nrf5340dk_nrf5340_cpuapp_ns_no_network_core.yml
+++ b/samples/nrf5340/extxip_smp_svr/pm_static_nrf5340dk_nrf5340_cpuapp_ns_no_network_core.yml
@@ -93,6 +93,12 @@ settings_storage:
   end_address: 0x100000
   region: flash_primary
   size: 0x10000
+nonsecure_storage:
+  address: 0xf0000
+  end_address: 0x100000
+  region: flash_primary
+  size: 0x10000
+  span: [settings_storage]
 sram_primary:
   address: 0x20000000
   end_address: 0x20070000


### PR DESCRIPTION
Added nonsecure_storage partition, which overlaps application storage - so TF-M configure access for nonsecure application properly.

ref.: NCSDK-1895, NCSIDB-1895, NCSDK-39208