### PR TITLE
tests: bluetooth: mesh: models test without pm

### DIFF
--- a/tests/subsys/bluetooth/mesh/models/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/bluetooth/mesh/models/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x00000000 0x000f0000>;
+		};
+
+		storage_partition: partition@f0000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x000f0000 0x00008000>;
+		};
+
+		emds_partition_0: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
+			label = "emds-0";
+			reg = <0x000f8000 0x00004000>;
+		};
+
+		emds_partition_1: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
+			label = "emds-1";
+			reg = <0x000fc000 0x00004000>;
+		};
+	};
+};


### PR DESCRIPTION
Commit fixes building mesh model unit test with emds without the partition manager.