### PR TITLE
net: nrf_cloud: elevate CoAP connection failure logs to visible levels

### DIFF
--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
@@ -809,7 +809,7 @@ static int nrf_cloud_coap_connect_host_cb(struct sockaddr *const addr)
 	sock = zsock_socket(addr->sa_family, SOCK_DGRAM, IPPROTO_DTLS_1_2);
 
 	if (sock < 0) {
-		LOG_DBG("Failed to create CoAP socket, errno: %d", errno);
+		LOG_ERR("Failed to create CoAP socket, errno: %d", errno);
 		err = -ENOTSOCK;
 		goto out;
 	}
@@ -818,7 +818,7 @@ static int nrf_cloud_coap_connect_host_cb(struct sockaddr *const addr)
 
 	err = nrfc_dtls_setup(sock);
 	if (err < 0) {
-		LOG_DBG("Failed to initialize the DTLS client: %d", err);
+		LOG_ERR("Failed to initialize the DTLS client: %d", err);
 		err = -EPROTO;
 		goto out;
 	}
@@ -830,7 +830,7 @@ static int nrf_cloud_coap_connect_host_cb(struct sockaddr *const addr)
 
 	err = zsock_connect(sock, addr, addr_size);
 	if (err) {
-		LOG_DBG("Connect failed, errno: %d", errno);
+		LOG_WRN("DTLS connect failed, errno: %d", errno);
 		err = -ECONNREFUSED;
 		goto out;
 	}

--- a/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_dns.c
+++ b/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_dns.c
@@ -23,7 +23,7 @@ static int nrf_cloud_try_addresses(const char *const host_name, uint16_t port,
 
 	err = zsock_getaddrinfo(host_name, NULL, hints, &info);
 	if (err) {
-		LOG_DBG("getaddrinfo for %s, port: %d failed: %d, errno: %d", host_name, port, err,
+		LOG_ERR("getaddrinfo for %s, port: %d failed: %d, errno: %d", host_name, port, err,
 			errno);
 		return -EADDRNOTAVAIL;
 	}
@@ -59,7 +59,8 @@ static int nrf_cloud_try_addresses(const char *const host_name, uint16_t port,
 		int sock = connect_cb(sa);
 
 		if (sock < 0) {
-			LOG_DBG("Failed to connect to IP address %s. Error: %d", ip, sock);
+			LOG_WRN("Failed to connect to server %s via IP address %s, port %d."
+				"Error: %d", host_name, ip, port, sock);
 			continue;
 		}
 


### PR DESCRIPTION
Promote connection-path log messages from LOG_DBG to LOG_ERR/LOG_WRN/LOG_INF so that DTLS handshake failures are visible at the default log level without requiring debug builds:

- nrf_cloud_dns: getaddrinfo failure -> LOG_ERR
- nrf_cloud_dns: per-address connect failure -> LOG_WRN (with server and port)
- nrf_cloud_coap_transport: socket creation failure -> LOG_ERR
- nrf_cloud_coap_transport: DTLS setup failure -> LOG_ERR
- nrf_cloud_coap_transport: zsock_connect failure -> LOG_ERR (with errno)

The zsock_connect errno is the key diagnostic: ETIMEDOUT (116) indicates the DTLS handshake timed out (port filtered), whereas ECONNREFUSED (111) indicates active rejection.

This change helps to debug connection issues especially when they are related to Wi-Fi network being used, when it silently drops DTLS messages.