### PR TITLE
doc: integrations: rename section to cover add-ons and mention Edge AI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -118,6 +118,7 @@
 /doc/nrf/external_comp/bt_fast_pair/      @nrfconnect/ncs-si-bluebagel-doc
 /doc/nrf/external_comp/coremark.rst       @nrfconnect/ncs-blenders-doc
 /doc/nrf/external_comp/dult.rst           @nrfconnect/ncs-si-bluebagel-doc
+/doc/nrf/external_comp/edgeai.rst         @nrfconnect/ncs-si-muffin-doc
 /doc/nrf/external_comp/memfault.rst       @nrfconnect/ncs-cia-doc
 /doc/nrf/external_comp/nrf_cloud.rst      @nrfconnect/ncs-nrf-cloud-doc
 /doc/nrf/gsg_guides.rst                   @nrfconnect/ncs-doc-leads @nrfconnect/ncs-vestavind-doc @nrfconnect/ncs-wayland-doc
@@ -255,6 +256,7 @@
 /doc/nrf/samples/debug.rst                @nrfconnect/ncs-cia-doc
 /doc/nrf/samples/dect.rst                 @nrfconnect/ncs-modem-doc
 /doc/nrf/samples/dfu.rst                  @nrfconnect/ncs-eris-doc
+/doc/nrf/samples/edge_impulse.rst         @nrfconnect/ncs-si-muffin-doc
 /doc/nrf/samples/esb.rst                  @nrfconnect/ncs-si-xcake-doc
 /doc/nrf/samples/fast_pair.rst            @nrfconnect/ncs-si-bluebagel-doc
 /doc/nrf/samples/gazell.rst               @nrfconnect/ncs-si-xcake-doc

--- a/doc/nrf/external_comp/edgeai.rst
+++ b/doc/nrf/external_comp/edgeai.rst
@@ -1,0 +1,7 @@
+.. _ug_edgeai:
+
+Edge AI
+#######
+
+The Edge AI add-on provides support for developing, training, and deploying neural network models into an |NCS| application.
+For more information, see the `Edge AI Add-on for nRF Connect SDK`_ page.

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -31,8 +31,9 @@ Remote observability
 Scalable and extensible
   The |NCS| is out-of-tree ready and can be used for projects and applications of all sizes and levels of complexity.
 
-Third-party integrations
+Third-party integrations and Add-ons
   The |NCS| provides integrations with third-party and Nordic products within the SDK, such as AWS, nRF Cloud, :ref:`Memfault (Remote Observability) <ug_memfault>` and more.
+  In addition to that, the |NCS| provides `Add-ons <nRF Connect SDK Add-ons_>`_ for specific areas or standards, such as Edge AI, Amazon Sidewalk, Zigbee, and more.
 
 Varied reference designs
   The |NCS| comes with advanced hardware reference designs for different use cases, ranging from nRF Desktop for Human Interface Devices to nRF Audio for audio devices based on Bluetooth LE Audio specifications.

--- a/doc/nrf/integrations.rst
+++ b/doc/nrf/integrations.rst
@@ -1,9 +1,12 @@
 .. _integrations:
 
-Integrations
-############
+Integrations and Add-ons
+########################
 
-An |NCS| integration allows for using third-party and Nordic products within the |NCS|.
+In addition to the |NCS| itself, Nordic Semiconductor provides integrations for third-party products as well as add-on repositories which extend the |NCS| functionality.
+The add-ons are separate repositories that provide additional functionality in a specific area or standard.
+To see the list of available add-ons, go to the `nRF Connect SDK Add-ons`_ page.
+
 Integrations of the following third-party products are documented in their private repositories:
 
 * Apple Find My
@@ -12,14 +15,19 @@ Integrations of the following third-party products are documented in their priva
 In the case of Find My, MFi licensees can get access to the repository by issuing a Nordic `DevZone`_ private ticket.
 
 .. note::
-    Integrations are available also through the `nRF Connect SDK Add-ons`_, a curated collection of supplementary |NCS| components.
     For more information, including how to contribute your own add-on to the index, read :file:`README.md` and :file:`CONTRIBUTING.md` in the `ncs-app-index repository <ncs-app-index_>`_.
 
 The following user guides describe available integrations:
 
 .. toctree::
    :maxdepth: 1
-   :caption: Subpages:
+   :caption: nRF Connect SDK add-on integrations:
+
+   external_comp/edgeai
+
+.. toctree::
+   :maxdepth: 1
+   :caption: nRF Connect SDK integrations:
 
    external_comp/bt_fast_pair/index
    external_comp/memfault

--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -52,6 +52,7 @@ General information about samples in the |NCS|
    samples/debug
    samples/dect
    samples/dfu
+   samples/edge_impulse
    samples/esb
    samples/gazell
    samples/keys

--- a/doc/nrf/samples/edge_impulse.rst
+++ b/doc/nrf/samples/edge_impulse.rst
@@ -1,0 +1,6 @@
+.. _edge_impulse_samples:
+
+Edge Impulse samples
+####################
+
+The Edge Impulse samples have been migrated from |NCS| to the `Edge AI Add-on for nRF Connect SDK`_.


### PR DESCRIPTION
This update extends the Integrations section of the top level page to specifically cover add-on repositories as well as mentions Edge AI add-on explicitly.
Edge Impulse section in samples is restored and point to the Edge AI add-on.