### PR TITLE
[Backport v3.4-branch] wifi: hostap_crypto: Fix missing configs

### DIFF
--- a/subsys/net/lib/hostap_crypto/Kconfig
+++ b/subsys/net/lib/hostap_crypto/Kconfig
@@ -30,6 +30,9 @@ config HOSTAP_CRYPTO_ALT_LEGACY_PSA
 	select PSA_WANT_KEY_TYPE_PASSWORD
 	select PSA_WANT_ALG_SHA_1
 	select PSA_WANT_ALG_SHA_256
+	# Zephyr hostap always defines CONFIG_SHA384; wpa_gmk_to_gtk() uses
+	# sha384_prf() -> PSA_ALG_HMAC(PSA_ALG_SHA_384) for GMK/GTK derivation.
+	select PSA_WANT_ALG_SHA_384
 	# Enable for non-TF-M builds to keep it simple, no overhead
 	select PSA_WANT_GENERATE_RANDOM
 	select MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS

--- a/subsys/net/lib/hostap_crypto/Kconfig
+++ b/subsys/net/lib/hostap_crypto/Kconfig
@@ -33,6 +33,11 @@ config HOSTAP_CRYPTO_ALT_LEGACY_PSA
 	# Zephyr hostap always defines CONFIG_SHA384; wpa_gmk_to_gtk() uses
 	# sha384_prf() -> PSA_ALG_HMAC(PSA_ALG_SHA_384) for GMK/GTK derivation.
 	select PSA_WANT_ALG_SHA_384
+	# Zephyr hostap always defines CONFIG_SHA512; sha512_prf() needs
+	# PSA_ALG_HMAC(PSA_ALG_SHA_512) for SAE/FT and similar paths.
+	select PSA_WANT_ALG_SHA_512
+	# omac1_aes_vector_psa() imports PSA_KEY_TYPE_AES for CMAC/BIP.
+	select PSA_WANT_KEY_TYPE_AES
 	# Enable for non-TF-M builds to keep it simple, no overhead
 	select PSA_WANT_GENERATE_RANDOM
 	select MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS


### PR DESCRIPTION
Backport 1706698e1739ee2abfdca2746ce6a6cc2230d0a6~2..1706698e1739ee2abfdca2746ce6a6cc2230d0a6 from #29368.