### PR TITLE
tests: benchmarks: peripheral_load: reorganize sample.yaml

### DIFF
--- a/tests/benchmarks/peripheral_load/sample.yaml
+++ b/tests/benchmarks/peripheral_load/sample.yaml
@@ -455,7 +455,7 @@ tests:
     integration_platforms:
       - nrf54ls05dk/nrf54ls05b/cpuapp
 
-  sample.benchmarks.peripheral_stress_test.nrf54lv10:
+  sample.benchmarks.peripheral_stress_test.nrf54lv10_lc10:
     filter: not CONFIG_COVERAGE
     harness_config:
       type: multi_line
@@ -477,10 +477,11 @@ tests:
       - CONFIG_PWM=n
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     integration_platforms:
       - nrf54lv10dk/nrf54lv10a/cpuapp
 
-  sample.benchmarks.peripheral_stress_test.nrf54lv10.mcuboot:
+  sample.benchmarks.peripheral_stress_test.nrf54lv10_lc10.mcuboot:
     filter: not CONFIG_COVERAGE
     harness_config:
       type: multi_line
@@ -505,93 +506,11 @@ tests:
       - mcuboot_CONFIG_FPROTECT=n
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     integration_platforms:
       - nrf54lv10dk/nrf54lv10a/cpuapp
 
-  sample.benchmarks.peripheral_stress_test.nrf54lv10.mcuboot.lto:
-    filter: not CONFIG_COVERAGE
-    harness_config:
-      type: multi_line
-      ordered: false
-      regex:
-        - ".*ADC thread has completed"
-        - ".*Counter thread has completed"
-        - ".*GPIO thread has completed"
-        - ".*TEMP thread has completed"
-        - ".*Timer thread has completed"
-        - ".*WDT thread has completed"
-        - ".*CPU load thread has completed"
-        - ".*Bluetooth init OK"
-        - ".*all \\d{1,} threads have completed"
-    extra_args:
-      - CONFIG_CAN=n
-      - CONFIG_FLASH=n
-      - CONFIG_I2S=n
-      - CONFIG_PWM=n
-      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
-      # Disabled FPROTECT does not affect benchmarks
-      - mcuboot_CONFIG_FPROTECT=n
-      - CONFIG_LTO=y
-      - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
-    platform_allow:
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-    integration_platforms:
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-
-  sample.benchmarks.peripheral_stress_test.nrf54lc10:
-    filter: not CONFIG_COVERAGE
-    harness_config:
-      type: multi_line
-      ordered: false
-      regex:
-        - ".*ADC thread has completed"
-        - ".*Counter thread has completed"
-        - ".*GPIO thread has completed"
-        - ".*TEMP thread has completed"
-        - ".*Timer thread has completed"
-        - ".*WDT thread has completed"
-        - ".*CPU load thread has completed"
-        - ".*Bluetooth init OK"
-        - ".*all \\d{1,} threads have completed"
-    extra_args:
-      - CONFIG_CAN=n
-      - CONFIG_FLASH=n
-      - CONFIG_I2S=n
-      - CONFIG_PWM=n
-    platform_allow:
-      - nrf54lc10dk/nrf54lc10a/cpuapp
-    integration_platforms:
-      - nrf54lc10dk/nrf54lc10a/cpuapp
-
-  sample.benchmarks.peripheral_stress_test.nrf54lc10.mcuboot:
-    filter: not CONFIG_COVERAGE
-    harness_config:
-      type: multi_line
-      ordered: false
-      regex:
-        - ".*ADC thread has completed"
-        - ".*Counter thread has completed"
-        - ".*GPIO thread has completed"
-        - ".*TEMP thread has completed"
-        - ".*Timer thread has completed"
-        - ".*WDT thread has completed"
-        - ".*CPU load thread has completed"
-        - ".*Bluetooth init OK"
-        - ".*all \\d{1,} threads have completed"
-    extra_args:
-      - CONFIG_CAN=n
-      - CONFIG_FLASH=n
-      - CONFIG_I2S=n
-      - CONFIG_PWM=n
-      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
-      # Disabled FPROTECT does not affect benchmarks
-      - mcuboot_CONFIG_FPROTECT=n
-    platform_allow:
-      - nrf54lc10dk/nrf54lc10a/cpuapp
-    integration_platforms:
-      - nrf54lc10dk/nrf54lc10a/cpuapp
-
-  sample.benchmarks.peripheral_stress_test.nrf54lc10.mcuboot.lto:
+  sample.benchmarks.peripheral_stress_test.nrf54lv10_lc10.mcuboot.lto:
     filter: not CONFIG_COVERAGE
     harness_config:
       type: multi_line
@@ -617,6 +536,7 @@ tests:
       - CONFIG_LTO=y
       - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
     platform_allow:
+      - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
     integration_platforms:
-      - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp


### PR DESCRIPTION
reorganize entries in sample.yaml, create common configuration for nrf54lv10 and nrf54lc10 targets.