### PR TITLE
samples: nrf_auraconfig: Adjust to timestamp changes

### DIFF
--- a/applications/nrf_audio/include/zbus_common.h
+++ b/applications/nrf_audio/include/zbus_common.h
@@ -13,6 +13,7 @@
 
 #define ZBUS_READ_TIMEOUT_MS	K_MSEC(100)
 #define ZBUS_ADD_OBS_TIMEOUT_MS K_MSEC(200)
+#define ZBUS_STREAMS_NUM_MAX	8
 
 /***** Messages for zbus ******/
 
@@ -48,14 +49,27 @@ struct le_audio_msg {
 	struct bt_bap_stream *stream;
 };
 
+enum tx_data_status {
+	STATUS_NOT_SET = 0,		  /* Initial status */
+	STATUS_SENT_WITH_TS,		  /* Data sent with timestamp */
+	STATUS_SENT_WITHOUT_TS,		  /* Data sent without timestamp */
+	STATUS_OVERRUN_FLUSHED,		  /* Data overrun, flushed */
+	STATUS_UNDERRUN_EMPTY_SDU_ON_AIR, /* Data underrun, empty SDU on air */
+	STATUS_ERROR,			  /* Error occurred (e.g. failed to send) */
+};
+
 /**
  * tx_sync_ts_us	The timestamp from get_tx_sync.
  * curr_ts_us		The current time. This must be in the controller frame of reference.
  */
 struct sdu_ref_msg {
 	uint32_t tx_sync_ts_us;
+	bool tx_sync_ts_us_valid;
 	uint32_t curr_ts_us;
+	enum tx_data_status status;
 	bool adjust;
+	struct stream_index idx[ZBUS_STREAMS_NUM_MAX];
+	uint8_t num_idx;
 };
 
 enum bt_mgmt_evt_type {

--- a/applications/nrf_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/broadcast/broadcast_source.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/zbus/zbus.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/cap.h>
@@ -49,11 +50,47 @@ static struct bt_cap_stream cap_streams[CONFIG_BT_ISO_MAX_BIG]
 
 static struct bt_bap_lc3_preset lc3_preset = BT_BAP_LC3_BROADCAST_PRESET_NRF_AUDIO;
 
-static bool initialized;
+static bool initialized[CONFIG_BT_ISO_MAX_BIG];
 static bool delete_broadcast_src[CONFIG_BT_ISO_MAX_BIG];
 static uint32_t stored_broadcast_id;
 
-BT_LE_AUDIO_TX_DEFINE(bt_le_audio_tx);
+/* Define one TX context per subgroup per BIG.
+ * Note: Nested LISTIFY is not supported by the C preprocessor due to
+ * blue-painting rules, so we use separate macros per BIG index.
+ */
+#define DEFINE_SG_CTX_BIG0(sg_idx, _) BT_LE_AUDIO_TX_DEFINE_INDEXED(tx_ctx, 0, sg_idx)
+LISTIFY(CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT, DEFINE_SG_CTX_BIG0, (;), ~);
+
+#if CONFIG_BT_ISO_MAX_BIG == 2
+#define DEFINE_SG_CTX_BIG1(sg_idx, _) BT_LE_AUDIO_TX_DEFINE_INDEXED(tx_ctx, 1, sg_idx)
+LISTIFY(CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT, DEFINE_SG_CTX_BIG1, (;), ~);
+#elif CONFIG_BT_ISO_MAX_BIG > 2
+#error Only up to 2 BIGs supported for static TX context allocation
+#endif
+
+#define SG_CTX_PTR_BIG0(sg_idx, _) (&tx_ctx_0_##sg_idx##_ctx)
+#define SG_CTX_PTR_BIG1(sg_idx, _) (&tx_ctx_1_##sg_idx##_ctx)
+
+static struct bt_le_audio_tx_ctx
+	*tx_ctx_arr[CONFIG_BT_ISO_MAX_BIG][CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT] = {
+		/* clang-format off */
+		{LISTIFY(CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT, SG_CTX_PTR_BIG0, (,), ~)},
+#if CONFIG_BT_ISO_MAX_BIG > 1
+		{LISTIFY(CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT, SG_CTX_PTR_BIG1, (,), ~)},
+#endif
+		/* clang-format on */
+};
+
+/* Helper to get context for a given BIG and subgroup */
+static struct bt_le_audio_tx_ctx *tx_ctx_get(uint8_t big_idx, uint8_t sg_idx)
+{
+	if (big_idx >= CONFIG_BT_ISO_MAX_BIG ||
+	    sg_idx >= CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT) {
+		return NULL;
+	}
+
+	return tx_ctx_arr[big_idx][sg_idx];
+}
 
 static int metadata_u8_add(uint8_t buffer[], uint8_t *index, uint8_t type, uint8_t value)
 {
@@ -115,7 +152,9 @@ static void stream_sent_cb(struct bt_bap_stream *stream)
 		le_audio_event_publish(LE_AUDIO_EVT_STREAM_SENT, &idx);
 	}
 
-	ERR_CHK(bt_le_audio_tx_stream_sent(bt_le_audio_tx, idx));
+	struct bt_le_audio_tx_ctx *ctx = tx_ctx_get(idx.lvl1, idx.lvl2);
+
+	ERR_CHK(bt_le_audio_tx_stream_sent(ctx, idx));
 }
 
 static void stream_started_cb(struct bt_bap_stream *stream)
@@ -128,7 +167,9 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 		return;
 	}
 
-	ERR_CHK(bt_le_audio_tx_stream_started(bt_le_audio_tx, idx));
+	struct bt_le_audio_tx_ctx *ctx = tx_ctx_get(idx.lvl1, idx.lvl2);
+
+	ERR_CHK(bt_le_audio_tx_stream_started(ctx, idx));
 
 	le_audio_event_publish(LE_AUDIO_EVT_STREAMING, &idx);
 
@@ -666,13 +707,11 @@ int broadcast_source_send(struct net_buf const *const audio_frame, uint8_t big_i
 		return -ECANCELED;
 	}
 
-	ret = bt_le_audio_tx_send(bt_le_audio_tx, audio_frame, tx, num_active_streams);
+	struct bt_le_audio_tx_ctx *ctx = tx_ctx_get(big_index, subgroup_index);
+
+	ret = bt_le_audio_tx_send(ctx, audio_frame, tx, num_active_streams);
 	if (ret) {
-		if (ret == -ECANCELED || ret == -ETIMEDOUT) {
-			LOG_DBG("Adjusted audio TX: %d", ret);
-		} else {
-			return ret;
-		}
+		return ret;
 	}
 
 	return 0;
@@ -710,7 +749,7 @@ int broadcast_source_disable(uint8_t big_index)
 		broadcast_sources[big_index] = NULL;
 	}
 
-	initialized = false;
+	initialized[big_index] = false;
 
 	LOG_DBG("Broadcast source disabled");
 
@@ -823,15 +862,6 @@ int broadcast_source_enable(struct broadcast_source_big const *const broadcast_p
 		return -EINVAL;
 	}
 
-	if (!initialized) {
-		/* A broadcast source is the Bluetooth central device */
-		ret = bt_le_audio_tx_init(bt_le_audio_tx, true);
-		if (ret != 0) {
-			LOG_ERR("Failed to initialize LE Audio TX: %d", ret);
-			return ret;
-		}
-	}
-
 	ret = bt_cap_initiator_register_cb(&cap_cbs);
 
 	if (ret == -EALREADY) {
@@ -847,12 +877,28 @@ int broadcast_source_enable(struct broadcast_source_big const *const broadcast_p
 		return ret;
 	}
 
-	/* Register callbacks per stream */
-	for (size_t j = 0U; j < create_param[big_index].subgroup_count; j++) {
-		for (size_t k = 0; k < create_param[big_index].subgroup_params[j].stream_count;
-		     k++) {
+	for (size_t i = 0; i < create_param[big_index].subgroup_count; i++) {
+		if (!initialized[big_index]) {
+			struct bt_le_audio_tx_ctx *ctx = tx_ctx_get(big_index, i);
+
+			if (ctx == NULL) {
+				LOG_ERR("Failed to get context for BIG %d subgroup %d", big_index,
+					i);
+				return -EINVAL;
+			}
+
+			ret = bt_le_audio_tx_init(ctx, true);
+			if (ret != 0) {
+				LOG_ERR("Failed to initialize LE Audio TX: %d", ret);
+				return ret;
+			}
+		}
+
+		/* Register callbacks per stream */
+		for (size_t j = 0; j < create_param[big_index].subgroup_params[i].stream_count;
+		     j++) {
 			bt_cap_stream_ops_register(
-				create_param[big_index].subgroup_params[j].stream_params[k].stream,
+				create_param[big_index].subgroup_params[i].stream_params[j].stream,
 				&stream_ops);
 		}
 	}
@@ -864,7 +910,7 @@ int broadcast_source_enable(struct broadcast_source_big const *const broadcast_p
 		return ret;
 	}
 
-	initialized = true;
+	initialized[big_index] = true;
 	LOG_INF("Created: %p %s", (void *)broadcast_sources[big_index],
 		broadcast_param->broadcast_name);
 

--- a/applications/nrf_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
@@ -11,7 +11,6 @@
 #include <zephyr/zbus/zbus.h>
 #include <../subsys/bluetooth/audio/bap_stream.h>
 #include <bluetooth/hci_vs_sdc.h>
-#include <audio_defines.h>
 #include <sdc_hci.h>
 
 #include "zbus_common.h"
@@ -59,6 +58,31 @@ ZBUS_CHAN_DEFINE(sdu_ref_chan, struct sdu_ref_msg, NULL, NULL, ZBUS_OBSERVERS_EM
  * to stabilize and potentially drop data to meet just-in-time requirements.
  */
 #define SUBSEQUENT_RAPID_CORRECTIONS_LIMIT 20U
+
+#define ISO_FLUSH_Q_STACK_SIZE 512
+
+BUILD_ASSERT(IS_ENABLED(CONFIG_BT_TX_PROCESSOR_THREAD), "BT_TX_PROCESSOR_THREAD must be enabled");
+
+#if CONFIG_BT_TX_PROCESSOR_THREAD_PRIO == K_LOWEST_APPLICATION_THREAD_PRIO
+#error "CONFIG_BT_TX_PROCESSOR_THREAD_PRIO must be set higher than K_LOWEST_APPLICATION_THREAD_PRIO"
+#endif
+#define ISO_FLUSH_Q_PRIORITY 0
+
+BUILD_ASSERT(ISO_FLUSH_Q_PRIORITY > CONFIG_BT_TX_PROCESSOR_THREAD_PRIO,
+	     "ISO_FLUSH_Q_PRIORITY must have a lower or equal priority than "
+	     "CONFIG_BT_TX_PROCESSOR_THREAD_PRIO");
+
+static const int prio_bt_tx = CONFIG_BT_TX_PROCESSOR_THREAD_PRIO;
+
+K_THREAD_STACK_DEFINE(iso_flush_work_q_stack_area, ISO_FLUSH_Q_STACK_SIZE);
+
+static struct k_work_q iso_flush_work_q;
+static struct k_work iso_flush_work;
+
+static void iso_flush_work_handler(struct k_work *work)
+{
+	(void)work;
+}
 
 /**
  * @brief Sends audio data over a single BAP stream.
@@ -292,6 +316,28 @@ static int controller_ts_tx_get(const struct bt_bap_stream *bap_stream, uint32_t
 		return ret;
 	}
 
+	/* The host may re-order ISO and command data. Hence, we flush the ISO data by executing
+	 * a workqueue which executes with lower priority than the BT TX processor.
+	 * See https://github.com/zephyrproject-rtos/zephyr/issues/110939.
+	 */
+	int prio_this = k_thread_priority_get(k_current_get());
+
+	LOG_DBG("Tx sync. Current prio: %d, BT TX processor prio: %d", prio_this, prio_bt_tx);
+
+	if (prio_this <= prio_bt_tx || prio_this < 0) {
+		ret = k_work_submit_to_queue(&iso_flush_work_q, &iso_flush_work);
+		if (ret < 0) {
+			LOG_WRN("Failed to submit ISO flush work: %d", ret);
+			return ret;
+		}
+
+		ret = k_work_queue_drain(&iso_flush_work_q, false);
+		if (ret < 0) {
+			LOG_ERR("Failed to drain ISO flush work return value: %d", ret);
+			return -EFAULT;
+		}
+	}
+
 	ret = get_tx_sync_sdc(tx_info->iso_conn_handle, &tx_info->iso_tx_readback);
 	if (ret != 0) {
 		LOG_ERR("Unable to get tx sync. ret: %d", ret);
@@ -364,8 +410,7 @@ static uint8_t tx_streams_send(struct bt_le_audio_tx_ctx *ctx,
 
 	for (int i = 0; i < num_tx; i++) {
 		const struct bt_bap_stream *bap_stream = &tx[i].cap_stream->bap_stream;
-		struct tx_inf *tx_info =
-			&ctx->tx_info_arr[tx[i].idx.lvl1][tx[i].idx.lvl2][tx[i].idx.lvl3];
+		struct tx_inf *tx_info = &ctx->tx_info_arr[tx[i].idx.lvl3];
 
 		/* Check if same audio is sent to all locations */
 		if (num_loc == 1U) {
@@ -403,7 +448,7 @@ static uint8_t tx_streams_send(struct bt_le_audio_tx_ctx *ctx,
 static int tx_controller_sync_and_correct(struct bt_le_audio_tx_ctx *ctx,
 					  const struct bt_bap_stream *last_successful_bap_stream,
 					  uint32_t common_interval_us, uint32_t ts_now_us,
-					  struct tx_inf *tx_info, int *status)
+					  struct tx_inf *tx_info)
 {
 	int ret;
 	uint32_t ts_ctlr_real_us = 0U;
@@ -440,6 +485,8 @@ static int tx_controller_sync_and_correct(struct bt_le_audio_tx_ctx *ctx,
 	}
 
 	corr_diff_us = (int64_t)ts_ctlr_real_us - (int64_t)ctx->ts_ctlr_esti_us;
+	LOG_DBG("Controller timestamp sync required. Estimated: %u us, Real: %u us, Diff: %lld us",
+		ctx->ts_ctlr_esti_us, ts_ctlr_real_us, corr_diff_us);
 
 	if ((uint32_t)(ts_now_us - ctx->ts_last_correction) < TX_TS_RESYNC_US) {
 		ctx->subsequent_rapid_corrections++;
@@ -480,18 +527,17 @@ static int tx_controller_sync_and_correct(struct bt_le_audio_tx_ctx *ctx,
 		LOG_DBG("TX clock corrected by (%lld us). Late: Empty packet(s) on air",
 			corr_diff_us);
 
-		ctx->ts_ctlr_esti_us_valid = false;
-		*status = -ETIMEDOUT;
-
+		ctx->ts_ctlr_esti_us_valid = true;
 	} else if (corr_diff_us < -half_common_interval_us) {
 		LOG_DBG("TX clock corrected by (%lld us). Early", corr_diff_us);
-		ctx->ts_ctlr_esti_us_valid = false;
+		ctx->ts_ctlr_esti_us_valid = true;
 	} else {
 		/* Ts corrected by some small factor*/
 		if (ctx->is_ble_clock_master) {
 			/* The gateway is the Bluetooth central. This shall not happen */
 			LOG_ERR("TX clock has been drift adjusted by (%lld us)", corr_diff_us);
 			ctx->ts_ctlr_esti_us_valid = false;
+			return -EFAULT;
 		} else {
 			LOG_DBG("TX clock has been drift adjusted by (%lld us)", corr_diff_us);
 			ctx->ts_ctlr_esti_us_valid = true;
@@ -507,26 +553,37 @@ static int tx_controller_sync_and_correct(struct bt_le_audio_tx_ctx *ctx,
 	return 0;
 }
 
-static void tx_publish_sdu_ref_and_finalize(struct bt_le_audio_tx_ctx *ctx, uint32_t ts_now_us)
+static int tx_publish_sdu_ref_and_finalize(struct bt_le_audio_tx_ctx *ctx, uint32_t ts_now_us,
+					   struct le_audio_tx_info *tx, uint8_t num_tx)
 {
 	int ret;
 	struct sdu_ref_msg msg;
 
 	msg.tx_sync_ts_us = ctx->ts_ctlr_esti_us;
-	msg.curr_ts_us = ts_now_us;
+	msg.tx_sync_ts_us_valid = ctx->ts_ctlr_esti_us_valid;
+	msg.curr_ts_us = audio_sync_timer_capture();
 	msg.adjust = true;
+	msg.status = ctx->last_data_status;
+
+	/* Add stream indices */
+	msg.num_idx = num_tx;
+	for (uint8_t i = 0; i < num_tx; i++) {
+		msg.idx[i] = tx[i].idx;
+	}
 
 	ret = zbus_chan_pub(&sdu_ref_chan, &msg, K_NO_WAIT);
 	if (ret != 0) {
-		LOG_WRN("Failed to publish timestamp: %d", ret);
+		LOG_ERR("Failed to publish timestamp: %d", ret);
+		return ret;
 	}
+
+	return 0;
 }
 
 int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *const audio_frame,
 			struct le_audio_tx_info *tx, uint8_t num_tx)
 {
 	int ret;
-	int status = 0;
 	size_t data_size_pr_stream = 0U;
 
 	if (unlikely(ctx == NULL || tx == NULL || num_tx == 0U || audio_frame == NULL)) {
@@ -582,21 +639,21 @@ int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *co
 		return ret;
 	}
 
-	if (num_streaming_state == 0U) {
-		LOG_DBG("No streams are in streaming state");
-		return 0;
-	}
-
-	uint8_t sent_streams = 0U;
-	const struct bt_bap_stream *last_successful_bap_stream = NULL;
-	struct tx_inf *tx_info = NULL;
-
 	if (common_interval_us == 0U) {
 		LOG_ERR("common_interval is zero");
 		return -EINVAL;
 	}
 
 	uint32_t ts_now_us = audio_sync_timer_capture();
+
+	if (num_streaming_state == 0U) {
+		LOG_DBG("No streams are in streaming state");
+		goto finalize;
+	}
+
+	uint8_t sent_streams = 0U;
+	const struct bt_bap_stream *last_successful_bap_stream = NULL;
+	struct tx_inf *tx_info = NULL;
 
 	tx_call_interval_check(ctx, ts_now_us, common_interval_us);
 
@@ -644,7 +701,7 @@ int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *co
 				TX_MARGIN_MIN_US);
 			ctx->ts_ctlr_esti_us -= common_interval_us;
 			ctx->last_data_status = STATUS_OVERRUN_FLUSHED;
-			return -ECANCELED;
+			goto finalize;
 		}
 
 		/* If ts_ctlr_esti_us_valid is false, this means we shall send with no timestamp.
@@ -669,14 +726,21 @@ int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *co
 	}
 
 	ret = tx_controller_sync_and_correct(ctx, last_successful_bap_stream, common_interval_us,
-					     ts_now_us, tx_info, &status);
+					     ts_now_us, tx_info);
 
 	if (ret != 0) {
+		LOG_WRN("Failed to sync and correct with controller after sending: %d", ret);
 		return ret;
 	}
 
-	tx_publish_sdu_ref_and_finalize(ctx, ts_now_us);
-	return status;
+finalize:
+	ret = tx_publish_sdu_ref_and_finalize(ctx, ts_now_us, tx, num_tx);
+	if (ret != 0) {
+		LOG_ERR("Failed to publish SDU reference and finalize: %d", ret);
+		return ret;
+	}
+
+	return 0;
 }
 
 int bt_le_audio_tx_stream_started(struct bt_le_audio_tx_ctx *ctx, struct stream_index idx)
@@ -692,15 +756,15 @@ int bt_le_audio_tx_stream_started(struct bt_le_audio_tx_ctx *ctx, struct stream_
 		return ret;
 	}
 
-	(void)atomic_clear(&ctx->tx_info_arr[idx.lvl1][idx.lvl2][idx.lvl3].iso_tx_pool_alloc);
+	(void)atomic_clear(&ctx->tx_info_arr[idx.lvl3].iso_tx_pool_alloc);
 
-	ctx->tx_info_arr[idx.lvl1][idx.lvl2][idx.lvl3].hci_wrn_printed = false;
-	ctx->tx_info_arr[idx.lvl1][idx.lvl2][idx.lvl3].iso_conn_handle = HANDLE_INVALID;
-	ctx->tx_info_arr[idx.lvl1][idx.lvl2][idx.lvl3].iso_tx_readback.seq_num = 0U;
+	ctx->tx_info_arr[idx.lvl3].hci_wrn_printed = false;
+	ctx->tx_info_arr[idx.lvl3].iso_conn_handle = HANDLE_INVALID;
+	ctx->tx_info_arr[idx.lvl3].iso_tx_readback.seq_num = 0U;
 	return 0;
 }
 
-int bt_le_audio_tx_stream_sent(struct bt_le_audio_tx_ctx *ctx, struct stream_index stream_idx)
+int bt_le_audio_tx_stream_sent(struct bt_le_audio_tx_ctx *ctx, struct stream_index idx)
 {
 	int ret;
 
@@ -708,13 +772,12 @@ int bt_le_audio_tx_stream_sent(struct bt_le_audio_tx_ctx *ctx, struct stream_ind
 		return -EINVAL;
 	}
 
-	ret = verify_stream_idx(stream_idx);
+	ret = verify_stream_idx(idx);
 	if (ret != 0) {
 		return ret;
 	}
 
-	(void)atomic_dec(&ctx->tx_info_arr[stream_idx.lvl1][stream_idx.lvl2][stream_idx.lvl3]
-				  .iso_tx_pool_alloc);
+	(void)atomic_dec(&ctx->tx_info_arr[idx.lvl3].iso_tx_pool_alloc);
 	return 0;
 }
 
@@ -724,6 +787,8 @@ int bt_le_audio_tx_init(struct bt_le_audio_tx_ctx *ctx, bool is_clock_master)
 		return -EINVAL;
 	}
 
+	static bool init_done;
+
 	struct net_buf_pool *tmp = ctx->iso_tx_pool;
 
 	(void)memset(ctx, 0, sizeof(*ctx));
@@ -731,13 +796,20 @@ int bt_le_audio_tx_init(struct bt_le_audio_tx_ctx *ctx, bool is_clock_master)
 	ctx->iso_tx_pool = tmp;
 	ctx->is_ble_clock_master = is_clock_master;
 
-	for (int i = 0; i < GROUP_MAX; i++) {
-		for (int j = 0; j < SUBGROUP_MAX; j++) {
-			for (int k = 0; k < TX_STREAMS_MAX; k++) {
-				ctx->tx_info_arr[i][j][k].iso_conn_handle = HANDLE_INVALID;
-			}
-		}
+	for (int i = 0; i < TX_STREAMS_MAX; i++) {
+		ctx->tx_info_arr[i].iso_conn_handle = HANDLE_INVALID;
 	}
+
+	if (!init_done) {
+		k_work_queue_init(&iso_flush_work_q);
+		k_work_init(&iso_flush_work, iso_flush_work_handler);
+
+		k_work_queue_start(&iso_flush_work_q, iso_flush_work_q_stack_area,
+				   K_THREAD_STACK_SIZEOF(iso_flush_work_q_stack_area),
+				   ISO_FLUSH_Q_PRIORITY, NULL);
+	}
+
+	init_done = true;
 
 	return 0;
 }

--- a/applications/nrf_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.h
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.h
@@ -21,7 +21,9 @@
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/cap.h>
 
+#include "zbus_common.h"
 #include "le_audio.h"
+#include "audio_defines.h"
 
 struct le_audio_tx_info {
 	struct stream_index idx;
@@ -53,15 +55,7 @@ struct bt_le_audio_tx_ctx;
 
 #define TX_STREAMS_MAX CONFIG_BT_ISO_MAX_CHAN
 
-#define TX_BUF_NUM (GROUP_MAX * SUBGROUP_MAX * TX_STREAMS_MAX * HCI_ISO_BUF_PER_CHAN)
-
-enum bt_le_audio_tx_last_data_status {
-	STATUS_NOT_SET = 0,		  /* Initial status */
-	STATUS_SENT_WITH_TS,		  /* Data sent with timestamp */
-	STATUS_SENT_WITHOUT_TS,		  /* Data sent without timestamp */
-	STATUS_OVERRUN_FLUSHED,		  /* Data overrun, flushed */
-	STATUS_UNDERRUN_EMPTY_SDU_ON_AIR, /* Data underrun, empty SDU on air */
-};
+#define TX_BUF_NUM (TX_STREAMS_MAX * HCI_ISO_BUF_PER_CHAN)
 
 struct tx_inf {
 	uint16_t iso_conn_handle;
@@ -73,7 +67,7 @@ struct tx_inf {
 
 struct bt_le_audio_tx_ctx {
 	struct net_buf_pool *iso_tx_pool;
-	struct tx_inf tx_info_arr[GROUP_MAX][SUBGROUP_MAX][TX_STREAMS_MAX];
+	struct tx_inf tx_info_arr[TX_STREAMS_MAX];
 	/* Estimated timestamp from the controller and validity */
 	uint32_t ts_ctlr_esti_us;
 	bool ts_ctlr_esti_us_valid;
@@ -91,7 +85,7 @@ struct bt_le_audio_tx_ctx {
 	/* This device is Bluetooth clock master (central/unicast client or broadcast source) */
 	bool is_ble_clock_master;
 	/* Status of the last submitted data */
-	enum bt_le_audio_tx_last_data_status last_data_status;
+	enum tx_data_status last_data_status;
 };
 
 #define BT_LE_AUDIO_TX_DEFINE(name)                                                                \
@@ -103,31 +97,57 @@ struct bt_le_audio_tx_ctx {
 	};                                                                                         \
 	static struct bt_le_audio_tx_ctx *name = &name##_ctx
 
+#define BT_LE_AUDIO_TX_DEFINE_INDEXED(name, group_idx, subgroup_idx)                               \
+	NET_BUF_POOL_FIXED_DEFINE(name##_##group_idx##_##subgroup_idx##_buf, TX_BUF_NUM,           \
+				  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),                       \
+				  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);                         \
+	static struct bt_le_audio_tx_ctx name##_##group_idx##_##subgroup_idx##_ctx = {             \
+		.iso_tx_pool = &name##_##group_idx##_##subgroup_idx##_buf,                         \
+	};                                                                                         \
+	__unused static struct bt_le_audio_tx_ctx *name##_##group_idx##_##subgroup_idx =           \
+		&name##_##group_idx##_##subgroup_idx##_ctx
+
 /**
- * @brief	Allocates buffers and sends data to the controller.
+ * @brief	Sends N channels of synchronized audio data to the controller.
  *
- * @note	Send all available channels in a single call.
- *		Do not call this for each channel.
+ * @details
+ * This function is the main LE Audio TX scheduling point. One call corresponds to one
+ * frame interval for the configured streams. All streams which shall be sent together
+ * (synchronized) are sent at the same time.
+ * This implies calling once for every subgroup when doing broadcast and once for each
+ * CIG in unicast. If 0 is returned, it publishes a reference message on @c sdu_ref_chan.
+ * This ZBUS message contains the current time, and when the SDU(s) are expected on air.
+ * Calling too late/slow will cause empty data on air, whilst calling too early/fast will
+ * trigger this module to flush reduce latency and avoid buffer overruns.
  *
- * @param[in]	ctx		Pointer to TX context.
- * @param[in]	audio_frame	Pointer to the encoded audio data.
- * @param[in]	tx		Pointer to an array of le_audio_tx_info elements.
+ * Summary:
+ * - Supply data which shall be sent synchronized in a  CIS/subgroup. (E.g,
+ *  2 streams every 10 ms).
+ * - Call @ref bt_le_audio_tx_stream_sent for each stream after TX completion to keep
+ *   pool accounting correct.
+ *
+ * @note Not tested for ISO interval not equal to frame length.
+ *
+ * @param[in]	ctx		Pointer to an initialized TX context pr CIG for unicast and pr
+ *				subgroup for broadcast.
+ * @param[in]	audio_frame	Pointer to encoded audio data and metadata.
+ * @param[in]	tx		Pointer to an array of @ref le_audio_tx_info elements.
  * @param[in]	num_tx		Number of elements in @p tx.
  *
- * @retval	0		Success.
- * @retval	-EINVAL		Invalid arguments or invalid audio/frame/stream configuration.
- * @retval	-ECANCELED	Current call is intentionally flushed due to previous late timing.
- * @retval	-ETIMEDOUT	Controller timestamp indicates late delivery (empty packet(s) on
- * air).
+ * @retval	0		Success (including controlled pacing cases where no SDU is sent,
+ *				but finalize/publish succeeds).
+ * @retval	-EINVAL		Invalid arguments, invalid stream index tuple, invalid frame
+ *				metadata, or inconsistent stream/audio configuration.
  * @retval	-EIO		No stream was sent successfully.
  *
- * @return	Other negative error codes may be propagated from timestamp/HCI operations.
+ * @return	Other negative error codes may be propagated from lower layers (for example
+ *		timestamp synchronization/HCI readback or SDU reference publish failures).
  */
 int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *const audio_frame,
 			struct le_audio_tx_info *tx, uint8_t num_tx);
 
 /**
- * @brief	Initializes a stream. Must be called when a TX stream is started.
+ * @brief	Initializes per-stream TX bookkeeping when a stream enters streaming state.
  *
  * @param[in]	ctx		Pointer to TX context.
  * @param[in]	stream_idx	Stream index.
@@ -139,7 +159,12 @@ int bt_le_audio_tx_send(struct bt_le_audio_tx_ctx *ctx, struct net_buf const *co
 int bt_le_audio_tx_stream_started(struct bt_le_audio_tx_ctx *ctx, struct stream_index stream_idx);
 
 /**
- * @brief	Frees a TX buffer. Must be called when a TX stream has been sent.
+ * @brief	Releases one outstanding TX pool allocation for the provided stream.
+ *
+ * @details
+ * Call this after TX completion notification for each stream that consumed one TX buffer.
+ * This keeps the module's per-stream pool accounting aligned with actual controller
+ * completions.
  *
  * @param[in]	ctx		Pointer to TX context.
  * @param[in]	stream_idx	Stream index.
@@ -151,12 +176,17 @@ int bt_le_audio_tx_stream_started(struct bt_le_audio_tx_ctx *ctx, struct stream_
 int bt_le_audio_tx_stream_sent(struct bt_le_audio_tx_ctx *ctx, struct stream_index stream_idx);
 
 /**
- * @brief	Initializes the TX path for ISO transmission.
+ * @brief	Initializes the TX path context and shared ISO flush worker.
  *
  * @param[in]	ctx		Pointer to TX context.
  * @param[in]	is_clock_master	Set to true if this device is a Bluetooth central,
  *				(Unicast client) or Broadcast source,
  *				false = peripheral (unicast server) or Broadcast sink.
+ *
+ * @details
+ * The context memory is cleared and re-initialized while preserving @p ctx->iso_tx_pool.
+ * A shared internal work queue used for deferred ISO flush handling is started once on the
+ * first successful call.
  *
  * @retval	0		Success.
  * @retval	-EINVAL		@p ctx is NULL or required configuration is missing.

--- a/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -1930,9 +1930,7 @@ int unicast_client_send(struct net_buf const *const audio_frame, uint8_t cig_ind
 	}
 
 	ret = bt_le_audio_tx_send(bt_le_audio_tx, audio_frame, info.tx, info.num_active_streams);
-	if (ret == -ECANCELED || ret == -ETIMEDOUT) {
-		LOG_DBG("Adjusted audio TX: %d", ret);
-	} else if (ret) {
+	if (ret) {
 		srv_store_unlock();
 		return ret;
 	}

--- a/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_server.c
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_server.c
@@ -695,9 +695,7 @@ int unicast_server_send(struct net_buf const *const audio_frame)
 	}
 
 	ret = bt_le_audio_tx_send(bt_le_audio_tx, audio_frame, tx, num_active_streams);
-	if (ret == -ECANCELED || ret == -ETIMEDOUT) {
-		LOG_DBG("Adjusted audio TX: %d", ret);
-	} else if (ret) {
+	if (ret) {
 		return ret;
 	}
 

--- a/samples/bluetooth/nrf_auraconfig/src/nrf_auraconfig.c
+++ b/samples/bluetooth/nrf_auraconfig/src/nrf_auraconfig.c
@@ -116,6 +116,15 @@ struct subgroup_lc3_stream_info {
 static struct subgroup_lc3_stream_info lc3_stream_infos[CONFIG_BT_ISO_MAX_BIG]
 						       [CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT];
 
+struct bis_work_item {
+	struct k_work_delayable work;
+	struct stream_index stream_idx;
+};
+
+static struct bis_work_item bis_work_items[CONFIG_BT_ISO_MAX_BIG]
+					  [CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT]
+					  [CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT];
+
 /* Find the most significant 1 in bits, bits will not be 0. */
 static int8_t context_msb_one(uint16_t bits)
 {
@@ -345,12 +354,29 @@ static void stream_frame_get_and_send(struct stream_index stream_idx)
 			++loaded_count;
 		}
 	}
+
 	if (loaded_count == num_bis) {
 		subgroup_send(stream_idx);
 
 		for (int i = 0; i < num_bis; i++) {
 			bis_info->frame_loaded[i] = false;
 			bis_info->frame_ptrs[i] = NULL;
+		}
+	}
+}
+
+static void pending_k_work_flush(void)
+{
+	int ret;
+
+	for (int i = 0; i < CONFIG_BT_ISO_MAX_BIG; i++) {
+		for (int j = 0; j < CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT; j++) {
+			for (int k = 0; k < CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT; k++) {
+				ret = k_work_cancel_delayable(&bis_work_items[i][j][k].work);
+				if (ret != 0 && ret != -EINVAL) {
+					LOG_ERR("Failed to cancel BIS work: %d", ret);
+				}
+			}
 		}
 	}
 }
@@ -375,13 +401,6 @@ static void le_audio_msg_sub_thread(void)
 		case LE_AUDIO_EVT_STREAM_SENT:
 			LOG_DBG("LE_AUDIO_EVT_STREAM_SENT for stream BIG %d sub: %d BIS: %d",
 				msg.idx.lvl1, msg.idx.lvl2, msg.idx.lvl3);
-
-			if (sd_card_present) {
-				stream_frame_get_and_send(msg.idx);
-			} else {
-				stream_frame_dummy_get_and_send(msg.idx);
-			}
-
 			break;
 
 		case LE_AUDIO_EVT_STREAMING:
@@ -399,6 +418,9 @@ static void le_audio_msg_sub_thread(void)
 		case LE_AUDIO_EVT_NOT_STREAMING:
 			LOG_DBG("LE audio evt not_streaming");
 
+			/* Remove any pending BIS work items */
+			pending_k_work_flush();
+
 			break;
 
 		default:
@@ -410,6 +432,65 @@ static void le_audio_msg_sub_thread(void)
 		STACK_USAGE_PRINT("le_audio_msg_thread", &le_audio_msg_sub_thread_data);
 	}
 }
+
+static void bis_work_items_fn(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct bis_work_item *bis_item = CONTAINER_OF(dwork, struct bis_work_item, work);
+
+	if (sd_card_present) {
+		stream_frame_get_and_send(bis_item->stream_idx);
+	} else {
+		stream_frame_dummy_get_and_send(bis_item->stream_idx);
+	}
+}
+
+static void stream_queue_sdu_ref_update(const struct zbus_channel *chan)
+{
+	int ret;
+	uint32_t tx_sync_ts_us;
+	uint32_t curr_ts_us;
+	uint32_t time_to_next_send_us;
+	const struct sdu_ref_msg *msg;
+
+	msg = zbus_chan_const_msg(chan);
+	tx_sync_ts_us = msg->tx_sync_ts_us;
+	curr_ts_us = msg->curr_ts_us;
+
+	/* There will only be one codec configuration per subgroup */
+	struct bt_audio_codec_cfg *codec_cfg = &broadcast_param[msg->idx[0].lvl1]
+							.subgroups[msg->idx[0].lvl2]
+							.group_lc3_preset.codec_cfg;
+
+	struct lc3_stream_cfg cfg;
+
+	ret = le_audio_duration_us_get(codec_cfg, &cfg.frame_duration_us);
+	if (ret) {
+		LOG_ERR("Failed to get frame duration: %d", ret);
+	}
+
+	if (!msg->tx_sync_ts_us_valid || tx_sync_ts_us < curr_ts_us) {
+		LOG_WRN("TX sync timestamp is invalid");
+		time_to_next_send_us = cfg.frame_duration_us;
+	} else {
+		time_to_next_send_us = tx_sync_ts_us - (curr_ts_us);
+	}
+
+	for (uint8_t i = 0; i < msg->num_idx; i++) {
+		LOG_DBG("Scheduling send for stream BIG %d sub: %d BIS: %d", msg->idx[i].lvl1,
+			msg->idx[i].lvl2, msg->idx[i].lvl3);
+
+		ret = k_work_schedule(
+			&bis_work_items[msg->idx[i].lvl1][msg->idx[i].lvl2][msg->idx[i].lvl3].work,
+			K_USEC(time_to_next_send_us));
+
+		if (ret < 0) {
+			LOG_ERR("Failed to schedule BIS work: %d", ret);
+		}
+	}
+}
+
+ZBUS_LISTENER_DEFINE(sdu_ref_msg_listen, stream_queue_sdu_ref_update);
 
 /**
  * @brief	Create zbus subscriber threads.
@@ -491,6 +572,12 @@ static int zbus_link_producers_observers(void)
 				ZBUS_ADD_OBS_TIMEOUT_MS);
 	if (ret) {
 		LOG_ERR("Failed to add le_audio sub");
+		return ret;
+	}
+
+	ret = zbus_chan_add_obs(&sdu_ref_chan, &sdu_ref_msg_listen, ZBUS_ADD_OBS_TIMEOUT_MS);
+	if (ret) {
+		LOG_ERR("Failed to add sdu_ref listener");
 		return ret;
 	}
 
@@ -728,6 +815,11 @@ void nrf_auraconfig_main(void)
 			for (int k = 0; k < CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT; k++) {
 				lc3_stream_infos[i][j].lc3_streamer_idx[k] =
 					LC3_STREAMER_INDEX_UNUSED;
+				bis_work_items[i][j][k].stream_idx.lvl1 = i;
+				bis_work_items[i][j][k].stream_idx.lvl2 = j;
+				bis_work_items[i][j][k].stream_idx.lvl3 = k;
+				k_work_init_delayable(&bis_work_items[i][j][k].work,
+						      bis_work_items_fn);
 			}
 		}
 	}

--- a/tests/nrf_audio/bt_le_audio_tx/Kconfig
+++ b/tests/nrf_audio/bt_le_audio_tx/Kconfig
@@ -58,6 +58,13 @@ config BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE
 	int
 	default 200
 
+config BT_TX_PROCESSOR_THREAD
+	bool
+	default y
+
+config BT_TX_PROCESSOR_THREAD_PRIO
+	int
+	default -1
 
 # Include Zephyr's Kconfig.
 source "Kconfig"

--- a/tests/nrf_audio/bt_le_audio_tx/src/main.c
+++ b/tests/nrf_audio/bt_le_audio_tx/src/main.c
@@ -13,6 +13,7 @@
 #include "zbus_fakes/zbus_fakes.h"
 #include "application/application.h"
 #include "zbus_common.h"
+#include "audio_defines.h"
 
 DEFINE_FFF_GLOBALS;
 
@@ -100,8 +101,8 @@ BT_LE_AUDIO_TX_DEFINE(audio_tx_ctx);
 	static const uint8_t chan_to_send = 3U;
 
 static void internals_verify_impl(int64_t corr_diff_us, bool ts_ctlr_esti_valid,
-				  uint32_t ts_ctlr_esti_us,
-				  enum bt_le_audio_tx_last_data_status last_data_status, int line)
+				  uint32_t ts_ctlr_esti_us, enum tx_data_status last_data_status,
+				  int line)
 {
 	struct bt_le_audio_tx_ctx *ctx = (struct bt_le_audio_tx_ctx *)audio_tx_ctx;
 
@@ -386,12 +387,12 @@ ZTEST(audio_tx, test_tx_send_send_too_fast)
 	audio_tx_ctx->ts_ctlr_esti_us = 25500;
 
 	ret = bt_le_audio_tx_send(audio_tx_ctx, dummy_audio_frame, tx, chan_to_send);
-	zassert_equal(-ECANCELED, ret, "ret %d", ret);
+	zassert_equal(0, ret, "ret %d", ret);
 	zassert_equal(2U, bt_cap_stream_send_fake.call_count);
 	zassert_equal(0U, bt_cap_stream_send_ts_fake.call_count);
 
 	zassert_equal(1U, hci_vs_sdc_iso_read_tx_timestamp_fake.call_count);
-	zassert_equal(1, zbus_chan_pub_fake.call_count);
+	zassert_equal(2, zbus_chan_pub_fake.call_count);
 
 	call_tx_sent(tx, chan_to_send);
 	/* Since we did not send anything, ts should not change*/


### PR DESCRIPTION
- Changed Auraconfig to await until the correct time to send, instead of sending immediately if the timestamp is in the past. This is to avoid flooding the air with retransmissions if the timestamp is slightly off.
- Make le_audio_tx context indexable to allow for multiple groups and subgroups.
- Created a low priority workq for ISO data to ensure host flushes the data before the timesync command is sent.
- OCT-3747