### PR TITLE
[Backport v3.4-branch] samples: bluetooth: hids: disable Partition Manager for nRF5340 ns

### DIFF
--- a/samples/bluetooth/central_hids/Kconfig.sysbuild
+++ b/samples/bluetooth/central_hids/Kconfig.sysbuild
@@ -5,7 +5,7 @@
 #
 
 config PARTITION_MANAGER
-	default n if !BOARD_IS_NON_SECURE
+	default n
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/central_hids/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/central_hids/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * No bootloader is built in this configuration.
+ * The default nRF5340 partition layout reserves the first 64 KB for MCUboot.
+ * The TF-M storage and settings partitions from the board devicetree
+ * (0xf0000 onwards) are kept and still used.
+ */
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+
+&flash0 {
+	partitions {
+		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x00000000 0xf0000>;
+			ranges = <0x0 0x0 0xf0000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_s_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-secure";
+				reg = <0x00000000 0x40000>;
+			};
+
+			slot0_ns_partition: partition@40000 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-nonsecure";
+				reg = <0x00040000 0xb0000>;
+			};
+		};
+	};
+};

--- a/samples/bluetooth/peripheral_hids_keyboard/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_hids_keyboard/Kconfig.sysbuild
@@ -5,7 +5,7 @@
 #
 
 config PARTITION_MANAGER
-	default n if !BOARD_IS_NON_SECURE
+	default n
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_hids_keyboard/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_hids_keyboard/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * No bootloader is built in this configuration.
+ * The default nRF5340 partition layout reserves the first 64 KB for MCUboot.
+ * The TF-M storage and settings partitions from the board devicetree
+ * (0xf0000 onwards) are kept and still used.
+ */
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+
+&flash0 {
+	partitions {
+		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x00000000 0xf0000>;
+			ranges = <0x0 0x0 0xf0000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_s_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-secure";
+				reg = <0x00000000 0x40000>;
+			};
+
+			slot0_ns_partition: partition@40000 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-nonsecure";
+				reg = <0x00040000 0xb0000>;
+			};
+		};
+	};
+};

--- a/samples/bluetooth/peripheral_hids_mouse/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_hids_mouse/Kconfig.sysbuild
@@ -5,7 +5,7 @@
 #
 
 config PARTITION_MANAGER
-	default n if !BOARD_IS_NON_SECURE
+	default n
 
 config NRF_DEFAULT_IPC_RADIO
 	default y

--- a/samples/bluetooth/peripheral_hids_mouse/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_hids_mouse/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * No bootloader is built in this configuration.
+ * The default nRF5340 partition layout reserves the first 64 KB for MCUboot.
+ * The TF-M storage and settings partitions from the board devicetree
+ * (0xf0000 onwards) are kept and still used.
+ */
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+
+&flash0 {
+	partitions {
+		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x00000000 0xf0000>;
+			ranges = <0x0 0x0 0xf0000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_s_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-secure";
+				reg = <0x00000000 0x40000>;
+			};
+
+			slot0_ns_partition: partition@40000 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-nonsecure";
+				reg = <0x00040000 0xb0000>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Backport fe255b2deb3b63d4bc5b11142be1ef40eee7e8be from #29386.