### PR TITLE
samples: bluetooth: remove nrf54ls05a from certain samples

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -309,9 +309,7 @@ Bluetooth samples
     * :ref:`direct_test_mode`
     * :ref:`ble_event_trigger`
     * :ref:`bluetooth_iso_combined_bis_cis`
-    * :ref:`bluetooth_isochronous_time_synchronization`
     * :ref:`ble_llpm`
-    * :ref:`bt_peripheral_with_multiple_identities`
     * :ref:`bluetooth_radio_coex_1wire_sample`
     * :ref:`ble_radio_notification_conn_cb`
     * :ref:`bt_scanning_while_connecting`

--- a/samples/bluetooth/iso_time_sync/sample.yaml
+++ b/samples/bluetooth/iso_time_sync/sample.yaml
@@ -22,7 +22,6 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54ls05dk/nrf54ls05b/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
     tags:
       - bluetooth
       - ci_build

--- a/samples/bluetooth/peripheral_with_multiple_identities/sample.yaml
+++ b/samples/bluetooth/peripheral_with_multiple_identities/sample.yaml
@@ -21,7 +21,6 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54ls05dk/nrf54ls05b/cpuapp
-      - nrf54ls05dk/nrf54ls05a/cpuapp
     tags:
       - bluetooth
       - ci_build


### PR DESCRIPTION
Due to RAM overflow that was caught in the CI, two samples have nrf54ls05a build removed.