### PR TITLE
[Backport v3.4-branch] applications: ipc_radio: remove Partition Manager

### DIFF
--- a/applications/ipc_radio/Kconfig.sysbuild
+++ b/applications/ipc_radio/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/applications/ipc_radio/sample.yaml
+++ b/applications/ipc_radio/sample.yaml
@@ -41,9 +41,7 @@ tests:
       - ci_applications_ipc_radio
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpurad
-    extra_args:
-      - EXTRA_CONF_FILE=overlay-bt_hci_ipc.conf
-      - SB_CONFIG_PARTITION_MANAGER=n
+    extra_args: EXTRA_CONF_FILE=overlay-bt_hci_ipc.conf
   applications.ipc_radio.rpc:
     sysbuild: true
     build_only: true
@@ -83,9 +81,7 @@ tests:
       - ci_applications_ipc_radio
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpurad
-    extra_args:
-      - EXTRA_CONF_FILE=overlay-bt_rpc.conf
-      - SB_CONFIG_PARTITION_MANAGER=n
+    extra_args: EXTRA_CONF_FILE=overlay-bt_rpc.conf
   applications.ipc_radio.802154:
     sysbuild: true
     build_only: true


### PR DESCRIPTION
Backport f91c9aeda24f19b496847521264e8b57820f6c1b from #29241.