### PR TITLE
tests: drivers: uart: Fix uart_baudrate_test

### DIFF
--- a/tests/drivers/uart/uart_baudrate_test/src/main.c
+++ b/tests/drivers/uart/uart_baudrate_test/src/main.c
@@ -22,7 +22,7 @@ static const struct gpio_dt_spec gpio_spec =
 	GPIO_DT_SPEC_GET_BY_IDX(DT_PATH(zephyr_user), gpios, 0);
 static const struct device *const uart_dev = DEVICE_DT_GET(DT_NODELABEL(dut));
 
-static const uint8_t tx_buf[] = {0x00, 0x00};
+static const uint8_t tx_buf[] = {0x00, 0x00, 0x00};
 
 #define PIN_STATE_SIZE 32768
 static uint8_t pin_state[PIN_STATE_SIZE] = {};


### PR DESCRIPTION
Add one more byte to the transmit buffer so that the test can capture at least one full byte of data. This is necessary for the test to operate at high baud rates, where the transmission may end before the test can capture the pin state.