### PR TITLE
[Backport v3.4-branch] net: samples: aws_iot: fix nrf7002dk mcuboot main stack size

### DIFF
--- a/samples/net/aws_iot/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/samples/net/aws_iot/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -8,7 +8,6 @@
 
 # General
 CONFIG_FLASH=y
-CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT=0
 
 # Serial Peripheral Interface (SPI)


### PR DESCRIPTION
Backport 1df821fb85ee873276e492145c823c11750509f3 from #29296.