### PR TITLE
tests: drivers: spi: spi_latency: Fix nrf9251dk configuration

### DIFF
--- a/tests/drivers/spi/spi_latency/boards/nrf9251dk_nrf9251_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_latency/boards/nrf9251dk_nrf9251_cpuapp_fast.overlay
@@ -22,16 +22,17 @@
 	spi120_default: spi120_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 5, 1)>,
-				<NRF_PSEL(SPIM_MISO, 5, 2)>,
-				<NRF_PSEL(SPIM_MOSI, 5, 4)>;
+				<NRF_PSEL(SPIM_MISO, 5, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 5, 2)>;
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
 		};
 	};
 
 	spi120_sleep: spi120_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 5, 1)>,
-				<NRF_PSEL(SPIM_MISO, 5, 2)>,
-				<NRF_PSEL(SPIM_MOSI, 5, 4)>;
+				<NRF_PSEL(SPIM_MISO, 5, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 5, 2)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Use correct MISO and MOSI and use extra high drive for 16 MHz.