### PR TITLE
tests: mcuboot: extend integration platforms in ref_smp_svr

### DIFF
--- a/tests/subsys/bootloader/upgrade/ref_smp_svr/testcase.yaml
+++ b/tests/subsys/bootloader/upgrade/ref_smp_svr/testcase.yaml
@@ -89,6 +89,8 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     harness_config:
       pytest_root:
         - "../pytest/test_serial_recovery.py::test_serial_recovery_after_pin_reset"
@@ -213,6 +215,8 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     tags:
       - encryption
     harness_config:
@@ -236,7 +240,10 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     integration_platforms:
-      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
     tags:
       - encryption
     harness_config:


### PR DESCRIPTION
Add nrf54l15 and nrf54lm20b to serial recovery pin reset and RSA encryption integration runs. Replace ecdsa_p256 integration set with nrf54l15, nrf54lm20 (a/b), and nrf54lv10 platforms.