### PR TITLE
samples: cellular: Build merged.hex for CI testing

### DIFF
--- a/samples/cellular/gnss/sample.yaml
+++ b/samples/cellular/gnss/sample.yaml
@@ -37,7 +37,9 @@ tests:
       - CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE="23.77588976"
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
       - CONFIG_LOG_BUFFER_SIZE=2048
-    extra_args: gnss_SNIPPET="nrf91-modem-trace-uart"
+    extra_args:
+      - gnss_SNIPPET="nrf91-modem-trace-uart"
+      - SB_CONFIG_MERGED_HEX_FILES=y
     integration_platforms:
       - nrf9151dk/nrf9151/ns
     platform_allow:
@@ -64,7 +66,9 @@ tests:
       - CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE="23.77588976"
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
       - CONFIG_LOG_BUFFER_SIZE=2048
-    extra_args: gnss_SNIPPET="nrf91-modem-trace-uart"
+    extra_args:
+      - gnss_SNIPPET="nrf91-modem-trace-uart"
+      - SB_CONFIG_MERGED_HEX_FILES=y
     integration_platforms:
       - nrf9151dk/nrf9151/ns
     platform_allow:
@@ -94,6 +98,7 @@ tests:
       - EXTRA_CONF_FILE=overlay-pgps.conf
       - EXTRA_DTC_OVERLAY_FILE=overlay-pgps.overlay
       - gnss_SNIPPET="nrf91-modem-trace-uart"
+      - SB_CONFIG_MERGED_HEX_FILES=y
     integration_platforms:
       - nrf9151dk/nrf9151/ns
     platform_allow:
@@ -120,7 +125,9 @@ tests:
       - CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE="23.77588976"
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
       - CONFIG_LOG_BUFFER_SIZE=2048
-    extra_args: gnss_SNIPPET="nrf91-modem-trace-uart"
+    extra_args:
+      - gnss_SNIPPET="nrf91-modem-trace-uart"
+      - SB_CONFIG_MERGED_HEX_FILES=y
     integration_platforms:
       - nrf9151dk/nrf9151/ns
     platform_allow:

--- a/samples/cellular/location/sample.yaml
+++ b/samples/cellular/location/sample.yaml
@@ -78,7 +78,9 @@ tests:
     extra_configs:
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
       - CONFIG_LOG_BUFFER_SIZE=2048
-    extra_args: location_SNIPPET="nrf91-modem-trace-uart"
+    extra_args:
+      - location_SNIPPET="nrf91-modem-trace-uart"
+      - SB_CONFIG_MERGED_HEX_FILES=y
     integration_platforms:
       - nrf9151dk/nrf9151/ns
     platform_allow:

--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -535,7 +535,9 @@ tests:
     extra_configs:
       - CONFIG_LTE_NETWORK_MODE_LTE_M=y
       - CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y
-    extra_args: modem_shell_SNIPPET="nrf91-modem-trace-uart"
+    extra_args:
+      - modem_shell_SNIPPET="nrf91-modem-trace-uart"
+      - SB_CONFIG_MERGED_HEX_FILES=y
     integration_platforms:
       - nrf9151dk/nrf9151/ns
     platform_allow:


### PR DESCRIPTION
Add SB_CONFIG_MERGED_HEX_FILES=y to modem_shell, location and gnss sample integration test configurations to get merged_<board>.hex file for CI testing.