### PR TITLE
scripts: quarantine: add ble samples for lc10/ns

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -75,8 +75,7 @@
     - nrf.extended.drivers.clock.nrf_lf_clock_start_xtal_stable
     - nrf.extended.drivers.comparator.gpio_loopback.nrf_comp
     - nrf.extended.drivers.comparator.gpio_loopback.nrf_lpcomp
-    - sample.bluetooth.peripheral_lbs
-    - sample.bluetooth.peripheral_uart
+    - sample.bluetooth.*
   platforms:
     - nrf54lc10dk@0.8.0/nrf54lc10a/cpuapp/ns
   comment: "no TFM for nrf54lc10 at the moment"


### PR DESCRIPTION
TF-M not supported.