### PR TITLE
samples: memfault: Fix TFM overflow

### DIFF
--- a/samples/debug/memfault/boards/nrf9151dk_nrf9151_ns.conf
+++ b/samples/debug/memfault/boards/nrf9151dk_nrf9151_ns.conf
@@ -40,3 +40,8 @@ CONFIG_SPI=y
 CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
+
+# Memfault requires SHA-1 when Mbed TLS is enabled (CONFIG_MBEDTLS_BUILTIN),
+# but enabling SHA-1 makes the TF-M image overflow over the 32kB it's given.
+CONFIG_MBEDTLS=n
+CONFIG_PSA_WANT_ALG_SHA_1=n

--- a/samples/debug/memfault/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/debug/memfault/boards/nrf9160dk_nrf9160_ns.conf
@@ -34,3 +34,8 @@ CONFIG_NRF_MODEM_LIB_NET_IF=y
 # due to not being properly implemented for offloaded interfaces.
 CONFIG_NET_IPV6_NBR_CACHE=n
 CONFIG_NET_IPV6_MLD=n
+
+# Memfault requires SHA-1 when Mbed TLS is enabled (CONFIG_MBEDTLS_BUILTIN),
+# but enabling SHA-1 makes the TF-M image overflow over the 32kB it's given.
+CONFIG_MBEDTLS=n
+CONFIG_PSA_WANT_ALG_SHA_1=n

--- a/samples/debug/memfault/boards/nrf9161dk_nrf9161_ns.conf
+++ b/samples/debug/memfault/boards/nrf9161dk_nrf9161_ns.conf
@@ -34,3 +34,8 @@ CONFIG_NRF_MODEM_LIB_NET_IF=y
 # due to not being properly implemented for offloaded interfaces.
 CONFIG_NET_IPV6_NBR_CACHE=n
 CONFIG_NET_IPV6_MLD=n
+
+# Memfault requires SHA-1 when Mbed TLS is enabled (CONFIG_MBEDTLS_BUILTIN),
+# but enabling SHA-1 makes the TF-M image overflow over the 32kB it's given.
+CONFIG_MBEDTLS=n
+CONFIG_PSA_WANT_ALG_SHA_1=n


### PR DESCRIPTION
Apply same fix for DKs as as done on Thingy boards in ea7054d.