### PR TITLE
doc: VSC extension June 2026 update

### DIFF
--- a/doc/nrf/app_dev/config_and_build/hardware/add_new_led_example.rst
+++ b/doc/nrf/app_dev/config_and_build/hardware/add_new_led_example.rst
@@ -9,7 +9,7 @@ Adding a dimmable LED node
 
 This example demonstrates how to add support for a dimmable LED node to your board in an overlay file.
 
-To implement this example, you can either edit the devicetree files manually or use |nRFVSC| with its `Devicetree language support`_ and the `Devicetree Visual Editor <How to work with Devicetree Visual Editor_>`_ (recommended).
+To implement this example, you can either edit the devicetree files manually or use |nRFVSC| with its `Devicetree Visual Editor <How to work with Devicetree Visual Editor_>`_ (recommended).
 
 For more advanced LED control, you can also use the :ref:`LEDs module <caf_leds>` of the :ref:`Common Application Framework (CAF) <lib_caf>`, which provides additional features, such as LED effects and power management integration.
 

--- a/doc/nrf/app_dev/config_and_build/hardware/index.rst
+++ b/doc/nrf/app_dev/config_and_build/hardware/index.rst
@@ -5,10 +5,8 @@ Configuring devicetree
 
 |nRFVSC| is the recommended tool for editing :ref:`configure_application_hw`.
 The extension offers several layers of `Devicetree integration <Devicetree support overview_>`_, ranging from summarizing devicetree settings in a menu and providing devicetree language support in the editor, to the Devicetree Visual Editor, a GUI tool for editing devicetree files.
-Follow the steps in `How to create devicetree files`_ and use one of the following options to edit the :file:`.dts`, :file:`.dtsi`, and :file:`.overlay` files:
 
-* `Devicetree Visual Editor <How to work with Devicetree Visual Editor_>`_
-* `Devicetree language support`_
+Follow the steps in `How to create devicetree files`_ in the extension documentation and use the `Devicetree Visual Editor <How to work with Devicetree Visual Editor_>`_ to edit the :file:`.dts`, :file:`.dtsi`, and :file:`.overlay` files.
 
 Like Kconfig fragment files, devicetree files can also be provided as overlays.
 The devicetree overlay files use the :ref:`normalized board target name <app_boards_names>` and the file extension :file:`.overlay` (for example, ``nrf54h20dk/nrf54h20/cpuapp`` becomes :file:`nrf54h20dk_nrf54h20_cpuapp.overlay`).

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_custom_pcb.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_custom_pcb.rst
@@ -31,7 +31,7 @@ Use the PCB layouts and component values provided by Nordic Semiconductor, espec
 Prepare the configuration files for your custom board in the |NCS|
 ******************************************************************
 
-Use the `nRF Connect for VS Code Extension Pack`_ to generate a custom board skeleton.
+Use `nRF Connect for VS Code`_ with the related extensions to generate a custom board skeleton.
 
 Use the nRF54H20 DK board files found in :file:`sdk-zephyr/boards/nordic/nrf54h20dk` as a reference point for configuring your own custom board.
 

--- a/doc/nrf/installation/install_ncs.rst
+++ b/doc/nrf/installation/install_ncs.rst
@@ -51,11 +51,11 @@ Depending on your preferred development environment, install the following softw
       Additionally, install |VSC|:
 
       * The latest version of |VSC| for your operating system from the `Visual Studio Code download page`_ or `using this direct link <start VS Code walkthrough_>`_.
-      * In |VSC|, the latest version of the `nRF Connect for VS Code Extension Pack`_.
+      * In |VSC|, the latest version of `nRF Connect for VS Code`_ with the related extensions.
         |nRFVSC| comes with its own bundled version of some of the nRF Util commands.
 
       .. note::
-         You can also use a different IDE compatible with the VSIX format and install the extensions that are part of the nRF Connect for VS Code Extension Pack from the `Open VSX Registry`_.
+         You can also use a different IDE compatible with the VSIX format and install the full set of extensions from the `Open VSX Registry`_.
          However, Nordic Semiconductor does not test editors other than |VSC| for compatibility with |nRFVSC|.
          While you are encouraged to report any issues you encounter on `DevZone`_, issues discovered in editors other than |VSC| and not reproducible in |VSC| will not be prioritized.
 

--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -407,7 +407,7 @@ Use the latest available release for development.
 
 The extensions are available for download from the following websites:
 
-* |VSC| Marketplace, where the extensions are bundled as the `nRF Connect for VS Code Extension Pack`_.
+* |VSC| Marketplace, where you can install the main `nRF Connect for VS Code`_ extension to get the full set of extensions.
 * `Open VSX Registry`_, from where you can install the extensions separately to editors based on |VSC| and compatible with the VSIX format.
 
   .. note::

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -853,7 +853,6 @@
 .. _`How to create devicetree files`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/how_to_create_dt_files.html
 .. _`How to work with Devicetree Visual Editor`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/work_with_devicetree_editor.html
 .. _`Devicetree support overview`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/ncs_configure_app.html#devicetree-overview
-.. _`Devicetree language support`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/ncs_configure_app.html#devicetree-language-support
 .. _`How to work with boards and devices`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/guides/bd_work_with_boards.html
 .. _`How to install the extension`:
 .. _`Installing on Linux`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/get_started/install.html
@@ -1847,7 +1846,7 @@
 
 .. ### Source: visualstudio.com
 
-.. _`nRF Connect for VS Code Extension Pack`: https://marketplace.visualstudio.com/items?itemName=nordic-semiconductor.nrf-connect-extension-pack
+.. _`nRF Connect for VS Code`: https://marketplace.visualstudio.com/items?itemName=nordic-semiconductor.nrf-connect
 .. _`VSMQTT`: https://marketplace.visualstudio.com/items?itemName=rpdswtk.vsmqtt
 .. _`Visual Studio Code download page`: https://code.visualstudio.com/download
 

--- a/doc/nrf/protocols/matter/getting_started/transmission_power.rst
+++ b/doc/nrf/protocols/matter/getting_started/transmission_power.rst
@@ -159,7 +159,7 @@ You can provide the desired value also as a CMake argument when building the sam
       To build a Matter sample with a custom Thread TX power in the nRF Connect for VS Code IDE, add the :kconfig:option:`CONFIG_OPENTHREAD_DEFAULT_TX_POWER` Kconfig option variable and the dBm value to the :term:`build configuration`'s :guilabel:`Extra CMake arguments` and rebuild the build configuration.
       For example, if you want to build for the ``nrf52840dk/nrf52840`` board target with the default Thread TX power equal to 2 dBm, add ``-DCONFIG_OPENTHREAD_DEFAULT_TX_POWER=2``.
 
-      See `nRF Connect for VS Code extension pack <How to work with build configurations_>`_ documentation for more information.
+      See the `nRF Connect for VS Code <How to work with build configurations_>`_ documentation for more information.
 
    .. group-tab:: Command line
 
@@ -216,7 +216,7 @@ You can do this by either editing the :file:`prj.conf` file or building the samp
       To build for the network core, make sure to add the ``childImageName_`` parameter between ``-D`` and the name of the Kconfig option.
       For example, if you want to build for Thread devices using the ``nrf5340dk/nrf5340/cpuapp`` board target with a Bluetooth LE TX power equal to 3 dBm, add ``-Dipc_radio_CONFIG_BT_CTLR_TX_PWR_PLUS_3=y`` as the CMake argument.
 
-      See `nRF Connect for VS Code extension pack <How to work with build configurations_>`_ documentation for more information.
+      See the `nRF Connect for VS Code <How to work with build configurations_>`_ documentation for more information.
 
    .. group-tab:: Command line
 

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_3.4.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_3.4.rst
@@ -48,7 +48,7 @@ Matter
 
         #include "<samples/matter/nrf54lm20_cpuapp_partitions.dtsi>"
 
-     After that, once the base is ready, you can modify partitions by using the |nRFVSC| with its `Devicetree language support`_ and the `Devicetree Visual Editor <How to work with Devicetree Visual Editor_>`_, or manually edit the :file:`.overlay` file.
+     After that, once the base is ready, you can modify partitions by using the |nRFVSC| with its `Devicetree Visual Editor <How to work with Devicetree Visual Editor_>`_, or manually edit the :file:`.overlay` file.
 
      For more information on how to configure partitions using DTS and how to migrate your existing configuration to DTS, see the :ref:`migration_partitions` page.
 

--- a/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/migration_guide_2.6.99-cs2_to_2_7_environment.rst
+++ b/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/migration_guide_2.6.99-cs2_to_2_7_environment.rst
@@ -77,7 +77,7 @@ You also need the following:
       #. Add the J-Link executable to the system path, on Linux and MacOS, or to the environment variables, on Windows, to run it from anywhere on the system.
 
 * The latest version of |VSC| for your operating system from the `Visual Studio Code download page`_.
-* In |VSC|, the latest version of the `nRF Connect for VS Code Extension Pack`_.
+* In |VSC|, the latest version of `nRF Connect for VS Code`_.
 * On Linux, the `nrf-udev`_ module with udev rules required to access USB ports on Nordic Semiconductor devices and program the firmware.
 
 Updating the |NCS| and its toolchain

--- a/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/transition_guide_2.4.99-cs3_to_2.7_environment.rst
+++ b/doc/nrf/releases_and_maturity/migration/nRF54H20_migration_2.7/transition_guide_2.4.99-cs3_to_2.7_environment.rst
@@ -77,7 +77,7 @@ You also need the following:
       #. Add the J-Link executable to the system path, on Linux and MacOS, or to the environment variables, on Windows, to run it from anywhere on the system.
 
 * The latest version of |VSC| for your operating system from the `Visual Studio Code download page`_.
-* In |VSC|, the latest version of the `nRF Connect for VS Code Extension Pack`_.
+* In |VSC|, the latest version of `nRF Connect for VS Code`_.
 * On Linux, the `nrf-udev`_ module with udev rules required to access USB ports on Nordic Semiconductor devices and program the firmware.
 
 Preliminary step


### PR DESCRIPTION
Updated the documentation for the nRF Connect for VS Code June 2026 release. VSC-3229.