### PR TITLE
doc: release-notes: Add release note for nRF93M1DK support

### DIFF
--- a/doc/nrf/app_dev/board_names.rst
+++ b/doc/nrf/app_dev/board_names.rst
@@ -176,6 +176,14 @@ Also see the :ref:`zephyr:boards` section in the Zephyr documentation.
 |                   |            |                                                        |                                                                          |
 |                   |            |                                                        | ``nrf7002dk/nrf5340/cpuapp/ns`` (:ref:`TF-M <app_boards_spe_nspe>`)      |
 +-------------------+------------+--------------------------------------------------------+--------------------------------------------------------------------------+
+| nRF93M1 DK        |            | :zephyr:board:`nrf93m1dk <nrf93m1dk>`                  | ``nrf93m1dk/nrf54l15/cpuapp``                                            |
+|                   |            |                                                        |                                                                          |
+|                   |            |                                                        | ``nrf93m1dk/nrf54l15/cpuapp/ns`` (:ref:`TF-M <app_boards_spe_nspe>`)     |
+|                   |            |                                                        |                                                                          |
+|                   |            |                                                        | ``nrf93m1dk/nrf54l15/cpuflpr``                                           |
+|                   |            |                                                        |                                                                          |
+|                   |            |                                                        | ``nrf93m1dk/nrf54l15/cpuflpr/xip``                                       |
++-------------------+------------+--------------------------------------------------------+--------------------------------------------------------------------------+
 
 .. note::
    In |NCS| releases before v1.6.1:

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -38,7 +38,8 @@ IDE, OS, and tool support
 Board support
 =============
 
-|no_changes_yet_note|
+* Added support for the :zephyr:board:`nrf93m1dk`, including a Zephyr cellular modem driver for the nRF93M1 Cat-1 bis LTE module.
+  The board uses the nRF93M1 module with the nRF54L15 as the host MCU.
 
 Build and configuration system
 ==============================


### PR DESCRIPTION
Add release note for nRF93M1DK board support
including the Zephyr modem driver for nRF93M1 module.

Board support medged in https://github.com/nrfconnect/sdk-zephyr/pull/4040
