### PR TITLE
Bluetooth: Controller: Add Kconfigs and ifdefs for unused commands

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -184,7 +184,11 @@ See `Samples`_ for lists of changes for the protocol-related samples.
 Bluetooth® LE
 -------------
 
-|no_changes_yet_note|
+* Added the following Kconfig options to enable support for certain HCI commands:
+
+  * :kconfig:option:`CONFIG_BT_CTLR_SDC_DATA_RELATED_ADDRESS_CHANGES`
+  * :kconfig:option:`CONFIG_BT_CTLR_SDC_RF_PATH_COMPENSATION`
+  * :kconfig:option:`CONFIG_BT_CTLR_SDC_ISO_TEST`
 
 Bluetooth Mesh
 --------------

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -748,6 +748,13 @@ config BT_CTLR_SDC_RF_PATH_COMPENSATION
 	help
 	  Support for LE RF Path Compensation
 
+config BT_CTLR_SDC_ISO_TEST
+	bool "LE ISO Test commands"
+	depends on BT_CTLR_ISO
+	default y if BT_HCI_RAW || BT_ISO_TEST_PARAMS
+	help
+	  Support for LE ISO test HCI commands
+
 config BT_CTLR_DTM
 	select EXPERIMENTAL
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -734,6 +734,13 @@ config BT_CTLR_SDC_ENABLE_LOWEST_FRAME_SPACE
 	  Note: This option forces ACL connections to always use the same
 	  TX and RX PHY.
 
+config BT_CTLR_SDC_DATA_RELATED_ADDRESS_CHANGES
+	bool "Data Related Address Changes"
+	depends on BT_BROADCASTER
+	default y if BT_HCI_RAW
+	help
+	  Support for LE Set Data Related Address Changes command
+
 config BT_CTLR_DTM
 	select EXPERIMENTAL
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -741,6 +741,13 @@ config BT_CTLR_SDC_DATA_RELATED_ADDRESS_CHANGES
 	help
 	  Support for LE Set Data Related Address Changes command
 
+config BT_CTLR_SDC_RF_PATH_COMPENSATION
+	bool "RF Path Compensation"
+	depends on BT_CTLR_LE_POWER_CONTROL || BT_CTLR_ADV_EXT
+	default y if BT_HCI_RAW
+	help
+	  Support for LE RF Path Compensation
+
 config BT_CTLR_DTM
 	select EXPERIMENTAL
 

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -595,7 +595,9 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 
 #if defined(CONFIG_BT_CTLR_CENTRAL_ISO)
 	cmds->hci_le_set_cig_parameters = 1;
+#if defined(CONFIG_BT_CTLR_SDC_ISO_TEST)
 	cmds->hci_le_set_cig_parameters_test = 1;
+#endif
 	cmds->hci_le_create_cis = 1;
 	cmds->hci_le_remove_cig = 1;
 #endif
@@ -609,7 +611,9 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 
 #if defined(CONFIG_BT_CTLR_ADV_ISO)
 	cmds->hci_le_create_big = 1;
+#if defined(CONFIG_BT_CTLR_SDC_ISO_TEST)
 	cmds->hci_le_create_big_test = 1;
+#endif
 	cmds->hci_le_terminate_big = 1;
 #endif
 
@@ -621,18 +625,22 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 #if defined(CONFIG_BT_CTLR_ISO)
 	cmds->hci_le_setup_iso_data_path = 1;
 	cmds->hci_le_remove_iso_data_path = 1;
+#if defined(CONFIG_BT_CTLR_SDC_ISO_TEST)
 	cmds->hci_le_iso_test_end = 1;
 	cmds->hci_le_iso_read_test_counters = 1;
+#endif
 	cmds->hci_le_read_iso_link_quality = 1;
 #endif
 
 #if defined(CONFIG_BT_CTLR_ISO_TX_BUFFERS)
 	cmds->hci_le_read_buffer_size_v2 = 1;
 	cmds->hci_le_read_iso_tx_sync = 1;
+#if defined(CONFIG_BT_CTLR_SDC_ISO_TEST)
 	cmds->hci_le_iso_transmit_test = 1;
 #endif
+#endif
 
-#if defined(CONFIG_BT_CTLR_ISO_RX_BUFFERS)
+#if defined(CONFIG_BT_CTLR_ISO_RX_BUFFERS) && defined(CONFIG_BT_CTLR_SDC_ISO_TEST)
 	cmds->hci_le_iso_receive_test = 1;
 #endif
 
@@ -1341,6 +1349,7 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 
 		return status;
 	}
+#if defined(CONFIG_BT_CTLR_SDC_ISO_TEST)
 	case SDC_HCI_OPCODE_CMD_LE_SET_CIG_PARAMS_TEST: {
 		sdc_hci_cmd_le_set_cig_params_test_return_t *p_cig_params_test_ret =
 			(sdc_hci_cmd_le_set_cig_params_test_return_t *)event_out_params;
@@ -1355,6 +1364,7 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 
 		return status;
 	}
+#endif /* CONFIG_BT_CTLR_SDC_ISO_TEST */
 
 	case SDC_HCI_OPCODE_CMD_LE_CREATE_CIS:
 		return sdc_hci_cmd_le_create_cis((sdc_hci_cmd_le_create_cis_t const *)cmd_params);
@@ -1380,9 +1390,11 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 #ifdef CONFIG_BT_CTLR_ADV_ISO
 	case SDC_HCI_OPCODE_CMD_LE_CREATE_BIG:
 		return sdc_hci_cmd_le_create_big((sdc_hci_cmd_le_create_big_t const *)cmd_params);
+#if defined(CONFIG_BT_CTLR_SDC_ISO_TEST)
 	case SDC_HCI_OPCODE_CMD_LE_CREATE_BIG_TEST:
 		return sdc_hci_cmd_le_create_big_test(
 			(sdc_hci_cmd_le_create_big_test_t const *)cmd_params);
+#endif
 	case SDC_HCI_OPCODE_CMD_LE_TERMINATE_BIG:
 		return sdc_hci_cmd_le_terminate_big(
 			(sdc_hci_cmd_le_terminate_big_t const *)cmd_params);
@@ -1400,14 +1412,16 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 			(sdc_hci_cmd_le_read_iso_tx_sync_t const *)cmd_params,
 			(sdc_hci_cmd_le_read_iso_tx_sync_return_t *)event_out_params);
 
+#if defined(CONFIG_BT_CTLR_SDC_ISO_TEST)
 	case SDC_HCI_OPCODE_CMD_LE_ISO_TRANSMIT_TEST:
 		*param_length_out += sizeof(sdc_hci_cmd_le_iso_transmit_test_return_t);
 		return sdc_hci_cmd_le_iso_transmit_test(
 			(sdc_hci_cmd_le_iso_transmit_test_t const *)cmd_params,
 			(sdc_hci_cmd_le_iso_transmit_test_return_t *)event_out_params);
+#endif /* CONFIG_BT_CTLR_SDC_ISO_TEST */
 #endif /* CONFIG_BT_CTLR_ISO_TX_BUFFERS */
 
-#if defined(CONFIG_BT_CTLR_ISO_RX_BUFFERS)
+#if defined(CONFIG_BT_CTLR_ISO_RX_BUFFERS) && defined(CONFIG_BT_CTLR_SDC_ISO_TEST)
 	case SDC_HCI_OPCODE_CMD_LE_ISO_RECEIVE_TEST:
 		*param_length_out += sizeof(sdc_hci_cmd_le_iso_receive_test_return_t);
 		return sdc_hci_cmd_le_iso_receive_test(
@@ -1416,11 +1430,13 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 #endif
 
 #if defined(CONFIG_BT_CTLR_ISO)
+#if defined(CONFIG_BT_CTLR_SDC_ISO_TEST)
 	case SDC_HCI_OPCODE_CMD_LE_ISO_READ_TEST_COUNTERS:
 		*param_length_out += sizeof(sdc_hci_cmd_le_iso_read_test_counters_return_t);
 		return sdc_hci_cmd_le_iso_read_test_counters(
 			(sdc_hci_cmd_le_iso_read_test_counters_t const *)cmd_params,
 			(sdc_hci_cmd_le_iso_read_test_counters_return_t *)event_out_params);
+#endif /* CONFIG_BT_CTLR_SDC_ISO_TEST */
 
 	case SDC_HCI_OPCODE_CMD_LE_SETUP_ISO_DATA_PATH:
 		*param_length_out += sizeof(sdc_hci_cmd_le_setup_iso_data_path_return_t);
@@ -1434,11 +1450,13 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 			(sdc_hci_cmd_le_remove_iso_data_path_t const *)cmd_params,
 			(sdc_hci_cmd_le_remove_iso_data_path_return_t *)event_out_params);
 
+#if defined(CONFIG_BT_CTLR_SDC_ISO_TEST)
 	case SDC_HCI_OPCODE_CMD_LE_ISO_TEST_END:
 		*param_length_out += sizeof(sdc_hci_cmd_le_iso_test_end_return_t);
 		return sdc_hci_cmd_le_iso_test_end(
 			(sdc_hci_cmd_le_iso_test_end_t const *)cmd_params,
 			(sdc_hci_cmd_le_iso_test_end_return_t *)event_out_params);
+#endif /* CONFIG_BT_CTLR_SDC_ISO_TEST */
 
 	case SDC_HCI_OPCODE_CMD_LE_READ_ISO_LINK_QUALITY:
 		*param_length_out += sizeof(sdc_hci_cmd_le_read_iso_link_quality_return_t);

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -422,7 +422,10 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_read_remote_features = 1;
 #endif
 
+#if defined(CONFIG_BT_CTLR_CRYPTO)
 	cmds->hci_le_encrypt = 1;
+#endif
+
 	cmds->hci_le_rand = 1;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC) && defined(CONFIG_BT_CENTRAL)
@@ -1016,9 +1019,11 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 		return sdc_hci_cmd_le_read_remote_features((void *)cmd_params);
 #endif
 
+#if defined(CONFIG_BT_CTLR_CRYPTO)
 	case SDC_HCI_OPCODE_CMD_LE_ENCRYPT:
 		*param_length_out += sizeof(sdc_hci_cmd_le_encrypt_return_t);
 		return sdc_hci_cmd_le_encrypt((void *)cmd_params, (void *)event_out_params);
+#endif
 
 	case SDC_HCI_OPCODE_CMD_LE_RAND:
 		*param_length_out += sizeof(sdc_hci_cmd_le_rand_return_t);

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -426,7 +426,9 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_encrypt = 1;
 #endif
 
+#if !defined(CONFIG_BT_HOST_CRYPTO_PRNG)
 	cmds->hci_le_rand = 1;
+#endif
 
 #if defined(CONFIG_BT_CTLR_LE_ENC) && defined(CONFIG_BT_CENTRAL)
 	cmds->hci_le_enable_encryption = 1;
@@ -1033,9 +1035,11 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 		return sdc_hci_cmd_le_encrypt((void *)cmd_params, (void *)event_out_params);
 #endif
 
+#if !defined(CONFIG_BT_HOST_CRYPTO_PRNG)
 	case SDC_HCI_OPCODE_CMD_LE_RAND:
 		*param_length_out += sizeof(sdc_hci_cmd_le_rand_return_t);
 		return sdc_hci_cmd_le_rand((void *)event_out_params);
+#endif
 
 #if defined(CONFIG_BT_CENTRAL)
 	case SDC_HCI_OPCODE_CMD_LE_ENABLE_ENCRYPTION:

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -575,8 +575,10 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 #endif
 
 #if defined(CONFIG_BT_CTLR_LE_POWER_CONTROL) || defined(CONFIG_BT_CTLR_ADV_EXT)
+#if defined(CONFIG_BT_CTLR_SDC_RF_PATH_COMPENSATION)
 	cmds->hci_le_read_rf_path_compensation = 1;
 	cmds->hci_le_write_rf_path_compensation = 1;
+#endif
 #endif
 
 #if defined(CONFIG_BT_CTLR_SCA_UPDATE)
@@ -1261,12 +1263,14 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 #endif
 
 #if defined(CONFIG_BT_CTLR_LE_POWER_CONTROL) || defined(CONFIG_BT_CTLR_ADV_EXT)
+#if defined(CONFIG_BT_CTLR_SDC_RF_PATH_COMPENSATION)
 	case SDC_HCI_OPCODE_CMD_LE_READ_RF_PATH_COMPENSATION:
 		*param_length_out += sizeof(sdc_hci_cmd_le_read_rf_path_compensation_return_t);
 		return sdc_hci_cmd_le_read_rf_path_compensation((void *)event_out_params);
 
 	case SDC_HCI_OPCODE_CMD_LE_WRITE_RF_PATH_COMPENSATION:
 		return sdc_hci_cmd_le_write_rf_path_compensation((void *)cmd_params);
+#endif
 #endif
 
 #if defined(CONFIG_BT_CTLR_SYNC_TRANSFER_SENDER)

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -387,7 +387,9 @@ void hci_internal_supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_set_advertising_data = 1;
 	cmds->hci_le_set_scan_response_data = 1;
 	cmds->hci_le_set_advertising_enable = 1;
+#if defined(CONFIG_BT_CTLR_SDC_DATA_RELATED_ADDRESS_CHANGES)
 	cmds->hci_le_set_data_related_address_changes = 1;
+#endif
 #endif
 
 #if defined(CONFIG_BT_OBSERVER)
@@ -955,8 +957,10 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 	case SDC_HCI_OPCODE_CMD_LE_SET_ADV_ENABLE:
 		return sdc_hci_cmd_le_set_adv_enable((void *)cmd_params);
 
+#if defined(CONFIG_BT_CTLR_SDC_DATA_RELATED_ADDRESS_CHANGES)
 	case SDC_HCI_OPCODE_CMD_LE_SET_DATA_RELATED_ADDRESS_CHANGES:
 		return sdc_hci_cmd_le_set_data_related_address_changes((void *)cmd_params);
+#endif
 #endif
 
 #if defined(CONFIG_BT_OBSERVER)


### PR DESCRIPTION
These commands are not used by Zephyr host. Removing them saves NVM size. Applications that call into HCI directly can enable these configs.