### PR TITLE
doc: install: tool support for debian 12

### DIFF
--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -346,6 +346,10 @@ For firmware OS support, see :ref:`the table at the top of the page <supported_O
     - Not supported
     - Not supported
     - Not supported
+  * - `Linux - Debian 12`_ (see note)
+    - Not supported
+    - Not supported
+    - Tier 1
   * - `macOS 26`_
     - n/a
     - Tier 3
@@ -362,6 +366,10 @@ For firmware OS support, see :ref:`the table at the top of the page <supported_O
     - n/a
     - Tier 3
     - Tier 3
+
+.. note::
+
+   nRF Util for Linux Debian 12 does not support SDK toolchain management using the ``nrfutil sdk-manager`` command.
 
 Tier definitions
   .. toggle:: Support levels

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1750,11 +1750,13 @@
 .. _`Google Home integration with Matter`: https://developers.home.google.com/matter
 .. _`Works with Google Home`: https://developers.home.google.com/matter/certification#wwgh_certification
 
-.. ### Source: ubuntu.com
+.. ### Source: ubuntu.com and debian.org
 
 .. _`Linux - Ubuntu 24.04 LTS`: https://releases.ubuntu.com/24.04/
 .. _`Linux - Ubuntu 22.04 LTS`: https://releases.ubuntu.com/22.04/
 .. _`Linux - Ubuntu 20.04 LTS`: https://releases.ubuntu.com/20.04/
+
+.. _`Linux - Debian 12`: https://www.debian.org/releases/oldstable/
 
 .. ### Source: bugs.launchpad.net
 


### PR DESCRIPTION
Updated the OS support table for proprietary tools with Debian 12 support status. NRFU-1824.

-----

- [ ] Changelog in https://github.com/nrfconnect/sdk-nrf/pull/29095