### PR TITLE
sysbuild: Add non-secure flash sim overlay file

### DIFF
--- a/modules/mcuboot/flash_sim.overlay
+++ b/modules/mcuboot/flash_sim.overlay
@@ -14,9 +14,15 @@
  */
 
 / {
+	/*
+	 * Non-secure is excluded from changing the chosen SRAM node, as images specify a memory
+	 * region in RAM that is dedicated to the non-secure image, thus no offset is needed.
+	 */
+#ifndef NS_PARTITION_LAYOUT
 	chosen {
 		zephyr,sram = &sram0_offset_for_dfu;
 	};
+#endif
 
 	soc {
 		/*

--- a/modules/mcuboot/flash_sim_ns.overlay
+++ b/modules/mcuboot/flash_sim_ns.overlay
@@ -1,0 +1,2 @@
+#define NS_PARTITION_LAYOUT
+#include "flash_sim.overlay"

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -801,10 +801,17 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
             ${ZEPHYR_NRF_MODULE_DIR}/modules/mcuboot/flash_sim_mcuboot.overlay
           )
 
-          add_overlay_dts(
-            ${DEFAULT_IMAGE}
-            ${ZEPHYR_NRF_MODULE_DIR}/modules/mcuboot/flash_sim.overlay
-          )
+          if(SB_CONFIG_BOARD_IS_NON_SECURE)
+            add_overlay_dts(
+              ${DEFAULT_IMAGE}
+              ${ZEPHYR_NRF_MODULE_DIR}/modules/mcuboot/flash_sim_ns.overlay
+            )
+          else()
+            add_overlay_dts(
+              ${DEFAULT_IMAGE}
+              ${ZEPHYR_NRF_MODULE_DIR}/modules/mcuboot/flash_sim.overlay
+            )
+          endif()
         endif()
       else()
         set_config_bool(mcuboot CONFIG_PCD_APP n)


### PR DESCRIPTION
Adds an overlay which is used on non-secure nRF53 board targets as they do not use RAM at the beginning of the RAM start area, due to being offset for the TF-M secure image