### PR TITLE
tests: drivers: uart: Use NFCT loopback in UART tests

### DIFF
--- a/tests/drivers/uart/uart_mixed_modes/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/drivers/uart/uart_mixed_modes/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -6,7 +6,7 @@
 
 /*
  * Required loopbacks:
- * P1.04 <-> P1.11
+ * P1.08 <-> P1.09 (connected with NFCT antena)
  * P2.03 <-> P2.09
  */
 
@@ -14,7 +14,7 @@
 	uart130_default_test: uart130_default_test {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 2, 3)>,
-				<NRF_PSEL(UART_RX, 1, 4)>;
+				<NRF_PSEL(UART_RX, 1, 8)>;
 			bias-pull-up;
 		};
 	};
@@ -22,14 +22,14 @@
 	uart130_sleep_test: uart130_sleep_test {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 2, 3)>,
-				<NRF_PSEL(UART_RX, 1, 4)>;
+				<NRF_PSEL(UART_RX, 1, 8)>;
 			low-power-enable;
 		};
 	};
 
 	uart131_default_test: uart131_default_test {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 11)>,
+			psels = <NRF_PSEL(UART_TX, 1, 9)>,
 				<NRF_PSEL(UART_RX, 2, 9)>;
 			bias-pull-up;
 		};
@@ -37,11 +37,15 @@
 
 	uart131_sleep_test: uart131_sleep_test {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 11)>,
+			psels = <NRF_PSEL(UART_TX, 1, 9)>,
 				<NRF_PSEL(UART_RX, 2, 9)>;
 			low-power-enable;
 		};
 	};
+};
+
+&uicr {
+	nfct-pins-as-gpios;
 };
 
 &cpuapp_dma_region {

--- a/tests/zephyr/drivers/uart/uart_async_dual/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/uart/uart_async_dual/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -5,26 +5,26 @@
  */
 
 /* Test requires loopbacks:
- * TX-RX: P1.04 - P1.11
- * RTS-CTS: P2.03 - P2.09
+ * TX-RX: P2.03 - P2.09
+ * RTS-CTS: P1.08 - P1.09 (connected with NFCT antena)
  */
 
 &pinctrl {
 	uart130_alt_default: uart130_alt_default {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 1, 4)>;
+			psels = <NRF_PSEL(UART_RX, 2, 3)>;
 			bias-pull-up;
 		};
 
 		group2 {
-			psels = <NRF_PSEL(UART_RTS, 2, 3)>;
+			psels = <NRF_PSEL(UART_RTS, 1, 8)>;
 		};
 	};
 
 	uart130_alt_sleep: uart130_alt_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 1, 4)>,
-				<NRF_PSEL(UART_RTS, 2, 3)>;
+			psels = <NRF_PSEL(UART_RX, 2, 3)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>;
 			low-power-enable;
 			bias-pull-up;
 		};
@@ -32,23 +32,27 @@
 
 	uart131_alt_default: uart131_alt_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 11)>;
+			psels = <NRF_PSEL(UART_TX, 2, 9)>;
 		};
 
 		group2 {
-			psels = <NRF_PSEL(UART_CTS, 2, 9)>;
+			psels = <NRF_PSEL(UART_CTS, 1, 9)>;
 			bias-pull-up;
 		};
 	};
 
 	uart131_alt_sleep: uart131_alt_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 11)>,
-				<NRF_PSEL(UART_CTS, 2, 9)>;
+			psels = <NRF_PSEL(UART_TX, 2, 9)>,
+				<NRF_PSEL(UART_CTS, 1, 9)>;
 			low-power-enable;
 			bias-pull-up;
 		};
 	};
+};
+
+&uicr {
+	nfct-pins-as-gpios;
 };
 
 &timer130 {

--- a/tests/zephyr/drivers/uart/uart_elementary/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/uart/uart_elementary/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -5,8 +5,8 @@
  */
 
 /* Test requires loopbacks:
- * TX-RX: P1.04 - P1.11
- * RTS-CTS: P2.03 - P2.09
+ * TX-RX: P2.03 - P2.09
+ * RTS-CTS: P1.08 - P1.09 (connected with NFCT antena)
  */
 
 &cpuapp_dma_region {
@@ -16,22 +16,26 @@
 &pinctrl {
 	uart131_default_alt: uart131_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 4)>,
-				<NRF_PSEL(UART_RX, 1, 11)>,
-				<NRF_PSEL(UART_RTS, 2, 3)>,
-				<NRF_PSEL(UART_CTS, 2, 9)>;
+			psels = <NRF_PSEL(UART_TX, 2, 3)>,
+				<NRF_PSEL(UART_RX, 2, 9)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>,
+				<NRF_PSEL(UART_CTS, 1, 9)>;
 		};
 	};
 
 	uart131_sleep_alt: uart131_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 4)>,
-				<NRF_PSEL(UART_RX, 1, 11)>,
-				<NRF_PSEL(UART_RTS, 2, 3)>,
-				<NRF_PSEL(UART_CTS, 2, 9)>;
+			psels = <NRF_PSEL(UART_TX, 2, 3)>,
+				<NRF_PSEL(UART_RX, 2, 9)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>,
+				<NRF_PSEL(UART_CTS, 1, 9)>;
 			low-power-enable;
 		};
 	};
+};
+
+&uicr {
+	nfct-pins-as-gpios;
 };
 
 dut: &uart131 {

--- a/tests/zephyr/drivers/uart/uart_elementary/boards/nrf9251dk_nrf9251_cpuapp_dual_uart.overlay
+++ b/tests/zephyr/drivers/uart/uart_elementary/boards/nrf9251dk_nrf9251_cpuapp_dual_uart.overlay
@@ -5,14 +5,14 @@
  */
 
 /* Test requires loopbacks:
- * RX-TX: P1.04 - P1.11
- * TX-RX: P2.03 - P2.09
+ * TX1-RX1: P2.03 - P2.09
+ * TX2-RX2: P1.08 - P1.09 (connected with NFCT antena)
  */
 
 &pinctrl {
 	uart131_default_alt: uart131_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 1, 4)>;
+			psels = <NRF_PSEL(UART_RX, 1, 8)>;
 			bias-pull-up;
 		};
 
@@ -23,7 +23,7 @@
 
 	uart131_sleep_alt: uart131_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 1, 4)>,
+			psels = <NRF_PSEL(UART_RX, 1, 8)>,
 				<NRF_PSEL(UART_TX, 2, 3)>;
 			low-power-enable;
 		};
@@ -36,17 +36,21 @@
 		};
 
 		group2 {
-			psels = <NRF_PSEL(UART_TX, 1, 11)>;
+			psels = <NRF_PSEL(UART_TX, 1, 9)>;
 		};
 	};
 
 	uart132_sleep_alt: uart132_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_RX, 2, 9)>,
-				<NRF_PSEL(UART_TX, 1, 11)>;
+				<NRF_PSEL(UART_TX, 1, 9)>;
 			low-power-enable;
 		};
 	};
+};
+
+&uicr {
+	nfct-pins-as-gpios;
 };
 
 dut: &uart131 {

--- a/tests/zephyr/drivers/uart/uart_errors/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/uart/uart_errors/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -5,26 +5,26 @@
  */
 
 /* Test requires loopbacks:
- * TX-RX: P1.04 - P1.11
- * RTS-CTS: P2.03 - P2.09
+ * TX-RX: P2.03 - P2.09
+ * RTS-CTS: P1.08 <-> P1.09 (connected with NFCT antena)
  */
 
 &pinctrl {
 	uart130_default_alt: uart130_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 1, 11)>;
+			psels = <NRF_PSEL(UART_RX, 2, 3)>;
 			bias-pull-up;
 		};
 
 		group2 {
-			psels = <NRF_PSEL(UART_RTS, 2, 3)>;
+			psels = <NRF_PSEL(UART_RTS, 1, 8)>;
 		};
 	};
 
 	uart130_sleep_alt: uart130_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 1, 11)>,
-				<NRF_PSEL(UART_RTS, 2, 3)>;
+			psels = <NRF_PSEL(UART_RX, 2, 3)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>;
 			low-power-enable;
 		};
 	};
@@ -33,19 +33,19 @@
 &pinctrl {
 	uart131_default_alt: uart131_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 4)>;
+			psels = <NRF_PSEL(UART_TX, 2, 9)>;
 		};
 
 		group2 {
-			psels = <NRF_PSEL(UART_CTS, 2, 9)>;
+			psels = <NRF_PSEL(UART_CTS, 1, 9)>;
 			bias-pull-up;
 		};
 	};
 
 	uart131_sleep_alt: uart131_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 4)>,
-				<NRF_PSEL(UART_CTS, 2, 9)>;
+			psels = <NRF_PSEL(UART_TX, 2, 9)>,
+				<NRF_PSEL(UART_CTS, 1, 9)>;
 			low-power-enable;
 		};
 	};

--- a/tests/zephyr/drivers/uart/uart_mix_fifo_poll/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/uart/uart_mix_fifo_poll/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -5,26 +5,26 @@
  */
 
 /* Test requires loopbacks:
- * - TX-RX: P1.04 - P1.11
- * - RTS-CTS: P2.03 - P2.09
+ * - TX-RX: P2.03 - P2.09
+ * - RTS-CTS: P1.08 <-> P1.09 (connected with NFCT antena)
  */
 
 &pinctrl {
 	uart130_default_alt: uart130_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 4)>,
-				<NRF_PSEL(UART_RX, 1, 11)>,
-				<NRF_PSEL(UART_RTS, 2, 3)>,
-				<NRF_PSEL(UART_CTS, 2, 9)>;
+			psels = <NRF_PSEL(UART_TX, 2, 3)>,
+				<NRF_PSEL(UART_RX, 2, 9)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>,
+				<NRF_PSEL(UART_CTS, 1, 9)>;
 		};
 	};
 
 	uart130_sleep_alt: uart130_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 4)>,
-				<NRF_PSEL(UART_RX, 1, 11)>,
-				<NRF_PSEL(UART_RTS, 2, 3)>,
-				<NRF_PSEL(UART_CTS, 2, 9)>;
+			psels = <NRF_PSEL(UART_TX, 2, 3)>,
+				<NRF_PSEL(UART_RX, 2, 9)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>,
+				<NRF_PSEL(UART_CTS, 1, 9)>;
 			low-power-enable;
 		};
 	};

--- a/tests/zephyr/drivers/uart/uart_pm/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/uart/uart_pm/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -5,21 +5,21 @@
  */
 
 /* Test requires loopbacks:
- * - TX-RX: P1.04 - P1.11
+ * - TX-RX: P2.03 - P2.09
  */
 
 &pinctrl {
 	uart131_default_alt: uart131_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 4)>,
-				<NRF_PSEL(UART_RX, 1, 11)>;
+			psels = <NRF_PSEL(UART_TX, 2, 3)>,
+				<NRF_PSEL(UART_RX, 2, 9)>;
 		};
 	};
 
 	uart131_sleep_alt: uart131_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 4)>,
-				<NRF_PSEL(UART_RX, 1, 11)>;
+			psels = <NRF_PSEL(UART_TX, 2, 3)>,
+				<NRF_PSEL(UART_RX, 2, 9)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Change nrf9251dk platform overlays in UART driver tests. Instead of using tripple loopback P1.02-P1.04-P1.11 use loopback P1.08-P1.09.

This requires pin function change from NFCT to GPIO.