### PR TITLE
tests: drivers: spim_mosi_toggles: frequency for nRF92

### DIFF
--- a/tests/drivers/spi/spim_mosi_toggles/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/drivers/spi/spim_mosi_toggles/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -59,6 +59,6 @@
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
-		spi-max-frequency = <1280000>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
 	};
 };


### PR DESCRIPTION
SPIM instance used in the test has 16 MHz base clock, so prescaler for 1.28 MHz could not be found. Use 1 MHz, just like other slow instances.