### PR TITLE
modules/mcuboot: Disable PM partition size configuration

### DIFF
--- a/modules/mcuboot/boot/zephyr/Kconfig
+++ b/modules/mcuboot/boot/zephyr/Kconfig
@@ -28,6 +28,8 @@ source "$(ZEPHYR_NRF_MODULE_DIR)/subsys/partition_manager/Kconfig.template.parti
 
 endif
 
+if PARTITION_MANAGER_ENABLED
+
 config PM_PARTITION_SIZE_MCUBOOT
 	hex "Flash space allocated for the MCUboot partition"
 	default 0x3e00 if (BOOT_USE_MIN_PARTITION_SIZE && BOOT_NRF_EXTERNAL_CRYPTO)
@@ -40,6 +42,8 @@ config PM_PARTITION_SIZE_MCUBOOT
 	default 0xc000
 	help
 	  Flash space set aside for the MCUboot partition.
+
+endif
 
 config BOOT_USE_NRF_CC310_BL
 	bool


### PR DESCRIPTION
Disable PM partition size configuration items when Partition Manager is disabled. These configuration options had no effect without Partition Manager; nevertheless they were lingering in .config for no reason.