### PR TITLE
net: lib: tls_credentials: Fix no sources given CMake warning

### DIFF
--- a/subsys/net/lib/tls_credentials/CMakeLists.txt
+++ b/subsys/net/lib/tls_credentials/CMakeLists.txt
@@ -4,10 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-zephyr_library()
-
-zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/lib/tls_credentials)
-
-zephyr_library_sources_ifdef(CONFIG_TLS_CREDENTIALS_BACKEND_NRF_MODEM
-  tls_credentials_nrf_modem.c
-)
+if(CONFIG_TLS_CREDENTIALS_BACKEND_NRF_MODEM)
+  zephyr_library()
+  zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/lib/tls_credentials)
+  zephyr_library_sources(tls_credentials_nrf_modem.c)
+endif()


### PR DESCRIPTION
The NCS extension of the library only include sources if nRF Modem is in use, in other cases it gives the warning:

  No SOURCES given to Zephyr library:
  ..__nrf__subsys__net__lib__tls_credentials

Wrap the library in `if(CONFIG_TLS_CREDENTIALS_BACKEND_NRF_MODEM)` block so that it's not generated if it's not going to have sources.