### PR TITLE
doc: supl: Add note about usage with the nRF Cloud CoAP library

### DIFF
--- a/doc/nrf/libraries/others/supl_os_client.rst
+++ b/doc/nrf/libraries/others/supl_os_client.rst
@@ -104,6 +104,10 @@ See :ref:`configure_application` for information on how to change configuration 
 
    SUPL client library v0.8.0 or later is required when picolibc is used.
 
+.. note::
+
+   SUPL client library usage with the :ref:`lib_nrf_cloud_coap` library enabled is not supported.
+
 Resource initialization and ownership
 =====================================
 


### PR DESCRIPTION
Added a note that the SUPL client library can not be used when the nRF CLoud CoAP library is enabled.