### PR TITLE
doc: Update lwm2m carrier library build instructions

### DIFF
--- a/doc/nrf/includes/lwm2m_carrier_library.txt
+++ b/doc/nrf/includes/lwm2m_carrier_library.txt
@@ -1,7 +1,7 @@
 The application supports the |NCS| :ref:`liblwm2m_carrier_readme` library that you can use to connect to the operator's device management platform.
 See the library's documentation for more information and configuration options.
 
-To enable the LwM2M carrier library, add the parameter ``-DOVERLAY_CONFIG=overlay-carrier.conf`` to your build command.
+To enable the LwM2M carrier library, add the parameters ``-DEXTRA_CONF_FILE=overlay-carrier.conf`` and ``-DEXTRA_DTC_OVERLAY_FILE=overlay-carrier.overlay`` to your build command.
 
 The CA root certificates that are needed for modem FOTA are not provisioned in the |application_sample_name|.
 You can flash the :ref:`lwm2m_carrier` sample to write the certificates to modem before flashing the |application_sample_name|, or use the :ref:`at_client_sample` sample as explained in :ref:`preparing the Cellular: LwM2M Client sample for production <lwm2m_client_provisioning>`.

--- a/samples/cellular/lwm2m_carrier/sample_description.rst
+++ b/samples/cellular/lwm2m_carrier/sample_description.rst
@@ -105,6 +105,8 @@ The following files are available:
   For more information, see the :ref:`lwm2m_carrier_dependent` section of the :ref:`liblwm2m_carrier_readme` documentation.
 * :file:`overlay-lgu.conf` and :file:`sysbuild-lgu.conf` - Enable configurations for LG U+.
   For more information, see the :ref:`lwm2m_carrier_dependent` section of the :ref:`liblwm2m_carrier_readme` documentation.
+* :file:`bootloader.overlay` - Partition changes to enable application updates.
+  Required for LG U+ and SoftBank.
 
 The sample can either be configured by editing the :file:`prj.conf` file and the relevant overlay files, or through menuconfig or guiconfig.
 
@@ -138,7 +140,7 @@ Example of building with the SoftBank configuration:
 .. parsed-literal::
    :class: highlight
 
-   west build -b *board_target* -- -DEXTRA_CONF_FILE=overlay-softbank.conf -DSB_CONF_FILE=sysbuild-softbank.conf
+   west build -b *board_target* -- -DEXTRA_CONF_FILE=overlay-softbank.conf -DSB_CONF_FILE=sysbuild-softbank.conf -DEXTRA_DTC_OVERLAY_FILE="bootloader.overlay"
 
 |board_target|
 

--- a/samples/cellular/modem_shell/README.rst
+++ b/samples/cellular/modem_shell/README.rst
@@ -1187,15 +1187,9 @@ The following is an example for the nRF9161 DK:
 LwM2M carrier library support
 =============================
 
-To build the MoSh sample with LwM2M carrier library support, use the ``-DEXTRA_CONF_FILE=overlay-carrier.conf`` option.
-For example:
+.. |application_sample_name| replace:: Modem Shell sample
 
-.. parsed-literal::
-   :class: highlight
-
-   west build -p -b *board_target* -- -DEXTRA_CONF_FILE=overlay-carrier.conf
-
-|board_target|
+.. include:: /includes/lwm2m_carrier_library.txt
 
 P-GPS support
 =============


### PR DESCRIPTION
Update the LwM2M Carrier library build instructions after Partition Manager deprecation.