### PR TITLE
dts: Update nrf9251 dtsi with Micr node and add its binding

### DIFF
--- a/dts/bindings/misc/nordic,nrf-micr.yaml
+++ b/dts/bindings/misc/nordic,nrf-micr.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Nordic Semiconductor
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+description: Nordic MICR (Module Information Configuration Registers)
+
+compatible: "nordic,nrf-micr"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/common/nordic/nrf9251.dtsi
+++ b/dts/common/nordic/nrf9251.dtsi
@@ -209,6 +209,11 @@
 			#nordic,ficr-cells = <1>;
 		};
 
+		micr: micr@fff6000 {
+			compatible = "nordic,nrf-micr";
+			reg = <0xfff6000 (DT_SIZE_K(1) - 104)>;
+		};
+
 		cpuapp_tcm_sram: sram@22000000 {
 			compatible = "mmio-sram";
 			reg = <0x22000000 DT_SIZE_K(32)>;


### PR DESCRIPTION
Make MICR accessible to applications via devicetree so SIPINFO can be read from application code.