### PR TITLE
[Backport v3.4-branch] samples: bluetooth: dtm: disable partition_manager

### DIFF
--- a/samples/bluetooth/direct_test_mode/Kconfig.sysbuild
+++ b/samples/bluetooth/direct_test_mode/Kconfig.sysbuild
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+config PARTITION_MANAGER
+	default n
+
 choice APPCORE
 	default APPCORE_EMPTY if SOC_NRF5340_CPUNET
 	depends on SUPPORT_APPCORE


### PR DESCRIPTION
Backport 2614aa404a79ee0b39f56d6a301556e7432207e9 from #29571.