### PR TITLE
net: lib: nrf_cloud: Remove unnecessary sub claim from JWT

### DIFF
--- a/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_jwt.c
+++ b/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_jwt.c
@@ -209,7 +209,8 @@ int nrf_cloud_jwt_generate(uint32_t time_valid_s, char *const jwt_buf, size_t jw
 		exp_delta_s = NRF_CLOUD_JWT_VALID_TIME_S_DEF;
 	}
 
-	if (IS_ENABLED(CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID)) {
+	if (IS_ENABLED(CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID) ||
+	    IS_ENABLED(CONFIG_NRF_CLOUD_CLIENT_ID_SRC_MDM_DEVICE_UUID)) {
 		/* The UUID is present in the iss claim, so there is no need
 		 * to also include it in the sub claim.
 		 */


### PR DESCRIPTION
Fixed regression from bd2d4a4, which caused a sub claim with the device UUID to be included in the generated JWT with nRF91x1. The sub claim is only needed when device UUID is not used as the nRF Cloud Device ID.