### PR TITLE
scripts: quarantine_zephyr: add crypto.psa.* for CryptoCell platforms

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -624,3 +624,15 @@
     - nrf54h20dk@0.9.0/nrf54h20/cpuapp
     - nrf54h20dk@0.9.0/nrf54h20/cpurad
   comment: "Not supported in NCS"
+
+- scenarios:
+    - crypto.psa.with_entropy_driver
+    - crypto.psa.without_entropy_driver
+  platforms:
+    - nrf52dk/nrf52832
+    - nrf52840dk/nrf52840
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf5340dk/nrf5340/cpunet
+    - nrf54l15dk/nrf54l15/cpuapp
+    - nrf9160dk@0.14.0/nrf9160
+  comment: "Doesn't work out of the box - we have our own crypto tests"


### PR DESCRIPTION
The test calls `psa_generate_random()` which fails on those platforms because of `CONFIG_PSA_WANT_GENERATE_RANDOM` not being enabled.

`CONFIG_ENTROPY_CC3XX` is used as entropy driver, and we make `CONFIG_PSA_WANT_GENERATE_RANDOM` default to y only when `CONFIG_ENTROPY_PSA_CRYPTO_RNG` is used.
Enabling `CONFIG_PSA_WANT_GENERATE_RANDOM` by default in more cases doesn't seem like a good solution as there are no good conditions to test for if we want to limit how much we enable it by default.

Making the test work would require adding a noup in `sdk-zephyr` to enable `CONFIG_PSA_WANT_GENERATE_RANDOM` but it doesn't really bring value as we already have our own (and better) crypto tests so just disable it.