### PR TITLE
tests: drivers: usb: Add PM test for USB + system off

### DIFF
--- a/tests/benchmarks/multicore/idle_usb/Kconfig
+++ b/tests/benchmarks/multicore/idle_usb/Kconfig
@@ -1,3 +1,6 @@
+config TEST_USB_AND_SYSTEMOFF
+	bool "Enter system offi nstead of system on all idle"
+
 source "$(ZEPHYR_BASE)/samples/subsys/usb/common/Kconfig.sample_usbd"
 
 source "Kconfig.zephyr"

--- a/tests/benchmarks/multicore/idle_usb/src/main.c
+++ b/tests/benchmarks/multicore/idle_usb/src/main.c
@@ -18,6 +18,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/gpio.h>
 #include <sample_usbd.h>
+#if defined(CONFIG_TEST_USB_AND_SYSTEMOFF)
+#include <zephyr/sys/poweroff.h>
+#endif
 
 LOG_MODULE_REGISTER(idle_usb, LOG_LEVEL_INF);
 
@@ -230,5 +233,9 @@ int main(void)
 
 	LOG_INF("Good night");
 	gpio_pin_set_dt(&led, 0);
+#if defined(CONFIG_TEST_USB_AND_SYSTEMOFF)
+	sys_poweroff();
+#else
 	k_sleep(K_FOREVER);
+#endif
 }

--- a/tests/benchmarks/multicore/idle_usb/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_usb/testcase.yaml
@@ -7,7 +7,7 @@ common:
     - usb
     - ppk_power_measure
 tests:
-  benchmarks.multicore.idle_usb.nrf54h20dk_cpuapp_cpurad.s2ram:
+  benchmarks.multicore.idle_usb:
     harness: pytest
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
@@ -20,3 +20,17 @@ tests:
       fixture: ppk_power_measure_usb
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_usb"
+
+  benchmarks.multicore.idle_usb.system_off:
+    harness: pytest
+    platform_allow:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+    integration_platforms:
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+    extra_configs:
+      - CONFIG_TEST_USB_AND_SYSTEMOFF=y
+    harness_config:
+      fixture: ppk_power_measure_usb
+      pytest_root:
+        - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_usb_system_off"


### PR DESCRIPTION
Extend the 'idle_usb' test, measure configuration
in which device enters 'System Off' after
the usb transmisssion.