### PR TITLE
manifest: sdk-zephyr: Pull fix for Wi-Fi DHCP client

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: aae7064db50007306a2f364e1b5f67165d5dd141
+      revision: 7f61a87979aa12615ca14b3463e8270c30ca895c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix issue of DHCP server not starting when Wi-Fi is connected.