### PR TITLE
[Backport v3.4-branch] samples: bluetooth: add boardfiles for the nRF54L15TAG to CS samples

### DIFF
--- a/samples/bluetooth/channel_sounding/ipt_initiator/boards/nrf54l15tag_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/channel_sounding/ipt_initiator/boards/nrf54l15tag_nrf54l15_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Overwriting antenna settings to use the additional antennas on the tag
+CONFIG_BT_CS_DE_MAX_NUM_ANTENNA_PATHS=4
+CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS=4
+CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS=2

--- a/samples/bluetooth/channel_sounding/ipt_initiator/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/channel_sounding/ipt_initiator/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	cs_antenna_switch: cs-antenna-config {
+		status = "okay";
+		compatible = "nordic,bt-cs-antenna-switch";
+		ant-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>,
+			    <&gpio1 10 GPIO_ACTIVE_HIGH>;
+		multiplexing-mode = <0>;
+	};
+};
+
+/* delete other nodes that drive the antenna pins so there is no duplicate access */
+/delete-node/ &sky13348;
+
+&gpio1 {
+	/delete-node/ antenna_switch_v1;
+	/delete-node/ antenna_switch_v2;
+};

--- a/samples/bluetooth/channel_sounding/ipt_reflector/boards/nrf54l15tag_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/boards/nrf54l15tag_nrf54l15_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Overwriting antenna settings to use the additional antennas on the tag
+CONFIG_BT_CS_DE_MAX_NUM_ANTENNA_PATHS=4
+CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS=4
+CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS=2

--- a/samples/bluetooth/channel_sounding/ipt_reflector/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	cs_antenna_switch: cs-antenna-config {
+		status = "okay";
+		compatible = "nordic,bt-cs-antenna-switch";
+		ant-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>,
+			    <&gpio1 10 GPIO_ACTIVE_HIGH>;
+		multiplexing-mode = <0>;
+	};
+};
+
+/* delete other nodes that drive the antenna pins so there is no duplicate access */
+/delete-node/ &sky13348;
+
+&gpio1 {
+	/delete-node/ antenna_switch_v1;
+	/delete-node/ antenna_switch_v2;
+};

--- a/samples/bluetooth/channel_sounding/ras_initiator/boards/nrf54l15tag_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/channel_sounding/ras_initiator/boards/nrf54l15tag_nrf54l15_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Overwriting antenna settings to use the additional antennas on the tag
+CONFIG_BT_CS_DE_MAX_NUM_ANTENNA_PATHS=4
+CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS=4
+CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS=2

--- a/samples/bluetooth/channel_sounding/ras_initiator/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/channel_sounding/ras_initiator/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	cs_antenna_switch: cs-antenna-config {
+		status = "okay";
+		compatible = "nordic,bt-cs-antenna-switch";
+		ant-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>,
+			    <&gpio1 10 GPIO_ACTIVE_HIGH>;
+		multiplexing-mode = <0>;
+	};
+};
+
+/* delete other nodes that drive the antenna pins so there is no duplicate access */
+/delete-node/ &sky13348;
+
+&gpio1 {
+	/delete-node/ antenna_switch_v1;
+	/delete-node/ antenna_switch_v2;
+};

--- a/samples/bluetooth/channel_sounding/ras_reflector/boards/nrf54l15tag_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/channel_sounding/ras_reflector/boards/nrf54l15tag_nrf54l15_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Overwriting antenna settings to use the additional antennas on the tag
+CONFIG_BT_CS_DE_MAX_NUM_ANTENNA_PATHS=4
+CONFIG_BT_CTLR_SDC_CS_MAX_ANTENNA_PATHS=4
+CONFIG_BT_CTLR_SDC_CS_NUM_ANTENNAS=2

--- a/samples/bluetooth/channel_sounding/ras_reflector/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
+++ b/samples/bluetooth/channel_sounding/ras_reflector/boards/nrf54l15tag_nrf54l15_cpuapp.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	cs_antenna_switch: cs-antenna-config {
+		status = "okay";
+		compatible = "nordic,bt-cs-antenna-switch";
+		ant-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>,
+			    <&gpio1 10 GPIO_ACTIVE_HIGH>;
+		multiplexing-mode = <0>;
+	};
+};
+
+/* delete other nodes that drive the antenna pins so there is no duplicate access */
+/delete-node/ &sky13348;
+
+&gpio1 {
+	/delete-node/ antenna_switch_v1;
+	/delete-node/ antenna_switch_v2;
+};


### PR DESCRIPTION
Backport 478d48a8cf703fc745755094404eb0e49f9204e0 from #29551.