### PR TITLE
scripts: sbom: Update report to SPDX 2.3

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -477,7 +477,11 @@ Scripts
 
 This section provides detailed lists of changes by :ref:`script <scripts>`.
 
-|no_changes_yet_note|
+* :ref:`west_sbom` script:
+
+* Updated:
+
+  * The SPDX output format from ``SPDX-2.2`` to ``SPDX-2.3``.
 
 Integrations
 ============

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -479,6 +479,10 @@ This section provides detailed lists of changes by :ref:`script <scripts>`.
 
 * :ref:`west_sbom` script:
 
+* Added:
+
+  * ``--package-download-format`` option to control the SPDX PackageDownloadLocation format.
+
 * Updated:
 
   * The SPDX output format from ``SPDX-2.2`` to ``SPDX-2.3``.

--- a/scripts/west_commands/sbom/README.rst
+++ b/scripts/west_commands/sbom/README.rst
@@ -237,7 +237,7 @@ You can specify the format of the report output using the ``output`` argument.
   The :file:`sbom_report.html` file is generated in your build directory
   (the first one if you specify more than one build directory).
 
-* To generate an SPDX 2.2 format report (for CRA/EO 14028/FDA compliance):
+* To generate an SPDX 2.3 format report (for CRA/EO 14028/FDA compliance):
 
   .. parsed-literal::
      :class: highlight
@@ -247,13 +247,16 @@ You can specify the format of the report output using the ``output`` argument.
   The SPDX report groups files into packages and includes:
 
   * Package supplier information (auto-detected from git URLs or specified via ``--package-supplier``)
-  * Component name, version, and download location
+  * Component name, version, and ``PackageDownloadLocation`` (``git+<url>@<sha>`` for git-resolved packages)
+  * ``PackageHomePage`` for browsable project links
   * Package URLs (PURLs) for unique package identification
   * Common Platform Enumeration (CPE) identifiers when specified via ``--package-cpe``
   * Dependency relationships showing supply chain connections
   * File checksums and license information
+  * ``PrimaryPackagePurpose`` (``APPLICATION``, ``SOURCE``, or ``OTHER``) auto-detected for each package
+  * ``BuiltDate`` on the application package, taken from the newest build-artifact timestamp
 
-  SPDX 2.2 is currently the supported machine-readable standardized output format.
+  SPDX 2.3 is the supported machine-readable standardized output format.
 
   This format meets requirements from:
 

--- a/scripts/west_commands/sbom/README.rst
+++ b/scripts/west_commands/sbom/README.rst
@@ -247,7 +247,7 @@ You can specify the format of the report output using the ``output`` argument.
   The SPDX report groups files into packages and includes:
 
   * Package supplier information (auto-detected from git URLs or specified via ``--package-supplier``)
-  * Component name, version, and ``PackageDownloadLocation`` (``git+<url>@<sha>`` for git-resolved packages)
+  * Component name, version, and ``PackageDownloadLocation`` (``git+<url>@<sha>`` for git-resolved packages; use ``--package-download-format github-archive`` to emit a GitHub archive zip URL instead)
   * ``PackageHomePage`` for browsable project links
   * Package URLs (PURLs) for unique package identification
   * Common Platform Enumeration (CPE) identifiers when specified via ``--package-cpe``

--- a/scripts/west_commands/sbom/args.py
+++ b/scripts/west_commands/sbom/args.py
@@ -70,6 +70,7 @@ class ArgsClass:
     output_spdx: 'str|None'
     package_supplier: 'str|None'
     package_cpe: 'str|None'
+    package_download_format: str
     debug_build_input_cache: 'str|None'
 
 
@@ -149,6 +150,11 @@ def add_arguments(parser: argparse.ArgumentParser):
     parser.add_argument('--package-cpe', default=None,
                         help='Set the Common Platform Enumeration (CPE) identifier for packages '
                              '(for CRA/EO/FDA compliance). Format: cpe:2.3:...')
+    parser.add_argument('--package-download-format', default='git',
+                        choices=('git', 'github-archive'),
+                        help='Format for the SPDX PackageDownloadLocation field. '
+                             '"git" (default) emits "git+<url>@<version>". '
+                             '"github-archive" emits a GitHub archive zip URL. ')
     # Hidden arguments (for debug purposes only)
     parser.add_argument('--debug-build-input-cache', default=None, help=argparse.SUPPRESS)
 

--- a/scripts/west_commands/sbom/common.py
+++ b/scripts/west_commands/sbom/common.py
@@ -71,6 +71,15 @@ def command_execute(*cmd_args: 'tuple[str|Path]', cwd: 'str|Path|None' = None,
             return result
 
 
+def is_sha(rev: str) -> bool:
+    '''Returns True if and only if `rev` looks like a full 40-byte git SHA.'''
+    try:
+        int(rev, 16)
+    except ValueError:
+        return False
+    return len(rev) == 40
+
+
 process_executor = None
 thread_executor = None
 

--- a/scripts/west_commands/sbom/data_structure.py
+++ b/scripts/west_commands/sbom/data_structure.py
@@ -39,6 +39,7 @@ class FileInfo(DataBaseClass):
     file_rel_path: Path
     licenses: 'set[str]' = set()
     license_expr: str
+    license_expr_friendly: str = ''
     package: 'str' = ''
     local_modifications: bool = False
     sha1: str
@@ -70,15 +71,17 @@ class License(DataBaseClass):
 class Package(DataBaseClass):
     ''' Contains package information
     Attributes:
-        id             ID of this package
-        name           User friendly name
-        url            URL pointing to the source of this package
-        version        Version string of this package
-        browser_url    URL that can be opened in a web browser
-        supplier       Supplier name
-        purl           Package URL (PURL) identifier
-        cpe            Common Platform Enumeration (CPE) identifier
-        dependencies   List of package IDs this package depends on
+        id                      ID of this package
+        name                    User friendly name
+        url                     URL pointing to the source of this package
+        version                 Version string of this package
+        browser_url             URL that can be opened in a web browser
+        supplier                Supplier name
+        purl                    Package URL (PURL) identifier
+        cpe                     Common Platform Enumeration (CPE) identifier
+        dependencies            List of package IDs this package depends on
+        primary_package_purpose Estimate of the most likely package usage; None to omit
+        built_date              Actual date the package was built; None to omit
     '''
     id: str = ''
     name: 'str|None' = None
@@ -89,6 +92,8 @@ class Package(DataBaseClass):
     purl: 'str|None' = None
     cpe: 'str|None' = None
     dependencies: 'list[str]' = list()
+    primary_package_purpose: 'str|None' = None
+    built_date: 'str|None' = None
 
 
 class LicenseExpr(DataBaseClass):

--- a/scripts/west_commands/sbom/git_info_detector.py
+++ b/scripts/west_commands/sbom/git_info_detector.py
@@ -14,6 +14,10 @@ from west import log
 
                                                     # FileInfo is used.
 
+_manifest_projects: 'dict[Path, object]' = {}
+_self_repo_path: 'Path|None' = None
+_self_repo_version: 'str|None' = None
+
 
 def split_lines(text: str) -> 'tuple[str]':
     '''Split input text into stripped lines removing empty lines.'''
@@ -127,6 +131,80 @@ def get_sha(absolute_path: Path) -> 'str|None':
     return output if (len(output) == 40) and (error_code == 0) else None
 
 
+def get_toplevel(absolute_path: Path) -> 'Path|None':
+    '''Returns the resolved git toplevel directory at `absolute_path`.'''
+    output, error_code = command_execute(args.git, 'rev-parse', '--show-toplevel',
+                                         cwd=absolute_path, return_error_code=True,
+                                         allow_stderr=True)
+    if error_code != 0:
+        return None
+    line = output.strip()
+    if not line:
+        return None
+    try:
+        return Path(line).resolve()
+    except OSError:
+        return None
+
+
+def upstream_url(project) -> 'str|None':
+    '''Returns userdata.ncs.upstream-url for a manifest project.'''
+    userdata = getattr(project, 'userdata', None)
+    if not isinstance(userdata, dict):
+        return None
+    ncs = userdata.get('ncs')
+    if not isinstance(ncs, dict):
+        return None
+    url = ncs.get('upstream-url')
+    return url.strip() if isinstance(url, str) and url.strip() else None
+
+
+def read_version(version_file: Path) -> 'str|None':
+    '''Returns "MAJOR.MINOR.PATCH" from `version_file` when PATCH != 99.
+
+    Expects the single-line "X.Y.Z" form used by sdk-nrf / sdk-nrf-bm.
+    Returns None on missing file, unparseable content, or PATCH == 99
+    (development snapshot — caller should fall back to the git SHA).
+    '''
+    try:
+        text = version_file.read_text(encoding='utf-8').strip()
+    except OSError:
+        return None
+    match = re.match(r'^(\d+)\.(\d+)\.(\d+)$', text)
+    if not match:
+        return None
+    major, minor, patch = (int(x) for x in match.groups())
+    return None if patch == 99 else f'{major}.{minor}.{patch}'
+
+
+def load_manifest():
+    '''Populate the module-level manifest caches consulted by detect_dir.'''
+    global _manifest_projects, _self_repo_path, _self_repo_version
+    _manifest_projects = {}
+    _self_repo_path = None
+    _self_repo_version = None
+    try:
+        from west.manifest import Manifest
+        manifest = Manifest.from_topdir()
+    except Exception:
+        return
+    for project in manifest.projects:
+        abspath = getattr(project, 'abspath', None)
+        if not abspath:
+            continue
+        try:
+            key = Path(abspath).resolve()
+        except OSError:
+            continue
+        if getattr(project, 'url', None):
+            _manifest_projects[key] = project
+        elif _self_repo_path is None:
+            # by west convention projects[0] is the manifest repo.
+            _self_repo_path = key
+    if _self_repo_path is not None:
+        _self_repo_version = read_version(_self_repo_path / 'VERSION')
+
+
 def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
     '''Read input file content and try to detect licenses by its content.'''
     files = func_args[0]
@@ -140,6 +218,13 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
     relative_path = Path(files_to_assign[0].file_rel_path).parent
     git_sha = get_sha(absolute_path)
     git_origin = get_origin(absolute_path, relative_path)
+    repo = get_toplevel(absolute_path)
+    project = _manifest_projects.get(repo) if repo is not None else None
+    if project is not None:
+        git_origin = project.url
+        git_sha = project.revision or git_sha
+    elif _self_repo_version is not None and repo == _self_repo_path:
+        git_sha = _self_repo_version
     if (git_sha is not None) and (git_origin is not None):
         package_id = f'git#{git_origin}#{git_sha}'.upper()
         output, error_code = command_execute(args.git, 'status', '--porcelain', '--ignored',
@@ -165,6 +250,8 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
         if git_origin and git_sha:
             package.purl = git_url_to_purl(git_origin, git_sha)
             package.supplier = args.package_supplier or extract_supplier_from_url(git_origin)
+        if project is not None:
+            package.browser_url = upstream_url(project)
         if args.package_cpe:
             package.cpe = args.package_cpe
         data.packages[package_id] = package
@@ -195,9 +282,12 @@ def detect(data: Data, optional: bool):
     ''' Fill "data" with version information obtained with the "git". '''
 
     check_external_tools()
+    load_manifest()
 
     group_by_dir = {}
     for file in data.files:
+        if '.git' in file.file_rel_path.parts:
+            continue
         dir_name = str(file.file_rel_path.parent)
         if dir_name not in group_by_dir:
             group_by_dir[dir_name] = ([], data)

--- a/scripts/west_commands/sbom/input_build.py
+++ b/scripts/west_commands/sbom/input_build.py
@@ -267,7 +267,6 @@ def register_toolchain_for_build(data: Data, build_dir: Path):
     pkg_version = version or detect_toolchain_version(resolved) or 'UNKNOWN'
     package.id = f'TOOLCHAIN#{pkg_name.upper()}#{pkg_version.upper()}'
     package.name = pkg_name
-    package.url = str(resolved)
     package.version = pkg_version
     if args.package_supplier:
         package.supplier = args.package_supplier

--- a/scripts/west_commands/sbom/main.py
+++ b/scripts/west_commands/sbom/main.py
@@ -7,6 +7,7 @@
 Main entry point for the script.
 '''
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 import cache_database_detector
@@ -63,7 +64,7 @@ def _run_pipeline():
         func(data, optional)
         log.dbg(f'DETECTOR: Done in {t}s')
 
-    output_pre_process.pre_process(data)
+    output_pre_process.pre_process(data, built_date=_compute_built_date())
 
     for generator_name, generator in generators.items():
         output_file = args.__dict__[f'output_{generator_name}']
@@ -71,6 +72,35 @@ def _run_pipeline():
             t = dbg_time(f'GENERATOR: {generator_name}')
             output_template.generate(data, output_file, Path(__file__).parent / generator)
             log.dbg(f'GENERATOR: Done in {t}s')
+
+
+def _compute_built_date() -> 'str|None':
+    '''Newest mtime across *.map and zephyr/runners.yaml as UTC ISO 8601,
+    or None when no artifact exists.'''
+    if not args.build_dir:
+        return None
+    mtimes = []
+    for entry in args.build_dir:
+        build_dir = Path(entry[0])
+        targets = entry[1:] or [input_build.DEFAULT_TARGET]
+        for target_with_map in targets:
+            target_name, separator, map_name = target_with_map.partition(':')
+            if separator:
+                map_file = build_dir / map_name
+            else:
+                map_file = (build_dir / target_name).with_suffix('.map')
+            if map_file.exists():
+                mtimes.append(map_file.stat().st_mtime)
+        runners_yaml = build_dir / 'zephyr' / 'runners.yaml'
+        if runners_yaml.exists():
+            mtimes.append(runners_yaml.stat().st_mtime)
+    if not mtimes:
+        return None
+    return (
+        datetime.fromtimestamp(max(mtimes), tz=timezone.utc)
+        .isoformat(timespec='seconds')
+        .replace('+00:00', 'Z')
+    )
 
 
 def _target_maps_present(build_dir: Path, targets: list[str]) -> bool:

--- a/scripts/west_commands/sbom/output_pre_process.py
+++ b/scripts/west_commands/sbom/output_pre_process.py
@@ -13,8 +13,10 @@ from license_utils import get_license, get_spdx_license_expr_info, is_spdx_licen
 DEPENDENCY_PLACEHOLDER_ID = 'DEPENDENCY-INFORMATION-UNAVAILABLE'
 
 
-def pre_process(data: Data):
-    '''Do pre-processing of data for simpler usage by the output modules.'''
+def pre_process(data: Data, built_date: 'str|None' = None):
+    '''Do pre-processing of data for simpler usage by the output modules.
+    built_date (UTC ISO 8601 or None) is stamped on application packages.
+    '''
     # Sort files
     data.files.sort(key=lambda f: f.file_path)
     # Convert list of licenses to license expression for each file
@@ -72,6 +74,10 @@ def pre_process(data: Data):
                     lic.friendly_id = id
                 used_licenses[id] = lic
     data.licenses = used_licenses
+    # Pre-compute friendly-cased license expression so the SPDX LicenseConcluded matches the casing
+    for file in data.files:
+        lic = data.licenses.get(file.license_expr)
+        file.license_expr_friendly = lic.friendly_id if lic is not None else file.license_expr
     # Sort licenses
     def lic_reorder(id: str):
         lic: License | LicenseExpr = data.licenses[id]
@@ -116,6 +122,7 @@ def pre_process(data: Data):
     files_by_package = group_files_by_package(data)
     assign_application_dependencies(data, files_by_package)
     add_dependency_placeholder_if_needed(data)
+    assign_primary_package_purpose(data, files_by_package, built_date)
     data.packages_sorted = sorted(data.packages.keys())
 
 
@@ -136,6 +143,8 @@ def assign_application_dependencies(data: Data, files_by_package: dict):
     for package_id in application_packages:
         if package_id not in data.packages:
             continue
+        if data.packages[package_id].url is not None:
+            continue
         deps = sorted(pkg for pkg in data.packages if pkg not in ('', package_id))
         data.packages[package_id].dependencies = deps
 
@@ -154,6 +163,45 @@ def packages_for_roots(roots: 'set[str]', files_by_package: dict) -> 'set[str]':
             if pkg_id in packages:
                 break
     return packages
+
+
+def assign_primary_package_purpose(data: Data, files_by_package: dict,
+                                   built_date: 'str|None' = None):
+    '''Set Package.primary_package_purpose and (for APPLICATION) Package.built_date.
+      DEPENDENCY_PLACEHOLDER_ID                                -> OTHER
+      no-URL package with files under data.application_roots   -> APPLICATION
+      package.purl set (git-resolved)                          -> SOURCE
+      otherwise                                                -> omit (left as None)
+
+    Only no-URL packages can be APPLICATION: they hold the build-specific
+    generated artifacts that uniquely identify this build.
+    '''
+    application_pkgs = packages_for_roots(data.application_roots, files_by_package)
+    app_name = application_name(data.application_roots)
+    for pkg_id, package in data.packages.items():
+        if pkg_id == DEPENDENCY_PLACEHOLDER_ID:
+            package.primary_package_purpose = 'OTHER'
+        elif pkg_id in application_pkgs and package.url is None:
+            package.primary_package_purpose = 'APPLICATION'
+            if built_date is not None:
+                package.built_date = built_date
+            if package.name is None and app_name:
+                package.name = app_name
+        elif package.purl:
+            package.primary_package_purpose = 'SOURCE'
+
+
+def application_name(application_roots: 'set[str]') -> 'str|None':
+    '''Application name derived from the application root path.
+
+    Returns the last path component of the first application root (e.g.
+    "temperature_sensor" from "nrf/samples/matter/temperature_sensor").
+    '''
+    for root in sorted(application_roots):
+        name = root.rstrip('/').rsplit('/', 1)[-1]
+        if name:
+            return name
+    return None
 
 
 def add_dependency_placeholder_if_needed(data: Data):

--- a/scripts/west_commands/sbom/output_template.py
+++ b/scripts/west_commands/sbom/output_template.py
@@ -13,7 +13,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import quote
 
-from data_structure import Data, FileInfo  # pylint: disable=unused-import
+from args import args
+from common import is_sha
+from data_structure import Data, FileInfo, Package  # pylint: disable=unused-import
 from jinja2 import Template, filters
 from west import log
 
@@ -65,6 +67,33 @@ def timestamp() -> str:
     return datetime.now(timezone.utc).isoformat(timespec='seconds').replace('+00:00', 'Z')
 
 
+def github_archive_url(git_url: str, version: str) -> 'str|None':
+    '''Convert a GitHub URL and revision to a downloadable archive zip URL.'''
+    url = git_url.strip()
+    if url.endswith('.git'):
+        url = url[:-4]
+    if 'github.com' not in url:
+        return None
+    parts = url.split('github.com', 1)[1].lstrip(':/').split('/')
+    if len(parts) < 2 or not parts[0] or not parts[1]:
+        return None
+    org, repo = parts[0], parts[1]
+    if is_sha(version):
+        return f'https://github.com/{org}/{repo}/archive/{version}.zip'
+    return f'https://github.com/{org}/{repo}/archive/refs/tags/{version}.zip'
+
+
+def download_location(package: Package) -> str:
+    '''Format the SPDX PackageDownloadLocation field for a package.'''
+    if package.purl:
+        if args.package_download_format == 'github-archive':
+            archive_url = github_archive_url(package.url, package.version)
+            if archive_url is not None:
+                return archive_url
+        return f'git+{package.url}@{package.version}'
+    return package.url or 'NONE'
+
+
 def get_ncs_version() -> 'str|None':
     '''NCS version from the repo's root VERSION file, or None if missing.'''
     try:
@@ -89,7 +118,8 @@ def data_to_dict(data: Data, output_directory: Path) -> dict:
         'group_by': group_by,
         'counter': counter,
         'relative_path': lambda file: relative_path(file, output_directory),
-        'timestamp': timestamp
+        'timestamp': timestamp,
+        'download_location': download_location,
     }
     ncs_version = get_ncs_version()
     result['ncs_version_suffix'] = f'-{ncs_version}' if ncs_version else ''

--- a/scripts/west_commands/sbom/output_template.py
+++ b/scripts/west_commands/sbom/output_template.py
@@ -65,6 +65,19 @@ def timestamp() -> str:
     return datetime.now(timezone.utc).isoformat(timespec='seconds').replace('+00:00', 'Z')
 
 
+def get_ncs_version() -> 'str|None':
+    '''NCS version from the repo's root VERSION file, or None if missing.'''
+    try:
+        version_file = Path(__file__).resolve().parents[3] / 'VERSION'
+        if version_file.is_file():
+            value = version_file.read_text(encoding='utf-8').strip()
+            if value:
+                return value
+    except Exception:
+        pass
+    return None
+
+
 def data_to_dict(data: Data, output_directory: Path) -> dict:
     '''Convert object to dict by copying public attributes to a new dictionary.'''
     result = dict()
@@ -78,6 +91,8 @@ def data_to_dict(data: Data, output_directory: Path) -> dict:
         'relative_path': lambda file: relative_path(file, output_directory),
         'timestamp': timestamp
     }
+    ncs_version = get_ncs_version()
+    result['ncs_version_suffix'] = f'-{ncs_version}' if ncs_version else ''
     return result
 
 

--- a/scripts/west_commands/sbom/templates/raport.spdx.jinja
+++ b/scripts/west_commands/sbom/templates/raport.spdx.jinja
@@ -42,11 +42,8 @@ PackageSupplier: Organization: {{package.supplier}}
 {% else -%}
 PackageSupplier: NOASSERTION
 {% endif -%}
-{% if package.purl and package.url and package.version -%}
-PackageDownloadLocation: git+{{package.url}}@{{package.version}}
-{% else -%}
-PackageDownloadLocation: {{package.url or 'NONE'}}
-{% endif -%}
+PackageDownloadLocation: {{func.download_location(package)}}
+
 {% if package.browser_url -%}
 PackageHomePage: {{package.browser_url}}
 {% endif -%}

--- a/scripts/west_commands/sbom/templates/raport.spdx.jinja
+++ b/scripts/west_commands/sbom/templates/raport.spdx.jinja
@@ -1,6 +1,6 @@
 # Document Information
 
-SPDXVersion: SPDX-2.2
+SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: west-ncs-sbom-report
@@ -8,7 +8,7 @@ DocumentNamespace: http://spdx.org/spdxdocs/west-ncs-sbom-{{report_uuid}}
 
 # Creation Info
 
-Creator: Tool: west-ncs-sbom
+Creator: Tool: west-ncs-sbom{{ncs_version_suffix}}
 Created: {{func.timestamp()}}
 CreatorComment:<text>Generated with west-ncs-sbom. For details, see https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/introduction.html#licenses.</text>
 
@@ -42,18 +42,29 @@ PackageSupplier: Organization: {{package.supplier}}
 {% else -%}
 PackageSupplier: NOASSERTION
 {% endif -%}
+{% if package.purl and package.url and package.version -%}
+PackageDownloadLocation: git+{{package.url}}@{{package.version}}
+{% else -%}
 PackageDownloadLocation: {{package.url or 'NONE'}}
+{% endif -%}
+{% if package.browser_url -%}
+PackageHomePage: {{package.browser_url}}
+{% endif -%}
 {% if package.purl -%}
 ExternalRef: PACKAGE-MANAGER purl {{package.purl}}
 {% endif -%}
 {% if package.cpe -%}
 ExternalRef: SECURITY cpe23Type {{package.cpe}}
 {% endif -%}
+{% if package.primary_package_purpose -%}
+PrimaryPackagePurpose: {{package.primary_package_purpose}}
+{% endif -%}
+{% if package.built_date -%}
+BuiltDate: {{package.built_date}}
+{% endif -%}
 FilesAnalyzed: {{'true' if package_files else 'false'}}
 {% if package_files -%}
 PackageVerificationCode: {{package_files | verification_code}}
-{% else -%}
-PackageVerificationCode: NOASSERTION
 {% endif -%}
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseInfoFromFiles: NOASSERTION
@@ -69,7 +80,7 @@ FileChecksum: SHA1: {{file.sha1}}
 {% if file.local_modifications -%}
 FileComment: <text>This file is modified locally.</text>
 {% endif -%}
-LicenseConcluded: {{ file.license_expr | adjust_identifier if file.license_expr != '' else 'NOASSERTION' }}
+LicenseConcluded: {{ file.license_expr_friendly if file.license_expr_friendly != '' else 'NOASSERTION' }}
 LicenseInfoInFile: NOASSERTION
 FileCopyrightText: NOASSERTION
 


### PR DESCRIPTION
SBOM report output according to SPDX 2.3:
- Bump output to SPDX-2.3
- Add PrimaryPackagePurpose auto-detection (APPLICATION / SOURCE / OTHER, omitted otherwise)
- Add BuiltDate on the app package, from the newest build-artifact mtime
- Add PackageHomePage from browser_url
- NCS version from the root VERSION file
- Fix PackageVerificationCode, now omitted when FilesAnalyzed: false instead of emitting an invalid NOASSERTION
- PackageDownloadLocation: git-resolved packages (git+<url>@<sha>)
- Remove SPDX invalid local toolchain paths into PackageDownloadLocation (toolchain now emits NONE)
- Fix LicenseRef-* (and standard SPDX ID) casing in LicenseConcluded so it matches the LicenseID: in the Extracted Licenses section