### PR TITLE
application: nrf_audio: Buildprog creates a duplicate structure

### DIFF
--- a/applications/nrf_audio/tools/buildprog/buildprog.py
+++ b/applications/nrf_audio/tools/buildprog/buildprog.py
@@ -119,8 +119,10 @@ def __build_cmd_get(core: Core, device: AudioDevice, build: BuildType,
                  f"--sysbuild")
 
     if core == Core.app:
+        dest_folder = TARGET_AUDIO_BUILD_FOLDER / options.transport / device / core / build
         build_cmd += " --domain nrf_audio"
     elif core == Core.net:
+        dest_folder = TARGET_AUDIO_BUILD_FOLDER / core / build
         build_cmd += " --domain ipc_radio"
     else:
         raise Exception("Invalid core!")
@@ -170,12 +172,11 @@ def __build_cmd_get(core: Core, device: AudioDevice, build: BuildType,
     if pristine:
         build_cmd += " --pristine"
 
-    dest_folder = TARGET_AUDIO_BUILD_FOLDER / options.transport / device / core / build
-
     return build_cmd, dest_folder, device_flag, release_flag, overlay_flag
 
 
 def __build_module(build_config, options, sirk=""):
+
     build_cmd, dest_folder, device_flag, release_flag, overlay_flag = __build_cmd_get(
         build_config.core,
         build_config.device,


### PR DESCRIPTION
OCT-3719

When building the audio application the system builds the net core for every option of transport and audio device. This has been changed so that the net core app is built once.