### PR TITLE
[Backport v3.4-branch] tests: lib: nrf_fuel_gauge: Disable partition manager

### DIFF
--- a/tests/lib/nrf_fuel_gauge/Kconfig.sysbuild
+++ b/tests/lib/nrf_fuel_gauge/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PARTITION_MANAGER
+	default n
+
+source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Backport c383737a4e3c2df8ceddebabf1b9e405e29070b5 from #29579.