### PR TITLE
samples: benchmarks: coremark: Fix support for nrf7120dk

### DIFF
--- a/samples/benchmarks/coremark/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/samples/benchmarks/coremark/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -4,30 +4,26 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include "app_aliases_common.dtsi"
+
 / {
-	chosen {
-		zephyr,console = &uart00;
-	};
-};
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-&cpuflpr_sram {
-	cpuflpr_sram_code_data: sram@0 {
-		compatible = "mmio-sram";
-		reg = <0x0 DT_SIZE_K(116)>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-	};
-};
+			cpuflpr_code_partition: image@3de000 {
+				/* FLPR core code partition */
+				reg = <0x3de000 DT_SIZE_K(116)>;
+			};
+		};
 
-&cpuflpr_mram {
-	partitions {
-		ranges;
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		cpuflpr_code_partition: partition@0 {
-			compatible = "zephyr,mapped-partition";
-			reg = <0x0 DT_SIZE_K(116)>;
+		cpuflpr_sram_code_data: memory@200e0000 {
+			compatible = "mmio-sram";
+			reg = <0x200e0000 DT_SIZE_K(116)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x200e0000 DT_SIZE_K(116)>;
 		};
 	};
 };
@@ -43,7 +39,7 @@
 	source-memory = <&cpuflpr_code_partition>;
 };
 
-&uart00 {
+&cpuapp_vevif_tx {
 	status = "okay";
 };
 

--- a/samples/benchmarks/coremark/sample.yaml
+++ b/samples/benchmarks/coremark/sample.yaml
@@ -29,6 +29,7 @@ tests:
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
     integration_platforms: *coremark_platforms
 
   sample.benchmark.coremark.flash_and_run:
@@ -43,23 +44,6 @@ tests:
         - "CoreMark started!"
         - "Correct operation validated."
       type: multi_line
-    extra_args: FILE_SUFFIX=flash_and_run
-
-  sample.benchmark.coremark.flash_and_run.nrf7120:
-    build_only: false
-    platform_exclude: *coremark_platforms
-    platform_allow:
-      - nrf7120dk/nrf7120/cpuapp
-    integration_platforms:
-      - nrf7120dk/nrf7120/cpuapp
-    harness: console
-    harness_config:
-      ordered: false
-      regex:
-        - "CoreMark started!"
-        - "Correct operation validated."
-      type: multi_line
-    timeout: 180
     extra_args: FILE_SUFFIX=flash_and_run
 
   sample.benchmark.coremark.heap_memory:

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -9,12 +9,6 @@
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-29460"
 
 - scenarios:
-    - sample.benchmark.coremark.flash_and_run.nrf7120
-  platforms:
-    - nrf7120dk/nrf7120/cpuapp
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-38741"
-
-- scenarios:
     - sample.dect.dect_shell.nrf_cloud_mqtt
   platforms:
     - nrf9151dk/nrf9151/ns


### PR DESCRIPTION
After previous zephyr upmerge coremark test was broken for nrf7120dk. This commit reinstates support for nrf7120dk in standard sample.benchmark.coremark.flash_and_run since FPGA no longer requires longer timeout.