### PR TITLE
tests: zephyr: drivers: uart: async_dual: Change pins for nrf9251dk

### DIFF
--- a/tests/zephyr/drivers/uart/uart_async_dual/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/uart/uart_async_dual/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -5,14 +5,14 @@
  */
 
 /* Test requires loopbacks:
- * TX-RX: P2.03 - P2.09
+ * TX-RX: P1.04 - P1.11
  * RTS-CTS: P1.08 - P1.09 (connected with NFCT antena)
  */
 
 &pinctrl {
 	uart130_alt_default: uart130_alt_default {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 2, 3)>;
+			psels = <NRF_PSEL(UART_RX, 1, 4)>;
 			bias-pull-up;
 		};
 
@@ -23,7 +23,7 @@
 
 	uart130_alt_sleep: uart130_alt_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 2, 3)>,
+			psels = <NRF_PSEL(UART_RX, 1, 4)>,
 				<NRF_PSEL(UART_RTS, 1, 8)>;
 			low-power-enable;
 			bias-pull-up;
@@ -32,7 +32,7 @@
 
 	uart131_alt_default: uart131_alt_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 2, 9)>;
+			psels = <NRF_PSEL(UART_TX, 1, 11)>;
 		};
 
 		group2 {
@@ -43,7 +43,7 @@
 
 	uart131_alt_sleep: uart131_alt_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 2, 9)>,
+			psels = <NRF_PSEL(UART_TX, 1, 11)>,
 				<NRF_PSEL(UART_CTS, 1, 9)>;
 			low-power-enable;
 			bias-pull-up;


### PR DESCRIPTION
P2.3 and P2.9 are connected to LED and resistor which may impact this stress test. Use P1.4-P1.11 instead which are not connected to anything on the DK.