### PR TITLE
cmake: introduce device support metadata yaml file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endforeach()
 include(cmake/extensions.cmake)
 include(cmake/version.cmake)
 include(cmake/version_app.cmake)
+include(cmake/device_support.cmake)
 include(cmake/hpf.cmake)
 
 zephyr_include_directories(include)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -737,6 +737,7 @@
 /scripts/pip-audit-whitelist.yml          @nrfconnect/ncs-co-build-system @nrfconnect/ncs-ci
 /scripts/tools-versions-*.txt             @nrfconnect/ncs-co-build-system @nrfconnect/ncs-ci
 /scripts/requirements-*.txt               @nrfconnect/ncs-co-build-system @nrfconnect/ncs-ci
+/scripts/schemas/                         @nrfconnect/ncs-co-build-system @nrfconnect/ncs-ci
 /scripts/west_commands/utils/             @gmarull
 /scripts/west_commands/create_board/      @nordicjm
 /scripts/west_commands/sbom/              @nrfconnect/ncs-co-scripts

--- a/cmake/device_support.cmake
+++ b/cmake/device_support.cmake
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+if(NOT EXISTS ${NRF_DIR}/release.yaml)
+  return()
+endif()
+
+yaml_load(FILE ${NRF_DIR}/release.yaml NAME device_support)
+
+yaml_length(device_length NAME device_support KEY devices)
+foreach(i RANGE ${device_length})
+  yaml_get(soc NAME device_support KEY devices ${i} soc)
+  if(soc STREQUAL SOC_NAME)
+    yaml_get(status NAME device_support KEY devices ${i} status)
+    if(status STREQUAL "pre-release")
+    elseif(status STREQUAL "maintenance")
+    elseif(status STREQUAL "community")
+    elseif(status STREQUAL "unsupported")
+    endif()
+    break()
+  endif()
+endforeach()
+
+if(NOT soc)
+  message(WARNING "SoC ${SOC_NAME} is not supported by this release.")
+endif()

--- a/scripts/schemas/release-schema.yaml
+++ b/scripts/schemas/release-schema.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+# Copyright (c) 2026, Nordic Semiconductor ASA
+
+# JSON Schema for release info YAML files
+# When possible, constraints and validation rules should be modeled directly in this file.
+
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: nRF Connect SDK release info schema
+description: Schema for validating nRF Connect SDK release file
+properties:
+  devices:
+    type: array
+    items:
+      type: object
+      properties:
+        soc:
+          type: string
+          description: Name of SoC.
+        status:
+          type: string
+          enum:
+            - "pre-release"
+            - "active"
+            - "maintenance"
+            - "community"
+            - "unsupported"
+        release:
+          type: string
+          description: Last known release with SoC support


### PR DESCRIPTION
This commit introduces release.yaml.

release.yaml will contain information regarding nRF Connect supported devices.
A device can have following states: pre-release, active, maintenance, discontinued, community, unsupported.

A CMake warning is printed for devices in maintenance, discontinued, or unsupported mode.

A warning is also printed for unknown devices.