### PR TITLE
samples: peripheral: 802154_sniffer: disable Partition Manager

### DIFF
--- a/samples/peripheral/802154_sniffer/sysbuild.conf
+++ b/samples/peripheral/802154_sniffer/sysbuild.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+SB_CONFIG_PARTITION_MANAGER=n


### PR DESCRIPTION
The IEEE 802.15.4 Sniffer sample relied on Partition Manager only because it was enabled by default in sysbuild.