### PR TITLE
applications: nrf_desktop: use mapped-partition binding for memory maps

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/memory_map.dtsi
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/memory_map.dtsi
@@ -8,21 +8,24 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x10000 DT_SIZE_K(440)>;
 		};
 
 		storage_partition: partition@7e000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7e000 DT_SIZE_K(8)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/memory_map_dongle_small.dtsi
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/memory_map_dongle_small.dtsi
@@ -8,21 +8,24 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(52)>;
 		};
 
 		slot0_partition: partition@d000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0xd000 DT_SIZE_K(452)>;
 		};
 
 		storage_partition: partition@7e000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7e000 DT_SIZE_K(8)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/memory_map_release.dtsi
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/memory_map_release.dtsi
@@ -8,21 +8,24 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(52)>;
 		};
 
 		slot0_partition: partition@d000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0xd000 DT_SIZE_K(452)>;
 		};
 
 		storage_partition: partition@7e000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7e000 DT_SIZE_K(8)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/memory_map_fast_pair.dtsi
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/memory_map_fast_pair.dtsi
@@ -8,31 +8,36 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(32)>;
 		};
 
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x8000 DT_SIZE_K(488)>;
 		};
 
 		slot1_partition: partition@82000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x82000 DT_SIZE_K(488)>;
 		};
 
 		bt_fast_pair_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "fast_pair";
 			reg = <0xfc000 DT_SIZE_K(4)>;
 		};
 
 		storage_partition: partition@fd000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xfd000 DT_SIZE_K(12)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/memory_map_mcuboot_qspi.dtsi
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/memory_map_mcuboot_qspi.dtsi
@@ -8,21 +8,24 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(48)>;
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0xc000 DT_SIZE_K(960)>;
 		};
 
 		storage_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xfc000 DT_SIZE_K(16)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/memory_map_fast_pair.dtsi
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/memory_map_fast_pair.dtsi
@@ -8,31 +8,36 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(32)>;
 		};
 
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x8000 DT_SIZE_K(488)>;
 		};
 
 		slot1_partition: partition@82000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x82000 DT_SIZE_K(488)>;
 		};
 
 		bt_fast_pair_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "fast_pair";
 			reg = <0xfc000 DT_SIZE_K(4)>;
 		};
 
 		storage_partition: partition@fd000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xfd000 DT_SIZE_K(12)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/memory_map_release_fast_pair.dtsi
+++ b/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/memory_map_release_fast_pair.dtsi
@@ -8,31 +8,36 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(24)>;
 		};
 
 		slot0_partition: partition@6000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x6000 DT_SIZE_K(236)>;
 		};
 
 		slot1_partition: partition@41000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x41000 DT_SIZE_K(236)>;
 		};
 
 		bt_fast_pair_partition: partition@7c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "fast_pair";
 			reg = <0x7c000 DT_SIZE_K(4)>;
 		};
 
 		storage_partition: partition@7d000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7d000 DT_SIZE_K(12)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/memory_map.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/memory_map.dtsi
@@ -11,16 +11,18 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0 DT_SIZE_K(484)>;
 		};
 
 		storage_partition: partition@79000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x79000 DT_SIZE_K(16)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/memory_map_release.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/memory_map_release.dtsi
@@ -11,26 +11,30 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(28)>;
 		};
 
 		slot0_partition: partition@7000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x7000 DT_SIZE_K(228)>;
 		};
 
 		slot1_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x40000 DT_SIZE_K(228)>;
 		};
 
 		storage_partition: partition@79000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x79000 DT_SIZE_K(16)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/memory_map_release_fast_pair.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l05_cpuapp/memory_map_release_fast_pair.dtsi
@@ -11,31 +11,36 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(28)>;
 		};
 
 		slot0_partition: partition@7000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x7000 DT_SIZE_K(224)>;
 		};
 
 		slot1_partition: partition@3f000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x3f000 DT_SIZE_K(224)>;
 		};
 
 		bt_fast_pair_partition: partition@77000 {
+			compatible = "zephyr,mapped-partition";
 			label = "fast_pair";
 			reg = <0x77000 DT_SIZE_K(4)>;
 		};
 
 		storage_partition: partition@78000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x78000 DT_SIZE_K(20)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/memory_map.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/memory_map.dtsi
@@ -11,26 +11,30 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(28)>;
 		};
 
 		slot0_partition: partition@7000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x7000 DT_SIZE_K(484)>;
 		};
 
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x80000 DT_SIZE_K(484)>;
 		};
 
 		storage_partition: partition@f9000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xf9000 DT_SIZE_K(16)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/memory_map_fast_pair.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l10_cpuapp/memory_map_fast_pair.dtsi
@@ -11,31 +11,36 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(28)>;
 		};
 
 		slot0_partition: partition@7000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x7000 DT_SIZE_K(480)>;
 		};
 
 		slot1_partition: partition@7f000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x7f000 DT_SIZE_K(480)>;
 		};
 
 		bt_fast_pair_partition: partition@f7000 {
+			compatible = "zephyr,mapped-partition";
 			label = "fast_pair";
 			reg = <0xf7000 DT_SIZE_K(4)>;
 		};
 
 		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xf8000 DT_SIZE_K(20)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/memory_map.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/memory_map.dtsi
@@ -11,26 +11,30 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(28)>;
 		};
 
 		slot0_partition: partition@7000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x7000 DT_SIZE_K(740)>;
 		};
 
 		slot1_partition: partition@c0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xc0000 DT_SIZE_K(740)>;
 		};
 
 		storage_partition: partition@179000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x179000 DT_SIZE_K(16)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/memory_map_fast_pair.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54l15dk_nrf54l15_cpuapp/memory_map_fast_pair.dtsi
@@ -11,31 +11,36 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(28)>;
 		};
 
 		slot0_partition: partition@7000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x7000 DT_SIZE_K(736)>;
 		};
 
 		slot1_partition: partition@bf000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xbf000 DT_SIZE_K(736)>;
 		};
 
 		bt_fast_pair_partition: partition@177000 {
+			compatible = "zephyr,mapped-partition";
 			label = "fast_pair";
 			reg = <0x177000 DT_SIZE_K(4)>;
 		};
 
 		storage_partition: partition@178000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x178000 DT_SIZE_K(20)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/memory_map.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/memory_map.dtsi
@@ -11,26 +11,30 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(20)>;
 		};
 
 		slot0_partition: partition@5000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x5000 DT_SIZE_K(1000)>;
 		};
 
 		slot1_partition: partition@ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xff000 DT_SIZE_K(1000)>;
 		};
 
 		storage_partition: partition@1f9000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1f9000 DT_SIZE_K(16)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/memory_map_llvm.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/memory_map_llvm.dtsi
@@ -11,26 +11,30 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(28)>;
 		};
 
 		slot0_partition: partition@7000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x7000 DT_SIZE_K(996)>;
 		};
 
 		slot1_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x100000 DT_SIZE_K(996)>;
 		};
 
 		storage_partition: partition@1f9000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1f9000 DT_SIZE_K(16)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/memory_map_ram_load.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20a_cpuapp/memory_map_ram_load.dtsi
@@ -12,29 +12,33 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Significantly increase the size of the MCUboot partition to make it fit
 		 * for the LLVM configuration variant.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(48)>;
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0xc000 DT_SIZE_K(984)>;
 		};
 
 		slot1_partition: partition@102000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x102000 DT_SIZE_K(984)>;
 		};
 
 		storage_partition: partition@1f8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1f8000 DT_SIZE_K(20)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20b_cpuapp/memory_map.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20b_cpuapp/memory_map.dtsi
@@ -11,26 +11,30 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(20)>;
 		};
 
 		slot0_partition: partition@5000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x5000 DT_SIZE_K(1000)>;
 		};
 
 		slot1_partition: partition@ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xff000 DT_SIZE_K(1000)>;
 		};
 
 		storage_partition: partition@1f9000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1f9000 DT_SIZE_K(16)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20b_cpuapp/memory_map_llvm.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20b_cpuapp/memory_map_llvm.dtsi
@@ -11,26 +11,30 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(28)>;
 		};
 
 		slot0_partition: partition@7000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x7000 DT_SIZE_K(996)>;
 		};
 
 		slot1_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x100000 DT_SIZE_K(996)>;
 		};
 
 		storage_partition: partition@1f9000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1f9000 DT_SIZE_K(16)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20b_cpuapp/memory_map_ram_load.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54lm20dk_nrf54lm20b_cpuapp/memory_map_ram_load.dtsi
@@ -12,29 +12,33 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Significantly increase the size of the MCUboot partition to make it fit
 		 * for the LLVM configuration variant.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(48)>;
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0xc000 DT_SIZE_K(984)>;
 		};
 
 		slot1_partition: partition@102000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x102000 DT_SIZE_K(984)>;
 		};
 
 		storage_partition: partition@1f8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1f8000 DT_SIZE_K(20)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54ls05dk_nrf54ls05b_cpuapp/memory_map.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54ls05dk_nrf54ls05b_cpuapp/memory_map.dtsi
@@ -9,16 +9,18 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0 DT_SIZE_K(492)>;
 		};
 
 		storage_partition: partition@7b000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7b000 DT_SIZE_K(16)>;
 		};

--- a/applications/nrf_desktop/configuration/nrf54ls05dk_nrf54ls05b_cpuapp/memory_map_release.dtsi
+++ b/applications/nrf_desktop/configuration/nrf54ls05dk_nrf54ls05b_cpuapp/memory_map_release.dtsi
@@ -8,26 +8,30 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(28)>;
 		};
 
 		slot0_partition: partition@7000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x7000 DT_SIZE_K(232)>;
 		};
 
 		slot1_partition: partition@41000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x41000 DT_SIZE_K(232)>;
 		};
 
 		storage_partition: partition@7b000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7b000 DT_SIZE_K(16)>;
 		};


### PR DESCRIPTION
Switch from the `fixed-partitions` binding
to the `zephyr,mapped-partition`.