### PR TITLE
tests: drivers: gpio: gpio_nfct: Fix nrf7120dk overlay

### DIFF
--- a/tests/drivers/gpio/gpio_nfct/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_nfct/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -23,7 +23,8 @@
 	};
 };
 
-&uicr {
+&nfct {
+	status = "disabled";
 	nfct-pins-as-gpios;
 };
 


### PR DESCRIPTION
The nRF7120 uses a new dedicated UICR binding (nordic,nrf71-uicr) which does not declare the legacy nfct-pins-as-gpios property. On v2 NFCT SoCs (nRF54H, nRF54L, nRF7120), the property has been moved to the NFCT node itself via the nordic,nrf-nfct-v2 binding.

Move nfct-pins-as-gpios from the &uicr node to the &nfct node and disable NFCT, matching the form already used by the nRF54H20 overlay in this test.