### PR TITLE
tests: drivers: ppi_seq: Run ppi_seq_i2c_spi on more platforms

### DIFF
--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires loopbacks:
+ * - between P0.06 and P0.07
+ * - between P0.00 and P0.01
+ */
+
+&pinctrl {
+	i2c130_default_alt: i2c130_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 6)>,
+				<NRF_PSEL(TWIM_SCL, 0, 0)>;
+		};
+	};
+
+	i2c130_sleep_alt: i2c130_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 6)>,
+				<NRF_PSEL(TWIM_SCL, 0, 0)>;
+			low-power-enable;
+		};
+	};
+
+	i2c131_default_alt: i2c131_default_alt {
+		group1 {
+			/* Temporary workaround as it is currently not possible
+			 * to configure pins for TWIS with pinctrl.
+			 */
+			psels = <NRF_PSEL(TWIM_SDA, 0, 7)>,
+				<NRF_PSEL(TWIM_SCL, 0, 1)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c131_sleep_alt: i2c131_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 6, 7)>,
+				<NRF_PSEL(TWIM_SCL, 0, 1)>;
+			low-power-enable;
+		};
+	};
+};
+
+test_timer: &timer130 {
+	status = "reserved";
+};
+
+&grtc {
+	/delete-property/ child-owned-channels;
+	/delete-property/ nonsecure-channels;
+	owned-channels = <0 4 5 6>;
+	extended-channels = <0>;
+};
+
+dut: &i2c130 {
+	compatible = "nordic,ppi-seq-i2c";
+	status = "okay";
+	pinctrl-0 = <&i2c130_default_alt>;
+	pinctrl-1 = <&i2c130_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	memory-regions = <&cpuapp_dma_region>;
+};
+
+tester: &i2c131 {
+	compatible = "nordic,nrf-twis";
+	status = "reserved";
+	pinctrl-0 = <&i2c131_default_alt>;
+	pinctrl-1 = <&i2c131_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+};

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54h20dk_nrf54h20_cpuapp_i2c_timer_notifier_counter.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54h20dk_nrf54h20_cpuapp_i2c_timer_notifier_counter.overlay
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires loopbacks:
+ * - between P0.06 and P0.07
+ * - between P0.00 and P0.01
+ */
+
+&pinctrl {
+	i2c130_default_alt: i2c130_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 6)>,
+				<NRF_PSEL(TWIM_SCL, 0, 0)>;
+		};
+	};
+
+	i2c130_sleep_alt: i2c130_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 6)>,
+				<NRF_PSEL(TWIM_SCL, 0, 0)>;
+			low-power-enable;
+		};
+	};
+
+	i2c131_default_alt: i2c131_default_alt {
+		group1 {
+			/* Temporary workaround as it is currently not possible
+			 * to configure pins for TWIS with pinctrl.
+			 */
+			psels = <NRF_PSEL(TWIM_SDA, 0, 7)>,
+				<NRF_PSEL(TWIM_SCL, 0, 1)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c131_sleep_alt: i2c131_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 7)>,
+				<NRF_PSEL(TWIM_SCL, 0, 1)>;
+			low-power-enable;
+		};
+	};
+};
+
+&hfxo {
+	status = "okay";
+};
+
+/* Timer used for triggering tasks in the PPI sequencer. */
+&timer131 {
+	status = "reserved";
+};
+
+/* Timer used for counting end events in the PPI sequencer. */
+&timer132 {
+	status = "reserved";
+};
+
+test_timer: &timer130 {
+	status = "reserved";
+};
+
+dut: &i2c130 {
+	compatible = "nordic,ppi-seq-i2c";
+	status = "okay";
+	pinctrl-0 = <&i2c130_default_alt>;
+	pinctrl-1 = <&i2c130_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	memory-regions = <&cpuapp_dma_region>;
+	timer = <&timer131>;
+	timer-notifier = <&timer132>;
+};
+
+tester: &i2c131 {
+	compatible = "nordic,nrf-twis";
+	status = "reserved";
+	pinctrl-0 = <&i2c131_default_alt>;
+	pinctrl-1 = <&i2c131_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+};

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54h20dk_nrf54h20_cpuapp_spi_timer.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54h20dk_nrf54h20_cpuapp_spi_timer.overlay
@@ -49,8 +49,12 @@
 	};
 };
 
+&hfxo {
+	status = "okay";
+};
+
 /* Used as trigger by the PPI sequencer. */
-&rtc130 {
+&timer131 {
 	status = "reserved";
 };
 
@@ -67,7 +71,7 @@ dut: &spi130 {
 	memory-regions = <&cpuapp_dma_region>;
 	cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
-	rtc = <&rtc130>;
+	timer = <&timer131>;
 };
 
 tester: &spi131 {

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54h20dk_nrf54h20_cpuapp_spi_timer_extra_op.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54h20dk_nrf54h20_cpuapp_spi_timer_extra_op.overlay
@@ -49,8 +49,19 @@
 	};
 };
 
+&hfxo {
+	status = "okay";
+};
+
+&grtc {
+	/delete-property/ child-owned-channels;
+	/delete-property/ nonsecure-channels;
+	owned-channels = <0 4 5 6>;
+	extended-channels = <0>;
+};
+
 /* Used as trigger by the PPI sequencer. */
-&rtc130 {
+&timer131 {
 	status = "reserved";
 };
 
@@ -67,7 +78,8 @@ dut: &spi130 {
 	memory-regions = <&cpuapp_dma_region>;
 	cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
-	rtc = <&rtc130>;
+	timer = <&timer131>;
+	extra-transfers = <50>;
 };
 
 tester: &spi131 {

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54h20dk_nrf54h20_cpuapp_spi_timer_notifier.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54h20dk_nrf54h20_cpuapp_spi_timer_notifier.overlay
@@ -49,8 +49,17 @@
 	};
 };
 
+&hfxo {
+	status = "okay";
+};
+
 /* Used as trigger by the PPI sequencer. */
-&rtc130 {
+&timer131 {
+	status = "reserved";
+};
+
+/* Used as PPI sequencer notifier. */
+&timer132 {
 	status = "reserved";
 };
 
@@ -67,7 +76,8 @@ dut: &spi130 {
 	memory-regions = <&cpuapp_dma_region>;
 	cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
-	rtc = <&rtc130>;
+	timer = <&timer131>;
+	timer-notifier = <&timer132>;
 };
 
 tester: &spi131 {

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -5,8 +5,8 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.11 and P1.10.
- * - between P1.12 and P1.13,
+ * - between P1.12 and P1.13
+ * - between P1.10 and P1.11
  */
 
 &pinctrl {
@@ -52,7 +52,7 @@ dut: &i2c21 {
 	pinctrl-0 = <&i2c21_default_alt>;
 	pinctrl-1 = <&i2c21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
-	clock-frequency = <400000>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 tester: &i2c22 {

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54l15dk_nrf54l15_cpuapp_i2c_timer_notifier_counter.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54l15dk_nrf54l15_cpuapp_i2c_timer_notifier_counter.overlay
@@ -5,38 +5,38 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.03 and P1.04
- * - between P1.13 and P1.14
+ * - between P1.12 and P1.13
+ * - between P1.10 and P1.11
  */
 
 &pinctrl {
 	i2c21_default_alt: i2c21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
-				<NRF_PSEL(TWIM_SCL, 1, 13)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 12)>,
+				<NRF_PSEL(TWIM_SCL, 1, 10)>;
 		};
 	};
 
 	i2c21_sleep_alt: i2c21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
-				<NRF_PSEL(TWIM_SCL, 1, 13)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 12)>,
+				<NRF_PSEL(TWIM_SCL, 1, 10)>;
 			low-power-enable;
 		};
 	};
 
 	i2c22_default_alt: i2c22_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
-				<NRF_PSEL(TWIM_SCL, 1, 14)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 13)>,
+				<NRF_PSEL(TWIM_SCL, 1, 11)>;
 			bias-pull-up;
 		};
 	};
 
 	i2c22_sleep_alt: i2c22_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
-				<NRF_PSEL(TWIM_SCL, 1, 14)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 13)>,
+				<NRF_PSEL(TWIM_SCL, 1, 11)>;
 			low-power-enable;
 		};
 	};

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires loopbacks:
+ * - between P1.00 and P1.01
+ * - between P1.02 and P1.03
+ */
+
+&pinctrl {
+	i2c20_default_alt: i2c20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 0)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+		};
+	};
+
+	i2c20_sleep_alt: i2c20_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 0)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			low-power-enable;
+		};
+	};
+
+	i2c21_default_alt: i2c21_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 1)>,
+				<NRF_PSEL(TWIS_SCL, 1, 3)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c21_sleep_alt: i2c21_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 1)>,
+				<NRF_PSEL(TWIS_SCL, 1, 3)>;
+			low-power-enable;
+		};
+	};
+};
+
+test_timer: &timer20 {
+	status = "reserved";
+};
+
+dut: &i2c20 {
+	compatible = "nordic,ppi-seq-i2c";
+	status = "okay";
+	pinctrl-0 = <&i2c20_default_alt>;
+	pinctrl-1 = <&i2c20_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+tester: &i2c21 {
+	compatible = "nordic,nrf-twis";
+	status = "reserved";
+	pinctrl-0 = <&i2c21_default_alt>;
+	pinctrl-1 = <&i2c21_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+};

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lc10dk_nrf54lc10a_cpuapp_i2c_timer_notifier_counter.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lc10dk_nrf54lc10a_cpuapp_i2c_timer_notifier_counter.overlay
@@ -5,38 +5,38 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.03 and P1.04
- * - between P1.13 and P1.14
+ * - between P1.00 and P1.01
+ * - between P1.02 and P1.03
  */
 
 &pinctrl {
+	i2c20_default_alt: i2c20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 0)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+		};
+	};
+
+	i2c20_sleep_alt: i2c20_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 0)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			low-power-enable;
+		};
+	};
+
 	i2c21_default_alt: i2c21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
-				<NRF_PSEL(TWIM_SCL, 1, 13)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 1)>,
+				<NRF_PSEL(TWIS_SCL, 1, 3)>;
+			bias-pull-up;
 		};
 	};
 
 	i2c21_sleep_alt: i2c21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
-				<NRF_PSEL(TWIM_SCL, 1, 13)>;
-			low-power-enable;
-		};
-	};
-
-	i2c22_default_alt: i2c22_default_alt {
-		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
-				<NRF_PSEL(TWIM_SCL, 1, 14)>;
-			bias-pull-up;
-		};
-	};
-
-	i2c22_sleep_alt: i2c22_sleep_alt {
-		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
-				<NRF_PSEL(TWIM_SCL, 1, 14)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 1)>,
+				<NRF_PSEL(TWIS_SCL, 1, 3)>;
 			low-power-enable;
 		};
 	};
@@ -52,25 +52,25 @@
 	status = "reserved";
 };
 
-test_timer: &timer23 {
+test_timer: &timer20 {
 	status = "reserved";
 };
 
-dut: &i2c21 {
+dut: &i2c20 {
 	compatible = "nordic,ppi-seq-i2c";
 	status = "okay";
-	pinctrl-0 = <&i2c21_default_alt>;
-	pinctrl-1 = <&i2c21_sleep_alt>;
+	pinctrl-0 = <&i2c20_default_alt>;
+	pinctrl-1 = <&i2c20_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	timer = <&timer21>;
 	timer-notifier = <&timer22>;
 };
 
-tester: &i2c22 {
+tester: &i2c21 {
 	compatible = "nordic,nrf-twis";
 	status = "reserved";
-	pinctrl-0 = <&i2c22_default_alt>;
-	pinctrl-1 = <&i2c22_sleep_alt>;
+	pinctrl-0 = <&i2c21_default_alt>;
+	pinctrl-1 = <&i2c21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 };

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lc10dk_nrf54lc10a_cpuapp_spi_timer.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lc10dk_nrf54lc10a_cpuapp_spi_timer.overlay
@@ -5,45 +5,45 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.03 and P1.04
- * - between P1.13 and P1.14
- * - between P1.23 and P1.24
- * - between P1.30 and P1.31
+ * - between P1.09 and P1.08
+ * - between P1.10 and P1.11
+ * - between P1.02 and P1.03
+ * - between P1.00 and P1.01
  */
 
 &pinctrl {
 	spi21_default_alt: spi21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
 		};
 	};
 
 	spi21_sleep_alt: spi21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
 			low-power-enable;
 		};
 	};
 
-	spi22_default_alt: spi22_default_alt {
+	spi20_default_alt: spi20_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 		};
 	};
 
-	spi22_sleep_alt: spi22_sleep_alt {
+	spi20_sleep_alt: spi20_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 			low-power-enable;
 		};
 	};
@@ -64,18 +64,17 @@ dut: &spi21 {
 	pinctrl-0 = <&spi21_default_alt>;
 	pinctrl-1 = <&spi21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
-	cs-gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
 	timer = <&timer22>;
-	extra-transfers = <50>;
 };
 
-tester: &spi22 {
+tester: &spi20 {
 	compatible = "nordic,nrf-spis";
 	status = "reserved";
 	def-char = <0x00>;
-	pinctrl-0 = <&spi22_default_alt>;
-	pinctrl-1 = <&spi22_sleep_alt>;
+	pinctrl-0 = <&spi20_default_alt>;
+	pinctrl-1 = <&spi20_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	/delete-property/ rx-delay-supported;
 	/delete-property/ rx-delay;

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lc10dk_nrf54lc10a_cpuapp_spi_timer_extra_op.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lc10dk_nrf54lc10a_cpuapp_spi_timer_extra_op.overlay
@@ -5,45 +5,45 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.03 and P1.04
- * - between P1.13 and P1.14
- * - between P1.23 and P1.24
- * - between P1.30 and P1.31
+ * - between P1.09 and P1.08
+ * - between P1.10 and P1.11
+ * - between P1.02 and P1.03
+ * - between P1.00 and P1.01
  */
 
 &pinctrl {
 	spi21_default_alt: spi21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
 		};
 	};
 
 	spi21_sleep_alt: spi21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
 			low-power-enable;
 		};
 	};
 
-	spi22_default_alt: spi22_default_alt {
+	spi20_default_alt: spi20_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 		};
 	};
 
-	spi22_sleep_alt: spi22_sleep_alt {
+	spi20_sleep_alt: spi20_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 			low-power-enable;
 		};
 	};
@@ -64,18 +64,18 @@ dut: &spi21 {
 	pinctrl-0 = <&spi21_default_alt>;
 	pinctrl-1 = <&spi21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
-	cs-gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
 	timer = <&timer22>;
 	extra-transfers = <50>;
 };
 
-tester: &spi22 {
+tester: &spi20 {
 	compatible = "nordic,nrf-spis";
 	status = "reserved";
 	def-char = <0x00>;
-	pinctrl-0 = <&spi22_default_alt>;
-	pinctrl-1 = <&spi22_sleep_alt>;
+	pinctrl-0 = <&spi20_default_alt>;
+	pinctrl-1 = <&spi20_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	/delete-property/ rx-delay-supported;
 	/delete-property/ rx-delay;

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lc10dk_nrf54lc10a_cpuapp_spi_timer_notifier.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lc10dk_nrf54lc10a_cpuapp_spi_timer_notifier.overlay
@@ -5,45 +5,45 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.03 and P1.04
- * - between P1.13 and P1.13
- * - between P1.23 and P1.24
- * - between P1.30 and P1.31
+ * - between P1.09 and P1.08
+ * - between P1.10 and P1.11
+ * - between P1.02 and P1.03
+ * - between P1.00 and P1.01
  */
 
 &pinctrl {
 	spi21_default_alt: spi21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
 		};
 	};
 
 	spi21_sleep_alt: spi21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
 			low-power-enable;
 		};
 	};
 
-	spi22_default_alt: spi22_default_alt {
+	spi20_default_alt: spi20_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 		};
 	};
 
-	spi22_sleep_alt: spi22_sleep_alt {
+	spi20_sleep_alt: spi20_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 			low-power-enable;
 		};
 	};
@@ -69,18 +69,18 @@ dut: &spi21 {
 	pinctrl-0 = <&spi21_default_alt>;
 	pinctrl-1 = <&spi21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
-	cs-gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
 	timer = <&timer22>;
 	timer-notifier = <&timer21>;
 };
 
-tester: &spi22 {
+tester: &spi20 {
 	compatible = "nordic,nrf-spis";
 	status = "reserved";
 	def-char = <0x00>;
-	pinctrl-0 = <&spi22_default_alt>;
-	pinctrl-1 = <&spi22_sleep_alt>;
+	pinctrl-0 = <&spi20_default_alt>;
+	pinctrl-1 = <&spi20_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	/delete-property/ rx-delay-supported;
 	/delete-property/ rx-delay;

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -5,8 +5,8 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.3 and P1.4
- * - between P1.13 and P1.14,
+ * - between P1.03 and P1.04
+ * - between P1.13 and P1.14
  */
 
 &pinctrl {
@@ -52,7 +52,7 @@ dut: &i2c21 {
 	pinctrl-0 = <&i2c21_default_alt>;
 	pinctrl-1 = <&i2c21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
-	clock-frequency = <400000>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 tester: &i2c22 {

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20a_cpuapp_spi_timer.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20a_cpuapp_spi_timer.overlay
@@ -5,10 +5,10 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.3 and P1.4.
- * - between P1.13 and P1.14,
- * - between P1.23 and P1.24,
- * - between P1.30 and P1.31,
+ * - between P1.03 and P1.04
+ * - between P1.13 and P1.14
+ * - between P1.23 and P1.24
+ * - between P1.30 and P1.31
  */
 
 &pinctrl {
@@ -65,7 +65,7 @@ dut: &spi21 {
 	pinctrl-1 = <&spi21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	cs-gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
-	frequency = <8000000>;
+	frequency = <DT_FREQ_M(8)>;
 	timer = <&timer22>;
 };
 

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54lm20dk_nrf54lm20a_cpuapp.overlay"

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp_i2c_timer_notifier_counter.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp_i2c_timer_notifier_counter.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54lm20dk_nrf54lm20a_cpuapp_i2c_timer_notifier_counter.overlay"

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp_spi_timer.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp_spi_timer.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54lm20dk_nrf54lm20a_cpuapp_spi_timer.overlay"

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp_spi_timer_extra_op.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp_spi_timer_extra_op.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54lm20dk_nrf54lm20a_cpuapp_spi_timer_extra_op.overlay"

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp_spi_timer_notifier.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp_spi_timer_notifier.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54lm20dk_nrf54lm20a_cpuapp_spi_timer_notifier.overlay"

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05a_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05a_cpuapp.overlay
@@ -5,54 +5,44 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.03 and P1.04
- * - between P1.13 and P1.14
+ * - between P1.04 and P1.20
+ * - between P1.08 and P1.09
  */
 
 &pinctrl {
 	i2c21_default_alt: i2c21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
-				<NRF_PSEL(TWIM_SCL, 1, 13)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
+				<NRF_PSEL(TWIM_SCL, 1, 8)>;
 		};
 	};
 
 	i2c21_sleep_alt: i2c21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
-				<NRF_PSEL(TWIM_SCL, 1, 13)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
+				<NRF_PSEL(TWIM_SCL, 1, 8)>;
 			low-power-enable;
 		};
 	};
 
 	i2c22_default_alt: i2c22_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
-				<NRF_PSEL(TWIM_SCL, 1, 14)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 20)>,
+				<NRF_PSEL(TWIS_SCL, 1, 9)>;
 			bias-pull-up;
 		};
 	};
 
 	i2c22_sleep_alt: i2c22_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
-				<NRF_PSEL(TWIM_SCL, 1, 14)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 20)>,
+				<NRF_PSEL(TWIS_SCL, 1, 9)>;
 			low-power-enable;
 		};
 	};
 };
 
-/* Timer used for triggering tasks in the PPI sequencer. */
-&timer21 {
-	status = "reserved";
-};
-
-/* Timer used for counting end events in the PPI sequencer. */
-&timer22 {
-	status = "reserved";
-};
-
-test_timer: &timer23 {
+test_timer: &timer20 {
 	status = "reserved";
 };
 
@@ -63,8 +53,6 @@ dut: &i2c21 {
 	pinctrl-1 = <&i2c21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	timer = <&timer21>;
-	timer-notifier = <&timer22>;
 };
 
 tester: &i2c22 {

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05a_cpuapp_i2c_timer_notifier_counter.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05a_cpuapp_i2c_timer_notifier_counter.overlay
@@ -5,54 +5,54 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.03 and P1.04
- * - between P1.13 and P1.14
+ * - between P1.04 and P1.20
+ * - between P1.08 and P1.09
  */
 
 &pinctrl {
 	i2c21_default_alt: i2c21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
-				<NRF_PSEL(TWIM_SCL, 1, 13)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
+				<NRF_PSEL(TWIM_SCL, 1, 8)>;
 		};
 	};
 
 	i2c21_sleep_alt: i2c21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
-				<NRF_PSEL(TWIM_SCL, 1, 13)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
+				<NRF_PSEL(TWIM_SCL, 1, 8)>;
 			low-power-enable;
 		};
 	};
 
 	i2c22_default_alt: i2c22_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
-				<NRF_PSEL(TWIM_SCL, 1, 14)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 20)>,
+				<NRF_PSEL(TWIS_SCL, 1, 9)>;
 			bias-pull-up;
 		};
 	};
 
 	i2c22_sleep_alt: i2c22_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
-				<NRF_PSEL(TWIM_SCL, 1, 14)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 20)>,
+				<NRF_PSEL(TWIS_SCL, 1, 9)>;
 			low-power-enable;
 		};
 	};
 };
 
 /* Timer used for triggering tasks in the PPI sequencer. */
-&timer21 {
+&timer20 {
 	status = "reserved";
 };
 
 /* Timer used for counting end events in the PPI sequencer. */
-&timer22 {
+&timer10 {
 	status = "reserved";
 };
 
-test_timer: &timer23 {
+test_timer: &timer00 {
 	status = "reserved";
 };
 
@@ -63,8 +63,8 @@ dut: &i2c21 {
 	pinctrl-1 = <&i2c21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	timer = <&timer21>;
-	timer-notifier = <&timer22>;
+	timer = <&timer20>;
+	timer-notifier = <&timer10>;
 };
 
 tester: &i2c22 {

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05a_cpuapp_spi_timer.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05a_cpuapp_spi_timer.overlay
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires loopbacks:
+ * - between P1.04 and P1.20
+ * - between P1.05 and P1.21
+ * - between P1.06 and P1.22
+ * - between P1.08 and P1.09
+ */
+
+&pinctrl {
+	spi22_default_alt: spi22_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+		};
+	};
+
+	spi22_sleep_alt: spi22_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+			low-power-enable;
+		};
+	};
+
+	spi21_default_alt: spi21_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 20)>,
+				<NRF_PSEL(SPIS_MISO, 1, 21)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 22)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
+		};
+	};
+
+	spi21_sleep_alt: spi21_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 20)>,
+				<NRF_PSEL(SPIS_MISO, 1, 21)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 22)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
+			low-power-enable;
+		};
+	};
+};
+
+/* Used as trigger by the PPI sequencer. */
+&timer20 {
+	status = "reserved";
+};
+
+test_timer: &timer00 {
+	status = "reserved";
+};
+
+dut: &spi22 {
+	compatible = "nordic,ppi-seq-spi";
+	status = "okay";
+	pinctrl-0 = <&spi22_default_alt>;
+	pinctrl-1 = <&spi22_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	cs-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+	frequency = <DT_FREQ_M(8)>;
+	timer = <&timer20>;
+};
+
+tester: &spi21 {
+	compatible = "nordic,nrf-spis";
+	status = "reserved";
+	def-char = <0x00>;
+	pinctrl-0 = <&spi21_default_alt>;
+	pinctrl-1 = <&spi21_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	/delete-property/ rx-delay-supported;
+	/delete-property/ rx-delay;
+};

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05a_cpuapp_spi_timer_extra_op.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05a_cpuapp_spi_timer_extra_op.overlay
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires loopbacks:
+ * - between P1.04 and P1.20
+ * - between P1.05 and P1.21
+ * - between P1.06 and P1.22
+ * - between P1.08 and P1.09
+ */
+
+&pinctrl {
+	spi22_default_alt: spi22_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+		};
+	};
+
+	spi22_sleep_alt: spi22_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+			low-power-enable;
+		};
+	};
+
+	spi21_default_alt: spi21_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 20)>,
+				<NRF_PSEL(SPIS_MISO, 1, 21)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 22)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
+		};
+	};
+
+	spi21_sleep_alt: spi21_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 20)>,
+				<NRF_PSEL(SPIS_MISO, 1, 21)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 22)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
+			low-power-enable;
+		};
+	};
+};
+
+/* Used as trigger by the PPI sequencer. */
+&timer20 {
+	status = "reserved";
+};
+
+test_timer: &timer00 {
+	status = "reserved";
+};
+
+dut: &spi22 {
+	compatible = "nordic,ppi-seq-spi";
+	status = "okay";
+	pinctrl-0 = <&spi22_default_alt>;
+	pinctrl-1 = <&spi22_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	cs-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+	frequency = <DT_FREQ_M(8)>;
+	timer = <&timer20>;
+	extra-transfers = <50>;
+};
+
+tester: &spi21 {
+	compatible = "nordic,nrf-spis";
+	status = "reserved";
+	def-char = <0x00>;
+	pinctrl-0 = <&spi21_default_alt>;
+	pinctrl-1 = <&spi21_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	/delete-property/ rx-delay-supported;
+	/delete-property/ rx-delay;
+};

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05a_cpuapp_spi_timer_notifier.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05a_cpuapp_spi_timer_notifier.overlay
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires loopbacks:
+ * - between P1.04 and P1.20
+ * - between P1.05 and P1.21
+ * - between P1.06 and P1.22
+ * - between P1.08 and P1.09
+ */
+
+&pinctrl {
+	spi22_default_alt: spi22_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+		};
+	};
+
+	spi22_sleep_alt: spi22_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 4)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
+			low-power-enable;
+		};
+	};
+
+	spi21_default_alt: spi21_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 20)>,
+				<NRF_PSEL(SPIS_MISO, 1, 21)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 22)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
+		};
+	};
+
+	spi21_sleep_alt: spi21_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 20)>,
+				<NRF_PSEL(SPIS_MISO, 1, 21)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 22)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
+			low-power-enable;
+		};
+	};
+};
+
+/* Used as trigger by the PPI sequencer. */
+&timer20 {
+	status = "reserved";
+};
+
+/* Used as PPI sequencer notifier. */
+&timer10 {
+	status = "reserved";
+};
+
+test_timer: &timer00 {
+	status = "reserved";
+};
+
+dut: &spi22 {
+	compatible = "nordic,ppi-seq-spi";
+	status = "okay";
+	pinctrl-0 = <&spi22_default_alt>;
+	pinctrl-1 = <&spi22_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	cs-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+	frequency = <DT_FREQ_M(8)>;
+	timer = <&timer20>;
+	timer-notifier = <&timer10>;
+};
+
+tester: &spi21 {
+	compatible = "nordic,nrf-spis";
+	status = "reserved";
+	def-char = <0x00>;
+	pinctrl-0 = <&spi21_default_alt>;
+	pinctrl-1 = <&spi21_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	/delete-property/ rx-delay-supported;
+	/delete-property/ rx-delay;
+};

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54ls05dk_nrf54ls05a_cpuapp.overlay"

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05b_cpuapp_i2c_timer_notifier_counter.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05b_cpuapp_i2c_timer_notifier_counter.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54ls05dk_nrf54ls05a_cpuapp_i2c_timer_notifier_counter.overlay"

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05b_cpuapp_spi_timer.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05b_cpuapp_spi_timer.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54ls05dk_nrf54ls05a_cpuapp_spi_timer.overlay"

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05b_cpuapp_spi_timer_extra_op.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05b_cpuapp_spi_timer_extra_op.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54ls05dk_nrf54ls05a_cpuapp_spi_timer_extra_op.overlay"

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05b_cpuapp_spi_timer_notifier.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54ls05dk_nrf54ls05b_cpuapp_spi_timer_notifier.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54ls05dk_nrf54ls05a_cpuapp_spi_timer_notifier.overlay"

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires loopbacks:
+ * - between P1.00 and P1.01
+ * - between P1.02 and P1.03
+ */
+
+&pinctrl {
+	i2c20_default_alt: i2c20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 0)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+		};
+	};
+
+	i2c20_sleep_alt: i2c20_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 0)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			low-power-enable;
+		};
+	};
+
+	i2c21_default_alt: i2c21_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 1)>,
+				<NRF_PSEL(TWIS_SCL, 1, 3)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c21_sleep_alt: i2c21_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 1)>,
+				<NRF_PSEL(TWIS_SCL, 1, 3)>;
+			low-power-enable;
+		};
+	};
+};
+
+test_timer: &timer20 {
+	status = "reserved";
+};
+
+dut: &i2c20 {
+	compatible = "nordic,ppi-seq-i2c";
+	status = "okay";
+	pinctrl-0 = <&i2c20_default_alt>;
+	pinctrl-1 = <&i2c20_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+tester: &i2c21 {
+	compatible = "nordic,nrf-twis";
+	status = "reserved";
+	pinctrl-0 = <&i2c21_default_alt>;
+	pinctrl-1 = <&i2c21_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+};

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lv10dk_nrf54lv10a_cpuapp_i2c_timer_notifier_counter.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lv10dk_nrf54lv10a_cpuapp_i2c_timer_notifier_counter.overlay
@@ -5,38 +5,38 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.03 and P1.04
- * - between P1.13 and P1.14
+ * - between P1.00 and P1.01
+ * - between P1.02 and P1.03
  */
 
 &pinctrl {
+	i2c20_default_alt: i2c20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 0)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+		};
+	};
+
+	i2c20_sleep_alt: i2c20_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 0)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			low-power-enable;
+		};
+	};
+
 	i2c21_default_alt: i2c21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
-				<NRF_PSEL(TWIM_SCL, 1, 13)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 1)>,
+				<NRF_PSEL(TWIS_SCL, 1, 3)>;
+			bias-pull-up;
 		};
 	};
 
 	i2c21_sleep_alt: i2c21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
-				<NRF_PSEL(TWIM_SCL, 1, 13)>;
-			low-power-enable;
-		};
-	};
-
-	i2c22_default_alt: i2c22_default_alt {
-		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
-				<NRF_PSEL(TWIM_SCL, 1, 14)>;
-			bias-pull-up;
-		};
-	};
-
-	i2c22_sleep_alt: i2c22_sleep_alt {
-		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
-				<NRF_PSEL(TWIM_SCL, 1, 14)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 1)>,
+				<NRF_PSEL(TWIS_SCL, 1, 3)>;
 			low-power-enable;
 		};
 	};
@@ -52,25 +52,25 @@
 	status = "reserved";
 };
 
-test_timer: &timer23 {
+test_timer: &timer20 {
 	status = "reserved";
 };
 
-dut: &i2c21 {
+dut: &i2c20 {
 	compatible = "nordic,ppi-seq-i2c";
 	status = "okay";
-	pinctrl-0 = <&i2c21_default_alt>;
-	pinctrl-1 = <&i2c21_sleep_alt>;
+	pinctrl-0 = <&i2c20_default_alt>;
+	pinctrl-1 = <&i2c20_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	timer = <&timer21>;
 	timer-notifier = <&timer22>;
 };
 
-tester: &i2c22 {
+tester: &i2c21 {
 	compatible = "nordic,nrf-twis";
 	status = "reserved";
-	pinctrl-0 = <&i2c22_default_alt>;
-	pinctrl-1 = <&i2c22_sleep_alt>;
+	pinctrl-0 = <&i2c21_default_alt>;
+	pinctrl-1 = <&i2c21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 };

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lv10dk_nrf54lv10a_cpuapp_spi_timer.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lv10dk_nrf54lv10a_cpuapp_spi_timer.overlay
@@ -5,45 +5,45 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.03 and P1.04
- * - between P1.13 and P1.14
- * - between P1.23 and P1.24
- * - between P1.30 and P1.31
+ * - between P1.09 and P1.08
+ * - between P1.10 and P1.11
+ * - between P1.02 and P1.03
+ * - between P1.00 and P1.01
  */
 
 &pinctrl {
 	spi21_default_alt: spi21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
 		};
 	};
 
 	spi21_sleep_alt: spi21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
 			low-power-enable;
 		};
 	};
 
-	spi22_default_alt: spi22_default_alt {
+	spi20_default_alt: spi20_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 		};
 	};
 
-	spi22_sleep_alt: spi22_sleep_alt {
+	spi20_sleep_alt: spi20_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 			low-power-enable;
 		};
 	};
@@ -64,18 +64,17 @@ dut: &spi21 {
 	pinctrl-0 = <&spi21_default_alt>;
 	pinctrl-1 = <&spi21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
-	cs-gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
 	timer = <&timer22>;
-	extra-transfers = <50>;
 };
 
-tester: &spi22 {
+tester: &spi20 {
 	compatible = "nordic,nrf-spis";
 	status = "reserved";
 	def-char = <0x00>;
-	pinctrl-0 = <&spi22_default_alt>;
-	pinctrl-1 = <&spi22_sleep_alt>;
+	pinctrl-0 = <&spi20_default_alt>;
+	pinctrl-1 = <&spi20_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	/delete-property/ rx-delay-supported;
 	/delete-property/ rx-delay;

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lv10dk_nrf54lv10a_cpuapp_spi_timer_extra_op.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lv10dk_nrf54lv10a_cpuapp_spi_timer_extra_op.overlay
@@ -5,45 +5,45 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.03 and P1.04
- * - between P1.13 and P1.14
- * - between P1.23 and P1.24
- * - between P1.30 and P1.31
+ * - between P1.09 and P1.08
+ * - between P1.10 and P1.11
+ * - between P1.02 and P1.03
+ * - between P1.00 and P1.01
  */
 
 &pinctrl {
 	spi21_default_alt: spi21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
 		};
 	};
 
 	spi21_sleep_alt: spi21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
 			low-power-enable;
 		};
 	};
 
-	spi22_default_alt: spi22_default_alt {
+	spi20_default_alt: spi20_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 		};
 	};
 
-	spi22_sleep_alt: spi22_sleep_alt {
+	spi20_sleep_alt: spi20_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 			low-power-enable;
 		};
 	};
@@ -64,18 +64,18 @@ dut: &spi21 {
 	pinctrl-0 = <&spi21_default_alt>;
 	pinctrl-1 = <&spi21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
-	cs-gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
 	timer = <&timer22>;
 	extra-transfers = <50>;
 };
 
-tester: &spi22 {
+tester: &spi20 {
 	compatible = "nordic,nrf-spis";
 	status = "reserved";
 	def-char = <0x00>;
-	pinctrl-0 = <&spi22_default_alt>;
-	pinctrl-1 = <&spi22_sleep_alt>;
+	pinctrl-0 = <&spi20_default_alt>;
+	pinctrl-1 = <&spi20_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	/delete-property/ rx-delay-supported;
 	/delete-property/ rx-delay;

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lv10dk_nrf54lv10a_cpuapp_spi_timer_notifier.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf54lv10dk_nrf54lv10a_cpuapp_spi_timer_notifier.overlay
@@ -5,45 +5,45 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.03 and P1.04
- * - between P1.13 and P1.13
- * - between P1.23 and P1.24
- * - between P1.30 and P1.31
+ * - between P1.09 and P1.08
+ * - between P1.10 and P1.11
+ * - between P1.02 and P1.03
+ * - between P1.00 and P1.01
  */
 
 &pinctrl {
 	spi21_default_alt: spi21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
 		};
 	};
 
 	spi21_sleep_alt: spi21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 3)>,
-				<NRF_PSEL(SPIM_MISO, 1, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 23)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+				<NRF_PSEL(SPIM_MISO, 1, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 2)>;
 			low-power-enable;
 		};
 	};
 
-	spi22_default_alt: spi22_default_alt {
+	spi20_default_alt: spi20_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 		};
 	};
 
-	spi22_sleep_alt: spi22_sleep_alt {
+	spi20_sleep_alt: spi20_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 1, 4)>,
-				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 24)>,
-				<NRF_PSEL(SPIS_CSN, 1, 31)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 3)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 			low-power-enable;
 		};
 	};
@@ -69,18 +69,18 @@ dut: &spi21 {
 	pinctrl-0 = <&spi21_default_alt>;
 	pinctrl-1 = <&spi21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
-	cs-gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
 	timer = <&timer22>;
 	timer-notifier = <&timer21>;
 };
 
-tester: &spi22 {
+tester: &spi20 {
 	compatible = "nordic,nrf-spis";
 	status = "reserved";
 	def-char = <0x00>;
-	pinctrl-0 = <&spi22_default_alt>;
-	pinctrl-1 = <&spi22_sleep_alt>;
+	pinctrl-0 = <&spi20_default_alt>;
+	pinctrl-1 = <&spi20_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	/delete-property/ rx-delay-supported;
 	/delete-property/ rx-delay;

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires loopbacks:
+ * - between P2.03 and P2.09
+ * - between P2.01 and P2.02
+ */
+
+&pinctrl {
+	i2c130_default_alt: i2c130_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 3)>,
+				<NRF_PSEL(TWIM_SCL, 2, 1)>;
+		};
+	};
+
+	i2c130_sleep_alt: i2c130_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 3)>,
+				<NRF_PSEL(TWIM_SCL, 2, 1)>;
+			low-power-enable;
+		};
+	};
+
+	i2c131_default_alt: i2c131_default_alt {
+		group1 {
+			/* Temporary workaround as it is currently not possible
+			 * to configure pins for TWIS with pinctrl.
+			 */
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 2, 2)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c131_sleep_alt: i2c131_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 2, 2)>;
+			low-power-enable;
+		};
+	};
+};
+
+test_timer: &timer130 {
+	status = "reserved";
+};
+
+&grtc {
+	/delete-property/ child-owned-channels;
+	/delete-property/ nonsecure-channels;
+	owned-channels = <0 4 5 6>;
+	extended-channels = <0>;
+};
+
+dut: &i2c130 {
+	compatible = "nordic,ppi-seq-i2c";
+	status = "okay";
+	pinctrl-0 = <&i2c130_default_alt>;
+	pinctrl-1 = <&i2c130_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	memory-regions = <&cpuapp_dma_region>;
+};
+
+tester: &i2c131 {
+	compatible = "nordic,nrf-twis";
+	status = "reserved";
+	pinctrl-0 = <&i2c131_default_alt>;
+	pinctrl-1 = <&i2c131_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+};

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp_i2c_timer_notifier_counter.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp_i2c_timer_notifier_counter.overlay
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Test requires loopbacks:
+ * - between P2.03 and P2.09
+ * - between P2.01 and P2.02
+ */
+
+&pinctrl {
+	i2c130_default_alt: i2c130_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 3)>,
+				<NRF_PSEL(TWIM_SCL, 2, 1)>;
+		};
+	};
+
+	i2c130_sleep_alt: i2c130_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 3)>,
+				<NRF_PSEL(TWIM_SCL, 2, 1)>;
+			low-power-enable;
+		};
+	};
+
+	i2c131_default_alt: i2c131_default_alt {
+		group1 {
+			/* Temporary workaround as it is currently not possible
+			 * to configure pins for TWIS with pinctrl.
+			 */
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 2, 2)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c131_sleep_alt: i2c131_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 2, 2)>;
+			low-power-enable;
+		};
+	};
+};
+
+&hfxo {
+	status = "okay";
+};
+
+/* Timer used for triggering tasks in the PPI sequencer. */
+&timer131 {
+	status = "reserved";
+};
+
+/* Timer used for counting end events in the PPI sequencer. */
+&timer132 {
+	status = "reserved";
+};
+
+test_timer: &timer130 {
+	status = "reserved";
+};
+
+&grtc {
+	/delete-property/ child-owned-channels;
+	/delete-property/ nonsecure-channels;
+	owned-channels = <0 4 5 6>;
+	extended-channels = <0>;
+};
+
+dut: &i2c130 {
+	compatible = "nordic,ppi-seq-i2c";
+	status = "okay";
+	pinctrl-0 = <&i2c130_default_alt>;
+	pinctrl-1 = <&i2c130_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	memory-regions = <&cpuapp_dma_region>;
+	timer = <&timer131>;
+	timer-notifier = <&timer132>;
+};
+
+tester: &i2c131 {
+	compatible = "nordic,nrf-twis";
+	status = "reserved";
+	pinctrl-0 = <&i2c131_default_alt>;
+	pinctrl-1 = <&i2c131_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+};

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp_spi_rtc.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp_spi_rtc.overlay
@@ -5,48 +5,56 @@
  */
 
 /* Test requires loopbacks:
- * - between P0.00 and P0.01
- * - between P0.06 and P0.07
- * - between P0.08 and P0.09
- * - between P0.10 and P0.11
+ * - between P1.00 and P1.01
+ * - between P1.04 and P1.11
+ * - between P2.03 and P2.09
+ * - between P1.08 and P1.09
  */
 
 &pinctrl {
 	spi130_default_alt: spi130_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
-				<NRF_PSEL(SPIM_MISO, 0, 6)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 0)>,
+				<NRF_PSEL(SPIM_MISO, 1, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 3)>;
 		};
 	};
 
 	spi130_sleep_alt: spi130_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
-				<NRF_PSEL(SPIM_MISO, 0, 6)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 0)>,
+				<NRF_PSEL(SPIM_MISO, 1, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 3)>;
 			low-power-enable;
 		};
 	};
 
 	spi131_default_alt: spi131_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
-				<NRF_PSEL(SPIS_MISO, 0, 7)>,
-				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
-				<NRF_PSEL(SPIS_CSN, 0, 11)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 1)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 2, 9)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
 		};
 	};
 
 	spi131_sleep_alt: spi131_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
-				<NRF_PSEL(SPIS_MISO, 0, 7)>,
-				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
-				<NRF_PSEL(SPIS_CSN, 0, 11)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 1)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 2, 9)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
 			low-power-enable;
 		};
 	};
+};
+
+&uicr {
+	nfct-pins-as-gpios;
+};
+
+&gpio1 {
+	status = "okay";
 };
 
 /* Used as trigger by the PPI sequencer. */
@@ -65,8 +73,9 @@ dut: &spi130 {
 	pinctrl-1 = <&spi130_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	memory-regions = <&cpuapp_dma_region>;
-	cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
+	spi-cs-setup-delay-ns = <1500>;
 	rtc = <&rtc130>;
 };
 

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp_spi_timer.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp_spi_timer.overlay
@@ -5,52 +5,64 @@
  */
 
 /* Test requires loopbacks:
- * - between P0.00 and P0.01
- * - between P0.06 and P0.07
- * - between P0.08 and P0.09
- * - between P0.10 and P0.11
+ * - between P1.00 and P1.01
+ * - between P1.04 and P1.11
+ * - between P2.03 and P2.09
+ * - between P1.08 and P1.09 (connected with antena)
  */
 
 &pinctrl {
 	spi130_default_alt: spi130_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
-				<NRF_PSEL(SPIM_MISO, 0, 6)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 0)>,
+				<NRF_PSEL(SPIM_MISO, 1, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 3)>;
 		};
 	};
 
 	spi130_sleep_alt: spi130_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
-				<NRF_PSEL(SPIM_MISO, 0, 6)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 0)>,
+				<NRF_PSEL(SPIM_MISO, 1, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 3)>;
 			low-power-enable;
 		};
 	};
 
 	spi131_default_alt: spi131_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
-				<NRF_PSEL(SPIS_MISO, 0, 7)>,
-				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
-				<NRF_PSEL(SPIS_CSN, 0, 11)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 1)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 2, 9)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
 		};
 	};
 
 	spi131_sleep_alt: spi131_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
-				<NRF_PSEL(SPIS_MISO, 0, 7)>,
-				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
-				<NRF_PSEL(SPIS_CSN, 0, 11)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 1)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 2, 9)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
 			low-power-enable;
 		};
 	};
 };
 
+&hfxo {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&uicr {
+	nfct-pins-as-gpios;
+};
+
 /* Used as trigger by the PPI sequencer. */
-&rtc130 {
+&timer131 {
 	status = "reserved";
 };
 
@@ -65,9 +77,10 @@ dut: &spi130 {
 	pinctrl-1 = <&spi130_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	memory-regions = <&cpuapp_dma_region>;
-	cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
-	rtc = <&rtc130>;
+	spi-cs-setup-delay-ns = <1500>;
+	timer = <&timer131>;
 };
 
 tester: &spi131 {

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp_spi_timer_extra_op.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp_spi_timer_extra_op.overlay
@@ -5,52 +5,71 @@
  */
 
 /* Test requires loopbacks:
- * - between P0.00 and P0.01
- * - between P0.06 and P0.07
- * - between P0.08 and P0.09
- * - between P0.10 and P0.11
+ * - between P1.00 and P1.01
+ * - between P1.04 and P1.11
+ * - between P2.03 and P2.09
+ * - between P1.08 and P1.09 (connected with antena)
  */
 
 &pinctrl {
 	spi130_default_alt: spi130_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
-				<NRF_PSEL(SPIM_MISO, 0, 6)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 0)>,
+				<NRF_PSEL(SPIM_MISO, 1, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 3)>;
 		};
 	};
 
 	spi130_sleep_alt: spi130_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
-				<NRF_PSEL(SPIM_MISO, 0, 6)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 0)>,
+				<NRF_PSEL(SPIM_MISO, 1, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 3)>;
 			low-power-enable;
 		};
 	};
 
 	spi131_default_alt: spi131_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
-				<NRF_PSEL(SPIS_MISO, 0, 7)>,
-				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
-				<NRF_PSEL(SPIS_CSN, 0, 11)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 1)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 2, 9)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
 		};
 	};
 
 	spi131_sleep_alt: spi131_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
-				<NRF_PSEL(SPIS_MISO, 0, 7)>,
-				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
-				<NRF_PSEL(SPIS_CSN, 0, 11)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 1)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 2, 9)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
 			low-power-enable;
 		};
 	};
 };
 
+&hfxo {
+	status = "okay";
+};
+
+&grtc {
+	/delete-property/ child-owned-channels;
+	/delete-property/ nonsecure-channels;
+	owned-channels = <0 4 5 6>;
+	extended-channels = <0>;
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&uicr {
+	nfct-pins-as-gpios;
+};
+
 /* Used as trigger by the PPI sequencer. */
-&rtc130 {
+&timer131 {
 	status = "reserved";
 };
 
@@ -65,9 +84,11 @@ dut: &spi130 {
 	pinctrl-1 = <&spi130_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	memory-regions = <&cpuapp_dma_region>;
-	cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
-	rtc = <&rtc130>;
+	spi-cs-setup-delay-ns = <1500>;
+	timer = <&timer131>;
+	extra-transfers = <50>;
 };
 
 tester: &spi131 {

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp_spi_timer_notifier.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp_spi_timer_notifier.overlay
@@ -5,52 +5,69 @@
  */
 
 /* Test requires loopbacks:
- * - between P0.00 and P0.01
- * - between P0.06 and P0.07
- * - between P0.08 and P0.09
- * - between P0.10 and P0.11
+ * - between P1.00 and P1.01
+ * - between P1.04 and P1.11
+ * - between P2.03 and P2.09
+ * - between P1.08 and P1.09 (connected with antena)
  */
 
 &pinctrl {
 	spi130_default_alt: spi130_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
-				<NRF_PSEL(SPIM_MISO, 0, 6)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 0)>,
+				<NRF_PSEL(SPIM_MISO, 1, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 3)>;
 		};
 	};
 
 	spi130_sleep_alt: spi130_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
-				<NRF_PSEL(SPIM_MISO, 0, 6)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 0)>,
+				<NRF_PSEL(SPIM_MISO, 1, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 3)>;
 			low-power-enable;
 		};
 	};
 
 	spi131_default_alt: spi131_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
-				<NRF_PSEL(SPIS_MISO, 0, 7)>,
-				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
-				<NRF_PSEL(SPIS_CSN, 0, 11)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 1)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 2, 9)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
 		};
 	};
 
 	spi131_sleep_alt: spi131_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
-				<NRF_PSEL(SPIS_MISO, 0, 7)>,
-				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
-				<NRF_PSEL(SPIS_CSN, 0, 11)>;
+			psels = <NRF_PSEL(SPIS_SCK, 1, 1)>,
+				<NRF_PSEL(SPIS_MISO, 1, 11)>,
+				<NRF_PSEL(SPIS_MOSI, 2, 9)>,
+				<NRF_PSEL(SPIS_CSN, 1, 9)>;
 			low-power-enable;
 		};
 	};
 };
 
+&hfxo {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&uicr {
+	nfct-pins-as-gpios;
+};
+
 /* Used as trigger by the PPI sequencer. */
-&rtc130 {
+&timer131 {
+	status = "reserved";
+};
+
+/* Used as PPI sequencer notifier. */
+&timer132 {
 	status = "reserved";
 };
 
@@ -65,9 +82,11 @@ dut: &spi130 {
 	pinctrl-1 = <&spi130_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	memory-regions = <&cpuapp_dma_region>;
-	cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 	frequency = <DT_FREQ_M(8)>;
-	rtc = <&rtc130>;
+	spi-cs-setup-delay-ns = <1500>;
+	timer = <&timer131>;
+	timer-notifier = <&timer132>;
 };
 
 tester: &spi131 {

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/src/main.c
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/src/main.c
@@ -397,6 +397,7 @@ static void test_single_run(void)
 
 	/* If TIMER is used for triggering then enable HFXO to ensure clock accuracy. */
 #if DT_NODE_HAS_PROP(DUT_NODE, timer)
+#ifdef CONFIG_CLOCK_CONTROL_NRF
 	struct onoff_client cli;
 
 	sys_notify_init_spinwait(&cli.notify);
@@ -407,7 +408,15 @@ static void test_single_run(void)
 		/* pend until clock is up and running */
 	}
 	zassert_ok(rv);
-#endif
+#elif CONFIG_CLOCK_CONTROL_NRF54H_HFXO
+	const struct device *hfxo = DEVICE_DT_GET(DT_NODELABEL(hfxo));
+
+	rv = nrf_clock_control_request_sync(hfxo, NULL, K_MSEC(1000));
+	zassert_ok(rv);
+#else
+	zassert_ok(false, "Should not get here.");
+#endif /* CONFIG_CLOCK_CONTROL_NRF / CONFIG_CLOCK_CONTROL_NRF54H_HFXO */
+#endif /* DT_NODE_HAS_PROP(DUT_NODE, timer) */
 
 	if (DT_NODE_HAS_PROP(DUT_NODE, timer_notifier)) {
 		uint32_t bytes = IS_ENABLED(TEST_I2C) ? 2 * (XFER_RX_LEN + XFER_TX_LEN) : XFER_LEN;
@@ -464,8 +473,13 @@ static void test_single_run(void)
 		       delta);
 
 #if DT_NODE_HAS_PROP(DUT_NODE, timer)
+#ifdef CONFIG_CLOCK_CONTROL_NRF
 	rv = onoff_release(z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF));
-#endif
+#elif CONFIG_CLOCK_CONTROL_NRF54H_HFXO
+	rv = nrf_clock_control_release(hfxo, NULL);
+
+#endif /* CONFIG_CLOCK_CONTROL_NRF / CONFIG_CLOCK_CONTROL_NRF54H_HFXO */
+#endif /* DT_NODE_HAS_PROP(DUT_NODE, timer) */
 }
 
 ZTEST(ppi_seq_twim, test_single_run)

--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/testcase.yaml
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/testcase.yaml
@@ -10,49 +10,80 @@ common:
     - ci_tests_drivers_ppi_seq
 tests:
   drivers.ppi_seq_i2c_spi.i2c:
-    depends_on: i2c
     integration_platforms:
       - nrf54lm20dk/nrf54lm20a/cpuapp
     platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
   drivers.ppi_seq_i2c_spi.spi_timer_trigger:
-    depends_on: spi
     extra_args:
-      - DTC_OVERLAY_FILE="boards/nrf54lm20dk_nrf54lm20a_cpuapp_spi_timer.overlay"
+      - FILE_SUFFIX="spi_timer"
     integration_platforms:
       - nrf54lm20dk/nrf54lm20a/cpuapp
     platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-  drivers.ppi_seq_i2c_spi.spi_extra_op:
-    depends_on: spi
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
+  drivers.ppi_seq_i2c_spi.spi_timer_extra_op:
     extra_args:
-      - DTC_OVERLAY_FILE="boards/nrf54lm20dk_nrf54lm20a_cpuapp_spi_timer_extra_op.overlay"
+      - FILE_SUFFIX="spi_timer_extra_op"
     integration_platforms:
       - nrf54lm20dk/nrf54lm20a/cpuapp
     platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
   drivers.ppi_seq_i2c_spi.spi_timer_notifier:
-    depends_on: spi
     extra_args:
-      - DTC_OVERLAY_FILE="boards/nrf54lm20dk_nrf54lm20a_cpuapp_spi_timer_notifier.overlay"
+      - FILE_SUFFIX="spi_timer_notifier"
     integration_platforms:
       - nrf54lm20dk/nrf54lm20a/cpuapp
     platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
   drivers.ppi_seq_i2c_spi.i2c_timer_notifier_counter:
-    depends_on: i2c
     extra_args:
-      - DTC_OVERLAY_FILE="boards/nrf54lm20dk_nrf54lm20a_cpuapp_i2c_timer_notifier_counter.overlay"
+      - FILE_SUFFIX="i2c_timer_notifier_counter"
     integration_platforms:
       - nrf54lm20dk/nrf54lm20a/cpuapp
     platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
   drivers.ppi_seq_i2c_spi.spi_rtc:
-    depends_on: spi
     extra_args:
-      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_spi_rtc.overlay"
+      - FILE_SUFFIX="spi_rtc"
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf9251dk/nrf9251/cpuapp


### PR DESCRIPTION
Add overlays required to run the ppi_seq_i2c_spi test on more platforms.