### PR TITLE
tests: benchmarks:  Add Saana to benchmarks.memory_access allowed pla…

### DIFF
--- a/tests/benchmarks/memory_access/testcase.yaml
+++ b/tests/benchmarks/memory_access/testcase.yaml
@@ -11,6 +11,8 @@ tests:
       - nrf54h20dk/nrf54h20/cpuflpr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuflpr
+      - nrf9251dk/nrf9251/cpuapp
+      - nrf9251dk/nrf9251/cpuppr
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     harness: console


### PR DESCRIPTION
…tforms

Run 'benchmarks.memory_access' on Saana