### PR TITLE
bluetooth: controller: Mark Flushable ACL Data commands as supported

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -667,6 +667,11 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 #endif /* CONFIG_BT_CENTRAL */
 	cmds->hci_le_read_minimum_supported_connection_interval = 1;
 #endif /* CONFIG_BT_CTLR_SHORTER_CONNECTION_INTERVALS */
+
+#if defined(CONFIG_BT_CTLR_LE_FLUSHABLE_ACL_DATA)
+	cmds->hci_read_automatic_flush_timeout = 1;
+	cmds->hci_write_automatic_flush_timeout = 1;
+#endif /* CONFIG_BT_CTLR_LE_FLUSHABLE_ACL_DATA */
 }
 
 #if defined(CONFIG_BT_HCI_VS)


### PR DESCRIPTION
Mark Flushable ACL Data HCI commands as supported by the controller when the CONFIG_BT_CTLR_LE_FLUSHABLE_ACL_DATA Kconfig is enabled.


(cherry picked from commit 6d2456ea0608683dae86e0470654c3803f378005)