### PR TITLE
[Backport v3.4-branch] samples: bluetooth: peripheral_hids conn_rate fail log fix

### DIFF
--- a/samples/bluetooth/peripheral_hids_keyboard/src/main.c
+++ b/samples/bluetooth/peripheral_hids_keyboard/src/main.c
@@ -382,7 +382,7 @@ static void conn_rate_changed(struct bt_conn *conn, uint8_t status,
 	}
 
 	if (status != BT_HCI_ERR_SUCCESS) {
-		printk("Connection %zu: Connection rate change failed: %s\n", i,
+		printk("Connection %zu: Connection rate change failed: 0x%02x %s\n", i, status,
 		       bt_hci_err_to_str(status));
 		return;
 	}

--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -490,7 +490,7 @@ static void conn_rate_changed(struct bt_conn *conn, uint8_t status,
 	}
 
 	if (status != BT_HCI_ERR_SUCCESS) {
-		printk("Connection %zu: Connection rate change failed: %s\n", i,
+		printk("Connection %zu: Connection rate change failed: 0x%02x %s\n", i, status,
 		       bt_hci_err_to_str(status));
 		return;
 	}


### PR DESCRIPTION
Backport a4fef4e4e8fafac83fa67591e5c6ea40767deb8b from #29438.