### PR TITLE
samples: dfu_multi_image: resize cpurad_slot0/1 partition

### DIFF
--- a/samples/dfu/dfu_multi_image/sysbuild/nrf54h20dk_nrf54h20_memory_map.dtsi
+++ b/samples/dfu/dfu_multi_image/sysbuild/nrf54h20dk_nrf54h20_memory_map.dtsi
@@ -32,7 +32,7 @@
 
 		cpurad_slot0_partition: partition@77000 {
 			compatible = "zephyr,mapped-partition";
-			reg = <0x77000 DT_SIZE_K(216)>;
+			reg = <0x77000 DT_SIZE_K(212)>;
 		};
 
 		cpuapp_slot1_partition: partition@ad000 {
@@ -42,7 +42,7 @@
 
 		cpurad_slot1_partition: partition@e2000 {
 			compatible = "zephyr,mapped-partition";
-			reg = <0xe2000 DT_SIZE_K(216)>;
+			reg = <0xe2000 DT_SIZE_K(212)>;
 		};
 
 		cpuppr_code_partition: partition@118000 {


### PR DESCRIPTION
mcuboot computes the IMG_MAX_SECTORS based on slot0_partition label which corresponds to cpuapp_slot0 partition.
This causes the boot to fail as cpurad_partition size is greater than cpuapp_partition.
Fix this by resizing cpurad_slot0/1 partition to match cpuapp partition layout.

Ref: NCSDK-39591 and NCSDK-39592