### PR TITLE
manifest: Update sdk-nrfxlib revision to fetch new OT libs

### DIFF
--- a/subsys/net/openthread/Kconfig.defconfig
+++ b/subsys/net/openthread/Kconfig.defconfig
@@ -19,8 +19,7 @@ config OPENTHREAD_LIBRARY_AVAILABLE
 	# Switch:
 	# - To `y` when libraries for the current OpenThread revision are provided
 	# - To `n` on the next OpenThread upmerge
-	# Temporarily setting to n as the libraries need to be rebuilt to align with Mbed TLS v4.
-	default n
+	default y
 	depends on OPENTHREAD_THREAD_VERSION_1_4
 	depends on (OPENTHREAD_NORDIC_LIBRARY_MASTER && (SOC_NRF52840 || SOC_SERIES_NRF54L)) || \
 		    OPENTHREAD_NORDIC_LIBRARY_FTD || OPENTHREAD_NORDIC_LIBRARY_MTD

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 4703bb23aef6118bc07cfa5f500b9f224c703fd2
+      revision: c6c1d076b40ac149a10744babbb81cb2582b21bf
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Updated OpenThread Libraries and removed the workaround.