### PR TITLE
net: nrf_cloud: coap: Replace deprecated PGPS endpoint for PGNSS

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -698,7 +698,11 @@ Libraries for networking
 
 * :ref:`lib_nrf_cloud_pgps` library:
 
-  * Updated the range for the :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_NUM_PREDICTIONS` and :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD` Kconfig options to values supported by nRF Cloud.
+  * Updated:
+
+    * The range for the :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_NUM_PREDICTIONS` and :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD` Kconfig options to values supported by nRF Cloud.
+    * The CoAP endpoint used for requesting predictions has been renamed from ``loc/pgps`` to ``loc/pgnss``.
+      The CBOR wire format is unchanged.
 
   * Fixed:
 

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap.c
@@ -29,7 +29,7 @@
 LOG_MODULE_REGISTER(nrf_cloud_coap, CONFIG_NRF_CLOUD_COAP_LOG_LEVEL);
 
 #define COAP_AGNSS_RSC "loc/agnss"
-#define COAP_PGPS_RSC "loc/pgps"
+#define COAP_PGPS_RSC "loc/pgnss"
 #define COAP_GND_FIX_RSC "loc/ground-fix"
 #define COAP_FOTA_GET_RSC "fota/exec/current"
 #define COAP_SHDW_RSC "state"


### PR DESCRIPTION
Upgrate the CoAP endpoint to use the /loc/pgnss

Jira: CLOUDMCU-214