### PR TITLE
tests: buetooth: mesh: remove pm

### DIFF
--- a/tests/subsys/bluetooth/mesh/metadata_extraction/Kconfig.sysbuild
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/Kconfig.sysbuild
@@ -19,4 +19,7 @@ config COMP_DATA_LAYOUT_ARRAY
 
 endchoice
 
+config PARTITION_MANAGER
+	default n
+
 source "share/sysbuild/Kconfig"

--- a/tests/subsys/bluetooth/mesh/models/Kconfig.sysbuild
+++ b/tests/subsys/bluetooth/mesh/models/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Commit removes explicitly PM from metadata_extract and models unit tests.