### PR TITLE
applications: nrf_audio: Only decode mic when terminal enabled

### DIFF
--- a/applications/nrf_audio/src/audio/audio_system.c
+++ b/applications/nrf_audio/src/audio/audio_system.c
@@ -341,6 +341,11 @@ int audio_system_decode(struct net_buf *audio_frame_in)
 		return -EPERM;
 	}
 
+	if (IS_ENABLED(CONFIG_AUDIO_SOURCE_USB) && !audio_usb_is_mic_enabled()) {
+		LOG_INF_RATELIMIT("Microphone not enabled, dropping data");
+		return 0;
+	}
+
 	if (audio_frame_in == NULL) {
 		LOG_ERR("Buffer pointer is NULL");
 		return -EINVAL;

--- a/applications/nrf_audio/src/modules/audio_usb.c
+++ b/applications/nrf_audio/src/modules/audio_usb.c
@@ -335,6 +335,11 @@ static struct uac2_ops ops = {
 
 static struct usbd_context *audio_usbd;
 
+bool audio_usb_is_mic_enabled(void)
+{
+	return terminal_headset_in_enabled;
+}
+
 int audio_usb_start(struct k_msgq *audio_q_tx_in, struct k_msgq *audio_q_rx_in)
 {
 	if (audio_usbd == NULL) {

--- a/applications/nrf_audio/src/modules/audio_usb.h
+++ b/applications/nrf_audio/src/modules/audio_usb.h
@@ -32,6 +32,13 @@
 struct usbd_context *audio_usbd_init_device(usbd_msg_cb_t msg_cb);
 
 /**
+ * @brief Check if the USB microphone (host input) is enabled.
+ *
+ * @return true if the USB microphone is enabled, false otherwise.
+ */
+bool audio_usb_is_mic_enabled(void);
+
+/**
  * @brief Set pointers to the queues to be used by the USB module and start sending/receiving data.
  *
  * @param queue_tx_in  Pointer to queue structure for tx.


### PR DESCRIPTION
- Throw away data coming from headsets in bidir mode if USB mic is disabled
- OCT-3751