### PR TITLE
doc: matter: Add link to DFU over Bluetooth LE to readme

### DIFF
--- a/doc/nrf/includes/matter/configuration/advanced/dfu.txt
+++ b/doc/nrf/includes/matter/configuration/advanced/dfu.txt
@@ -10,6 +10,7 @@ Device firmware upgrade support
      In this case, the DFU can be done either using a smartphone application or a PC command-line tool.
      This protocol is not part of the Matter specification.
 
+   For detailed information about how to perform an update over Matter or Bluetooth LE, see :doc:`matter:nrfconnect_examples_software_update`.
    In both cases, the :ref:`MCUboot <mcuboot:mcuboot_wrapper>` secure bootloader is used to apply the new firmware image.
 
    The DFU over Matter is enabled by default.


### PR DESCRIPTION
Added a link to detailed guide on how to perform DFU over Bluetooth LE to all Matter samples.