### PR TITLE
ci: license action use merge-base in git diff

### DIFF
--- a/.github/workflows/license-reusable.yml
+++ b/.github/workflows/license-reusable.yml
@@ -93,7 +93,7 @@ jobs:
         ${ZEPHYR_BASE}/../nrf/scripts/ci/check_license.py \
             --github \
             -l ${ZEPHYR_BASE}/../${{ inputs.license_allow_list }} \
-            -c origin/${BASE_REF}..
+            -c origin/${BASE_REF}...
 
     - name: Upload results
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4


### PR DESCRIPTION
I believe we should care about PR diff here and ignore diffs that were already made to main (two dot notation). Example where current action code caused false alarm and checks fail on files that were never touched in PR: https://github.com/nrfconnect/sdk-nrf/actions/runs/26630276479/job/78477079737?pr=29104
