### PR TITLE
ext: curl: Fix POLLERR handling

### DIFF
--- a/ext/curl/lib/select.c
+++ b/ext/curl/lib/select.c
@@ -263,31 +263,19 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
   num = 0;
   if(readfd0 != CURL_SOCKET_BAD) {
     pfd[num].fd = readfd0;
-#if !defined(CONFIG_NRF_CURL_INTEGRATION)
     pfd[num].events = POLLRDNORM|POLLIN|POLLRDBAND|POLLPRI;
-#else //POLLPRI not supported
-    pfd[num].events = POLLRDNORM|POLLIN;
-#endif
     pfd[num].revents = 0;
     num++;
   }
   if(readfd1 != CURL_SOCKET_BAD) {
     pfd[num].fd = readfd1;
-#if !defined(CONFIG_NRF_CURL_INTEGRATION)
     pfd[num].events = POLLRDNORM|POLLIN|POLLRDBAND|POLLPRI;
-#else //POLLPRI not supported
-    pfd[num].events = POLLRDNORM|POLLIN;
-#endif
     pfd[num].revents = 0;
     num++;
   }
   if(writefd != CURL_SOCKET_BAD) {
     pfd[num].fd = writefd;
-#if !defined(CONFIG_NRF_CURL_INTEGRATION)
     pfd[num].events = POLLWRNORM|POLLOUT|POLLPRI;
-#else //POLLPRI not supported
-    pfd[num].events = POLLWRNORM|POLLOUT;
-#endif
     pfd[num].revents = 0;
     num++;
   }
@@ -301,37 +289,22 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
   if(readfd0 != CURL_SOCKET_BAD) {
     if(pfd[num].revents & (POLLRDNORM|POLLIN|POLLERR|POLLHUP))
       r |= CURL_CSELECT_IN;
-#if !defined(CONFIG_NRF_CURL_INTEGRATION)
     if(pfd[num].revents & (POLLRDBAND|POLLPRI|POLLNVAL))
       r |= CURL_CSELECT_ERR;
-#else //POLLPRI not supported
-    if(pfd[num].revents & (POLLNVAL))
-      r |= CURL_CSELECT_ERR;
-#endif
     num++;
   }
   if(readfd1 != CURL_SOCKET_BAD) {
     if(pfd[num].revents & (POLLRDNORM|POLLIN|POLLERR|POLLHUP))
       r |= CURL_CSELECT_IN2;
-#if !defined(CONFIG_NRF_CURL_INTEGRATION)
     if(pfd[num].revents & (POLLRDBAND|POLLPRI|POLLNVAL))
       r |= CURL_CSELECT_ERR;
-#else //POLLPRI not supported
-    if(pfd[num].revents & (POLLNVAL))
-      r |= CURL_CSELECT_ERR;
-#endif
     num++;
   }
   if(writefd != CURL_SOCKET_BAD) {
     if(pfd[num].revents & (POLLWRNORM|POLLOUT))
       r |= CURL_CSELECT_OUT;
-#if !defined(CONFIG_NRF_CURL_INTEGRATION)
     if(pfd[num].revents & (POLLERR|POLLHUP|POLLPRI|POLLNVAL))
       r |= CURL_CSELECT_ERR;
-#else //POLLPRI not supported      
-    if(pfd[num].revents & (POLLERR|POLLHUP|POLLNVAL))
-      r |= CURL_CSELECT_ERR;
-#endif
   }
 
   return r;
@@ -402,15 +375,10 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
   for(i = 0; i < nfds; i++) {
     if(ufds[i].fd == CURL_SOCKET_BAD)
       continue;
-    if (ufds[i].revents & POLLHUP) {
-	    ufds[i].revents |= POLLIN;
-    }
-    if (ufds[i].revents & POLLERR) {
-#if defined(CONFIG_NRF_CURL_INTEGRATION)
-	    printk("\npoll() returned: POLLERR\n");
-#endif
-	    ufds[i].revents |= POLLIN | POLLOUT;
-    }
+    if(ufds[i].revents & POLLHUP)
+      ufds[i].revents |= POLLIN;
+    if(ufds[i].revents & POLLERR)
+      ufds[i].revents |= POLLIN|POLLOUT;
   }
 
 #else  /* HAVE_POLL_FINE */
@@ -425,23 +393,16 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
     if(ufds[i].fd == CURL_SOCKET_BAD)
       continue;
     VERIFY_SOCK(ufds[i].fd);
-#if !defined(CONFIG_NRF_CURL_INTEGRATION)
     if(ufds[i].events & (POLLIN|POLLOUT|POLLPRI|
                          POLLRDNORM|POLLWRNORM|POLLRDBAND)) {
-#else //POLLPRI not supported 
-    if(ufds[i].events & (POLLIN|POLLOUT|
-                         POLLRDNORM|POLLWRNORM)) {
-#endif
       if(ufds[i].fd > maxfd)
         maxfd = ufds[i].fd;
       if(ufds[i].events & (POLLRDNORM|POLLIN))
         FD_SET(ufds[i].fd, &fds_read);
       if(ufds[i].events & (POLLWRNORM|POLLOUT))
         FD_SET(ufds[i].fd, &fds_write);
-#if !defined(CONFIG_NRF_CURL_INTEGRATION)
       if(ufds[i].events & (POLLRDBAND|POLLPRI))
         FD_SET(ufds[i].fd, &fds_err);
-#endif //POLLPRI not supported 
     }
   }
 
@@ -473,12 +434,10 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
         ufds[i].revents |= POLLOUT;
     }
     if(FD_ISSET(ufds[i].fd, &fds_err)) {
-#if !defined(CONFIG_NRF_CURL_INTEGRATION)
       if(ufds[i].events & POLLRDBAND)
         ufds[i].revents |= POLLRDBAND;
       if(ufds[i].events & POLLPRI)
         ufds[i].revents |= POLLPRI;
-#endif //POLLPRI not supported         
     }
     if(ufds[i].revents != 0)
       r++;


### PR DESCRIPTION
`POLLERR` from `poll()` caused curl to print errors in a loop. This commit removes the integration modifications and restores the original code. `POLLPRI` flagging is no longer necessary and the unmodified code works correctly.

Jira: MOSH-671