### PR TITLE
scripts: quarantine: add nrf54lc10 hpf tests.

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -110,6 +110,21 @@
   comment: "https://nordicsemi.atlassian.net/browse/NRFX-9465"
 
 - scenarios:
+    - drivers.hpf.gpio.loopback.icbmsg
+    - drivers.hpf.gpio.loopback.icmsg
+    - drivers.hpf.gpio.loopback.mbox
+    - drivers.mspi.hpf_app_fault_timer.emul_mspi_dev
+    - drivers.mspi.error_cases.hpf
+    - drivers.mspi.mspi_with_spis.nrf54lv10_lc10.hpf
+    - drivers.mspi.hpf_trap_handler.lv10_lc10
+    - nrf.extended.sample.basic.blinky.hpf.gpio.icbmsg
+    - nrf.extended.sample.basic.blinky.hpf.gpio.icmsg
+    - nrf.extended.sample.basic.blinky.hpf.gpio.mbox
+  platforms:
+    - nrf54lc10dk@0.8.0/nrf54lc10a/cpuapp
+  comment: "no HPF for nrf54lc10 at the moment"
+
+- scenarios:
     - benchmarks.current_consumption.beacon_idle.nrf54l
     - benchmarks.current_consumption.beacon_idle.nrf54l.lfrc
     - benchmarks.current_consumption.beacon_vs_vdd


### PR DESCRIPTION
HPF is currently not suported for nrf54lc10dk.