### PR TITLE
samples: cellular: Add nRF9251 DK builds to integration

### DIFF
--- a/samples/cellular/at_client/sample.yaml
+++ b/samples/cellular/at_client/sample.yaml
@@ -9,11 +9,13 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
+      - nrf9251dk/nrf9251/cpuapp
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
+      - nrf9251dk/nrf9251/cpuapp
       - thingy91x/nrf9151/ns
     tags:
       - ci_build

--- a/samples/cellular/gnss/sample.yaml
+++ b/samples/cellular/gnss/sample.yaml
@@ -8,10 +8,12 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
+      - nrf9251dk/nrf9251/cpuapp
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
+      - nrf9251dk/nrf9251/cpuapp
     tags:
       - ci_build
       - sysbuild

--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -14,6 +14,17 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_cellular
+  sample.cellular.modem_shell.nrf9251:
+    sysbuild: true
+    build_only: true
+    integration_platforms:
+      - nrf9251dk/nrf9251/cpuapp
+    platform_allow:
+      - nrf9251dk/nrf9251/cpuapp
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_cellular
   sample.cellular.modem_shell_debug:
     sysbuild: true
     build_only: true


### PR DESCRIPTION
Added nRF9251 DK builds to sample.yaml for at_client, gnss and modem_shell samples.