### PR TITLE
Mbed TLS v4.1.0 update fixup

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -140,6 +140,15 @@
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39503"
 
 - scenarios:
+    - sample.net.ocpp.tls
+  platforms:
+    - nrf52840dk/nrf52840
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf9160dk@0.14.0/nrf9160/ns
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39503"
+
+- scenarios:
     - benchmarks.multicore.idle_gpio.nrf54h20dk_cpuapp_cpuppr.s2ram.wakeup_from_uart_pins
   platforms:
     - nrf54h20dk@0.9.0/nrf54h20/cpuapp

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -140,15 +140,6 @@
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39503"
 
 - scenarios:
-    - sample.net.ocpp.tls
-  platforms:
-    - nrf52840dk/nrf52840
-    - nrf5340dk/nrf5340/cpuapp
-    - nrf5340dk/nrf5340/cpuapp/ns
-    - nrf9160dk@0.14.0/nrf9160/ns
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39503"
-
-- scenarios:
     - benchmarks.multicore.idle_gpio.nrf54h20dk_cpuapp_cpuppr.s2ram.wakeup_from_uart_pins
   platforms:
     - nrf54h20dk@0.9.0/nrf54h20/cpuapp

--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -316,7 +316,7 @@
     - cpp.libcxx.glibcxx.newlib
     - cpp.libcxx.glibcxx.newlib_nano
     - cpp.libcxx.glibcxx.picolibc
-    - crypto.mbedtls_psa.without_entropy_driver
+    - crypto.psa.without_entropy_driver
     - drivers.can.shell
     - drivers.eeprom.shell
     - drivers.gpio.build

--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -252,24 +252,6 @@
     - nrf7120dk/nrf7120/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-31980"
 
-- scenarios:
-    - sample.net.ocpp.tls
-  platforms:
-    - nrf52840dk/nrf52840
-    - nrf5340dk/nrf5340/cpuapp
-    - nrf5340dk/nrf5340/cpuapp/ns
-    - nrf9160dk@0.14.0/nrf9160/ns
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39503"
-
-- scenarios:
-    - net.coap.server.secure
-  platforms:
-    - nrf52840dk/nrf52840
-    - nrf5340dk/nrf5340/cpuapp
-    - nrf5340dk/nrf5340/cpuapp/ns
-    - nrf9160dk@0.14.0/nrf9160/ns
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39505"
-
 # ---------------------------------   Won't fix section -----------------------------------
 
 - scenarios:

--- a/west.yml
+++ b/west.yml
@@ -139,11 +139,11 @@ manifest:
     - name: mbedtls
       path: modules/crypto/mbedtls
       repo-path: sdk-mbedtls
-      revision: 92d44566209a0d94a571cc7f71a4a7b9262f7602
+      revision: 5b7ca76723b3aa77a9ab066e552fe0dca4975f45
     - name: oberon-psa-crypto
       path: modules/crypto/oberon-psa-crypto
       repo-path: sdk-oberon-psa-crypto
-      revision: 3a9005029dae919e3f6d9d4182465a8e2572cf9f
+      revision: ce39726a33b6263b8a006ba404f78b209be1806c
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a9f47784f568c8b4ede9e3b6ea53758e5a391c93
+      revision: 6086d15e0350f5c3359a9500ef80cea23fc9f8b2
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix CI issues that have appeared with https://github.com/nrfconnect/sdk-nrf/pull/28496.