### PR TITLE
lib: lte_link_control: Align system mode LTE preference descriptions

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -187,34 +187,24 @@ enum lte_lc_system_mode_preference {
 	LTE_LC_SYSTEM_MODE_PREFER_AUTO = 0,
 
 	/**
-	 * LTE-M is preferred over PLMN selection.
-	 *
-	 * The modem will prioritize to use LTE-M and switch over to a PLMN where LTE-M is available
-	 * whenever possible.
+	 * LTE-M preferred.
 	 */
 	LTE_LC_SYSTEM_MODE_PREFER_LTEM,
 
 	/**
-	 * NB-IoT is preferred over PLMN selection.
-	 *
-	 * The modem will prioritize to use NB-IoT and switch over to a PLMN where NB-IoT is
-	 * available whenever possible.
+	 * NB-IoT preferred.
 	 */
 	LTE_LC_SYSTEM_MODE_PREFER_NBIOT,
 
 	/**
-	 * LTE-M is preferred, but PLMN selection is more important.
-	 *
-	 * The modem will prioritize to stay on home network and switch over to NB-IoT if LTE-M is
-	 * not available.
+	 * Network selection priorities override system priority, but if the same network or
+	 * equal priority networks are found, LTE-M is preferred.
 	 */
 	LTE_LC_SYSTEM_MODE_PREFER_LTEM_PLMN_PRIO,
 
 	/**
-	 * NB-IoT is preferred, but PLMN selection is more important.
-	 *
-	 * The modem will prioritize to stay on home network and switch over to LTE-M if NB-IoT is
-	 * not available.
+	 * Network selection priorities override system priority, but if the same network or
+	 * equal priority networks are found, NB-IoT is preferred.
 	 */
 	LTE_LC_SYSTEM_MODE_PREFER_NBIOT_PLMN_PRIO
 };

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -366,33 +366,27 @@ config LTE_MODE_PREFERENCE_LTE_M
 	bool "LTE-M"
 	depends on LTE_NETWORK_MODE_LTE_M_NBIOT || LTE_NETWORK_MODE_LTE_M_NBIOT_GPS
 	help
-	  LTE-M is preferred over PLMN selection. The modem will prioritize to
-	  use LTE-M and switch over to a PLMN where LTE-M is available whenever
-	  possible.
+	  LTE-M preferred.
 
 config LTE_MODE_PREFERENCE_NBIOT
 	bool "NB-IoT"
 	depends on LTE_NETWORK_MODE_LTE_M_NBIOT || LTE_NETWORK_MODE_LTE_M_NBIOT_GPS
 	help
-	  NB-IoT is preferred over PLMN selection. The modem will prioritize to
-	  use NB-IoT and switch over to a PLMN where NB-IoT is available
-	  whenever possible.
+	  NB-IoT preferred.
 
 config LTE_MODE_PREFERENCE_LTE_M_PLMN_PRIO
 	bool "LTE-M, PLMN prioritized"
 	depends on LTE_NETWORK_MODE_LTE_M_NBIOT || LTE_NETWORK_MODE_LTE_M_NBIOT_GPS
 	help
-	  LTE-M is preferred, but PLMN selection is more important. The modem
-	  will prioritize to stay on home network and switch over to NB-IoT
-	  if LTE-M is not available.
+	  Network selection priorities override system priority, but if the same network or
+	  equal priority networks are found, LTE-M is preferred.
 
 config LTE_MODE_PREFERENCE_NBIOT_PLMN_PRIO
 	bool "NB-IoT, PLMN prioritized"
 	depends on LTE_NETWORK_MODE_LTE_M_NBIOT || LTE_NETWORK_MODE_LTE_M_NBIOT_GPS
 	help
-	  NB-IoT is preferred, but PLMN selection is more important. The modem
-	  will prioritize to stay on home network and switch over to LTE-M
-	  if NB-IoT is not available.
+	  Network selection priorities override system priority, but if the same network or
+	  equal priority networks are found, NB-IoT is preferred.
 
 endchoice
 

--- a/lib/lte_link_control/modules/xsystemmode.c
+++ b/lib/lte_link_control/modules/xsystemmode.c
@@ -65,15 +65,10 @@ static const char *const system_mode_params[] = {
 
 /* LTE preference to be passed using AT%XSYSTEMMMODE=<params>,<preference> */
 static const char system_mode_preference[] = {
-	/* No LTE preference, automatically selected by the modem. */
 	[LTE_LC_SYSTEM_MODE_PREFER_AUTO] = '0',
-	/* LTE-M has highest priority. */
 	[LTE_LC_SYSTEM_MODE_PREFER_LTEM] = '1',
-	/* NB-IoT has highest priority. */
 	[LTE_LC_SYSTEM_MODE_PREFER_NBIOT] = '2',
-	/* Equal priority, but prefer LTE-M. */
 	[LTE_LC_SYSTEM_MODE_PREFER_LTEM_PLMN_PRIO] = '3',
-	/* Equal priority, but prefer NB-IoT. */
 	[LTE_LC_SYSTEM_MODE_PREFER_NBIOT_PLMN_PRIO] = '4',
 };
 


### PR DESCRIPTION
Aligned LTE preference descriptions in the library API and the Kconfig options with the AT command documentation.

Removed incorrect LTE preference descriptions from `xsystemmode.c`.