### PR TITLE
[Backport v3.4-branch] tests: buetooth: mesh: remove pm

### DIFF
--- a/tests/subsys/bluetooth/mesh/metadata_extraction/Kconfig.sysbuild
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/Kconfig.sysbuild
@@ -19,4 +19,7 @@ config COMP_DATA_LAYOUT_ARRAY
 
 endchoice
 
+config PARTITION_MANAGER
+	default n
+
 source "share/sysbuild/Kconfig"

--- a/tests/subsys/bluetooth/mesh/models/Kconfig.sysbuild
+++ b/tests/subsys/bluetooth/mesh/models/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Backport 4e184cee27d62e1490cb6678e492b56b1438d4c3 from #29291.