### PR TITLE
[Backport v3.4-branch] samples/tests: locator_tag: Explicitly enable Partition Manager

### DIFF
--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/configuration/nrf5340dk_nrf5340_cpuapp/sysbuild.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/configuration/nrf5340dk_nrf5340_cpuapp/sysbuild.conf
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+SB_CONFIG_PARTITION_MANAGER=y
+
 SB_CONFIG_NETCORE_IPC_RADIO=y
 
 SB_CONFIG_BOOTLOADER_MCUBOOT=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/configuration/nrf5340dk_nrf5340_cpuapp_ns/sysbuild.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/configuration/nrf5340dk_nrf5340_cpuapp_ns/sysbuild.conf
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+SB_CONFIG_PARTITION_MANAGER=y
+
 SB_CONFIG_NETCORE_IPC_RADIO=y
 
 SB_CONFIG_BOOTLOADER_MCUBOOT=y

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/configuration/thingy53_nrf5340_cpuapp/sysbuild.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/configuration/thingy53_nrf5340_cpuapp/sysbuild.conf
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+SB_CONFIG_PARTITION_MANAGER=y
+
 SB_CONFIG_NETCORE_IPC_RADIO=y
 
 # Majority of bootloader configurations are set at the Thingy:53 board level

--- a/samples/bluetooth/fast_pair/locator_tag/sysbuild/configuration/thingy53_nrf5340_cpuapp_ns/sysbuild.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/sysbuild/configuration/thingy53_nrf5340_cpuapp_ns/sysbuild.conf
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+SB_CONFIG_PARTITION_MANAGER=y
+
 SB_CONFIG_NETCORE_IPC_RADIO=y
 
 # Majority of bootloader configurations are set at the Thingy:53 board level

--- a/tests/subsys/bluetooth/fast_pair/locator_tag_legacy/Kconfig.sysbuild
+++ b/tests/subsys/bluetooth/fast_pair/locator_tag_legacy/Kconfig.sysbuild
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+config PARTITION_MANAGER
+	default y
+
 config BT_FAST_PAIR_MODEL_ID
 	default 0x4A436B
 


### PR DESCRIPTION
Backport 429be77c7cb090cb8c86d464b6a6fe30cc09ed20~2..429be77c7cb090cb8c86d464b6a6fe30cc09ed20 from #29470.