### PR TITLE
[Backport v3.4-branch] tests: lib: sfloat: disable Partition Manager

### DIFF
--- a/tests/lib/sfloat/Kconfig.sysbuild
+++ b/tests/lib/sfloat/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Backport 1837f3ee3c1e707fdfd9a620b2526197acc6eaa6 from #29358.