### PR TITLE
sysbuild: Fix merged hex output

### DIFF
--- a/applications/image_flasher/CMakeLists.txt
+++ b/applications/image_flasher/CMakeLists.txt
@@ -29,15 +29,29 @@ endif()
 # west expects it
 set(PROJECT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/zephyr)
 
-# Copy over Kconfig and dts files from the main image
+# Done as a 2-step operation to avoid CI Kconfig compliance issue
+set(soc_nrf CONFIG_SOC)
+string(APPEND soc_nrf _NRF)
+
+# Copy over Kconfig and dts configuration from the main image
 set(base_image_binary_dir ${PROJECT_BINARY_DIR}/../../${base_image}/zephyr)
-zephyr_file_copy(${base_image_binary_dir}/.config ${PROJECT_BINARY_DIR}/.config
+
+add_custom_target(${base_image}_kconfig)
+import_kconfig(CONFIG_ ${base_image_binary_dir}/.config TARGET ${base_image}_kconfig)
+get_target_property(${base_image}_kconfig_keys ${base_image}_kconfig kconfigs)
+list(FILTER ${base_image}_kconfig_keys INCLUDE REGEX
+  "^${soc_nrf}|^CONFIG_SOC_SERIES|^CONFIG_SOC_FAMILY|^CONFIG_BOARD_"
+)
+foreach(key ${${base_image}_kconfig_keys})
+  get_target_property(value ${base_image}_kconfig ${key})
+  list(APPEND image_flasher_config "${key}=${value}\n")
+endforeach()
+
+file(WRITE ${PROJECT_BINARY_DIR}/.config.new ${image_flasher_config})
+zephyr_file_copy(${PROJECT_BINARY_DIR}/.config.new ${PROJECT_BINARY_DIR}/.config
   ONLY_IF_DIFFERENT
 )
-zephyr_file_copy(${base_image_binary_dir}/edt.pickle ${PROJECT_BINARY_DIR}/edt.pickle
-  ONLY_IF_DIFFERENT
-)
-import_kconfig(CONFIG_ ${base_image_binary_dir}/.config)
+import_kconfig(CONFIG_ ${PROJECT_BINARY_DIR}/.config)
 
 # Manually include board configuration to enable automatic runners.yaml generation
 foreach(dir ${BOARD_DIRECTORIES})

--- a/cmake/sysbuild/b0_mcuboot_signing.cmake
+++ b/cmake/sysbuild/b0_mcuboot_signing.cmake
@@ -168,9 +168,21 @@ function(ncs_secure_boot_mcuboot_sign application bin_files signed_targets prefi
 
   if(byproducts)
     add_custom_target(${application}_signed_packaged_target
-        ALL DEPENDS
-        ${byproducts}
-        )
+      ALL DEPENDS
+      ${byproducts}
+    )
+
+    if(SB_CONFIG_MERGED_HEX_FILES)
+      set(board_target)
+      sysbuild_get(board_target IMAGE ${application} VAR CONFIG_BOARD_TARGET KCONFIG)
+      string(REPLACE "/" "_" board_target ${board_target})
+      string(REPLACE "@" "_" board_target ${board_target})
+
+      set_property(GLOBAL APPEND
+        PROPERTY sysbuild_merged_hex_dependencies_${board_target}
+          ${application}_signed_packaged_target
+      )
+    endif()
 
     list(APPEND signed_targets ${application}_signed_packaged_target)
     set(signed_targets ${signed_targets} PARENT_SCOPE)

--- a/cmake/sysbuild/bootconf.cmake
+++ b/cmake/sysbuild/bootconf.cmake
@@ -42,6 +42,19 @@ add_custom_target(bootconf_target
   DEPENDS ${bootconf_hex}
 )
 
+if(SB_CONFIG_MERGED_HEX_FILES)
+  set(board_target)
+  sysbuild_get(board_target IMAGE b0 VAR CONFIG_BOARD_TARGET KCONFIG)
+  string(REPLACE "/" "_" board_target ${board_target})
+  string(REPLACE "@" "_" board_target ${board_target})
+
+  set_property(GLOBAL APPEND
+    PROPERTY sysbuild_merged_hex_dependencies_${board_target} bootconf_target
+  )
+
+  set(board_target)
+endif()
+
 if(SB_CONFIG_PARTITION_MANAGER)
   set_property(
     GLOBAL PROPERTY

--- a/cmake/sysbuild/fast_pair/hex.cmake
+++ b/cmake/sysbuild/fast_pair/hex.cmake
@@ -114,7 +114,19 @@ function(fast_pair_hex_dts)
     ALL
     DEPENDS
     "${fp_provisioning_data_hex}"
-    )
+  )
+
+    if(SB_CONFIG_MERGED_HEX_FILES)
+      set(board_target)
+      sysbuild_get(board_target IMAGE ${DEFAULT_IMAGE} VAR CONFIG_BOARD_TARGET KCONFIG)
+      string(REPLACE "/" "_" board_target ${board_target})
+      string(REPLACE "@" "_" board_target ${board_target})
+
+      set_property(GLOBAL APPEND
+        PROPERTY sysbuild_merged_hex_dependencies_${board_target} ${fp_partition_name}_target
+      )
+    endif()
+#message(WARNING "added ${fp_partition_name}_target to sysbuild_merged_hex_dependencies_${board_target}")
 endfunction()
 
 function(fast_pair_device_model_warning)

--- a/cmake/sysbuild/image_signing_extra.cmake
+++ b/cmake/sysbuild/image_signing_extra.cmake
@@ -238,6 +238,20 @@ if(num_binaries GREATER 0)
 
     add_custom_target(extra_img_${extra_image_number}_target ALL DEPENDS ${output_hex})
 
+    if(SB_CONFIG_MERGED_HEX_FILES)
+      set(board_target)
+      sysbuild_get(board_target IMAGE ${DEFAULT_IMAGE} VAR CONFIG_BOARD_TARGET KCONFIG)
+      string(REPLACE "/" "_" board_target ${board_target})
+      string(REPLACE "@" "_" board_target ${board_target})
+
+      set_property(GLOBAL APPEND
+        PROPERTY sysbuild_merged_hex_dependencies_${board_target}
+          extra_img_${extra_image_number}_target
+      )
+
+      set(board_target)
+    endif()
+
     set_property(GLOBAL PROPERTY ${image_name}_PM_HEX_FILE ${output_hex})
     set_property(GLOBAL PROPERTY ${image_name}_PM_TARGET extra_img_${extra_image_number}_target)
 

--- a/cmake/sysbuild/image_signing_nrf700x.cmake
+++ b/cmake/sysbuild/image_signing_nrf700x.cmake
@@ -95,6 +95,17 @@ function(nrf7x_signing_tasks input output_hex output_bin dependencies)
     )
   endif()
 
+  if(SB_CONFIG_MERGED_HEX_FILES)
+    set(board_target)
+    sysbuild_get(board_target IMAGE ${DEFAULT_IMAGE} VAR CONFIG_BOARD_TARGET KCONFIG)
+    string(REPLACE "/" "_" board_target ${board_target})
+    string(REPLACE "@" "_" board_target ${board_target})
+
+    set_property(GLOBAL APPEND
+      PROPERTY sysbuild_merged_hex_dependencies_${board_target} nrf70_wifi_fw_patch_signed_target
+    )
+  endif()
+
   add_custom_command(OUTPUT ${output_hex}
     COMMAND
     ${imgtool_sign} ${imgtool_args} ${input} ${output_hex}

--- a/cmake/sysbuild/nrf700x.cmake
+++ b/cmake/sysbuild/nrf700x.cmake
@@ -34,6 +34,17 @@ function(setup_nrf700x_xip_data)
       ALL
       DEPENDS ${CMAKE_BINARY_DIR}/nrf70.hex
     )
+
+    if(SB_CONFIG_MERGED_HEX_FILES)
+      set(board_target)
+      sysbuild_get(board_target IMAGE ${DEFAULT_IMAGE} VAR CONFIG_BOARD_TARGET KCONFIG)
+      string(REPLACE "/" "_" board_target ${board_target})
+      string(REPLACE "@" "_" board_target ${board_target})
+
+      set_property(GLOBAL APPEND
+        PROPERTY sysbuild_merged_hex_dependencies_${board_target} nrf70_wifi_fw_patch_target
+      )
+    endif()
   else()
     add_custom_target(nrf70_wifi_fw_patch_target
       DEPENDS ${CMAKE_BINARY_DIR}/nrf70.hex

--- a/cmake/sysbuild/provision_hex.cmake
+++ b/cmake/sysbuild/provision_hex.cmake
@@ -222,6 +222,21 @@ function(provision application prefix_name)
       DEPENDS
       ${PROVISION_HEX}
     )
+
+    if(SB_CONFIG_MERGED_HEX_FILES)
+      if(cpunet_target)
+        sysbuild_get(board_target IMAGE b0n VAR CONFIG_BOARD_TARGET KCONFIG)
+      else()
+        sysbuild_get(board_target IMAGE ${DEFAULT_IMAGE} VAR CONFIG_BOARD_TARGET KCONFIG)
+      endif()
+
+      string(REPLACE "/" "_" board_target ${board_target})
+      string(REPLACE "@" "_" board_target ${board_target})
+      set_property(GLOBAL APPEND
+        PROPERTY sysbuild_merged_hex_dependencies_${board_target} ${prefix_name}provision_target
+      )
+    endif()
+#message(WARNING "added ${prefix_name}provision_target to sysbuild_merged_hex_dependencies_${board_target}")
   endif()
 endfunction()
 

--- a/cmake/sysbuild/sign.cmake
+++ b/cmake/sysbuild/sign.cmake
@@ -287,6 +287,17 @@ function(b0_sign_image slot cpunet_target)
     )
   endif()
 
+  if(SB_CONFIG_MERGED_HEX_FILES)
+    set(board_target)
+    sysbuild_get(board_target IMAGE ${target_name} VAR CONFIG_BOARD_TARGET KCONFIG)
+    string(REPLACE "/" "_" board_target ${board_target})
+    string(REPLACE "@" "_" board_target ${board_target})
+
+    set_property(GLOBAL APPEND
+      PROPERTY sysbuild_merged_hex_dependencies_${board_target} ${slot}_signature_file_target
+    )
+  endif()
+
   cmake_path(GET signed_hex FILENAME signed_hex_filename)
   cmake_path(GET to_sign FILENAME to_sign_filename)
   set(validation_comment "Creating validation for ${to_sign_filename}, storing to ${signed_hex_filename}")

--- a/sysbuild/matter.cmake
+++ b/sysbuild/matter.cmake
@@ -13,4 +13,17 @@ if(SB_CONFIG_ZEPHYR_CONNECTEDHOMEIP_MODULE AND SB_CONFIG_MATTER AND
     NAME matter_factory_data
     HEX_FILE "${CMAKE_BINARY_DIR}/matter_factory_data/zephyr/factory_data.hex"
   )
+
+  if(SB_CONFIG_MERGED_HEX_FILES)
+    set(board_target)
+    sysbuild_get(board_target IMAGE ${DEFAULT_IMAGE} VAR CONFIG_BOARD_TARGET KCONFIG)
+    string(REPLACE "/" "_" board_target ${board_target})
+    string(REPLACE "@" "_" board_target ${board_target})
+
+    set_property(GLOBAL APPEND
+      PROPERTY sysbuild_merged_hex_dependencies_${board_target} factory_data
+    )
+
+    set(board_target)
+  endif()
 endif()

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 544950b66a38cde53c651a4259a76d392d390006
+      revision: 0fdd247d86a2567be3cdda97a2bd39be221b3883
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
    applications: image_flasher: Create minimal Kconfig output
    
    Creates a minified Kconfig .config file, selecting Kconfigs from
    the parent image which contains only specific Kconfigs that the
    west flash runner needs to program the image


    sysbuild: cmake: Add dependencies for merged hex files
    
    Uses the newly introduced Zephyr property for dependencies in
    sysbuild merged hex files
