### PR TITLE
[Backport v3.4-branch] tests: tf-m: Disable Partition Manager

### DIFF
--- a/tests/zephyr/modules/tf-m/regression/Kconfig.sysbuild
+++ b/tests/zephyr/modules/tf-m/regression/Kconfig.sysbuild
@@ -5,6 +5,6 @@
 #
 
 config PARTITION_MANAGER
-	default n if !((SOC_SERIES_NRF91 || SOC_SERIES_NRF53) && BOARD_IS_NON_SECURE)
+	default n
 
 source "share/sysbuild/Kconfig"

--- a/tests/zephyr/modules/tf-m/regression/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/tests/zephyr/modules/tf-m/regression/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-# TF-M needs more flash to fit when CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
-CONFIG_PM_PARTITION_SIZE_TFM=0x48000
-
 # NCSDK-38968: Attestation tests don't work
 
 #CONFIG_TFM_PARTITION_INITIAL_ATTESTATION=y

--- a/tests/zephyr/modules/tf-m/regression/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/tests/zephyr/modules/tf-m/regression/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,8 +1,82 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x48000>;
+		};
+
+		slot0_ns_partition: partition@48000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x48000 0xac000>;
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+/*
+ * TrustZone SRAM split mirroring the Partition Manager layout for this test:
+ * - Secure image RAM (&sram0_s) gets 192 KiB (0x30000) at the base of SRAM.
+ * - Non-secure RAM begins at 0x20030000 and spans 0x50000 (320 KiB) which
+ *   includes the 64 KiB sram0_shared region used for app/network-core IPC
+ *   (see nrf5340_shared_sram_partition.dtsi); the NS application portion
+ *   (&sram0_ns_app) gets the remaining 256 KiB.
+ */
+&sram0_s {
+	reg = <0x0 0x30000>;
+};
+
+&sram0_ns {
+	reg = <0x30000 0x50000>;
+	ranges = <0x0 0x30000 0x50000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x40000>;
+};
+
 &uart0 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;

--- a/tests/zephyr/modules/tf-m/regression/boards/nrf9151dk_nrf9151_ns.conf
+++ b/tests/zephyr/modules/tf-m/regression/boards/nrf9151dk_nrf9151_ns.conf
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-# TF-M needs more flash to fit when CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
-CONFIG_PM_PARTITION_SIZE_TFM=0x48000
-
 # NCSDK-38968: Attestation tests don't work
 
 #CONFIG_TFM_PARTITION_INITIAL_ATTESTATION=y

--- a/tests/zephyr/modules/tf-m/regression/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/tests/zephyr/modules/tf-m/regression/boards/nrf9151dk_nrf9151_ns.overlay
@@ -1,8 +1,13 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+#include <samples/cellular/nrf91_crypto_partitions.dtsi>
+
+#include <samples/cellular/nrf91_sram_crypto_partitions.dtsi>
+
 &uart0 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;

--- a/tests/zephyr/modules/tf-m/regression/boards/nrf9160dk_nrf9160_ns.conf
+++ b/tests/zephyr/modules/tf-m/regression/boards/nrf9160dk_nrf9160_ns.conf
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-# TF-M needs more flash to fit when CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
-CONFIG_PM_PARTITION_SIZE_TFM=0x48000
-
 # NCSDK-38968: Attestation tests don't work
 
 #CONFIG_TFM_PARTITION_INITIAL_ATTESTATION=y

--- a/tests/zephyr/modules/tf-m/regression/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/tests/zephyr/modules/tf-m/regression/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,8 +1,13 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+#include <samples/cellular/nrf91_crypto_partitions.dtsi>
+
+#include <samples/cellular/nrf91_sram_crypto_partitions.dtsi>
+
 &uart0 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;

--- a/tests/zephyr/modules/tf-m/regression/boards/nrf9161dk_nrf9161_ns.conf
+++ b/tests/zephyr/modules/tf-m/regression/boards/nrf9161dk_nrf9161_ns.conf
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-# TF-M needs more flash to fit when CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y
-CONFIG_PM_PARTITION_SIZE_TFM=0x48000
-
 # NCSDK-38968: Attestation tests don't work
 
 #CONFIG_TFM_PARTITION_INITIAL_ATTESTATION=y

--- a/tests/zephyr/modules/tf-m/regression/boards/nrf9161dk_nrf9161_ns.overlay
+++ b/tests/zephyr/modules/tf-m/regression/boards/nrf9161dk_nrf9161_ns.overlay
@@ -1,8 +1,13 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+#include <samples/cellular/nrf91_crypto_partitions.dtsi>
+
+#include <samples/cellular/nrf91_sram_crypto_partitions.dtsi>
+
 &uart0 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;


### PR DESCRIPTION
Backport 3dbfcd5fff5b38108c7ddb74f28ad38ca7f96471 from #29301.