### PR TITLE
doc: security: Add note on countermeasures

### DIFF
--- a/doc/nrf/security/crypto/crypto_supported_features.rst
+++ b/doc/nrf/security/crypto/crypto_supported_features.rst
@@ -11688,6 +11688,8 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
          .. tab:: CRACEN
 
             .. note::
+               :kconfig:option:`CONFIG_CRACEN_LITE_ECC_COUNTERMEASURES_EXTENDED` does not support scalar blinding for Montgomery curve multiplication (X25519, X448).
+
                nRF54L15, nRF54L10, and nRF54L05 do not support countermeasures for Montgomery curve multiplication (X25519, X448), EdDSA base point multiplication, and Edwards point multiplication.
 
             .. list-table:: Side-channel countermeasures support (CRACEN driver) - nRF54L Series
@@ -11719,10 +11721,10 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                * - ECC extended (Montgomery/Edwards)
-                 - :kconfig:option:`CONFIG_CRACEN_LITE_ECC_COUNTERMEASURES_EXTENDED`
-                 - -- (see note above)
-                 - -- (see note above)
-                 - -- (see note above)
+                 - :kconfig:option:`CONFIG_CRACEN_LITE_ECC_COUNTERMEASURES_EXTENDED` (see note above)
+                 - --
+                 - --
+                 - --
                  - Supported
                  - Supported
                  - Supported

--- a/doc/nrf/security/crypto/crypto_supported_features.rst
+++ b/doc/nrf/security/crypto/crypto_supported_features.rst
@@ -11704,6 +11704,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
+                 - nRF54LS05
                * - ECC scalar randomization
                  - :kconfig:option:`CONFIG_CRACEN_ECC_COUNTERMEASURES`
                  - Supported
@@ -11712,6 +11713,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - Supported
+                 - --
                * - ECC projective coordinate randomization
                  - :kconfig:option:`CONFIG_CRACEN_ECC_COUNTERMEASURES`
                  - Supported
@@ -11720,6 +11722,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - Supported
+                 - --
                * - ECC extended (Montgomery/Edwards)
                  - :kconfig:option:`CONFIG_CRACEN_LITE_ECC_COUNTERMEASURES_EXTENDED` (see note above)
                  - --
@@ -11728,6 +11731,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - Supported
+                 - --
                * - RSA exponent randomization
                  - :kconfig:option:`CONFIG_CRACEN_RSA_COUNTERMEASURES`
                  - Supported
@@ -11736,6 +11740,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - Supported
+                 - --
                * - RSA modulus randomization
                  - :kconfig:option:`CONFIG_CRACEN_RSA_COUNTERMEASURES`
                  - Supported
@@ -11744,3 +11749,4 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - Supported
+                 - --

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/cmddefs_ecc.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/cmddefs_ecc.c
@@ -14,9 +14,9 @@ static const struct sx_pk_cmd_def CMD_MG_PTMUL = {PK_OP_MG_PTMUL, (1 << OP_SLOT_
 						  (1 << OP_SLOT_PTR_A) | (1 << OP_SLOT_PTR_B),
 						  OP_SLOT_PTR_A,
 #if defined(CONFIG_CRACEN_LITE_ECC_COUNTERMEASURES_EXTENDED)
-						/* Temporary workaround due to failures when
-						 * running twist curve operations
-						 * NCSDK-38476
+						/* Scalar blinding is not supported for
+						 * Montgomery curve multiplication
+						 * (X25519 and X448).
 						 */
 						  SX_PK_OP_FLAGS_RANDPROJ
 #endif


### PR DESCRIPTION
Montegomery, x25519 and x448 does not support Scalar blinding.