### PR TITLE
doc: security: tf-m v2.3.0

### DIFF
--- a/doc/nrf/security/psa_certified_api_overview.rst
+++ b/doc/nrf/security/psa_certified_api_overview.rst
@@ -128,7 +128,7 @@ Depending on the implementation you are using, the |NCS| build system can use di
    * - :ref:`Oberon PSA Crypto <ug_crypto_architecture_implementation_standards_oberon>`
      - `v1.4.0 <PSA Certified Crypto API 1.4.0_>`_
    * - :ref:`TF-M Crypto Service <ug_crypto_architecture_implementation_standards_tfm>`
-     - `v1.4.0 <PSA Certified Crypto API 1.4.0_>`_
+     - `v1.4.1 <PSA Certified Crypto API 1.4.0_>`_
    * - :ref:`IronSide Secure Enclave <ug_crypto_architecture_implementation_standards_ironside>`
      - `v1.3.1 <PSA Certified Crypto API 1.3.1_>`_
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -13,7 +13,7 @@
 .. |ironside_se_ver| replace:: v23.7.0+30
 
 .. |mbed_tls_ver| replace:: 3.6.6
-.. |tf-m_ver| replace:: v2.2.2
+.. |tf-m_ver| replace:: v2.3.0
 
 .. ### Config shortcuts
 


### PR DESCRIPTION
Updated docs to mention v2.3.0 of TF-M.

----

- [x] Awaiting https://github.com/nrfconnect/sdk-nrf/pull/28975
- [x] Release note in #29095 