### PR TITLE
samples: netboot: Fix for FW version handling

### DIFF
--- a/samples/nrf5340/netboot/src/main.c
+++ b/samples/nrf5340/netboot/src/main.c
@@ -89,7 +89,7 @@ int main(void)
 		err = pcd_find_fw_version();
 		if (err < 0) {
 			printk("Unable to find valid firmware version %d\n\r", err);
-			pcd_fw_copy_invalidate();
+			goto failure;
 		}
 		pcd_done();
 


### PR DESCRIPTION
Do not overwrite failure status with success status.

Ref: NCSDK-24216