### PR TITLE
Bluetooth: Extension API for SDC

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -30,3 +30,6 @@ zephyr_library_include_directories_ifdef(
 )
 
 zephyr_include_directories(.)
+
+zephyr_iterable_section(NAME hci_internal_user_extension_handler GROUP RODATA_REGION)
+zephyr_linker_sources(SECTIONS hci_internal_user_extension.ld)

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -1584,6 +1584,16 @@ static int hci_driver_init(const struct device *dev)
 		return err;
 	}
 
+	STRUCT_SECTION_FOREACH(hci_internal_user_extension_handler, handler)
+	{
+		if (handler->init) {
+			err = handler->init();
+			if (err) {
+				return err;
+			}
+		}
+	}
+
 	configure_supported_features();
 
 	err = configure_memory_usage();

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -1855,6 +1855,17 @@ static void cmd_put(uint8_t *cmd_in, uint8_t * const raw_event_out)
 					  &generate_command_status_event);
 	}
 
+	STRUCT_SECTION_FOREACH(hci_internal_user_extension_handler, handler)
+	{
+		if (handler->hci_handler) {
+			status = handler->hci_handler(cmd_in, raw_event_out, &return_param_length,
+						      &generate_command_status_event);
+			if (status != BT_HCI_ERR_UNKNOWN_CMD) {
+				break;
+			}
+		}
+	}
+
 	if (status == BT_HCI_ERR_UNKNOWN_CMD) {
 
 		switch (BT_OGF(opcode)) {

--- a/subsys/bluetooth/controller/hci_internal.h
+++ b/subsys/bluetooth/controller/hci_internal.h
@@ -13,6 +13,7 @@
 #include <sdc_hci_cmd_le.h>
 #include <sdc_hci_cmd_info_params.h>
 #include <zephyr/drivers/bluetooth.h>
+#include <zephyr/sys/slist.h>
 
 #ifndef HCI_INTERNAL_H__
 #define HCI_INTERNAL_H__
@@ -23,8 +24,9 @@ struct hci_driver_data {
 
 /** @brief Send an HCI command packet to the SoftDevice Controller.
  *
- * If the application has provided a user handler, this handler get precedence
- * above the default HCI command handlers. See @ref hci_internal_user_cmd_handler_register.
+ * If the application has provided user handlers, these handlers get precedence
+ * above the default HCI command handlers. See @ref hci_internal_user_cmd_handler_register and
+ * @ref hci_internal_user_extension_handler_register.
  *
  * @param[in] cmd_in  HCI Command packet. The first byte in the buffer should correspond to
  *                    OpCode, as specified by the Bluetooth Core Specification.
@@ -67,10 +69,23 @@ typedef uint8_t (*hci_internal_user_cmd_handler_t)(uint8_t const *cmd,
  *
  * @note Only one handler can be registered.
  *
- * @param[in] handler
+ * @param[in] handler A user implementable HCI command handler.
  * @return Zero on success or (negative) error code otherwise
+ *
+ * @deprecated Use @ref hci_internal_user_extension_handler_register instead
  */
 int hci_internal_user_cmd_handler_register(const hci_internal_user_cmd_handler_t handler);
+
+struct hci_internal_user_extension_handler {
+	hci_internal_user_cmd_handler_t hci_handler;
+	int (*init)(void);
+};
+
+#define DEFINE_HCI_USER_EXTENSION_HANDLER(name, cmd_handler, init_handler)                         \
+	STRUCT_SECTION_ITERABLE(hci_internal_user_extension_handler, name) = {                     \
+		.hci_handler = cmd_handler,                                                        \
+		.init = init_handler,                                                              \
+	}
 
 /** @brief Retrieve an HCI packet from the SoftDevice Controller.
  *

--- a/subsys/bluetooth/controller/hci_internal_user_extension.ld
+++ b/subsys/bluetooth/controller/hci_internal_user_extension.ld
@@ -1,0 +1,3 @@
+#include <zephyr/linker/iterable_sections.h>
+
+ITERABLE_SECTION_ROM(hci_internal_user_extension_handler, Z_LINK_ITERABLE_SUBALIGN)


### PR DESCRIPTION
Add an extension API for SDC. This allows out-of-tree extensions to be called right after the SDC is configured to update the SDC config.