### PR TITLE
codeowners: Fix invalid team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -744,10 +744,10 @@
 /scripts/west_commands/create_board/      @nordicjm
 /scripts/west_commands/sbom/              @nrfconnect/ncs-co-scripts
 /scripts/west_commands/thingy91x_dfu.py   @nrfconnect/ncs-cia
-/scripts/west_commands/ncs_cherry_pick.py @nrfconnect/ncs-vestavind
+/scripts/west_commands/ncs_cherry_pick.py @nrfconnect/ncs-co-scripts
 /scripts/west_commands/ncs_ironside_se_update.py @nrfconnect/ncs-aurora
 /scripts/west_commands/ncs_provision.py   @nrfconnect/ncs-eris
-/scripts/west_commands/tests/test_ncs_cherry_pick.py @nrfconnect/ncs-vestavind
+/scripts/west_commands/tests/test_ncs_cherry_pick.py @nrfconnect/ncs-co-scripts
 /scripts/bootloader/                      @nrfconnect/ncs-eris
 /scripts/reglock.py                       @nrfconnect/ncs-eris
 /scripts/ncs-docker-version.txt           @nrfconnect/ncs-ci


### PR DESCRIPTION
The ncs-vestavind team does not exist, use ncs-co-scripts instead.