### PR TITLE
release-notes: Document nrf54lc10dk support in Bluetooth HIDS samples

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -294,7 +294,7 @@ This section provides detailed lists of changes by :ref:`sample <samples>`.
 Bluetooth samples
 -----------------
 
-|no_changes_yet_note|
+* Added support for the ``nrf54lc10dk/nrf54lc10a/cpuapp`` board target in the :ref:`bluetooth_central_hids`, :ref:`peripheral_hids_keyboard`, and :ref:`peripheral_hids_mouse` samples.
 
 Bluetooth Mesh samples
 ----------------------


### PR DESCRIPTION
Board support for central_hids, peripheral_hids_keyboard, and peripheral_hids_mouse added was added in a previous commit.