### PR TITLE
Bugfix/ncsdk 39708

### DIFF
--- a/applications/installer/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/applications/installer/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&spi00 {
+	status = "disabled";
+};
+
+&mx25r64 {
+	status = "disabled";
+};

--- a/samples/dfu/single_slot/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/dfu/single_slot/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -38,3 +38,11 @@
 		};
 	};
 };
+
+&spi00 {
+	status = "disabled";
+};
+
+&mx25r64 {
+	status = "disabled";
+};

--- a/samples/dfu/single_slot/boards/nrf54l15dk_nrf54l15_cpuapp_boot_req.overlay
+++ b/samples/dfu/single_slot/boards/nrf54l15dk_nrf54l15_cpuapp_boot_req.overlay
@@ -35,3 +35,11 @@
 		};
 	};
 };
+
+&spi00 {
+	status = "disabled";
+};
+
+&mx25r64 {
+	status = "disabled";
+};


### PR DESCRIPTION
 samples/dfu/single_slot:  & applications/installer:

    Disabled spi00 and mx25r64 DTS nodes so their drivers are not
    compiled in.
    These peripherals are not used by any configuration
    on nrf54l15dk in this sample, but are causing linking
    error as spim driver dependencies are not meet.

ref.: NCSDK-39708