### PR TITLE
tests: emds: fix flash_area_write alignment for rram

### DIFF
--- a/tests/subsys/emds/emds_flash/src/main.c
+++ b/tests/subsys/emds/emds_flash/src/main.c
@@ -154,7 +154,7 @@ snapshot_make(const struct emds_partition *partition,
 	zassert_ok(flash_area_write(partition->fa, metadata_off, &metadata, sizeof(metadata)),
 		   "Failed to write metadata to flash area");
 
-	data_len = ROUND_UP(data_len, sizeof(uint32_t));
+	data_len = ROUND_UP(data_len, partition->fp->write_block_size);
 	zassert_ok(flash_area_write(partition->fa, metadata.data_instance_off, data, data_len),
 		   "Failed to write data to flash area");
 
@@ -531,7 +531,7 @@ ZTEST(emds_flash, test_allocation_if_data_garbaged)
 	};
 	const struct flash_area *fa = partition[partition_index].fa;
 	const struct flash_parameters *fp = partition[partition_index].fp;
-	uint8_t garbage[sizeof(struct emds_data_entry)];
+	uint8_t garbage[EMDS_FLASH_BLOCK_SIZE];
 	int rc;
 
 	for (int i = 0; i < sizeof(garbage); i++) {
@@ -539,7 +539,7 @@ ZTEST(emds_flash, test_allocation_if_data_garbaged)
 	}
 
 	zassert_ok(flash_area_write(fa, 0, &garbage, sizeof(garbage)),
-		   "Failed to write garbage into metadata flash area");
+		   "Failed to write garbage into data flash area");
 
 	rc = emds_flash_allocate_snapshot(&partition[partition_index], NULL, &allocated_snapshot,
 					  100);


### PR DESCRIPTION
Zephyr commit c7616308e69 added alignment validation to nrf_rram_write() and nrf_rram_erase(). Write address and length must be multiples of WRITE_LINE_SIZE (16 bytes).

In snapshot_make(), data length was rounded up to 4 bytes (sizeof(uint32_t)) before flash_area_write(). This causes -EINVAL on rram targets where write_block_size is 16 bytes. Round up to write_block_size instead.

In test_allocation_if_data_garbaged(), garbage buffer was sizeof(struct emds_data_entry) (4 bytes). Increase to EMDS_FLASH_BLOCK_SIZE to satisfy write alignment.
Also fix misleading error string ("metadata" -> "data").