### PR TITLE
tests: drivers: spi: enable SPI support for FLPR core

### DIFF
--- a/tests/drivers/spi/spi_latency/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
+++ b/tests/drivers/spi/spi_latency/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# nRF54H20 FLPR has no GPIO interrupts available
+CONFIG_GPIO_NRFX_INTERRUPT=n
+CONFIG_NRFX_GPIOTE=y
+
+CONFIG_DK_LIBRARY=n

--- a/tests/drivers/spi/spi_latency/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
+++ b/tests/drivers/spi/spi_latency/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Required loopbacks:
+ * P7.06 <-> P7.07
+ */
+
+&cpuflpr_code_partition {
+	reg = <0xf4000 DT_SIZE_K(64)>;
+};
+
+/ {
+	aliases {
+		tst-timer = &timer120;
+	};
+};
+
+&pinctrl {
+	spi120_default: spi120_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 7, 6)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
+		};
+	};
+
+	spi120_sleep: spi120_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MISO, 7, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio7 {
+	status = "okay";
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&spi120 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	pinctrl-0 = <&spi120_default>;
+	pinctrl-1 = <&spi120_sleep>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	memory-regions = <&dma_fast_region>;
+	cs-gpios = <&gpio7 2 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
+
+	dut_spi: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+};
+
+&uart120 {
+	status = "disabled";
+};
+
+&timer120 {
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_latency/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_latency/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&pinctrl {
+	spi120_default: spi120_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 7, 6)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
+		};
+	};
+
+	spi120_sleep: spi120_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MISO, 7, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio7 {
+	status = "reserved";
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&spi120 {
+	status = "reserved";
+	pinctrl-0 = <&spi120_default>;
+	pinctrl-1 = <&spi120_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+	interrupt-parent = <&cpuflpr_clic>;
+};
+
+&timer120 {
+	status = "reserved";
+	interrupt-parent = <&cpuflpr_clic>;
+};

--- a/tests/drivers/spi/spi_latency/sysbuild/vpr_launcher/prj.conf
+++ b/tests/drivers/spi/spi_latency/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,1 @@
+# Nothing here

--- a/tests/drivers/spi/spi_latency/testcase.yaml
+++ b/tests/drivers/spi/spi_latency/testcase.yaml
@@ -26,7 +26,16 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE="boards/spi_1MHz.overlay"
 
   drivers.spim_latency_8Mbps:
-    platform_allow: *standard_spi_platforms
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpuflpr/xip
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
 

--- a/tests/drivers/spi/spim_instances/boards/nrf54h20dk_nrf54h20_cpuflpr.conf
+++ b/tests/drivers/spi/spim_instances/boards/nrf54h20dk_nrf54h20_cpuflpr.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# nRF54H20 FLPR has no GPIO interrupts available
+CONFIG_GPIO_NRFX_INTERRUPT=n
+CONFIG_NRFX_GPIOTE=y

--- a/tests/drivers/spi/spim_instances/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
+++ b/tests/drivers/spi/spim_instances/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -48,80 +48,36 @@
 	};
 };
 
-&exmif {
-	status = "disabled";
+&gpio6 {
+	status = "okay";
+};
+
+&gpio7 {
+	status = "okay";
 };
 
 &dma_fast_region {
 	status = "okay";
 };
 
-&nfct {
-	status = "disabled";
-	nfct-pins-as-gpios;
-};
-
-&gpiote130 {
-	nonsecure-channels = <7>;
-	child-owned-channels = <7>;
-};
-
-&gpio6 {
-	status = "reserved";
-};
-
-&gpio7 {
-	status = "reserved";
-};
-
 &spi120 {
-	status = "reserved";
+	status = "okay";
 	pinctrl-0 = <&spi120_default_test>;
 	pinctrl-1 = <&spi120_sleep_test>;
 	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
 	memory-regions = <&dma_fast_region>;
-	interrupt-parent = <&cpuflpr_clic>;
 };
 
 &spi121 {
-	status = "reserved";
+	status = "okay";
 	pinctrl-0 = <&spi121_default_test>;
 	pinctrl-1 = <&spi121_sleep_test>;
 	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
 	memory-regions = <&dma_fast_region>;
-	interrupt-parent = <&cpuflpr_clic>;
 };
 
-&spi130 {
-	status = "reserved";
-	interrupt-parent = <&cpuppr_clic>;
-};
-
-&spi131 {
-	status = "reserved";
-	interrupt-parent = <&cpuppr_clic>;
-};
-
-&spi132 {
-	status = "reserved";
-	interrupt-parent = <&cpuppr_clic>;
-};
-
-&spi133 {
-	status = "reserved";
-	interrupt-parent = <&cpuppr_clic>;
-};
-
-&spi134 {
-	status = "reserved";
-	interrupt-parent = <&cpuppr_clic>;
-};
-
-/* spi135 inaccessible due to cpuppr console on uart135 */
-
-/* spi136 inaccessible due to cpuapp console on uart136 */
-
-&spi137 {
-	status = "reserved";
-	interrupt-parent = <&cpuppr_clic>;
+&uart120 {
+	status = "disabled";
 };

--- a/tests/drivers/spi/spim_instances/testcase.yaml
+++ b/tests/drivers/spi/spim_instances/testcase.yaml
@@ -11,6 +11,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpuppr
+      - nrf54h20dk/nrf54h20/cpuflpr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp


### PR DESCRIPTION
Add corresponding test overlays so that the SPI
tests run correctly under Twister for the FLPR core.