### PR TITLE
doc: zephyr: Limit twister execution to Nordic boards

### DIFF
--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -100,6 +100,9 @@ warnings_filter_silent = True
 
 kconfig_generate_db = False
 
+# -- Options for zephyr.domain -------------------------------------------------
+zephyr_hw_features_vendor_filter = ["nordic"]
+
 # -- Options for zephyr.gh_utils -----------------------------------------------
 
 gh_link_version = "main" if version.endswith("99") else f"v{version}"


### PR DESCRIPTION
Upstream introduced twister board catalog execution with a vendor filter here: https://github.com/zephyrproject-rtos/zephyr/pull/89344

Use the vendor filter in our conf.py so that only Nordic boards are processed.