### PR TITLE
[Backport v3.4-branch] samples: esb: disable Partition Manager in sysbuild

### DIFF
--- a/samples/esb/esb_prx/Kconfig.sysbuild
+++ b/samples/esb/esb_prx/Kconfig.sysbuild
@@ -5,7 +5,7 @@
 #
 
 config PARTITION_MANAGER
-	default n if !BOARD_IS_NON_SECURE
+	default n
 
 config NRF_DEFAULT_EMPTY
 	default y if SOC_SERIES_NRF53X

--- a/samples/esb/esb_prx_ble/Kconfig.sysbuild
+++ b/samples/esb/esb_prx_ble/Kconfig.sysbuild
@@ -1,3 +1,12 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
 config NRF_DEFAULT_EMPTY
 	default y if SOC_SERIES_NRF53X
 

--- a/samples/esb/esb_ptx/Kconfig.sysbuild
+++ b/samples/esb/esb_ptx/Kconfig.sysbuild
@@ -5,7 +5,7 @@
 #
 
 config PARTITION_MANAGER
-	default n if !BOARD_IS_NON_SECURE
+	default n
 
 config NRF_DEFAULT_EMPTY
 	default y if SOC_SERIES_NRF53X

--- a/samples/esb/esb_ptx_ble/Kconfig.sysbuild
+++ b/samples/esb/esb_ptx_ble/Kconfig.sysbuild
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+config PARTITION_MANAGER
+	default n
+
 config NRF_DEFAULT_EMPTY
 	default y if SOC_SERIES_NRF53X
 


### PR DESCRIPTION
Backport c54ff8635a3ed26506f36f4966f28f401bbf62c1 from #29456.