### PR TITLE
samples: bluetooth: peripheral_hids conn_rate fail log fix

### DIFF
--- a/samples/bluetooth/peripheral_hids_keyboard/src/main.c
+++ b/samples/bluetooth/peripheral_hids_keyboard/src/main.c
@@ -382,7 +382,7 @@ static void conn_rate_changed(struct bt_conn *conn, uint8_t status,
 	}
 
 	if (status != BT_HCI_ERR_SUCCESS) {
-		printk("Connection %zu: Connection rate change failed: %s\n", i,
+		printk("Connection %zu: Connection rate change failed: 0x%02x %s\n", i, status,
 		       bt_hci_err_to_str(status));
 		return;
 	}

--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -490,7 +490,7 @@ static void conn_rate_changed(struct bt_conn *conn, uint8_t status,
 	}
 
 	if (status != BT_HCI_ERR_SUCCESS) {
-		printk("Connection %zu: Connection rate change failed: %s\n", i,
+		printk("Connection %zu: Connection rate change failed: 0x%02x %s\n", i, status,
 		       bt_hci_err_to_str(status));
 		return;
 	}


### PR DESCRIPTION
The log printed in conn_rate_changed failure only printed bt_hci_err_to_str(status) and not the hex error (as is done in the connected/disconnected failure case).

This led to an empty error string being printed
when CONFIG_BT_HCI_ERR_TO_STR=n