### PR TITLE
doc: Add HVAC Integration NLC Profile 1.0 to Bluetooth Mesh overview

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1324,6 +1324,7 @@
 .. _`Basic Scene Selector NLC Profile`: https://www.bluetooth.com/specifications/specs/bssnlcp-1-0-1/
 .. _`Dimming Control NLC Profile`: https://www.bluetooth.com/specifications/specs/dicnlcp-1-0-1/
 .. _`Energy Monitor NLC Profile`: https://www.bluetooth.com/specifications/specs/enmnlcp-1-0-1/
+.. _`HVAC Integration NLC Profile`: https://www.bluetooth.com/specifications/specs/hvac-integration-nlc-profile/
 .. _`Occupancy Sensor NLC Profile`: https://www.bluetooth.com/specifications/specs/ocsnlcp-1-0-1/
 .. _`Bluetooth Mesh model overview`: https://www.bluetooth.com/bluetooth-resources/bluetooth-mesh-models/
 .. _`Bluetooth Mesh glossary`: https://www.bluetooth.com/learn-about-bluetooth/recent-enhancements/mesh/mesh-glossary/

--- a/doc/nrf/protocols/bt/bt_mesh/overview/index.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/overview/index.rst
@@ -29,6 +29,7 @@ The Bluetooth Mesh technology is covered by the following set of specifications:
 * `Basic Scene Selector NLC Profile`_ v1.0.1
 * `Dimming Control NLC Profile`_ v1.0.1
 * `Energy Monitor NLC Profile`_ v1.0.1
+* `HVAC Integration NLC Profile`_ v1.0
 * `Occupancy Sensor NLC Profile`_ v1.0.1
 
 Bluetooth Mesh in the |NCS| supports all mandatory features and almost all optional features of the `Bluetooth Mesh protocol specification`_.

--- a/doc/nrf/protocols/bt/bt_mesh/overview/nlc.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/overview/nlc.rst
@@ -4,7 +4,7 @@ Bluetooth Networked Lighting Control profiles
 #############################################
 
 Bluetooth® Networked Lighting Control (NLC) profiles are a set of device profiles built on top of the Bluetooth Mesh protocol, specified by the Bluetooth Special Interest Group (SIG) in the `Bluetooth NLC profile specifications`_.
-The NLC profiles can be used to implement interoperable network controlled lighting setups, including sensors, light fixtures, energy monitoring, scene selectors and dimmer controls.
+The NLC profiles can be used to implement interoperable network controlled lighting setups, including sensors, light fixtures, energy monitoring, scene selectors, dimmer controls, and HVAC integration.
 Each of the profiles specifies a set of models and a set of performance parameters.
 
 Multiple NLC profiles can be combined on a single device.


### PR DESCRIPTION
List the SIG HVAC Integration NLC Profile alongside other NLC specs, add the specification link, and mention HVAC in the NLC profiles page.