### PR TITLE
Bluetooth: Mesh: Remove stale PM references in docs

### DIFF
--- a/doc/nrf/includes/mesh_ext_flash_settings.txt
+++ b/doc/nrf/includes/mesh_ext_flash_settings.txt
@@ -29,5 +29,5 @@ For :ref:`ZMS <zephyr:zms_api>` backend:
 
 The sector size depends on the flash memory layout.
 
-Apart from this, the allocated partitions are managed by the :ref:`partition_manager`.
-It is required that the size of the partition allocated by the partition manager must be equal to the memory size configured for the settings subsystem.
+Apart from this, the allocated partitions are defined in a devicetree (DTS) overlay file.
+The size of the ``storage_partition`` node defined in the DTS overlay must be equal to the memory size configured for the settings subsystem.

--- a/doc/nrf/protocols/bt/bt_mesh/configuring.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/configuring.rst
@@ -68,8 +68,6 @@ The provided values are meant as suggestions only, and should be individually ad
 * :kconfig:option:`CONFIG_HWINFO` - Enables the hardware information driver.
   The hardware information driver must be enabled to perform provisioning of the device.
   See the UUID section of :ref:`bt_mesh_dk_prov`.
-* :kconfig:option:`CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE` - Sets the size of the partition used for settings storage.
-  Use the option to increase the size if necessary.
 * :kconfig:option:`CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE` - Enables partial erase on supported hardware platforms.
   Partial erase allows the flash page erase operation to be split into several small chunks preventing longer CPU stalls.
   This improves responsiveness of a mesh node during the defragmentation of storage areas used by the settings subsystem.

--- a/samples/bluetooth/mesh/dfu/target/README.rst
+++ b/samples/bluetooth/mesh/dfu/target/README.rst
@@ -179,11 +179,8 @@ Only 2 options are supported by this sample:
 .. note::
    To create the new Composition Data and see the :c:enum:`BT_MESH_DFU_EFFECT_UNPROV` effect, you can, for example, turn off the Friend feature in the :file:`prj.conf` file by setting the :kconfig:option:`CONFIG_BT_MESH_FRIEND` option to ``n``.
 
-In this sample, the device flash is split into partitions using the :ref:`partition_manager`.
+In this sample, the device flash is split into partitions using DTS overlays.
 When the DFU transfer starts, the sample stores the new firmware at the MCUboot secondary slot using the :ref:`zephyr:flash_map_api`.
-
-.. note::
-   For the :zephyr:board:`nrf52840dongle`, the sample has a static partition management file :file:`pm_static_nrf52840dongle_nrf52840.yml` to reserve the space for the `nRF5 SDK Bootloader`_.
 
 When the DFU transfer ends, the sample requests the MCUboot to replace slot-0 with slot-1 and reboots the device.
 The MCUboot performs the validation of the image located at slot-1.


### PR DESCRIPTION
This removes references to Partition Manager from various locations in the Mesh-related documentation. Partition Manager is no longer used, and the documentation is updated to reflect this.

(Do note that the Thingy53 platform still uses Partition Manager, but we don't support external flash in any sample on this platform so this is not relevant to the changes in this PR)