### PR TITLE
[Backport v3.4-branch] test: subsys: nrf_profiler: disable Partition Manager for nRF5340 ns

### DIFF
--- a/tests/subsys/nrf_profiler/Kconfig.sysbuild
+++ b/tests/subsys/nrf_profiler/Kconfig.sysbuild
@@ -5,6 +5,6 @@
 #
 
 config PARTITION_MANAGER
-	default n if !BOARD_IS_NON_SECURE
+	default n if !BOARD_IS_NON_SECURE || SOC_SERIES_NRF53
 
 source "share/sysbuild/Kconfig"

--- a/tests/subsys/nrf_profiler/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/tests/subsys/nrf_profiler/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * No bootloader is built in this configuration.
+ * The default nRF5340 partition layout reserves the first 64 KB for MCUboot.
+ * The TF-M storage and settings partitions from the board devicetree
+ * (0xf0000 onwards) are kept and still used.
+ */
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+
+&flash0 {
+	partitions {
+		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x00000000 0xf0000>;
+			ranges = <0x0 0x0 0xf0000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_s_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-secure";
+				reg = <0x00000000 0x40000>;
+			};
+
+			slot0_ns_partition: partition@40000 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-nonsecure";
+				reg = <0x00040000 0xb0000>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Backport c329fcc3295e85e813c87fb553f7d832877d381c from #29422.