### PR TITLE
[Backport v3.4-branch] applicatations: nrf_audio: Adjusted timestamp handling.

### DIFF
--- a/applications/nrf_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
@@ -642,7 +642,7 @@ int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *co
 				" %d (not in range: %u - %u)",
 				time_diff_us, TX_MARGIN_MAX_US + common_interval_us,
 				TX_MARGIN_MIN_US);
-
+			ctx->ts_ctlr_esti_us -= common_interval_us;
 			ctx->last_data_status = STATUS_OVERRUN_FLUSHED;
 			return -ECANCELED;
 		}

--- a/tests/nrf_audio/bt_le_audio_tx/src/main.c
+++ b/tests/nrf_audio/bt_le_audio_tx/src/main.c
@@ -394,7 +394,8 @@ ZTEST(audio_tx, test_tx_send_send_too_fast)
 	zassert_equal(1, zbus_chan_pub_fake.call_count);
 
 	call_tx_sent(tx, chan_to_send);
-	internals_verify(0, true, 35500, STATUS_OVERRUN_FLUSHED);
+	/* Since we did not send anything, ts should not change*/
+	internals_verify(0, true, 25500, STATUS_OVERRUN_FLUSHED);
 
 	net_buf_unref(dummy_audio_frame);
 }


### PR DESCRIPTION
Backport 335aeb7695114e36a97d3a7c8375527a001dd077 from #29220.