### PR TITLE
[Backport v3.4-branch] dts: nordic: nrf54lv10: Add bl_storage partition

### DIFF
--- a/dts/common/nordic/nrf54lv10a_cpuapp_partition.dtsi
+++ b/dts/common/nordic/nrf54lv10a_cpuapp_partition.dtsi
@@ -55,3 +55,12 @@
 #endif
 	};
 };
+
+&uicr {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	bl_storage: uicr@500 {
+		reg = <0x500 0x460>;
+	};
+};


### PR DESCRIPTION
Backport fc09cc64ac65ea9df335378d699a6afacf9c0750 from #29424.