### PR TITLE
application: nrf_audio: CIS USB return audio is of very poor quality

### DIFF
--- a/applications/nrf_audio/src/audio/audio_system.c
+++ b/applications/nrf_audio/src/audio/audio_system.c
@@ -24,30 +24,30 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(audio_system, CONFIG_AUDIO_SYSTEM_LOG_LEVEL);
 
-#define FIFO_TX_BLOCK_COUNT (CONFIG_FIFO_FRAME_SPLIT_NUM * CONFIG_FIFO_TX_FRAME_COUNT)
-#define FIFO_RX_BLOCK_COUNT (CONFIG_FIFO_FRAME_SPLIT_NUM * CONFIG_FIFO_RX_FRAME_COUNT)
+#define FIFO_OUT_BLOCK_COUNT (USB_1MS_BLOCKS_NUM_MAX * CONFIG_FIFO_TX_FRAME_COUNT)
+#define FIFO_IN_BLOCK_COUNT  (CONFIG_FIFO_FRAME_SPLIT_NUM * CONFIG_FIFO_RX_FRAME_COUNT)
 
 /* Size these to fit the use case as part of optimization (e.g. increase decoder pool when it is
  * wrapped in a thread).
  */
 #define FIFO_ENC_POOL_BLK_COUNT 2
-#define FIFO_DEC_POOL_BLK_COUNT 1
+#define FIFO_DEC_POOL_BLK_COUNT 2
 
 #define DEBUG_INTERVAL_NUM     1000
 #define TEST_TONE_BASE_FREQ_HZ 1000
 
 K_THREAD_STACK_DEFINE(encoder_thread_stack, CONFIG_ENCODER_STACK_SIZE);
 
-K_MSGQ_DEFINE(audio_q_tx, sizeof(struct net_buf *), FIFO_TX_BLOCK_COUNT, sizeof(void *));
-K_MSGQ_DEFINE(audio_q_rx, sizeof(struct net_buf *), FIFO_RX_BLOCK_COUNT, sizeof(void *));
+K_MSGQ_DEFINE(audio_q_out, sizeof(struct net_buf *), FIFO_OUT_BLOCK_COUNT, sizeof(void *));
+K_MSGQ_DEFINE(audio_q_in, sizeof(struct net_buf *), FIFO_IN_BLOCK_COUNT, sizeof(void *));
 
-NET_BUF_POOL_FIXED_DEFINE(audio_q_rx_pool, FIFO_RX_BLOCK_COUNT, FRAME_SIZE_BYTES,
+NET_BUF_POOL_FIXED_DEFINE(audio_q_in_pool, FIFO_IN_BLOCK_COUNT, FRAME_SIZE_BYTES,
 			  sizeof(struct audio_metadata), NULL);
 NET_BUF_POOL_FIXED_DEFINE(audio_q_enc_pool, FIFO_ENC_POOL_BLK_COUNT, ENC_MULTI_CHAN_MAX_FRAME_SIZE,
 			  sizeof(struct audio_metadata), NULL);
 NET_BUF_POOL_FIXED_DEFINE(audio_q_dec_pool, FIFO_DEC_POOL_BLK_COUNT, PCM_NUM_BYTES_MULTI_CHAN,
 			  sizeof(struct audio_metadata), NULL);
-NET_BUF_POOL_FIXED_DEFINE(audio_q_tx_pool, FIFO_TX_BLOCK_COUNT, USB_BLOCK_SIZE_MULTI_CHAN,
+NET_BUF_POOL_FIXED_DEFINE(audio_q_out_pool, FIFO_OUT_BLOCK_COUNT, USB_BLOCK_MULTI_CHAN_1MS_SIZE,
 			  sizeof(struct audio_metadata), NULL);
 
 static K_SEM_DEFINE(sem_encoder_start, 0, 1);
@@ -64,6 +64,8 @@ static struct sw_codec_config sw_codec_cfg;
 /* Buffer which can hold max 1 period test tone at 1000 Hz */
 static int16_t test_tone_buf[CONFIG_AUDIO_SAMPLE_RATE_HZ / 1000];
 static size_t test_tone_size;
+
+static struct net_buf *usb_out_spillover;
 
 /* The meta data for the decoder and the expected format of the USB.
  * An improvement would be to have the USB convert incoming data to the format it requires.
@@ -149,8 +151,8 @@ static void encoder_thread(void *arg1, void *arg2, void *arg3)
 		/* Get complete PCM frame from USB */
 		struct net_buf *audio_frame_in;
 
-		ret = k_msgq_get(&audio_q_rx, (void *)&audio_frame_in, K_FOREVER);
-		ERR_CHK_MSG(ret, "Failed to get complete audio frame from RX queue");
+		ret = k_msgq_get(&audio_q_in, (void *)&audio_frame_in, K_FOREVER);
+		ERR_CHK_MSG(ret, "Failed to get complete audio frame from IN queue");
 
 		if (likely(sw_codec_cfg.initialized && sw_codec_cfg.encoder.enabled)) {
 			audio_frame_out = net_buf_alloc(&audio_q_enc_pool, K_NO_WAIT);
@@ -208,8 +210,8 @@ static void encoder_thread(void *arg1, void *arg2, void *arg3)
 
 		/* Print block usage - reduced overhead */
 		if (unlikely(++debug_trans_count >= DEBUG_INTERVAL_NUM)) {
-			audio_q_num_used = k_msgq_num_used_get(&audio_q_rx);
-			LOG_DBG(COLOR_CYAN "RX filled: %d" COLOR_RESET, audio_q_num_used);
+			audio_q_num_used = k_msgq_num_used_get(&audio_q_in);
+			LOG_DBG(COLOR_CYAN "IN filled: %d" COLOR_RESET, audio_q_num_used);
 			debug_trans_count = 0;
 		}
 
@@ -331,6 +333,7 @@ int audio_system_decode(struct net_buf *audio_frame_in)
 {
 	int ret;
 	static int debug_trans_count;
+	size_t len;
 
 	if (!sw_codec_cfg.initialized) {
 		/* Throw away data */
@@ -341,7 +344,13 @@ int audio_system_decode(struct net_buf *audio_frame_in)
 		return -EPERM;
 	}
 
-	if (IS_ENABLED(CONFIG_AUDIO_SOURCE_USB) && !audio_usb_is_mic_enabled()) {
+	if (!audio_usb_headset_in_enabled()) {
+		/* Ensure spillover is released and reset if the headset in is disabled */
+		if (usb_out_spillover != NULL) {
+			net_buf_unref(usb_out_spillover);
+			usb_out_spillover = NULL;
+		}
+
 		LOG_INF_RATELIMIT("Microphone not enabled, dropping data");
 		return 0;
 	}
@@ -376,61 +385,101 @@ int audio_system_decode(struct net_buf *audio_frame_in)
 	}
 
 	/* If not enough space for a full frame, remove oldest samples to make room */
-	while (k_msgq_num_free_get(&audio_q_tx) < CONFIG_FIFO_FRAME_SPLIT_NUM) {
+	while (k_msgq_num_free_get(&audio_q_out) < USB_1MS_BLOCKS_NUM_MAX) {
 		struct net_buf *stale_buf;
 
-		ret = k_msgq_get(&audio_q_tx, (void *)&stale_buf, K_NO_WAIT);
+		ret = k_msgq_get(&audio_q_out, (void *)&stale_buf, K_NO_WAIT);
 		if (ret == -ENOMSG) {
 			/* If there are no more blocks in FIFO, break */
+			LOG_DBG("No more stale buffers");
 			break;
 		}
 
 		net_buf_unref(stale_buf);
 	}
 
-	/* Split decoded frame into CONFIG_FIFO_FRAME_SPLIT_NUM blocks */
-	for (int i = 0; i < CONFIG_FIFO_FRAME_SPLIT_NUM; i++) {
-		struct net_buf *audio_block = net_buf_alloc(&audio_q_tx_pool, K_NO_WAIT);
+	size_t usb_out_1ms_frame_size =
+		USB_BLOCK_1MS_MONO_SIZE * audio_metadata_num_loc_get(meta_out);
 
-		if (audio_block == NULL) {
-			LOG_ERR("Out of TX buffers");
+	if (usb_out_spillover != NULL) {
+		len = MIN((usb_out_1ms_frame_size - usb_out_spillover->len), audio_frame_out->len);
+
+		/* Add decoded PCM output to spillover buffer */
+		net_buf_add_mem(usb_out_spillover, audio_frame_out->data, len);
+		net_buf_pull_mem(audio_frame_out, len);
+
+		/* If the working spillover buff is not a full 1ms frame then we return and wait for
+		 * the next audio_frame_out
+		 */
+		if (usb_out_spillover->len < usb_out_1ms_frame_size) {
+			/* Release this input buffer as we have consumed it */
+			net_buf_unref(audio_frame_out);
+			return 0;
+		}
+
+		struct audio_metadata *usb_spill_meta = net_buf_user_data(usb_out_spillover);
+
+		*usb_spill_meta = *meta_out;
+		usb_spill_meta->bytes_per_location = USB_BLOCK_1MS_MONO_SIZE;
+
+		ret = k_msgq_put(&audio_q_out, (void *)&usb_out_spillover, K_NO_WAIT);
+		if (ret) {
+			net_buf_unref(audio_frame_out);
+			net_buf_unref(usb_out_spillover);
+			usb_out_spillover = NULL;
+			return ret;
+		}
+	}
+
+	/* Split decoded frame into 1ms blocks */
+	while (audio_frame_out->len >= usb_out_1ms_frame_size) {
+		struct net_buf *usb_block = net_buf_alloc(&audio_q_out_pool, K_NO_WAIT);
+
+		if (unlikely(usb_block == NULL)) {
+			LOG_ERR("Out of USB OUT buffers");
 			net_buf_unref(audio_frame_out);
 			return -ENOMEM;
 		}
 
-		struct audio_metadata *meta_blk = net_buf_user_data(audio_block);
+		struct audio_metadata *usb_block_meta = net_buf_user_data(usb_block);
 
-		net_buf_add_mem(audio_block,
-				(char *)audio_frame_out->data +
-					(i * (audio_frame_out->len / CONFIG_FIFO_FRAME_SPLIT_NUM)),
-				(audio_frame_out->len / CONFIG_FIFO_FRAME_SPLIT_NUM));
-		net_buf_user_data_copy(audio_block, audio_frame_out);
+		net_buf_add_mem(usb_block, audio_frame_out->data, usb_out_1ms_frame_size);
+		*usb_block_meta = *meta_out;
+		usb_block_meta->bytes_per_location = USB_BLOCK_1MS_MONO_SIZE;
+		net_buf_pull_mem(audio_frame_out, usb_out_1ms_frame_size);
 
-		meta_blk->data_len_us = meta_out->data_len_us / CONFIG_FIFO_FRAME_SPLIT_NUM;
-		meta_blk->bytes_per_location =
-			(audio_frame_out->len / CONFIG_FIFO_FRAME_SPLIT_NUM) /
-			audio_metadata_num_loc_get(meta_out);
-
-		ret = k_msgq_put(&audio_q_tx, (void *)&audio_block, K_NO_WAIT);
+		ret = k_msgq_put(&audio_q_out, (void *)&usb_block, K_NO_WAIT);
 		if (ret) {
-			LOG_ERR("Failed to put block onto queue");
-			net_buf_unref(audio_block);
 			net_buf_unref(audio_frame_out);
 			return ret;
 		}
 	}
 
-	if (debug_trans_count == DEBUG_INTERVAL_NUM) {
-		uint32_t audio_q_num_used = k_msgq_num_used_get(&audio_q_tx);
+	if (audio_frame_out->len != 0) {
+		struct net_buf *usb_out_spillover = net_buf_alloc(&audio_q_out_pool, K_NO_WAIT);
 
-		LOG_DBG(COLOR_MAGENTA "TX fill grade: %d/%d" COLOR_RESET, audio_q_num_used,
+		if (unlikely(usb_out_spillover == NULL)) {
+			LOG_ERR("Out of USB OUT buffers");
+			net_buf_unref(audio_frame_out);
+			return -ENOMEM;
+		}
+
+		net_buf_add_mem(usb_out_spillover, audio_frame_out->data, audio_frame_out->len);
+	} else {
+		usb_out_spillover = NULL;
+	}
+
+	net_buf_unref(audio_frame_out);
+
+	if (debug_trans_count == DEBUG_INTERVAL_NUM) {
+		uint32_t audio_q_num_used = k_msgq_num_used_get(&audio_q_out);
+
+		LOG_DBG(COLOR_MAGENTA "OUT fill grade: %d/%d" COLOR_RESET, audio_q_num_used,
 			CONFIG_FIFO_TX_FRAME_COUNT);
 		debug_trans_count = 0;
 	} else {
 		debug_trans_count++;
 	}
-
-	net_buf_unref(audio_frame_out);
 
 	return 0;
 }
@@ -465,7 +514,7 @@ void audio_system_start(void)
 	}
 
 #if ((CONFIG_AUDIO_SOURCE_USB) && (CONFIG_AUDIO_DEV == GATEWAY))
-	ret = audio_usb_start(&audio_q_tx, &audio_q_rx);
+	ret = audio_usb_start(&audio_q_out, &audio_q_in);
 	ERR_CHK(ret);
 #else
 	if (IS_ENABLED(CONFIG_BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP)) {
@@ -473,7 +522,7 @@ void audio_system_start(void)
 		ERR_CHK(ret);
 	}
 
-	ret = audio_datapath_start(&audio_q_rx);
+	ret = audio_datapath_start(&audio_q_in);
 	ERR_CHK(ret);
 #endif /* ((CONFIG_AUDIO_SOURCE_USB) && (CONFIG_AUDIO_DEV == GATEWAY))) */
 }

--- a/applications/nrf_audio/src/modules/audio_usb.c
+++ b/applications/nrf_audio/src/modules/audio_usb.c
@@ -25,28 +25,29 @@ LOG_MODULE_REGISTER(audio_usb, CONFIG_MODULE_AUDIO_USB_LOG_LEVEL);
 #define TERMINAL_ID_HEADPHONES_OUT UAC2_ENTITY_ID(DT_NODELABEL(hp_out_terminal))
 #define TERMINAL_ID_HEADSET_IN	  UAC2_ENTITY_ID(DT_NODELABEL(in_terminal))
 
-/* Absolute minimum is 2 TX buffers but add 2 additional buffers to prevent out of memory
+/* Absolute minimum is 2 OUT buffers but add 2 additional buffers to prevent out of memory
  * errors when USB host decides to perform rapid terminal enable/disable cycles.
  */
 #define USB_BLOCKS 4
 
 /* See udc_buf.h for more information about UDC_BUF_GRANULARITY and UDC_BUF_ALIGN */
-K_MEM_SLAB_DEFINE_STATIC(usb_tx_slab, ROUND_UP(USB_BLOCK_SIZE_MULTI_CHAN, UDC_BUF_GRANULARITY),
+K_MEM_SLAB_DEFINE_STATIC(usb_out_slab, ROUND_UP(USB_BLOCK_MULTI_CHAN_1MS_SIZE, UDC_BUF_GRANULARITY),
 			 USB_BLOCKS, UDC_BUF_ALIGN);
-K_MEM_SLAB_DEFINE_STATIC(usb_rx_slab, ROUND_UP(USB_BLOCK_SIZE_MULTI_CHAN, UDC_BUF_GRANULARITY),
+K_MEM_SLAB_DEFINE_STATIC(usb_in_slab, ROUND_UP(USB_BLOCK_MULTI_CHAN_1MS_SIZE, UDC_BUF_GRANULARITY),
 			 USB_BLOCKS, UDC_BUF_ALIGN);
 
-static struct k_msgq *audio_q_tx;
-static struct k_msgq *audio_q_rx;
+static struct k_msgq *audio_q_in;
+static struct k_msgq *audio_q_out;
 
 /* USB blocks are 1 ms each, but we split them into 0.5 ms blocks for processing,
  * hence the dividing by two
  */
 NET_BUF_POOL_FIXED_DEFINE(pool_in, USB_BLOCKS,
-			  (USB_BLOCK_SIZE_MULTI_CHAN * CONFIG_FIFO_FRAME_SPLIT_NUM / 2),
+			  (USB_BLOCK_MULTI_CHAN_1MS_SIZE * CONFIG_FIFO_FRAME_SPLIT_NUM / 2),
 			  sizeof(struct audio_metadata), NULL);
 
-static uint32_t rx_num_overruns;
+static uint32_t in_num_overruns;
+static uint32_t out_num_underruns;
 static bool terminal_headset_out_enabled;
 static bool terminal_headphones_out_enabled;
 static bool terminal_headset_in_enabled;
@@ -62,13 +63,11 @@ struct audio_metadata usb_in_meta = {.data_coding = PCM,
 				     .sample_rate_hz = CONFIG_AUDIO_SAMPLE_RATE_HZ,
 				     .bits_per_sample = CONFIG_AUDIO_BIT_DEPTH_BITS,
 				     .carried_bits_per_sample = CONFIG_AUDIO_BIT_DEPTH_BITS,
-				     .bytes_per_location = USB_BLOCK_SIZE_MULTI_CHAN / 2,
+				     .bytes_per_location = USB_BLOCK_MULTI_CHAN_1MS_SIZE / 2,
 				     .interleaved = true,
 				     .locations = BT_AUDIO_LOCATION_FRONT_LEFT |
 						  BT_AUDIO_LOCATION_FRONT_RIGHT,
 				     .bad_data = 0};
-
-static uint32_t tx_num_underruns;
 
 static void terminal_update_cb(const struct device *dev, uint8_t terminal, bool enabled,
 			       bool microframes, void *user_data)
@@ -83,6 +82,7 @@ static void terminal_update_cb(const struct device *dev, uint8_t terminal, bool 
 		terminal_headphones_out_enabled = enabled;
 	} else if (terminal == TERMINAL_ID_HEADSET_IN) {
 		terminal_headset_in_enabled = enabled;
+		out_num_underruns = 0;
 	} else {
 		LOG_WRN("Unknown terminal ID: %d", terminal);
 		return;
@@ -95,52 +95,59 @@ static void usb_send_cb(const struct device *dev, void *user_data)
 {
 	int ret;
 	void *pcm_buf;
-	struct net_buf *data_out;
+	struct net_buf *usb_data_out;
 
 	/* Fast path exit - cache combined condition */
-	bool tx_ready = (audio_q_tx != NULL && terminal_headset_in_enabled && playing_state &&
-			 local_host_in);
+	bool out_ready = (audio_q_in != NULL && terminal_headset_in_enabled && playing_state &&
+			  local_host_in);
 
-	if (unlikely(!tx_ready)) {
+	if (unlikely(!out_ready)) {
 		return;
 	}
 
-	ret = k_mem_slab_alloc(&usb_tx_slab, &pcm_buf, K_NO_WAIT);
+	ret = k_mem_slab_alloc(&usb_out_slab, &pcm_buf, K_NO_WAIT);
 	if (unlikely(ret != 0)) {
 		LOG_WRN("Could not allocate pcm_buf, ret: %d", ret);
 		return;
 	}
 
-	ret = k_msgq_get(audio_q_tx, &data_out, K_NO_WAIT);
+	ret = k_msgq_get(audio_q_in, &usb_data_out, K_NO_WAIT);
 	if (unlikely(ret)) {
 		/* Reduce logging overhead */
-		if (unlikely((++tx_num_underruns % 100) == 1)) {
-			LOG_WRN("USB TX underrun. Num: %d", tx_num_underruns);
+		if (unlikely((++out_num_underruns % 100) == 1)) {
+			LOG_WRN("USB OUT underrun. Num: %d", out_num_underruns);
 		}
-		k_mem_slab_free(&usb_tx_slab, pcm_buf);
+
+		k_mem_slab_free(&usb_out_slab, pcm_buf);
 		return;
 	}
 
-	struct audio_metadata *usb_out_meta = net_buf_user_data(data_out);
+	struct audio_metadata *usb_data_out_meta = net_buf_user_data(usb_data_out);
 	size_t pcm_size = 0;
 
-	if (audio_metadata_num_loc_get(usb_out_meta) == 1) {
+	if (audio_metadata_num_loc_get(usb_data_out_meta) == 1) {
 		/* Mono to stereo copy */
-		pscm_copy_pad((char *)data_out->data, data_out->len, CONFIG_AUDIO_BIT_DEPTH_BITS,
-			      (char *)pcm_buf, &pcm_size);
+		ret = pscm_copy_pad((char *)usb_data_out->data, usb_data_out->len,
+				    usb_data_out_meta->carried_bits_per_sample, (char *)pcm_buf,
+				    &pcm_size);
+		if (ret) {
+			k_mem_slab_free(&usb_out_slab, pcm_buf);
+			net_buf_unref(usb_data_out);
+			return;
+		}
 	} else {
 		/* Direct copy for stereo */
-		memcpy(pcm_buf, data_out->data, data_out->len);
-		pcm_size = data_out->len;
+		memcpy(pcm_buf, usb_data_out->data, usb_data_out->len);
+		pcm_size = usb_data_out->len;
 	}
 
 	ret = usbd_uac2_send(dev, TERMINAL_ID_HEADSET_IN, pcm_buf, pcm_size);
 	if (ret) {
-		LOG_WRN("USB TX failed, ret: %d", ret);
-		k_mem_slab_free(&usb_tx_slab, pcm_buf);
+		LOG_WRN("USB OUT failed, ret: %d", ret);
+		k_mem_slab_free(&usb_out_slab, pcm_buf);
 	}
 
-	net_buf_unref(data_out);
+	net_buf_unref(usb_data_out);
 }
 
 static void send_buf_release_cb(const struct device *dev, uint8_t terminal, void *buf,
@@ -154,7 +161,7 @@ static void send_buf_release_cb(const struct device *dev, uint8_t terminal, void
 		return;
 	}
 
-	k_mem_slab_free(&usb_tx_slab, buf);
+	k_mem_slab_free(&usb_out_slab, buf);
 }
 
 static void *get_recv_buf_cb(const struct device *dev, uint8_t terminal, uint16_t size,
@@ -168,7 +175,7 @@ static void *get_recv_buf_cb(const struct device *dev, uint8_t terminal, uint16_
 	void *buf = NULL;
 
 	if (terminal == TERMINAL_ID_HEADSET_OUT || terminal == TERMINAL_ID_HEADPHONES_OUT) {
-		ret = k_mem_slab_alloc(&usb_rx_slab, &buf, K_NO_WAIT);
+		ret = k_mem_slab_alloc(&usb_in_slab, &buf, K_NO_WAIT);
 	}
 
 	return buf;
@@ -211,14 +218,14 @@ static void data_recv_cb(const struct device *dev, uint8_t terminal, void *buf, 
 	/* Fast exit conditions */
 	if (unlikely(size == 0 || !playing_state) ||
 	    !(terminal_headset_out_enabled || terminal_headphones_out_enabled)) {
-		k_mem_slab_free(&usb_rx_slab, buf);
+		k_mem_slab_free(&usb_in_slab, buf);
 		return;
 	}
 
 	/* Size validation */
-	if (unlikely(size != USB_BLOCK_SIZE_MULTI_CHAN)) {
-		LOG_WRN("Incorrect buffer size: %d (%u)", size, USB_BLOCK_SIZE_MULTI_CHAN);
-		k_mem_slab_free(&usb_rx_slab, buf);
+	if (unlikely(size != USB_BLOCK_MULTI_CHAN_1MS_SIZE)) {
+		LOG_WRN("Incorrect buffer size: %d (%u)", size, USB_BLOCK_MULTI_CHAN_1MS_SIZE);
+		k_mem_slab_free(&usb_in_slab, buf);
 		return;
 	}
 
@@ -231,14 +238,14 @@ static void data_recv_cb(const struct device *dev, uint8_t terminal, void *buf, 
 			blocks_in_frame_spillover = 0;
 		} else {
 			/* Check space availability */
-			if (unlikely(k_msgq_num_free_get(audio_q_rx) == 0 ||
+			if (unlikely(k_msgq_num_free_get(audio_q_out) == 0 ||
 				     pool_in.avail_count == 0)) {
 				goto overrun_cleanup;
 			}
 
 			frame_current = net_buf_alloc(&pool_in, K_NO_WAIT);
 			if (unlikely(frame_current == NULL)) {
-				LOG_WRN("Out of RX buffers for frame");
+				LOG_WRN("Out of IN buffers for frame");
 				goto overrun_cleanup;
 			}
 
@@ -271,7 +278,7 @@ static void data_recv_cb(const struct device *dev, uint8_t terminal, void *buf, 
 		 */
 		frame_spillover = net_buf_alloc(&pool_in, K_NO_WAIT);
 		if (unlikely(frame_spillover == NULL)) {
-			LOG_WRN("Out of RX buffers for spill over frame");
+			LOG_WRN("Out of IN buffers for spill over frame");
 			goto overrun_cleanup;
 		}
 
@@ -299,12 +306,12 @@ static void data_recv_cb(const struct device *dev, uint8_t terminal, void *buf, 
 	}
 
 	/* Release USB buffer */
-	k_mem_slab_free(&usb_rx_slab, buf);
+	k_mem_slab_free(&usb_in_slab, buf);
 
 	/* Check if we have a complete frame */
 	if (blocks_in_frame_current >= CONFIG_FIFO_FRAME_SPLIT_NUM) {
-		/* Put complete frame into RX queue */
-		ret = k_msgq_put(audio_q_rx, (void *)&frame_current, K_NO_WAIT);
+		/* Put complete frame into IN queue */
+		ret = k_msgq_put(audio_q_out, (void *)&frame_current, K_NO_WAIT);
 		if (ret) {
 			LOG_ERR("Failed to store complete frame");
 			net_buf_unref(frame_current);
@@ -318,11 +325,11 @@ static void data_recv_cb(const struct device *dev, uint8_t terminal, void *buf, 
 	return;
 
 overrun_cleanup:
-	if (unlikely((++rx_num_overruns % 100) == 1)) {
-		LOG_WRN("USB RX overrun. Num: %d", rx_num_overruns);
+	if (unlikely((++in_num_overruns % 100) == 1)) {
+		LOG_WRN("USB IN overrun. Num: %d", in_num_overruns);
 	}
 
-	k_mem_slab_free(&usb_rx_slab, buf);
+	k_mem_slab_free(&usb_in_slab, buf);
 }
 
 static struct uac2_ops ops = {
@@ -335,38 +342,50 @@ static struct uac2_ops ops = {
 
 static struct usbd_context *audio_usbd;
 
-bool audio_usb_is_mic_enabled(void)
+bool audio_usb_headphones_out_enabled(void)
+{
+	return terminal_headphones_out_enabled;
+}
+
+bool audio_usb_headset_out_enabled(void)
+{
+	return terminal_headset_out_enabled;
+}
+
+bool audio_usb_headset_in_enabled(void)
 {
 	return terminal_headset_in_enabled;
 }
 
-int audio_usb_start(struct k_msgq *audio_q_tx_in, struct k_msgq *audio_q_rx_in)
+int audio_usb_start(struct k_msgq *audio_q_out_ptr, struct k_msgq *audio_q_in_ptr)
 {
 	if (audio_usbd == NULL) {
 		LOG_ERR("USB device not initialized");
 		return -ENOTCONN;
 	}
 
-	if (audio_q_tx_in == NULL || audio_q_rx_in == NULL) {
+	if (audio_q_out_ptr == NULL || audio_q_in_ptr == NULL) {
 		return -EINVAL;
 	}
 
-	audio_q_tx = audio_q_tx_in;
-	audio_q_rx = audio_q_rx_in;
+	audio_q_in = audio_q_out_ptr;
+	audio_q_out = audio_q_in_ptr;
 
 	playing_state = true;
 
 	return 0;
 }
 
-void audio_usb_stop(void)
+int audio_usb_stop(void)
 {
 	if (audio_usbd == NULL) {
 		LOG_ERR("USB device not initialized");
-		return;
+		return -ENOTCONN;
 	}
 
 	playing_state = false;
+
+	return 0;
 }
 
 int audio_usb_disable(void)
@@ -384,9 +403,9 @@ int audio_usb_disable(void)
 		return ret;
 	}
 
-	audio_usb_stop();
+	ret = audio_usb_stop();
 
-	return 0;
+	return ret;
 }
 
 int audio_usb_init(bool host_in, bool host_out)

--- a/applications/nrf_audio/src/modules/audio_usb.h
+++ b/applications/nrf_audio/src/modules/audio_usb.h
@@ -25,36 +25,59 @@
 #error USB only supports 48kHz stereo
 #endif /* (CONFIG_AUDIO_SOURCE_USB && !CONFIG_AUDIO_SAMPLE_RATE_48000_HZ) */
 
-#define USB_BLOCK_SIZE_MULTI_CHAN                                                                  \
-	(((CONFIG_AUDIO_SAMPLE_RATE_HZ * CONFIG_AUDIO_BIT_DEPTH_OCTETS) / 1000) *                  \
-	 MAX(CONFIG_AUDIO_INPUT_CHANNELS, CONFIG_AUDIO_OUTPUT_CHANNELS))
+#define USB_1MS_BLOCKS_NUM_MAX                                                                     \
+	((CONFIG_AUDIO_FRAME_DURATION_US / USEC_PER_MSEC) +                                        \
+	 (CONFIG_AUDIO_FRAME_DURATION_US % USEC_PER_MSEC ? 1 : 0))
+#define USB_BLOCK_1MS_MONO_SIZE                                                                    \
+	(CONFIG_AUDIO_SAMPLE_RATE_HZ * CONFIG_AUDIO_BIT_DEPTH_OCTETS / MSEC_PER_SEC)
+#define USB_BLOCK_MULTI_CHAN_1MS_SIZE                                                              \
+	(USB_BLOCK_1MS_MONO_SIZE * MAX(CONFIG_AUDIO_INPUT_CHANNELS, CONFIG_AUDIO_OUTPUT_CHANNELS))
 
 struct usbd_context *audio_usbd_init_device(usbd_msg_cb_t msg_cb);
 
 /**
- * @brief Check if the USB microphone (host input) is enabled.
+ * @brief Get the state of the USB devices headphones out.
  *
- * @return true if the USB microphone is enabled, false otherwise.
+ * @return true: USB headphones out enabled.
+ *         false: USB headphones out disabled.
  */
-bool audio_usb_is_mic_enabled(void);
+bool audio_usb_headphones_out_enabled(void);
+
+/**
+ * @brief Get the state of the USB devices headset out.
+ *
+ * @return true: USB headset out enabled.
+ *         false: USB headset out disabled.
+ */
+bool audio_usb_headset_out_enabled(void);
+
+/**
+ * @brief Get the state of the USB devices headset in.
+ *
+ * @return true: USB headset in enabled.
+ *         false: USB headset in disabled.
+ */
+bool audio_usb_headset_in_enabled(void);
 
 /**
  * @brief Set pointers to the queues to be used by the USB module and start sending/receiving data.
  *
- * @param queue_tx_in  Pointer to queue structure for tx.
- * @param queue_rx_in  Pointer to queue structure for rx.
+ * @param audio_q_out_ptr  Pointer to queue structure for out.
+ * @param audio_q_in_ptr   Pointer to queue structure for in.
  *
  * @return 0 if successful, error otherwise
  */
-int audio_usb_start(struct k_msgq *queue_tx_in, struct k_msgq *queue_rx_in);
+int audio_usb_start(struct k_msgq *audio_q_out_ptr, struct k_msgq *audio_q_in_ptr);
 
 /**
  * @brief Stop sending/receiving data.
  *
  * @note The USB device will still be running, but all data sent to
  *       it will be discarded.
+ *
+ * @return 0 if successful, error otherwise
  */
-void audio_usb_stop(void);
+int audio_usb_stop(void);
 
 /**
  * @brief Stop and disable USB device.
@@ -69,7 +92,8 @@ int audio_usb_disable(void);
  * @param	host_in		If true, initializes USB as input (host in),
  * @param	host_out	If true, initializes USB as output (host out).
  *
- * @note If both @p host_in and @p host_out are true, USB is initialized as bidirectional (headset).
+ * @note If both @p host_in and @p host_out are true, USB is initialized as bidirectional
+ * (headset).
  *
  * @return 0 if successful, error otherwise.
  */


### PR DESCRIPTION
OCT-3752

When running bidirectional, CIS, USB, the returned audio from the microphone is very choppy.
This is due to the change of block size being passed to the USB driver, 0.5ms when expecting 1ms. Send 1ms blocks built from any decoded buffer size.