### PR TITLE
tests: lib: sfloat: disable Partition Manager

### DIFF
--- a/tests/lib/sfloat/Kconfig.sysbuild
+++ b/tests/lib/sfloat/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Wasn't disabled explicitly, so adding the appropriate config.