### PR TITLE
Fix Large ICMP Ping Payload Failure

### DIFF
--- a/samples/wifi/shell/Kconfig
+++ b/samples/wifi/shell/Kconfig
@@ -19,11 +19,13 @@ if NET_BUF_VARIABLE_DATA_SIZE
 # nRF52 and nRF54 Series targets have less memory
 # so smaller pool sizes are recommended for these targets.
 config NET_PKT_BUF_TX_DATA_POOL_SIZE
+	default 50000 if SOC_NRF54LM20A || SOC_NRF54LM20B
 	default 40000 if SOC_SERIES_NRF54H
 	default 35000 if !SOC_SERIES_NRF52 && !SOC_SERIES_NRF54L && BUILD_WITH_TFM
 	default 50000 if !SOC_SERIES_NRF52 && !SOC_SERIES_NRF54L
 
 config NET_PKT_BUF_RX_DATA_POOL_SIZE
+	default 20000 if SOC_NRF54LM20A || SOC_NRF54LM20B
 	default 20000 if !SOC_SERIES_NRF52 && !SOC_SERIES_NRF54L
 
 endif


### PR DESCRIPTION
[SHEL-4228] Fix Large ICMP Ping Payload Failure on nRF54LM20DK + nRF7002EB2.

[SHEL-4228]: https://nordicsemi.atlassian.net/browse/SHEL-4228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ