### PR TITLE
boards: nordic: nrf54lm20dongle: Fix dtsi include path

### DIFF
--- a/boards/nordic/nrf54lm20dongle/nrf54lm20dongle_nrf54lm20b_cpuflpr.dts
+++ b/boards/nordic/nrf54lm20dongle/nrf54lm20dongle_nrf54lm20b_cpuflpr.dts
@@ -5,7 +5,7 @@
  */
 
 /dts-v1/;
-#include <nordic/nrf54lm20b_cpuflpr.dtsi>
+#include <vendor/nordic/nrf54lm20_a_b_cpuflpr.dtsi>
 #include "nrf54lm20dongle_nrf54lm20b-common.dtsi"
 
 / {


### PR DESCRIPTION
The common dtsi file had been renamed.