### PR TITLE
samples: zephyr: tfm_integration: prefix names with nrf.extended

### DIFF
--- a/samples/zephyr/tfm_integration/psa_protected_storage/sample.yaml
+++ b/samples/zephyr/tfm_integration/psa_protected_storage/sample.yaml
@@ -2,7 +2,12 @@ sample:
   description: Protected Storage API sample
   name: PSA Protected Storage
 common:
-  tags: psa
+  tags:
+    - psa
+    - trusted-firmware-m
+    - mcuboot
+    - ci_samples_zephyr_tfm_integration
+
   platform_allow:
     - nrf54l15dk/nrf54l15/cpuapp/ns
     - nrf54lm20dk/nrf54lm20b/cpuapp/ns
@@ -24,7 +29,4 @@ common:
       - "Removing UID1"
 
 tests:
-  sample.tfm.protected_storage:
-    tags:
-      - trusted-firmware-m
-      - mcuboot
+  nrf.extended.sample.tfm.protected_storage: {}

--- a/samples/zephyr/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/zephyr/tfm_integration/tfm_ipc/sample.yaml
@@ -2,11 +2,15 @@ sample:
   description: This app provides an example of using TF-M on the secure side, with
     Zephyr on the NS side, using IPC.
   name: TF-M IPC example
+common:
+  tags:
+    - introduction
+    - trusted-firmware-m
+    - ci_samples_zephyr_tfm_integration
+
 tests:
-  sample.tfm_ipc:
+  nrf.extended.sample.tfm_ipc:
     tags:
-      - introduction
-      - trusted-firmware-m
       - mcuboot
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp/ns
@@ -21,10 +25,7 @@ tests:
         - "The version of the PSA Framework API is"
         - "The PSA Crypto service minor version is"
         - "Generating 256 bytes of random data"
-  sample.tfm_ipc.no_bl2:
-    tags:
-      - introduction
-      - trusted-firmware-m
+  nrf.extended.sample.tfm_ipc.no_bl2:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp/ns

--- a/samples/zephyr/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/zephyr/tfm_integration/tfm_secure_partition/sample.yaml
@@ -2,6 +2,7 @@ common:
   tags:
     - trusted-firmware-m
     - mcuboot
+    - ci_samples_zephyr_tfm_integration
   platform_allow:
     - nrf54l15dk/nrf54l15/cpuapp/ns
     - nrf54lm20dk/nrf54lm20b/cpuapp/ns
@@ -21,9 +22,9 @@ sample:
   name: "TFM Secure Partition Sample"
 
 tests:
-  sample.tfm.secure_partition.ipc:
+  nrf.extended.sample.tfm.secure_partition.ipc:
     extra_configs:
       - CONFIG_TFM_IPC=y
-  sample.tfm.secure_partition.sfn:
+  nrf.extended.sample.tfm.secure_partition.sfn:
     extra_configs:
       - CONFIG_TFM_SFN=y

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -2055,3 +2055,8 @@ ci_tests_zephyr_application_development_ram_context_for_isr:
   files:
     - nrf/tests/zephyr/application_development/ram_context_for_isr/
     - zephyr/tests/application_development/ram_context_for_isr/
+
+ci_samples_zephyr_tfm_integration:
+  files:
+    - nrf/samples/zephyr/tfm_integration/
+    - zephyr/samples/tfm_integration/


### PR DESCRIPTION
Prevent duplicated names with original zephyr sample. Add missing ci tag.