### PR TITLE
tests: ram_context_for_isr: Remove partition manager

### DIFF
--- a/tests/zephyr/application_development/ram_context_for_isr/Kconfig.sysbuild
+++ b/tests/zephyr/application_development/ram_context_for_isr/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Don't enable partition manager by default