### PR TITLE
quarantine: remove iso_time_sync and peri with mult identities

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -298,15 +298,3 @@
   platforms:
     - nrf7120dk/nrf7120/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39364"
-
-- scenarios:
-    - sample.bluetooth.peripheral_with_multiple_identities
-  platforms:
-    - nrf54ls05dk@0.2.0/nrf54ls05a/cpuapp
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39365"
-
-- scenarios:
-    - sample.bluetooth.iso_time_sync
-  platforms:
-    - nrf54ls05dk@0.2.0/nrf54ls05a/cpuapp
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39366"


### PR DESCRIPTION
The nrf54ls05a build configurations were removed from those samples.