### PR TITLE
tests: subsys: caf: Remove Partition Manager

### DIFF
--- a/tests/subsys/caf/sensor_data_aggregator/Kconfig.sysbuild
+++ b/tests/subsys/caf/sensor_data_aggregator/Kconfig.sysbuild
@@ -5,6 +5,6 @@
 #
 
 config PARTITION_MANAGER
-	default n if !BOARD_IS_NON_SECURE
+	default n
 
 source "share/sysbuild/Kconfig"

--- a/tests/subsys/caf/sensor_data_aggregator/boards/nrf9160dk_nrf9160_ns.conf
+++ b/tests/subsys/caf/sensor_data_aggregator/boards/nrf9160dk_nrf9160_ns.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_TFM_PROFILE_TYPE_MINIMAL=y

--- a/tests/subsys/caf/sensor_data_aggregator/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/tests/subsys/caf/sensor_data_aggregator/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/cellular/nrf91_no_bootloader_partitions.dtsi>
+
+#include <samples/cellular/nrf91_sram_partitions.dtsi>
+
+/ {
+	agg0: agg0 {
+		compatible = "caf,aggregator";
+		sensor_descr = "void_basic_test_sensor";
+		buf_data_length = <160>;
+		sample_size = <2>;
+		status = "okay";
+	};
+
+	agg1: agg1 {
+		compatible = "caf,aggregator";
+		sensor_descr = "void_order_test_sensor";
+		buf_data_length = <80>;
+		sample_size = <1>;
+		status = "okay";
+	};
+
+	agg2: agg2 {
+		compatible = "caf,aggregator";
+		sensor_descr = "void_status_test_sensor";
+		buf_data_length = <80>;
+		sample_size = <1>;
+		status = "okay";
+	};
+};

--- a/tests/subsys/caf/sensor_manager/Kconfig.sysbuild
+++ b/tests/subsys/caf/sensor_manager/Kconfig.sysbuild
@@ -5,6 +5,6 @@
 #
 
 config PARTITION_MANAGER
-	default n if !BOARD_IS_NON_SECURE
+	default n
 
 source "share/sysbuild/Kconfig"

--- a/tests/subsys/caf/sensor_manager/boards/nrf9160dk_nrf9160_ns.conf
+++ b/tests/subsys/caf/sensor_manager/boards/nrf9160dk_nrf9160_ns.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_TFM_PROFILE_TYPE_MINIMAL=y

--- a/tests/subsys/caf/sensor_manager/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/tests/subsys/caf/sensor_manager/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/cellular/nrf91_no_bootloader_partitions.dtsi>
+
+#include <samples/cellular/nrf91_sram_partitions.dtsi>
+
+/ {
+	sensor_sim_1: sensor_sim_1 {
+		compatible = "nordic,sensor-sim";
+		acc-signal = "wave";
+	};
+
+	sensor_sim_2: sensor_sim_2 {
+		compatible = "nordic,sensor-sim";
+		acc-signal = "wave";
+	};
+
+	sensor_sim_3: sensor_sim_3 {
+		compatible = "nordic,sensor-sim";
+		acc-signal = "wave";
+	};
+};


### PR DESCRIPTION
This commit finally removes Partition Manager from the outstanding targets, but some additional configuration is required.