### PR TITLE
net: lib: downloader: remove TLS-only guard on hostname check

### DIFF
--- a/subsys/net/lib/downloader/src/dl_socket.c
+++ b/subsys/net/lib/downloader/src/dl_socket.c
@@ -261,7 +261,7 @@ static int dl_socket_create_and_connect(int *fd, int proto, int type, uint16_t p
 			goto cleanup;
 		}
 
-		if (proto == NET_IPPROTO_TLS_1_2 && !is_ip_address(hostname)) {
+		if (!is_ip_address(hostname)) {
 			err = socket_ZSOCK_TLS_HOSTNAME_set(*fd, hostname);
 			if (err) {
 				goto cleanup;

--- a/tests/subsys/net/lib/downloader/src/main.c
+++ b/tests/subsys/net/lib/downloader/src/main.c
@@ -647,12 +647,18 @@ int z_impl_zsock_setsockopt_coaps_ok(int sock, int level, int optname, const voi
 		TEST_ASSERT_EQUAL_MEMORY(sec_tags, optval, sizeof(sec_tags));
 		break;
 	case 4:
+		TEST_ASSERT_EQUAL(ZSOCK_SOL_TLS, level);
+		TEST_ASSERT_EQUAL(ZSOCK_TLS_HOSTNAME, optname);
+		TEST_ASSERT_EQUAL(strlen(HOSTNAME), optlen);
+		TEST_ASSERT_EQUAL_MEMORY(HOSTNAME, optval, strlen(HOSTNAME));
+		break;
+	case 5:
 		TEST_ASSERT_EQUAL(ZSOCK_SOL_SOCKET, level);
 		TEST_ASSERT_EQUAL(ZSOCK_SO_SNDTIMEO, optname);
 		TEST_ASSERT_EQUAL(sizeof(struct timeval), optlen);
 		/* Ignore value */
 		break;
-	case 5:
+	case 6:
 		TEST_ASSERT_EQUAL(ZSOCK_SOL_SOCKET, level);
 		TEST_ASSERT_EQUAL(ZSOCK_SO_RCVTIMEO, optname);
 		TEST_ASSERT_EQUAL(sizeof(struct timeval), optlen);
@@ -769,16 +775,22 @@ int z_impl_zsock_setsockopt_coaps_cid_ok(int sock, int level, int optname, const
 		break;
 	case 4:
 		TEST_ASSERT_EQUAL(ZSOCK_SOL_TLS, level);
+		TEST_ASSERT_EQUAL(ZSOCK_TLS_HOSTNAME, optname);
+		TEST_ASSERT_EQUAL(strlen(HOSTNAME), optlen);
+		TEST_ASSERT_EQUAL_MEMORY(HOSTNAME, optval, strlen(HOSTNAME));
+		break;
+	case 5:
+		TEST_ASSERT_EQUAL(ZSOCK_SOL_TLS, level);
 		TEST_ASSERT_EQUAL(ZSOCK_TLS_DTLS_CID, optname);
 		TEST_ASSERT_EQUAL(sizeof(uint32_t), optlen);
 		break;
-	case 5:
+	case 6:
 		TEST_ASSERT_EQUAL(ZSOCK_SOL_SOCKET, level);
 		TEST_ASSERT_EQUAL(ZSOCK_SO_SNDTIMEO, optname);
 		TEST_ASSERT_EQUAL(sizeof(struct timeval), optlen);
 		/* Ignore value */
 		break;
-	case 6:
+	case 7:
 		TEST_ASSERT_EQUAL(ZSOCK_SOL_SOCKET, level);
 		TEST_ASSERT_EQUAL(ZSOCK_SO_RCVTIMEO, optname);
 		TEST_ASSERT_EQUAL(sizeof(struct timeval), optlen);


### PR DESCRIPTION
The hostname was only set for TLS_1_2, skipping DTLS_1_2. The hostname should be verified for both, otherwise host-side cert verification fails. Remove the check so the hostname is always set.

Signed-off-by: Syver Haraldsen <syver.haraldsen@nordicsemi.no>