### PR TITLE
lib: modem_info: add configurable log level

### DIFF
--- a/lib/modem_info/Kconfig
+++ b/lib/modem_info/Kconfig
@@ -68,4 +68,8 @@ config MODEM_INFO_ADD_DEVICE
 	help
 	  Add the device information to outgoing deviceInfo device messages.
 
+module=MODEM_INFO
+module-str=nRF91 modem information library
+source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
+
 endif # MODEM_INFO

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -21,7 +21,7 @@
 #include <zephyr/types.h>
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_REGISTER(modem_info);
+LOG_MODULE_REGISTER(modem_info, CONFIG_MODEM_INFO_LOG_LEVEL);
 
 #define INVALID_DESCRIPTOR	-1
 
@@ -876,7 +876,7 @@ int modem_info_get_rsrp(int *val)
 	}
 
 	if (*val == CELL_RSRP_INVALID) {
-		LOG_WRN("No valid RSRP");
+		LOG_DBG("No valid RSRP");
 		return -ENOENT;
 	}
 

--- a/lib/modem_info/modem_info_params.c
+++ b/lib/modem_info/modem_info_params.c
@@ -12,7 +12,7 @@
 #include <ncs_commit.h>
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_REGISTER(modem_info_params);
+LOG_MODULE_DECLARE(modem_info, CONFIG_MODEM_INFO_LOG_LEVEL);
 
 int modem_info_params_init(struct modem_param_info *modem)
 {


### PR DESCRIPTION
Add a Kconfig log level option for the modem_info library and use it when registering log modules. Also demote the "No valid RSRP" message from `LOG_WRN` to `LOG_DBG` to reduce noise at default log levels.