### PR TITLE
lib: nrf_modem_lib: SO_POLLCB support

### DIFF
--- a/lib/nrf_modem_lib/nrf9x_sockets.c
+++ b/lib/nrf_modem_lib/nrf9x_sockets.c
@@ -52,6 +52,7 @@ static struct nrf_sock_ctx {
 	int zvfs_fd; /* ZVFS socket descriptor. */
 	struct k_mutex *lock; /* Mutex associated with the socket. */
 	struct k_poll_signal poll; /* poll() signal. */
+	struct socket_ncs_pollcb pollcb; /* Poll callback (owned by the app). */
 	struct socket_ncs_sendcb sendcb; /* Send callback. */
 } offload_ctx[NRF_MODEM_MAX_SOCKET_COUNT];
 
@@ -91,6 +92,7 @@ static void release_ctx(struct nrf_sock_ctx *ctx)
 	ctx->nrf_fd = -1;
 	ctx->lock = NULL;
 	ctx->zvfs_fd = -1;
+	memset(&ctx->pollcb, 0, sizeof(ctx->pollcb));
 	memset(&ctx->sendcb, 0, sizeof(ctx->sendcb));
 
 	k_mutex_unlock(&ctx_lock);
@@ -520,6 +522,27 @@ static void sendcb(const struct nrf_modem_sendcb_params *nrf_params)
 	ctx->sendcb.callback(&params);
 }
 
+static void pollcb(struct nrf_pollfd *pollfd)
+{
+	struct nrf_sock_ctx *ctx;
+	struct socket_ncs_pollcb_params params;
+
+	ctx = find_ctx(pollfd->fd);
+	if (!ctx || !ctx->pollcb.callback) {
+		return;
+	}
+
+	params.fd = ctx->zvfs_fd;
+	params.events = ctx->pollcb.events;
+	params.revents = pollfd->revents;
+
+	ctx->pollcb.callback(&params);
+
+	if (ctx->pollcb.oneshot) {
+		memset(&ctx->pollcb, 0, sizeof(ctx->pollcb));
+	}
+}
+
 static int nrf9x_socket_offload_setsockopt(void *obj, int level, int optname,
 					   const void *optval, net_socklen_t optlen)
 {
@@ -546,6 +569,41 @@ static int nrf9x_socket_offload_setsockopt(void *obj, int level, int optname,
 
 		errno = EOPNOTSUPP;
 		return -1;
+	}
+
+	if ((level == ZSOCK_SOL_SOCKET) && (optname == SO_POLLCB)) {
+		if ((optval && optlen != sizeof(struct socket_ncs_pollcb)) ||
+		    (!optval && optlen != 0)) {
+			errno = EINVAL;
+			return -1;
+		}
+
+		if (!optval) {
+			/* Remove from the modem and clear local state. */
+			(void)nrf_setsockopt(sd, NRF_SOL_SOCKET, NRF_SO_POLLCB, NULL, 0);
+			memset(&ctx->pollcb, 0, sizeof(ctx->pollcb));
+			return 0;
+		}
+
+		const struct socket_ncs_pollcb *pollcb_opt = optval;
+
+		if (!pollcb_opt->callback) {
+			errno = EINVAL;
+			return -1;
+		}
+
+		/* Store before registering with the modem so pollcb() finds valid state
+		 * if the modem evaluates readiness immediately upon set.
+		 */
+		ctx->pollcb = *pollcb_opt;
+
+		struct nrf_modem_pollcb pcb = {
+			.callback = pollcb,
+			.events = pollcb_opt->events,
+			.oneshot = pollcb_opt->oneshot,
+		};
+
+		return nrf_setsockopt(sd, NRF_SOL_SOCKET, NRF_SO_POLLCB, &pcb, sizeof(pcb));
 	}
 
 	if (z_to_nrf_optname(level, optname, &nrf_optname) < 0) {
@@ -916,7 +974,7 @@ static int nrf9x_socket_offload_fcntl(int fd, int cmd, va_list args)
 	return retval;
 }
 
-static void pollcb(struct nrf_pollfd *pollfd)
+static void pollcb_internal(struct nrf_pollfd *pollfd)
 {
 	struct nrf_sock_ctx *ctx;
 
@@ -936,7 +994,7 @@ static int nrf9x_poll_prepare(struct nrf_sock_ctx *ctx, struct zsock_pollfd *pfd
 	unsigned int signaled;
 	int fd = OBJ_TO_SD(ctx);
 	struct nrf_modem_pollcb pcb = {
-		.callback = pollcb,
+		.callback = pollcb_internal,
 		.events = pfd->events,
 		.oneshot = true, /* callback invoked only once */
 	};
@@ -948,6 +1006,9 @@ static int nrf9x_poll_prepare(struct nrf_sock_ctx *ctx, struct zsock_pollfd *pfd
 
 	k_poll_signal_init(&ctx->poll);
 	k_poll_event_init(*pev, K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &ctx->poll);
+
+	/* Remove any application-defined poll callbacks, as it will be overwritten in the modem. */
+	memset(&ctx->pollcb, 0, sizeof(ctx->pollcb));
 
 	err = nrf_setsockopt(fd, NRF_SOL_SOCKET, NRF_SO_POLLCB, &pcb, sizeof(pcb));
 	if (err) {

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 4fc5fb33e45fb30cc08eb5adab7844b951ce3cbf
+      revision: pull/4075/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Implement SO_POLLCB in the offloading layer. Only one callback may be
set per socket. If poll() is called on a socket with SO_POLLCB, the
poll callback gets overwritten.
