### PR TITLE
applications: nrf_audio: Make sure SDU size is within our range

### DIFF
--- a/applications/nrf_audio/src/bluetooth/bt_stream/unicast/server_store.c
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/unicast/server_store.c
@@ -201,6 +201,35 @@ static bool pac_parse(struct bt_data *data, struct bt_bap_lc3_preset *preset,
 		 */
 		uint16_t lc3_min_frame_length = sys_get_le16(data->data);
 		uint16_t lc3_max_frame_length = sys_get_le16(data->data + sizeof(uint16_t));
+		int frame_dur_us = 0;
+
+		ret = le_audio_duration_us_get(&preset->codec_cfg, &frame_dur_us);
+		if (ret) {
+			LOG_WRN("Failed to get frame duration: %d", ret);
+			memset(preset, 0, sizeof(struct bt_bap_lc3_preset));
+			return false;
+		}
+
+		if (!IN_RANGE(lc3_min_frame_length,
+			      LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE_MIN, frame_dur_us),
+			      LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE_MAX, frame_dur_us)) &&
+		    !IN_RANGE(lc3_max_frame_length,
+			      LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE_MIN, frame_dur_us),
+			      LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE_MAX, frame_dur_us))) {
+			LOG_WRN("LC3 frame length %d - %d not in range [%d, %d], not possible to "
+				"find a preset that meets these capabilities",
+				lc3_min_frame_length, lc3_max_frame_length, CONFIG_LC3_BITRATE_MIN,
+				CONFIG_LC3_BITRATE_MAX);
+			memset(preset, 0, sizeof(struct bt_bap_lc3_preset));
+			return false;
+		}
+
+		lc3_min_frame_length =
+			MAX(lc3_min_frame_length,
+			    LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE_MIN, frame_dur_us));
+		lc3_max_frame_length =
+			MIN(lc3_max_frame_length,
+			    LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE_MAX, frame_dur_us));
 
 		int preset_octets_per_frame = 0;
 


### PR DESCRIPTION
- Limit frame_length to be within our range for LC3
- OCT-3748