### PR TITLE
samples: matter: Align Matter storage partition sizes in DTS

### DIFF
--- a/dts/samples/matter/nrf52840_partitions.dtsi
+++ b/dts/samples/matter/nrf52840_partitions.dtsi
@@ -36,7 +36,7 @@
 		storage_partition: partition@f8000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x000f8000 DT_SIZE_K(40)>;
+			reg = <0x000f8000 DT_SIZE_K(32)>;
 		};
 	};
 };

--- a/dts/samples/matter/nrf54lm20_cpuapp_internal_partitions.dtsi
+++ b/dts/samples/matter/nrf54lm20_cpuapp_internal_partitions.dtsi
@@ -50,7 +50,7 @@
 		storage_partition: partition@1f1000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x001f1000 DT_SIZE_K(40)>;
+			reg = <0x001f1000 DT_SIZE_K(48)>;
 		};
 	};
 };

--- a/dts/samples/matter/nrf54lm20_cpuapp_partitions.dtsi
+++ b/dts/samples/matter/nrf54lm20_cpuapp_partitions.dtsi
@@ -39,7 +39,7 @@
 		storage_partition: partition@1f1000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x001f1000 DT_SIZE_K(40)>;
+			reg = <0x001f1000 DT_SIZE_K(48)>;
 		};
 	};
 };


### PR DESCRIPTION
Restore settings storage sizes to match NCS v3.2/v3.3 pm_static layouts after the PM-to-DTS migration on main. Use 48 KB on nRF54LM20 (LM20A and LM20B, internal and external variants) and 32 KB on nRF52840 so the storage region no longer exceeds available flash.