### PR TITLE
[Backport v3.4-branch] samples: bluetooth: remove pm from enocean

### DIFF
--- a/samples/bluetooth/enocean/Kconfig.sysbuild
+++ b/samples/bluetooth/enocean/Kconfig.sysbuild
@@ -10,4 +10,7 @@ config NRF_DEFAULT_IPC_RADIO
 config NETCORE_IPC_RADIO_BT_HCI_IPC
 	default y
 
+config PARTITION_MANAGER
+	default n
+
 source "$(ZEPHYR_BASE)/share/sysbuild/Kconfig"


### PR DESCRIPTION
Backport 35acf3588ca28bee7b05a93d12a36670fb1bf49c from #29205.