### PR TITLE
Add nrf7120 to tfm system off service

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -549,7 +549,7 @@ config TFM_NRF_SYSTEM_OFF_SERVICE
 	bool "TF-M System OFF service [EXPERIMENTAL]"
 	depends on TFM_ISOLATION_LEVEL = 1
 	depends on TFM_SFN
-	depends on SOC_SERIES_NRF54L
+	depends on SOC_SERIES_NRF54L || SOC_SERIES_NRF71
 	depends on !RETAINED_MEM_NRF_RAM_CTRL
 	select EXPERIMENTAL
 	help


### PR DESCRIPTION
Enable nRF7120 to make use of tfm system off service. 