### PR TITLE
[Backport v3.4-branch] bluetooth: hids: Remove stale SCI multi hosts warning + fix docs

### DIFF
--- a/doc/nrf/libraries/bluetooth/services/hids.rst
+++ b/doc/nrf/libraries/bluetooth/services/hids.rst
@@ -72,8 +72,7 @@ The feature requires the Zephyr :kconfig:option:`CONFIG_BT_SHORTER_CONNECTION_IN
    An attempt to initialize a second HID service will result in an error.
 
 .. note::
-   Currently, only one HID host can be connected to a HID device supporting HID SCI.
-   Connecting a second HID host may cause unexpected results.
+   In case of multiple HID hosts connected to a single HID device supporting HID SCI, a separate HID SCI mode as well as a separate set of connection parameters is used for each connected host.
 
 Additional Kconfig options:
 

--- a/subsys/bluetooth/services/hids.c
+++ b/subsys/bluetooth/services/hids.c
@@ -115,21 +115,6 @@ int bt_hids_connected(struct bt_hids *hids_obj, struct bt_conn *conn)
 	__ASSERT_NO_MSG(conn != NULL);
 	__ASSERT_NO_MSG(hids_obj != NULL);
 
-#if defined(CONFIG_BT_HIDS_SCI)
-	/* TODO: NCSDK-38983: Remove this loop once multiple connections are supported */
-	for (size_t i = 0; i < bt_conn_ctx_count(hids_obj->conn_ctx); i++) {
-		const struct bt_conn_ctx *ctx =
-			bt_conn_ctx_get_by_id(hids_obj->conn_ctx, i);
-
-		if (ctx) {
-			LOG_WRN("Currently only one connection "
-				"per HID service supporting SCI is supported. "
-				"Using HID SCI modes might produce unexpected results.");
-			bt_conn_ctx_release(hids_obj->conn_ctx, ctx->data);
-		}
-	}
-#endif
-
 	struct bt_hids_conn_data *conn_data =
 		bt_conn_ctx_alloc(hids_obj->conn_ctx, conn);
 


### PR DESCRIPTION
Backport edc1422794d19117e9b7b11cc92e04ad4b1136fb from #29123.