### PR TITLE
nrf_security: CRACEN: Fix function to get entropy from TRNG

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_ctr_drbg.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_ctr_drbg.c
@@ -67,18 +67,17 @@ NRF_SECURITY_MUTEX_DEFINE(cracen_prng_trng_mutex);
  *
  * @return 0 on success, nonzero on failure.
  */
-static int trng_get_entropy(uint8_t *dst, int num_trng_bytes)
+static int trng_get_entropy(uint8_t *dst, size_t num_trng_bytes)
 {
-	int sx_err;
+	int sx_err = SX_ERR_RESET_NEEDED;
 	struct sx_trng trng;
-	int trng_chunk_size;
+	size_t trng_chunk_size;
 	bool loop_continue;
 
 	while (num_trng_bytes) {
 		/* The sx_trng_get function suggests to return <= 32 bytes at a time */
 		trng_chunk_size = MIN(num_trng_bytes, 32);
 
-		sx_err = SX_ERR_RESET_NEEDED;
 		loop_continue = true;
 		while (loop_continue) {
 			switch (sx_err) {
@@ -104,13 +103,15 @@ static int trng_get_entropy(uint8_t *dst, int num_trng_bytes)
 			}
 		}
 
-		(void)sx_trng_close(&trng);
-		if (sx_err != SX_OK) {
-			return sx_err;
-		}
-
 		num_trng_bytes -= trng_chunk_size;
 		dst += trng_chunk_size;
+
+		if (num_trng_bytes && sx_err == SX_OK) {
+			sx_err = SX_ERR_HW_PROCESSING;
+		} else {
+			(void)sx_trng_close(&trng);
+			return sx_err;
+		}
 	}
 
 	return SX_OK;


### PR DESCRIPTION
The internal trng_get_entropy() function calls sx_trng_get() iteratively to get the required number of TRNG bytes since it's recommended to not request more than 32 bytes of data.

The issue is that TRNG initialization/deinitialization (as well as CRACEN power off) happens before a call to sx_trng_get() which leads to the activation of health tests which might take signigficant time.

For instance, for nRF54LM20A 384-bit seed generation before the fix took approx. 8.7ms and 5ms after.