### PR TITLE
Nrfx none remove memory regions on cpuppr

### DIFF
--- a/samples/zephyr/drivers/adc/adc_dt/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/samples/zephyr/drivers/adc/adc_dt/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -14,7 +14,6 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";
-	memory-regions = <&cpuapp_dma_region>;
 
 	channel@0 {
 		reg = <0>;

--- a/samples/zephyr/drivers/adc/adc_sequence/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/samples/zephyr/drivers/adc/adc_sequence/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -13,7 +13,6 @@
 &adc {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	memory-regions = <&cpuapp_dma_region>;
 	status = "okay";
 
 	channel@0 {

--- a/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/adc/adc_accuracy_test/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -19,7 +19,6 @@
 &adc {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	memory-regions = <&cpuapp_dma_region>;
 	status = "okay";
 
 	channel@0 {

--- a/tests/zephyr/drivers/adc/adc_api/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/adc/adc_api/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -13,7 +13,6 @@
 &adc {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	memory-regions = <&cpuapp_dma_region>;
 	status = "okay";
 
 	channel@0 {

--- a/tests/zephyr/drivers/adc/adc_error_cases/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/adc/adc_error_cases/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -11,6 +11,5 @@
 };
 
 &adc {
-	memory-regions = <&cpuapp_dma_region>;
 	status = "okay";
 };

--- a/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -71,6 +71,7 @@
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 	zephyr,pm-device-runtime-auto;
+	memory-regions = <&cpuapp_dma_region>;
 
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
@@ -89,12 +90,5 @@ dut_spis: &spi131 {
 	/delete-property/ rx-delay-supported;
 	/delete-property/ rx-delay;
 	zephyr,pm-device-runtime-auto;
-};
-
-&spi130 {
-	memory-regions = <&cpuapp_dma_region>;
-};
-
-&dut_spis {
 	memory-regions = <&cpuapp_dma_region>;
 };

--- a/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf9251dk_nrf9251_cpuppr.overlay
+++ b/tests/zephyr/drivers/spi/spi_controller_peripheral/boards/nrf9251dk_nrf9251_cpuppr.overlay
@@ -5,3 +5,11 @@
  */
 
 #include "nrf9251dk_nrf9251_cpuapp.overlay"
+
+&spi130 {
+	/delete-property/ memory-regions;
+};
+
+&dut_spis {
+	/delete-property/ memory-regions;
+};

--- a/tests/zephyr/drivers/spi/spi_error_cases/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_error_cases/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -71,6 +71,7 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+	memory-regions = <&cpuapp_dma_region>;
 
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
@@ -88,12 +89,5 @@ dut_spis: &spi131 {
 	pinctrl-names = "default", "sleep";
 	/delete-property/ rx-delay-supported;
 	/delete-property/ rx-delay;
-};
-
-&spi130 {
-	memory-regions = <&cpuapp_dma_region>;
-};
-
-dut_spis: &spi131 {
 	memory-regions = <&cpuapp_dma_region>;
 };

--- a/tests/zephyr/drivers/spi/spi_error_cases/boards/nrf9251dk_nrf9251_cpuppr.overlay
+++ b/tests/zephyr/drivers/spi/spi_error_cases/boards/nrf9251dk_nrf9251_cpuppr.overlay
@@ -5,3 +5,11 @@
  */
 
 #include "nrf9251dk_nrf9251_cpuapp.overlay"
+
+&spi130 {
+	/delete-property/ memory-regions;
+};
+
+&dut_spis {
+	/delete-property/ memory-regions;
+};

--- a/tests/zephyr/drivers/spi/spi_loopback/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/spi/spi_loopback/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -39,6 +39,7 @@
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
 	status = "okay";
+	memory-regions = <&cpuapp_dma_region>;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
@@ -65,8 +66,4 @@
 
 &gpiote130 {
 	status = "okay";
-};
-
-&spi130 {
-	memory-regions = <&cpuapp_dma_region>;
 };

--- a/tests/zephyr/drivers/spi/spi_loopback/boards/nrf9251dk_nrf9251_cpuppr_xip.overlay
+++ b/tests/zephyr/drivers/spi/spi_loopback/boards/nrf9251dk_nrf9251_cpuppr_xip.overlay
@@ -5,3 +5,7 @@
  */
 
 #include "nrf9251dk_nrf9251_cpuapp.overlay"
+
+&spi130 {
+	/delete-property/ memory-regions;
+};

--- a/tests/zephyr/drivers/uart/uart_async_api/boards/nrf9251dk_nrf9251_cpuppr.overlay
+++ b/tests/zephyr/drivers/uart/uart_async_api/boards/nrf9251dk_nrf9251_cpuppr.overlay
@@ -5,3 +5,11 @@
  */
 
 #include "nrf9251dk_nrf9251_cpuapp.overlay"
+
+&uart130 {
+	/delete-property/ memory-regions;
+};
+
+&uart120 {
+	/delete-property/ memory-regions;
+};

--- a/tests/zephyr/drivers/uart/uart_async_dual/boards/nrf9251dk_nrf9251_cpuppr.overlay
+++ b/tests/zephyr/drivers/uart/uart_async_dual/boards/nrf9251dk_nrf9251_cpuppr.overlay
@@ -9,3 +9,11 @@
 &timer133 {
 	interrupts = <435 (NRF_DEFAULT_IRQ_PRIORITY + 1)>;
 };
+
+&dut {
+	/delete-property/ memory-regions;
+};
+
+&dut_aux {
+	/delete-property/ memory-regions;
+};


### PR DESCRIPTION
Fix handling of memory-regions after nrf9251dk_nrf9251_common.dtsi was removed