### PR TITLE
samples: ipc: ipc_service: Add ranges property to reserved-memory

### DIFF
--- a/samples/bluetooth/nrf_dm/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/nrf_dm/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -16,6 +16,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_ipc0: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/bluetooth/nrf_dm/sysbuild/ipc_radio/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/nrf_dm/sysbuild/ipc_radio/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -21,6 +21,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_ipc0: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/caf_sensor_manager/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/caf_sensor_manager/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -8,6 +8,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram0_aggregator_area0: memory@2007f000 {
 			reg = <0x2007f000 0x1000>;

--- a/samples/event_manager_proxy/boards/nrf5340dk_nrf5340_cpuapp_icmsg.overlay
+++ b/samples/event_manager_proxy/boards/nrf5340dk_nrf5340_cpuapp_icmsg.overlay
@@ -16,6 +16,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_tx: memory@20070000 {
 			reg = <0x20070000 0x0800>;

--- a/samples/event_manager_proxy/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/event_manager_proxy/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -9,18 +9,17 @@
 		/delete-property/ zephyr,bt-hci;
 	};
 
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20018000 {
-				reg = <0x20018000 0x8000>;
-			};
+		sram_rx: memory@20018000 {
+			reg = <0x20018000 0x8000>;
+		};
 
-			sram_tx: memory@20020000 {
-				reg = <0x20020000 0x8000>;
-			};
+		sram_tx: memory@20020000 {
+			reg = <0x20020000 0x8000>;
 		};
 	};
 

--- a/samples/event_manager_proxy/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/event_manager_proxy/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -9,18 +9,17 @@
 		/delete-property/ zephyr,bt-hci;
 	};
 
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_rx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_tx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/event_manager_proxy/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/event_manager_proxy/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -9,18 +9,17 @@
 		/delete-property/ zephyr,bt-hci;
 	};
 
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20057c00 {
-				reg = <0x20057c00 0x8000>;
-			};
+		sram_rx: memory@20057c00 {
+			reg = <0x20057c00 0x8000>;
+		};
 
-			sram_tx: memory@2005fc00 {
-				reg = <0x2005fc00 0x8000>;
-			};
+		sram_tx: memory@2005fc00 {
+			reg = <0x2005fc00 0x8000>;
 		};
 	};
 

--- a/samples/event_manager_proxy/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/samples/event_manager_proxy/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -9,18 +9,17 @@
 		/delete-property/ zephyr,bt-hci;
 	};
 
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_rx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_tx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/event_manager_proxy/remote/boards/nrf5340dk_nrf5340_cpunet_icmsg.overlay
+++ b/samples/event_manager_proxy/remote/boards/nrf5340dk_nrf5340_cpunet_icmsg.overlay
@@ -15,6 +15,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_rx: memory@20070000 {
 			reg = <0x20070000 0x0800>;

--- a/samples/event_manager_proxy/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/samples/event_manager_proxy/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20018000 {
-				reg = <0x20018000 0x8000>;
-			};
+		sram_tx: memory@20018000 {
+			reg = <0x20018000 0x8000>;
+		};
 
-			sram_rx: memory@20020000 {
-				reg = <0x20020000 0x8000>;
-			};
+		sram_rx: memory@20020000 {
+			reg = <0x20020000 0x8000>;
 		};
 	};
 

--- a/samples/event_manager_proxy/remote/boards/nrf54lc10dk_nrf54lc10a_cpuflpr.overlay
+++ b/samples/event_manager_proxy/remote/boards/nrf54lc10dk_nrf54lc10a_cpuflpr.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_tx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_rx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/event_manager_proxy/remote/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
+++ b/samples/event_manager_proxy/remote/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20057c00 {
-				reg = <0x20057c00 0x8000>;
-			};
+		sram_tx: memory@20057c00 {
+			reg = <0x20057c00 0x8000>;
+		};
 
-			sram_rx: memory@2005fc00 {
-				reg = <0x2005fc00 0x8000>;
-			};
+		sram_rx: memory@2005fc00 {
+			reg = <0x2005fc00 0x8000>;
 		};
 	};
 

--- a/samples/event_manager_proxy/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr.overlay
+++ b/samples/event_manager_proxy/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_tx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_rx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay
+++ b/samples/ipc/ipc_service/boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay
@@ -16,6 +16,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_tx: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/ipc/ipc_service/boards/nrf5340dk_nrf5340_cpuapp_icmsg.overlay
+++ b/samples/ipc/ipc_service/boards/nrf5340dk_nrf5340_cpuapp_icmsg.overlay
@@ -16,6 +16,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_tx: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/ipc/ipc_service/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/ipc/ipc_service/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20018000 {
-				reg = <0x20018000 0x8000>;
-			};
+		sram_rx: memory@20018000 {
+			reg = <0x20018000 0x8000>;
+		};
 
-			sram_tx: memory@20020000 {
-				reg = <0x20020000 0x8000>;
-			};
+		sram_tx: memory@20020000 {
+			reg = <0x20020000 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay
+++ b/samples/ipc/ipc_service/boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20018000 {
-				reg = <0x20018000 0x8000>;
-			};
+		sram_rx: memory@20018000 {
+			reg = <0x20018000 0x8000>;
+		};
 
-			sram_tx: memory@20020000 {
-				reg = <0x20020000 0x8000>;
-			};
+		sram_tx: memory@20020000 {
+			reg = <0x20020000 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/ipc/ipc_service/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_rx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_tx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/boards/nrf54lc10dk_nrf54lc10a_cpuapp_icbmsg.overlay
+++ b/samples/ipc/ipc_service/boards/nrf54lc10dk_nrf54lc10a_cpuapp_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_rx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_tx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/ipc/ipc_service/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20057c00 {
-				reg = <0x20057c00 0x8000>;
-			};
+		sram_rx: memory@20057c00 {
+			reg = <0x20057c00 0x8000>;
+		};
 
-			sram_tx: memory@2005fc00 {
-				reg = <0x2005fc00 0x8000>;
-			};
+		sram_tx: memory@2005fc00 {
+			reg = <0x2005fc00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/boards/nrf54lm20dk_nrf54lm20a_cpuapp_icbmsg.overlay
+++ b/samples/ipc/ipc_service/boards/nrf54lm20dk_nrf54lm20a_cpuapp_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20057c00 {
-				reg = <0x20057c00 0x8000>;
-			};
+		sram_rx: memory@20057c00 {
+			reg = <0x20057c00 0x8000>;
+		};
 
-			sram_tx: memory@2005fc00 {
-				reg = <0x2005fc00 0x8000>;
-			};
+		sram_tx: memory@2005fc00 {
+			reg = <0x2005fc00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/samples/ipc/ipc_service/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_rx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_tx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/boards/nrf54lv10dk_nrf54lv10a_cpuapp_icbmsg.overlay
+++ b/samples/ipc/ipc_service/boards/nrf54lv10dk_nrf54lv10a_cpuapp_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_rx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_tx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_icbmsg.overlay
+++ b/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_icbmsg.overlay
@@ -16,6 +16,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_tx: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_icmsg.overlay
+++ b/samples/ipc/ipc_service/boards/nrf7002dk_nrf5340_cpuapp_icmsg.overlay
@@ -16,6 +16,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_tx: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/ipc/ipc_service/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/samples/ipc/ipc_service/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -5,18 +5,13 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		sram_rx: memory@20080000 {
+			reg = <0x20080000 0x8000>;
+		};
 
-			sram_rx: memory@20080000 {
-				reg = <0x20080000 0x8000>;
-			};
-
-			sram_tx: memory@20088000 {
-				reg = <0x20088000 0x8000>;
-			};
+		sram_tx: memory@20088000 {
+			reg = <0x20088000 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/remote/boards/nrf5340dk_nrf5340_cpunet_icbmsg.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf5340dk_nrf5340_cpunet_icbmsg.overlay
@@ -15,6 +15,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_rx: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/ipc/ipc_service/remote/boards/nrf5340dk_nrf5340_cpunet_icmsg.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf5340dk_nrf5340_cpunet_icmsg.overlay
@@ -15,6 +15,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_rx: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/ipc/ipc_service/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20018000 {
-				reg = <0x20018000 0x8000>;
-			};
+		sram_tx: memory@20018000 {
+			reg = <0x20018000 0x8000>;
+		};
 
-			sram_rx: memory@20020000 {
-				reg = <0x20020000 0x8000>;
-			};
+		sram_rx: memory@20020000 {
+			reg = <0x20020000 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20018000 {
-				reg = <0x20018000 0x8000>;
-			};
+		sram_tx: memory@20018000 {
+			reg = <0x20018000 0x8000>;
+		};
 
-			sram_rx: memory@20020000 {
-				reg = <0x20020000 0x8000>;
-			};
+		sram_rx: memory@20020000 {
+			reg = <0x20020000 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/remote/boards/nrf54lc10dk_nrf54lc10a_cpuflpr.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf54lc10dk_nrf54lc10a_cpuflpr.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_tx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_rx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/remote/boards/nrf54lc10dk_nrf54lc10a_cpuflpr_icbmsg.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf54lc10dk_nrf54lc10a_cpuflpr_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_tx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_rx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/remote/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20057c00 {
-				reg = <0x20057c00 0x8000>;
-			};
+		sram_tx: memory@20057c00 {
+			reg = <0x20057c00 0x8000>;
+		};
 
-			sram_rx: memory@2005fc00 {
-				reg = <0x2005fc00 0x8000>;
-			};
+		sram_rx: memory@2005fc00 {
+			reg = <0x2005fc00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/remote/boards/nrf54lm20dk_nrf54lm20a_cpuflpr_icbmsg.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf54lm20dk_nrf54lm20a_cpuflpr_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20057c00 {
-				reg = <0x20057c00 0x8000>;
-			};
+		sram_tx: memory@20057c00 {
+			reg = <0x20057c00 0x8000>;
+		};
 
-			sram_rx: memory@2005fc00 {
-				reg = <0x2005fc00 0x8000>;
-			};
+		sram_rx: memory@2005fc00 {
+			reg = <0x2005fc00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_tx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_rx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr_icbmsg.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_tx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_rx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet_icbmsg.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet_icbmsg.overlay
@@ -15,6 +15,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_rx: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet_icmsg.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf7002dk_nrf5340_cpunet_icmsg.overlay
@@ -15,6 +15,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_rx: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/ipc/ipc_service/remote/boards/nrf7120dk_nrf7120_cpuflpr.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf7120dk_nrf7120_cpuflpr.overlay
@@ -5,18 +5,13 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		sram_tx: memory@20080000 {
+			reg = <0x20080000 0x8000>;
+		};
 
-			sram_tx: memory@20080000 {
-				reg = <0x20080000 0x8000>;
-			};
-
-			sram_rx: memory@20088000 {
-				reg = <0x20088000 0x8000>;
-			};
+		sram_rx: memory@20088000 {
+			reg = <0x20088000 0x8000>;
 		};
 	};
 

--- a/samples/zephyr/subsys/ipc/ipc_service/icmsg/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/zephyr/subsys/ipc/ipc_service/icmsg/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_rx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_tx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/zephyr/subsys/ipc/ipc_service/icmsg/boards/nrf54lc10dk_nrf54lc10a_cpuapp_icbmsg.overlay
+++ b/samples/zephyr/subsys/ipc/ipc_service/icmsg/boards/nrf54lc10dk_nrf54lc10a_cpuapp_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_rx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_tx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/zephyr/subsys/ipc/ipc_service/icmsg/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/zephyr/subsys/ipc/ipc_service/icmsg/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20057c00 {
-				reg = <0x20057c00 0x8000>;
-			};
+		sram_rx: memory@20057c00 {
+			reg = <0x20057c00 0x8000>;
+		};
 
-			sram_tx: memory@2005fc00 {
-				reg = <0x2005fc00 0x8000>;
-			};
+		sram_tx: memory@2005fc00 {
+			reg = <0x2005fc00 0x8000>;
 		};
 	};
 

--- a/samples/zephyr/subsys/ipc/ipc_service/icmsg/boards/nrf54lm20dk_nrf54lm20a_cpuapp_icbmsg.overlay
+++ b/samples/zephyr/subsys/ipc/ipc_service/icmsg/boards/nrf54lm20dk_nrf54lm20a_cpuapp_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20057c00 {
-				reg = <0x20057c00 0x8000>;
-			};
+		sram_rx: memory@20057c00 {
+			reg = <0x20057c00 0x8000>;
+		};
 
-			sram_tx: memory@2005fc00 {
-				reg = <0x2005fc00 0x8000>;
-			};
+		sram_tx: memory@2005fc00 {
+			reg = <0x2005fc00 0x8000>;
 		};
 	};
 

--- a/samples/zephyr/subsys/ipc/ipc_service/icmsg/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/samples/zephyr/subsys/ipc/ipc_service/icmsg/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_rx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_tx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/zephyr/subsys/ipc/ipc_service/icmsg/boards/nrf54lv10dk_nrf54lv10a_cpuapp_icbmsg.overlay
+++ b/samples/zephyr/subsys/ipc/ipc_service/icmsg/boards/nrf54lv10dk_nrf54lv10a_cpuapp_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_rx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_tx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/zephyr/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54lc10dk_nrf54lc10a_cpuflpr.overlay
+++ b/samples/zephyr/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54lc10dk_nrf54lc10a_cpuflpr.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_tx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_rx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/zephyr/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54lc10dk_nrf54lc10a_cpuflpr_icbmsg.overlay
+++ b/samples/zephyr/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54lc10dk_nrf54lc10a_cpuflpr_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_tx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_rx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/zephyr/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
+++ b/samples/zephyr/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20057c00 {
-				reg = <0x20057c00 0x8000>;
-			};
+		sram_tx: memory@20057c00 {
+			reg = <0x20057c00 0x8000>;
+		};
 
-			sram_rx: memory@2005fc00 {
-				reg = <0x2005fc00 0x8000>;
-			};
+		sram_rx: memory@2005fc00 {
+			reg = <0x2005fc00 0x8000>;
 		};
 	};
 

--- a/samples/zephyr/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54lm20dk_nrf54lm20a_cpuflpr_icbmsg.overlay
+++ b/samples/zephyr/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54lm20dk_nrf54lm20a_cpuflpr_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20057c00 {
-				reg = <0x20057c00 0x8000>;
-			};
+		sram_tx: memory@20057c00 {
+			reg = <0x20057c00 0x8000>;
+		};
 
-			sram_rx: memory@2005fc00 {
-				reg = <0x2005fc00 0x8000>;
-			};
+		sram_rx: memory@2005fc00 {
+			reg = <0x2005fc00 0x8000>;
 		};
 	};
 

--- a/samples/zephyr/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr.overlay
+++ b/samples/zephyr/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_tx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_rx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/samples/zephyr/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr_icbmsg.overlay
+++ b/samples/zephyr/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr_icbmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_tx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_rx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/snippets/hpf/gpio/icbmsg/soc/nrf7120_cpuapp.overlay
+++ b/snippets/hpf/gpio/icbmsg/soc/nrf7120_cpuapp.overlay
@@ -7,19 +7,17 @@
 #include "../../hpf-gpio-app.overlay"
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20080000 {
-				reg = <0x20080000 0x0800>;
-			};
+		sram_rx: memory@20080000 {
+			reg = <0x20080000 0x0800>;
+		};
 
-			sram_tx: memory@20080800 {
-				reg = <0x20080800 0x0800>;
-			};
+		sram_tx: memory@20080800 {
+			reg = <0x20080800 0x0800>;
 		};
 	};
 

--- a/snippets/hpf/gpio/icbmsg/soc/nrf7120_cpuflpr.overlay
+++ b/snippets/hpf/gpio/icbmsg/soc/nrf7120_cpuflpr.overlay
@@ -5,19 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20080000 {
-				reg = <0x20080000 0x0800>;
-			};
+		sram_tx: memory@20080000 {
+			reg = <0x20080000 0x0800>;
+		};
 
-			sram_rx: memory@20080800 {
-				reg = <0x20080800 0x0800>;
-			};
+		sram_rx: memory@20080800 {
+			reg = <0x20080800 0x0800>;
 		};
 	};
 

--- a/snippets/hpf/gpio/icmsg/soc/nrf7120_cpuapp.overlay
+++ b/snippets/hpf/gpio/icmsg/soc/nrf7120_cpuapp.overlay
@@ -7,19 +7,17 @@
 #include "../../hpf-gpio-app.overlay"
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20080000 {
-				reg = <0x20080000 0x0800>;
-			};
+		sram_rx: memory@20080000 {
+			reg = <0x20080000 0x0800>;
+		};
 
-			sram_tx: memory@20080800 {
-				reg = <0x20080800 0x0800>;
-			};
+		sram_tx: memory@20080800 {
+			reg = <0x20080800 0x0800>;
 		};
 	};
 

--- a/snippets/hpf/gpio/icmsg/soc/nrf7120_cpuflpr.overlay
+++ b/snippets/hpf/gpio/icmsg/soc/nrf7120_cpuflpr.overlay
@@ -5,19 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20080000 {
-				reg = <0x20080000 0x0800>;
-			};
+		sram_tx: memory@20080000 {
+			reg = <0x20080000 0x0800>;
+		};
 
-			sram_rx: memory@20080800 {
-				reg = <0x20080800 0x0800>;
-			};
+		sram_rx: memory@20080800 {
+			reg = <0x20080800 0x0800>;
 		};
 	};
 

--- a/snippets/hpf/gpio/mbox/soc/nrf7120_cpuapp.overlay
+++ b/snippets/hpf/gpio/mbox/soc/nrf7120_cpuapp.overlay
@@ -7,19 +7,17 @@
 #include "../../hpf-gpio-app.overlay"
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20080000 {
-				reg = <0x20080000 0x0800>;
-			};
+		sram_rx: memory@20080000 {
+			reg = <0x20080000 0x0800>;
+		};
 
-			sram_tx: memory@20080800 {
-				reg = <0x20080800 0x0800>;
-			};
+		sram_tx: memory@20080800 {
+			reg = <0x20080800 0x0800>;
 		};
 	};
 

--- a/snippets/hpf/gpio/mbox/soc/nrf7120_cpuflpr.overlay
+++ b/snippets/hpf/gpio/mbox/soc/nrf7120_cpuflpr.overlay
@@ -5,19 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20080000 {
-				reg = <0x20080000 0x0800>;
-			};
+		sram_tx: memory@20080000 {
+			reg = <0x20080000 0x0800>;
+		};
 
-			sram_rx: memory@20080800 {
-				reg = <0x20080800 0x0800>;
-			};
+		sram_rx: memory@20080800 {
+			reg = <0x20080800 0x0800>;
 		};
 	};
 

--- a/snippets/hpf/mspi/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/hpf/mspi/soc/nrf54l15_cpuapp.overlay
@@ -8,6 +8,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_rx: memory@2003b400 {
 			reg = <0x2003b400 0x07f0>;

--- a/snippets/hpf/mspi/soc/nrf54lm20a_cpuapp.overlay
+++ b/snippets/hpf/mspi/soc/nrf54lm20a_cpuapp.overlay
@@ -12,6 +12,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_rx: memory@2007a800 {
 			reg = <0x2007a800 0x0c00>;

--- a/snippets/hpf/mspi/soc/nrf54lv10a_cpuapp.overlay
+++ b/snippets/hpf/mspi/soc/nrf54lv10a_cpuapp.overlay
@@ -8,6 +8,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_rx: memory@2002b000 {
 			reg = <0x2002b000 0x07f0>;

--- a/tests/subsys/event_manager_proxy/boards/nrf5340dk_nrf5340_cpuapp_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/boards/nrf5340dk_nrf5340_cpuapp_icmsg.overlay
@@ -16,6 +16,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_tx: memory@20070000 {
 			reg = <0x20070000 0x0800>;

--- a/tests/subsys/event_manager_proxy/boards/nrf54l15dk_nrf54l15_cpuapp_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/boards/nrf54l15dk_nrf54l15_cpuapp_icmsg.overlay
@@ -9,18 +9,17 @@
 		/delete-property/ zephyr,bt-hci;
 	};
 
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20018000 {
-				reg = <0x20018000 0x8000>;
-			};
+		sram_rx: memory@20018000 {
+			reg = <0x20018000 0x8000>;
+		};
 
-			sram_tx: memory@20020000 {
-				reg = <0x20020000 0x8000>;
-			};
+		sram_tx: memory@20020000 {
+			reg = <0x20020000 0x8000>;
 		};
 	};
 

--- a/tests/subsys/event_manager_proxy/boards/nrf54lm20dk_nrf54lm20a_cpuapp_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/boards/nrf54lm20dk_nrf54lm20a_cpuapp_icmsg.overlay
@@ -9,18 +9,17 @@
 		/delete-property/ zephyr,bt-hci;
 	};
 
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@20057c00 {
-				reg = <0x20057c00 0x8000>;
-			};
+		sram_rx: memory@20057c00 {
+			reg = <0x20057c00 0x8000>;
+		};
 
-			sram_tx: memory@2005fc00 {
-				reg = <0x2005fc00 0x8000>;
-			};
+		sram_tx: memory@2005fc00 {
+			reg = <0x2005fc00 0x8000>;
 		};
 	};
 

--- a/tests/subsys/event_manager_proxy/boards/nrf54lv10dk_nrf54lv10a_cpuapp_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/boards/nrf54lv10dk_nrf54lv10a_cpuapp_icmsg.overlay
@@ -9,18 +9,17 @@
 		/delete-property/ zephyr,bt-hci;
 	};
 
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_rx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_rx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_tx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/tests/subsys/event_manager_proxy/remote/boards/nrf5340dk_nrf5340_cpunet_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/remote/boards/nrf5340dk_nrf5340_cpunet_icmsg.overlay
@@ -15,6 +15,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_rx: memory@20070000 {
 			reg = <0x20070000 0x0800>;

--- a/tests/subsys/event_manager_proxy/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20018000 {
-				reg = <0x20018000 0x8000>;
-			};
+		sram_tx: memory@20018000 {
+			reg = <0x20018000 0x8000>;
+		};
 
-			sram_rx: memory@20020000 {
-				reg = <0x20020000 0x8000>;
-			};
+		sram_rx: memory@20020000 {
+			reg = <0x20020000 0x8000>;
 		};
 	};
 

--- a/tests/subsys/event_manager_proxy/remote/boards/nrf54lm20dk_nrf54lm20a_cpuflpr_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/remote/boards/nrf54lm20dk_nrf54lm20a_cpuflpr_icmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@20057c00 {
-				reg = <0x20057c00 0x8000>;
-			};
+		sram_tx: memory@20057c00 {
+			reg = <0x20057c00 0x8000>;
+		};
 
-			sram_rx: memory@2005fc00 {
-				reg = <0x2005fc00 0x8000>;
-			};
+		sram_rx: memory@2005fc00 {
+			reg = <0x2005fc00 0x8000>;
 		};
 	};
 

--- a/tests/subsys/event_manager_proxy/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr_icmsg.overlay
@@ -5,18 +5,17 @@
  */
 
 / {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-			sram_tx: memory@2000fc00 {
-				reg = <0x2000fc00 0x8000>;
-			};
+		sram_tx: memory@2000fc00 {
+			reg = <0x2000fc00 0x8000>;
+		};
 
-			sram_rx: memory@20017c00 {
-				reg = <0x20017c00 0x8000>;
-			};
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 	};
 

--- a/tests/subsys/ipc/ipc_latency/boards/nrf5340dk_nrf5340_cpuapp_icmsg.overlay
+++ b/tests/subsys/ipc/ipc_latency/boards/nrf5340dk_nrf5340_cpuapp_icmsg.overlay
@@ -22,6 +22,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_tx: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/tests/subsys/ipc/ipc_latency/remote/boards/nrf5340dk_nrf5340_cpunet_icmsg.overlay
+++ b/tests/subsys/ipc/ipc_latency/remote/boards/nrf5340dk_nrf5340_cpunet_icmsg.overlay
@@ -15,6 +15,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		sram_rx: memory@20070000 {
 			reg = <0x20070000 0x8000>;


### PR DESCRIPTION
Property "ranges" is required for "reserved-memory" node.
Set it unless already done at the board definition level (nrf54h20, nrf9251, nrf7120).

"reserved-memory" node must be placed under root node.

Fix overlays for all platforms.

See [DTS specification](https://github.com/devicetree-org/devicetree-specification/releases/tag/v0.4) 
```
reserved-memory should never be under any node apart from root see spec 3.5 first line
and as per DTS Spec table in 3.5.1 ranges is also required
```