### PR TITLE
tests: subsys: ipc: Fix ipc_reconnect test

### DIFF
--- a/tests/subsys/ipc/ipc_reconnect/remote/src/main.c
+++ b/tests/subsys/ipc/ipc_reconnect/remote/src/main.c
@@ -23,7 +23,6 @@ static void ep_bound_callback(void *priv)
 
 static void ep_unbound_callback(void *priv)
 {
-	printk("IPC endpoint unbounded\n");
 	k_sem_give(&endpoint_unbound_sem);
 }
 
@@ -75,7 +74,7 @@ static void configure_ipc(struct ipc_ept *endpoint)
 	if (ret) {
 		printk("IPC timeout occurred while waiting for endpoint bound\n");
 	} else {
-		printk("Binding done\n");
+		printk("IPC endpoint bound\n");
 	}
 
 	k_msleep(10);
@@ -90,6 +89,7 @@ int main(void)
 
 	while (1) {
 		if (k_sem_take(&endpoint_unbound_sem, K_NO_WAIT) == 0) {
+			printk("Endpoint unbounded\n");
 			printk("Reconnecting\n");
 			configure_ipc(&test_endpoint);
 		}

--- a/tests/subsys/ipc/ipc_reconnect/src/main.c
+++ b/tests/subsys/ipc/ipc_reconnect/src/main.c
@@ -35,12 +35,12 @@ static void prepare_test_data(uint8_t *test_data, size_t len)
 static void ep_bound_callback(void *priv)
 {
 	k_sem_give(&endpoint_bound_sem);
-	printk("IPC endpoint bound\n");
+
 }
 
 static void ep_unbound_callback(void *priv)
 {
-	printk("IPC endpoint unboun\n");
+
 }
 
 static void ep_recv_callback(const void *data, size_t len, void *priv)
@@ -87,7 +87,7 @@ static void configure_ipc(struct ipc_ept *endpoint)
 	if (ret) {
 		printk("IPC timeout occurred while waiting for endpoint bound\n");
 	} else {
-		printk("Binding done\n");
+		printk("IPC endpoint bound\n");
 	}
 
 	k_msleep(10);

--- a/tests/subsys/ipc/ipc_reconnect/testcase.yaml
+++ b/tests/subsys/ipc/ipc_reconnect/testcase.yaml
@@ -9,10 +9,9 @@ common:
     type: multi_line
     regex:
       - "Instance opened"
-      - "IPC endpoint bound"
       - "Endpoint registered"
       - "Waiting for binding"
-      - "Binding done"
+      - "IPC endpoint bound"
       - "Message 0 sent"
       - "Message 0 received"
       - "Message 1 sent"
@@ -26,7 +25,7 @@ common:
       - "Instance opened"
       - "Endpoint registered"
       - "Waiting for binding"
-      - "Binding done"
+      - "IPC endpoint bound"
       - "Message 2 sent"
       - "Message 2 received"
 


### PR DESCRIPTION
Do not use logging in the IPC callbacks.
Twister regex relies on these messages, but they
are asynchronous and their timing varies.
These async messages used by regex have been removed.