### PR TITLE
samples: bluetooth: Remove PM from dragoon samples

### DIFF
--- a/samples/bluetooth/channel_sounding/ipt_initiator/Kconfig.sysbuild
+++ b/samples/bluetooth/channel_sounding/ipt_initiator/Kconfig.sysbuild
@@ -1,10 +1,10 @@
 #
-# Copyright (c) 2025 Nordic Semiconductor ASA
+# Copyright (c) 2026 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 config PARTITION_MANAGER
-	default n if !BOARD_IS_NON_SECURE
+	default n
 
 source "share/sysbuild/Kconfig"

--- a/samples/bluetooth/channel_sounding/ipt_reflector/Kconfig.sysbuild
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/Kconfig.sysbuild
@@ -1,10 +1,10 @@
 #
-# Copyright (c) 2025 Nordic Semiconductor ASA
+# Copyright (c) 2026 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 config PARTITION_MANAGER
-	default n if !BOARD_IS_NON_SECURE
+	default n
 
 source "share/sysbuild/Kconfig"

--- a/samples/bluetooth/path_loss_monitoring/central/Kconfig.sysbuild
+++ b/samples/bluetooth/path_loss_monitoring/central/Kconfig.sysbuild
@@ -11,3 +11,6 @@ config NRF_DEFAULT_IPC_RADIO
 
 config NETCORE_IPC_RADIO_BT_HCI_IPC
 	default y
+
+config PARTITION_MANAGER
+	default n

--- a/samples/bluetooth/path_loss_monitoring/peripheral/Kconfig.sysbuild
+++ b/samples/bluetooth/path_loss_monitoring/peripheral/Kconfig.sysbuild
@@ -11,3 +11,6 @@ config NRF_DEFAULT_IPC_RADIO
 
 config NETCORE_IPC_RADIO_BT_HCI_IPC
 	default y
+
+config PARTITION_MANAGER
+	default n

--- a/samples/bluetooth/rssi_power_control/central/Kconfig.sysbuild
+++ b/samples/bluetooth/rssi_power_control/central/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/samples/bluetooth/rssi_power_control/peripheral/Kconfig.sysbuild
+++ b/samples/bluetooth/rssi_power_control/peripheral/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Disable PM in the following samples:
- channel_sounding/ipt_initiator
- channel_sounding/ipt_reflector
- rssi_power_control/central
- rssi_power_control/peripheral
- path_loss_monitoring/central
- path_loss_monitoring/peripheral