### PR TITLE
samples: bluetooth: dtm: disable partition_manager

### DIFF
--- a/samples/bluetooth/direct_test_mode/Kconfig.sysbuild
+++ b/samples/bluetooth/direct_test_mode/Kconfig.sysbuild
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+config PARTITION_MANAGER
+	default n
+
 choice APPCORE
 	default APPCORE_EMPTY if SOC_NRF5340_CPUNET
 	depends on SUPPORT_APPCORE


### PR DESCRIPTION
disable partition manager which was enabled by
mistake in 516637584a0743e47d908a48f8821376fcccfd14