### PR TITLE
tests: drivers: ppi_seq_with_spi: Enable test on mre platforms

### DIFF
--- a/tests/drivers/ppi_seq/ppi_seq_with_spi/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_with_spi/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires loopbacks:
+ * SCK:  P1.09 - P1.08
+ * MISO: P1.10 - P1.11
+ * MOSI: P1.02 - P1.03
+ * CS:   P1.00 - P1.01
+ */
+
+&pinctrl {
+	spi21_default_alt: spi21_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
+		};
+	};
+
+	spi21_sleep_alt: spi21_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
+			low-power-enable;
+		};
+	};
+
+	spi20_default_alt: spi20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
+		};
+	};
+
+	spi20_sleep_alt: spi20_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut_cnt_timer: &timer21 {
+	status = "reserved";
+};
+
+dut_trig_timer: &timer22 {
+	status = "reserved";
+};
+
+test_timer: &timer23 {
+	status = "reserved";
+};
+
+dut_spi: &spi21 {
+	status = "okay";
+	pinctrl-0 = <&spi21_default_alt>;
+	pinctrl-1 = <&spi21_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	cs-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
+	};
+};
+
+dut_spis: &spi20 {
+	compatible = "nordic,nrf-spis";
+	status = "okay";
+	def-char = <0x00>;
+	pinctrl-0 = <&spi20_default_alt>;
+	pinctrl-1 = <&spi20_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	/delete-property/ rx-delay-supported;
+	/delete-property/ rx-delay;
+	zephyr,pm-device-runtime-auto;
+};

--- a/tests/drivers/ppi_seq/ppi_seq_with_spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_with_spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54lm20dk_nrf54lm20a_cpuapp.overlay"

--- a/tests/drivers/ppi_seq/ppi_seq_with_spi/boards/nrf54ls05dk_nrf54ls05a_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_with_spi/boards/nrf54ls05dk_nrf54ls05a_cpuapp.overlay
@@ -5,59 +5,59 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.3 and P1.4.
- * - between P1.13 and P1.14.
- * - between P1.23 and P1.24,
- * - between P1.30 and P1.31,
+ * - between P1.04 and P1.20.
+ * - between P1.05 and P1.21.
+ * - between P1.06 and P1.22,
+ * - between P1.08 and P1.09,
  */
 
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
 		};
 	};
 
 	spi22_sleep_alt: spi22_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
 			low-power-enable;
 		};
 	};
 
 	spi21_default_alt: spi21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 20)>,
+				<NRF_PSEL(SPIS_MISO, 1, 21)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 22)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
 		};
 	};
 
 	spi21_sleep_alt: spi21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 20)>,
+				<NRF_PSEL(SPIS_MISO, 1, 21)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 22)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
 			low-power-enable;
 		};
 	};
 };
 
-dut_cnt_timer: &timer21 {
+dut_cnt_timer: &timer10 {
 	status = "reserved";
 };
 
-dut_trig_timer: &timer22 {
+dut_trig_timer: &timer20 {
 	status = "reserved";
 };
 
-test_timer: &timer23 {
+test_timer: &timer00 {
 	status = "reserved";
 };
 
@@ -67,7 +67,7 @@ dut_spi: &spi22 {
 	pinctrl-1 = <&spi22_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
-	cs-gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 	zephyr,pm-device-runtime-auto;
 
 	dut_spi_dt: test-spi-dev@0 {

--- a/tests/drivers/ppi_seq/ppi_seq_with_spi/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_with_spi/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54ls05dk_nrf54ls05a_cpuapp.overlay"

--- a/tests/drivers/ppi_seq/ppi_seq_with_spi/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_with_spi/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires loopbacks:
+ * SCK:  P1.09 - P1.08
+ * MISO: P1.10 - P1.11
+ * MOSI: P1.02 - P1.03
+ * CS:   P1.00 - P1.01
+ */
+
+&pinctrl {
+	spi21_default_alt: spi21_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
+		};
+	};
+
+	spi21_sleep_alt: spi21_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
+			low-power-enable;
+		};
+	};
+
+	spi20_default_alt: spi20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
+		};
+	};
+
+	spi20_sleep_alt: spi20_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut_cnt_timer: &timer21 {
+	status = "reserved";
+};
+
+dut_trig_timer: &timer22 {
+	status = "reserved";
+};
+
+test_timer: &timer23 {
+	status = "reserved";
+};
+
+dut_spi: &spi21 {
+	status = "okay";
+	pinctrl-0 = <&spi21_default_alt>;
+	pinctrl-1 = <&spi21_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	cs-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
+	};
+};
+
+dut_spis: &spi20 {
+	compatible = "nordic,nrf-spis";
+	status = "okay";
+	def-char = <0x00>;
+	pinctrl-0 = <&spi20_default_alt>;
+	pinctrl-1 = <&spi20_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	/delete-property/ rx-delay-supported;
+	/delete-property/ rx-delay;
+	zephyr,pm-device-runtime-auto;
+};

--- a/tests/drivers/ppi_seq/ppi_seq_with_spi/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_with_spi/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+/* Test requires loopbacks:
+ * SCK:  P1.00 - P1.01
+ * MISO: P1.04 - P1.11
+ * MOSI: P2.03 - P2.09
+ * CS:   P1.08 - P1.09 (connected with antena)
+ */
+
+&pinctrl {
+	spi130_default_alt: spi130_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 0)>,
+				<NRF_PSEL(SPIM_MISO, 1, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 3)>;
+		};
+	};
+
+	spi130_sleep_alt: spi130_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 0)>,
+				<NRF_PSEL(SPIM_MISO, 1, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 3)>;
+			low-power-enable;
+		};
+	};
+
+	spi131_default_alt: spi131_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 1)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 2, 9)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
+		};
+	};
+
+	spi131_sleep_alt: spi131_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 1)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 2, 9)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
+			low-power-enable;
+		};
+	};
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&uicr {
+	nfct-pins-as-gpios;
+};
+
+&grtc {
+	/delete-property/ child-owned-channels;
+	/delete-property/ nonsecure-channels;
+	owned-channels = <0 4 5 6>;
+	extended-channels = <0>;
+};
+
+dut_cnt_timer: &timer131 {
+	status = "reserved";
+};
+
+dut_trig_timer: &timer130 {
+	status = "reserved";
+};
+
+test_timer: &timer132 {
+	status = "reserved";
+};
+
+dut_rtc: &rtc130 {
+	status = "reserved";
+};
+
+dut_spi: &spi130 {
+	status = "okay";
+	pinctrl-0 = <&spi130_default_alt>;
+	pinctrl-1 = <&spi130_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	cs-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+	memory-regions = <&cpuapp_dma_region>;
+	zephyr,pm-device-runtime-auto;
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
+	};
+};
+
+dut_spis: &spi131 {
+	compatible = "nordic,nrf-spis";
+	status = "okay";
+	def-char = <0x00>;
+	pinctrl-0 = <&spi131_default_alt>;
+	pinctrl-1 = <&spi131_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+	/delete-property/ rx-delay-supported;
+	/delete-property/ rx-delay;
+	zephyr,pm-device-runtime-auto;
+};

--- a/tests/drivers/ppi_seq/ppi_seq_with_spi/testcase.yaml
+++ b/tests/drivers/ppi_seq/ppi_seq_with_spi/testcase.yaml
@@ -11,5 +11,11 @@ tests:
     integration_platforms:
       - nrf54lm20dk/nrf54lm20a/cpuapp
     platform_allow:
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf9251dk/nrf9251/cpuapp


### PR DESCRIPTION
Add overlays required to run the ppi_seq_with_spi test on more platforms.