### PR TITLE
config: bluetooth: fixed dependency issue for CS config

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -561,6 +561,7 @@ config BT_CTLR_FRAME_SPACE_UPDATE
 config BT_CTLR_CHANNEL_SOUNDING
 	bool "Channel Sounding support [EXPERIMENTAL for nRF54H20 radio core]"
 	select EXPERIMENTAL if SOC_NRF54H20_CPURAD
+	depends on BT_CTLR_CHANNEL_SOUNDING_SUPPORT
 	help
 	  Enable Channel Sounding support.
 


### PR DESCRIPTION
the way the current config was developed, it was possible to enable CS for platforms that did not support the feature in the controller. This logically does not make sense and would lead to a lot of build failures, so adding a dependency here to avoid user confusion