### PR TITLE
sysbuild: mcuboot use PSA_Crypto on nRF54h20

### DIFF
--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -449,6 +449,10 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
         set_config_bool(mcuboot CONFIG_NCS_MCUBOOT_LOAD_PERIPHCONF n)
         set_config_bool(mcuboot CONFIG_NRF_PERIPHCONF_GENERATE_ENTRIES_LOCK y)
       endif()
+
+      if(SB_CONFIG_BOOT_SIGNATURE_TYPE_ED25519)
+        set_config_bool(mcuboot CONFIG_PSA_CRYPTO y)
+      endif()
     endif()
 
     # A v1 board doesn't define board qualifiers, thus below test will just test the pure board


### PR DESCRIPTION
MCUboot should use PSA_Crypto, not the TinyCrypt.