### PR TITLE
Bluetooth: Services: Add RAS RRSP MTU check

### DIFF
--- a/subsys/bluetooth/services/ras/rrsp/ras_rrsp.c
+++ b/subsys/bluetooth/services/ras/rrsp/ras_rrsp.c
@@ -326,7 +326,14 @@ static int rd_segment_send(struct bt_ras_rrsp *rrsp)
 	 * shall be used to fill the characteristic message.
 	 * An extra byte is reserved for the segment header
 	 */
-	uint16_t max_data_len = bt_gatt_get_mtu(rrsp->conn) - (4 + sizeof(struct ras_seg_header));
+	uint16_t mtu = bt_gatt_get_mtu(rrsp->conn);
+
+	if (mtu <= (4 + sizeof(struct ras_seg_header))) {
+		LOG_WRN("Invalid MTU: %d", mtu);
+		return -ENOTCONN;
+	}
+
+	uint16_t max_data_len = mtu - (4 + sizeof(struct ras_seg_header));
 
 	/* segment_buf is only accessed by the RRSP WQ, so is safe to reuse. */
 	net_buf_simple_reset(&segment_buf);
@@ -409,7 +416,14 @@ static void send_data_work_handler(struct k_work *work)
 
 	int err = rd_segment_send(rrsp);
 
-	if (err) {
+	if (err == -ENOTCONN) {
+		rrsp->streaming = false;
+		if (rrsp->active_buf) {
+			bt_ras_rd_buffer_release(rrsp->active_buf);
+			rrsp->active_buf = NULL;
+			rrsp->active_buf_read_cursor = 0;
+		}
+	} else if (err) {
 		/* Will keep retrying. */
 		LOG_WRN("Failed to send segment: %d", err);
 	}

--- a/subsys/bluetooth/services/ras/rrsp/ras_rrsp.c
+++ b/subsys/bluetooth/services/ras/rrsp/ras_rrsp.c
@@ -179,9 +179,14 @@ static ssize_t ras_cp_write(struct bt_conn *conn, struct bt_gatt_attr const *att
 
 	struct bt_ras_rrsp *rrsp = rrsp_find(conn);
 
-	if (!rrsp || k_work_is_pending(&rrsp->rascp_work) || len > RASCP_WRITE_MAX_LEN) {
+	if (!rrsp || k_work_is_pending(&rrsp->rascp_work)) {
 		LOG_DBG("Write rejected");
 		return BT_GATT_ERR(RAS_ATT_ERROR_WRITE_REQ_REJECTED);
+	}
+
+	if (len > RASCP_WRITE_MAX_LEN || len < RASCP_CMD_OPCODE_LEN) {
+		LOG_DBG("RAS CP write: Invalid length: %d", len);
+		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	}
 
 	memcpy(rrsp->rascp_cmd_buf, buf, len);


### PR DESCRIPTION
Adds a check to prevent an underflow when calculating the maximum data length in `rd_segment_send`. The underflow could occur if the connection was disconnected in the middle of a CS procedure. The function is scheduled in the rrsp_wq. If for some reason the system work queue is blocked for a period of time, preventing the disconnect cleanup work from being processed, the maximum data length could be calculated using an invalid/zero MTU from the ATT connection no longer being valid.