### PR TITLE
net: openthread: rpc: server: Minor fixes

### DIFF
--- a/subsys/net/openthread/rpc/server/ot_rpc_dns_client.c
+++ b/subsys/net/openthread/rpc/server/ot_rpc_dns_client.c
@@ -450,14 +450,15 @@ static void resp_get_info(const struct nrf_rpc_group *group, struct nrf_rpc_cbor
 		return;
 	}
 
+	/* Clamp the peer-declared sizes to the local buffers to avoid a stack overflow. */
 	if (max_name_size) {
 		info.mHostNameBuffer = name;
-		info.mHostNameBufferSize = max_name_size;
+		info.mHostNameBufferSize = MIN(max_name_size, sizeof(name));
 	}
 
 	if (max_txt_size) {
 		info.mTxtData = txt;
-		info.mTxtDataSize = max_txt_size;
+		info.mTxtDataSize = MIN(max_txt_size, sizeof(txt));
 	}
 
 	ot_rpc_mutex_lock();


### PR DESCRIPTION
* Validate malloc() succeded before using buffers
* Ensure that stack-allocated buffers do not overflow

Assisted-by: Cursor:Opus 4.8