### PR TITLE
nrf7120 ble builds

### DIFF
--- a/samples/bluetooth/central_and_peripheral_hrs/sample.yaml
+++ b/samples/bluetooth/central_and_peripheral_hrs/sample.yaml
@@ -19,6 +19,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns

--- a/samples/bluetooth/central_bas/sample.yaml
+++ b/samples/bluetooth/central_bas/sample.yaml
@@ -24,6 +24,7 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
     tags:
       - bluetooth
       - ci_build

--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -42,6 +42,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp
@@ -62,6 +63,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
     extra_args: FILE_SUFFIX=hid_sci

--- a/samples/bluetooth/central_hr_coded/sample.yaml
+++ b/samples/bluetooth/central_hr_coded/sample.yaml
@@ -18,6 +18,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns

--- a/samples/bluetooth/central_smp_client/sample.yaml
+++ b/samples/bluetooth/central_smp_client/sample.yaml
@@ -24,6 +24,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -27,6 +27,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dongle/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
@@ -70,6 +71,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dongle/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/direct_test_mode/sample.yaml
+++ b/samples/bluetooth/direct_test_mode/sample.yaml
@@ -25,6 +25,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp

--- a/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
@@ -18,6 +18,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/direction_finding_peripheral/sample.yaml
+++ b/samples/bluetooth/direction_finding_peripheral/sample.yaml
@@ -19,6 +19,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/event_trigger/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/samples/bluetooth/event_trigger/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		egu = &egu10;
+	};
+};

--- a/samples/bluetooth/event_trigger/sample.yaml
+++ b/samples/bluetooth/event_trigger/sample.yaml
@@ -19,6 +19,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/iso_combined_bis_and_cis/sample.yaml
+++ b/samples/bluetooth/iso_combined_bis_and_cis/sample.yaml
@@ -20,6 +20,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/llpm/sample.yaml
+++ b/samples/bluetooth/llpm/sample.yaml
@@ -18,6 +18,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/sample.yaml
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/sample.yaml
@@ -23,6 +23,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
   sample.bluetooth.mesh.ble_and_mesh.settings_ext_flash:
     sysbuild: true
     build_only: true

--- a/samples/bluetooth/mesh/chat/sample.yaml
+++ b/samples/bluetooth/mesh/chat/sample.yaml
@@ -22,6 +22,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
   sample.bluetooth.mesh.chat.settings_ext_flash:
     sysbuild: true
     build_only: true

--- a/samples/bluetooth/mesh/dfu/distributor/sample.yaml
+++ b/samples/bluetooth/mesh/dfu/distributor/sample.yaml
@@ -18,6 +18,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
   sample.bluetooth.mesh_dfu_distributor.smp_bt_auth:
     sysbuild: true
     build_only: true
@@ -29,6 +30,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
     extra_args: OVERLAY_CONFIG=overlay-smp-bt-auth.conf
   sample.bluetooth.mesh_dfu_distributor.dfu_ext_flash:
     sysbuild: true

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -26,6 +26,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
   sample.bluetooth.mesh.light.dfu:
     sysbuild: true
     build_only: true
@@ -38,6 +39,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp/ns
     extra_args: FILE_SUFFIX=dfu

--- a/samples/bluetooth/mesh/light_ctrl/sample.yaml
+++ b/samples/bluetooth/mesh/light_ctrl/sample.yaml
@@ -27,6 +27,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
   sample.bluetooth.mesh.light_ctrl.emds:
     sysbuild: true
     build_only: true

--- a/samples/bluetooth/mesh/light_dimmer/sample.yaml
+++ b/samples/bluetooth/mesh/light_dimmer/sample.yaml
@@ -27,6 +27,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
   sample.bluetooth.mesh.light_dimmer.settings_ext_flash:
     sysbuild: true
     build_only: true

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -26,6 +26,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
   sample.bluetooth.mesh.light_switch.lpn:
     sysbuild: true
     build_only: true
@@ -40,6 +41,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
     extra_args: OVERLAY_CONFIG=overlay-lpn.conf
   sample.bluetooth.mesh.light_switch.settings_ext_flash:
     sysbuild: true

--- a/samples/bluetooth/mesh/sensor_client/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_client/sample.yaml
@@ -21,6 +21,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
   sample.bluetooth.mesh.sensor_client.settings_ext_flash:
     sysbuild: true
     build_only: true

--- a/samples/bluetooth/mesh/sensor_server/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_server/sample.yaml
@@ -23,6 +23,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
   sample.bluetooth.mesh.sensor_server.settings_ext_flash:
     sysbuild: true
     build_only: true

--- a/samples/bluetooth/mesh/silvair_enocean/sample.yaml
+++ b/samples/bluetooth/mesh/silvair_enocean/sample.yaml
@@ -25,6 +25,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
   sample.bluetooth.mesh.silvair_enocean.settings_ext_flash:
     sysbuild: true
     build_only: true

--- a/samples/bluetooth/multiple_adv_sets/sample.yaml
+++ b/samples/bluetooth/multiple_adv_sets/sample.yaml
@@ -19,6 +19,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns

--- a/samples/bluetooth/peripheral_ams_client/sample.yaml
+++ b/samples/bluetooth/peripheral_ams_client/sample.yaml
@@ -18,6 +18,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns

--- a/samples/bluetooth/peripheral_ancs_client/sample.yaml
+++ b/samples/bluetooth/peripheral_ancs_client/sample.yaml
@@ -18,6 +18,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns

--- a/samples/bluetooth/peripheral_bms/sample.yaml
+++ b/samples/bluetooth/peripheral_bms/sample.yaml
@@ -19,6 +19,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/peripheral_cgms/sample.yaml
+++ b/samples/bluetooth/peripheral_cgms/sample.yaml
@@ -21,6 +21,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/peripheral_cts_client/sample.yaml
+++ b/samples/bluetooth/peripheral_cts_client/sample.yaml
@@ -20,6 +20,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/peripheral_gatt_dm/sample.yaml
+++ b/samples/bluetooth/peripheral_gatt_dm/sample.yaml
@@ -24,6 +24,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
     tags:
       - bluetooth
       - ci_build

--- a/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
@@ -39,6 +39,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
@@ -61,5 +62,6 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -40,6 +40,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
@@ -65,6 +66,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
@@ -90,6 +92,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
@@ -148,5 +151,6 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/peripheral_hr_coded/sample.yaml
+++ b/samples/bluetooth/peripheral_hr_coded/sample.yaml
@@ -19,6 +19,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -29,6 +29,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp
@@ -116,6 +117,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp

--- a/samples/bluetooth/peripheral_mds/sample.yaml
+++ b/samples/bluetooth/peripheral_mds/sample.yaml
@@ -23,6 +23,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
+++ b/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
@@ -21,6 +21,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
     tags:
       - bluetooth
       - ci_build

--- a/samples/bluetooth/peripheral_power_profiling/sample.yaml
+++ b/samples/bluetooth/peripheral_power_profiling/sample.yaml
@@ -34,6 +34,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp
@@ -57,6 +58,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp
@@ -180,6 +182,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp
@@ -263,6 +266,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
@@ -294,6 +298,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp

--- a/samples/bluetooth/peripheral_rscs/sample.yaml
+++ b/samples/bluetooth/peripheral_rscs/sample.yaml
@@ -20,6 +20,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/peripheral_status/sample.yaml
+++ b/samples/bluetooth/peripheral_status/sample.yaml
@@ -36,6 +36,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp
@@ -61,6 +62,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/peripheral_with_multiple_identities/sample.yaml
+++ b/samples/bluetooth/peripheral_with_multiple_identities/sample.yaml
@@ -18,6 +18,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/radio_notification_cb/sample.yaml
+++ b/samples/bluetooth/radio_notification_cb/sample.yaml
@@ -18,6 +18,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/scanning_while_connecting/sample.yaml
+++ b/samples/bluetooth/scanning_while_connecting/sample.yaml
@@ -18,6 +18,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/shell_bt_nus/sample.yaml
+++ b/samples/bluetooth/shell_bt_nus/sample.yaml
@@ -19,6 +19,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns

--- a/samples/bluetooth/shorter_conn_intervals/sample.yaml
+++ b/samples/bluetooth/shorter_conn_intervals/sample.yaml
@@ -18,6 +18,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
       - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/bluetooth/subrating/sample.yaml
+++ b/samples/bluetooth/subrating/sample.yaml
@@ -20,6 +20,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp

--- a/samples/bluetooth/throughput/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/samples/bluetooth/throughput/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * The throughput sample's default app.overlay puts the shell on uart0 with
+ * hardware flow control. On the nRF7120 DK the console/VCOM is exposed on
+ * uart20 and the onboard debugger does not wire RTS/CTS, so route the shell to
+ * uart20 and drop the hardware-flow-control requirement.
+ */
+/ {
+	chosen {
+		zephyr,shell-uart = &uart20;
+	};
+};
+
+&uart20 {
+	/delete-property/ hw-flow-control;
+};

--- a/samples/bluetooth/throughput/sample.yaml
+++ b/samples/bluetooth/throughput/sample.yaml
@@ -19,6 +19,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns


### PR DESCRIPTION
## Summary
Adds `nrf7120dk/nrf7120/cpuapp` build coverage to the relevant Bluetooth samples 