### PR TITLE
subsys: mpsl: Make init SoC config extensible and feature-based

### DIFF
--- a/drivers/mpsl/flash_sync/flash_sync_mpsl.c
+++ b/drivers/mpsl/flash_sync/flash_sync_mpsl.c
@@ -57,6 +57,10 @@ struct mpsl_context {
 
 static struct mpsl_context _context;
 
+/* The get_timeslot_time_us() is supported only for nRF52 and nRF53 series. Check for existence
+ * of timer0 node in the device tree is enough to figure out whether the function is supported.
+ */
+#if DT_NODE_EXISTS(DT_NODELABEL(timer0))
 /**
  * Get time in microseconds since the beginning of the timeslot.
  *
@@ -64,17 +68,10 @@ static struct mpsl_context _context;
  */
 static uint32_t get_timeslot_time_us(void)
 {
-#ifdef CONFIG_SOC_COMPATIBLE_NRF54LX
-	nrf_timer_task_trigger(NRF_TIMER10, NRF_TIMER_TASK_CAPTURE0);
-	return nrf_timer_cc_get(NRF_TIMER10, NRF_TIMER_CC_CHANNEL0);
-#elif CONFIG_SOC_NRF54H20
-	/* Unused */
-	return 0;
-#else
-	nrf_timer_task_trigger(NRF_TIMER0, NRF_TIMER_TASK_CAPTURE0);
-	return nrf_timer_cc_get(NRF_TIMER0, NRF_TIMER_CC_CHANNEL0);
-#endif /* CONFIG_SOC_COMPATIBLE_NRF54LX */
+	nrf_timer_task_trigger(MPSL_TIMER0, NRF_TIMER_TASK_CAPTURE0);
+	return nrf_timer_cc_get(MPSL_TIMER0, NRF_TIMER_CC_CHANNEL0);
 }
+#endif /* DT_NODE_EXISTS(DT_NODELABEL(timer0)) */
 
 static void reschedule_next_timeslot(void)
 {
@@ -246,19 +243,22 @@ void nrf_flash_sync_get_timestamp_begin(void)
 
 bool nrf_flash_sync_check_time_limit(uint32_t iteration)
 {
-#if defined(CONFIG_SOC_COMPATIBLE_NRF54LX) || defined(CONFIG_SOC_NRF54H20)
+#if DT_NODE_EXISTS(DT_NODELABEL(timer0))
+	/* The get_timeslot_time_us() is supported only for nRF52 and nRF53 series. Check for
+	 * existence of timer0 node in the device tree is enough to figure out whether the function
+	 * is supported.
+	 */
+	uint32_t now_us = get_timeslot_time_us();
+	uint32_t time_per_iteration_us = now_us / iteration;
+
+	return now_us + time_per_iteration_us >= _context.request_length_us;
+#else
 	/* The time taken in a previous write is not a predictor of the time taken
 	 * for the next write. Writing the same value as is already stored is much
 	 * faster than writing a different value. If the first few writes are fast
 	 * and the later ones are slow we may get an overstay assert. The configured
 	 * event length is only guaranteed to fit one write block.
 	 */
-
-	(void)get_timeslot_time_us; /* Needed to avoid build time warning: unused static function*/
 	return true;
-#else
-	uint32_t now_us = get_timeslot_time_us();
-	uint32_t time_per_iteration_us = now_us / iteration;
-	return now_us + time_per_iteration_us >= _context.request_length_us;
-#endif /* CONFIG_SOC_COMPATIBLE_NRF54LX || CONFIG_SOC_NRF54H20 */
+#endif /* DT_NODE_EXISTS(DT_NODELABEL(timer0)) */
 }

--- a/subsys/mpsl/init/CMakeLists.txt
+++ b/subsys/mpsl/init/CMakeLists.txt
@@ -4,6 +4,18 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-zephyr_library()
+# Create the library name based on the $ZEPHYR_NRF_MODULE_DIR path.
+# This removes the `nrf` part from the library name. It allows to amend library with
+# zephyr_library_amend() from out-of-tree modules.
+zephyr_library_get_current_dir_lib_name(${ZEPHYR_NRF_MODULE_DIR} lib_name)
+zephyr_library_named(${lib_name})
 
 zephyr_library_sources(mpsl_init.c)
+
+if(CONFIG_SOC_COMPATIBLE_NRF52X OR
+    CONFIG_SOC_COMPATIBLE_NRF53X OR
+    CONFIG_SOC_COMPATIBLE_NRF54LX OR
+    CONFIG_SOC_SERIES_NRF54H OR
+    CONFIG_SOC_SERIES_NRF71)
+  zephyr_library_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+endif()

--- a/subsys/mpsl/init/Kconfig
+++ b/subsys/mpsl/init/Kconfig
@@ -128,6 +128,14 @@ config MPSL_FORCE_RRAM_ON_ALL_THE_TIME
 	  This is not needed when only basic bluetooth features are used.
 	  Only needed when for example LLPM, Frame space update, ISO or Channel Sounding is used.
 
+config MPSL_LOW_LATENCY_CALLBACKS
+	bool
+	default y if SOC_COMPATIBLE_NRF54LX
+	help
+	  This option enables the use of low latency callbacks implemented in the MPSL subsystem.
+	  These callbacks are used to acquire and release low latency settings to the system when
+	  time-critical code is executed (for example around radio activity).
+
 module=MPSL
 module-str=MPSL
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"

--- a/subsys/mpsl/init/include/mpsl_init_soc.h
+++ b/subsys/mpsl/init/include/mpsl_init_soc.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file mpsl_init_soc.h
+ *
+ * @brief SoC-specific parameters for MPSL init.
+ *
+ */
+
+#ifndef MPSL_INIT_SOC_H__
+#define MPSL_INIT_SOC_H__
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF52X) || defined(CONFIG_SOC_COMPATIBLE_NRF53X)
+#define MPSL_INIT_SOC_COUNTER_RESERVED_NODES rtc0, timer0
+#define MPSL_TIMER_IRQn                      TIMER0_IRQn
+#define MPSL_RTC_IRQn                        RTC0_IRQn
+#define MPSL_RADIO_IRQn                      RADIO_IRQn
+
+#elif defined(CONFIG_SOC_COMPATIBLE_NRF54LX) || defined(CONFIG_SOC_SERIES_NRF71)
+#define MPSL_INIT_SOC_COUNTER_RESERVED_NODES timer10
+#define MPSL_TIMER_IRQn                      TIMER10_IRQn
+#define MPSL_RTC_IRQn                        GRTC_3_IRQn
+#define MPSL_RADIO_IRQn                      RADIO_0_IRQn
+
+#define MPSL_RESERVED_GRTC_CHANNELS ((1U << 7) | (1U << 8) | (1U << 9) | (1U << 10) | (1U << 11))
+
+#elif defined(CONFIG_SOC_SERIES_NRF54H)
+#define MPSL_INIT_SOC_COUNTER_RESERVED_NODES timer020
+#define MPSL_TIMER_IRQn                      TIMER020_IRQn
+#define MPSL_RTC_IRQn                        GRTC_2_IRQn
+#define MPSL_RADIO_IRQn                      RADIO_0_IRQn
+#define MPSL_RESERVED_IPCT_SOURCE_CHANNELS   (1U << 0)
+#define MPSL_RESERVED_DPPI_SOURCE_CHANNELS   (1U << 0)
+#define MPSL_RESERVED_DPPI_SINK_CHANNELS     (1U << 0)
+
+#define MPSL_RESERVED_GRTC_CHANNELS ((1U << 8) | (1U << 9) | (1U << 10) | (1U << 11) | (1U << 12))
+#endif /* CONFIG_SOC_COMPATIBLE_NRF52X || CONFIG_SOC_NRF5340_CPUNET */
+
+#if defined(CONFIG_SOC_SERIES_NRF54L)
+#define MPSL_INIT_SOC_CPU_FREQ_MHZ 128
+#endif
+
+#endif /* MPSL_INIT_SOC_H__ */

--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -20,12 +20,23 @@
 #include "tfm_platform_api.h"
 #include "tfm_ioctl_core_api.h"
 #endif
-#if IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF54LX)
+
+#if IS_ENABLED(CONFIG_MPSL_LOW_LATENCY_CALLBACKS)
+#if IS_ENABLED(CONFIG_NRFX_POWER)
 #include <nrfx_power.h>
-#endif
-#if IS_ENABLED(CONFIG_SOC_SERIES_NRF54L)
+#else
+#include <hal/nrf_power.h>
+#endif /* CONFIG_NRFX_POWER */
+
+#if IS_ENABLED(CONFIG_NRF_SYS_EVENT)
 #include <nrf_sys_event.h>
-#endif
+#endif /* CONFIG_NRF_SYS_EVENT */
+#endif /* IS_ENABLED(CONFIG_MPSL_LOW_LATENCY_CALLBACKS) */
+
+/* Include SoC-specific parameters for MPSL init.
+ * Keep this include as is to do not break the overload functionality.
+ */
+#include <mpsl_init_soc.h>
 
 #if defined(CONFIG_SOC_SERIES_NRF54H)
 #include <hal/nrf_dppi.h>
@@ -59,47 +70,20 @@ extern void rtc_pretick_rtc0_isr_hook(void);
 #endif
 
 #if IS_ENABLED(CONFIG_COUNTER)
-#if IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF52X) || IS_ENABLED(CONFIG_SOC_NRF5340_CPUNET)
-BUILD_ASSERT(!DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(rtc0)),
-	     "MPSL reserves RTC0 on this SoC.");
-BUILD_ASSERT(!DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(timer0)),
-	     "MPSL reserves TIMER0 on this SoC.");
-#elif IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF54LX) || IS_ENABLED(CONFIG_SOC_SERIES_NRF71)
-BUILD_ASSERT(!DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(timer10)),
-	     "MPSL reserves TIMER10 on this SoC.");
-#elif IS_ENABLED(CONFIG_SOC_SERIES_NRF54H)
-BUILD_ASSERT(!DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(timer020)),
-	     "MPSL reserves TIMER020 on this SoC.");
+/* Macros used below are declared in mpsl_init_soc.h */
+#if defined(MPSL_INIT_SOC_COUNTER_RESERVED_NODES)
+#define MPSL_BUILD_ASSERT_COUNTER_NODE_NOT_OKAY(node)                                              \
+	BUILD_ASSERT(!DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(node)),                                 \
+		     "MPSL reserves " #node " on this SoC. Please disable this node in device tree")
+FOR_EACH(MPSL_BUILD_ASSERT_COUNTER_NODE_NOT_OKAY, (;),
+	 MPSL_INIT_SOC_COUNTER_RESERVED_NODES)
+#undef MPSL_BUILD_ASSERT_COUNTER_NODE_NOT_OKAY
 #else
-#error
+#error "Counter DTS nodes reserved for MPSL are missing"
 #endif
 #endif /* IS_ENABLED(CONFIG_COUNTER) */
 
-#if defined(CONFIG_SOC_COMPATIBLE_NRF52X) || defined(CONFIG_SOC_COMPATIBLE_NRF53X)
-#define MPSL_TIMER_IRQn TIMER0_IRQn
-#define MPSL_RTC_IRQn RTC0_IRQn
-#define MPSL_RADIO_IRQn RADIO_IRQn
-#elif defined(CONFIG_SOC_COMPATIBLE_NRF54LX) || defined(CONFIG_SOC_SERIES_NRF71)
-#define MPSL_TIMER_IRQn TIMER10_IRQn
-#define MPSL_RTC_IRQn GRTC_3_IRQn
-#define MPSL_RADIO_IRQn RADIO_0_IRQn
-#elif defined(CONFIG_SOC_SERIES_NRF54H)
-#define MPSL_TIMER_IRQn TIMER020_IRQn
-#define MPSL_RTC_IRQn GRTC_2_IRQn
-#define MPSL_RADIO_IRQn RADIO_0_IRQn
-#endif
-
-#if defined(CONFIG_SOC_SERIES_NRF54H)
-/* Basic build time sanity checking */
-#define MPSL_RESERVED_GRTC_CHANNELS ((1U << 8) | (1U << 9) | (1U << 10) | (1U << 11) | (1U << 12))
-#elif defined(CONFIG_SOC_COMPATIBLE_NRF54LX) || defined(CONFIG_SOC_SERIES_NRF71)
-#define MPSL_RESERVED_GRTC_CHANNELS ((1U << 7) | (1U << 8) | (1U << 9) | (1U << 10) | (1U << 11))
-#endif
-
-#if defined(CONFIG_SOC_SERIES_NRF54H) || \
-	defined(CONFIG_SOC_COMPATIBLE_NRF54LX) || \
-	defined(CONFIG_SOC_SERIES_NRF71)
-
+#if IS_ENABLED(CONFIG_NRFX_GRTC)
 BUILD_ASSERT(MPSL_RTC_IRQn != DT_IRQN(DT_NODELABEL(grtc)), "MPSL requires a dedicated GRTC IRQ");
 
 #define CHECK_IRQ(val, _) (DT_IRQ_BY_IDX(DT_NODELABEL(grtc), val, irq) == MPSL_RTC_IRQn)
@@ -114,12 +98,9 @@ BUILD_ASSERT(MPSL_IRQ_IN_DT, "The MPSL GRTC IRQ is not in the device tree");
 BUILD_ASSERT((NRFX_CONFIG_MASK_DT(DT_NODELABEL(grtc), child_owned_channels) &
 	      MPSL_RESERVED_GRTC_CHANNELS) == MPSL_RESERVED_GRTC_CHANNELS,
 	     "The GRTC channels used by MPSL must not be used by zephyr");
-#endif
+#endif /* IS_ENABLED(CONFIG_NRFX_GRTC) */
 
-#if defined(CONFIG_SOC_SERIES_NRF54H)
-#define MPSL_RESERVED_IPCT_SOURCE_CHANNELS (1U << 0)
-#define MPSL_RESERVED_DPPI_SOURCE_CHANNELS (1U << 0)
-#define MPSL_RESERVED_DPPI_SINK_CHANNELS (1U << 0)
+#if IS_ENABLED(CONFIG_SOC_SERIES_NRF54H) /* IPCT is relevant for nRF54H only */
 /* check the GRTC source channels.
  * i.e. ensure something similar to this is present in the DT
  * &dppic132 {
@@ -171,11 +152,11 @@ BUILD_ASSERT((IPCT_SOURCE_CHANNELS & MPSL_RESERVED_IPCT_SOURCE_CHANNELS) ==
 		     MPSL_RESERVED_IPCT_SOURCE_CHANNELS,
 	     "The required IPCT source channels are not reserved");
 
-#endif
+#endif /* CONFIG_SOC_SERIES_NRF54H */
 
-#if defined(CONFIG_SOC_SERIES_NRF54L)
-BUILD_ASSERT(NRF_CONFIG_CPU_FREQ_MHZ == 128, "Currently mpsl only works when frequency is 128MHz");
-#endif
+#ifdef MPSL_INIT_SOC_CPU_FREQ_MHZ
+BUILD_ASSERT(NRF_CONFIG_CPU_FREQ_MHZ == MPSL_INIT_SOC_CPU_FREQ_MHZ, "Unsupported CPU frequency");
+#endif /* MPSL_INIT_SOC_CPU_FREQ_MHZ */
 
 #if IS_ENABLED(CONFIG_NRF_GRTC_TIMER) && !defined(CONFIG_SOC_SERIES_NRF54H)
 BUILD_ASSERT(IS_ENABLED(CONFIG_NRF_GRTC_TIMER_AUTO_KEEP_ALIVE),
@@ -194,13 +175,26 @@ static struct k_work mpsl_low_prio_work;
 struct k_work_q mpsl_work_q;
 static K_THREAD_STACK_DEFINE(mpsl_work_stack, CONFIG_MPSL_WORK_STACK_SIZE);
 
-#if IS_ENABLED(CONFIG_SOC_SERIES_NRF54L) && !IS_ENABLED(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+#if IS_ENABLED(CONFIG_MPSL_LOW_LATENCY_CALLBACKS) && !IS_ENABLED(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+/* Check existence of rram_controller node in the device tree to figure out whether RRAMC is
+ * supported.
+ *
+ * Note: The standard CONFIG_HAS_HW_NRF_RRAMC expects the DTS node to be set (okay).
+ *       The CONFIG_NRFX_RRAMC informs if the node is in DTS but it is not selected by default
+ *       so it is not defined for preprocessor.
+ */
+#if DT_NODE_EXISTS(DT_NODELABEL(rram_controller))
+#define MPSL_HW_HAS_RRAMC 1
+#endif /* DT_NODE_EXISTS(DT_NODELABEL(rram_controller)) */
+
 #if IS_ENABLED(CONFIG_NRF_SYS_EVENT_IRQ_LATENCY)
 static int m_nvm_low_latency_event_handle = -1;
 #else
 static uint32_t m_rram_lowpower_config;
 #endif /* IS_ENABLED(CONFIG_NRF_SYS_EVENT_IRQ_LATENCY) */
-#endif /* IS_ENABLED(CONFIG_SOC_SERIES_NRF54L) && !IS_ENABLED(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
+#endif /* IS_ENABLED(CONFIG_MPSL_LOW_LATENCY_CALLBACKS) &&
+	* !IS_ENABLED(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	*/
 
 #define MPSL_TIMESLOT_SESSION_COUNT (\
 	CONFIG_MPSL_TIMESLOT_SESSION_COUNT + \
@@ -597,10 +591,13 @@ int32_t mpsl_lib_uninit(void)
 #endif /* IS_ENABLED(CONFIG_MPSL_DYNAMIC_INTERRUPTS) */
 }
 
-#if defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
+#if defined(CONFIG_MPSL_LOW_LATENCY_CALLBACKS)
 void mpsl_low_latency_acquire_callback(void)
 {
-#if IS_ENABLED(CONFIG_SOC_SERIES_NRF54L)
+/* We need to know whether RRAMC is supported on the platform. The IS_ENABLED() returns true if the
+ * KConfig is set. In this case it is enough to check whether there is
+ */
+#if defined(MPSL_HW_HAS_RRAMC)
 #if IS_ENABLED(CONFIG_NRF_SYS_EVENT)
 	int err;
 
@@ -609,10 +606,10 @@ void mpsl_low_latency_acquire_callback(void)
 		LOG_ERR("NVM low latency request has failed (%d)", err);
 	}
 #elif IS_ENABLED(CONFIG_NRFX_POWER)
-	nrfx_power_constlat_mode_request();
+	(void)nrfx_power_constlat_mode_request();
 #else
 	nrf_power_task_trigger(NRF_POWER, NRF_POWER_TASK_CONSTLAT);
-#endif /* IS_ENABLED(CONFIG_NRF_SYS_EVENT) */
+#endif /* NRF_POWER_HAS_CONST_LATENCY && NRF_POWER_HAS_LOW_POWER */
 
 #if !IS_ENABLED(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 #if IS_ENABLED(CONFIG_NRF_SYS_EVENT_IRQ_LATENCY)
@@ -630,12 +627,12 @@ void mpsl_low_latency_acquire_callback(void)
 					  << RRAMC_POWER_LOWPOWERCONFIG_MODE_Pos;
 #endif /* IS_ENABLED(CONFIG_NRF_SYS_EVENT_IRQ_LATENCY) */
 #endif /* !IS_ENABLED(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
-#endif /* IS_ENABLED(CONFIG_SOC_SERIES_NRF54L) */
+#endif /* defined(MPSL_HW_HAS_RRAMC) */
 }
 
 void mpsl_low_latency_release_callback(void)
 {
-#if IS_ENABLED(CONFIG_SOC_SERIES_NRF54L)
+#if defined(MPSL_HW_HAS_RRAMC)
 #if IS_ENABLED(CONFIG_NRF_SYS_EVENT)
 	int ret;
 
@@ -644,7 +641,7 @@ void mpsl_low_latency_release_callback(void)
 		LOG_ERR("NVM low latency release has failed (%d)", ret);
 	}
 #elif IS_ENABLED(CONFIG_NRFX_POWER)
-	nrfx_power_constlat_mode_free();
+	(void)nrfx_power_constlat_mode_free();
 #else
 	nrf_power_task_trigger(NRF_POWER, NRF_POWER_TASK_LOWPWR);
 #endif /* IS_ENABLED(CONFIG_NRF_SYS_EVENT) */
@@ -661,9 +658,9 @@ void mpsl_low_latency_release_callback(void)
 	NRF_RRAMC->POWER.LOWPOWERCONFIG = m_rram_lowpower_config;
 #endif /* IS_ENABLED(CONFIG_NRF_SYS_EVENT_IRQ_LATENCY) */
 #endif /* !IS_ENABLED(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
-#endif /* IS_ENABLED(CONFIG_SOC_SERIES_NRF54L) */
+#endif /* defined(MPSL_HW_HAS_RRAMC) */
 }
-#endif /* defined(CONFIG_SOC_COMPATIBLE_NRF54LX) */
+#endif /* defined(CONFIG_MPSL_LOW_LATENCY_CALLBACKS) */
 
 #if defined(CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL)
 #define MPSL_INIT_LEVEL POST_KERNEL


### PR DESCRIPTION
Today, MPSL init hard-codes per-soc-series IRQs, timers, channel
masks and so on, inside mpsl_init.c. That prevents from extending
the MPSL confiuration from out-of-tree modules.

This change separates concerns: MSPL init keep the initializaiton
flow and safety checks; the common SoC conifguration is supplied
with mpsl_init_soc.h. The new header file is unconditionally
included in mpsl_init.c but the include directory path depends on
the SoC series. That allows to override the include directory path
from out-of-tree modules. In case unknown SoC series is used the
compilation will fail.

Changed MPSL init library definition in CMakelist.txt,
using the zephyr_library_get_current_dir_lib_name() based on the
ZEPHYR_NRF_MODULE_DIR, allows to use zephyr_library_amend() and
modify the library in similar way e.g. sdk-nrf/drviers amed
their counterpart in zephyr/drivers.

MPSL init configuration should not ask “which nRF series is this?”
when the real question is “does this hardware have for example:
TIMER10 / GRTC?”. Where possible, series checks are replaced by
existing HW Kconfig (HAS_HW_NRF_TIMER10, HAS_HW_NRF_GRTC) or an
explicit MPSL feature (MPSL_LOW_LATENCY_CALLBACKS), so compatible
SoCs opt in by capability, not by pretending to be another series.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>