### PR TITLE
doc: nrf54l: add glosarry for errata support table

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54l/errata_nrf54l.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/errata_nrf54l.rst
@@ -21,6 +21,25 @@ nRF54L Series Errata documents contain descriptions of identified hardware anoma
 * `nRF54LS05B Errata`_
 
 Some of the anomalies can be fixed by applying workarounds directly in the software components, requiring minimal or zero effort from the end user.
+
+Errata status definitions
+*************************
+
+Not applicable
+   The anomaly is not applicable for the given device.
+
+Not implemented
+   The anomaly is applicable for the given device but the workaround is not implemented in the |NCS|.
+
+Enabled
+   The workaround is implemented and enabled by default.
+
+Available
+   The workaround is implemented, but specific action is required to enable it. Refer to the provided information on how to enable the workaround.
+
+Errata workaround status per device
+***********************************
+
 Refer to the following table for the current workaround list:
 
 .. tabs::


### PR DESCRIPTION
To explain what each entry in the errata support table means.

Glosarry was originally added in https://github.com/nrfconnect/sdk-nrf/pull/27865#discussion_r3026929538 but rejected during review. Turned out it was requested to be re-added by Product Management for v3.4.0 release