### PR TITLE
tests: drivers: i2c: latency: Change nrf9251dk pins

### DIFF
--- a/tests/drivers/i2c/i2c_latency/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_latency/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -13,14 +13,14 @@
 &pinctrl {
 	i2c130_default_alt: i2c130_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
+			psels = <NRF_PSEL(TWIM_SDA, 1, 9)>,
 				<NRF_PSEL(TWIM_SCL, 1, 0)>;
 		};
 	};
 
 	i2c130_sleep_alt: i2c130_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
+			psels = <NRF_PSEL(TWIM_SDA, 1, 9)>,
 				<NRF_PSEL(TWIM_SCL, 1, 0)>;
 			low-power-enable;
 		};
@@ -28,7 +28,7 @@
 
 	i2c131_default_alt: i2c131_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+			psels = <NRF_PSEL(TWIM_SDA, 1, 8)>,
 				<NRF_PSEL(TWIM_SCL, 1, 1)>;
 			bias-pull-up;
 		};
@@ -36,11 +36,16 @@
 
 	i2c131_sleep_alt: i2c131_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+			psels = <NRF_PSEL(TWIM_SDA, 1, 8)>,
 				<NRF_PSEL(TWIM_SCL, 1, 1)>;
 			low-power-enable;
 		};
 	};
+};
+
+&nfct {
+	status = "disabled";
+	nfct-pins-as-gpios;
 };
 
 dut_twim: &i2c130 {


### PR DESCRIPTION
Use P1.9-P1.8 pair for data pin.