### PR TITLE
samples: matter: fix MCUboot for nRF54L external flash and TF-M

### DIFF
--- a/samples/matter/closure/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/closure/sysbuild/mcuboot/prj.conf
@@ -11,7 +11,7 @@ CONFIG_BOOT_BOOTSTRAP=n
 CONFIG_PM=n
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
+# FPROTECT: not set here; nRF54L MCUboot uses Kconfig default (disabled)
 
 # Bootloader size optimization
 CONFIG_CBPRINTF_NANO=y

--- a/samples/matter/contact_sensor/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/contact_sensor/sysbuild/mcuboot/prj.conf
@@ -11,7 +11,7 @@ CONFIG_BOOT_BOOTSTRAP=n
 CONFIG_PM=n
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
+# FPROTECT: not set here; nRF54L MCUboot uses Kconfig default (disabled)
 
 # Bootloader size optimization
 CONFIG_CBPRINTF_NANO=y

--- a/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2026 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #

--- a/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
+++ b/samples/matter/light_bulb/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/matter/nrf54l15_cpuapp_ns_partitions.dtsi>
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};
+
+&mx25r64 {
+	status = "okay";
+};

--- a/samples/matter/light_bulb/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/light_bulb/sysbuild/mcuboot/prj.conf
@@ -11,7 +11,7 @@ CONFIG_BOOT_BOOTSTRAP=n
 CONFIG_PM=n
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
+# FPROTECT: not set here; nRF54L MCUboot uses Kconfig default (disabled)
 
 # Bootloader size optimization
 CONFIG_CBPRINTF_NANO=y

--- a/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2026 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #

--- a/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
+++ b/samples/matter/light_switch/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/matter/nrf54l15_cpuapp_ns_partitions.dtsi>
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};
+
+&mx25r64 {
+	status = "okay";
+};

--- a/samples/matter/light_switch/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/light_switch/sysbuild/mcuboot/prj.conf
@@ -11,7 +11,7 @@ CONFIG_BOOT_BOOTSTRAP=n
 CONFIG_PM=n
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
+# FPROTECT: not set here; nRF54L MCUboot uses Kconfig default (disabled)
 
 # Bootloader size optimization
 CONFIG_CBPRINTF_NANO=y

--- a/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2026 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #

--- a/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
+++ b/samples/matter/manufacturer_specific/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/matter/nrf54l15_cpuapp_ns_partitions.dtsi>
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};
+
+&mx25r64 {
+	status = "okay";
+};

--- a/samples/matter/manufacturer_specific/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/manufacturer_specific/sysbuild/mcuboot/prj.conf
@@ -11,7 +11,7 @@ CONFIG_BOOT_BOOTSTRAP=n
 CONFIG_PM=n
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
+# FPROTECT: not set here; nRF54L MCUboot uses Kconfig default (disabled)
 
 # Bootloader size optimization
 CONFIG_CBPRINTF_NANO=y

--- a/samples/matter/smoke_co_alarm/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/smoke_co_alarm/sysbuild/mcuboot/prj.conf
@@ -11,7 +11,7 @@ CONFIG_BOOT_BOOTSTRAP=n
 CONFIG_PM=n
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
+# FPROTECT: not set here; nRF54L MCUboot uses Kconfig default (disabled)
 
 # Bootloader size optimization
 CONFIG_CBPRINTF_NANO=y

--- a/samples/matter/temperature_sensor/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/temperature_sensor/sysbuild/mcuboot/prj.conf
@@ -11,7 +11,7 @@ CONFIG_BOOT_BOOTSTRAP=n
 CONFIG_PM=n
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
+# FPROTECT: not set here; nRF54L MCUboot uses Kconfig default (disabled)
 
 # Bootloader size optimization
 CONFIG_CBPRINTF_NANO=y

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/matter/nrf54l15_cpuapp_ns_partitions.dtsi>
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};
+
+&mx25r64 {
+	status = "okay";
+};

--- a/samples/matter/template/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/template/sysbuild/mcuboot/prj.conf
@@ -11,7 +11,7 @@ CONFIG_BOOT_BOOTSTRAP=n
 CONFIG_PM=n
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
+# FPROTECT: not set here; nRF54L MCUboot uses Kconfig default (disabled)
 
 # Bootloader size optimization
 CONFIG_CBPRINTF_NANO=y

--- a/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2026 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #

--- a/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
+++ b/samples/matter/thermostat/sysbuild/mcuboot/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/matter/nrf54l15_cpuapp_ns_partitions.dtsi>
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};
+
+&mx25r64 {
+	status = "okay";
+};

--- a/samples/matter/thermostat/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/thermostat/sysbuild/mcuboot/prj.conf
@@ -11,7 +11,7 @@ CONFIG_BOOT_BOOTSTRAP=n
 CONFIG_PM=n
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
+# FPROTECT: not set here; nRF54L MCUboot uses Kconfig default (disabled)
 
 # Bootloader size optimization
 CONFIG_CBPRINTF_NANO=y

--- a/samples/matter/window_covering/sysbuild/mcuboot/prj.conf
+++ b/samples/matter/window_covering/sysbuild/mcuboot/prj.conf
@@ -11,7 +11,7 @@ CONFIG_BOOT_BOOTSTRAP=n
 CONFIG_PM=n
 
 CONFIG_FLASH=y
-CONFIG_FPROTECT=y
+# FPROTECT: not set here; nRF54L MCUboot uses Kconfig default (disabled)
 
 # Bootloader size optimization
 CONFIG_CBPRINTF_NANO=y


### PR DESCRIPTION
FPROTECT: Matter mcuboot/prj.conf had global CONFIG_FPROTECT=y, overriding Kconfig. On nRF54L, MCUboot now defaults FPROTECT off (d1c66b201c). Forcing y in prj.conf risked boot hang when partition/driver config exceeds RRAMC lock budget. Fix: drop global y, rely on Kconfig default — no per-board FPROTECT=n on external flash, no explicit y on internal.

cpuapp/ns: TF-M + external flash needs MCUboot overlay (nrf54l15_cpuapp_ns_partitions.dtsi) so slot1 is on MX25R64. Without it, swap target missing. MULTITHREADING, MAIN_STACK_SIZE=16384, BOOT_MAX_IMG_SECTORS=512 match smp_svr ext-flash MCUboot for large SPI NOR image swap.