### PR TITLE
samples: net: azure_iot_hub: dps: Switch to NVS

### DIFF
--- a/samples/net/azure_iot_hub/dps.conf
+++ b/samples/net/azure_iot_hub/dps.conf
@@ -8,3 +8,6 @@ CONFIG_AZURE_IOT_HUB_DPS=y
 
 # The ID scope can be omitted and provided at run time
 CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE=""
+
+CONFIG_NVS=y
+CONFIG_SETTINGS_NVS=y


### PR DESCRIPTION
This commit fixes a regression after switching from PM to DTS in 1b9e209a90.

FCB was working before because storage_partition was on external flash while now storage_partition lives on RRAM with write-block-size = 16, and FCB's 8-byte header write fails, half of RRAM's mandatory minimum.