### PR TITLE
doc: Removed duplicated link to Matter section

### DIFF
--- a/doc/matter/index.rst
+++ b/doc/matter/index.rst
@@ -16,7 +16,6 @@ This documentation set includes a selection of pages available in the `Matter <h
    BUILDING
    chip_tool_guide
    access-control-guide
-   README
    openthread_border_router_pi
    openthread_rcp_nrf_dongle.md
 


### PR DESCRIPTION
In the generated docs there is the same link to
Matter/CHIP Certificate Tool in two sections. Removed the link from Matter SDK guides, as it is already in Matter SDK development tools.