### PR TITLE
[Backport v3.4-branch] lib: modem_info: fix sprintf issues

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -659,6 +659,10 @@ Modem libraries
 * Removed the deprecated PDN library.
   Use the PDN management functionality in the :ref:`lte_lc_readme` library instead.
 
+* :ref:`modem_info_readme` library:
+
+  * Fixed a bug where supplying a very large buffer would cause a buffer overflow internally due to incorrect format string usage.
+
 Multiprotocol Service Layer libraries
 -------------------------------------
 

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -767,7 +767,10 @@ int modem_info_get_fw_version(char *buf, size_t buf_size)
 		return -EINVAL;
 	}
 
-	sprintf(format, "%%%%SHORTSWVER: %%%d[^\r\n]", buf_size);
+	/* The format buffer only has room for two digits, so limit the buffer size to 99 */
+	buf_size = MIN(99, buf_size);
+
+	snprintf(format, ARRAY_SIZE(format), "%%%%SHORTSWVER: %%%d[^\r\n]", buf_size);
 
 	ret = nrf_modem_at_scanf("AT%SHORTSWVER",
 				 format,
@@ -789,7 +792,10 @@ int modem_info_get_hw_version(char *buf, uint8_t buf_size)
 		return -EINVAL;
 	}
 
-	sprintf(format, HWVER_FMT_STR, buf_size);
+	/* The format buffer only has room for two digits, so limit the buffer size to 99 */
+	buf_size = MIN(99, buf_size);
+
+	snprintf(format, ARRAY_SIZE(format), HWVER_FMT_STR, buf_size);
 
 	ret = nrf_modem_at_scanf("AT%" HWVER_CMD_STR, format, buf);
 


### PR DESCRIPTION
Backport 1f76c684ee6ddf87d95ebaf8262832ffb056e9e3 from #27131.