### PR TITLE
Samples: Bluetooth: Mesh: Avoid error during input OOB

### DIFF
--- a/samples/bluetooth/mesh/light_dimmer/src/model_handler.c
+++ b/samples/bluetooth/mesh/light_dimmer/src/model_handler.c
@@ -221,7 +221,6 @@ static void scene_button_handler(struct scene_btn_ctx *ctx, bool pressed)
 static void button_handler_cb(uint32_t pressed, uint32_t changed)
 {
 	if (!bt_mesh_is_provisioned()) {
-		LOG_ERR("Node is not provisioned");
 		return;
 	}
 

--- a/samples/bluetooth/mesh/sensor_server/src/model_handler.c
+++ b/samples/bluetooth/mesh/sensor_server/src/model_handler.c
@@ -934,7 +934,6 @@ static void motion_button_handler(bool pressed)
 static void button_handler_cb(uint32_t pressed, uint32_t changed)
 {
 	if (!bt_mesh_is_provisioned()) {
-		printk("Node is not provisioned");
 		return;
 	}
 


### PR DESCRIPTION
For samples which add a button handler for sample-specific functionality, this will run in parallell with the OOB button handler during OOB input. This affects two samples which print or log an error when buttons are pressed when the node is unprovisioned, which will be printed on every button press during input OOB, which is noisy. This print/log has been removed for these samples (light_dimmer and sensor_server), which is aligned with the silent handling of unprovisioned nodes already done in the light_switch and sensor_client samples.