### PR TITLE
tests: tfm: regression: Increase stack

### DIFF
--- a/tests/zephyr/modules/tf-m/regression/prj.conf
+++ b/tests/zephyr/modules/tf-m/regression/prj.conf
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+CONFIG_MAIN_STACK_SIZE=4096
+
 CONFIG_TFM_SECURE_UART_SHARE_INSTANCE=n
 
 # Enable IPC mode and isolation level 2 by default


### PR DESCRIPTION
The regression tests ended up with 1024 bytes of stack size. This is not enough and causes a stack overflow so increase it to a more reasonable default.