### PR TITLE
doc: Add README for CI-shell and zpref snippets

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -783,6 +783,7 @@
 
 # Snippets
 /snippets/ci-shell/                       @nrfconnect/ncs-protocols-serialization
+/snippets/ci-shell/*.rst                  @nrfconnect/ncs-terahertz-doc
 /snippets/coverage_support/               @nrfconnect/ncs-low-level-test
 /snippets/hpf/                            @nrfconnect/ncs-ll-ursus
 /snippets/hw-flow-control/                @nrfconnect/ncs-low-level-test @miha-nordic
@@ -800,6 +801,7 @@
 /snippets/tfm-enable-share-uart/          @nrfconnect/ncs-cia
 /snippets/wpa-supplicant-debug/           @krish2718 @sachinthegreen
 /snippets/zperf/                          @nrfconnect/ncs-protocols-serialization
+/snippets/zperf/*.rst                     @nrfconnect/ncs-terahertz-doc
 
 # SoC
 /soc/nordic/                              @nrfconnect/ncs-code-owners

--- a/snippets/ci-shell/README.rst
+++ b/snippets/ci-shell/README.rst
@@ -1,0 +1,29 @@
+.. _snippet-ci-shell:
+
+CI shell snippet (ci-shell)
+###########################
+
+.. contents::
+   :local:
+   :depth: 2
+
+This snippet configures the Zephyr shell for automated testing and continuous integration (CI) environments by making the console output clean, consistent, and easy to parse.
+It removes interactive elements and visual formatting that can interfere with automated analysis.
+
+The snippet applies the following configuration:
+
+* Disables the boot banner (:kconfig:option:`CONFIG_BOOT_BANNER`) to keep the startup output clean.
+* Sets an empty shell prompt (:kconfig:option:`CONFIG_SHELL_PROMPT_UART`) so that the prompt string does not appear in the captured output.
+* Disables VT100 color escape sequences (:kconfig:option:`CONFIG_SHELL_VT100_COLORS`) to avoid control characters in the output.
+* Sets a wide default terminal width (:kconfig:option:`CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH`) to prevent the shell from wrapping long lines.
+* Keeps the device running after a fatal error by disabling the :kconfig:option:`CONFIG_RESET_ON_FATAL_ERROR` Kconfig option so that the failure state can be inspected.
+* Enables thread information for debugging (:kconfig:option:`CONFIG_DEBUG_THREAD_INFO`).
+
+Usage
+*****
+
+Apply the snippet when building, for example:
+
+.. code-block:: console
+
+   west build -S ci-shell [...]

--- a/snippets/zperf/README.rst
+++ b/snippets/zperf/README.rst
@@ -1,0 +1,27 @@
+.. _snippet-zperf:
+
+Zperf snippet (zperf)
+#####################
+
+.. contents::
+   :local:
+   :depth: 2
+
+This snippet enables the :ref:`Zperf <zephyr:zperf>` network throughput measurement tool, allowing you to benchmark TCP and UDP performance over the device network connection.
+It configures the device to run as a zperf server and exposes the network and zperf shell commands for controlling the measurements.
+
+The snippet applies the following configuration:
+
+* Enables the network shell (:kconfig:option:`CONFIG_NET_SHELL`) to provide the ``net`` and ``zperf`` shell commands.
+* Enables the zperf tool (:kconfig:option:`CONFIG_NET_ZPERF`) and the zperf server (:kconfig:option:`CONFIG_NET_ZPERF_SERVER`).
+* Enables BSD sockets support (:kconfig:option:`CONFIG_NET_SOCKETS`) and a receive timeout for network contexts (:kconfig:option:`CONFIG_NET_CONTEXT_RCVTIMEO`).
+* Increases the maximum number of concurrently open file descriptors (:kconfig:option:`CONFIG_ZVFS_OPEN_MAX`) and the maximum number of file descriptors that can be polled (:kconfig:option:`CONFIG_ZVFS_POLL_MAX`) to accommodate the sockets used during measurements.
+
+Usage
+*****
+
+Apply the snippet when building, for example:
+
+.. code-block:: console
+
+   west build -S zperf [...]


### PR DESCRIPTION
Add README for CI-shell and zpref snippets.

Planning to add README for all snippets, which later be added under Application development -> Configuring and building.

NCSDK-31921