### PR TITLE
tests: lib: nrf_fuel_gauge: Disable partition manager

### DIFF
--- a/tests/lib/nrf_fuel_gauge/Kconfig.sysbuild
+++ b/tests/lib/nrf_fuel_gauge/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Explicitly disable partition manager,
which was not used.