### PR TITLE
tools: update ccache version to 4.13.4

### DIFF
--- a/scripts/tools-versions-darwin.yml
+++ b/scripts/tools-versions-darwin.yml
@@ -22,6 +22,8 @@ zephyr-sdk:
   architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v1.0.1
     - arm-zephyr-eabi
     - riscv64-zephyr-elf
+ccache:
+  version: 4.13.6
 doxygen:
   version: 1.12.0
 pip:

--- a/scripts/tools-versions-linux.yml
+++ b/scripts/tools-versions-linux.yml
@@ -22,7 +22,7 @@ zephyr-sdk:
     - arm-zephyr-eabi
     - riscv64-zephyr-elf
 ccache:
-  version: 4.8.2
+  version: 4.12.3
 dfu_util:
   version: 0.9-1
 doxygen:

--- a/scripts/tools-versions-win10.yml
+++ b/scripts/tools-versions-win10.yml
@@ -21,6 +21,8 @@ zephyr-sdk:
   architectures: # https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v1.0.1
     - arm-zephyr-eabi
     - riscv64-zephyr-elf
+ccache:
+  version: 4.13.4
 doxygen:
   version: 1.12.0
 pip:


### PR DESCRIPTION
ccache <4.12 has a bug causing it to miss cache, see: https://github.com/ccache/ccache/issues/1625

Update ccache version to 4.13.4 to ensure a working ccache for build performance improvements.

Also add ccache to Windows tools so windows can benefit from ccache.