### PR TITLE
samples: zephyr: subsys: settings: Remove invalid filter

### DIFF
--- a/samples/zephyr/subsys/settings/testcase.yaml
+++ b/samples/zephyr/subsys/settings/testcase.yaml
@@ -39,6 +39,7 @@ common:
 tests:
   nrf.extended.sample.subsys.settings.zms:
     platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -47,13 +48,13 @@ tests:
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
     integration_platforms:
       - nrf54ls05dk/nrf54ls05b/cpuapp
     extra_args:
       - CONFIG_SETTINGS_ZMS=y
       - CONFIG_ZMS=y
   nrf.extended.sample.subsys.settings.nvs:
-    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     platform_allow:
       - nrf9251dk/nrf9251/cpuapp
     integration_platforms:

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -192,6 +192,7 @@
     - subsys.west_debug.normal
     - subsys.west_debug.thread_info
     - subsys.west_flash
+    - nrf.extended.sample.subsys.settings.nvs
   platforms:
     - nrf9251dk@0.1.0/nrf9251/cpuapp
   comment: "Missing modem support"


### PR DESCRIPTION
After mram partitions were moved from `fixed-partitions` to `zephyr,mapped-partitions` this filter is no longer meet.