### PR TITLE
subsys: shell: reset NUS buffers on BT disconnect

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -471,7 +471,7 @@ Other libraries
 Shell libraries
 ---------------
 
-|no_changes_yet_note|
+* Fixed a potential lockup in the NUS shell transport after a Bluetooth disconnect.
 
 sdk-nrfxlib
 -----------

--- a/subsys/shell/shell_bt_nus.c
+++ b/subsys/shell/shell_bt_nus.c
@@ -173,6 +173,14 @@ void shell_bt_nus_disable(void)
 			(const struct shell_bt_nus *)shell_transport_bt_nus.ctx;
 
 	bt_nus->ctrl_blk->conn = NULL;
+	ring_buf_reset(bt_nus->tx_ringbuf);
+	ring_buf_reset(bt_nus->rx_ringbuf);
+
+	if (atomic_clear(&bt_nus->ctrl_blk->tx_busy) != 0) {
+		bt_nus->ctrl_blk->handler(SHELL_TRANSPORT_EVT_TX_RDY,
+					  bt_nus->ctrl_blk->context);
+	}
+
 	k_sem_give(&shell_bt_nus_ready);
 }
 


### PR DESCRIPTION
Reset the NUS shell TX and RX buffers when the transport is disabled and clear any pending TX busy state.

Fixes lockup issue after BT disconnect reported on DevZone (#360023).