### PR TITLE
samples: zephyr: tfm_integration: Use unique test scenario name

### DIFF
--- a/samples/zephyr/tfm_integration/psa_protected_storage/sample.yaml
+++ b/samples/zephyr/tfm_integration/psa_protected_storage/sample.yaml
@@ -24,7 +24,7 @@ common:
       - "Removing UID1"
 
 tests:
-  sample.tfm.protected_storage:
+  nrf.extended.sample.tfm.protected_storage:
     tags:
       - trusted-firmware-m
       - mcuboot

--- a/samples/zephyr/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/zephyr/tfm_integration/tfm_ipc/sample.yaml
@@ -3,7 +3,7 @@ sample:
     Zephyr on the NS side, using IPC.
   name: TF-M IPC example
 tests:
-  sample.tfm_ipc:
+  nrf.extended.sample.tfm_ipc:
     tags:
       - introduction
       - trusted-firmware-m
@@ -21,7 +21,7 @@ tests:
         - "The version of the PSA Framework API is"
         - "The PSA Crypto service minor version is"
         - "Generating 256 bytes of random data"
-  sample.tfm_ipc.no_bl2:
+  nrf.extended.sample.tfm_ipc.no_bl2:
     tags:
       - introduction
       - trusted-firmware-m

--- a/samples/zephyr/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/zephyr/tfm_integration/tfm_secure_partition/sample.yaml
@@ -21,9 +21,9 @@ sample:
   name: "TFM Secure Partition Sample"
 
 tests:
-  sample.tfm.secure_partition.ipc:
+  nrf.extended.sample.tfm.secure_partition.ipc:
     extra_configs:
       - CONFIG_TFM_IPC=y
-  sample.tfm.secure_partition.sfn:
+  nrf.extended.sample.tfm.secure_partition.sfn:
     extra_configs:
       - CONFIG_TFM_SFN=y


### PR DESCRIPTION
When sample/test is copied from sdk-zephyr to sdk-nrf, it must get unique name.
Otherwise Twister will fail reporting:
twisterlib.error.TwisterRuntimeError: Duplicated test scenarios found