### PR TITLE
applications: nrf_desktop: Fix B0 partition labels in DTS memory maps

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/memory_map_b0.dtsi
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/memory_map_b0.dtsi
@@ -24,13 +24,16 @@
 			reg = <0x5000 DT_SIZE_K(4)>;
 		};
 
-		s0_partition: partition@6000 {
+		/* Define 'slot0_partition' and 'slot1_partition' as additional labels.
+		 * This keeps compatibility with the Partition Manager.
+		 */
+		slot0_partition: s0_partition: partition@6000 {
 			compatible = "zephyr,mapped-partition";
 			label = "b0-image-0";
 			reg = <0x6000 DT_SIZE_K(496)>;
 		};
 
-		s1_partition: partition@82000 {
+		slot1_partition: s1_partition: partition@82000 {
 			compatible = "zephyr,mapped-partition";
 			label = "b0-image-1";
 			reg = <0x82000 DT_SIZE_K(496)>;

--- a/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpuapp/memory_map_b0.dtsi
+++ b/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpuapp/memory_map_b0.dtsi
@@ -24,13 +24,16 @@
 			reg = <0x8000 DT_SIZE_K(4)>;
 		};
 
-		s0_partition: partition@9000 {
+		/* Define 'slot0_partition' and 'slot1_partition' as additional labels.
+		 * This keeps compatibility with the Partition Manager.
+		 */
+		slot0_partition: s0_partition: partition@9000 {
 			compatible = "zephyr,mapped-partition";
 			label = "b0-image-0";
 			reg = <0x9000 DT_SIZE_K(488)>;
 		};
 
-		s1_partition: partition@83000 {
+		slot1_partition: s1_partition: partition@83000 {
 			compatible = "zephyr,mapped-partition";
 			label = "b0-image-1";
 			reg = <0x83000 DT_SIZE_K(488)>;


### PR DESCRIPTION
After migrating B0 memory maps from PM to DTS, the B0 image partitions only used s0_partition and s1_partition labels.
That broke compatibility with configurations that expect the PM.
