### PR TITLE
samples: cellular: modem_shell: Add support for new GNSS features

### DIFF
--- a/samples/cellular/modem_shell/src/gnss/gnss.c
+++ b/samples/cellular/modem_shell/src/gnss/gnss.c
@@ -96,6 +96,7 @@ static bool agnss_inject_neq = true;
 static bool agnss_inject_time = true;
 static bool agnss_inject_pos = true;
 static bool agnss_inject_int = true;
+static bool agnss_inject_ggto = true;
 #endif /* CONFIG_NRF_CLOUD_AGNSS || CONFIG_SUPL_CLIENT_LIB */
 
 #if defined(CONFIG_NRF_CLOUD_AGNSS) && !defined(CONFIG_NRF_CLOUD_MQTT) && \
@@ -128,7 +129,7 @@ struct event_item {
 	void    *data;
 };
 
-K_MSGQ_DEFINE(gnss_event_msgq, sizeof(struct event_item), 10, 4);
+K_MSGQ_DEFINE(gnss_event_msgq, sizeof(struct event_item), 30, 4);
 
 /* Output configuration */
 static uint8_t pvt_output_level = 2;
@@ -233,6 +234,7 @@ static void gnss_event_handler(int event_id)
 	err = k_msgq_put(&gnss_event_msgq, &event, K_NO_WAIT);
 	if (err) {
 		/* Failed to put event into queue */
+		mosh_warn("GNSS: Event msgq full");
 		k_free(event.data);
 	}
 }
@@ -629,6 +631,10 @@ static void get_filtered_agnss_request(struct nrf_modem_gnss_agnss_data_frame *a
 	if (agnss_inject_int) {
 		agnss_request->data_flags |=
 			agnss_need.data_flags & NRF_MODEM_GNSS_AGNSS_INTEGRITY_REQUEST;
+	}
+	if (agnss_inject_ggto) {
+		agnss_request->data_flags |=
+			agnss_need.data_flags & NRF_MODEM_GNSS_AGNSS_GGTO_REQUEST;
 	}
 }
 
@@ -1358,6 +1364,66 @@ int gnss_set_nmea_mask(uint16_t nmea_mask)
 	return err;
 }
 
+int gnss_set_nmea_talker_mode(enum gnss_nmea_talker_mode talker_mode)
+{
+	int err;
+	uint8_t mode;
+
+	gnss_api_init();
+
+	switch (talker_mode) {
+	case GNSS_NMEA_TALKER_MODE_STANDARD:
+		mode = NRF_MODEM_GNSS_NMEA_TALKER_MODE_STANDARD;
+		break;
+
+	case GNSS_NMEA_TALKER_MODE_GP_ONLY:
+		mode = NRF_MODEM_GNSS_NMEA_TALKER_MODE_GP_ONLY;
+		break;
+
+	default:
+		mosh_error("GNSS: Invalid NMEA talker mode value %d", talker_mode);
+		return -EINVAL;
+	}
+
+	err = nrf_modem_gnss_nmea_talker_mode_set(mode);
+	if (err) {
+		mosh_error("GNSS: Failed to set NMEA talker mode, error: %d (%s)",
+			   err, gnss_err_to_str(err));
+	}
+
+	return err;
+}
+
+int gnss_set_nmea_qzss_mode(enum gnss_nmea_qzss_mode nmea_mode)
+{
+	int err;
+	uint8_t mode;
+
+	gnss_api_init();
+
+	switch (nmea_mode) {
+	case GNSS_NMEA_QZSS_MODE_STANDARD:
+		mode = NRF_MODEM_GNSS_QZSS_NMEA_MODE_STANDARD;
+		break;
+
+	case GNSS_NMEA_QZSS_MODE_CUSTOM:
+		mode = NRF_MODEM_GNSS_QZSS_NMEA_MODE_CUSTOM;
+		break;
+
+	default:
+		mosh_error("GNSS: Invalid QZSS NMEA mode value %d", nmea_mode);
+		return -EINVAL;
+	}
+
+	err = nrf_modem_gnss_qzss_nmea_mode_set(mode);
+	if (err) {
+		mosh_error("GNSS: Failed to set QZSS NMEA mode, error: %d (%s)",
+			   err, gnss_err_to_str(err));
+	}
+
+	return err;
+}
+
 int gnss_set_priority_time_windows(bool value)
 {
 	int err;
@@ -1406,36 +1472,6 @@ int gnss_set_dynamics_mode(enum gnss_dynamics_mode mode)
 	err = nrf_modem_gnss_dyn_mode_change(dynamics_mode);
 	if (err) {
 		mosh_error("GNSS: Failed to change dynamics mode, error: %d (%s)",
-			   err, gnss_err_to_str(err));
-	}
-
-	return err;
-}
-
-int gnss_set_qzss_nmea_mode(enum gnss_qzss_nmea_mode mode)
-{
-	int err;
-	uint8_t nmea_mode;
-
-	gnss_api_init();
-
-	switch (mode) {
-	case GNSS_QZSS_NMEA_MODE_STANDARD:
-		nmea_mode = NRF_MODEM_GNSS_QZSS_NMEA_MODE_STANDARD;
-		break;
-
-	case GNSS_QZSS_NMEA_MODE_CUSTOM:
-		nmea_mode = NRF_MODEM_GNSS_QZSS_NMEA_MODE_CUSTOM;
-		break;
-
-	default:
-		mosh_error("GNSS: Invalid QZSS NMEA mode value %d", mode);
-		return -EINVAL;
-	}
-
-	err = nrf_modem_gnss_qzss_nmea_mode_set(nmea_mode);
-	if (err) {
-		mosh_error("GNSS: Failed to set QZSS NMEA mode, error: %d (%s)",
 			   err, gnss_err_to_str(err));
 	}
 
@@ -1518,8 +1554,8 @@ int gnss_set_timing_source(enum gnss_timing_source source)
 	return err;
 }
 
-int gnss_set_agnss_data_enabled(bool ephe, bool alm, bool utc, bool klob,
-				bool neq, bool time, bool pos, bool integrity)
+int gnss_set_agnss_data_enabled(bool ephe, bool alm, bool utc, bool klob, bool neq,
+				bool time, bool pos, bool integrity, bool ggto)
 {
 #if defined(CONFIG_NRF_CLOUD_AGNSS) || defined(CONFIG_SUPL_CLIENT_LIB)
 	agnss_inject_ephe = ephe;
@@ -1530,6 +1566,7 @@ int gnss_set_agnss_data_enabled(bool ephe, bool alm, bool utc, bool klob,
 	agnss_inject_time = time;
 	agnss_inject_pos = pos;
 	agnss_inject_int = integrity;
+	agnss_inject_ggto = ggto;
 
 	return 0;
 #else
@@ -1552,25 +1589,11 @@ int gnss_set_agnss_automatic(bool value)
 #endif
 }
 
-#if defined(CONFIG_NRF_CLOUD_AGNSS)
-static bool qzss_assistance_is_supported(void)
-{
-	char resp[32];
-
-	if (nrf_modem_at_cmd(resp, sizeof(resp), "AT+CGMM") == 0) {
-		/* nRF9160 does not support QZSS assistance, while nRF91x1 do. */
-		if (strstr(resp, "nRF9160") != NULL) {
-			return false;
-		}
-	}
-
-	return true;
-}
-#endif /* CONFIG_NRF_CLOUD_AGNSS */
-
 int gnss_inject_agnss_data(void)
 {
 #if defined(CONFIG_NRF_CLOUD_AGNSS) || defined(CONFIG_SUPL_CLIENT_LIB)
+	uint8_t system_count = 0;
+
 	gnss_api_init();
 
 	/* Pretend modem requested all A-GNSS data */
@@ -1581,18 +1604,27 @@ int gnss_inject_agnss_data(void)
 		NRF_MODEM_GNSS_AGNSS_GPS_SYS_TIME_AND_SV_TOW_REQUEST |
 		NRF_MODEM_GNSS_AGNSS_POSITION_REQUEST |
 		NRF_MODEM_GNSS_AGNSS_INTEGRITY_REQUEST;
-	agnss_need.system_count = 1;
-	agnss_need.system[0].system_id = NRF_MODEM_GNSS_SYSTEM_GPS;
-	agnss_need.system[0].sv_mask_ephe = 0xffffffff;
-	agnss_need.system[0].sv_mask_alm = 0xffffffff;
+	agnss_need.system[system_count].system_id = NRF_MODEM_GNSS_SYSTEM_GPS;
+	agnss_need.system[system_count].sv_mask_ephe = 0xffffffffu;
+	agnss_need.system[system_count].sv_mask_alm = 0xffffffffu;
+	system_count++;
 #if defined(CONFIG_NRF_CLOUD_AGNSS)
-	if (qzss_assistance_is_supported()) {
-		agnss_need.system_count = 2;
-		agnss_need.system[1].system_id = NRF_MODEM_GNSS_SYSTEM_QZSS;
-		agnss_need.system[1].sv_mask_ephe = 0x3ff;
-		agnss_need.system[1].sv_mask_alm = 0x3ff;
-	}
-#endif
+#if !defined(CONFIG_SOC_NRF9160)
+	agnss_need.system[system_count].system_id = NRF_MODEM_GNSS_SYSTEM_QZSS;
+	agnss_need.system[system_count].sv_mask_ephe = 0x3ffu;
+	agnss_need.system[system_count].sv_mask_alm = 0x3ffu;
+	system_count++;
+#endif /* !CONFIG_SOC_NRF9160 */
+#if defined(CONFIG_SOC_SERIES_NRF92)
+	agnss_need.data_flags |= NRF_MODEM_GNSS_AGNSS_GGTO_REQUEST;
+	agnss_need.system[system_count].system_id = NRF_MODEM_GNSS_SYSTEM_GAL;
+	agnss_need.system[system_count].sv_mask_ephe = 0xfffffffffu;
+	agnss_need.system[system_count].sv_mask_alm = 0xfffffffffu;
+	system_count++;
+#endif /* CONFIG_SOC_SERIES_NRF92 */
+#endif /* CONFIG_NRF_CLOUD_AGNSS */
+
+	agnss_need.system_count = system_count;
 
 	k_work_submit_to_queue(&mosh_common_work_q, &get_agnss_data_work);
 
@@ -1687,6 +1719,8 @@ int gnss_get_agnss_expiry(void)
 	mosh_print("Integrity:  %s", expiry_string);
 	get_expiry_string(expiry_string, sizeof(expiry_string), agnss_expiry.position_expiry);
 	mosh_print("Position:   %s", expiry_string);
+	get_expiry_string(expiry_string, sizeof(expiry_string), agnss_expiry.ggto_expiry);
+	mosh_print("GGTO:       %s", expiry_string);
 
 	for (int i = 0; i < agnss_expiry.sv_count; i++) {
 		system_string = gnss_system_str_get(agnss_expiry.sv[i].system_id);

--- a/samples/cellular/modem_shell/src/gnss/gnss.h
+++ b/samples/cellular/modem_shell/src/gnss/gnss.h
@@ -34,11 +34,16 @@ enum gnss_timing_source {
 	GNSS_TIMING_SOURCE_TCXO
 };
 
-enum gnss_qzss_nmea_mode {
+enum gnss_nmea_talker_mode {
+	GNSS_NMEA_TALKER_MODE_STANDARD,
+	GNSS_NMEA_TALKER_MODE_GP_ONLY
+};
+
+enum gnss_nmea_qzss_mode {
 	/** Standard NMEA PRN reporting. */
-	GNSS_QZSS_NMEA_MODE_STANDARD,
+	GNSS_NMEA_QZSS_MODE_STANDARD,
 	/** Custom NMEA PRN reporting (PRN IDs 193...202 used for QZSS satellites). */
-	GNSS_QZSS_NMEA_MODE_CUSTOM
+	GNSS_NMEA_QZSS_MODE_CUSTOM
 };
 
 struct gnss_1pps_mode {
@@ -233,6 +238,28 @@ int gnss_set_use_case(bool low_accuracy_enabled, bool scheduled_downloads_disabl
 int gnss_set_nmea_mask(uint16_t nmea_mask);
 
 /**
+ * @brief Sets the NMEA talker mode. In standard mode, talker IDs GP/GA/GN etc. are used.
+ *        In GP only mode, only the GP talker ID is used and other systems are not reported.
+ *
+ * @param talker_mode NMEA talker mode.
+ *
+ * @retval 0 if the operation was successful.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int gnss_set_nmea_talker_mode(enum gnss_nmea_talker_mode talker_mode);
+
+/**
+ * @brief Sets the QZSS NMEA mode. In standard NMEA mode QZSS satellites are not reported.
+ *        In custom NMEA mode QZSS satellites are reported using PRN IDs 193...202.
+ *
+ * @param nmea_mode QZSS NMEA mode.
+ *
+ * @retval 0 if the operation was successful.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int gnss_set_nmea_qzss_mode(enum gnss_nmea_qzss_mode nmea_mode);
+
+/**
  * @brief Enables/disables priority time window requests.
  *
  * When priority time windows are enabled, GNSS requests longer RF time windows
@@ -259,20 +286,9 @@ int gnss_set_priority_time_windows(bool value);
 int gnss_set_dynamics_mode(enum gnss_dynamics_mode mode);
 
 /**
- * @brief Sets the QZSS NMEA mode. In standard NMEA mode QZSS satellites are not reported.
- *        In custom NMEA mode QZSS satellites are reported using PRN IDs 193...202.
- *
- * @param nmea_mode QZSS NMEA mode.
- *
- * @retval 0 if the operation was successful.
- *         Otherwise, a (negative) error code is returned.
- */
-int gnss_set_qzss_nmea_mode(enum gnss_qzss_nmea_mode nmea_mode);
-
-/**
  * @brief Sets the QZSS PRN mask.
  *
- * @param mask Bits 0 to 9 when set correspond to PRNs 193...202 being enabled.
+ * @param mask Bits 0 to 9 when set correspond to QZSS PRNs 193...202 being enabled.
  *             Bits 10...15 are reserved.
  *
  * @retval 0 if the operation was successful.
@@ -312,12 +328,13 @@ int gnss_set_timing_source(enum gnss_timing_source source);
  * @param time True if system time is enabled, false if not.
  * @param pos True if position is enabled, false if not.
  * @param integrity True if integrity data is enabled, false if not.
+ * @param ggto True if GGTO data is enabled, false if not.
  *
  * @retval 0 if the operation was successful.
  *         Otherwise, a (negative) error code is returned.
  */
-int gnss_set_agnss_data_enabled(bool ephe, bool alm, bool utc, bool klob,
-				bool neq, bool time, bool pos, bool integrity);
+int gnss_set_agnss_data_enabled(bool ephe, bool alm, bool utc, bool klob, bool neq,
+				bool time, bool pos, bool integrity, bool ggto);
 
 /**
  * @brief Sets whether A-GNSS data is automatically fetched whenever requested

--- a/samples/cellular/modem_shell/src/gnss/gnss_shell.c
+++ b/samples/cellular/modem_shell/src/gnss/gnss_shell.c
@@ -160,6 +160,14 @@ static int cmd_gnss_config_system(const struct shell *shell, size_t argc, char *
 		system_mask |= 0x4;
 	}
 
+	/* GAL (optional) */
+	if (argc > 2) {
+		value = atoi(argv[2]);
+		if (value == 1) {
+			system_mask |= 0x8;
+		}
+	}
+
 	return gnss_set_system_mask(system_mask) == 0 ? 0 : -ENOEXEC;
 }
 
@@ -206,7 +214,7 @@ static int cmd_gnss_config_use_case(const struct shell *shell, size_t argc, char
 		0 : -ENOEXEC;
 }
 
-static int cmd_gnss_config_nmea(const struct shell *shell, size_t argc, char **argv)
+static int cmd_gnss_config_nmea_mask(const struct shell *shell, size_t argc, char **argv)
 {
 	uint8_t value;
 	uint16_t nmea_mask;
@@ -225,6 +233,26 @@ static int cmd_gnss_config_nmea(const struct shell *shell, size_t argc, char **a
 	return gnss_set_nmea_mask(nmea_mask) == 0 ? 0 : -ENOEXEC;
 }
 
+static int cmd_gnss_config_nmea_talker_standard(const struct shell *shell, size_t argc, char **argv)
+{
+	return gnss_set_nmea_talker_mode(GNSS_NMEA_TALKER_MODE_STANDARD) == 0 ? 0 : -ENOEXEC;
+}
+
+static int cmd_gnss_config_nmea_talker_gp_only(const struct shell *shell, size_t argc, char **argv)
+{
+	return gnss_set_nmea_talker_mode(GNSS_NMEA_TALKER_MODE_GP_ONLY) == 0 ? 0 : -ENOEXEC;
+}
+
+static int cmd_gnss_config_nmea_qzss_standard(const struct shell *shell, size_t argc, char **argv)
+{
+	return gnss_set_nmea_qzss_mode(GNSS_NMEA_QZSS_MODE_STANDARD) == 0 ? 0 : -ENOEXEC;
+}
+
+static int cmd_gnss_config_nmea_qzss_custom(const struct shell *shell, size_t argc, char **argv)
+{
+	return gnss_set_nmea_qzss_mode(GNSS_NMEA_QZSS_MODE_CUSTOM) == 0 ? 0 : -ENOEXEC;
+}
+
 static int cmd_gnss_config_powersave_off(const struct shell *shell, size_t argc, char **argv)
 {
 	return gnss_set_duty_cycling_policy(GNSS_DUTY_CYCLING_DISABLED) == 0 ? 0 : -ENOEXEC;
@@ -240,33 +268,20 @@ static int cmd_gnss_config_powersave_power(const struct shell *shell, size_t arg
 	return gnss_set_duty_cycling_policy(GNSS_DUTY_CYCLING_POWER) == 0 ? 0 : -ENOEXEC;
 }
 
-static int cmd_gnss_config_qzss_nmea_standard(const struct shell *shell, size_t argc, char **argv)
-{
-	return gnss_set_qzss_nmea_mode(GNSS_QZSS_NMEA_MODE_STANDARD) == 0 ? 0 : -ENOEXEC;
-}
-
-static int cmd_gnss_config_qzss_nmea_custom(const struct shell *shell, size_t argc, char **argv)
-{
-	return gnss_set_qzss_nmea_mode(GNSS_QZSS_NMEA_MODE_CUSTOM) == 0 ? 0 : -ENOEXEC;
-}
-
 static int cmd_gnss_config_qzss_mask(const struct shell *shell, size_t argc, char **argv)
 {
-	int value;
-	uint16_t qzss_mask;
-	uint16_t qzss_mask_bit;
+	int err = 0;
+	uint32_t mask;
 
-	qzss_mask = 0;
-	qzss_mask_bit = 1;
-	for (int i = 0; i < 10; i++) {
-		value = atoi(argv[i + 1]);
-		if (value == 1) {
-			qzss_mask |= qzss_mask_bit;
-		}
-		qzss_mask_bit = qzss_mask_bit << 1;
+	mask = shell_strtoul(argv[1], 16, &err);
+
+	if (err || mask > 0x3ff) {
+		mosh_error("mask: invalid mask value %s", argv[1]);
+
+		return -ENOEXEC;
 	}
 
-	return gnss_set_qzss_mask(qzss_mask) == 0 ? 0 : -ENOEXEC;
+	return gnss_set_qzss_mask(mask) == 0 ? 0 : -ENOEXEC;
 }
 
 static int cmd_gnss_config_timing_rtc(const struct shell *shell, size_t argc, char **argv)
@@ -423,10 +438,12 @@ static int cmd_gnss_agnss_filter(const struct shell *shell, size_t argc, char **
 	bool time_enabled;
 	bool pos_enabled;
 	bool int_enabled;
+	bool ggto_enabled;
 
-	if (argc != 9) {
+	if (argc != 10) {
 		mosh_error("filter: wrong parameter count");
-		mosh_print("filter: <ephe> <alm> <utc> <klob> <neq> <time> <pos> <integrity>");
+		mosh_print("filter: <ephe> <alm> <utc> <klob> <neq> <time> <pos> <integrity> "
+			   "<ggto>");
 		mosh_print("ephe:\n  0 = disabled\n  1 = enabled");
 		mosh_print("alm:\n  0 = disabled\n  1 = enabled");
 		mosh_print("utc:\n  0 = disabled\n  1 = enabled");
@@ -435,6 +452,7 @@ static int cmd_gnss_agnss_filter(const struct shell *shell, size_t argc, char **
 		mosh_print("time:\n  0 = disabled\n  1 = enabled");
 		mosh_print("pos:\n  0 = disabled\n  1 = enabled");
 		mosh_print("integrity:\n  0 = disabled\n  1 = enabled");
+		mosh_print("ggto:\n  0 = disabled\n  1 = enabled");
 		return -EINVAL;
 	}
 
@@ -446,10 +464,12 @@ static int cmd_gnss_agnss_filter(const struct shell *shell, size_t argc, char **
 	time_enabled = atoi(argv[6]) == 1 ? true : false;
 	pos_enabled = atoi(argv[7]) == 1 ? true : false;
 	int_enabled = atoi(argv[8]) == 1 ? true : false;
+	ggto_enabled = atoi(argv[9]) == 1 ? true : false;
 
-	return gnss_set_agnss_data_enabled(ephe_enabled, alm_enabled, utc_enabled,
-					   klob_enabled, neq_enabled, time_enabled,
-					   pos_enabled, int_enabled) == 0 ? 0 : -ENOEXEC;
+	return gnss_set_agnss_data_enabled(
+		ephe_enabled, alm_enabled, utc_enabled,
+		klob_enabled, neq_enabled, time_enabled,
+		pos_enabled, int_enabled, ggto_enabled) == 0 ? 0 : -ENOEXEC;
 }
 
 static int cmd_gnss_1pps_enable(const struct shell *shell, size_t argc, char **argv)
@@ -748,21 +768,13 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 );
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
-	sub_gnss_config_qzss_nmea,
-	SHELL_CMD_ARG(standard, NULL, "Standard NMEA reporting.",
-		      cmd_gnss_config_qzss_nmea_standard, 1, 0),
-	SHELL_CMD_ARG(custom, NULL, "Custom NMEA reporting (default).",
-		      cmd_gnss_config_qzss_nmea_custom, 1, 0),
-	SHELL_SUBCMD_SET_END
-);
-
-SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_gnss_config_qzss,
-	SHELL_CMD(nmea, &sub_gnss_config_qzss_nmea, "QZSS NMEA mode.", mosh_print_help_shell),
 	SHELL_CMD_ARG(mask, NULL,
-		      "<193> <194> <195> <196> <197> <198> <199> <200> <201> <202>\n"
-		      "QZSS NMEA mask for PRNs 193...202. 0 = disabled, 1 = enabled.",
-		      cmd_gnss_config_qzss_mask, 11, 0),
+		      "<bitmask in hex>\n"
+		      "QZSS PRN mask. Bits 0...9 when set correspond to PRNs 193...202 being "
+		      "enabled. The bitmask is given in hex, for example \"3ff\" to enable all "
+		      "10 QZSS PRNs.",
+		      cmd_gnss_config_qzss_mask, 2, 0),
 	SHELL_SUBCMD_SET_END
 );
 
@@ -774,11 +786,41 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 );
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_gnss_config_nmea_talker,
+	SHELL_CMD_ARG(standard, NULL, "Standard talker mode. Use GP/GA/GN etc.",
+		      cmd_gnss_config_nmea_talker_standard, 1, 0),
+	SHELL_CMD_ARG(gp_only, NULL, "GP only talker mode. No output for other systems.",
+		      cmd_gnss_config_nmea_talker_gp_only, 1, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_gnss_config_nmea_qzss,
+	SHELL_CMD_ARG(standard, NULL, "Standard NMEA mode. QZSS satellites not reported.",
+		      cmd_gnss_config_nmea_qzss_standard, 1, 0),
+	SHELL_CMD_ARG(custom, NULL, "Custom NMEA mode. QZSS reported as PRNs 193...202 (default).",
+		      cmd_gnss_config_nmea_qzss_custom, 1, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_gnss_config_nmea,
+	SHELL_CMD_ARG(mask, NULL,
+		      "<GGA enabled> <GLL enabled> <GSA enabled> <GSV enabled> <RMC enabled>\n"
+		      "NMEA mask. 0 = disabled, 1 = enabled (default all enabled).",
+		      cmd_gnss_config_nmea_mask, 6, 0),
+	SHELL_CMD(talker, &sub_gnss_config_nmea_talker, "NMEA talker configuration.",
+		  mosh_print_help_shell),
+	SHELL_CMD(qzss, &sub_gnss_config_nmea_qzss, "QZSS NMEA mode.", mosh_print_help_shell),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_gnss_config,
 	SHELL_CMD_ARG(system, NULL,
-		      "<QZSS enabled>\n"
+		      "<QZSS enabled> [GAL enabled]\n"
 		      "System mask. 0 = disabled, 1 = enabled. GPS L1 C/A is always enabled.",
-		      cmd_gnss_config_system, 2, 0),
+		      cmd_gnss_config_system, 2, 2),
 	SHELL_CMD(elevation, NULL, "<angle>\nElevation threshold angle.",
 		  cmd_gnss_config_elevation),
 	SHELL_CMD_ARG(use_case, NULL,
@@ -786,10 +828,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "Use case configuration. 0 = option disabled, 1 = option enabled "
 		      "(default all disabled).",
 		      cmd_gnss_config_use_case, 3, 0),
-	SHELL_CMD_ARG(nmea, NULL,
-		      "<GGA enabled> <GLL enabled> <GSA enabled> <GSV enabled> <RMC enabled>\n"
-		      "NMEA mask. 0 = disabled, 1 = enabled (default all enabled).",
-		      cmd_gnss_config_nmea, 6, 0),
+	SHELL_CMD(nmea, &sub_gnss_config_nmea, "NMEA configuration.", mosh_print_help_shell),
 	SHELL_CMD(powersave, &sub_gnss_config_powersave, "Continuous tracking power saving mode.",
 		  mosh_print_help_shell),
 	SHELL_CMD(qzss, &sub_gnss_config_qzss, "QZSS configuration.", mosh_print_help_shell),
@@ -836,7 +875,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 				    "server.",
 		      cmd_gnss_agnss_inject, 1, 1),
 	SHELL_CMD(filter, NULL,
-		  "<ephe> <alm> <utc> <klob> <neq> <time> <pos> <integrity>\nSet filter for "
+		  "<ephe> <alm> <utc> <klob> <neq> <time> <pos> <integrity> <ggto>\nSet filter for "
 		  "allowed A-GNSS data. 0 = disabled, 1 = enabled (default all enabled).",
 		  cmd_gnss_agnss_filter),
 	SHELL_CMD(filtephem, &sub_gnss_agnss_filtered,

--- a/samples/cellular/modem_shell/src/utils/str_utils.c
+++ b/samples/cellular/modem_shell/src/utils/str_utils.c
@@ -108,6 +108,9 @@ void agnss_data_flags_str_get(char *flags_string, uint32_t data_flags)
 	if (data_flags & NRF_MODEM_GNSS_AGNSS_INTEGRITY_REQUEST) {
 		(void)strcat(flags_string, "int | ");
 	}
+	if (data_flags & NRF_MODEM_GNSS_AGNSS_GGTO_REQUEST) {
+		(void)strcat(flags_string, "ggto | ");
+	}
 
 	len = strlen(flags_string);
 	if (len == 0) {
@@ -128,6 +131,9 @@ const char *gnss_system_str_get(uint8_t system_id)
 
 	case NRF_MODEM_GNSS_SYSTEM_QZSS:
 		return "QZSS";
+
+	case NRF_MODEM_GNSS_SYSTEM_GAL:
+		return "GAL";
 
 	default:
 		return "unknown";


### PR DESCRIPTION
Added support for Galileo.

Added support for NMEA mode and rearranged NMEA configuration subcommands.

Changed QZSS PRN mask configuration to use a hex mask.