### PR TITLE
[Backport v3.4-branch] tests: ram_pwrdn: disable Partition Manager

### DIFF
--- a/tests/lib/ram_pwrdn/Kconfig.sysbuild
+++ b/tests/lib/ram_pwrdn/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Backport 47ae72483fbc0870a47dc2fe7f58e9ca765a7e79 from #29300.