### PR TITLE
quarantine: Add memfault targets

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -15,6 +15,16 @@
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-38328"
 
 - scenarios:
+    - sample.debug.memfault.sample.debug.memfault
+    - sample.debug.memfault.etb.sample.debug.memfault.etb
+    - sample.debug.memfault.modem_trace_to_memfault
+    - sample.debug.memfault.etb
+  platforms:
+    - nrf9151dk/nrf9151/ns
+    - nrf9161dk/nrf9161/ns
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-38328"
+
+- scenarios:
     - nrf.extended.sample.basic.blinky
   platforms:
     - nrf54lm20dongle/nrf54lm20b/cpuapp


### PR DESCRIPTION
The memfault application before the TF-M 2.3 took
98% of the available 32K for the TF-M image.

The recent update to TF-M 2.3 slightly increased the TF-M image (~1K) and this made the TF-M minimal
profile to overflow.

There is a solution that is being worked by using
new version of the CryptoCell library which
decreases the flash size drastically and should
solve the current issue. This commit
will be dropped soon.