### PR TITLE
[Backport v3.4-branch] manifest: Update sdk-connectedhomeip revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -159,7 +159,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 689ea79ea5318ed1300ef1656c6d9c3401350989
+      revision: 1206d45da3271670e676f2371670a30154d4429e
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Backport changes from nrfconnect/sdk-connectedhomeip#725 to address KRKNWK-21931