### PR TITLE
samples: event_manager_proxy: extend ipc timeout for lv10

### DIFF
--- a/samples/event_manager_proxy/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
+++ b/samples/event_manager_proxy/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_EVENT_MANAGER_PROXY_BIND_TIMEOUT_MS=4000


### PR DESCRIPTION
Similar like for lm20, make sample more stable with flpr.