### PR TITLE
drivers: ppi_seq: Add gpio retention configuration and cleanup in overlays

### DIFF
--- a/drivers/ppi_seq/ppi_seq_i2c_spi.c
+++ b/drivers/ppi_seq/ppi_seq_i2c_spi.c
@@ -273,6 +273,10 @@ static int ppi_seq_spi_init(const struct device *dev)
 	} else {
 		nrf_gpio_pin_set(ss_pin);
 	}
+
+#if NRF_GPIO_HAS_RETENTION_SETCLEAR
+	nrf_gpio_pin_retain_disable(ss_pin);
+#endif
 	nrf_gpio_cfg_output(ss_pin);
 	nrf_spim_csn_configure(config->nrfx_dev.spim->p_reg, ss_pin, ss_pol, ss_dur);
 

--- a/samples/peripheral/ppi_seq_spi/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/peripheral/ppi_seq_spi/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -40,17 +40,3 @@ sample_spi: &spi130 {
 	frequency = <8000000>;
 	rtc = <&rtc130>;
 };
-
-&dppic130 {
-	status = "okay";
-	owned-channels = <4>;
-	/* RTC130->SPI130 */
-	source-channels = <4>;
-};
-
-&dppic133 {
-	status = "okay";
-	owned-channels = <4>;
-	/* SPI130<-RTC130/GRTC */
-	sink-channels = <4>;
-};

--- a/samples/peripheral/ppi_seq_spi/remote/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/samples/peripheral/ppi_seq_spi/remote/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -5,24 +5,6 @@
  */
 
 / {
-	cpus {
-		power-states {
-			wait: wait {
-				compatible = "zephyr,power-state";
-				power-state-name = "standby";
-				substate-id = <0>;
-				min-residency-us = <20000>;
-			};
-
-			hibernate: hibernate {
-				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-ram";
-				substate-id = <0>;
-				min-residency-us = <10000>;
-			};
-		};
-	};
-
 	chosen {
 		zephyr,console = &uart136;
 	};
@@ -34,10 +16,6 @@
 
 &uart136 {
 	status = "okay";
-};
-
-&cpu {
-	cpu-power-states = <&wait &hibernate>;
 };
 
 &pinctrl {

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54h20dk_nrf54h20_cpuapp_spi_rtc.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54h20dk_nrf54h20_cpuapp_spi_rtc.overlay
@@ -5,8 +5,10 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.11 and P1.10.
- * - between P1.12 and P1.13,
+ * - between P0.00 and P0.01
+ * - between P0.06 and P0.07
+ * - between P0.08 and P0.09
+ * - between P0.10 and P0.11
  */
 
 &pinctrl {
@@ -78,18 +80,4 @@ tester: &spi131 {
 	memory-regions = <&cpuapp_dma_region>;
 	/delete-property/ rx-delay-supported;
 	/delete-property/ rx-delay;
-};
-
-&dppic130 {
-	status = "okay";
-
-	owned-channels = <1>;
-	source-channels = <1>;
-};
-
-&dppic133 {
-	status = "okay";
-
-	owned-channels = <0 1 2 3 4 5 6 7>;
-	sink-channels = <1>;
 };

--- a/tests/drivers/ppi_seq/ppi_seq_with_spi/src/main.c
+++ b/tests/drivers/ppi_seq/ppi_seq_with_spi/src/main.c
@@ -234,6 +234,9 @@ static void spim_init(bool use_hw_ss)
 
 	/* CS configure. */
 	if (use_hw_ss) {
+#if NRF_GPIO_HAS_RETENTION_SETCLEAR
+		nrf_gpio_pin_retain_disable(ss_pin);
+#endif
 		nrf_gpio_pin_set(ss_pin);
 		nrf_gpio_cfg_output(ss_pin);
 		nrf_spim_csn_configure(spim_data.spim.p_reg, ss_pin, NRF_SPIM_CSN_POL_LOW, 32);


### PR DESCRIPTION
nrf54h20 tests were failing due to missing configuration of the pin retention for CS pin used by SPIM.
Additionally, removed redundant content from test and sample overlays.