### PR TITLE
snippets: Add nordic-vregmain-ldo

### DIFF
--- a/snippets/nordic-vregmain-ldo/README.rst
+++ b/snippets/nordic-vregmain-ldo/README.rst
@@ -1,0 +1,28 @@
+.. _nordic-vregmain-ldo:
+
+Nordic Main Voltage Regulator LDO snippet (nordic-vregmain-ldo)
+###############################################################
+
+.. code-block:: console
+
+   west build -S nordic-vregmain-ldo [...]
+
+Overview
+********
+
+This snippet allows you to build applications with the main voltage regulator enabled in LDO (Low Dropout) mode.
+The LDO mode provides regulated power output with a lower dropout voltage requirement compared to other regulation modes.
+
+Supported boards
+****************
+
+* ``nrf5340dk/nrf5340/cpuapp``
+* ``nrf54l15dk/nrf54l05/cpuapp``
+* ``nrf54l15dk/nrf54l10/cpuapp``
+* ``nrf54l15dk/nrf54l15/cpuapp``
+* ``nrf54lc10dk/nrf54lc10a/cpuapp``
+* ``nrf54lm20dk/nrf54lm20a/cpuapp``
+* ``nrf54lm20dk/nrf54lm20b/cpuapp``
+* ``nrf54ls05dk/nrf54ls05a/cpuapp``
+* ``nrf54ls05dk/nrf54ls05b/cpuapp``
+* ``nrf54lv10dk/nrf54lv10a/cpuapp``

--- a/snippets/nordic-vregmain-ldo/nordic-vregmain-ldo.overlay
+++ b/snippets/nordic-vregmain-ldo/nordic-vregmain-ldo.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&vregmain {
+	status = "okay";
+	regulator-initial-mode = <NRF5X_REG_MODE_LDO>;
+};

--- a/snippets/nordic-vregmain-ldo/snippet.yml
+++ b/snippets/nordic-vregmain-ldo/snippet.yml
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+name: nordic-vregmain-ldo
+
+boards:
+  /.*/nrf5340/cpuapp/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: nordic-vregmain-ldo.overlay
+  /.*/nrf54l05/cpuapp/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: nordic-vregmain-ldo.overlay
+  /.*/nrf54l10/cpuapp/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: nordic-vregmain-ldo.overlay
+  /.*/nrf54l15/cpuapp/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: nordic-vregmain-ldo.overlay
+  /.*/nrf54lc10./cpuapp/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: nordic-vregmain-ldo.overlay
+  /.*/nrf54lm20./cpuapp/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: nordic-vregmain-ldo.overlay
+  /.*/nrf54ls05./cpuapp/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: nordic-vregmain-ldo.overlay
+  /.*/nrf54lv10./cpuapp/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: nordic-vregmain-ldo.overlay


### PR DESCRIPTION
Add a snippet that enables the use of the main regulator in LDO mode.