### PR TITLE
net: lwm2m_client_utils: Add buffer for optional Speed resource (6/0/6)

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m_obj_location_optional.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m_obj_location_optional.c
@@ -15,10 +15,12 @@
 #define LOCATION_ALTITUDE_ID 2
 #define LOCATION_RADIUS_ID   3
 #define LOCATION_VELOCITY_ID 4
+#define LOCATION_SPEED_ID    6
 
 static double altitude;
 static double radius;
 static double velocity;
+static double speed;
 
 static int lwm2m_init_optional_location_res(void)
 {
@@ -39,6 +41,12 @@ static int lwm2m_init_optional_location_res(void)
 
 	path = LWM2M_OBJ(LWM2M_OBJECT_LOCATION_ID, 0, LOCATION_VELOCITY_ID);
 	ret = lwm2m_set_res_buf(&path, &velocity, sizeof(velocity), sizeof(velocity), 0);
+	if (ret < 0) {
+		return ret;
+	}
+
+	path = LWM2M_OBJ(LWM2M_OBJECT_LOCATION_ID, 0, LOCATION_SPEED_ID);
+	ret = lwm2m_set_res_buf(&path, &speed, sizeof(speed), sizeof(speed), 0);
 	if (ret < 0) {
 		return ret;
 	}


### PR DESCRIPTION
The LwM2M Location object initializes the Speed resource (ID 6) as optional with no backing buffer. When a GNSS fix is received, lwm2m_location.c calls lwm2m_set_f64() on this resource, which results in an error:

  <err> net_lwm2m_registry: res instance data pointer is NULL [6/0/6/0:3]

Fix this by adding a static buffer and registering it with lwm2m_set_res_buf() for the Speed resource in
lwm2m_obj_location_optional.c, following the same pattern used for Altitude, Radius, and Velocity.