### PR TITLE
Bluetooth: Mesh: Fix Light LC fade transitions

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -320,7 +320,11 @@ static uint16_t light_get(struct bt_mesh_light_ctrl_srv *srv)
 	uint16_t end = srv->cfg.light[srv->state];
 
 	/* Linear interpolation: */
-	return start + ((end - start) * curr) / srv->fade.duration;
+	if (end >= start) {
+		return start + ((uint32_t)(end - start) * curr) / srv->fade.duration;
+	}
+
+	return start - ((uint32_t)(start - end) * curr) / srv->fade.duration;
 }
 
 #if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
@@ -340,7 +344,11 @@ static uint32_t centilux_get(struct bt_mesh_light_ctrl_srv *srv)
 	uint32_t init = srv->fade.initial_centilux;
 	uint32_t cfg = srv->cfg.centilux[srv->state];
 
-	return init + ((cfg - init) * delta) / srv->fade.duration;
+	if (cfg >= init) {
+		return init + ((cfg - init) * delta) / srv->fade.duration;
+	}
+
+	return init - ((init - cfg) * delta) / srv->fade.duration;
 }
 
 static float lux_getf(struct bt_mesh_light_ctrl_srv *srv)

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -412,10 +412,10 @@ static void transition_start(struct bt_mesh_light_ctrl_srv *srv,
 			     enum bt_mesh_light_ctrl_srv_state state,
 			     uint32_t fade_time)
 {
-	srv->state = state;
 	srv->fade.initial_light = light_get(srv);
-	srv->fade.duration = fade_time;
 	srv->fade.initial_centilux = centilux_get(srv);
+	srv->state = state;
+	srv->fade.duration = fade_time;
 
 	atomic_set_bit(&srv->flags, FLAG_TRANSITION);
 	if (!IS_ENABLED(CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG) ||

--- a/tests/subsys/bluetooth/mesh/light_ctrl/src/main.c
+++ b/tests/subsys/bluetooth/mesh/light_ctrl/src/main.c
@@ -624,6 +624,37 @@ ZTEST(light_ctrl_test, test_default_cfg)
 }
 
 /**
+ * Verify that transition_start() captures the current lightness level as the fade initial value
+ * rather than the target state's configured level. This tests the fix where srv->state was
+ * incorrectly updated before reading the initial light value.
+ */
+ZTEST(light_ctrl_test, test_fade_initial_light_capture)
+{
+	enable_ctrl();
+
+	/* Set distinct lightness levels for each state. */
+	light_ctrl_srv.cfg.light[LIGHT_CTRL_STATE_STANDBY] = 100;
+	light_ctrl_srv.cfg.light[LIGHT_CTRL_STATE_ON] = 50000;
+	light_ctrl_srv.cfg.light[LIGHT_CTRL_STATE_PROLONG] = 25000;
+
+	/* After enable_ctrl(), server is in STANDBY state with no active transition.
+	 * light_get() should return cfg.light[STANDBY] = 100.
+	 * When we turn on, transition_start should capture initial_light = 100 (not 50000).
+	 */
+	expect_turn_on_state_change();
+	bt_mesh_light_ctrl_srv_on(&light_ctrl_srv);
+
+	/* Verify initial_light was captured from the previous state (STANDBY=100),
+	 * not the target state (ON=50000).
+	 */
+	zassert_equal(light_ctrl_srv.fade.initial_light, 100,
+		      "Expected initial_light=100 (standby level), got: %d",
+		      light_ctrl_srv.fade.initial_light);
+	zassert_equal(light_ctrl_srv.state, LIGHT_CTRL_STATE_ON,
+		      "Expected state=ON after turn_on");
+}
+
+/**
  * Verify that PI Regulator keeps internal sum and its output within the range defined in
  * MeshMDLv1.0.1, table 6.53.
  */
@@ -1151,6 +1182,82 @@ ZTEST(light_ctrl_pi_reg_test, test_internal_sum_recalculation)
 	trigger_pi_reg(1, true);
 	zassert_equal(pi_reg_test_ctx.lightness, expected_lightness, "Expected: %d, got: %d",
 		      expected_lightness, pi_reg_test_ctx.lightness);
+}
+
+/**
+ * Verify that transition_start() captures the correct initial lightness when transitioning
+ * from ON to PROLONG (fade down). The initial value should be the ON level, not PROLONG level.
+ */
+ZTEST(light_ctrl_pi_reg_test, test_fade_initial_light_on_to_prolong)
+{
+	/* pi_reg_test_ctx is enabled, so lightness_srv_change_lvl won't check expectations. */
+	light_ctrl_srv.cfg.light[LIGHT_CTRL_STATE_STANDBY] = 0;
+	light_ctrl_srv.cfg.light[LIGHT_CTRL_STATE_ON] = 40000;
+	light_ctrl_srv.cfg.light[LIGHT_CTRL_STATE_PROLONG] = 15000;
+	light_ctrl_srv.cfg.fade_prolong = 5000;
+
+	/* Server is in ON state after setup_pi_reg(). Wait for transition to complete. */
+	wait_for_timeout(STATE_TIMER, K_MSEC(light_ctrl_srv.cfg.on + 1));
+
+	/* Now the state timer fired -> prolong() is called -> transition_start to PROLONG. */
+	zassert_equal(light_ctrl_srv.state, LIGHT_CTRL_STATE_PROLONG,
+		      "Expected state=PROLONG, got: %d", light_ctrl_srv.state);
+	zassert_equal(light_ctrl_srv.fade.initial_light, 40000,
+		      "Expected initial_light=40000 (ON level), got: %d",
+		      light_ctrl_srv.fade.initial_light);
+	zassert_equal(light_ctrl_srv.fade.duration, 5000,
+		      "Expected fade duration=5000, got: %d",
+		      light_ctrl_srv.fade.duration);
+}
+
+/**
+ * Verify that light_get() correctly interpolates when fading down (end < start) without
+ * unsigned underflow. This tests the fix for the arithmetic bug by exercising the regulator
+ * path which calls light_get() internally.
+ */
+ZTEST(light_ctrl_pi_reg_test, test_fade_interpolation_no_underflow)
+{
+	/* Configure a high ON level and lower PROLONG level to test fade-down. */
+	light_ctrl_srv.cfg.light[LIGHT_CTRL_STATE_ON] = 50000;
+	light_ctrl_srv.cfg.light[LIGHT_CTRL_STATE_PROLONG] = 10000;
+	light_ctrl_srv.cfg.fade_prolong = 500;
+	/* Use short ON time to avoid ambient light level timeout (20s) which would
+	 * reset measured lux to 0 and cause regulator to saturate.
+	 * Reschedule the already-running ON timer to fire sooner.
+	 */
+	light_ctrl_srv.cfg.on = 1000;
+	k_work_reschedule(&light_ctrl_srv.timer, K_MSEC(1000));
+
+	/* Server is in ON state after setup_pi_reg(). Start the regulator with ambient lux
+	 * matching the target so regulator output is minimal — this lets us observe light_get()
+	 * providing the floor value to the regulator.
+	 */
+	start_reg((float)light_ctrl_srv.cfg.centilux[LIGHT_CTRL_STATE_ON] * 0.01f);
+
+	/* Wait for ON timer to expire, which triggers prolong() -> transition to PROLONG.
+	 * This creates a fade-down: initial_light=50000, target=10000.
+	 */
+	wait_for_timeout(STATE_TIMER, K_MSEC(light_ctrl_srv.cfg.on + 1));
+
+	zassert_equal(light_ctrl_srv.state, LIGHT_CTRL_STATE_PROLONG,
+		      "Expected PROLONG state, got: %d", light_ctrl_srv.state);
+	zassert_equal(light_ctrl_srv.fade.initial_light, 50000,
+		      "Expected initial_light=50000, got: %d",
+		      light_ctrl_srv.fade.initial_light);
+
+	/* Trigger the regulator during the fade-down. The regulator calls light_get() internally.
+	 * If unsigned underflow occurs, light_get() would return a huge value (>50000) instead
+	 * of a value between 10000 and 50000.
+	 */
+	trigger_pi_reg(1, true);
+
+	/* The pi_reg_test_ctx.lightness should be reasonable (between PROLONG and ON levels).
+	 * Without the underflow fix, this would be a wrapped-around value > 50000.
+	 */
+	zassert_true(pi_reg_test_ctx.lightness <= 50000,
+		     "Lightness wrapped around (underflow): %d", pi_reg_test_ctx.lightness);
+	zassert_true(pi_reg_test_ctx.lightness >= 10000,
+		     "Lightness below target: %d", pi_reg_test_ctx.lightness);
 }
 
 ZTEST_SUITE(light_ctrl_test, NULL, NULL, setup, teardown, NULL);


### PR DESCRIPTION
### Description

The Light LC (Lightness Control) model fade transitions were effectively instantaneous — the light level jumped directly to the target value instead of gradually fading. Two bugs caused this:

1. **Initial value not captured:** In `transition_start()`, `srv->state` was updated *before* reading the current lightness via `light_get()`. Since `light_get()` uses `srv->state` to determine the target level (when `FLAG_TRANSITION` is not set), it returned the new target value instead of the current level. This made `initial_light == target`, resulting in zero-duration effective fades.

2. **Unsigned underflow on fade-down:** The interpolation formula `(end - start) * elapsed / duration` used unsigned subtraction. When fading down (`end < start`), this wrapped around to a large value instead of producing the correct intermediate level.

### Changes

- **Commit 1**: Reorder `transition_start()` to capture `fade.initial_light` and `fade.initial_centilux` *before* updating `srv->state`.
- **Commit 2**: Add direction-aware interpolation in `light_get()` and `centilux_get()` to handle both fade-up and fade-down without underflow.
- **Commit 3**: Add unit tests covering both fixes.

### Testing

| Test | What it verifies |
|------|-----------------|
| `test_fade_initial_light_capture` | STANDBY→ON captures standby level as initial |
| `test_fade_initial_light_on_to_prolong` | ON→PROLONG captures ON level as initial |
| `test_fade_interpolation_no_underflow` | Fade-down interpolation stays within `[target, initial]` |

All three tests **FAIL** without the fixes and **PASS** with them applied.

### Spec reference

Mesh Model Specification v1.1.1, Section 6.2.5.13.2, Table 6.47 — *Lightness Out* is defined as linear interpolation from the initial value to the target over the configured Transition Time.