### PR TITLE
doc: remove Zoomin integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,6 @@ manifest (west.yml).
 Documentation
 *************
 
-Official latest documentation at https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html
+Official latest documentation at https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/index.html
 
 For earlier versions, open the latest version and use the drop-down under the title header.

--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -7,7 +7,7 @@
 # This boilerplate is automatically included through ZephyrBuildConfig.cmake, found in
 # ${NRF_DIR}/share/zephyrbuild-package/cmake/ZephyrBuildConfig.cmake
 # For more information regarding the Zephyr Build Configuration CMake package, please refer to:
-# https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/build/zephyr_cmake_package.html#zephyr_build_configuration_cmake_packages
+# https://nrfconnectdocs.nordicsemi.com/ncs/latest/zephyr/build/zephyr_cmake_package.html#zephyr_build_configuration_cmake_packages
 
 include(${NRF_DIR}/boards/deprecated.cmake)
 

--- a/doc/matter/index.rst
+++ b/doc/matter/index.rst
@@ -6,7 +6,7 @@ Matter documentation
 This documentation set includes a selection of pages available in the `Matter <https://github.com/nrfconnect/sdk-connectedhomeip>`_ repository fork, and focuses on the nRF Connect platform in Matter.
 
 .. note::
-   To read about Matter in the nRF Connect SDK, see the `Matter protocol <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/index.html>`_ section under the nRF Connect SDK documentation.
+   To read about Matter in the nRF Connect SDK, see the `Matter protocol <https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/protocols/matter/index.html>`_ section under the nRF Connect SDK documentation.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/mcuboot/links.txt
+++ b/doc/mcuboot/links.txt
@@ -13,15 +13,15 @@
 
 .. ### Source:  https://docs.nordicsemi.com/
 
-.. _`Immutable first-stage bootloader`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader.html#immutable-bootloader
-.. _`Second-stage upgradable bootloader`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader.html#upgradable-bootloader
-.. _`Secure bootloader chain`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader.html
-.. _`Enabling a bootloader chain using sysbuild`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_adding_sysbuild.html
-.. _`MCUboot and NSIB`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_mcuboot_nsib.html
-.. _`Partitioning device memory`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_partitioning.html
-.. _`Customizing the bootloader`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_config.html
-.. _`Signature keys`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/config_and_build/bootloaders/bootloader_signature_keys.html
-.. _`MCUboot output build files`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/config_and_build/output_build_files.html#mcuboot-output-build-files
+.. _`Immutable first-stage bootloader`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader.html#immutable-bootloader
+.. _`Second-stage upgradable bootloader`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader.html#upgradable-bootloader
+.. _`Secure bootloader chain`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader.html
+.. _`Enabling a bootloader chain using sysbuild`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_adding_sysbuild.html
+.. _`MCUboot and NSIB`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_mcuboot_nsib.html
+.. _`Partitioning device memory`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_partitioning.html
+.. _`Customizing the bootloader`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_config.html
+.. _`Signature keys`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/config_and_build/bootloaders/bootloader_signature_keys.html
+.. _`MCUboot output build files`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/app_dev/config_and_build/output_build_files.html#mcuboot-output-build-files
 
 .. ### Source: other
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -910,7 +910,7 @@
 
 .. _`TF-M documentation`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/tfm/wrapper.html
 .. _`TF-M secure partition integration guide`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/tfm/integration_guide/services/tfm_secure_partition_addition.html
-.. _`TF-M Platform`: https://docs.nordicsemi.com/bundle/ncs-latest/page/tfm/integration_guide/services/tfm_platform_integration_guide.html
+.. _`TF-M Platform`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/tfm/integration_guide/services/tfm_platform_integration_guide.html
 .. _`TF-M ITS`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/tfm/integration_guide/services/tfm_its_integration_guide.html
 .. _`TF-M Crypto`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/tfm/integration_guide/services/tfm_crypto_integration_guide.html
 .. _`TF-M PS`: https://nrfconnectdocs.nordicsemi.com/ncs/latest/tfm/integration_guide/services/tfm_ps_integration_guide.html

--- a/doc/tfm/wrapper.rst
+++ b/doc/tfm/wrapper.rst
@@ -6,12 +6,12 @@ Trusted Firmware-M reference documentation
 This section includes a selection of pages from the official `Trusted Firmware-M (TF-M) <https://www.trustedfirmware.org/projects/tf-m/>`_ documentation.
 The pages are published as-is using the sources from the downstream `TF-M repository <https://github.com/nrfconnect/sdk-trusted-firmware-m>`_.
 
-The pages provide background information about some of the aspects of `TF-M integration in the nRF Connect SDK <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/security/tfm/index.html>`_.
+The pages provide background information about some of the aspects of `TF-M integration in the nRF Connect SDK <https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/security/tfm/index.html>`_.
 Use these pages for reference only.
 
 .. note::
    Not all TF-M features mentioned in this section are used by the nRF Connect SDK.
-   For more information, see `TF-M support and limitations in the nRF Connect SDK <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/security/tfm/tfm_supported_services.html>`_.
+   For more information, see `TF-M support and limitations in the nRF Connect SDK <https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/security/tfm/tfm_supported_services.html>`_.
 
 For the complete TF-M upstream documentation, visit the `official TF-M documentation website <https://trustedfirmware-m.readthedocs.io/en/latest/index.html>`_.
 

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -205,7 +205,7 @@ int fota_download_with_host_cfg(const char *host, const char *file,
  *              download, both paths will be treated as upgradable bootloader slot 0
  *              and slot 1 binaries respectively, and only the binary corresponding to
  *              the currently inactive bootloader slot will be selected and downloaded.
- *              See <a href="https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/config_and_build/bootloaders/bootloader.html">
+ *              See <a href="https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/config_and_build/bootloaders/bootloader.html">
  *              Secure Bootloader Chain Docs</a> for details regarding the upgradable
  *              bootloader slots.
  * @param sec_tag_list Security tags that you want to use with HTTPS. Pass NULL to disable TLS.

--- a/subsys/nrf_security/include/nrf_security_api_structure.h
+++ b/subsys/nrf_security/include/nrf_security_api_structure.h
@@ -24,7 +24,7 @@
  *   - CRACEN (hardware acceleration for nRF54L and nRF71 Series)
  *
  * For detailed documentation on these drivers, see the nRF Connect SDK documentation:
- * https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/security/nrf_security.html
+ * https://nrfconnectdocs.nordicsemi.com/ncs/latest/nrf/libraries/security/nrf_security.html
  *
  * The Nordic-specific implementation also uses files located at:
  * - https://github.com/nrfconnect/sdk-nrf/blob/main/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_primitives.h


### PR DESCRIPTION
Drop the Zoomin documentation publishing pipeline along with all of its supporting assets: the SFTP upload step in the docpublish workflow, the "Prepare Zoomin upload" step in the docbuild workflow, the custom.properties / tags.yml templates and footer_patch.py helper under doc/_zoomin/, and the related CODEOWNERS, CMake and ruff entries.