### PR TITLE
mpsl: init: Fix missing semicolon in counter reserved-node asserts

### DIFF
--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -77,12 +77,13 @@ extern void rtc_pretick_rtc0_isr_hook(void);
 #define MPSL_BUILD_ASSERT_COUNTER_NODE_NOT_OKAY(node)                                              \
 	BUILD_ASSERT(!DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(node)),                                 \
 		     "MPSL reserves " #node " on this SoC. Please disable this node in device tree")
-FOR_EACH(MPSL_BUILD_ASSERT_COUNTER_NODE_NOT_OKAY, (;),
-	 MPSL_INIT_SOC_COUNTER_RESERVED_NODES)
+FOR_EACH_NONEMPTY_TERM(MPSL_BUILD_ASSERT_COUNTER_NODE_NOT_OKAY, (;),
+		       MPSL_INIT_SOC_COUNTER_RESERVED_NODES)
+
 #undef MPSL_BUILD_ASSERT_COUNTER_NODE_NOT_OKAY
 #else
 #error "Counter DTS nodes reserved for MPSL are missing"
-#endif
+#endif /* MPSL_INIT_SOC_COUNTER_RESERVED_NODES */
 #endif /* IS_ENABLED(CONFIG_COUNTER) */
 
 #if IS_ENABLED(CONFIG_NRFX_GRTC)


### PR DESCRIPTION
The counter reserved-node check used FOR_EACH() with "(;)" as a separator, which only inserts the separator between elements. When MPSL_INIT_SOC_COUNTER_RESERVED_NODES contained a single node (e.g. timer10), the generated BUILD_ASSERT() had no trailing semicolon, so the next BUILD_ASSERT() expanded to a second _Static_assert immediately after the first. This caused the compiler error: expected ';' before '_Static_assert'.

Use FOR_EACH_NONEMPTY_TERM(..., (;), ...) so each generated BUILD_ASSERT statement is properly terminated, including the last element.