### PR TITLE
tests: drivers: i2c: i2c_latency: Change pins for nrf9251dk

### DIFF
--- a/tests/drivers/i2c/i2c_latency/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_latency/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,6 +1,6 @@
 /* Test requires two loopbacks:
- * - P2.01 - P2.02,
- * - P2.03 - P2.09.
+ * - P1.00 - P1.01,
+ * - P1.04 - P1.11.
  */
 
 / {
@@ -13,31 +13,31 @@
 &pinctrl {
 	i2c130_default_alt: i2c130_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 2, 3)>,
-				<NRF_PSEL(TWIM_SCL, 2, 1)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
+				<NRF_PSEL(TWIM_SCL, 1, 0)>;
 		};
 	};
 
 	i2c130_sleep_alt: i2c130_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 2, 3)>,
-				<NRF_PSEL(TWIM_SCL, 2, 1)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
+				<NRF_PSEL(TWIM_SCL, 1, 0)>;
 			low-power-enable;
 		};
 	};
 
 	i2c131_default_alt: i2c131_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
-				<NRF_PSEL(TWIM_SCL, 2, 2)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+				<NRF_PSEL(TWIM_SCL, 1, 1)>;
 			bias-pull-up;
 		};
 	};
 
 	i2c131_sleep_alt: i2c131_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
-				<NRF_PSEL(TWIM_SCL, 2, 2)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+				<NRF_PSEL(TWIM_SCL, 1, 1)>;
 			low-power-enable;
 		};
 	};

--- a/tests/drivers/i2c/i2c_latency/src/main.c
+++ b/tests/drivers/i2c/i2c_latency/src/main.c
@@ -14,7 +14,6 @@
 #include <nrfx_twis.h>
 
 #include <zephyr/drivers/counter.h>
-#include <dk_buttons_and_leds.h>
 
 #include <zephyr/ztest.h>
 
@@ -161,9 +160,7 @@ static void *test_setup(void)
 	int ret;
 
 	zassert_true(device_is_ready(fixture.dev), "TWIM device is not ready");
-	zassert_equal(dk_leds_init(), 0, "DK leds init failed");
 
-	dk_set_led_off(DK_LED1);
 	zassert_equal(0, nrfx_twis_init(&twis, &config, i2s_slave_handler),
 		      "TWIS initialization failed");
 
@@ -227,11 +224,9 @@ static void test_i2c_read_latency(size_t buffer_size, uint8_t i2c_speed_setting)
 	for (uint32_t repeat_counter = 0; repeat_counter < MEASUREMENT_REPEATS; repeat_counter++) {
 		memset(fixture.slave_buffer, 0, buffer_size);
 		counter_reset(tst_timer_dev);
-		dk_set_led_on(DK_LED1);
 		counter_start(tst_timer_dev);
 		ret = i2c_read(fixture.dev, fixture.master_buffer, buffer_size, fixture.addr);
 		counter_get_value(tst_timer_dev, &tst_timer_value);
-		dk_set_led_off(DK_LED1);
 		counter_stop(tst_timer_dev);
 		timer_value_us[repeat_counter] =
 			counter_ticks_to_us(tst_timer_dev, tst_timer_value);
@@ -275,11 +270,9 @@ static void test_i2c_write_latency(size_t buffer_size, uint8_t i2c_speed_setting
 	for (uint32_t repeat_counter = 0; repeat_counter < MEASUREMENT_REPEATS; repeat_counter++) {
 		memset(fixture.slave_buffer, 0, buffer_size);
 		counter_reset(tst_timer_dev);
-		dk_set_led_on(DK_LED1);
 		counter_start(tst_timer_dev);
 		ret = i2c_write(fixture.dev, fixture.master_buffer, buffer_size, fixture.addr);
 		counter_get_value(tst_timer_dev, &tst_timer_value);
-		dk_set_led_off(DK_LED1);
 		counter_stop(tst_timer_dev);
 		timer_value_us[repeat_counter] =
 			counter_ticks_to_us(tst_timer_dev, tst_timer_value);


### PR DESCRIPTION
Use different pins for nrf9251dk as pin 2.3 and 2.9 are used for LEDs and they have additional external registers connected which impacts the test at higher I2C speeds.

Additionally, remove use of LEDs in the test as they may conflict with the pins used by the test.