### PR TITLE
samples: mbox: Fix APP belboard channel on nrf9251dk

### DIFF
--- a/samples/zephyr/drivers/mbox/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/samples/zephyr/drivers/mbox/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -6,7 +6,7 @@
 / {
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
-		mboxes = <&cpuppr_vevif 15>, <&cpuapp_bellboard 18>;
+		mboxes = <&cpuppr_vevif 15>, <&cpuapp_bellboard 13>;
 		mbox-names = "tx", "rx";
 	};
 };

--- a/samples/zephyr/drivers/mbox/remote/boards/nrf9251dk_nrf9251_cpuppr.overlay
+++ b/samples/zephyr/drivers/mbox/remote/boards/nrf9251dk_nrf9251_cpuppr.overlay
@@ -6,7 +6,7 @@
 / {
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
-		mboxes = <&cpuppr_vevif 15>, <&cpuapp_bellboard 18>;
+		mboxes = <&cpuppr_vevif 15>, <&cpuapp_bellboard 13>;
 		mbox-names = "rx", "tx";
 	};
 };

--- a/samples/zephyr/drivers/mbox/sample.yaml
+++ b/samples/zephyr/drivers/mbox/sample.yaml
@@ -74,7 +74,7 @@ tests:
       ordered: false
       regex:
         - "Ping \\(on channel 15\\)"
-        - "Pong \\(on channel 18\\)"
+        - "Pong \\(on channel 13\\)"
 
   nrf.extended.sample.drivers.mbox.nrf9251_app_flpr:
     platform_allow:

--- a/tests/zephyr/drivers/mbox/mbox_error_cases/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/zephyr/drivers/mbox/mbox_error_cases/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -7,7 +7,7 @@
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
 		mboxes = <&cpuppr_vevif 15>, <&cpuppr_vevif 32>,
-			 <&cpuapp_bellboard 18>, <&cpuapp_bellboard 32>;
+			 <&cpuapp_bellboard 13>, <&cpuapp_bellboard 32>;
 		mbox-names = "remote_valid", "remote_incorrect",
 			     "local_valid", "local_incorrect";
 	};
@@ -15,6 +15,14 @@
 
 &cpuapp_bellboard {
 	status = "okay";
+	/* The following bells on this bellboard are rang by these cores
+	 *  - Bell 0: cpusec
+	 *  - Bell 6: cpusys
+	 *  - Bell 13: cpuppr
+	 *  - Bell 14: cpuflpr
+	 *  - Bells 24, 25, 29, 31: cpucell
+	 */
+	nordic,interrupt-mapping = <0xa3006041 0>;
 };
 
 &cpuppr_vevif {

--- a/tests/zephyr/drivers/mbox/mbox_error_cases/boards/nrf9251dk_nrf9251_cpuppr.overlay
+++ b/tests/zephyr/drivers/mbox/mbox_error_cases/boards/nrf9251dk_nrf9251_cpuppr.overlay
@@ -6,7 +6,7 @@
 / {
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
-		mboxes = <&cpuapp_bellboard 18>, <&cpuapp_bellboard 32>,
+		mboxes = <&cpuapp_bellboard 13>, <&cpuapp_bellboard 32>,
 			 <&cpuppr_vevif 15>, <&cpuppr_vevif 32>;
 		mbox-names = "remote_valid", "remote_incorrect",
 			     "local_valid", "local_incorrect";


### PR DESCRIPTION
Regression after https://github.com/nrfconnect/sdk-nrf/commit/49a7b3aa51bf18e3d8c335717e460d9056b85cbc

Bell 18 shall be rang by cpurad. Since, there is no Radio core on nrf9251dk, bell 18 was disabled.

MOBX samples and tests were using bell 18 to communicate with PPR core. Fix overlays by using dedicated bell 13 instead.