### PR TITLE
net: lib: mqtt_helper: Conditionally request IPv6 address

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -662,6 +662,10 @@ Libraries for networking
 
   * Updated the status from experimental to supported.
 
+* :ref:`lib_mqtt_helper` library:
+
+  * Fixed an issue where the library could overflow the broker address buffer if an IPv6 address was returned by the DNS resolver while the :kconfig:option:`CONFIG_NET_IPV6` Kconfig option was disabled.
+
 Libraries for NFC
 -----------------
 

--- a/subsys/net/lib/mqtt_helper/mqtt_helper.c
+++ b/subsys/net/lib/mqtt_helper/mqtt_helper.c
@@ -378,10 +378,18 @@ static int broker_init(struct net_sockaddr_storage *broker,
 		       struct mqtt_helper_conn_params *conn_params)
 {
 	int err;
+	bool resolved = false;
 	struct zsock_addrinfo *result;
 	struct zsock_addrinfo *addr;
 	struct zsock_addrinfo hints = {
-		.ai_socktype = NET_SOCK_STREAM
+		.ai_socktype = NET_SOCK_STREAM,
+#if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV4)
+		.ai_family = NET_AF_UNSPEC,
+#elif defined(CONFIG_NET_IPV6)
+		.ai_family = NET_AF_INET6,
+#else
+		.ai_family = NET_AF_INET,
+#endif
 	};
 	char addr_str[NET_IPV6_ADDR_LEN];
 
@@ -402,6 +410,7 @@ static int broker_init(struct net_sockaddr_storage *broker,
 	addr = result;
 
 	while (addr != NULL) {
+#if defined(CONFIG_NET_IPV6)
 		if (addr->ai_family == NET_AF_INET6) {
 			struct net_sockaddr_in6 *broker6 = ((struct net_sockaddr_in6 *)broker);
 
@@ -414,8 +423,14 @@ static int broker_init(struct net_sockaddr_storage *broker,
 					addr_str, sizeof(addr_str));
 			LOG_DBG("IPv6 Address found %s (%s)", addr_str,
 				net_family2str(addr->ai_family));
+
+			resolved = true;
+
 			break;
-		} else if (addr->ai_family == NET_AF_INET) {
+		}
+#endif /* CONFIG_NET_IPV6 */
+
+		if (addr->ai_family == NET_AF_INET) {
 			struct net_sockaddr_in *broker4 = ((struct net_sockaddr_in *)broker);
 
 			net_ipaddr_copy(&broker4->sin_addr,
@@ -427,17 +442,27 @@ static int broker_init(struct net_sockaddr_storage *broker,
 					addr_str, sizeof(addr_str));
 			LOG_DBG("IPv4 Address found %s (%s)", addr_str,
 				net_family2str(addr->ai_family));
+
+			resolved = true;
+
 			break;
-		} else {
-			LOG_DBG("Unknown address family %d", (unsigned int)addr->ai_family);
 		}
+
+		LOG_DBG("Skipping unsupported address family %d",
+			(unsigned int)addr->ai_family);
 
 		addr = addr->ai_next;
 	}
 
 	zsock_freeaddrinfo(result);
 
-	return err;
+	if (!resolved) {
+		LOG_ERR("No usable address returned for %s", conn_params->hostname.ptr);
+
+		return -ENOENT;
+	}
+
+	return 0;
 }
 
 static int client_connect(struct mqtt_helper_conn_params *conn_params)

--- a/tests/subsys/net/lib/mqtt_helper/src/mqtt_helper_test.c
+++ b/tests/subsys/net/lib/mqtt_helper/src/mqtt_helper_test.c
@@ -51,6 +51,17 @@ extern void mqtt_helper_poll_loop(void);
 extern void on_publish(const struct mqtt_evt *mqtt_evt);
 extern char payload_buf[];
 
+/* Fake addrinfo entries returned from the mocked zsock_getaddrinfo(). */
+static struct net_sockaddr_in test_sockaddr_in = {
+	.sin_family = NET_AF_INET,
+};
+static struct zsock_addrinfo test_addrinfo = {
+	.ai_family = NET_AF_INET,
+	.ai_addr = (struct net_sockaddr *)&test_sockaddr_in,
+	.ai_addrlen = sizeof(test_sockaddr_in),
+	.ai_next = NULL,
+};
+
 /* Semaphores used by tests to wait for a certain callbacks */
 static K_SEM_DEFINE(connack_success_sem, 0, 1);
 static K_SEM_DEFINE(connack_failed_sem, 0, 1);
@@ -273,12 +284,7 @@ void test_mqtt_helper_connect_when_disconnected(void)
 			.size = TEST_DEVICE_ID_LEN,
 		},
 	};
-
-	/* Make getddrinfo return a pointer that points to NULL. Otherwise the unit under test
-	 * would be dereferencing uninitialized memory location. The behavior of the unit
-	 * under test for when non-NULL values are returned is out of scope of this test.
-	 */
-	struct zsock_addrinfo *test_res = NULL;
+	struct zsock_addrinfo *test_res = &test_addrinfo;
 
 	__cmock_zsock_getaddrinfo_ExpectAndReturn(NULL, NULL, NULL, NULL, 0);
 	__cmock_zsock_getaddrinfo_IgnoreArg_host();
@@ -286,6 +292,7 @@ void test_mqtt_helper_connect_when_disconnected(void)
 	__cmock_zsock_getaddrinfo_IgnoreArg_res();
 	__cmock_zsock_getaddrinfo_ReturnThruPtr_res(&test_res);
 
+	__cmock_zsock_inet_ntop_IgnoreAndReturn(NULL);
 	__cmock_zsock_freeaddrinfo_ExpectAnyArgs();
 	__cmock_mqtt_connect_ExpectAndReturn(&mqtt_client, 0);
 
@@ -298,15 +305,7 @@ void test_mqtt_helper_connect_when_disconnected(void)
 void test_mqtt_helper_connect_when_disconnected_mqtt_api_error(void)
 {
 	struct mqtt_helper_conn_params conn_params_dummy;
-
-	__cmock_zsock_freeaddrinfo_ExpectAnyArgs();
-	__cmock_mqtt_connect_ExpectAndReturn(&mqtt_client, -2);
-
-	/* Make getddrinfo return a pointer that points to NULL. Otherwise the unit under test
-	 * would be dereferencing uninitialized memory location. The behavior of the unit
-	 * under test for when non-NULL values are returned is out of scope of this test.
-	 */
-	struct zsock_addrinfo *test_res = NULL;
+	struct zsock_addrinfo *test_res = &test_addrinfo;
 
 	__cmock_zsock_getaddrinfo_ExpectAndReturn(NULL, NULL, NULL, NULL, 0);
 	__cmock_zsock_getaddrinfo_IgnoreArg_host();
@@ -314,9 +313,13 @@ void test_mqtt_helper_connect_when_disconnected_mqtt_api_error(void)
 	__cmock_zsock_getaddrinfo_IgnoreArg_res();
 	__cmock_zsock_getaddrinfo_ReturnThruPtr_res(&test_res);
 
+	__cmock_zsock_inet_ntop_IgnoreAndReturn(NULL);
+	__cmock_zsock_freeaddrinfo_ExpectAnyArgs();
+	__cmock_mqtt_connect_ExpectAndReturn(&mqtt_client, -ENOENT);
+
 	mqtt_state = MQTT_STATE_DISCONNECTED;
 
-	TEST_ASSERT_EQUAL(-2, mqtt_helper_connect(&conn_params_dummy));
+	TEST_ASSERT_EQUAL(-ENOENT, mqtt_helper_connect(&conn_params_dummy));
 	TEST_ASSERT_EQUAL(MQTT_STATE_DISCONNECTED, mqtt_state_get());
 }
 


### PR DESCRIPTION
Only request Ipv6 address if CONFIG_NET_IPV6 is enabled. This fixes a possible buffer overflow where neighboring memory could be overwritten by IPv6 address if CONFIG_NET_IPV6 was not enabled, but DNS request responded with an IPv6 address.