### PR TITLE
scripts: sbom: Fix license headers

### DIFF
--- a/applications/nrf_desktop/src/util/chmap_filter/license.txt
+++ b/applications/nrf_desktop/src/util/chmap_filter/license.txt
@@ -2,4 +2,8 @@
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ * The following tag tells the "west ncs-sbom" tool which files are covered
+ * by the license information above.
+ * NCS-SBOM-Apply-To-File: ./lib/**/*.a
  */

--- a/doc/_scripts/merge_search_indexes.py
+++ b/doc/_scripts/merge_search_indexes.py
@@ -13,6 +13,8 @@ Usage
 python merge_search_indexes.py -b path/to/doc/build/dir
 
 Copyright (c) 2021 Nordic Semiconductor ASA
+
+SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 """
 
 import argparse


### PR DESCRIPTION
Update license headers to allow ncs-sbom tool to detect it.