### PR TITLE
sysbuild: image_signing: set ih_load_addr from slot0 partition

### DIFF
--- a/cmake/sysbuild/image_signing.cmake
+++ b/cmake/sysbuild/image_signing.cmake
@@ -62,6 +62,10 @@ function(zephyr_mcuboot_tasks)
   dt_chosen(flash_node PROPERTY "zephyr,flash")
   dt_nodelabel(slot0_flash NODELABEL "slot0_partition" REQUIRED)
   dt_reg_size(slot_size PATH "${slot0_flash}" REQUIRED)
+  # Absolute slot0 address is used to set ih_load_addr in the image header so
+  # that the MCUBOOT_CHECK_HEADER_LOAD_ADDRESS feature can verify the
+  # secondary-slot image is intended for the primary slot.
+  dt_partition_addr(slot0_partition_address PATH "${slot0_flash}" REQUIRED ABSOLUTE)
   dt_prop(write_block_size PATH "${flash_node}" PROPERTY "write-block-size")
 
   if(NOT write_block_size)
@@ -90,7 +94,7 @@ function(zephyr_mcuboot_tasks)
     set(imgtool_rom_command)
     if(CONFIG_MCUBOOT_IMGTOOL_OVERWRITE_ONLY)
       # Use overwrite-only instead of swap upgrades.
-      set(imgtool_rom_command --overwrite-only --align 1)
+      set(imgtool_rom_command --overwrite-only --align 1 --rom-fixed ${slot0_partition_address})
     elseif(CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD OR
            CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD_WITH_REVERT)
       # RAM load requires setting the location of where to load the image to
@@ -124,7 +128,7 @@ function(zephyr_mcuboot_tasks)
       dt_reg_size(slot_size PATH "${code_partition}" REQUIRED)
       set(imgtool_rom_command --rom-fixed ${code_partition_offset} --align ${write_block_size})
     else()
-      set(imgtool_rom_command --align ${write_block_size})
+      set(imgtool_rom_command --align ${write_block_size} --rom-fixed ${slot0_partition_address})
     endif()
 
     # TF-M combined images need --pad-header because the MCUboot header gap is

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -472,6 +472,7 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
        OR SB_CONFIG_MCUBOOT_COMPRESSED_IMAGE_SUPPORT
        OR SB_CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
        # Do not use the upstream mcuboot.cmake on new platforms.
+       OR SB_CONFIG_SOC_SERIES_NRF53
        OR SB_CONFIG_SOC_SERIES_NRF54L
        OR SB_CONFIG_SOC_SERIES_NRF54H OR SB_CONFIG_QSPI_XIP_SPLIT_IMAGE
        # TF-M NS builds require signing tfm_merged.hex, not zephyr.hex.


### PR DESCRIPTION
## Summary

Fixes the NCS sysbuild signing pipeline so that the application image header carries a non-zero `ih_load_addr`, making `CONFIG_MCUBOOT_CHECK_HEADER_LOAD_ADDRESS=y` work for legitimate DFU updates instead of rejecting every package.

## Background

MCUboot's `CONFIG_MCUBOOT_CHECK_HEADER_LOAD_ADDRESS` feature verifies that an image in the secondary slot is intended for the primary slot by comparing the `ih_load_addr` field in the image header against the primary slot boundaries (`bootloader/mcuboot/boot/bootutil/src/loader.c`, `boot_validate_slot()`, lines ~810-890):

```c
if (BOOT_CURR_IMG(state) == CONFIG_MCUBOOT_APPLICATION_IMAGE_NUMBER) {
    min_addr = flash_area_get_off(BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY));
    max_addr = flash_area_get_size(BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY)) + min_addr;
    check_addresses = true;
}
#ifdef MCUBOOT_CHECK_HEADER_LOAD_ADDRESS
    internal_img_addr = secondary_hdr->ih_load_addr;
#endif
if (check_addresses == true && (internal_img_addr < min_addr || internal_img_addr >= max_addr)) {
    /* reject */
}
```

The NCS sysbuild signing script (`nrf/cmake/sysbuild/image_signing.cmake`) did not pass `--load-addr` or `--rom-fixed` to `imgtool` for the `CONFIG_MCUBOOT_IMGTOOL_OVERWRITE_ONLY=y` branch and for the default swap branch. The signed application image therefore had `ih_load_addr = 0x0`, which is outside the primary slot range, so MCUboot would reject every legitimate update.

The same gap exists in upstream `zephyr/cmake/mcuboot.cmake`; a follow-up fix is needed there for users that do not route through the NCS sysbuild signing script.

## Changes

1. **`nrf/cmake/sysbuild/image_signing.cmake`** — read the absolute `slot0_partition` address with `dt_partition_addr(... REQUIRED ABSOLUTE)` and pass it to `imgtool` as `--rom-fixed ${slot0_partition_address}` for both the `OVERWRITE_ONLY` and default swap branches. `--rom-fixed` matches the pattern already used by the cpunet image signing in `nrf/cmake/sysbuild/b0_mcuboot_signing.cmake` and avoids the spurious `IMAGE_F_RAM_LOAD` flag that `--load-addr` would set.
2. **`nrf/sysbuild/CMakeLists.txt`** — add `SB_CONFIG_SOC_SERIES_NRF53` to the list of platforms that route through the NCS sysbuild signing script. This makes non-PM nRF53 builds (such as the Fast Pair Locator Tag sample being migrated to DTS in PR #28462) pick up the fix. Mirrors the existing treatment of `SB_CONFIG_SOC_SERIES_NRF54L` and `SB_CONFIG_SOC_SERIES_NRF54H`.

## Verification

Built the Fast Pair Locator Tag sample for `nrf5340dk/nrf5340/cpuapp` against this branch + the DTS-migrated sample (PR #28462). Used `imgtool dumpinfo` to inspect the signed images and the resulting `dfu_application.zip`:

| Image | Before this PR | After this PR |
|---|---|---|
| `locator_tag.signed.bin` (app) | `load_addr = 0x0`, `flags = 0x0` | `load_addr = 0xc000`, `flags = ROM_FIXED` |
| `signed_by_mcuboot_and_b0_ipc_radio.bin` (cpunet) | `load_addr = 0x01002800`, `flags = ROM_FIXED` | unchanged |

`0xc000` matches the `slot0_partition@c000` reg in `samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf5340dk_nrf5340_cpuapp.overlay`, derived from DT (no sample-level Kconfig workaround needed).

## Notes

- The `IMAGE_F_ROM_FIXED` flag is only consulted by MCUboot in `MCUBOOT_DIRECT_XIP` mode (`boot_rom_address_check()` in `loader.c`), so it has no runtime side effect in OVERWRITE_ONLY/swap configurations beyond providing the `ih_load_addr` value that the new `CHECK_HEADER_LOAD_ADDRESS` check needs.
- An equivalent fix should land in upstream Zephyr `zephyr/cmake/mcuboot.cmake` for users that build outside the NCS sysbuild signing path. I am happy to follow up with a PR to the Zephyr fork once this lands.
- Related: the cpunet check is currently a range membership check (`min_addr <= ih_load_addr < max_addr`), not equality to the slot start, so a deliberately mis-targeted cpunet image inside the slot still passes verification. Tightening that to require `ih_load_addr == NETCPU_APP_SLOT_OFFSET` is a separate MCUboot improvement.

Ref: NCSDK-38010