### PR TITLE
applications: hpf: move VIO pin mappings to a common location

### DIFF
--- a/applications/hpf/common/hpf_pin_map.c
+++ b/applications/hpf/common/hpf_pin_map.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "hpf_pin_map.h"
+
+#include <zephyr/sys/util.h>
+#include <nrfx.h>
+
+#if !defined(FLPR_VIO_PORT) || !defined(FLPR_VIO_PIN_OFFSET) || !defined(FLPR_VIO_PIN_INDICES)
+#error "Unsupported SoC"
+#endif
+
+#define HPF_PIN_MAP_VIO_PORT       FLPR_VIO_PORT
+#define HPF_PIN_MAP_VIO_PIN_OFFSET FLPR_VIO_PIN_OFFSET
+
+static const uint8_t hpf_pin_map[] = {
+	FLPR_VIO_PIN_INDICES
+};
+
+#define HPF_PIN_MAP_VIO_PIN_COUNT ARRAY_SIZE(hpf_pin_map)
+#define HPF_PIN_MAP_VIO_VALID_PINS_MASK					    \
+	GENMASK(HPF_PIN_MAP_VIO_PIN_OFFSET + HPF_PIN_MAP_VIO_PIN_COUNT - 1, \
+		HPF_PIN_MAP_VIO_PIN_OFFSET)
+
+uint8_t hpf_pin_map_to_vio_index(uint8_t port, uint8_t pin)
+{
+	/* Check if the pin and the port can be accessed by VIO. */
+	size_t hpf_map_index = pin - HPF_PIN_MAP_VIO_PIN_OFFSET;
+
+	if ((port != HPF_PIN_MAP_VIO_PORT) ||
+		(hpf_map_index >= ARRAY_SIZE(hpf_pin_map))) {
+		return HPF_PIN_MAP_VIO_PIN_INVALID;
+	}
+	return hpf_pin_map[hpf_map_index];
+}
+
+uint16_t hpf_pin_map_to_vio_mask(uint32_t gpio_pin_mask)
+{
+	/* Check if all of the pins specified by the mask can be accessed by VIO. */
+	if ((gpio_pin_mask & (~HPF_PIN_MAP_VIO_VALID_PINS_MASK)) != 0) {
+		return HPF_PIN_MAP_VIO_MASK_INVALID;
+	}
+	uint16_t vio_mask = 0;
+
+	for (size_t i = 0; i < ARRAY_SIZE(hpf_pin_map); i++) {
+		if (gpio_pin_mask & BIT(i + HPF_PIN_MAP_VIO_PIN_OFFSET)) {
+			vio_mask |= BIT(hpf_pin_map[i]);
+		}
+	}
+	return vio_mask;
+}

--- a/applications/hpf/common/hpf_pin_map.h
+++ b/applications/hpf/common/hpf_pin_map.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _HPF_PIN_MAP_H__
+#define _HPF_PIN_MAP_H__
+
+#include <stdint.h>
+
+#define HPF_PIN_MAP_VIO_PIN_INVALID  UINT8_MAX
+#define HPF_PIN_MAP_VIO_MASK_INVALID UINT16_MAX
+
+/**
+ * @brief Convert GPIO pin number to VIO index.
+ *
+ * @param[in] port GPIO port number.
+ * @param[in] pin  GPIO pin number.
+ *
+ * @return VIO index corresponding to the given GPIO pin, or HPF_PIN_MAP_VIO_PIN_INVALID
+ *         if the pin cannot be accessed by VIO.
+ */
+uint8_t hpf_pin_map_to_vio_index(uint8_t port, uint8_t pin);
+
+/**
+ * @brief Convert GPIO pin mask to VIO mask.
+ *
+ * @param[in] gpio_pin_mask Mask of GPIO pins.
+ *
+ * @return VIO mask corresponding to the given GPIO pin mask, or HPF_PIN_MAP_VIO_MASK_INVALID
+ *         if any of the pins cannot be accessed by VIO.
+ */
+uint16_t hpf_pin_map_to_vio_mask(uint32_t gpio_pin_mask);
+
+#endif /* _HPF_PIN_MAP_H__ */

--- a/applications/hpf/gpio/CMakeLists.txt
+++ b/applications/hpf/gpio/CMakeLists.txt
@@ -11,7 +11,8 @@ project(hpf_gpio)
 
 hpf_assembly_install(app "${CMAKE_SOURCE_DIR}/src/hrt/hrt.c")
 
-target_sources(app PRIVATE src/main.c)
+target_include_directories(app PRIVATE ../common)
+target_sources(app PRIVATE src/main.c ../common/hpf_pin_map.c)
 
 target_sources_ifdef(CONFIG_HPF_GPIO_BACKEND_ICMSG app PRIVATE src/backend/backend_icmsg.c)
 target_sources_ifdef(CONFIG_HPF_GPIO_BACKEND_ICBMSG app PRIVATE src/backend/backend_icmsg.c)

--- a/applications/hpf/gpio/src/main.c
+++ b/applications/hpf/gpio/src/main.c
@@ -7,6 +7,8 @@
 #include "./backend/backend.h"
 #include "./hrt/hrt.h"
 
+#include "hpf_pin_map.h"
+
 #include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/drivers/gpio.h>
@@ -25,98 +27,8 @@
 #define VEVIF_IRQN(vevif) VEVIF_IRQN_1(vevif)
 #define VEVIF_IRQN_1(vevif) VPRCLIC_##vevif##_IRQn
 
-#if defined(CONFIG_SOC_NRF54L15) || defined(CONFIG_SOC_NRF54LM20A) || defined(CONFIG_SOC_NRF54LM20B)
-static const uint8_t pin_to_vio_map[] = {
-	4,  /* Physical pin 0 */
-	0,  /* Physical pin 1 */
-	1,  /* Physical pin 2 */
-	3,  /* Physical pin 3 */
-	2,  /* Physical pin 4 */
-	5,  /* Physical pin 5 */
-	6,  /* Physical pin 6 */
-	7,  /* Physical pin 7 */
-	8,  /* Physical pin 8 */
-	9,  /* Physical pin 9 */
-	10, /* Physical pin 10 */
-};
-
-#define VIO_PORT 2
-#define VIO_PIN_OFFSET 0
-
-#elif defined(CONFIG_SOC_NRF54LV10A) || defined(CONFIG_SOC_NRF54LC10A)
-static const uint8_t pin_to_vio_map[] = {
-	4,  /* Physical pin 15 */
-	0,  /* Physical pin 16 */
-	1,  /* Physical pin 17 */
-	3,  /* Physical pin 18 */
-	2,  /* Physical pin 19 */
-	5,  /* Physical pin 20 */
-	6,  /* Physical pin 21 */
-	7,  /* Physical pin 22 */
-	8,  /* Physical pin 23 */
-	9,  /* Physical pin 24 */
-};
-
-#define VIO_PORT 1
-#define VIO_PIN_OFFSET 15
-
-#elif defined(CONFIG_SOC_NRF7120)
-static const uint8_t pin_to_vio_map[] = {
-	6,  /* Physical pin 0 */
-	7,  /* Physical pin 1 */
-	8,  /* Physical pin 2 */
-	9,  /* Physical pin 3 */
-	10, /* Physical pin 4 */
-	11, /* Physical pin 5 */
-	0,  /* Physical pin 6 */
-	1,  /* Physical pin 7 */
-	2,  /* Physical pin 8 */
-	3,  /* Physical pin 9 */
-	4,  /* Physical pin 10 */
-	5,  /* Physical pin 11 */
-};
-
-#define VIO_PORT 2
-#define VIO_PIN_OFFSET 0
-
-#else
-#error "Unsupported target"
-#endif
-
-#define VIO_INDEX_INVALID UINT8_MAX
-#define VIO_PIN_MASK_INVALID UINT16_MAX
-
-#define VIO_PIN_COUNT ARRAY_SIZE(pin_to_vio_map)
-#define VIO_VALID_PIN_MASK ((BIT(VIO_PIN_COUNT) - 1) << VIO_PIN_OFFSET)
-
 volatile uint16_t irq_arg;
 volatile uint16_t irq_arg2;
-
-static uint8_t gpio_pin_port_to_vio_index(uint8_t port, uint16_t pin)
-{
-	/* Check if the pin and the port can be accessed by VIO. */
-	if ((port != VIO_PORT) || (pin < VIO_PIN_OFFSET) ||
-	    (pin >= (VIO_PIN_OFFSET + VIO_PIN_COUNT))) {
-		return VIO_INDEX_INVALID;
-	}
-	return pin_to_vio_map[pin - VIO_PIN_OFFSET];
-}
-
-static uint16_t gpio_pin_mask_to_vio_mask(uint32_t gpio_pin_mask)
-{
-	/* Check if all of the pins specified by the mask can be accessed by VIO. */
-	if ((gpio_pin_mask & (~VIO_VALID_PIN_MASK)) != 0) {
-		return VIO_PIN_MASK_INVALID;
-	}
-	uint16_t vio_mask = 0;
-
-	for (int i = 0; i < VIO_PIN_COUNT; i++) {
-		if (gpio_pin_mask & BIT(i + VIO_PIN_OFFSET)) {
-			vio_mask |= BIT(pin_to_vio_map[i]);
-		}
-	}
-	return vio_mask;
-}
 
 static nrf_gpio_pin_pull_t get_pull(gpio_flags_t flags)
 {
@@ -131,9 +43,9 @@ static nrf_gpio_pin_pull_t get_pull(gpio_flags_t flags)
 
 static int gpio_hpf_pin_configure(uint8_t port, uint16_t pin, uint32_t flags)
 {
-	uint8_t pin_vio_index = gpio_pin_port_to_vio_index(port, pin);
+	uint8_t pin_vio_index = hpf_pin_map_to_vio_index(port, pin);
 
-	if (pin_vio_index == VIO_INDEX_INVALID) {
+	if (pin_vio_index == HPF_PIN_MAP_VIO_PIN_INVALID) {
 		return -EINVAL;
 	}
 	uint32_t abs_pin = NRF_GPIO_PIN_MAP(port, pin);
@@ -204,9 +116,10 @@ void process_packet(hpf_gpio_data_packet_t *packet)
 		(void)ret;
 		__ASSERT_NO_MSG(ret == 0);
 	} else {
-		uint16_t vio_mask = gpio_pin_mask_to_vio_mask(packet->pin);
+		uint16_t vio_mask = hpf_pin_map_to_vio_mask(packet->pin);
 
-		__ASSERT_NO_MSG((packet->port == VIO_PORT) && vio_mask != VIO_PIN_MASK_INVALID);
+		__ASSERT_NO_MSG((packet->port == VIO_PORT) &&
+				(vio_mask != HPF_PIN_MAP_VIO_MASK_INVALID));
 
 		irq_arg = vio_mask;
 		switch (packet->opcode) {
@@ -223,7 +136,7 @@ void process_packet(hpf_gpio_data_packet_t *packet)
 						     VEVIF_IRQN(HRT_VEVIF_IDX_GPIO_TOGGLE));
 			break;
 		case HPF_GPIO_PORT_SET_MASKED:
-			irq_arg2 = gpio_pin_mask_to_vio_mask(packet->flags & packet->pin);
+			irq_arg2 = hpf_pin_map_to_vio_mask(packet->flags & packet->pin);
 			nrf_vpr_clic_int_pending_set(NRF_VPRCLIC,
 						     VEVIF_IRQN(HRT_VEVIF_IDX_GPIO_SET_MASKED));
 			break;

--- a/applications/hpf/mspi/CMakeLists.txt
+++ b/applications/hpf/mspi/CMakeLists.txt
@@ -11,4 +11,5 @@ project(hpf_mspi)
 
 hpf_assembly_install(app "${CMAKE_SOURCE_DIR}/src/hrt/hrt.c")
 
-target_sources(app PRIVATE src/main.c)
+target_include_directories(app PRIVATE ../common)
+target_sources(app PRIVATE src/main.c ../common/hpf_pin_map.c)

--- a/applications/hpf/mspi/src/main.c
+++ b/applications/hpf/mspi/src/main.c
@@ -6,6 +6,8 @@
 
 #include "hrt/hrt.h"
 
+#include "hpf_pin_map.h"
+
 #include <zephyr/drivers/mspi.h>
 #include <zephyr/ipc/ipc_service.h>
 #include <zephyr/kernel.h>
@@ -48,57 +50,11 @@
 #define VEVIF_IRQN(vevif)   VEVIF_IRQN_1(vevif)
 #define VEVIF_IRQN_1(vevif) VPRCLIC_##vevif##_IRQn
 
-#if defined(CONFIG_SOC_NRF54L15) || defined(CONFIG_SOC_NRF54LM20A) || \
-	defined(CONFIG_SOC_NRF54LM20B)
-
-static const uint8_t pin_to_vio_map[HPF_MSPI_PIN_COUNT] = {
-	4,  /* Physical pin 0 */
-	0,  /* Physical pin 1 */
-	1,  /* Physical pin 2 */
-	3,  /* Physical pin 3 */
-	2,  /* Physical pin 4 */
-	5,  /* Physical pin 5 */
-	6,  /* Physical pin 6 */
-	7,  /* Physical pin 7 */
-	8,  /* Physical pin 8 */
-	9,  /* Physical pin 9 */
-	10, /* Physical pin 10 */
-};
-#define VIO_PIN_OFFSET 0
-
-#elif defined(CONFIG_SOC_NRF54LV10A) || defined(CONFIG_SOC_NRF54LC10A)
-static const uint8_t pin_to_vio_map[HPF_MSPI_PIN_COUNT] = {
-	4,  /* Physical pin 15 */
-	0,  /* Physical pin 16 */
-	1,  /* Physical pin 17 */
-	3,  /* Physical pin 18 */
-	2,  /* Physical pin 19 */
-	5,  /* Physical pin 20 */
-	6,  /* Physical pin 21 */
-	7,  /* Physical pin 22 */
-	8,  /* Physical pin 23 */
-	9,  /* Physical pin 24 */
-};
-#define VIO_PIN_OFFSET 15
-
-#else
-#error "Unsupported SoC for HPF MSPI"
-#endif
-
 #define DATA_LINE_INDEX(pinctr_fun) (pinctr_fun - NRF_FUN_HPF_MSPI_DQ0)
 
 #ifndef CONFIG_HPF_MSPI_IPC_NO_COPY
 BUILD_ASSERT(CONFIG_HPF_MSPI_MAX_RESPONSE_SIZE > 0, "Response max size should be greater that 0");
 #endif
-
-static uint8_t gpio_pin_to_vio_index(uint16_t pin)
-{
-	/* Check if the pin and the port can be accessed by VIO. */
-	if ((pin >= VIO_PIN_OFFSET) && (pin < (VIO_PIN_OFFSET + HPF_MSPI_PIN_COUNT))) {
-		return pin_to_vio_map[pin - VIO_PIN_OFFSET];
-	}
-	return INVALID_VIO;
-}
 
 static const hrt_xfer_bus_widths_t io_modes[SUPPORTED_IO_MODES_COUNT] = {
 	{1, 1, 1, 1}, /* MSPI_IO_MODE_SINGLE */
@@ -401,9 +357,11 @@ static void config_pins(hpf_mspi_pinctrl_soc_pin_msg_t *pins_cfg)
 		}
 
 		uint8_t pin_number = NRF_PIN_NUMBER_TO_PIN(psel);
-		uint8_t vio_pin = gpio_pin_to_vio_index(pin_number);
+		uint8_t port_number = NRF_PIN_NUMBER_TO_PORT(psel);
 
-		NRFX_ASSERT(vio_pin != INVALID_VIO);
+		uint8_t vio_pin = hpf_pin_map_to_vio_index(port_number, pin_number);
+
+		NRFX_ASSERT(vio_pin != HPF_PIN_MAP_VIO_PIN_INVALID);
 
 		if ((fun >= NRF_FUN_HPF_MSPI_CS0) && (fun <= NRF_FUN_HPF_MSPI_CS4)) {
 


### PR DESCRIPTION
Move GPIO-VIO pin mappings from MSPI and GPIO applications to a common location.