### PR TITLE
modules: mcuboot: flash_sim: Increase size to 256KiB

### DIFF
--- a/modules/mcuboot/flash_sim.overlay
+++ b/modules/mcuboot/flash_sim.overlay
@@ -38,7 +38,7 @@
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
-				reg = <0x00000000 DT_SIZE_K(224)>;
+				reg = <0x00000000 DT_SIZE_K(256)>;
 
 				partitions {
 					compatible = "fixed-partitions";
@@ -52,7 +52,7 @@
 					 */
 					slot2_partition: partition@0 {
 						label = "image-2";
-						reg = <0x00000000 DT_SIZE_K(224)>;
+						reg = <0x00000000 DT_SIZE_K(256)>;
 					};
 				};
 			};


### PR DESCRIPTION
    Increases size to allow for smaller b0 images. This was originally
    reduced in size for non-PM usage because images for the network
    core cannot be 256KiB and having a slot that size wastes flash
    and RAM on the application core and allows pointlessly uploading
    images that cannot fit, but existing applications have been built
    around this invalid assumption, so the is being changed back to
    align with what PM did, which is not optimal