### PR TITLE
modules: memfault-firmware-sdk: migrate coredump from PM to devicetree

### DIFF
--- a/doc/nrf/libraries/debug/memfault_ncs.rst
+++ b/doc/nrf/libraries/debug/memfault_ncs.rst
@@ -137,6 +137,37 @@ The Kconfig options for Memfault that are defined in |NCS| provide some addition
 * :kconfig:option:`CONFIG_MEMFAULT_NCS_STACK_METRICS`
 * :kconfig:option:`CONFIG_MEMFAULT_NCS_BT_METRICS`
 
+.. _snippet-memfault-coredump:
+
+Flash-backed coredump storage
+-----------------------------
+
+When the :kconfig:option:`CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP` Kconfig option is enabled, the storage region is resolved at build time using one of the following sources:
+
+* **Partition Manager** (legacy): When :kconfig:option:`CONFIG_PARTITION_MANAGER_ENABLED` is ``y``, a ``MEMFAULT_STORAGE`` partition is generated automatically.
+  The size defaults to 64 kB, and you can override it with :kconfig:option:`CONFIG_PM_PARTITION_SIZE_MEMFAULT_STORAGE`.
+* **Devicetree** (|NCS| v3.4.0 or later recommended): When Partition Manager is disabled, the backend locates a fixed partition labeled ``memfault_coredump_partition`` under the internal flash controller.
+
+The easiest way to enable the devicetree path is the :ref:`snippet-memfault-coredump` snippet that supplies a board-specific overlay defining the partition:
+
+.. code-block:: console
+
+   west build -b <board> -S memfault-coredump <application>
+
+For boards not covered by the snippet, add a node similar to the following to your application overlay:
+
+.. code-block:: dts
+
+   &flash0 {
+       partitions {
+           memfault_coredump_partition: partition@fc000 {
+               compatible = "zephyr,mapped-partition";
+               label = "memfault_coredump_partition";
+               reg = <0x000fc000 0x4000>;
+           };
+       };
+   };
+
 The |NCS| integration of `Memfault SDK`_ provides default values for some metadata that is required to identify the firmware when it is sent to Memfault cloud.
 You can control the defaults by using the configuration options below:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -800,7 +800,11 @@ Edge Impulse integration
 Memfault integration
 --------------------
 
-|no_changes_yet_note|
+* Added:
+
+  * Devicetree support for the internal flash coredump backend (:kconfig:option:`CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP`).
+    The backend now locates its storage from a fixed partition labeled ``memfault_coredump_partition`` when Partition Manager is disabled, while continuing to support Partition Manager when enabled.
+  * The :ref:`snippet-memfault-coredump` snippet that supplies a board-specific partition overlay for flash-backed coredump storage on common DKs and Thingy:91 or Thingy:91 X.
 
 AVSystem integration
 --------------------

--- a/modules/memfault-firmware-sdk/Kconfig
+++ b/modules/memfault-firmware-sdk/Kconfig
@@ -280,10 +280,16 @@ config MEMFAULT_NCS_ETB_CAPTURE
 config MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP
 	bool "Save coredump to internal flash instead of RAM"
 	select MEMFAULT_COREDUMP_STORAGE_CUSTOM
-	depends on PARTITION_MANAGER_ENABLED
 	depends on FLASH
 	help
-	  Use internal flash to store coredump data
+	  Use internal flash to store coredump data.
+
+	  Storage location is resolved at build time from one of:
+	  - Partition Manager: a MEMFAULT_STORAGE partition (default size 0x10000)
+	    is generated automatically when CONFIG_PARTITION_MANAGER_ENABLED=y.
+	  - Devicetree: a fixed-partition with label "memfault_coredump_partition"
+	    under the internal flash controller. Enable the "memfault-coredump"
+	    snippet (-S memfault-coredump) or supply your own DT overlay.
 
 if MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP
 
@@ -291,9 +297,13 @@ config MEMFAULT_NCS_FLASH_REGION_SIZE
 	hex
 	default $(dt_node_int_prop_hex,$(DT_CHOSEN_ZEPHYR_FLASH),erase-block-size)
 
+if PARTITION_MANAGER_ENABLED
+
 partition=MEMFAULT_STORAGE
 partition-size=0x10000
 source "$(ZEPHYR_NRF_MODULE_DIR)/subsys/partition_manager/Kconfig.template.partition_config"
+
+endif # PARTITION_MANAGER_ENABLED
 
 endif # MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP
 

--- a/modules/memfault-firmware-sdk/memfault_flash_coredump_storage.c
+++ b/modules/memfault-firmware-sdk/memfault_flash_coredump_storage.c
@@ -21,6 +21,29 @@
  * should be used when the system is in this state.
  */
 
+/* Locate the coredump storage region. Two options are supported:
+ *
+ *   1. Partition Manager (legacy): PARTITION_*(MEMFAULT_STORAGE) macros resolve
+ *      via <pm_config.h> when CONFIG_PARTITION_MANAGER_ENABLED=y.
+ *   2. Devicetree (NCS 3.4+): set nordic,memfault-coredump-partition in the
+ *      chosen node to point at the coredump storage partition.
+ */
+#ifdef CONFIG_PARTITION_MANAGER_ENABLED
+#include <pm_config.h>
+#define MFLT_STORAGE_OFFSET PARTITION_OFFSET(MEMFAULT_STORAGE)
+#define MFLT_STORAGE_SIZE   PARTITION_SIZE(MEMFAULT_STORAGE)
+#define MFLT_STORAGE_FA_ID  PARTITION_ID(MEMFAULT_STORAGE)
+#else
+#define MFLT_STORAGE_NODE DT_CHOSEN(nordic_memfault_coredump_partition)
+BUILD_ASSERT(DT_NODE_EXISTS(MFLT_STORAGE_NODE),
+	     "nordic,memfault-coredump-partition chosen property not set. "
+	     "Add the memfault-coredump snippet (-S memfault-coredump) or set "
+	     "nordic,memfault-coredump-partition in the chosen node of your overlay.");
+#define MFLT_STORAGE_OFFSET PARTITION_NODE_ADDRESS(MFLT_STORAGE_NODE)
+#define MFLT_STORAGE_SIZE   PARTITION_NODE_SIZE(MFLT_STORAGE_NODE)
+#define MFLT_STORAGE_FA_ID  DT_PARTITION_ID(MFLT_STORAGE_NODE)
+#endif
+
 /* Note: While the system is running, flash writes for the nRF (soc_flash_nrf.c)
  *	 may be asynchronous so we use a static to track when a coredump clear
  *	 request has been issued.
@@ -30,7 +53,7 @@ static bool last_coredump_cleared;
 void memfault_platform_coredump_storage_get_info(sMfltCoredumpStorageInfo *info)
 {
 	*info = (sMfltCoredumpStorageInfo) {
-		.size = PARTITION_SIZE(MEMFAULT_STORAGE),
+		.size = MFLT_STORAGE_SIZE,
 	};
 }
 
@@ -53,7 +76,7 @@ bool memfault_platform_coredump_storage_read(uint32_t offset, void *data, size_t
 	}
 
 	/* Note: internal flash is memory mapped so we can just memcpy it out */
-	const uint32_t address = PARTITION_OFFSET(MEMFAULT_STORAGE) + offset;
+	const uint32_t address = MFLT_STORAGE_OFFSET + offset;
 
 	memcpy(data, (void *)address, read_len);
 	return true;
@@ -75,7 +98,7 @@ bool memfault_platform_coredump_storage_erase(uint32_t offset, size_t erase_size
 	}
 
 	for (size_t page = offset; page < erase_size; page += page_size) {
-		const uint32_t address = PARTITION_OFFSET(MEMFAULT_STORAGE) + page;
+		const uint32_t address = MFLT_STORAGE_OFFSET + page;
 
 		nrfx_nvmc_page_erase(address);
 	}
@@ -88,7 +111,7 @@ bool memfault_platform_coredump_storage_erase(uint32_t offset, size_t erase_size
  */
 bool memfault_platform_coredump_storage_buffered_write(sCoredumpWorkingBuffer *blk)
 {
-	const uint32_t start_addr = PARTITION_OFFSET(MEMFAULT_STORAGE);
+	const uint32_t start_addr = MFLT_STORAGE_OFFSET;
 	const uint32_t addr = start_addr + blk->write_offset;
 
 	if (!prv_op_within_flash_bounds(blk->write_offset, MEMFAULT_COREDUMP_STORAGE_WRITE_SIZE)) {
@@ -122,7 +145,7 @@ void memfault_platform_coredump_storage_clear(void)
 	const struct flash_area *flash_area;
 	int err;
 
-	err = flash_area_open(PARTITION_ID(MEMFAULT_STORAGE), &flash_area);
+	err = flash_area_open(MFLT_STORAGE_FA_ID, &flash_area);
 	if (err) {
 		MEMFAULT_LOG_ERROR("Unable to open coredump storage: 0x%x", err);
 		return;

--- a/samples/debug/memfault/README.rst
+++ b/samples/debug/memfault/README.rst
@@ -137,7 +137,13 @@ Check and configure the following options for Memfault that are specific to |NCS
 * :kconfig:option:`CONFIG_MEMFAULT_NCS_STACK_METRICS`
 * :kconfig:option:`CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP`
 
-If :kconfig:option:`CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP` is enabled, :kconfig:option:`CONFIG_PM_PARTITION_SIZE_MEMFAULT_STORAGE` can be used to set the flash partition size for the flash storage.
+If :kconfig:option:`CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP` is enabled, you can use :kconfig:option:`CONFIG_PM_PARTITION_SIZE_MEMFAULT_STORAGE` to set the flash partition size for the flash storage when Partition Manager is in use.
+
+When building without Partition Manager (|NCS| v3.4.0 or later), enable the :ref:`snippet-memfault-coredump` snippet to supply the coredump partition using devicetree:
+
+.. code-block:: console
+
+   west build -b <board> -S memfault-coredump samples/debug/memfault
 
 .. include:: /includes/wifi_credentials_shell.txt
 

--- a/snippets/memfault-coredump/README.rst
+++ b/snippets/memfault-coredump/README.rst
@@ -1,0 +1,35 @@
+.. _snippet-memfault-coredump:
+
+Memfault coredump snippet (memfault-coredump)
+#############################################
+
+.. code-block:: console
+
+   west build -S memfault-coredump [...]
+
+Overview
+********
+
+This snippet enables flash-backed Memfault coredump storage without requiring Partition Manager.
+It sets the :kconfig:option:`CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP` Kconfig option and applies a board-specific devicetree overlay that defines a ``memfault_coredump_partition`` node within internal flash and sets the ``nordic,memfault-coredump-partition`` chosen property to point at it.
+
+Supported boards
+****************
+
+* ``nrf52840dk/nrf52840``
+* ``nrf5340dk/nrf5340/cpuapp`` and ``nrf5340dk/nrf5340/cpuapp/ns``
+* ``nrf9160dk/nrf9160/ns``
+* ``nrf9151dk/nrf9151/ns``
+* ``nrf9161dk/nrf9161/ns``
+* ``thingy91/nrf9160/ns``
+* ``thingy91x/nrf9151/ns``
+
+For other boards, add a ``zephyr,mapped-partition`` node under the internal flash controller in your overlay file and set the ``nordic,memfault-coredump-partition`` chosen property to point at it, ensuring the size is aligned to a multiple of the flash erase block (typically 4 kB).
+
+Notes
+*****
+
+Set the :kconfig:option:`SB_CONFIG_PARTITION_MANAGER` Kconfig option to ``n`` (for example, using a ``Kconfig.sysbuild`` fragment in your application) to disable Partition Manager.
+
+The nRF91 ``ns`` overlays redefine the full flash and modem-shared SRAM layout because disabling Partition Manager removes the TF-M and modem partition generation that the |NCS| would otherwise generate.
+The layouts mirror those used by the :ref:`at_client_sample` sample.

--- a/snippets/memfault-coredump/boards/nrf52840dk_nrf52840.overlay
+++ b/snippets/memfault-coredump/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Carve a 64 kB memfault coredump partition out of the application-reserved
+ * region at the end of internal flash. The default nrf52840 layout reserves
+ * the storage partition at 0x000f8000-0x00100000 (32 kB). Shrink it to 16 kB
+ * and place memfault_coredump_partition immediately after.
+ *
+ *   0x000f8000  storage_partition           (16 kB)
+ *   0x000fc000  memfault_coredump_partition (16 kB)
+ *
+ * Adjust the layout to taste in your own overlay if you need different sizes.
+ */
+
+/ {
+	chosen {
+		nordic,memfault-coredump-partition = &memfault_coredump_partition;
+	};
+};
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x000f8000 0x00004000>;
+		};
+
+		memfault_coredump_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
+			label = "memfault_coredump_partition";
+			reg = <0x000fc000 0x00004000>;
+		};
+	};
+};

--- a/snippets/memfault-coredump/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/snippets/memfault-coredump/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Shrink the default 32 kB storage partition and append a 16 kB memfault
+ * coredump partition at the end of internal flash.
+ *
+ *   0x000f8000  storage_partition           (16 kB)
+ *   0x000fc000  memfault_coredump_partition (16 kB)
+ */
+
+/ {
+	chosen {
+		nordic,memfault-coredump-partition = &memfault_coredump_partition;
+	};
+};
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x000f8000 0x00004000>;
+		};
+
+		memfault_coredump_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
+			label = "memfault_coredump_partition";
+			reg = <0x000fc000 0x00004000>;
+		};
+	};
+};

--- a/snippets/memfault-coredump/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/snippets/memfault-coredump/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* See nrf5340dk_nrf5340_cpuapp.overlay for the layout rationale. */
+
+/ {
+	chosen {
+		nordic,memfault-coredump-partition = &memfault_coredump_partition;
+	};
+};
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x000f8000 0x00004000>;
+		};
+
+		memfault_coredump_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
+			label = "memfault_coredump_partition";
+			reg = <0x000fc000 0x00004000>;
+		};
+	};
+};

--- a/snippets/memfault-coredump/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/snippets/memfault-coredump/boards/nrf9151dk_nrf9151_ns.overlay
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* See nrf9160dk_nrf9160_ns.overlay for the layout rationale. */
+
+/ {
+	chosen {
+		nordic,memfault-coredump-partition = &memfault_coredump_partition;
+	};
+};
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &storage_partition;
+/delete-node/ &sram0_s;
+/delete-node/ &sram0_ns;
+
+&flash0 {
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x0 0xf8000>;
+			ranges = <0x0 0x0 0xf8000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_s_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-secure";
+				reg = <0x0 0x8000>;
+			};
+
+			slot0_ns_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-nonsecure";
+				reg = <0x8000 0xf0000>;
+			};
+		};
+
+		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x000f8000 0x00004000>;
+		};
+
+		memfault_coredump_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
+			label = "memfault_coredump_partition";
+			reg = <0x000fc000 0x00004000>;
+		};
+	};
+};
+
+&sram0 {
+	/*
+	 * 0x2000_0000  Secure RAM                   (  32 kB)
+	 * 0x2000_8000  Non-secure RAM area          ( 224 kB)
+	 *   0x2000_8000  Modem shared area          (  18 kB)
+	 *     0x2000_8000  control                  (1832 B)
+	 *     0x2000_8728  app -> cell              (8408 B)
+	 *     0x2000_a800  cell -> app              (   8 kB)
+	 *   0x2000_c800  Application RAM            ( 206 kB)
+	 */
+
+	sram0_s: sram@0 {
+		reg = <0x0 0x8000>;
+	};
+
+	sram0_ns: sram@8000 {
+		reg = <0x8000 0x38000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x8000 0x38000>;
+
+		/* Must be in first 128 kB of RAM. */
+		sram0_ns_modem: sram0_ns@0 {
+			/* Modem (shared) memory */
+			reg = <0x0 0x4800>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x0 0x4800>;
+
+			cpuapp_cpucell_ipc_shm_ctrl: sram0_ns_modem@0 {
+				/* Modem IPC control */
+				reg = <0x0 0x728>;
+			};
+
+			cpuapp_cpucell_ipc_shm_heap: sram0_ns_modem@728 {
+				/* Modem IPC transmit */
+				reg = <0x728 0x20d8>;
+			};
+
+			cpucell_cpuapp_ipc_shm_heap: sram0_ns_modem@2800 {
+				/* Modem IPC receive */
+				reg = <0x2800 0x2000>;
+			};
+		};
+
+		sram0_ns_app: sram0_ns@4800 {
+			/* Non-Secure application memory */
+			reg = <0x4800 0x33800>;
+		};
+	};
+};

--- a/snippets/memfault-coredump/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/snippets/memfault-coredump/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Devicetree-based partition layout for the nrf9160dk_nrf9160_ns target, used
+ * when CONFIG_PARTITION_MANAGER_ENABLED=n. Mirrors the layout adopted by the
+ * cellular at_client sample (see samples/cellular/at_client/boards/) and
+ * carves a 16 kB memfault_coredump_partition out of the storage region.
+ *
+ *   0x0000_0000  Reserved / preloaded MCUboot region
+ *   0x0000_c000  image-0          (image-0-secure + image-0-nonsecure, 944 kB)
+ *   0x000f_8000  storage          (16 kB)
+ *   0x000f_c000  memfault_coredump_partition (16 kB)
+ */
+
+/ {
+	chosen {
+		nordic,memfault-coredump-partition = &memfault_coredump_partition;
+	};
+};
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &storage_partition;
+/delete-node/ &sram0_s;
+/delete-node/ &sram0_ns;
+
+&flash0 {
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x0 0xf8000>;
+			ranges = <0x0 0x0 0xf8000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_s_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-secure";
+				reg = <0x0 0x8000>;
+			};
+
+			slot0_ns_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-nonsecure";
+				reg = <0x8000 0xf0000>;
+			};
+		};
+
+		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x000f8000 0x00004000>;
+		};
+
+		memfault_coredump_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
+			label = "memfault_coredump_partition";
+			reg = <0x000fc000 0x00004000>;
+		};
+	};
+};
+
+&sram0 {
+	/*
+	 * 0x2000_0000  Secure RAM                   (  32 kB)
+	 * 0x2000_8000  Non-secure RAM area          ( 224 kB)
+	 *   0x2000_8000  Modem shared area          (  18 kB)
+	 *     0x2000_8000  control                  (1832 B)
+	 *     0x2000_8728  app -> cell              (8408 B)
+	 *     0x2000_a800  cell -> app              (   8 kB)
+	 *   0x2000_c800  Application RAM            ( 206 kB)
+	 */
+
+	sram0_s: sram@0 {
+		reg = <0x0 0x8000>;
+	};
+
+	sram0_ns: sram@8000 {
+		reg = <0x8000 0x38000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x8000 0x38000>;
+
+		/* Must be in first 128 kB of RAM. */
+		sram0_ns_modem: sram0_ns@0 {
+			/* Modem (shared) memory */
+			reg = <0x0 0x4800>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x0 0x4800>;
+
+			cpuapp_cpucell_ipc_shm_ctrl: sram0_ns_modem@0 {
+				/* Modem IPC control */
+				reg = <0x0 0x728>;
+			};
+
+			cpuapp_cpucell_ipc_shm_heap: sram0_ns_modem@728 {
+				/* Modem IPC transmit */
+				reg = <0x728 0x20d8>;
+			};
+
+			cpucell_cpuapp_ipc_shm_heap: sram0_ns_modem@2800 {
+				/* Modem IPC receive */
+				reg = <0x2800 0x2000>;
+			};
+		};
+
+		sram0_ns_app: sram0_ns@4800 {
+			/* Non-Secure application memory */
+			reg = <0x4800 0x33800>;
+		};
+	};
+};

--- a/snippets/memfault-coredump/boards/nrf9161dk_nrf9161_ns.overlay
+++ b/snippets/memfault-coredump/boards/nrf9161dk_nrf9161_ns.overlay
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Devicetree-based partition layout for the nrf9161dk_nrf9161_ns target, used
+ * when CONFIG_PARTITION_MANAGER_ENABLED=n. Mirrors the layout adopted by the
+ * cellular at_client sample (see samples/cellular/at_client/boards/) and
+ * carves a 16 kB memfault_coredump_partition from the storage region.
+ *
+ *   0x0000_0000  image-0                      (960 kB)
+ *     +0x0000    image-0-secure               ( 32 kB)
+ *     +0x8000    image-0-nonsecure            (928 kB)
+ *   0x000f_8000  storage                      ( 32 kB)
+ *     +0x0000    settings-storage             ( 16 kB)
+ *     +0x4000    memfault_coredump_partition  ( 16 kB)
+ */
+
+/ {
+	chosen {
+		zephyr,settings-partition = &settings_storage_partition;
+		nordic,memfault-coredump-partition = &memfault_coredump_partition;
+	};
+};
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &storage_partition;
+/delete-node/ &sram0_s;
+/delete-node/ &sram0_ns;
+
+&flash0 {
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x0 0xf8000>;
+			ranges = <0x0 0x0 0xf8000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_s_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-secure";
+				reg = <0x0 0x8000>;
+			};
+
+			slot0_ns_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-nonsecure";
+				reg = <0x8000 0xf0000>;
+			};
+		};
+
+		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x000f8000 0x8000>;
+			ranges = <0x0 0x000f8000 0x8000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			settings_storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "settings-storage";
+				reg = <0x00000000 0x4000>;
+			};
+
+			memfault_coredump_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "memfault_coredump_partition";
+				reg = <0x00004000 0x4000>;
+			};
+		};
+	};
+};
+
+&sram0 {
+	sram0_s: sram@0 {
+		reg = <0x0 0x8000>;
+	};
+
+	sram0_ns: sram@8000 {
+		reg = <0x8000 0x38000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x8000 0x38000>;
+
+		sram0_ns_modem: sram0_ns@0 {
+			reg = <0x0 0x4800>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x0 0x4800>;
+
+			cpuapp_cpucell_ipc_shm_ctrl: sram0_ns_modem@0 {
+				reg = <0x0 0x728>;
+			};
+
+			cpuapp_cpucell_ipc_shm_heap: sram0_ns_modem@728 {
+				reg = <0x728 0x20d8>;
+			};
+
+			cpucell_cpuapp_ipc_shm_heap: sram0_ns_modem@2800 {
+				reg = <0x2800 0x2000>;
+			};
+		};
+
+		sram0_ns_app: sram0_ns@4800 {
+			reg = <0x4800 0x33800>;
+		};
+	};
+};

--- a/snippets/memfault-coredump/boards/thingy91_nrf9160_ns.overlay
+++ b/snippets/memfault-coredump/boards/thingy91_nrf9160_ns.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Thingy:91 (nRF9160) already ships a devicetree partition layout in
+ * boards/nordic/thingy91/thingy91_nrf9160_partition.dtsi. The default layout
+ * leaves an 8 kB gap between the scratch partition (ends at 0x000fc000) and
+ * the storage partition (starts at 0x000fe000). Place a memfault coredump
+ * partition there.
+ */
+
+/ {
+	chosen {
+		nordic,memfault-coredump-partition = &memfault_coredump_partition;
+	};
+};
+
+&flash0 {
+	partitions {
+		memfault_coredump_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
+			label = "memfault_coredump_partition";
+			reg = <0x000fc000 0x00002000>;
+		};
+	};
+};

--- a/snippets/memfault-coredump/boards/thingy91x_nrf9151_ns.overlay
+++ b/snippets/memfault-coredump/boards/thingy91x_nrf9151_ns.overlay
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Thingy:91 X (nRF9151) has its devicetree layout in
+ * boards/nordic/thingy91x/thingy91x_nrf9151_partition.dtsi. The internal
+ * flash is fully consumed by slot0_partition; the secondary slot lives on
+ * external flash. Shrink the non-secure image area by 16 kB to free space
+ * for a memfault coredump partition at the end of internal flash.
+ *
+ *   slot0_partition  0x00030000 - 0x000fc000   (shrunk from 832 kB to 816 kB)
+ *     slot0_s        +0x00000   - +0x08000     (32 kB, unchanged)
+ *     slot0_ns       +0x08000   - +0xcc000     (784 kB, was 800 kB)
+ *   memfault_coredump_partition  0x000fc000 - 0x00100000  (16 kB)
+ */
+
+/ {
+	chosen {
+		nordic,memfault-coredump-partition = &memfault_coredump_partition;
+	};
+};
+
+/delete-node/ &slot0_partition;
+
+&flash0 {
+	partitions {
+		slot0_partition: partition@30000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x00030000 0xcc000>;
+			ranges = <0x0 0x00030000 0xcc000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_s_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-secure";
+				reg = <0x00000000 0x8000>;
+			};
+
+			slot0_ns_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-nonsecure";
+				reg = <0x00008000 0xc4000>;
+			};
+		};
+
+		memfault_coredump_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
+			label = "memfault_coredump_partition";
+			reg = <0x000fc000 0x00004000>;
+		};
+	};
+};

--- a/snippets/memfault-coredump/memfault-coredump.conf
+++ b/snippets/memfault-coredump/memfault-coredump.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP=y

--- a/snippets/memfault-coredump/snippet.yml
+++ b/snippets/memfault-coredump/snippet.yml
@@ -1,0 +1,28 @@
+name: memfault-coredump
+append:
+  EXTRA_CONF_FILE: memfault-coredump.conf
+boards:
+  nrf52840dk/nrf52840:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf52840dk_nrf52840.overlay
+  nrf5340dk/nrf5340/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf5340dk_nrf5340_cpuapp.overlay
+  nrf5340dk/nrf5340/cpuapp/ns:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+  nrf9160dk/nrf9160/ns:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf9160dk_nrf9160_ns.overlay
+  nrf9151dk/nrf9151/ns:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf9151dk_nrf9151_ns.overlay
+  nrf9161dk/nrf9161/ns:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf9161dk_nrf9161_ns.overlay
+  thingy91/nrf9160/ns:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/thingy91_nrf9160_ns.overlay
+  thingy91x/nrf9151/ns:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/thingy91x_nrf9151_ns.overlay


### PR DESCRIPTION
Enable support for device-tree allocated "memfault_coredump_partition" for Memfault coredump storage.

Maintain support for PM-assigned partition.

Partition name matches what's used in the recent memfault-firmware-sdk RRAM/MRAM backends.

Add a "memfault-coredump" snippet that supplies per-board overlays for nRF52, nRF53, nRF91 DKs and Thingy:91 / Thingy:91 X, so users can enable flash-backed coredumps without writing DTS boilerplate, and instructions describing how to use the snippet or a manual overlay.

Verified with:

```bash
# Partition Manager (default)
west build -p -b nrf9160dk/nrf9160/ns samples/debug/memfault \
  -- -DCONFIG_MEMFAULT_NCS_PROJECT_KEY=\"dummy\"

# Devicetree (no PM) via snippet
west build -p -b nrf9160dk/nrf9160/ns -S memfault-coredump \
    samples/debug/memfault -- -DCONFIG_MEMFAULT_NCS_PROJECT_KEY=\"dummy\"

# For nRF52
west build -p -b nrf52840dk/nrf52840 -S memfault-coredump \
    samples/debug/memfault -- -DCONFIG_MEMFAULT_NCS_PROJECT_KEY=\"dummy\"
# For nRF53, same as above but board = nrf5340dk/nrf5340/cpuapp
```

Note: RRAM/MRAM chips (nRF54L, nRF54H, nRF92) should use the upstream memfault-firmware-sdk backends, so this patch only covers chips that currently use the PM-managed internal flash backend.