### PR TITLE
cmake: Support for PCD with fixed-partitions

### DIFF
--- a/cmake/sysbuild/provision_hex.cmake
+++ b/cmake/sysbuild/provision_hex.cmake
@@ -131,7 +131,13 @@ function(provision application prefix_name)
     endif()
 
     dt_nodelabel(bl_storage_path NODELABEL bl_storage REQUIRED TARGET ${bl_storage_target})
-    dt_reg_addr(provision_address PATH "${bl_storage_path}" TARGET ${bl_storage_target})
+
+    if(${bl_storage_path} MATCHES /uicr)
+      dt_reg_addr(provision_address PATH "${bl_storage_path}" TARGET ${bl_storage_target})
+    else()
+      dt_partition_addr(provision_address PATH "${bl_storage_path}" TARGET ${bl_storage_target} ABSOLUTE REQUIRED)
+    endif()
+
     dt_reg_size(provision_size PATH "${bl_storage_path}" TARGET ${bl_storage_target})
   endif()
 

--- a/subsys/bootloader/bl_boot/bl_boot.c
+++ b/subsys/bootloader/bl_boot/bl_boot.c
@@ -30,10 +30,14 @@
 #define BL_STORAGE_SIZE		PM_PROVISION_SIZE
 #else
 /* Address of storage as seen in processor address space */
+#if DT_NODE_HAS_COMPAT(DT_PARENT(DT_NODELABEL(bl_storage)), nordic_nrf_uicr)
 #define BL_STORAGE_ADDRESS	DT_REG_ADDR(DT_NODELABEL(bl_storage))
 #define BL_STORAGE_SIZE		DT_REG_SIZE(DT_NODELABEL(bl_storage))
+#else
+#define BL_STORAGE_ADDRESS	PARTITION_ADDRESS(bl_storage)
+#define BL_STORAGE_SIZE		PARTITION_SIZE(bl_storage)
 #endif
-
+#endif
 
 #if USE_PARTITION_MANAGER
 #define RWX_PROTECTION_REGION	PM_B0_SIZE

--- a/subsys/bootloader/bl_storage/bl_storage.c
+++ b/subsys/bootloader/bl_storage/bl_storage.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <nrfx.h>
 #include <assert.h>
+#include <zephyr/devicetree.h>
 
 #if !defined(CONFIG_BUILD_WITH_TFM)
 #include <zephyr/kernel.h>
@@ -22,7 +23,13 @@
 #define BL_STORAGE_ADDRESS	TFM_BL_STORAGE_ADDR
 #else
 /* Address of storage as seen in processor address space */
+#if DT_NODE_HAS_COMPAT(DT_PARENT(DT_NODELABEL(bl_storage)), nordic_nrf_uicr)
 #define BL_STORAGE_ADDRESS	DT_REG_ADDR(DT_NODELABEL(bl_storage))
+#else
+#include <zephyr/storage/flash_map.h>
+
+#define BL_STORAGE_ADDRESS	PARTITION_ADDRESS(bl_storage)
+#endif
 #endif
 
 const volatile struct bl_storage_data *const BL_STORAGE =

--- a/subsys/pcd/CMakeLists.txt
+++ b/subsys/pcd/CMakeLists.txt
@@ -11,14 +11,12 @@ zephyr_library_sources(
 )
 
 if(CONFIG_PCD_APP AND NOT CONFIG_PARTITION_MANAGER_ENABLED)
+  include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/bootloader_dts_utils.cmake)
+
   # Read s0 address from b0n image
   add_custom_target(b0n_target)
   zephyr_dt_import(EDT_PICKLE_FILE ${CMAKE_BINARY_DIR}/../b0n/zephyr/edt.pickle TARGET b0n_target)
   dt_nodelabel(s0_partition_path NODELABEL s0_partition REQUIRED TARGET b0n_target)
-  dt_reg_addr(s0_partition_address PATH ${s0_partition_path} TARGET b0n_target)
-  # TODO: Likely need rework when mapped-partition is available/used
-  dt_chosen(flash_path PROPERTY "zephyr,flash" TARGET b0n_target)
-  dt_reg_addr(flash_address PATH ${flash_path} TARGET b0n_target)
-  math(EXPR s0_offset_address "${s0_partition_address} - ${flash_address}" OUTPUT_FORMAT HEXADECIMAL)
-  zephyr_library_compile_options("-DPCD_NET_CORE_APP_OFFSET=${s0_offset_address}")
+  dt_partition_addr(s0_partition_offset PATH ${s0_partition_path} TARGET b0n_target REQUIRED)
+  zephyr_library_compile_options("-DPCD_NET_CORE_APP_OFFSET=${s0_partition_offset}")
 endif()


### PR DESCRIPTION
Adds support for using the legacy partitioning system

NCSDK-38755