### PR TITLE
applications: nrf_desktop: Improve Partition Manager testing in CI

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/app.overlay
@@ -7,6 +7,5 @@
 / {
 	chosen {
 		zephyr,code-partition = &boot_partition;
-		nordic,pm-ext-flash = &mx25r64;
 	};
 };

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/app_mcuboot_qspi.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/images/mcuboot/app_mcuboot_qspi.overlay
@@ -11,6 +11,10 @@
  */
 / {
 	chosen {
+		/* Used by the Partition Manager (when enabled through sysbuild).
+		 * Unused when the DTS-based memory map is used.
+		 */
+		nordic,pm-ext-flash = &mx25r64;
 		zephyr,code-partition = &boot_partition;
 	};
 };

--- a/applications/nrf_desktop/sample.yaml
+++ b/applications/nrf_desktop/sample.yaml
@@ -342,3 +342,22 @@ tests:
       - SB_CONFIG_PARTITION_MANAGER=y
       - mcuboot_CONFIG_BOOT_MAX_IMG_SECTORS=256
     harness: console
+  applications.nrf_desktop.zdebug_partition_manager_b0:
+    build_only: true
+    platform_allow:
+      - nrf52840dk/nrf52840
+    integration_platforms:
+      - nrf52840dk/nrf52840
+    extra_args:
+      - SB_CONFIG_PARTITION_MANAGER=y
+  applications.nrf_desktop.zdebug_partition_manager_mcuboot_swap_qspi:
+    build_only: true
+    platform_allow:
+      - nrf52840dk/nrf52840
+    integration_platforms:
+      - nrf52840dk/nrf52840
+    extra_args:
+      - FILE_SUFFIX=mcuboot_qspi
+      - SB_CONFIG_PARTITION_MANAGER=y
+      - SB_CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY=y
+      - mcuboot_CONFIG_BOOT_MAX_IMG_SECTORS=2048


### PR DESCRIPTION
Add configurations with Partition Manager to sample.yaml to improve test coverage. Change adds a configuration with B0 bootloader and a configuration with MCUboot with swap and external FLASH.

Jira: NCSDK-39720