### PR TITLE
doc: nRF 52, 53 and 54L device guides: Added text about nRF Cloud FOTA

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf52/fota_update.rst
+++ b/doc/nrf/app_dev/device_guides/nrf52/fota_update.rst
@@ -23,6 +23,9 @@ See the :ref:`app_dfu` page for general Device Firmware Update (DFU) information
 FOTA over Bluetooth Low Energy
 ******************************
 
+.. note::
+   |bluetooth_fota_note|
+
 .. fota_upgrades_over_ble_intro_start
 
 FOTA updates are supported using MCUmgr's Simple Management Protocol (SMP) over Bluetooth.

--- a/doc/nrf/app_dev/device_guides/nrf53/fota_update_nrf5340.rst
+++ b/doc/nrf/app_dev/device_guides/nrf53/fota_update_nrf5340.rst
@@ -16,6 +16,9 @@ FOTA updates with nRF5340 DK
 FOTA over Bluetooth Low Energy
 ******************************
 
+.. note::
+   |bluetooth_fota_note|
+
 .. include:: /app_dev/device_guides/nrf52/fota_update.rst
    :start-after: fota_upgrades_over_ble_intro_start
    :end-before: fota_upgrades_over_ble_intro_end

--- a/doc/nrf/app_dev/device_guides/nrf54l/fota_update.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/fota_update.rst
@@ -27,6 +27,9 @@ For more information about introducing immutable MCUboot bootloader, refer to :r
 FOTA over Bluetooth Low Energy
 ******************************
 
+.. note::
+   |bluetooth_fota_note|
+
 .. fota_upgrades_over_ble_intro_start
 
 FOTA updates are supported using MCUmgr's Simple Management Protocol (SMP) over Bluetooth®.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1644,7 +1644,7 @@
 .. _`nRF Cloud Preconnect Provisioning`: https://docs.nordicsemi.com/bundle/nrf-cloud/page/Devices/Associations/Onboarding.html#preconnect-onboarding
 .. _`nRF Cloud Onboarding`:
 .. _`nRF Cloud Provisioning`: https://docs.nordicsemi.com/bundle/nrf-cloud/page/SecurityServices/ProvisioningService/ProvisioningOverview.html
-.. _`nRF Cloud FOTA`: https://docs.nordicsemi.com/bundle/nrf-cloud/page/Devices/FirmwareUpdate/FOTAOverview.html
+.. _`nRF Cloud FOTA`: https://docs.nrfcloud.com/docs/nrfcloud/fota-overview
 .. _`nRF Cloud MQTT FOTA`: https://docs.nordicsemi.com/bundle/nrf-cloud/page/Devices/FirmwareUpdate/FOTAOverview.html#mqtt-job-execution-notifications
 .. _`nRF Cloud Getting Started FOTA documentation`: https://docs.nordicsemi.com/bundle/nrf-cloud/page/Devices/FirmwareUpdate/FOTATutorial.html
 .. _`Securely generating credentials`: https://docs.nordicsemi.com/bundle/nrf-cloud/page/Devices/Security/Credentials.html

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -66,6 +66,10 @@
 
 .. |open_terminal_window_with_environment| replace:: Start the :ref:`toolchain environment <using_toolchain_environment>` in a terminal window.
 
+.. |bluetooth_fota_note| replace:: The Bluetooth LE FOTA method is suited for local, proximity-based updates.
+   For production fleet management where you need to manage update rollouts across large production fleets, target specific device cohorts, monitor update progress, and roll back on failure, you can use nRF Cloud powered by Memfault to manage FOTA updates remotely from the cloud.
+   See `nRF Cloud FOTA`_ for further details on nRF Cloud FOTA.
+
 .. ### Board shortcuts
 
 .. |nRF5340DKnoref| replace:: nRF5340 DK board (PCA10095)


### PR DESCRIPTION
As requested by the nRF Cloud/Memfault team, added a bit of text about Bluetooth LE FOTA and a link to the new Cloud docs site.