### PR TITLE
mpsl: init: Add missing semicolon

### DIFF
--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -78,7 +78,7 @@ extern void rtc_pretick_rtc0_isr_hook(void);
 	BUILD_ASSERT(!DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(node)),                                 \
 		     "MPSL reserves " #node " on this SoC. Please disable this node in device tree")
 FOR_EACH(MPSL_BUILD_ASSERT_COUNTER_NODE_NOT_OKAY, (;),
-	 MPSL_INIT_SOC_COUNTER_RESERVED_NODES)
+	 MPSL_INIT_SOC_COUNTER_RESERVED_NODES);
 #undef MPSL_BUILD_ASSERT_COUNTER_NODE_NOT_OKAY
 #else
 #error "Counter DTS nodes reserved for MPSL are missing"


### PR DESCRIPTION
FOR_EACH missed semicolon at the end and failed to compile.