### PR TITLE
samples: Disable Partition Manager in selected samples

### DIFF
--- a/samples/peripheral/ppi_seq_spi/Kconfig.sysbuild
+++ b/samples/peripheral/ppi_seq_spi/Kconfig.sysbuild
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+config PARTITION_MANAGER
+	default n
+
 if SOC_NRF54H20_CPUAPP
 
 choice NETCORE

--- a/samples/zephyr/basic/blinky/Kconfig.sysbuild
+++ b/samples/zephyr/basic/blinky/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/bluetooth/beacon/Kconfig.sysbuild
+++ b/samples/zephyr/bluetooth/beacon/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/bluetooth/hci_uart/Kconfig.sysbuild
+++ b/samples/zephyr/bluetooth/hci_uart/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/bluetooth/peripheral_hr/Kconfig.sysbuild
+++ b/samples/zephyr/bluetooth/peripheral_hr/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/boards/nordic/nrf_sys_event/Kconfig.sysbuild
+++ b/samples/zephyr/boards/nordic/nrf_sys_event/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/boards/nordic/system_off/Kconfig.sysbuild
+++ b/samples/zephyr/boards/nordic/system_off/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/drivers/i2c/rtio_loopback/Kconfig.sysbuild
+++ b/samples/zephyr/drivers/i2c/rtio_loopback/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/drivers/jesd216/Kconfig.sysbuild
+++ b/samples/zephyr/drivers/jesd216/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/drivers/regulator/ship_mode/Kconfig.sysbuild
+++ b/samples/zephyr/drivers/regulator/ship_mode/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/drivers/spi_bitbang/Kconfig.sysbuild
+++ b/samples/zephyr/drivers/spi_bitbang/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/drivers/spi_flash/Kconfig.sysbuild
+++ b/samples/zephyr/drivers/spi_flash/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/drivers/watchdog/Kconfig.sysbuild
+++ b/samples/zephyr/drivers/watchdog/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/sensor/accel_polling/Kconfig.sysbuild
+++ b/samples/zephyr/sensor/accel_polling/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/sensor/bme680/Kconfig.sysbuild
+++ b/samples/zephyr/sensor/bme680/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/sensor/qdec/Kconfig.sysbuild
+++ b/samples/zephyr/sensor/qdec/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/zephyr/subsys/settings/Kconfig.sysbuild
+++ b/samples/zephyr/subsys/settings/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Disable Partition Manager as:
- it is obsolete,
- it's NOT required by the sample.