### PR TITLE
manifest: update sdk-zephyr revision

### DIFF
--- a/subsys/bluetooth/rpc/client/bt_rpc_conn_client.c
+++ b/subsys/bluetooth/rpc/client/bt_rpc_conn_client.c
@@ -241,6 +241,28 @@ const bt_addr_le_t *bt_conn_get_dst(const struct bt_conn *conn)
 	}
 }
 
+/* Note: The Zephyr implementation of `bt_conn_dst_tmp_str()` supports multiple connection types
+ * (BR/EDR, SCO, LE, ISO). Currently, the RPC implementation is LE-only, so the function
+ * definition is simplified. The `bt_conn` struct as defined here and in `conn_internal.h` are not
+ * identical, so an identical definition of `bt_conn_dst_tmp_str()` cannot be used.
+ */
+struct bt_conn_tmp_str bt_conn_dst_tmp_str(const struct bt_conn *conn)
+{
+	struct bt_conn_tmp_str val = {0};
+	const bt_addr_le_t *dst;
+
+	if (conn == NULL) {
+		return val;
+	}
+
+	dst = bt_conn_get_dst(conn);
+	if (dst != NULL) {
+		(void)bt_addr_le_to_str(dst, val.str, sizeof(val.str));
+	}
+
+	return val;
+}
+
 uint8_t bt_conn_index(const struct bt_conn *conn)
 {
 	return get_conn_index(conn);

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0fdd247d86a2567be3cdda97a2bd39be221b3883
+      revision: aae7064db50007306a2f364e1b5f67165d5dd141
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
- Updates sdk-zephyr revision
- Adds a definition of `bt_conn_dst_tmp_str` to bt_rpc_conn_client.c to match newly added address logging utils in upstream conn.c/h