### PR TITLE
samples: cellular: modem_shell: Fix full modem FOTA and Memfault configurations

### DIFF
--- a/samples/cellular/modem_shell/overlay-memfault.conf
+++ b/samples/cellular/modem_shell/overlay-memfault.conf
@@ -20,6 +20,10 @@ CONFIG_HW_ID_LIBRARY_SOURCE_IMEI=y
 
 # Add to pick up support for sending Memfault data over HTTP
 CONFIG_MEMFAULT_HTTP_ENABLE=y
+# Memfault HTTP implementation requires SHA-1
+CONFIG_PSA_WANT_ALG_SHA_1=y
+# Needed to make it work with minimal TF-M
+CONFIG_TFM_LOG_LEVEL_SILENCE=y
 
 # Certificate management
 CONFIG_MODEM_KEY_MGMT=y

--- a/samples/cellular/modem_shell/overlay-modem_fota_full.conf
+++ b/samples/cellular/modem_shell/overlay-modem_fota_full.conf
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Decrease buffer to make it work with minimal TF-M.
-CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE_BUF_SIZE=1024
+# Enable SHA-256 algorithm for full modem FOTA
+CONFIG_PSA_WANT_ALG_SHA_256=y
+# These are needed to make it work with minimal TF-M
 CONFIG_TFM_LOG_LEVEL_SILENCE=y
+CONFIG_FOTA_DOWNLOAD_FULL_MODEM_BUF_SZ=512
 
 # Full modem FOTA
 CONFIG_DFU_TARGET=y


### PR DESCRIPTION
Fixed full modem FOTA configuration. The configuration was incorrect and did not work after disabling Partition Manager in commit 870d0f8.

Memfault HTTP implementation requires SHA-1, enabled it in the configuration.

Jira: MOSH-670