### PR TITLE
tests: subsys: net: lib: nrf_cloud: Disable Partition Manager

### DIFF
--- a/tests/subsys/net/lib/nrf_cloud/client_id/Kconfig.sysbuild
+++ b/tests/subsys/net/lib/nrf_cloud/client_id/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/tests/subsys/net/lib/nrf_cloud/client_id/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/tests/subsys/net/lib/nrf_cloud/client_id/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/cellular/nrf91_no_bootloader_partitions.dtsi>
+
+#include <samples/cellular/nrf91_sram_partitions.dtsi>

--- a/tests/subsys/net/lib/nrf_cloud/cloud/Kconfig.sysbuild
+++ b/tests/subsys/net/lib/nrf_cloud/cloud/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/tests/subsys/net/lib/nrf_cloud/cloud/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/tests/subsys/net/lib/nrf_cloud/cloud/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/cellular/nrf91_no_bootloader_partitions.dtsi>
+
+#include <samples/cellular/nrf91_sram_partitions.dtsi>

--- a/tests/subsys/net/lib/nrf_cloud/fota_common/Kconfig.sysbuild
+++ b/tests/subsys/net/lib/nrf_cloud/fota_common/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"

--- a/tests/subsys/net/lib/nrf_cloud/fota_common/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/tests/subsys/net/lib/nrf_cloud/fota_common/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/cellular/nrf91_bootloader_partitions.dtsi>
+
+#include <samples/cellular/nrf91_sram_partitions.dtsi>


### PR DESCRIPTION
Add Devicetree partitions and disable Partition Manager for the
client_id, cloud, and fota_common test suites.

Signed-off-by: Noah Pendleton <noah.pendleton@nordicsemi.no>
