### PR TITLE
[Backport v3.4-branch] Bluetooth: Controller: remove EXPERIMENTAL from DTM

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -755,9 +755,6 @@ config BT_CTLR_SDC_ISO_TEST
 	help
 	  Support for LE ISO test HCI commands
 
-config BT_CTLR_DTM
-	select EXPERIMENTAL
-
 config BT_CTLR_LE_FLUSHABLE_ACL_DATA
 	bool "LE Flushable ACL Data [EXPERIMENTAL]"
 	depends on BT_CTLR_EXTENDED_FEAT_SET


### PR DESCRIPTION
Backport a6ab0202777632a8525eb432be6f3deb4c100892 from #29511.