### PR TITLE
wifi: fix SoftAP init

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0ab46164b3bd0063c09711f314ecb3bb39775908
+      revision: 78a10f5a6f7fb1c01d78894e803267ece14e0728
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above

--- a/west.yml
+++ b/west.yml
@@ -285,7 +285,7 @@ manifest:
     - name: hostap
       repo-path: sdk-hostap
       path: modules/lib/hostap
-      revision: a50c3c2c78eb3ed9709803eb7479d3df33d7c1bb
+      revision: dc22e8cf8dd03c8ff2bdde68002a4496525f6eb2
   # West-related configuration for the nrf repository.
   self:
     # This repository should be cloned to ncs/nrf.


### PR DESCRIPTION
Fix regression in SoftAP due to a recent upstream change pulled in Wi-Fi NM module and also improve the error reporting.