### PR TITLE
doc: nrf: Update information about FLPRs in nRF54L

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54l/building_nrf54l.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/building_nrf54l.rst
@@ -33,15 +33,11 @@ Building for the application and FLPR core
 Building for both the application and the FLPR cores is different from the default |NCS| procedure.
 Using the FLPR core also requires additional configuration to enable it.
 This section outlines how to build and program for both the application and FLPR core, covering separate builds and sysbuild configurations.
-The FLPR core supports two variants:
+The FLPR core supports variant:
 
 * ``<board target>/cpuflpr``, where *board target* depends on the device you are using.
   In this variant, FLPR runs from SRAM, which is the recommended method.
   To build FLPR image with this variant, the application core image must include the ``nordic-flpr`` :ref:`snippet <app_build_snippets>`.
-
-* ``<board target>/cpuflpr/xip``, where *board target* depends on the device you are using.
-  In this variant, FLPR runs from RRAM.
-  To build FLPR image with this variant, the application core image must include the ``nordic-flpr-xip`` snippet.
 
 Standard build
 --------------
@@ -101,14 +97,14 @@ Depending on the selected method, complete the following steps:
       3. Build the application image by setting the following options:
 
          * Appropriate board target, depending on the device you are using.
-         * Choose either ``nordic-flpr`` or ``nordic-flpr-xip`` snippet depending on the FLPR image target.
+         * Choose ``nordic-flpr`` snippet depending on the FLPR image target.
          * System build to :guilabel:`No sysbuild`.
 
          For more information, see :ref:`cmake_options`.
 
       #. Build the FLPR image by setting the following options:
 
-         * Board target to ``board target/cpuflpr`` (recommended) or ``board target/cpuflpr/xip``.
+         * Board target to ``board target/cpuflpr``.
          * System build to :guilabel:`No sysbuild`.
 
          For more information, see :ref:`cmake_options`.

--- a/doc/nrf/app_dev/device_guides/nrf54l/vpr_flpr.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/vpr_flpr.rst
@@ -22,52 +22,21 @@ The following section provides a support overview for various FLPR targets:
    * - Target
      - Zephyr build target
      - Kernel support
-     - Supported drivers
    * - nRF54L15 FLPR running from SRAM
      - ``nrf54l15dk/nrf54l15/cpuflpr``
      - Supported
-     - * GPIO
-       * GPIOTE
-       * GRTC
-       * TWIM
-       * UARTE
-       * VPR
-   * - nRF54L15 FLPR running from RRAM
-     - ``nrf54l15dk/nrf54l15/cpuflpr/xip``
-     - Supported
-     - --
    * - nRF54L10 FLPR running from SRAM
-     - Not available
-     - --
-     - --
-   * - nRF54L10 FLPR running from RRAM
-     - Not available
-     - --
-     - --
+     - ``nrf54l15dk/nrf54l10/cpuflpr``
+     - Supported
    * - nRF54L05 FLPR running from SRAM
-     - Not available
-     - --
-     - --
-   * - nRF54L05 FLPR running from RRAM
-     - Not available
-     - --
-     - --
+     - ``nrf54l15dk/nrf54l10/cpuflpr``
+     - Supported
    * - nRF54LM20A FLPR running from SRAM
      - ``nrf54lm20dk/nrf54lm20a/cpuflpr``
-     - Experimental
-     - --
-   * - nRF54LM20A FLPR running from RRAM
-     - ``nrf54lm20dk/nrf54lm20a/cpuflpr/xip``
-     - Experimental
-     - --
+     - Supported
    * - nRF54LV10 FLPR running from SRAM
      - ``nrf54lv10dk/nrf54lv10a/cpuflpr``
-     - Experimental
-     - --
-   * - nRF54LV10 FLPR running from RRAM
-     - ``nrf54lv10dk/nrf54lv10a/cpuflpr/xip``
-     - Experimental
-     - --
+     - Supported
 
 .. _vpr_flpr_nrf54l_initiating:
 
@@ -84,7 +53,7 @@ Bootstrapping the FLPR core
 The |NCS| provides an FLPR snippet that adds an overlay required for bootstrapping the FLPR core.
 Snippet's primary function is to enable the code that transfers the FLPR code to the designated region (if necessary) and to initiate the FLPR core.
 
-When building for the ``<board target>/cpuflpr`` or ``<board target>/cpuflpr/xip``, where *board target* depends on the device you are using, a minimal sample is automatically loaded onto the application core.
+When building for the ``<board target>/cpuflpr``, where *board target* depends on the device you are using, a minimal sample is automatically loaded onto the application core.
 See more information on :ref:`building_nrf54l_app_flpr_core`.
 
 Peripherals emulation on FLPR


### PR DESCRIPTION
Update information regarding VPR support and remove information about RRAM configuration due to limitations when use with application and BLE stack.