### PR TITLE
[Backport v3.4-branch] applications: nrf_audio: Disable partition manager

### DIFF
--- a/applications/nrf_audio/Kconfig.sysbuild
+++ b/applications/nrf_audio/Kconfig.sysbuild
@@ -7,4 +7,7 @@
 config NRF_DEFAULT_IPC_RADIO
 	default y
 
+config PARTITION_MANAGER
+	default n
+
 source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Backport 99a5d95a133db1f35b6810bf21234286b85e4b94 from #29106.