### PR TITLE
Fix TF-M minimal

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -9,12 +9,6 @@
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-29460"
 
 - scenarios:
-    - sample.dect.dect_shell.nrf_cloud_mqtt
-  platforms:
-    - nrf9151dk/nrf9151/ns
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-38328"
-
-- scenarios:
     - nrf.extended.drivers.uart.async_dual
     - nrf.extended.drivers.uart.async_dual.busy_sim
     - nrf.extended.drivers.uart.async_dual.pm_runtime

--- a/subsys/nrf_security/src/drivers/Kconfig
+++ b/subsys/nrf_security/src/drivers/Kconfig
@@ -16,6 +16,7 @@ config PSA_CRYPTO_DRIVER_OBERON
 config PSA_CRYPTO_DRIVER_CC3XX
 	bool "CryptoCell PSA driver"
 	depends on HAS_HW_NRF_CC3XX
+	default y if TFM_PROFILE_TYPE_MINIMAL
 	help
 	  This configuration enables the usage of CryptoCell for the supported operations.
 	  Disabling this option will result in all crypto operations being handled by


### PR DESCRIPTION
This default-enables nrf_cc3xx for TFM_PROFILE_TYPE_MINIMAL which depends on nrf_cc3xx for the smallest possible build. 

Due to some refactoring, `nrf_oberon` was picked even when this was not intended. There was a fix in nrf_cc3xx 0.9.22 that is also required for this removal of quarantine

ref: NCSDK-38328