### PR TITLE
scripts: ci: test_plan: test suite filtering only for tests or samples

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -339,6 +339,11 @@ class Filters:
             self.full_twister = True
             return
 
+        if not all("sample" in test_path or "tests" in test_path for test_path in tests):
+            logging.warning("Skipping test handling. Allowed when tests or samples were modified only. Revert to default")
+            self.full_twister = True
+            return
+
         if _options:
             logging.info(f'Potential test filters...({len(tests)} changed...)')
             if self.platforms:


### PR DESCRIPTION
Test suite filtering was prepared for tests or samples only. However, at sdk-nrf, there are also applications,
which have dedicated tests.

Without this PR, changing application code only will not trigger its tests, as test suite filtering will remove /tests from paths, preventing tag base filtering to work.
Thus limit test suite filtering only for tests or samples changes only.