### PR TITLE
samples: bluetooth: peripheral_nfc_pairing: revert LC10 and LV10 support

### DIFF
--- a/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
+++ b/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
@@ -21,10 +21,6 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
-      - nrf54lc10dk/nrf54lc10a/cpuapp
-      - nrf54lc10dk/nrf54lc10a/cpuapp/ns
     tags:
       - bluetooth
       - ci_build


### PR DESCRIPTION
Revert build test support for the nRF54LC10 and nRF54LV10 DKs in the peripheral_nfc_pairing sample. These variants were added by mistake in commit bf0b0cfb28. The nRF54LC10 and nRF54LV10 SoCs do not have the NFCT peripheral.