### PR TITLE
manifest: sdk-hostap: Switch to NCS fork

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -92,7 +92,6 @@ manifest:
           - hal_st # required for ST sensors (unrelated to STM32 MCUs)
           - hal_tdk # required for Invensense sensors such as ICM42670
           - hal_wurthelektronik
-          - hostap
           - liblc3
           - libmetal
           - libsbc
@@ -279,7 +278,10 @@ manifest:
       revision: d5fad6bd094899101a4e5fd53af7298160ced6ab
       groups:
         - benchmark
-
+    - name: hostap
+      repo-path: sdk-hostap
+      path: modules/lib/hostap
+      revision: a50c3c2c78eb3ed9709803eb7479d3df33d7c1bb
   # West-related configuration for the nrf repository.
   self:
     # This repository should be cloned to ncs/nrf.


### PR DESCRIPTION
Use NCS fork instead of hostap from Zephyr, this eases the maintenance esp. post RC1 for every release.