### PR TITLE
samples: fast_pair: locator_tag: Switch to NCS_MCUBOOT_DISABLE_SELF_RWX

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -357,8 +357,13 @@ Bluetooth Fast Pair samples
 
 * :ref:`fast_pair_locator_tag` sample:
 
-  * Updated the UI thread handling for reference board targets with a speaker by moving the speaker control into the common indication thread.
-    The signaling is now done using the :ref:`zephyr:events` API.
+  * Updated:
+
+    * UI thread handling for reference board targets with a speaker by moving the speaker control into the common indication thread.
+      The signaling is now done using the :ref:`zephyr:events` API.
+    * The configuration of the non-volatile memory self-protection mechanism in the MCUboot image on the nRF54L board targets.
+      The :kconfig:option:`CONFIG_NCS_MCUBOOT_DISABLE_SELF_RWX` Kconfig option now replaces the :kconfig:option:`CONFIG_FPROTECT`, which is associated with the :ref:`fprotect_readme` library.
+      The new mechanism uses a dedicated RRAMC region to disable read, write, and execute access to the MCUboot partition right before jumping to the application image.
 
   * Fixed the ringing status indications with the green LED flashes for reference board targets.
     A ringing status indication was often skipped during the motion detection event.

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf52833dk_nrf52833.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf52833dk_nrf52833.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Use FPROTECT region protection on nRF52 targets.
+CONFIG_FPROTECT=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf52840dk_nrf52840.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf52840dk_nrf52840.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Use FPROTECT region protection on nRF52 targets.
+CONFIG_FPROTECT=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf52dk_nrf52832.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf52dk_nrf52832.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Use FPROTECT region protection on nRF52 targets.
+CONFIG_FPROTECT=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor
+# Copyright (c) 2024-2026 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -19,3 +19,6 @@ CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE=16
 CONFIG_FLASH_SIMULATOR=y
 CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES=y
 CONFIG_FLASH_SIMULATOR_STATS=n
+
+# Use FPROTECT region protection on nRF53 targets.
+CONFIG_FPROTECT=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l05_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l05_cpuapp.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Nordic Semiconductor
+# Copyright (c) 2025-2026 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -10,3 +10,6 @@ CONFIG_SPI_NOR=n
 # Optimize memory usage (Locator tag disables system clock for MCUboot image).
 CONFIG_NRF_GRTC_TIMER=n
 CONFIG_NRF_GRTC_START_SYSCOUNTER=n
+
+# Use RRAMC region protection on nRF54L targets.
+CONFIG_NCS_MCUBOOT_DISABLE_SELF_RWX=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Nordic Semiconductor
+# Copyright (c) 2025-2026 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -10,3 +10,6 @@ CONFIG_SPI_NOR=n
 # Optimize memory usage (Locator tag disables system clock for MCUboot image).
 CONFIG_NRF_GRTC_TIMER=n
 CONFIG_NRF_GRTC_START_SYSCOUNTER=n
+
+# Use RRAMC region protection on nRF54L targets.
+CONFIG_NCS_MCUBOOT_DISABLE_SELF_RWX=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -10,3 +10,6 @@ CONFIG_SPI_NOR=n
 # Optimize memory usage (Locator tag disables system clock for MCUboot image).
 CONFIG_NRF_GRTC_TIMER=n
 CONFIG_NRF_GRTC_START_SYSCOUNTER=n
+
+# Use RRAMC region protection on nRF54L targets.
+CONFIG_NCS_MCUBOOT_DISABLE_SELF_RWX=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54l15tag_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54l15tag_nrf54l15_cpuapp.conf
@@ -7,3 +7,6 @@
 # Optimize memory usage (Locator tag disables system clock for MCUboot image).
 CONFIG_NRF_GRTC_TIMER=n
 CONFIG_NRF_GRTC_START_SYSCOUNTER=n
+
+# Use RRAMC region protection on nRF54L targets.
+CONFIG_NCS_MCUBOOT_DISABLE_SELF_RWX=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
@@ -7,3 +7,6 @@
 # Optimize memory usage (Locator tag disables system clock for MCUboot image).
 CONFIG_NRF_GRTC_TIMER=n
 CONFIG_NRF_GRTC_START_SYSCOUNTER=n
+
+# Use RRAMC region protection on nRF54L targets.
+CONFIG_NCS_MCUBOOT_DISABLE_SELF_RWX=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
@@ -7,3 +7,6 @@
 # Optimize memory usage (Locator tag disables system clock for MCUboot image).
 CONFIG_NRF_GRTC_TIMER=n
 CONFIG_NRF_GRTC_START_SYSCOUNTER=n
+
+# Use RRAMC region protection on nRF54L targets.
+CONFIG_NCS_MCUBOOT_DISABLE_SELF_RWX=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54ls05dk_nrf54ls05b_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/nrf54ls05dk_nrf54ls05b_cpuapp.conf
@@ -5,6 +5,8 @@
 #
 
 # Optimize memory usage (Locator tag disables system clock for MCUboot image).
-CONFIG_FPROTECT=n
 CONFIG_NRF_GRTC_TIMER=n
 CONFIG_NRF_GRTC_START_SYSCOUNTER=n
+
+# Use RRAMC region protection on nRF54L targets.
+CONFIG_NCS_MCUBOOT_DISABLE_SELF_RWX=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/thingy53_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/boards/thingy53_nrf5340_cpuapp.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor
+# Copyright (c) 2024-2026 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -22,3 +22,6 @@ CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE=16
 CONFIG_FLASH_SIMULATOR=y
 CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES=y
 CONFIG_FLASH_SIMULATOR_STATS=n
+
+# Use FPROTECT region protection on nRF53 targets.
+CONFIG_FPROTECT=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/prj.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/mcuboot/prj.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor
+# Copyright (c) 2024-2026 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -11,7 +11,6 @@ CONFIG_MAIN_STACK_SIZE=10240
 CONFIG_HW_STACK_PROTECTION=y
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
 CONFIG_ASSERT=n
 CONFIG_BOOT_BANNER=n
 CONFIG_NCS_BOOT_BANNER=n


### PR DESCRIPTION
Change mcuboot protection mechanism from fprotect
to NCS_MCUBOOT_DISABLE_SELF_RWX.

Jira: NCSDK-39106