### PR TITLE
nrf_cloud: add bootloader version to deviceInfo

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -681,6 +681,10 @@ Libraries for networking
     * The :kconfig:option:`CONFIG_NRF_CLOUD_CLIENT_ID_SRC_IMEI` and :kconfig:option:`CONFIG_NRF_CLOUD_CLIENT_ID_SRC_HW_ID` Kconfig options.
       Use the default UUID source for new applications.
 
+  * Added:
+
+    * Added the :kconfig:option:`CONFIG_NRF_CLOUD_SEND_DEVICE_INFO_BOOTLOADER_VERSION` Kconfig option to include the active MCUboot (B1) ``fw_info`` version as ``bootloaderVersion`` in ``deviceInfo``.
+
   * Fixed:
 
     * An issue where PEM private keys with CRLF line endings could not be decoded correctly for JWT signing used in nRF Cloud CoAP authentication.

--- a/include/net/nrf_cloud_defs.h
+++ b/include/net/nrf_cloud_defs.h
@@ -179,6 +179,7 @@
 #define NRF_CLOUD_JSON_KEY_KEEPALIVE		"keepalive"
 #define NRF_CLOUD_JSON_KEY_CONN			"connection"
 #define NRF_CLOUD_JSON_KEY_APP_VER		"appVersion"
+#define NRF_CLOUD_JSON_KEY_BOOTLOADER_VER	"bootloaderVersion"
 #define NRF_CLOUD_JSON_KEY_SMP_APP_VER		"smpDevAppVer"
 #define NRF_CLOUD_JSON_KEY_CONN_INFO		"connectionInfo"
 #define NRF_CLOUD_JSON_KEY_PROTOCOL		"protocol"

--- a/subsys/net/lib/nrf_cloud/CMakeLists.txt
+++ b/subsys/net/lib/nrf_cloud/CMakeLists.txt
@@ -12,6 +12,9 @@ zephyr_library_sources(
   common/src/nrf_cloud_sec_tag.c
   common/src/nrf_cloud_info.c
 )
+zephyr_library_sources_ifdef(CONFIG_NRF_CLOUD_SEND_DEVICE_INFO_BOOTLOADER_VERSION
+  common/src/nrf_cloud_bootloader_version.c
+)
 zephyr_library_sources_ifdef(CONFIG_MODEM_JWT common/src/nrf_cloud_jwt.c)
 zephyr_library_sources_ifdef(CONFIG_NRF_CLOUD_JWT_SOURCE_CUSTOM common/src/nrf_cloud_jwt.c)
 zephyr_library_sources_ifdef(

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_shadow_info
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_shadow_info
@@ -25,6 +25,17 @@ config NRF_CLOUD_SEND_DEVICE_STATUS
 	help
 	  Add "deviceInfo" section containing hardware and firmware version information.
 
+config NRF_CLOUD_SEND_DEVICE_INFO_BOOTLOADER_VERSION
+	bool "Send MCUboot (B1) fw_info version in deviceInfo"
+	depends on NRF_CLOUD_SEND_DEVICE_STATUS
+	depends on TRUSTED_EXECUTION_NONSECURE
+	depends on $(dt_nodelabel_enabled,s0_partition)
+	depends on $(dt_nodelabel_enabled,s1_partition)
+	select FW_INFO
+	help
+	  Add the "bootloaderVersion" field to deviceInfo using the fw_info version
+	  from the active B1 slot (s0_partition / s1_partition in devicetree).
+
 config NRF_CLOUD_SEND_DEVICE_STATUS_NETWORK
 	bool "Send network status information on initial connection"
 	depends on MODEM_INFO

--- a/subsys/net/lib/nrf_cloud/common/include/nrf_cloud_bootloader_version.h
+++ b/subsys/net/lib/nrf_cloud/common/include/nrf_cloud_bootloader_version.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef NRF_CLOUD_BOOTLOADER_VERSION_H__
+#define NRF_CLOUD_BOOTLOADER_VERSION_H__
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Read the active MCUboot (B1) fw_info version as a decimal string.
+ *
+ * TF-M non-secure builds only. Uses s0_partition and s1_partition from devicetree
+ * and reads the active slot through tfm_platform_s0_active() and
+ * tfm_platform_firmware_info().
+ *
+ * @param buf Buffer for the version string.
+ * @param len Size of @p buf.
+ *
+ * @retval 0 Success. @p buf contains the fw_info version as a decimal string.
+ * @retval -EINVAL @p buf is NULL or @p len is zero.
+ * @retval -ENOENT Firmware info was read but is not valid.
+ * @retval -ENOMEM @p buf is too small for the formatted version string.
+ */
+int nrf_cloud_bootloader_version_string_get(char *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRF_CLOUD_BOOTLOADER_VERSION_H__ */

--- a/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_bootloader_version.c
+++ b/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_bootloader_version.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ */
+
+#include <errno.h>
+#include <stdio.h>
+
+#include <zephyr/devicetree.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+#include <fw_info_bare.h>
+#include <nrf_cloud_bootloader_version.h>
+#include <tfm/tfm_ioctl_api.h>
+
+BUILD_ASSERT(DT_REG_SIZE(DT_NODELABEL(s0_partition)) != 0,
+	     "s0_partition must have non-zero size");
+BUILD_ASSERT(DT_REG_SIZE(DT_NODELABEL(s1_partition)) != 0,
+	     "s1_partition must have non-zero size");
+
+#define NRF_CLOUD_B1_S0_ADDRESS DT_REG_ADDR(DT_NODELABEL(s0_partition))
+#define NRF_CLOUD_B1_S1_ADDRESS DT_REG_ADDR(DT_NODELABEL(s1_partition))
+
+BUILD_ASSERT(NRF_CLOUD_B1_S0_ADDRESS != NRF_CLOUD_B1_S1_ADDRESS,
+	     "MCUboot B1 slot addresses must differ");
+
+LOG_MODULE_REGISTER(nrf_cloud_bootloader_version, CONFIG_NRF_CLOUD_LOG_LEVEL);
+
+static int active_b1_fw_info_get(struct fw_info *info)
+{
+	bool s0_active;
+	int err;
+
+	err = tfm_platform_s0_active(NRF_CLOUD_B1_S0_ADDRESS, NRF_CLOUD_B1_S1_ADDRESS,
+				     &s0_active);
+	if (err) {
+		return err;
+	}
+
+	return tfm_platform_firmware_info(
+		s0_active ? NRF_CLOUD_B1_S0_ADDRESS : NRF_CLOUD_B1_S1_ADDRESS, info);
+}
+
+int nrf_cloud_bootloader_version_string_get(char *buf, size_t len)
+{
+	int err;
+	int written;
+	struct fw_info info;
+
+	if ((buf == NULL) || (len == 0U)) {
+		LOG_ERR("Invalid buffer");
+		return -EINVAL;
+	}
+
+	err = active_b1_fw_info_get(&info);
+	if (err) {
+		LOG_ERR("active_b1_fw_info_get, error: %d", err);
+		return err;
+	}
+
+	if (info.valid != CONFIG_FW_INFO_VALID_VAL) {
+		LOG_ERR("Invalid firmware info");
+		return -ENOENT;
+	}
+
+	written = snprintk(buf, len, "%u", info.version);
+	if ((written < 0) || (written >= len)) {
+		LOG_ERR("Failed to format bootloader version");
+		return -ENOMEM;
+	}
+
+	return 0;
+}

--- a/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_codec_internal.c
@@ -5,6 +5,7 @@
  */
 
 #include "nrf_cloud_codec_internal.h"
+#include "nrf_cloud_bootloader_version.h"
 #include "nrf_cloud_mem.h"
 #include <net/nrf_cloud_codec.h>
 #include <net/nrf_cloud_location.h>
@@ -993,6 +994,23 @@ static int encode_modem_info_json_object(struct modem_param_info *modem, cJSON *
 			}
 		}
 #endif /* CONFIG_NRF_CLOUD_FOTA_SMP */
+
+#if defined(CONFIG_NRF_CLOUD_SEND_DEVICE_INFO_BOOTLOADER_VERSION)
+		if (!ret) {
+			char bl_ver[12];
+
+			ret = nrf_cloud_bootloader_version_string_get(bl_ver, sizeof(bl_ver));
+			if (ret) {
+				LOG_ERR("nrf_cloud_bootloader_version_string_get, err: %d", ret);
+				cJSON_Delete(device_obj);
+				return ret;
+			}
+
+			ret = !cJSON_AddStringToObjectCS(device_obj,
+							 NRF_CLOUD_JSON_KEY_BOOTLOADER_VER,
+							 bl_ver);
+		}
+#endif /* CONFIG_NRF_CLOUD_SEND_DEVICE_INFO_BOOTLOADER_VERSION */
 
 		if (ret) {
 			cJSON_Delete(device_obj);


### PR DESCRIPTION
Add support for reporting the active MCUboot B1 slot fw_info version as `bootloaderVersion` in the `deviceInfo` shadow section. Gated behind `CONFIG_NRF_CLOUD_SEND_DEVICE_INFO_BOOTLOADER_VERSION`, which requires TF-M non-secure builds with `s0_partition`/`s1_partition` in devicetree.