### PR TITLE
[Backport v3.3-branch] doc: zephyr: Limit twister execution to Nordic boards

### DIFF
--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -102,6 +102,9 @@ warnings_filter_silent = True
 
 kconfig_generate_db = False
 
+# -- Options for zephyr.domain -------------------------------------------------
+zephyr_hw_features_vendor_filter = ["nordic"]
+
 # -- Options for zephyr.gh_utils -----------------------------------------------
 
 gh_link_version = "main" if version.endswith("99") else f"v{version}"


### PR DESCRIPTION
Backport b0da3ef3feb5fbdfea55ad5171bf59df525d5dd6 from #28794.