### PR TITLE
cmake: Fix wrongly changing hex file to flash with b0 and MCUboot

### DIFF
--- a/cmake/sysbuild/image_signing_b0.cmake
+++ b/cmake/sysbuild/image_signing_b0.cmake
@@ -6,7 +6,11 @@ if(NOT CONFIG_PARTITION_MANAGER_ENABLED)
 
   if(CONFIG_SECURE_BOOT)
     if(CONFIG_BOOTLOADER_MCUBOOT)
-      zephyr_runner_file(hex ${CMAKE_BINARY_DIR}/../signed_by_mcuboot_and_b0_${SYSBUILD_NAME}.hex)
+      if(${CONFIG_MCUBOOT_MCUBOOT_IMAGE_NUMBER} STREQUAL "-1" OR
+        (NOT ${CONFIG_MCUBOOT_MCUBOOT_IMAGE_NUMBER} STREQUAL "-1" AND CONFIG_MCUBOOT)
+      )
+        zephyr_runner_file(hex ${CMAKE_BINARY_DIR}/../signed_by_mcuboot_and_b0_${SYSBUILD_NAME}.hex)
+      endif()
     else()
       zephyr_runner_file(hex ${CMAKE_BINARY_DIR}/../signed_by_b0_${SYSBUILD_NAME}.hex)
     endif()


### PR DESCRIPTION
Fixes an issue whereby a hex file to flash CMake change was wrongly running for both MCUboot and the application when MCUboot and b0 were enabled