### PR TITLE
doc: hpf: document support for HPF on nRF54LC10A

### DIFF
--- a/applications/hpf/gpio/README.rst
+++ b/applications/hpf/gpio/README.rst
@@ -10,7 +10,7 @@ High-Performance Framework GPIO
 
 .. caution::
 
-   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15, nRF54LM20A, nRF54LV10A, and nRF7120 devices.
+   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15, nRF54LM20, nRF54LC10A, nRF54LV10A, and nRF7120 devices.
 
 This application demonstrates how to write a :ref:`High-Performance Framework (HPF) <hpf_index>` application implementing a simple peripheral.
 The application implements a subset of the Zephyr GPIO API.

--- a/applications/hpf/hpf.rst
+++ b/applications/hpf/hpf.rst
@@ -5,7 +5,7 @@ High-Performance Framework
 
 .. caution::
 
-   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15, nRF54LM20, nRF54LV10A, and nRF7120 devices.
+   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15, nRF54LM20, nRF54LC10A, nRF54LV10A, and nRF7120 devices.
 
 High-Performance Framework, is a framework designed to facilitate the creation and integration of :ref:`peripheral emulations using coprocessors <coprocessors_index>`.
 The following applications are created using HPF:

--- a/applications/hpf/mspi/README.rst
+++ b/applications/hpf/mspi/README.rst
@@ -9,7 +9,7 @@ High-Performance Framework MSPI
 
 .. caution::
 
-   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15, nRF54LM20A/B, and nRF54LV10A devices.
+   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15, nRF54LM20A/B, nRF54LC10A, and nRF54LV10A devices.
 
 This application demonstrates how to write a :ref:`High-Performance Framework (HPF) <hpf_index>` application and communicate with it.
 The application implements a subset of the Zephyr MSPI API.
@@ -361,7 +361,7 @@ The following tests utilize the MSPI driver along with this application:
 * ``nrf/tests/zephyr/drivers/mspi/flash``
 * ``nrf/tests/zephyr/drivers/flash/common``
 
-These tests report results over the serial port, using the USB debug port on the nRF54L15, nRF54LM20, or nRF54LV10 DK.
+These tests report results over the serial port, using the USB debug port on the nRF54L15, nRF54LM20, nrf54LC10 or nRF54LV10 DK.
 
 Dependencies
 ************
@@ -398,4 +398,5 @@ FLPR application HRT
   * :file:`applications/hpf/mspi/src/hrt/hrt-nrf54l15.s`
   * :file:`applications/hpf/mspi/src/hrt/hrt-nrf54lm20a.s`
   * :file:`applications/hpf/mspi/src/hrt/hrt-nrf54lm20b.s`
+  * :file:`applications/hpf/mspi/src/hrt/hrt-nrf54lc10a.s`
   * :file:`applications/hpf/mspi/src/hrt/hrt-nrf54lv10a.s`

--- a/doc/nrf/app_dev/device_guides/coprocessors/rt_peripherals.rst
+++ b/doc/nrf/app_dev/device_guides/coprocessors/rt_peripherals.rst
@@ -9,7 +9,7 @@ Real-time peripherals
 
 .. caution::
 
-   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15, nRF54LM20, and nRF54LV10A devices.
+   The High-Performance Framework (HPF) support in the |NCS| is :ref:`experimental <software_maturity>` and is limited to the nRF54L15, nRF54LM20, nRF54LC10A, and nRF54LV10A devices.
 
 .. contents::
    :local:
@@ -114,6 +114,9 @@ The interrupt line triggered varies depending on the System on Chip (SoC):
    * - nRF54LM20 FLPR
      - 31
 
+   * - nRF54LC10A FLPR
+     - 31
+
    * - nRF54LV10A FLPR
      - 31
 
@@ -143,7 +146,7 @@ See the following table for pin mapping between GPIO and VIO for specific target
 
    * - VIO pin number
      - Corresponding GPIO pin for nRF54L15/nRF54LM20
-     - Corresponding GPIO pin for nRF54LV10A
+     - Corresponding GPIO pin for nRF54LC10A/nRF54LV10A
 
    * - 0
      - P2.01

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -193,7 +193,7 @@ Connectivity bridge
 High-Performance Framework (HPF)
 --------------------------------
 
-|no_changes_yet_note|
+* Added support for the nRF54LC10A SoC.
 
 IPC radio firmware
 ------------------


### PR DESCRIPTION
Add an entry documenting support for HPF on nRF54LC10A.