### PR TITLE
[Backport v3.4-branch] scripts: quarantine: remove sample.bluetooth.mesh

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -141,15 +141,6 @@
   comment: "https://nordicsemi.atlassian.net/browse/NRFX-9631"
 
 - scenarios:
-    - sample.bluetooth.mesh.chat
-    - sample.bluetooth.mesh.ble_and_mesh
-    - sample.bluetooth.mesh.light_ctrl
-    - sample.bluetooth.mesh.sensor_server
-  platforms:
-    - nrf52dk/nrf52832
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39503"
-
-- scenarios:
     - sample.debug.memfault
     - sample.debug.memfault.etb
   platforms:


### PR DESCRIPTION
Fixed.

Backport of dd3235a951f922f4326ff2d55087aad26f335600

(cherry picked from commit 2223669d26914ed820032f06e69295a0637acfd2)