### PR TITLE
tests: drivers: spi: latency: Use DMM api for section and alignment

### DIFF
--- a/tests/benchmarks/multicore/idle_spim_loopback/src/main.c
+++ b/tests/benchmarks/multicore/idle_spim_loopback/src/main.c
@@ -10,8 +10,8 @@ LOG_MODULE_REGISTER(idle_spim_loopback, LOG_LEVEL_INF);
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
-#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/pm/device_runtime.h>
+#include <dmm.h>
 
 static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(DT_ALIAS(led), gpios);
 
@@ -55,13 +55,8 @@ static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), 
 
 static const struct gpio_dt_spec pin_in = GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), test_gpios);
 
-#define MEMORY_SECTION(node)                                                                       \
-	COND_CODE_1(DT_NODE_HAS_PROP(node, memory_regions),                                        \
-		    (__attribute__((__section__(                                                   \
-			    LINKER_DT_NODE_REGION_NAME(DT_PHANDLE(node, memory_regions)))))),      \
-		    ())
-
-static uint8_t spim_buffer[2 * CONFIG_DATA_FIELD] MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
+static uint8_t spim_buffer[2 * CONFIG_DATA_FIELD]
+	DMM_MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
 
 /* Variables used to count edges on SPI CS */
 static struct gpio_callback gpio_input_cb_data;

--- a/tests/benchmarks/spi_endless/src/main.c
+++ b/tests/benchmarks/spi_endless/src/main.c
@@ -9,8 +9,7 @@ LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/spi.h>
-#include <zephyr/linker/devicetree_regions.h>
-
+#include <dmm.h>
 
 #if CONFIG_TESTED_SPI_MODE == 0
 #define SPI_MODE (SPI_WORD_SET(8) | SPI_LINES_SINGLE | SPI_TRANSFER_LSB)
@@ -39,14 +38,8 @@ static const struct spi_config spis_config = {
 };
 #endif
 
-#define MEMORY_SECTION(node)                                                           \
-	COND_CODE_1(DT_NODE_HAS_PROP(node, memory_regions),                                \
-		    (__attribute__((__section__(                                               \
-			    LINKER_DT_NODE_REGION_NAME(DT_PHANDLE(node, memory_regions)))))),      \
-		    ())
-
-static uint8_t spim_buffer[32] MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
-static uint8_t spis_buffer[32] MEMORY_SECTION(DT_NODELABEL(dut_spis));
+static uint8_t spim_buffer[32] DMM_MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
+static uint8_t spis_buffer[32] DMM_MEMORY_SECTION(DT_NODELABEL(dut_spis));
 
 struct test_data {
 	int spim_alloc_idx;

--- a/tests/drivers/spi/spi_latency/src/main.c
+++ b/tests/drivers/spi/spi_latency/src/main.c
@@ -8,8 +8,8 @@
 #include <zephyr/ztest.h>
 #include <zephyr/drivers/spi.h>
 #include <nrfx_spim.h>
-#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/drivers/counter.h>
+#include <dmm.h>
 #include <math.h>
 
 #define TEST_TIMER_COUNT_TIME_LIMIT_MS 500
@@ -24,14 +24,8 @@
 static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi), SPI_MODE);
 const struct device *const tst_timer_dev = DEVICE_DT_GET(DT_ALIAS(tst_timer));
 
-#define MEMORY_SECTION(node)                                                                       \
-	COND_CODE_1(DT_NODE_HAS_PROP(node, memory_regions),                                        \
-		    (__attribute__((__section__(                                                   \
-			    LINKER_DT_NODE_REGION_NAME(DT_PHANDLE(node, memory_regions)))))),      \
-		    ())
-
-static uint8_t tx_buffer[MAX_TEST_BUFFER_SIZE] MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi)));
-static uint8_t rx_buffer[MAX_TEST_BUFFER_SIZE] MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi)));
+static uint8_t tx_buffer[MAX_TEST_BUFFER_SIZE] DMM_MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi)));
+static uint8_t rx_buffer[MAX_TEST_BUFFER_SIZE] DMM_MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi)));
 
 static void *test_setup(void)
 {

--- a/tests/drivers/spi/spim_clock_control/src/main.c
+++ b/tests/drivers/spi/spim_clock_control/src/main.c
@@ -6,9 +6,9 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/spi.h>
-#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/devicetree/clocks.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
+#include <dmm.h>
 #include <zephyr/ztest.h>
 
 /* SPI MODE 0 */
@@ -21,14 +21,8 @@
 static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPI_MODE);
 const struct device *const fll16m_dev = DEVICE_DT_GET(DT_NODELABEL(fll16m));
 
-#define MEMORY_SECTION(node)                                                                       \
-	COND_CODE_1(DT_NODE_HAS_PROP(node, memory_regions),                                        \
-		    (__attribute__((__section__(                                                   \
-			    LINKER_DT_NODE_REGION_NAME(DT_PHANDLE(node, memory_regions)))))),      \
-		    ())
-
-static uint8_t tx_buffer[TEST_BUFFER_SIZE] MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
-static uint8_t rx_buffer[TEST_BUFFER_SIZE] MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
+static uint8_t tx_buffer[TEST_BUFFER_SIZE] DMM_MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
+static uint8_t rx_buffer[TEST_BUFFER_SIZE] DMM_MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
 
 const struct nrf_clock_spec fll16m_open_loop_mode = {
 	.frequency = MHZ(16),

--- a/tests/drivers/spi/spim_instances/src/spim_instances.c
+++ b/tests/drivers/spi/spim_instances/src/spim_instances.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/ztest.h>
+#include <dmm.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(test);
@@ -27,12 +28,6 @@ typedef bool (*capability_func_t)(const struct device *dev);
 
 
 #define DATA_FIELD (16)
-
-#define MEMORY_SECTION(node)                                                                       \
-	COND_CODE_1(DT_NODE_HAS_PROP(node, memory_regions),                                        \
-		    (__attribute__((__section__(                                                   \
-			    LINKER_DT_NODE_REGION_NAME(DT_PHANDLE(node, memory_regions)))))),      \
-		    ())
 
 static struct spi_config default_spi_cfg = {
 	.frequency = 4000000,
@@ -80,7 +75,7 @@ static void test_all_instances(test_func_t func, capability_func_t capability_ch
  */
 static void test_transceive_data_instance(const struct device *dev)
 {
-	uint8_t spim_buffer[2 * DATA_FIELD] MEMORY_SECTION(DT_BUS(dev));
+	static uint8_t spim_buffer[2 * DATA_FIELD] DMM_MEMORY_SECTION(DT_BUS(dev));
 	int ret = 0;
 
 	/* SPI buffer sets */

--- a/tests/drivers/spi/spim_mosi_toggles/src/main.c
+++ b/tests/drivers/spi/spim_mosi_toggles/src/main.c
@@ -14,7 +14,7 @@ LOG_MODULE_REGISTER(spim_mosi_toggles, LOG_LEVEL_INF);
 #include <nrfx_gpiote.h>
 #include <gpiote_nrfx.h>
 #include <zephyr/drivers/spi.h>
-#include <zephyr/linker/devicetree_regions.h>
+#include <dmm.h>
 
 /* Number of bytes transmitted in single transaction. */
 #define TEST_DATA_SIZE 6
@@ -22,14 +22,7 @@ LOG_MODULE_REGISTER(spim_mosi_toggles, LOG_LEVEL_INF);
 #define SPI_MODE (SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_LINES_SINGLE | SPI_TRANSFER_MSB)
 
 static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPI_MODE);
-
-#define MEMORY_SECTION(node)                                                                       \
-	COND_CODE_1(DT_NODE_HAS_PROP(node, memory_regions),                                        \
-		    (__attribute__((__section__(                                                   \
-			    LINKER_DT_NODE_REGION_NAME(DT_PHANDLE(node, memory_regions)))))),      \
-		    ())
-
-static uint8_t spim_buffer[2 * TEST_DATA_SIZE] MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
+static uint8_t spim_buffer[2 * TEST_DATA_SIZE] DMM_MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
 
 /* Variables used to count edges on SPI MOSI line. */
 #define CLOCK_INPUT_PIN	NRF_DT_GPIOS_TO_PSEL(DT_PATH(zephyr_user), test_gpios)

--- a/tests/drivers/spi/spim_pan/src/main.c
+++ b/tests/drivers/spi/spim_pan/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/spi.h>
 #include <nrfx_spim.h>
 #include <nrfx_timer.h>
-#include <zephyr/linker/devicetree_regions.h>
+#include <dmm.h>
 
 #include <zephyr/drivers/counter.h>
 #include <helpers/nrfx_gppi.h>
@@ -35,15 +35,8 @@ static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), 
 NRF_SPIM_Type *spim_reg = (NRF_SPIM_Type *)DT_REG_ADDR(DUT_SPI_NODE);
 
 static nrfx_timer_t test_timer = NRFX_TIMER_INSTANCE(DT_REG_ADDR(DT_NODELABEL(tst_timer)));
-
-#define MEMORY_SECTION(node)                                                                       \
-	COND_CODE_1(DT_NODE_HAS_PROP(node, memory_regions),                                        \
-		    (__attribute__((__section__(                                                   \
-			    LINKER_DT_NODE_REGION_NAME(DT_PHANDLE(node, memory_regions)))))),      \
-		    ())
-
-static uint8_t tx_buffer[TEST_BUFFER_SIZE] MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
-static uint8_t rx_buffer[TEST_BUFFER_SIZE] MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
+static uint8_t tx_buffer[TEST_BUFFER_SIZE] DMM_MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
+static uint8_t rx_buffer[TEST_BUFFER_SIZE] DMM_MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
 
 static void *test_setup(void)
 {


### PR DESCRIPTION
Use DMM API for getting a memory section and alignment for SPI buffers.