### PR TITLE
 NCSDK-35089: image discovery migrates to ih_load_address

### DIFF
--- a/cmake/sysbuild/image_signing.cmake
+++ b/cmake/sysbuild/image_signing.cmake
@@ -127,6 +127,15 @@ function(zephyr_mcuboot_tasks)
       set(imgtool_rom_command --align ${write_block_size})
     endif()
 
+    # Set ih_load_addr to the code partition address using --rom-fixed.
+    # This allows MCUboot to match an update candidate to the primary slot when the
+    # secondary slot is shared, including for encrypted images.
+    if(CONFIG_NCS_MCUBOOT_IMGTOOL_SET_ROM_FIXED_ADDRESS)
+      dt_chosen(code_partition PROPERTY "zephyr,code-partition")
+      dt_partition_addr(code_partition_address PATH "${code_partition}" ABSOLUTE REQUIRED)
+      set(imgtool_rom_command ${imgtool_rom_command} --rom-fixed ${code_partition_address})
+    endif()
+
     # TF-M combined images need --pad-header because the MCUboot header gap is
     # at the combined slot start (in tfm_s.hex), not at the NS partition start.
     set(imgtool_pad_header_arg)

--- a/cmake/sysbuild/image_signing_firmware_loader.cmake
+++ b/cmake/sysbuild/image_signing_firmware_loader.cmake
@@ -11,6 +11,7 @@
 # function to avoid polluting the top-level scope.
 
 include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/ironside_se_tlv.cmake)
+include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/bootloader_dts_utils.cmake)
 
 function(zephyr_runner_file type path)
   # Property magic which makes west flash choose the signed build
@@ -122,6 +123,15 @@ function(zephyr_mcuboot_tasks)
     cmake_path(APPEND APPLICATION_BINARY_DIR "zephyr" "edt.pickle" OUTPUT_VARIABLE edt_pickle)
     message(STATUS "Passing DTS-based MCUboot configuration: ${mcuboot_configs}")
     set(imgtool_args ${imgtool_args} --edt-config "${edt_pickle}")
+  endif()
+
+  # Set ih_load_addr to the code partition address using --rom-fixed.
+  # This allows MCUboot to match an update candidate to the primary slot when the
+  # secondary slot is shared, including for encrypted images.
+  if(CONFIG_NCS_MCUBOOT_IMGTOOL_SET_ROM_FIXED_ADDRESS)
+    dt_chosen(code_partition PROPERTY "zephyr,code-partition")
+    dt_partition_addr(code_partition_address PATH "${code_partition}" ABSOLUTE REQUIRED)
+    set(imgtool_args ${imgtool_args} --rom-fixed ${code_partition_address})
   endif()
 
   # Extensionless prefix of any output file.

--- a/cmake/sysbuild/image_signing_split.cmake
+++ b/cmake/sysbuild/image_signing_split.cmake
@@ -97,7 +97,7 @@ function(zephyr_mcuboot_tasks)
   if(NOT CONFIG_PARTITION_MANAGER_ENABLED)
     dt_chosen(code_partition_path PROPERTY "zephyr,code-partition")
     dt_partition_size(slot_size PATH "${code_partition_path}" REQUIRED)
-    dt_partition_addr(slot_address PATH "${code_partition_path}" REQUIRED)
+    dt_partition_addr(slot_address PATH "${code_partition_path}" REQUIRED ABSOLUTE)
     dt_nodelabel(slot0_partition_path NODELABEL "slot0_partition" REQUIRED)
     dt_nodelabel(slot1_partition_path NODELABEL "slot1_partition" REQUIRED)
 
@@ -128,6 +128,9 @@ function(zephyr_mcuboot_tasks)
       set(imgtool_internal_rom_command --rom-fixed ${slot_address})
       set(imgtool_external_rom_command --rom-fixed ${qspi_slot_address})
     endif()
+  elseif(NOT CONFIG_PARTITION_MANAGER_ENABLED AND CONFIG_NCS_MCUBOOT_IMGTOOL_SET_ROM_FIXED_ADDRESS)
+    # Set ih_load_addr to the slot address using --rom-fixed for image matching.
+    set(imgtool_internal_rom_command --rom-fixed ${slot_address})
   endif()
 
   if(CONFIG_PARTITION_MANAGER_ENABLED)

--- a/cmake/sysbuild/sign_nrf54h20.cmake
+++ b/cmake/sysbuild/sign_nrf54h20.cmake
@@ -290,7 +290,6 @@ function(mcuboot_sign_merged_nrf54h20 merged_hex main_image merged_images)
       math(EXPR start_offset "${start_offset} + ${start_offset_dts}")
       set(pad_header "--pad-header")
     endif()
-    set(imgtool_rom_command --rom-fixed ${slot_addr})
   else()
     message(FATAL_ERROR "Only Direct XIP and firmware updater MCUboot modes are supported.")
     return()
@@ -345,6 +344,16 @@ function(mcuboot_sign_merged_nrf54h20 merged_hex main_image merged_images)
     message(STATUS "Passing DTS-based MCUboot configuration: ${mcuboot_configs}")
     set(imgtool_args ${imgtool_args} --edt-config "${edt_pickle}")
     list(APPEND imgtool_depends ${edt_pickle})
+  endif()
+
+  # Set --rom_fixed parameter to the code partition address.
+  # This allows to use the header load_address field during image resolution for encrypted images.
+  set(imgtool_set_rom_fixed_address)
+  sysbuild_get(imgtool_set_rom_fixed_address IMAGE ${main_image} VAR CONFIG_NCS_MCUBOOT_IMGTOOL_SET_ROM_FIXED_ADDRESS KCONFIG)
+  if(imgtool_set_rom_fixed_address)
+    dt_chosen(code_partition PROPERTY "zephyr,code-partition" TARGET "${main_image}")
+    dt_partition_addr(code_partition_address PATH "${code_partition}" TARGET "${main_image}" ABSOLUTE REQUIRED)
+    set(imgtool_args ${imgtool_args} --rom-fixed ${code_partition_address})
   endif()
 
   # List of additional build byproducts.

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -222,6 +222,22 @@ config NCS_MCUBOOT_MANIFEST_IMAGE_INDEX
 
 endif # NCS_MCUBOOT_MANIFEST_UPDATES
 
+config NCS_MCUBOOT_IMGTOOL_SET_ROM_FIXED_ADDRESS
+	bool "Set ih_load_addr using imgtool --rom-fixed when signing images"
+	depends on !MCUBOOT_BOOTLOADER_MODE_SINGLE_APP
+	depends on !MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
+	depends on !MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT
+	depends on !MCUBOOT_BOOTLOADER_MODE_RAM_LOAD
+	depends on !MCUBOOT_BOOTLOADER_MODE_RAM_LOAD_WITH_REVERT
+	depends on !MCUBOOT_BOOTLOADER_MODE_SINGLE_APP_RAM_LOAD
+	default y
+	help
+	  When signing application images, pass the --rom-fixed imgtool argument with the
+	  absolute address of the zephyr,code-partition. This sets the ih_load_addr field and
+	  IMAGE_F_ROM_FIXED flag in the image header, which allows MCUboot to match an incoming
+	  update candidate to the correct primary slot when the secondary slot is shared between
+	  images. The image header is always plain text, so this also works for encrypted images.
+
 DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
 DT_NODELABEL_SECONDARY_PARTITION := secondary_app_partition
 DT_NODELABEL_SLOT1_PARTITION := slot1_partition

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -493,6 +493,7 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
        OR SB_CONFIG_MCUBOOT_COMPRESSED_IMAGE_SUPPORT
        OR SB_CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
        # Do not use the upstream mcuboot.cmake on new platforms.
+       OR SB_CONFIG_SOC_SERIES_NRF53
        OR SB_CONFIG_SOC_SERIES_NRF54L
        OR SB_CONFIG_SOC_SERIES_NRF54H OR SB_CONFIG_QSPI_XIP_SPLIT_IMAGE
        # TF-M NS builds require signing tfm_merged.hex, not zephyr.hex.


### PR DESCRIPTION
Align all image's matching exercises to MCUBOOT_CHECK_HEADER_LOAD_ADDRES. This method uses ih_load_address field of the image header instead of reset vector address. This allows to match
incoming image to the partition even when it is for instance encrypted, as the image header is always plain-text.

ref.: NCSIDB-1173,NCSIDB-1783, NCSDK-35089