### PR TITLE
tests: nrf_cloud: codec/cbor: Fix build after REST removal

### DIFF
--- a/include/net/nrf_cloud_coap.h
+++ b/include/net/nrf_cloud_coap.h
@@ -27,15 +27,18 @@ struct nrf_cloud_coap_pgps_request;
 struct nrf_cloud_pgps_result;
 #endif
 #include <net/nrf_cloud_codec.h>
-#if defined(CONFIG_NRF_CLOUD_COAP)
+/* <zephyr/net/coap.h> is always available and provides
+ * enum coap_content_format. <zephyr/net/coap_client.h> requires
+ * CONFIG_COAP_CLIENT_* symbols that only exist when CoAP client is
+ * enabled, so it is only pulled in when this library is built with
+ * CoAP support.
+ */
 #include <zephyr/net/coap.h>
+#if defined(CONFIG_NRF_CLOUD_COAP)
 #include <zephyr/net/coap_client.h>
 #else
 /* Work around missing Kconfigs upstream in coap_client.h */
 #define coap_client_response_cb_t void *
-enum coap_content_format {
-	dummy
-};
 struct coap_client {};
 struct coap_client_option {};
 #endif

--- a/include/net/nrf_cloud_pgps.h
+++ b/include/net/nrf_cloud_pgps.h
@@ -113,15 +113,18 @@ struct nrf_cloud_pgps_result {
 	size_t path_sz;
 };
 
-#if defined(CONFIG_NRF_CLOUD_COAP)
-/** @brief Data required for nRF Cloud Predicted GPS (P-GPS) request */
+/** @brief Data required for nRF Cloud Predicted GPS (P-GPS) request.
+ *
+ * Defined here unconditionally so callers can construct a P-GPS request
+ * via @ref nrf_cloud_coap_pgps_url_get without depending on the full
+ * CoAP transport machinery being enabled.
+ */
 struct nrf_cloud_coap_pgps_request {
 	/** Data to be included in the P-GPS request. To omit an item
 	 * use the appropriate `NRF_CLOUD_PGPS_REQ_NO_` define.
 	 */
 	const struct gps_pgps_request *pgps_req;
 };
-#endif /* CONFIG_NRF_CLOUD_COAP */
 
 /** @brief P-GPS error code: current time unknown. */
 #define ETIMEUNKNOWN	8000

--- a/tests/subsys/net/lib/nrf_cloud/codec/cbor/src/fakes.c
+++ b/tests/subsys/net/lib/nrf_cloud/codec/cbor/src/fakes.c
@@ -19,7 +19,7 @@
  *   - nrf_cloud_calloc / nrf_cloud_free / nrf_cloud_malloc  (link-time deps)
  *
  * The remaining symbols (nrf_cloud_encode_message, nrf_cloud_error_msg_decode,
- * nrf_cloud_rest_fota_execution_decode) are only reachable via JSON paths that
+ * nrf_cloud_coap_fota_execution_decode) are only reachable via JSON paths that
  * the CBOR tests do not exercise; they are stubbed out with safe no-op or
  * error-returning implementations so that the linker is satisfied.
  *
@@ -89,7 +89,7 @@ int nrf_cloud_error_msg_decode(const char *const buf, const char *const app_id,
 	return -ENOENT;
 }
 
-int nrf_cloud_rest_fota_execution_decode(const char *const response,
+int nrf_cloud_coap_fota_execution_decode(const char *const response,
 					 struct nrf_cloud_fota_job_info *const job)
 {
 	ARG_UNUSED(response);
@@ -99,7 +99,7 @@ int nrf_cloud_rest_fota_execution_decode(const char *const response,
 
 /* -------------------------------------------------------------------------
  * nrf_cloud_agnss_type_array_get — called in the CBOR path of
- * coap_codec_agnss_encode when type == NRF_CLOUD_REST_AGNSS_REQ_CUSTOM.
+ * coap_codec_agnss_encode when type == NRF_CLOUD_COAP_AGNSS_REQ_CUSTOM.
  *
  * The real implementation parses an nrf_modem_gnss_agnss_data_frame bitmask
  * and fills in an array of nrf_cloud_agnss_type values.  For unit testing

--- a/tests/subsys/net/lib/nrf_cloud/codec/cbor/src/main.c
+++ b/tests/subsys/net/lib/nrf_cloud/codec/cbor/src/main.c
@@ -41,8 +41,9 @@
  */
 #include <net/nrf_cloud_codec.h>
 #include <net/nrf_cloud_location.h>   /* lte_lc.h, wifi_location_common.h, nrf_cloud.h */
-#include <net/nrf_cloud_rest.h>        /* nrf_cloud_rest_agnss_request/result */
 #include <net/nrf_cloud_pgps.h>        /* nrf_cloud_pgps_result, gps_pgps_request */
+/* nrf_cloud_coap_agnss_request/result, nrf_cloud_coap_pgps_request */
+#include <net/nrf_cloud_coap.h>
 #include <nrf_modem_gnss.h>            /* struct nrf_modem_gnss_agnss_data_frame */
 #include <zephyr/net/coap.h>           /* COAP_CONTENT_FORMAT_* */
 #include "coap_codec.h"
@@ -486,8 +487,8 @@ ZTEST(coap_cbor_agnss, test_encode_custom_type)
 	 * because our stub ignores the content and returns fixed types.
 	 */
 	struct nrf_modem_gnss_agnss_data_frame agnss_data = {0};
-	struct nrf_cloud_rest_agnss_request request = {
-		.type = NRF_CLOUD_REST_AGNSS_REQ_CUSTOM,
+	struct nrf_cloud_coap_agnss_request request = {
+		.type = NRF_CLOUD_COAP_AGNSS_REQ_CUSTOM,
 		.agnss_req = &agnss_data,
 		.net_info = NULL,
 		.filtered = false,
@@ -514,8 +515,8 @@ ZTEST(coap_cbor_agnss, test_encode_with_net_info_and_filter)
 			.rsrp = 50,  /* != LTE_LC_CELL_RSRP_INVALID */
 		},
 	};
-	struct nrf_cloud_rest_agnss_request request = {
-		.type = NRF_CLOUD_REST_AGNSS_REQ_CUSTOM,
+	struct nrf_cloud_coap_agnss_request request = {
+		.type = NRF_CLOUD_COAP_AGNSS_REQ_CUSTOM,
 		.agnss_req = &agnss_data,
 		.net_info = &net_info,
 		.filtered = true,
@@ -533,8 +534,8 @@ ZTEST(coap_cbor_agnss, test_encode_non_custom_type_returns_enotsup)
 	uint8_t buf[AGNSS_GET_CBOR_MAX_SIZE];
 	size_t len = sizeof(buf);
 	struct nrf_modem_gnss_agnss_data_frame agnss_data = {0};
-	struct nrf_cloud_rest_agnss_request request = {
-		.type = NRF_CLOUD_REST_AGNSS_REQ_ASSISTANCE,  /* not CUSTOM */
+	struct nrf_cloud_coap_agnss_request request = {
+		.type = NRF_CLOUD_COAP_AGNSS_REQ_ASSISTANCE,  /* not CUSTOM */
 		.agnss_req = &agnss_data,
 	};
 
@@ -548,8 +549,8 @@ ZTEST(coap_cbor_agnss, test_encode_invalid_fmt_returns_enotsup)
 	uint8_t buf[AGNSS_GET_CBOR_MAX_SIZE];
 	size_t len = sizeof(buf);
 	struct nrf_modem_gnss_agnss_data_frame agnss_data = {0};
-	struct nrf_cloud_rest_agnss_request request = {
-		.type = NRF_CLOUD_REST_AGNSS_REQ_CUSTOM,
+	struct nrf_cloud_coap_agnss_request request = {
+		.type = NRF_CLOUD_COAP_AGNSS_REQ_CUSTOM,
 		.agnss_req = &agnss_data,
 	};
 
@@ -562,7 +563,7 @@ ZTEST(coap_cbor_agnss, test_decode_cbor_fmt_returns_enotsup)
 	/* A-GNSS responses are binary octet-stream, not CBOR.
 	 * Passing CBOR format must return -ENOTSUP.
 	 */
-	struct nrf_cloud_rest_agnss_result result = {0};
+	struct nrf_cloud_coap_agnss_result result = {0};
 	const uint8_t dummy[] = {0x01, 0x02};
 
 	zassert_equal(coap_codec_agnss_resp_decode(&result, dummy, sizeof(dummy),
@@ -576,7 +577,7 @@ ZTEST(coap_cbor_agnss, test_decode_octet_stream)
 	 */
 	static const uint8_t payload[] = {0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04};
 	uint8_t out[sizeof(payload)];
-	struct nrf_cloud_rest_agnss_result result = {
+	struct nrf_cloud_coap_agnss_result result = {
 		.buf = out,
 		.buf_sz = sizeof(out),
 	};
@@ -592,7 +593,7 @@ ZTEST(coap_cbor_agnss, test_decode_octet_stream_truncated)
 	/* When result->buf_sz < response length the data is truncated to buf_sz. */
 	static const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04, 0x05};
 	uint8_t out[3];
-	struct nrf_cloud_rest_agnss_result result = {
+	struct nrf_cloud_coap_agnss_result result = {
 		.buf = out,
 		.buf_sz = sizeof(out),
 	};
@@ -621,7 +622,7 @@ ZTEST(coap_cbor_pgps, test_encode_valid)
 		.gps_day = 3000,
 		.gps_time_of_day = 43200,
 	};
-	struct nrf_cloud_rest_pgps_request request = {
+	struct nrf_cloud_coap_pgps_request request = {
 		.pgps_req = &pgps_req,
 	};
 
@@ -642,7 +643,7 @@ ZTEST(coap_cbor_pgps, test_encode_invalid_fmt_returns_enotsup)
 		.gps_day = 1,
 		.gps_time_of_day = 0,
 	};
-	struct nrf_cloud_rest_pgps_request request = {.pgps_req = &pgps_req};
+	struct nrf_cloud_coap_pgps_request request = {.pgps_req = &pgps_req};
 
 	zassert_equal(coap_codec_pgps_encode(&request, buf, &len,
 					     COAP_CONTENT_FORMAT_APP_JSON), -ENOTSUP);
@@ -658,7 +659,7 @@ ZTEST(coap_cbor_pgps, test_encode_buf_too_small)
 		.gps_day = 3000,
 		.gps_time_of_day = 43200,
 	};
-	struct nrf_cloud_rest_pgps_request request = {.pgps_req = &pgps_req};
+	struct nrf_cloud_coap_pgps_request request = {.pgps_req = &pgps_req};
 
 	zassert_equal(coap_codec_pgps_encode(&request, buf, &len,
 					     COAP_CONTENT_FORMAT_APP_CBOR), -EINVAL);


### PR DESCRIPTION
The CBOR codec unit-test PR (#27892) and the REST removal PR (#28522) were merged independently and produced a semantic conflict that left net.lib.nrf_cloud.codec.cbor failing to build on main:

  * The test referenced REST types (nrf_cloud_rest_agnss_request, nrf_cloud_rest_pgps_request, nrf_cloud_rest_agnss_result, NRF_CLOUD_REST_AGNSS_REQ_*, nrf_cloud_rest_fota_execution_decode) that were renamed to their nrf_cloud_coap_* counterparts by the REST removal.

  * The REST removal made coap_codec.h transitively pull in net/nrf_cloud_coap.h. Its CoAP-disabled fallback redefined enum coap_content_format, conflicting with zephyr/net/coap.h that the test (and the codec source) include directly.

  * struct nrf_cloud_coap_pgps_request was gated on CONFIG_NRF_CLOUD_COAP in net/nrf_cloud_pgps.h, so building any codec consumer with PGPS but without COAP left the struct undeclared.

Fixes applied:
  * Rename REST types in the test sources to their nrf_cloud_coap_* equivalents.
  * In nrf_cloud_coap.h, include zephyr/net/coap.h unconditionally so enum coap_content_format always comes from the canonical Zephyr header. Only zephyr/net/coap_client.h stays gated on CONFIG_NRF_CLOUD_COAP since it requires CONFIG_COAP_CLIENT_*.
  * In nrf_cloud_pgps.h, define struct nrf_cloud_coap_pgps_request unconditionally - it is a pure data carrier and does not require any CoAP machinery.

Verified: net.lib.nrf_cloud.codec.cbor and net.lib.nrf_cloud.codec.json both pass on native_sim and qemu_cortex_m3 (266/266 test cases).