### PR TITLE
[Backport v3.4-branch] tools: Bump nrfutil device to 2.19.0

### DIFF
--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -29,4 +29,4 @@ pip:
 nrfutil:
   version: 8.1.1
   subcommands:
-    device: 2.17.5
+    device: 2.19.0

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -32,4 +32,4 @@ pip:
 nrfutil:
   version: 8.1.1
   subcommands:
-    device: 2.17.5
+    device: 2.19.0

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -28,4 +28,4 @@ pip:
 nrfutil:
   version: 8.1.1
   subcommands:
-    device: 2.17.5
+    device: 2.19.0


### PR DESCRIPTION
Backport 9928246eccaf4fa656dd79723443028e0ff98ae9 from #29146.