### PR TITLE
quarantine_windows: Add LWM2M Carier sample

### DIFF
--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -27,3 +27,9 @@
     - thingy53/nrf5340/cpuapp/ns
     - thingy53/nrf5340/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/SHEL-3161"
+
+- scenarios:
+    - sample.cellular.lwm2m_carrier.shell
+  platforms:
+    - nrf9151dk/nrf9151/ns
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39639"


### PR DESCRIPTION
Test configuration is added due to CMake build failure.