### PR TITLE
[Backport v3.4-branch] tests: hw_unique_key: Remove partition manager

### DIFF
--- a/samples/keys/hw_unique_key/Kconfig.sysbuild
+++ b/samples/keys/hw_unique_key/Kconfig.sysbuild
@@ -5,6 +5,6 @@
 #
 
 config PARTITION_MANAGER
-	default n if !((SOC_SERIES_NRF91 || SOC_SERIES_NRF53) && BOARD_IS_NON_SECURE)
+	default n
 
 source "share/sysbuild/Kconfig"

--- a/samples/keys/hw_unique_key/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/keys/hw_unique_key/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x40000>;
+		};
+
+		slot0_ns_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x40000 0xb4000>;
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};

--- a/samples/keys/hw_unique_key/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/samples/keys/hw_unique_key/boards/nrf9151dk_nrf9151_ns.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/cellular/nrf91_crypto_partitions.dtsi>

--- a/samples/keys/hw_unique_key/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/samples/keys/hw_unique_key/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/cellular/nrf91_crypto_partitions.dtsi>

--- a/samples/keys/hw_unique_key/boards/nrf9161dk_nrf9161_ns.overlay
+++ b/samples/keys/hw_unique_key/boards/nrf9161dk_nrf9161_ns.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/cellular/nrf91_crypto_partitions.dtsi>

--- a/tests/lib/hw_unique_key_tfm/Kconfig.sysbuild
+++ b/tests/lib/hw_unique_key_tfm/Kconfig.sysbuild
@@ -5,6 +5,6 @@
 #
 
 config PARTITION_MANAGER
-	default n if !((SOC_SERIES_NRF91 || SOC_SERIES_NRF53) && BOARD_IS_NON_SECURE)
+	default n
 
 source "share/sysbuild/Kconfig"

--- a/tests/lib/hw_unique_key_tfm/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/tests/lib/hw_unique_key_tfm/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x40000>;
+		};
+
+		slot0_ns_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x40000 0xb4000>;
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};

--- a/tests/lib/hw_unique_key_tfm/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/tests/lib/hw_unique_key_tfm/boards/nrf9151dk_nrf9151_ns.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/cellular/nrf91_crypto_partitions.dtsi>

--- a/tests/lib/hw_unique_key_tfm/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/tests/lib/hw_unique_key_tfm/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/cellular/nrf91_crypto_partitions.dtsi>

--- a/tests/lib/hw_unique_key_tfm/boards/nrf9161dk_nrf9161_ns.overlay
+++ b/tests/lib/hw_unique_key_tfm/boards/nrf9161dk_nrf9161_ns.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/cellular/nrf91_crypto_partitions.dtsi>


### PR DESCRIPTION
Backport 133d4689e6389c1efc82d998c66e252b68c31f88~2..133d4689e6389c1efc82d998c66e252b68c31f88 from #29298.