### PR TITLE
net: samples: aws_iot: fix nrf7002dk mcuboot main stack size

### DIFF
--- a/samples/net/aws_iot/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/samples/net/aws_iot/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -8,7 +8,6 @@
 
 # General
 CONFIG_FLASH=y
-CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT=0
 
 # Serial Peripheral Interface (SPI)


### PR DESCRIPTION
Go back to default of 10240 instead of local override. The override was resulting in a stack overflow:
```
uart:~$ *** Booting My Application v2.3.0-dev-69c7ba763a23 ***                                                                                            
*** Using nRF Connect SDK v3.3.99-e66fa1f95651 ***                                                                                                        
*** Using Zephyr OS v4.4.0-63898974807f ***                                                                                                               
***** USAGE FAULT *****                                                                                                                                   
  Stack overflow (context area not valid)                                    
r0/a1:  0x4001  r1/a2:  0x800  r2/a3:  0x10e                                                                                                              
r3/a4:  0x6000309 r12/ip:  0x20002d4c r14/lr:  0x51fd                                                                                                     
 xpsr:  0x69000200                                                           
Faulting instruction address (r15/pc): 0x5752
```

Ticket: NCSDK-39704