### PR TITLE
Samples: Bluetooth: Mesh: Explicitly enable PM for Thingy53

### DIFF
--- a/samples/bluetooth/mesh/light/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/light/Kconfig.sysbuild
@@ -8,6 +8,7 @@ config NRF_DEFAULT_IPC_RADIO
 	default y
 
 config PARTITION_MANAGER
-	default n if !BOARD_THINGY53_NRF5340_CPUAPP
+	default y if BOARD_THINGY53_NRF5340_CPUAPP
+	default n
 
 source "share/sysbuild/Kconfig"

--- a/samples/bluetooth/mesh/light_ctrl/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/light_ctrl/Kconfig.sysbuild
@@ -5,7 +5,8 @@
 #
 
 config PARTITION_MANAGER
-	default n if !BOARD_THINGY53_NRF5340_CPUAPP
+	default y if BOARD_THINGY53_NRF5340_CPUAPP
+	default n
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/mesh/light_dimmer/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/light_dimmer/Kconfig.sysbuild
@@ -8,6 +8,7 @@ config NRF_DEFAULT_IPC_RADIO
 	default y
 
 config PARTITION_MANAGER
-	default n if !BOARD_THINGY53_NRF5340_CPUAPP
+	default y if BOARD_THINGY53_NRF5340_CPUAPP
+	default n
 
 source "share/sysbuild/Kconfig"

--- a/samples/bluetooth/mesh/light_switch/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/light_switch/Kconfig.sysbuild
@@ -8,6 +8,7 @@ config NRF_DEFAULT_IPC_RADIO
 	default y
 
 config PARTITION_MANAGER
-	default n if !BOARD_THINGY53_NRF5340_CPUAPP
+	default y if BOARD_THINGY53_NRF5340_CPUAPP
+	default n
 
 source "share/sysbuild/Kconfig"

--- a/samples/bluetooth/mesh/sensor_server/Kconfig.sysbuild
+++ b/samples/bluetooth/mesh/sensor_server/Kconfig.sysbuild
@@ -8,6 +8,7 @@ config NRF_DEFAULT_IPC_RADIO
 	default y
 
 config PARTITION_MANAGER
-	default n if !BOARD_THINGY53_NRF5340_CPUAPP
+	default y if BOARD_THINGY53_NRF5340_CPUAPP
+	default n
 
 source "share/sysbuild/Kconfig"


### PR DESCRIPTION
This explicitly enables Partition Manager for Mesh samples when targeting the Thingy53 platform, in preparation for the global default to change.