### PR TITLE
[Backport v3.4-branch] samples: peripheral: 802154_sniffer: disable Partition Manager

### DIFF
--- a/samples/peripheral/802154_sniffer/sysbuild.conf
+++ b/samples/peripheral/802154_sniffer/sysbuild.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+SB_CONFIG_PARTITION_MANAGER=n


### PR DESCRIPTION
Backport dd229c7f4815375ec08f1f3eceb4bf9dcf709159 from #29512.