### PR TITLE
[Backport v3.4-branch] manifest: Update nrfxlib to fetch the new OpenThread libraries

### DIFF
--- a/subsys/net/openthread/Kconfig.defconfig
+++ b/subsys/net/openthread/Kconfig.defconfig
@@ -19,8 +19,7 @@ config OPENTHREAD_LIBRARY_AVAILABLE
 	# Switch:
 	# - To `y` when libraries for the current OpenThread revision are provided
 	# - To `n` on the next OpenThread upmerge
-	# Temporarily setting to n as the libraries need to be rebuilt to align with Mbed TLS v4.
-	default n
+	default y
 	depends on OPENTHREAD_THREAD_VERSION_1_4
 	depends on (OPENTHREAD_NORDIC_LIBRARY_MASTER && (SOC_NRF52840 || SOC_SERIES_NRF54L)) || \
 		    OPENTHREAD_NORDIC_LIBRARY_FTD || OPENTHREAD_NORDIC_LIBRARY_MTD

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v3.4.0-rc1
+      revision: 99bde0a0045a90aee7429d1d6b9ccf306eaf63bf
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Regenrated OpenThread libraries to align with the new MBEDTls version.


(cherry picked from commit 6867339)