### PR TITLE
tests: secure_services: Fix wrong address

### DIFF
--- a/tests/tfm/secure_services/src/main.c
+++ b/tests/tfm/secure_services/src/main.c
@@ -22,10 +22,8 @@
 #else
 
 #define TEST_SRAM_BASE       DT_REG_ADDR(DT_NODELABEL(sram0))
-#define TEST_SRAM_NS_ADDRESS (DT_REG_ADDR(DT_NODELABEL(sram0)) + \
-			      DT_REG_ADDR(DT_NODELABEL(sram0_ns)))
-#define TEST_SRAM_S_ADDRESS  (DT_REG_ADDR(DT_NODELABEL(sram0)) + \
-			      DT_REG_ADDR(DT_NODELABEL(sram0_s)))
+#define TEST_SRAM_NS_ADDRESS DT_REG_ADDR(DT_NODELABEL(sram0_ns))
+#define TEST_SRAM_S_ADDRESS  DT_REG_ADDR(DT_NODELABEL(sram0_s))
 #define TEST_NS_FLASH_ADDR   DT_REG_ADDR(DT_NODELABEL(slot0_ns_partition))
 #endif
 


### PR DESCRIPTION
Base address would be added to the absolute address not the relative one.
Updated to just use absolute address.