### PR TITLE
[Backport v3.4-branch] boards: nordic: nrf54l:  skip glitch detector disable at lv10 and lc10

### DIFF
--- a/boards/nordic/nrf54lc10dk/Kconfig.defconfig
+++ b/boards/nordic/nrf54lc10dk/Kconfig.defconfig
@@ -8,9 +8,6 @@ DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
 config HAS_BT_CTLR
 	default BT
 
-config SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE
-	default y
-
 config NRF_RRAM_WRITE_BUFFER_SIZE
 	default 16
 

--- a/boards/nordic/nrf54lv10dk/Kconfig.defconfig
+++ b/boards/nordic/nrf54lv10dk/Kconfig.defconfig
@@ -8,9 +8,6 @@ DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
 config HAS_BT_CTLR
 	default BT
 
-config SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE
-	default y
-
 config NRF_RRAM_WRITE_BUFFER_SIZE
 	default 16
 


### PR DESCRIPTION
Backport 111f85aa1e34186aa4d9bb135bd95ed5c8761c93 from #29046.