### PR TITLE
nrf_wifi: Fix issues with patch download on NRF54H20

### DIFF
--- a/snippets/nrf70-fw-patch-ext-flash/overlay-fw-patch-ext-flash.conf
+++ b/snippets/nrf70-fw-patch-ext-flash/overlay-fw-patch-ext-flash.conf
@@ -5,4 +5,6 @@
 #
 
 CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_STORE=y
-CONFIG_NRF_WIFI_FW_FLASH_CHUNK_SIZE=8192
+# Leave NRF_WIFI_FW_FLASH_CHUNK_SIZE at its default (NRF70_PATCH_DL_CHUNK_SIZE)
+# so the flash read chunk stays within the host bus DMA limits. Forcing 8192
+# here overran the nRF91 EasyDMA MAXCNT and the nRF54H20 DMA bounce region.

--- a/subsys/net/lib/nrf70_fw_ext/Kconfig
+++ b/subsys/net/lib/nrf70_fw_ext/Kconfig
@@ -42,11 +42,17 @@ endchoice
 if NRF_WIFI_PATCHES_EXT_FLASH_STORE
 config NRF_WIFI_FW_FLASH_CHUNK_SIZE
 	int "Chunk size for nRF70 FW patches to be read from external flash"
-	default 8192
+	default NRF70_PATCH_DL_CHUNK_SIZE
 	help
 	  Chunk size for nRF70 FW patches to be read from external flash.
 	  This option impacts the loading time of the nRF70 FW patches and
 	  RAM usage (heap) of the application.
+
+	  Each chunk read from flash is written to the RPU in a single SPI/QSPI
+	  transfer, so it must stay within the host EasyDMA MAXCNT and any DMA
+	  bounce region of the bus driver. It therefore defaults to
+	  NRF70_PATCH_DL_CHUNK_SIZE, which is sized for the most constrained
+	  supported SoC. Do not raise it above that limit.
 
 config NRF_WIFI_FW_PATCH_INTEGRITY_CHECK
 	bool "Integrity check of nRF70 FW patches"

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 9cbcc38202206a8a27d7b4f651ddde63df922e20
+      revision: a27b77c0610ab942a5dfcf405e8f791eb6f0934b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above

--- a/west.yml
+++ b/west.yml
@@ -243,7 +243,7 @@ manifest:
       groups:
         - doc-internal
     - name: nrf_wifi
-      revision: d28d7e972a208f5007f745bd0a116d4cde3c4100
+      revision: 5046744cb4c9640eb8b11cb92f1ea0b9554c20cf
       path: modules/lib/nrf_wifi
 
     # Other third-party repositories.


### PR DESCRIPTION
Fix Wi-Fi boot failure due to large chunk size in nRF54H.