### PR TITLE
doc: crypto: lm20b and ls05a update

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1031,6 +1031,7 @@
 .. _`AP-Protect for nRF54LV10A`: https://docs.nordicsemi.com/bundle/ps_nrf54LV10A/page/ctrl-ap.html
 .. _`AP-Protect for nRF54LM20A`: https://docs.nordicsemi.com/bundle/ps_nrf54LM20A/page/ctrl-ap.html
 .. _`AP-Protect for nRF54L15`: https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/ctrl-ap.html
+.. _`AP-Protect for nRF54LS05A`: https://docs.nordicsemi.com/bundle/ps_nrf54LS05A/page/ctrl-ap.html
 .. _`AP-Protect for nRF5340`: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/debugandtrace.html#ariaid-title9
 .. _`AP-Protect for nRF52840`:
 .. _`access port protection mechanism`: https://docs.nordicsemi.com/bundle/ps_nrf52840/page/dif.html#ariaid-title3

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -2800,7 +2800,7 @@ The lists are organized by device Series and implementation.
               - Supported
               - Supported
               - Supported
-              - --
+              - Supported
               - Supported
             * - :ref:`TF-M Crypto Service <ug_crypto_architecture_implementation_standards_tfm>`
               - --

--- a/doc/nrf/security/ap_protect.rst
+++ b/doc/nrf/security/ap_protect.rst
@@ -675,7 +675,7 @@ nRF54L Series
 
       This command issues the ``ERASEALL`` command.
       Make sure to wait for the command to be completed.
-      On this device, this command also programs a piece of firmware that corresponds to setting :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE` and :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_DISABLE` to ``y``.
+      On this device, this command also programs a piece of firmware that corresponds to selecting :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE` and :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_DISABLE`.
 
       **Keeping AP-Protect disabled after hard reset:**
 
@@ -765,9 +765,9 @@ nRF54L Series
          :start-after: .. nrf54l15_approtect_tab_start
          :end-before: .. nrf54l15_approtect_tab_end
 
-   .. tab:: nRF54LM20
+   .. tab:: nRF54LM20A
 
-      .. list-table:: nRF54LM20 AP-Protect support
+      .. list-table:: nRF54LM20A AP-Protect support
          :header-rows: 1
          :align: center
          :widths: auto
@@ -780,6 +780,34 @@ nRF54L Series
            - ✔
            - ✔
            - `AP-Protect for nRF54LM20A`_
+
+      .. include:: ./ap_protect.rst
+         :start-after: .. nrf54l15_approtect_tab_kconfigs_standard_start
+         :end-before: .. nrf54l15_approtect_tab_kconfigs_standard_end
+
+      .. include:: ./ap_protect.rst
+         :start-after: .. nrf54l15_approtect_tab_kconfigs_secure_start
+         :end-before: .. nrf54l15_approtect_tab_kconfigs_secure_end
+
+      .. include:: ./ap_protect.rst
+         :start-after: .. nrf54l15_approtect_tab_start
+         :end-before: .. nrf54l15_approtect_tab_end
+
+   .. tab:: nRF54LM20B
+
+      .. list-table:: nRF54LM20B AP-Protect support
+         :header-rows: 1
+         :align: center
+         :widths: auto
+
+         * - AP-Protect (hardware only)
+           - AP-Protect (hardware and software)
+           - Secure AP-Protect
+           - Hardware documentation
+         * - ✗
+           - ✔
+           - ✔
+           - `AP-Protect for nRF54LM20B <AP-Protect for nRF54LM20A_>`_
 
       .. include:: ./ap_protect.rst
          :start-after: .. nrf54l15_approtect_tab_kconfigs_standard_start
@@ -821,9 +849,9 @@ nRF54L Series
          :start-after: .. nrf54l15_approtect_tab_start
          :end-before: .. nrf54l15_approtect_tab_end
 
-   .. tab:: nRF54LS05
+   .. tab:: nRF54LS05A
 
-      .. list-table:: nRF54LS05 AP-Protect support
+      .. list-table:: nRF54LS05A AP-Protect support
          :header-rows: 1
          :align: center
          :widths: auto
@@ -835,7 +863,7 @@ nRF54L Series
          * - ✗
            - ✔
            - ✗
-           - *Documentation not yet available*
+           - `AP-Protect for nRF54LS05A`_
 
       .. note::
          This device supports ``UICR.ERASEPROTECT``, which might prevent the ``ERASEALL`` command from executing when AP-Protect is enabled.
@@ -843,7 +871,7 @@ nRF54L Series
 
       **Configuring AP-Protect on the software side:**
 
-      The following Kconfig options configure AP-Protect on the software side on nRF54LS05 in the |NCS|:
+      The following Kconfig options configure AP-Protect on the software side on nRF54LS05A in the |NCS|:
 
       .. include:: ./ap_protect.rst
          :start-after: .. nrf54l15_approtect_tab_kconfigs_standard_start
@@ -871,7 +899,84 @@ nRF54L Series
 
       This command issues the ``ERASEALL`` command.
       Make sure to wait for the command to be completed.
-      On this device, this command also programs a piece of firmware that corresponds to setting :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE` to ``y``.
+      On this device, this command also programs a piece of firmware that corresponds to selecting :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE`.
+
+      **Keeping AP-Protect disabled after hard reset:**
+
+      If you want to keep the AP-Protect disabled after hard reset, you must flash firmware that opens the `debugger signals in Tamper Controller <nRF54L15 Debugger signals_>`_.
+      In the |NCS|, :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE` (enabled by default) handles the software unlock.
+
+      **Forcing AP-Protect to be disabled after hard reset:**
+
+      To force AP-Protect to be disabled after hard reset, issue an ``ERASEALL`` command using the following nRF Util command:
+
+      .. code-block:: console
+
+         nrfutil device recover
+
+      The device is automatically unlocked after erase.
+
+      **Production programming:**
+
+      For the devices that are in a production environment, it is highly recommended to lock the ``UICR.APPROTECT`` register to prevent unauthorized access to the device. If the access port protection is configured this way, it cannot be disabled without erasing the non-volatile memory.
+
+      Check also the following documentation pages for more information:
+
+      * `Disabling AP-Protect on nRF54L`_
+      * `Enabling device protection on nRF54L`_
+      * `Checking AP-Protect status on nRF54L`_
+
+   .. tab:: nRF54LS05B
+
+      .. list-table:: nRF54LS05B AP-Protect support
+         :header-rows: 1
+         :align: center
+         :widths: auto
+
+         * - AP-Protect (hardware only)
+           - AP-Protect (hardware and software)
+           - Secure AP-Protect
+           - Hardware documentation
+         * - ✗
+           - ✔
+           - ✗
+           - `AP-Protect for nRF54LS05B <AP-Protect for nRF54LS05A_>`_
+
+      .. note::
+         This device supports ``UICR.ERASEPROTECT``, which might prevent the ``ERASEALL`` command from executing when AP-Protect is enabled.
+         See hardware documentation for more information.
+
+      **Configuring AP-Protect on the software side:**
+
+      The following Kconfig options configure AP-Protect on the software side on nRF54LS05B in the |NCS|:
+
+      .. include:: ./ap_protect.rst
+         :start-after: .. nrf54l15_approtect_tab_kconfigs_standard_start
+         :end-before: .. nrf54l15_approtect_tab_kconfigs_standard_end
+
+      **Enabling AP-Protect on the hardware side:**
+
+      To enable AP-Protect on the hardware side, write ``Enabled`` to ``UICR.APPROTECT`` using the following nRF Util command:
+
+      .. code-block:: console
+
+         nrfutil device protection-set All
+
+      This set of commands enables AP-Protect on the hardware side and hard resets the device.
+
+      For more information about the ``nrfutil device protection-set`` command, see `Configuring readback protection`_ in the nRF Util documentation.
+
+      **Disabling AP-Protect:**
+
+      To disable AP-Protect, run the following nRF Util command:
+
+      .. code-block:: console
+
+         nrfutil device recover
+
+      This command issues the ``ERASEALL`` command.
+      Make sure to wait for the command to be completed.
+      On this device, this command also programs a piece of firmware that corresponds to selecting :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE`.
 
       **Keeping AP-Protect disabled after hard reset:**
 

--- a/doc/nrf/security/crypto/crypto_supported_features.rst
+++ b/doc/nrf/security/crypto/crypto_supported_features.rst
@@ -751,7 +751,8 @@ The options are grouped by Series and drivers available for the device Series, a
                 - nRF54LM20A
                 - nRF54LM20B
                 - nRF54LV10A
-                - nRF54LS05
+                - nRF54LS05A
+                - nRF54LS05B
               * - AES
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_AES`
                 - Supported
@@ -760,6 +761,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Experimental
+                - --
                 - --
               * - Chacha20
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
@@ -770,6 +772,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Experimental
                 - --
+                - --
               * - ECC Key Pair Import
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
                 - Supported
@@ -778,6 +781,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Experimental
+                - --
                 - --
               * - ECC Key Pair Export
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
@@ -788,6 +792,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Experimental
                 - --
+                - --
               * - ECC Key Pair Generate
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
                 - Supported
@@ -796,6 +801,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Experimental
+                - --
                 - --
               * - ECC Key Pair Derive
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
@@ -806,6 +812,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Experimental
                 - --
+                - --
               * - ECC Public Key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
                 - Supported
@@ -814,6 +821,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Experimental
+                - --
                 - --
               * - RSA Key Pair Import
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
@@ -824,6 +832,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Experimental
                 - --
+                - --
               * - RSA Key Pair Export
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
                 - Supported
@@ -832,6 +841,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Experimental
+                - --
                 - --
               * - RSA Key Pair Generate
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
@@ -842,6 +852,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Experimental
                 - --
+                - --
               * - RSA Key Pair Derive
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                 - Supported
@@ -850,6 +861,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Experimental
+                - --
                 - --
               * - RSA Public Key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
@@ -860,8 +872,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Experimental
                 - --
+                - --
               * - XChaCha20
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                - --
                 - --
                 - --
                 - --
@@ -878,8 +892,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Experimental
                 - --
+                - --
               * - HSS Public Key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                - --
                 - --
                 - --
                 - --
@@ -896,8 +912,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - XMSS Public Key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                - --
                 - --
                 - --
                 - --
@@ -914,8 +932,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-DSA-44
                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                - --
                 - --
                 - --
                 - --
@@ -932,8 +952,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-DSA-87
                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                - --
                 - --
                 - --
                 - --
@@ -950,8 +972,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-DSA Key Pair Export
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                - --
                 - --
                 - --
                 - --
@@ -968,8 +992,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-DSA Key Pair Derive
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                - --
                 - --
                 - --
                 - --
@@ -986,8 +1012,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM-512
                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                - --
                 - --
                 - --
                 - --
@@ -1004,8 +1032,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM-1024
                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                - --
                 - --
                 - --
                 - --
@@ -1022,8 +1052,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM Key Pair Export
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                - --
                 - --
                 - --
                 - --
@@ -1040,8 +1072,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM Key Pair Derive
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                - --
                 - --
                 - --
                 - --
@@ -1058,6 +1092,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - WPA3-SAE key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_WPA3_SAE`
                 - Experimental
@@ -1066,6 +1101,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Experimental
                 - Experimental
                 - Experimental
+                - --
                 - --
 
          .. tab:: nrf_oberon
@@ -1082,9 +1118,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - AES
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_AES`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1101,8 +1139,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - ECC Key Pair Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1119,8 +1159,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - ECC Key Pair Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1137,8 +1179,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - ECC Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1155,8 +1199,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - RSA Key Pair Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1173,8 +1219,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - RSA Key Pair Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1191,8 +1239,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - XChaCha20
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1209,8 +1259,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - HSS Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1227,8 +1279,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - XMSS Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1245,8 +1299,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA-44
                  - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1263,8 +1319,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA-87
                  - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1281,8 +1339,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA Key Pair Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1299,8 +1359,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA Key Pair Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1317,8 +1379,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-KEM-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1335,8 +1399,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-KEM-1024
                  - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1353,8 +1419,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-KEM Key Pair Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1371,8 +1439,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-KEM Key Pair Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1389,6 +1459,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - WPA3-SAE PT key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_WPA3_SAE`
                  - Experimental
@@ -1398,8 +1469,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ASCON
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ASCON`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -2363,7 +2436,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECB no padding
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECB_NO_PADDING`
                  - Supported
@@ -2372,6 +2446,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - CBC no padding
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CBC_NO_PADDING`
@@ -2382,6 +2457,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - CBC PKCS#7 padding
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CBC_PKCS7`
                  - Supported
@@ -2390,6 +2466,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - CTR
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CTR`
@@ -2400,8 +2477,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - CCM* no tag
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM_STAR_NO_TAG`
+                 - --
                  - --
                  - --
                  - --
@@ -2417,6 +2496,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
 
             .. note::
@@ -2440,9 +2520,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECB no padding
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECB_NO_PADDING`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -2459,8 +2541,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - CBC PKCS#7 padding
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CBC_PKCS7`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -2477,6 +2561,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - CCM* no tag
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM_STAR_NO_TAG`
                  - Supported
@@ -2486,8 +2571,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Stream cipher
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_STREAM_CIPHER`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -2883,7 +2970,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECDH
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDH`
                  - Supported
@@ -2892,6 +2980,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -2908,9 +2997,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECDH
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDH`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -3155,9 +3246,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ML-KEM
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_KEM`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -3475,7 +3568,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - HKDF
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF`
                  - Supported
@@ -3484,6 +3578,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - HKDF-Extract
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF_EXTRACT`
@@ -3494,6 +3589,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - HKDF-Expand
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF_EXPAND`
                  - Supported
@@ -3502,6 +3598,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - PBKDF2-HMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_PBKDF2_HMAC`
@@ -3512,6 +3609,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - PBKDF2-AES-CMAC-PRF-128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_PBKDF2_AES_CMAC_PRF_128`
                  - Supported
@@ -3520,6 +3618,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - TLS 1.2 PRF
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PRF`
@@ -3530,6 +3629,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - TLS 1.2 PSK to MS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PSK_TO_MS`
                  - Supported
@@ -3538,6 +3638,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - TLS 1.2 EC J-PAKE to PMS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS`
@@ -3548,6 +3649,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - SP 800-108r1 CMAC w/counter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC`
                  - Supported
@@ -3556,6 +3658,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - SP 800-108 HMAC counter mode
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_HMAC`
@@ -3566,6 +3669,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - WPA3-SAE hash-to-element
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_H2E`
                  - Experimental
@@ -3574,6 +3678,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -3590,9 +3695,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - HKDF
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -3609,8 +3716,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - HKDF-Expand
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF_EXPAND`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -3627,8 +3736,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - PBKDF2-AES-CMAC-PRF-128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_PBKDF2_AES_CMAC_PRF_128`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -3645,8 +3756,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - TLS 1.2 PSK to MS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PSK_TO_MS`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -3663,8 +3776,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - SP 800-108r1 CMAC w/counter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -3681,8 +3796,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - WPA3-SAE hash-to-element
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_H2E`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -3989,7 +4106,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - AES Key wrap (AES-KW)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_AES_KW`
                  - Experimental
@@ -3999,6 +4117,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental (with exceptions, see note)
                  - Experimental (with exceptions, see note)
                  - --
+                 - --
                * - AES Key wrap with Padding (AES-KWP)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_AES_KWP`
                  - Experimental
@@ -4007,6 +4126,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental (with exceptions, see note)
                  - Experimental (with exceptions, see note)
                  - Experimental (with exceptions, see note)
+                 - --
                  - --
 
             .. note::
@@ -4030,7 +4150,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - AES Key wrap (AES-KW)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_AES_KW`
                  - Experimental
@@ -4040,8 +4161,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - AES Key wrap with Padding (AES-KWP)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_AES_KWP`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -4240,7 +4363,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - CMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CMAC`
                  - Supported
@@ -4250,6 +4374,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported (with exceptions, see note)
                  - Experimental (with exceptions, see note)
                  - --
+                 - --
                * - HMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC`
                  - Supported
@@ -4258,6 +4383,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
 
             .. note::
@@ -4281,7 +4407,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - CMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CMAC`
                  - Supported
@@ -4291,8 +4418,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - HMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -4684,7 +4813,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - CCM
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`
                  - Supported
@@ -4693,6 +4823,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - GCM
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_GCM`
@@ -4703,6 +4834,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported (with exceptions, see note)
                  - Experimental
                  - --
+                 - --
                * - ChaCha20-Poly1305
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305`
                  - Supported
@@ -4712,8 +4844,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - XChaCha20-Poly1305
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
+                 - --
                  - --
                  - --
                  - --
@@ -4744,9 +4878,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - CCM
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -4763,8 +4899,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - ChaCha20-Poly1305
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -4781,8 +4919,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ASCON AEAD128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_AEAD128`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -5379,7 +5519,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECDSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA`
                  - Supported
@@ -5388,6 +5529,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - ECDSA without hashing
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA_ANY`
@@ -5398,6 +5540,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - ECDSA (deterministic)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ECDSA`
                  - Supported
@@ -5406,6 +5549,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - PureEdDSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_PURE_EDDSA`
@@ -5416,6 +5560,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - HashEdDSA Edwards25519
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ED25519PH`
                  - Supported
@@ -5424,6 +5569,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - HashEdDSA Edwards448
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ED448PH`
@@ -5434,6 +5580,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - RSA PKCS#1 v1.5 sign
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN`
                  - Supported
@@ -5442,6 +5589,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - RSA PSS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`
@@ -5452,8 +5600,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - HSS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                 - --
                  - --
                  - --
                  - --
@@ -5470,8 +5620,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - ML-DSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - --
                  - --
                  - --
                  - --
@@ -5488,8 +5640,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - XMSS-MT
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
+                 - --
                  - --
                  - --
                  - --
@@ -5512,9 +5666,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECDSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -5531,8 +5687,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - ECDSA (deterministic)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ECDSA`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -5549,8 +5707,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - HashEdDSA Edwards25519
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ED25519PH`
+                 - --
                  - --
                  - --
                  - --
@@ -5567,8 +5727,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - RSA PKCS#1 v1.5 sign
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -5585,8 +5747,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - HSS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -5603,8 +5767,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -5621,8 +5787,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - XMSS-MT
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -5639,6 +5807,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - Deterministic ML-DSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ML_DSA`
                  - Experimental
@@ -5648,8 +5817,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - Deterministic Hash ML-DSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_HASH_ML_DSA`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -6181,7 +6352,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - RSA OAEP
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_OAEP`
                  - Supported
@@ -6191,6 +6363,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - RSA PKCS#1 v1.5 crypt
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_CRYPT`
                  - Supported
@@ -6199,6 +6372,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -6215,7 +6389,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - RSA OAEP
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_OAEP`
                  - Supported
@@ -6225,8 +6400,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - RSA PKCS#1 v1.5 crypt
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_CRYPT`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -6776,7 +6953,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - BrainpoolP224r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_224`
                  - Supported
@@ -6785,6 +6963,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - BrainpoolP256r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_256`
@@ -6795,6 +6974,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - BrainpoolP320r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_320`
                  - Supported
@@ -6803,6 +6983,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - BrainpoolP384r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_384`
@@ -6813,6 +6994,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - BrainpoolP512r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_512`
                  - Supported
@@ -6821,6 +7003,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - Curve25519 (X25519)
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_MONTGOMERY_255`
@@ -6831,6 +7014,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - Curve448 (X448)
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_MONTGOMERY_448`
                  - Supported
@@ -6839,6 +7023,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - Edwards25519 (Ed25519)
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_TWISTED_EDWARDS_255`
@@ -6849,6 +7034,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - Edwards448 (Ed448)
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_TWISTED_EDWARDS_448`
                  - Supported
@@ -6857,6 +7043,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - secp256k1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_K1_256`
@@ -6867,6 +7054,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - secp224r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_224`
                  - Supported
@@ -6875,6 +7063,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - secp256r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_256`
@@ -6885,6 +7074,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - secp384r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_384`
                  - Supported
@@ -6894,6 +7084,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - secp521r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_521`
                  - Supported
@@ -6902,6 +7093,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -6918,9 +7110,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - BrainpoolP224r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_224`
+                 - --
                  - --
                  - --
                  - --
@@ -6937,8 +7131,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - BrainpoolP320r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_320`
+                 - --
                  - --
                  - --
                  - --
@@ -6955,8 +7151,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - BrainpoolP512r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_512`
+                 - --
                  - --
                  - --
                  - --
@@ -6973,8 +7171,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Edwards25519 (Ed25519)
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_TWISTED_EDWARDS_255`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -6991,8 +7191,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Edwards448 (Ed448)
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_TWISTED_EDWARDS_448`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -7009,8 +7211,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - secp224r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_224`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -7027,6 +7231,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - secp384r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_384`
                  - Supported
@@ -7036,8 +7241,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - secp521r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_521`
+                 - --
                  - --
                  - --
                  - --
@@ -7599,7 +7806,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - RNG support
                  - :kconfig:option:`CONFIG_PSA_WANT_GENERATE_RANDOM`
                  - Supported
@@ -7608,6 +7816,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - CTR-DRBG
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CTR_DRBG`
@@ -7618,8 +7827,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - HMAC-DRBG
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC_DRBG`
+                 - --
                  - --
                  - --
                  - --
@@ -7642,9 +7853,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - RNG support
                  - :kconfig:option:`CONFIG_PSA_WANT_GENERATE_RANDOM`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -7661,8 +7874,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - HMAC-DRBG
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC_DRBG`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -8232,7 +8447,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - SHA-1 (weak)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_1`
                  - Supported
@@ -8241,6 +8457,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - SHA-224
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_224`
@@ -8251,6 +8468,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - SHA-256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256`
                  - Supported
@@ -8259,6 +8477,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - SHA-384
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_384`
@@ -8269,6 +8488,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - SHA-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_512`
                  - Supported
@@ -8277,6 +8497,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - SHA3-224
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_224`
@@ -8287,6 +8508,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - SHA3-256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_256`
                  - Supported
@@ -8295,6 +8517,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - SHA3-384
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_384`
@@ -8305,6 +8528,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - SHA3-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_512`
                  - Supported
@@ -8314,8 +8538,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - SHA-256/192
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                 - --
                  - --
                  - --
                  - --
@@ -8332,8 +8558,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - SHAKE256 192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                 - --
                  - --
                  - --
                  - --
@@ -8350,6 +8578,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - SHAKE256 512 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
                  - Supported
@@ -8358,6 +8587,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -8374,9 +8604,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - SHA-1 (weak)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_1`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -8393,8 +8625,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - SHA-256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -8411,8 +8645,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - SHA-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_512`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -8429,8 +8665,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - SHA3-256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_256`
+                 - --
                  - --
                  - --
                  - --
@@ -8447,8 +8685,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - SHA3-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_512`
+                 - --
                  - --
                  - --
                  - --
@@ -8465,8 +8705,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - SHAKE128 256 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -8483,8 +8725,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - SHAKE256 256 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -8501,8 +8745,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - ASCON HASH256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_HASH256`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -8986,9 +9232,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - SHAKE128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -9005,6 +9253,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ASCON XOF128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_XOF128`
                  - Experimental
@@ -9014,8 +9263,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ASCON CXOF128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_CXOF128`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -9314,7 +9565,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - EC J-PAKE
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_JPAKE`
                  - Supported
@@ -9323,6 +9575,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - SPAKE2+ with HMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SPAKE2P_HMAC`
@@ -9333,6 +9586,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - SPAKE2+ with CMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SPAKE2P_CMAC`
                  - Supported
@@ -9341,6 +9595,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - SPAKE2+ for Matter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SPAKE2P_MATTER`
@@ -9351,6 +9606,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - SRP-6
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_6`
                  - Experimental
@@ -9359,6 +9615,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - Experimental
+                 - --
                  - --
                * - SRP password hashing
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_PASSWORD_HASH`
@@ -9369,6 +9626,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - Experimental
                  - --
+                 - --
                * - WPA3-SAE fixed
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_FIXED`
                  - Experimental
@@ -9378,6 +9636,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - --
+                 - --
                * - WPA3-SAE GDH
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_GDH`
                  - Experimental
@@ -9386,6 +9645,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -9797,7 +10057,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
                  - Supported
@@ -9806,6 +10067,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
@@ -9816,6 +10078,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
                  - Supported
@@ -9825,6 +10088,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                  - Supported
@@ -9833,6 +10097,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -9849,9 +10114,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -9868,6 +10135,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
                  - --
@@ -9877,8 +10145,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10063,12 +10333,14 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_IMPORT`
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                  - --
                  - --
@@ -10082,6 +10354,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - Experimental
                  - --
+                 - --
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_GENERATE`
                  - Supported
@@ -10091,6 +10364,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - Experimental
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_DERIVE`
                  - Supported
@@ -10099,6 +10373,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -10115,9 +10390,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_IMPORT`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10134,6 +10411,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_GENERATE`
                  - --
@@ -10143,8 +10421,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_DERIVE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10327,7 +10607,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_IMPORT`
                  - Supported
@@ -10336,6 +10617,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_EXPORT`
@@ -10346,6 +10628,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_GENERATE`
                  - Supported
@@ -10355,6 +10638,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_DERIVE`
                  - Supported
@@ -10363,6 +10647,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -10379,9 +10664,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_IMPORT`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10398,6 +10685,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_GENERATE`
                  - Supported
@@ -10407,8 +10695,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_DERIVE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10635,7 +10925,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
                  - Supported
@@ -10644,6 +10935,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
@@ -10654,6 +10946,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
                  - Supported
@@ -10663,6 +10956,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                  - Supported
@@ -10671,6 +10965,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -10687,9 +10982,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10706,6 +11003,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
                  - Supported
@@ -10715,8 +11013,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10971,7 +11271,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - 128 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_128`
                  - Supported
@@ -10981,11 +11282,13 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - 192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_192`
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                  - --
                  - --
@@ -10998,6 +11301,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -11014,9 +11318,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - 128 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_128`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11033,8 +11339,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - 256 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_256`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11295,9 +11603,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - 1024 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_1024`
+                 - --
                  - --
                  - --
                  - --
@@ -11314,6 +11624,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - 2048 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_2048`
                  - Supported
@@ -11322,6 +11633,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - 3072 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_3072`
@@ -11332,6 +11644,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - 4096 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_4096`
                  - Supported
@@ -11340,6 +11653,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - 6144 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_6144`
@@ -11350,8 +11664,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - 8192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_8192`
+                 - --
                  - --
                  - --
                  - --
@@ -11374,9 +11690,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - 1024 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_1024`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11393,8 +11711,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - 2048 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_2048`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11411,8 +11731,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - 4096 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_4096`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11429,8 +11751,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - 8192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_8192`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11593,7 +11917,8 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECC scalar randomization
                  - :kconfig:option:`CONFIG_CRACEN_ECC_COUNTERMEASURES`
                  - Supported
@@ -11602,6 +11927,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - ECC projective coordinate randomization
                  - :kconfig:option:`CONFIG_CRACEN_ECC_COUNTERMEASURES`
@@ -11612,6 +11938,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - --
+                 - --
                * - ECC extended (Montgomery/Edwards)
                  - :kconfig:option:`CONFIG_CRACEN_LITE_ECC_COUNTERMEASURES_EXTENDED` (see note above)
                  - --
@@ -11620,6 +11947,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - RSA exponent randomization
                  - :kconfig:option:`CONFIG_CRACEN_RSA_COUNTERMEASURES`
@@ -11630,6 +11958,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - --
+                 - --
                * - RSA modulus randomization
                  - :kconfig:option:`CONFIG_CRACEN_RSA_COUNTERMEASURES`
                  - Supported
@@ -11638,4 +11967,5 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --

--- a/doc/nrf/security/tfm/tfm_building.rst
+++ b/doc/nrf/security/tfm/tfm_building.rst
@@ -57,7 +57,8 @@ See :ref:`app_boards_names` for the complete list of boards and board targets su
    * - nRF54LM20 DK
      - PCA10184
      - :zephyr:board:`nrf54lm20dk <nrf54lm20dk>`
-     - ``nrf54lm20dk/nrf54lm20a/cpuapp/ns``
+     - | ``nrf54lm20dk/nrf54lm20a/cpuapp/ns``
+       | ``nrf54lm20dk/nrf54lm20b/cpuapp/ns``
    * - nRF54L15 DK
      - PCA10156
      - :zephyr:board:`nrf54l15dk <nrf54l15dk>`


### PR DESCRIPTION
Added entries for the nRF54LM20B and nRF54LS05A
to the security documentation where they were missing. NCSDK-38891 and NCSDK-38892.