### PR TITLE
manifest: update sdk-zephyr and sdk-tfm to point to nrf7120 RAM changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: dd3483846f15aeb8ae06a3ccebfa43226dd23404
+      revision: 14033cef1f737389bd00bced5a0971925c3e518f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -154,7 +154,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: c9f73070ad6d9469574fc13a4e297ed33ab7e84a
+      revision: 7e50389b35b352897a0f0adcd94c887104a58b20
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
nrf7120 NS application to use full RAM, and reduce sram0_s to 128Kb. Both changes are needed to pass CI.