### PR TITLE
CODEOWNERS: team ncs-bifrost owns nRF Cloud MQTT library

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -864,6 +864,7 @@
 /subsys/net/lib/lwm2m_client_utils/       @nrfconnect/ncs-co-networking @nrfconnect/ncs-iot-oulu
 /subsys/net/lib/nrf70_fw_ext/             @krish2718 @sachinthegreen
 /subsys/net/lib/nrf_cloud/                @nrfconnect/ncs-nrf-cloud
+/subsys/net/lib/nrf_cloud/mqtt/           @nrfconnect/ncs-bifrost
 /subsys/net/lib/nrf_provisioning/         @nrfconnect/ncs-iot-oulu
 /subsys/net/lib/zzhc/                     @junqingzou
 /subsys/net/lib/softap_wifi_provision/    @nrfconnect/ncs-cia


### PR DESCRIPTION
ncs-bifrost becomes owner of the nRF Cloud MQTT library, as the primary use-case for the library is Wi-Fi products.

Ticket: NCSDK-39643