### PR TITLE
scripts: ci: add an entry to the pm_legacy.txt file

### DIFF
--- a/scripts/ci/pm_legacy.txt
+++ b/scripts/ci/pm_legacy.txt
@@ -25,6 +25,7 @@
 # ---------------------------------------------------------------------------
 
 thingy53
+partition_manager
 applications.nrf_desktop.zdebug_partition_manager_mcuboot_direct_xip.uart
 applications.nrf_desktop.zdebug_partition_manager_mcuboot_single_app
 applications.nrf_desktop.zdebug_partition_manager_single_image.uart


### PR DESCRIPTION
Mark all tests in tests/subsys/partition_manager/ as part of the filtered tests that will still use partition_manager.