### PR TITLE
CI: Add downstream job for Wi-Fi networking samples

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -489,6 +489,12 @@
   - "subsys/net/lib/hostap_crypto/**/*"
   - "boards/shields/nrf7002eb2/**/*"
 
+"CI-wifi-net-samples":
+  - "samples/net/mqtt/**/*"
+  - "samples/net/coap_client/**/*"
+  - "subsys/net/lib/mqtt_helper/**/*"
+  - "subsys/net/lib/hostap_crypto/**/*"
+
 "CI-cloud-test":
   - "include/caf/**/*"
   - "include/date_time.h"


### PR DESCRIPTION
Add a new test-spec label that fires the test-sdk-wifi-debug downstream job when any of the Wi-Fi networking samples or their driver dependencies change in a PR. Covers: mqtt with tls fragment, coap_client, mqtt_helper and hostap modules.