### PR TITLE
tests: tfm: Migrate nRF5340 to Devicetree partitions

### DIFF
--- a/tests/tfm/secure_services/Kconfig.sysbuild
+++ b/tests/tfm/secure_services/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n if !SOC_SERIES_NRF91
+
+source "share/sysbuild/Kconfig"

--- a/tests/tfm/secure_services/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/tests/tfm/secure_services/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,22 +1,8 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-&uart0 {
-	compatible = "nordic,nrf-uarte";
-	current-speed = <115200>;
-	status = "okay";
-	hw-flow-control;
-};
-
-&uart1 {
-	compatible = "nordic,nrf-uarte";
-	current-speed = <115200>;
-	/* Set to disabled in application, since TF-M will be using it. */
-	status = "disabled";
-	hw-flow-control;
-};
 
 /delete-node/ &boot_partition;
 /delete-node/ &slot0_partition;

--- a/tests/tfm/secure_services/src/main.c
+++ b/tests/tfm/secure_services/src/main.c
@@ -5,11 +5,29 @@
  */
 
  #include <zephyr/ztest.h>
+ #include <zephyr/devicetree.h>
  #include <tfm_ns_interface.h>
  #include <tfm_ioctl_api.h>
+#if USE_PARTITION_MANAGER
  #include <pm_config.h>
+#endif
 
  #include <hal/nrf_gpio.h>
+
+#if USE_PARTITION_MANAGER
+#define TEST_SRAM_BASE       CONFIG_PM_SRAM_BASE
+#define TEST_SRAM_NS_ADDRESS PM_SRAM_ADDRESS
+#define TEST_SRAM_S_ADDRESS  PM_TFM_SRAM_ADDRESS
+#define TEST_NS_FLASH_ADDR   PM_ADDRESS
+#else
+
+#define TEST_SRAM_BASE       DT_REG_ADDR(DT_NODELABEL(sram0))
+#define TEST_SRAM_NS_ADDRESS (DT_REG_ADDR(DT_NODELABEL(sram0)) + \
+			      DT_REG_ADDR(DT_NODELABEL(sram0_ns)))
+#define TEST_SRAM_S_ADDRESS  (DT_REG_ADDR(DT_NODELABEL(sram0)) + \
+			      DT_REG_ADDR(DT_NODELABEL(sram0_s)))
+#define TEST_NS_FLASH_ADDR   DT_REG_ADDR(DT_NODELABEL(slot0_ns_partition))
+#endif
 
 ZTEST_SUITE(test_secure_service, NULL, NULL, NULL, NULL, NULL);
 
@@ -18,13 +36,13 @@ static bool is_secure(intptr_t ptr)
 	/* We can not use 'arm_cmse_addr_is_secure here since this firmware
 	 * is built as non secure.
 	 */
-	if (ptr >= CONFIG_PM_SRAM_BASE) {
+	if (ptr >= TEST_SRAM_BASE) {
 		/* Check if RAM address is secure */
-		return ptr < PM_SRAM_ADDRESS;
+		return ptr < TEST_SRAM_NS_ADDRESS;
 	}
 
 	/* Check if flash address is secure */
-	return ptr < PM_ADDRESS;
+	return ptr < TEST_NS_FLASH_ADDR;
 }
 
 ZTEST(test_secure_service, test_tfm_read_service)
@@ -34,7 +52,7 @@ ZTEST(test_secure_service, test_tfm_read_service)
 
 	uint8_t output[4];
 	uint8_t data_length = sizeof(output);
-	void *secure_ptr = (size_t *)PM_TFM_SRAM_ADDRESS;
+	void *secure_ptr = (size_t *)TEST_SRAM_S_ADDRESS;
 
 	uint32_t err = 0;
 	enum tfm_platform_err_t plt_err;

--- a/tests/tfm/tfm_psa_test/Kconfig.sysbuild
+++ b/tests/tfm/tfm_psa_test/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n if !SOC_SERIES_NRF91
+
+source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Disable Partition Manager for non-nRF91 targets in the TFM secure_services and tfm_psa_test tests, and provide Devicetree partition overlays for the nRF5340 /ns build.