### PR TITLE
samples: cellular: modem_shell: Fix compilation with Memfault

### DIFF
--- a/samples/cellular/modem_shell/overlay-memfault.conf
+++ b/samples/cellular/modem_shell/overlay-memfault.conf
@@ -12,6 +12,10 @@ CONFIG_MEMFAULT_HTTP_PERIODIC_UPLOAD=y
 CONFIG_MEMFAULT_NCS_LTE_METRICS=y
 CONFIG_MEMFAULT_LOGGING_ENABLE=y
 CONFIG_MEMFAULT_LOG_LEVEL_DBG=y
+# Currently, it's not possible to disable Memfault FOTA support and the NCS FOTA backend
+# requires larger buffer sizes for the Downloader library. Enable the dummy FOTA backend to
+# avoid the need to increase the buffer sizes, because we don't need Memfault FOTA support.
+CONFIG_MEMFAULT_ZEPHYR_FOTA_BACKEND_DUMMY=y
 CONFIG_HW_ID_LIBRARY_SOURCE_IMEI=y
 
 # Add to pick up support for sending Memfault data over HTTP


### PR DESCRIPTION
Enabled `CONFIG_MEMFAULT_ZEPHYR_FOTA_BACKEND_DUMMY` as a workaround to avoid having to increase Downloader library buffer sizes for Memfault FOTA support.