### PR TITLE
[Backport v3.4-branch] samples: matter: Remove /ns from sample.yaml

### DIFF
--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -23,7 +23,6 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15tag/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp


### PR DESCRIPTION
Backport 25491211224ff86cbd9c929cfea286f14c7a90e5 from #29435.