### PR TITLE
manifest: sdk-hostap: Override hostname checks in supplicant

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -279,7 +279,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: 8fd18deb93f639919650fd7a35546a958c3f25c6
+      revision: pull/185/head
 
   # West-related configuration for the nrf repository.
   self:


### PR DESCRIPTION
Override hostap checks done in MbedTLS with the
checks that are being done in supplicant.

Fixes SHEL-3683.