### PR TITLE
doc: extensions: introducing kconfigdiff extension

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -112,6 +112,11 @@ jobs:
             SPHINXOPTS_EXTRA="${SPHINXOPTS_EXTRA} -t kapa"
           fi
 
+          VERSION_REGEX="^v([0-9a-zA-Z\.\-]+)$"
+          if [[ ${GITHUB_REF#refs/tags/} =~ $VERSION_REGEX ]]; then
+            SPHINXOPTS_EXTRA="${SPHINXOPTS_EXTRA} -D kconfigdiff_is_release=1"
+          fi
+
           cmake -GNinja -Bdoc/_build -Sdoc -DSPHINXOPTS_EXTRA="${SPHINXOPTS_EXTRA}" ${BUILD_CONF}
           ninja -C doc/_build
 

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -114,7 +114,7 @@ jobs:
 
           VERSION_REGEX="^v([0-9a-zA-Z\.\-]+)$"
           if [[ ${GITHUB_REF#refs/tags/} =~ $VERSION_REGEX ]]; then
-            SPHINXOPTS_EXTRA="${SPHINXOPTS_EXTRA} -D kconfigdiff_is_release=1"
+            BUILD_CONF="${BUILD_CONF} -DNCS_RELEASE=YES"
           fi
 
           cmake -GNinja -Bdoc/_build -Sdoc -DSPHINXOPTS_EXTRA="${SPHINXOPTS_EXTRA}" ${BUILD_CONF}

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           SPHINXOPTS_EXTRA="-q"
           if [[ "${{ github.event_name }}" == "push" ]]; then
-            BUILD_CONF="-DDTS_BINDINGS=ON -DHW_FEATURES=ON"
+            BUILD_CONF="-DDTS_BINDINGS=ON -DHW_FEATURES=ON -DKCONFIGDIFF=ON"
           fi
 
           # Enable the Kapa.ai widget for "latest" builds only (push to main)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SPHINXOPTS "-j auto -W --keep-going -T" CACHE STRING "Default Sphinx Options
 set(SPHINXOPTS_EXTRA "" CACHE STRING "Extra Sphinx Options")
 set(DTS_BINDINGS OFF CACHE BOOL "Generate dts bindings documentation")
 set(HW_FEATURES OFF CACHE BOOL "Generate hardware features")
+set(KCONFIGDIFF OFF CACHE BOOL "Generate Kconfig diff against the previous release")
 
 separate_arguments(SPHINXOPTS)
 separate_arguments(SPHINXOPTS_EXTRA)
@@ -364,7 +365,11 @@ endif()
 #-------------------------------------------------------------------------------
 # docset: kconfig
 
-add_docset(kconfig "")
+if(KCONFIGDIFF)
+  set(KCONFIG_SPHINXOPTS -D kconfigdiff_should_build=1)
+endif()
+
+add_docset(kconfig "" SPHINXOPTS ${KCONFIG_SPHINXOPTS})
 
 #-------------------------------------------------------------------------------
 # Global targets

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SPHINXOPTS_EXTRA "" CACHE STRING "Extra Sphinx Options")
 set(DTS_BINDINGS OFF CACHE BOOL "Generate dts bindings documentation")
 set(HW_FEATURES OFF CACHE BOOL "Generate hardware features")
 set(KCONFIGDIFF OFF CACHE BOOL "Generate Kconfig diff against the previous release")
+set(NCS_RELEASE OFF CACHE BOOL "Bool specifying whether current build is release.")
 
 separate_arguments(SPHINXOPTS)
 separate_arguments(SPHINXOPTS_EXTRA)
@@ -365,8 +366,13 @@ endif()
 #-------------------------------------------------------------------------------
 # docset: kconfig
 
+set(KCONFIG_SPHINXOPTS)
 if(KCONFIGDIFF)
-  set(KCONFIG_SPHINXOPTS -D kconfigdiff_should_build=1)
+  list(APPEND KCONFIG_SPHINXOPTS "-Dkconfigdiff_should_build=1")
+endif()
+
+if(NCS_RELEASE)
+  list(APPEND KCONFIG_SPHINXOPTS "-Dkconfigdiff_is_release=1")
 endif()
 
 add_docset(kconfig "" SPHINXOPTS ${KCONFIG_SPHINXOPTS})

--- a/doc/_extensions/kconfigdiff/__init__.py
+++ b/doc/_extensions/kconfigdiff/__init__.py
@@ -28,6 +28,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_css_file("kconfigdiff.css")
 
     app.add_config_value("kconfigdiff_should_build", False, "env", types=bool)
+    app.add_config_value("kconfigdiff_is_release", False, "env", types=bool)
 
     return {
         "version": __version__,

--- a/doc/_extensions/kconfigdiff/__init__.py
+++ b/doc/_extensions/kconfigdiff/__init__.py
@@ -9,18 +9,73 @@ Kconfigdiff extension for displaying changes in kconfig
 files between releases.
 """
 
+import json
+import logging
+import re
+from pathlib import Path
+
 from sphinx.application import Sphinx
 from sphinx.util.typing import ExtensionMetadata
 
 from .kconfig_utils import RESOURCES_DIR
 from .rendering import KconfigDiffDirective
 
+VERSIONS_FILE = Path(__file__).parents[2] / "versions.json"
+
+logger = logging.Logger(__name__)
+
 __version__ = "0.1.0"
+
+VERSION_REGEX = re.compile(r"^\d+\.\d+\.\d+$")
+MAJOR_VERSION_REGEX = re.compile(r"^\d+\.\d+\.0$")
+
+
+def is_major(version: str):
+    return MAJOR_VERSION_REGEX.match(version)
+
+
+def get_major_version(versions: list[str]) -> str | None:
+    return next((v for v in versions if is_major(v)), None)
+
+
+def get_versions(app) -> tuple[str, str] | None:
+    current = "latest"
+
+    with open(VERSIONS_FILE, "rb") as f:
+        versions = json.load(f)
+        if not versions:
+            logger.error("Ill formatted versions file")
+            return None
+
+        if versions[0].endswith("99"):
+            # skip the placeholder .99 version
+            versions.pop(0)
+
+        # Filter out preview versions (and other -addition versions)
+        versions = [v for v in versions if VERSION_REGEX.match(v)]
+
+        if app.config.kconfigdiff_is_release:
+            current = versions[0]
+            if is_major(current) and (prev := get_major_version(versions[1:])):
+                return current, prev
+            elif len(versions) >= 2:
+                return current, versions[1]
+            else:
+                logger.error("Not enough versions to generate comparison")
+                return None
+
+        if prev := get_major_version(versions):
+            return current, prev
+
+        logger.error("Not enough versions to generate comparison")
+        return None
 
 
 def kconfigdiff_install(app: Sphinx) -> None:
     app.config.html_static_path.append(RESOURCES_DIR.as_posix())
 
+    versions = get_versions(app)
+    app.config.kconfigdiff_versions = versions
 
 def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_directive("kconfigdiff", KconfigDiffDirective)

--- a/doc/_extensions/kconfigdiff/__init__.py
+++ b/doc/_extensions/kconfigdiff/__init__.py
@@ -9,7 +9,6 @@ Kconfigdiff extension for displaying changes in kconfig
 files between releases.
 """
 
-from page_filter import read_versions
 from sphinx.application import Sphinx
 from sphinx.util.typing import ExtensionMetadata
 
@@ -21,7 +20,6 @@ __version__ = "0.1.0"
 
 def kconfigdiff_install(app: Sphinx) -> None:
     app.config.html_static_path.append(RESOURCES_DIR.as_posix())
-    read_versions(app)
 
 
 def setup(app: Sphinx) -> ExtensionMetadata:

--- a/doc/_extensions/kconfigdiff/__init__.py
+++ b/doc/_extensions/kconfigdiff/__init__.py
@@ -77,6 +77,19 @@ def kconfigdiff_install(app: Sphinx) -> None:
     versions = get_versions(app)
     app.config.kconfigdiff_versions = versions
 
+    if versions:
+        latest, prev = versions
+
+        app.config.rst_prolog = (
+            (app.config.rst_prolog or "")
+            + "\n"
+            + (
+                f".. |kconfigdiff_current| replace:: {latest}\n"
+                f".. |kconfigdiff_previous| replace:: {prev}\n"
+            )
+        )
+
+
 def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_directive("kconfigdiff", KconfigDiffDirective)
     app.connect("builder-inited", kconfigdiff_install)

--- a/doc/_extensions/kconfigdiff/__init__.py
+++ b/doc/_extensions/kconfigdiff/__init__.py
@@ -18,6 +18,7 @@ from sphinx.application import Sphinx
 from sphinx.util.typing import ExtensionMetadata
 
 from .kconfig_utils import RESOURCES_DIR
+from .legend import KconfigDiffLegendDirective
 from .rendering import KconfigDiffDirective
 
 VERSIONS_FILE = Path(__file__).parents[2] / "versions.json"
@@ -84,14 +85,15 @@ def kconfigdiff_install(app: Sphinx) -> None:
             (app.config.rst_prolog or "")
             + "\n"
             + (
-                f".. |kconfigdiff_current| replace:: {latest}\n"
-                f".. |kconfigdiff_previous| replace:: {prev}\n"
+                f".. |kconfigdiff_current| replace:: **nRF Connect SDK {latest}**\n"
+                f".. |kconfigdiff_previous| replace:: **nRF Connect SDK {prev}**\n"
             )
         )
 
 
 def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_directive("kconfigdiff", KconfigDiffDirective)
+    app.add_directive("kconfigdiff-legend", KconfigDiffLegendDirective)
     app.connect("builder-inited", kconfigdiff_install)
     app.add_css_file("kconfigdiff.css")
 

--- a/doc/_extensions/kconfigdiff/__init__.py
+++ b/doc/_extensions/kconfigdiff/__init__.py
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+"""
+Kconfigdiff extension for displaying changes in kconfig
+files between releases.
+"""
+
+from page_filter import read_versions
+from sphinx.application import Sphinx
+from sphinx.util.typing import ExtensionMetadata
+
+from .kconfig_utils import RESOURCES_DIR
+from .rendering import KconfigDiffDirective
+
+__version__ = "0.1.0"
+
+
+def kconfigdiff_install(app: Sphinx) -> None:
+    app.config.html_static_path.append(RESOURCES_DIR.as_posix())
+    read_versions(app)
+
+
+def setup(app: Sphinx) -> ExtensionMetadata:
+    app.add_directive("kconfigdiff", KconfigDiffDirective)
+    app.connect("builder-inited", kconfigdiff_install)
+    app.add_css_file("kconfigdiff.css")
+
+    return {
+        "version": __version__,
+        "env_version": 1,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/_extensions/kconfigdiff/__init__.py
+++ b/doc/_extensions/kconfigdiff/__init__.py
@@ -29,6 +29,8 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.connect("builder-inited", kconfigdiff_install)
     app.add_css_file("kconfigdiff.css")
 
+    app.add_config_value("kconfigdiff_should_build", False, "env", types=bool)
+
     return {
         "version": __version__,
         "env_version": 1,

--- a/doc/_extensions/kconfigdiff/__main__.py
+++ b/doc/_extensions/kconfigdiff/__main__.py
@@ -24,6 +24,9 @@ def main() -> None:
     os.environ['ZEPHYR_NRF_KCONFIG'] = str(NRF_BASE / 'Kconfig.nrf')
     os.environ['SYSBUILD_NRF_KCONFIG'] = str(NRF_BASE / 'sysbuild/Kconfig.sysbuild')
 
+    # Unset toolchain variant to match docbuild.yml environment
+    os.environ['ZEPHYR_TOOLCHAIN_VARIANT'] = ""
+
     kconfig, sysbuild_kconfig, _ = kconfig_load([ZEPHYR_BASE, NRF_BASE])
 
     pickler.save_kconfig("kconfig.zip", kconfig, sysbuild_kconfig)

--- a/doc/_extensions/kconfigdiff/__main__.py
+++ b/doc/_extensions/kconfigdiff/__main__.py
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+"""
+Kconfig snapshot generator
+
+Run with ``python -m kconfigdiff`` to load the Kconfig tree and write a pickled
+snapshot that the ``kconfigdiff`` directive can diff.
+"""
+
+import os
+
+from . import pickler
+from .kconfig_utils import NRF_BASE, ZEPHYR_BASE, kconfig_load
+
+
+def main() -> None:
+    os.environ['NCS_MEMFAULT_FIRMWARE_SDK_KCONFIG'] = str(
+        NRF_BASE / 'modules/memfault-firmware-sdk/Kconfig'
+    )
+    os.environ['ZEPHYR_NRF_KCONFIG'] = str(NRF_BASE / 'Kconfig.nrf')
+    os.environ['SYSBUILD_NRF_KCONFIG'] = str(NRF_BASE / 'sysbuild/Kconfig.sysbuild')
+
+    kconfig, sysbuild_kconfig, _ = kconfig_load([ZEPHYR_BASE, NRF_BASE])
+
+    pickler.save_kconfig("kconfig.zip", kconfig, sysbuild_kconfig)
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/_extensions/kconfigdiff/kconfig_utils.py
+++ b/doc/_extensions/kconfigdiff/kconfig_utils.py
@@ -179,6 +179,17 @@ def kconfig_load(
         return kconfiglib.Kconfig(ZEPHYR_BASE / "Kconfig"), sysbuild_output, module_paths
 
 
+def is_path_in_workspace(zephyr_dir: str, path) -> bool:
+    path = os.path.normpath(path)
+    zephyr_dir = os.path.normpath(Path(zephyr_dir).parent)
+    return os.path.commonpath([path, zephyr_dir]) == zephyr_dir
+
+
+def get_path_rel2node(node: SC, path) -> str:
+    orig_zephyr_base = node.kconfig.srctree
+    return path if not os.path.isabs(path) else os.path.relpath(path, orig_zephyr_base)
+
+
 def kconfig_node_generator(
     kconfigs: list[kconfiglib.Kconfig],
 ) -> Generator[tuple[kconfiglib.MenuNode, SC], None, None]:
@@ -251,12 +262,20 @@ class KconfigEntryProperties:
         if isinstance(sc, self._kconfiglib.Symbol):
             if sc.nodes:
                 return f'{prefix}{sc.name}'
-        elif isinstance(sc, self._kconfiglib.Choice):
-            if not sc.name:
-                return "&ltchoice&gt"
-            return f'&ltchoice {prefix}{sc.name}&gt'
 
-        return self._kconfiglib.standard_sc_expr_str(sc)
+            if sc.is_constant and sc.name not in self._kconfiglib.STR_TO_TRI:
+                formatted = self._kconfiglib.escape(sc.name)
+                if os.path.isabs(formatted) and is_path_in_workspace(
+                    self._node.kconfig.srctree, formatted
+                ):
+                    formatted = get_path_rel2node(self._node, formatted)
+                return f'"{formatted}"'
+
+            return sc.name
+
+        if not sc.name:
+            return "&ltchoice&gt"
+        return f'&ltchoice {prefix}{sc.name}&gt'
 
     def _init_deps(self) -> list[str]:
         deps = []
@@ -369,7 +388,7 @@ def diff_generator(
     """
 
     def node_uid(node: kconfiglib.MenuNode, sc: SC) -> str:
-        return f"{entry_name(sc)}/{node.filename}"
+        return f"{entry_name(sc)}/{get_path_rel2node(node, node.filename)}"
 
     new_map: dict[str, list[tuple[kconfiglib.MenuNode, kconfiglib.Symbol | kconfiglib.Choice]]] = (
         defaultdict(list)

--- a/doc/_extensions/kconfigdiff/kconfig_utils.py
+++ b/doc/_extensions/kconfigdiff/kconfig_utils.py
@@ -1,0 +1,379 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+from collections.abc import Generator
+from itertools import chain
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TypeAlias
+
+from dotenv import load_dotenv
+
+from . import pickler
+
+sys.path.insert(0, str(Path(__file__).parents[4] / "zephyr/scripts"))
+sys.path.insert(0, str(Path(__file__).parents[4] / "zephyr/scripts/kconfig"))
+
+import kconfiglib
+import list_boards
+import list_hardware
+import zephyr_module
+
+RESOURCES_DIR = Path(__file__).parent / "static"
+ZEPHYR_BASE = Path(__file__).parents[4] / "zephyr"
+NRF_BASE = Path(__file__).parents[3]
+
+MAX_ENTRY_LINE_CHANGE = 5
+
+SC: TypeAlias = kconfiglib.Symbol | kconfiglib.Choice
+
+
+def kconfig_load(
+    ext_kconfigs: list[Path | str],
+) -> tuple[kconfiglib.Kconfig, kconfiglib.Kconfig, dict[str, str]]:
+    """Load Kconfig"""
+    with TemporaryDirectory() as td:
+        modules = zephyr_module.parse_modules(ZEPHYR_BASE)
+
+        # generate Kconfig.modules file
+        kconfig_module_dirs = ""
+        kconfig = ""
+        sysbuild_kconfig = ""
+        for module in modules:
+            kconfig_module_dirs += zephyr_module.process_kconfig_module_dir(
+                module.project, module.meta, False
+            )
+            kconfig += zephyr_module.process_kconfig(module.project, module.meta)
+            sysbuild_kconfig += zephyr_module.process_sysbuildkconfig(module.project, module.meta)
+
+        with open(Path(td) / "kconfig_module_dirs.env", "w") as f:
+            f.write(kconfig_module_dirs)
+
+        with open(Path(td) / "Kconfig.modules", "w") as f:
+            f.write(kconfig)
+
+        with open(Path(td) / "Kconfig.sysbuild.modules", "w") as f:
+            f.write(sysbuild_kconfig)
+
+        # generate dummy Kconfig.dts file
+        kconfig = ""
+
+        with open(Path(td) / "Kconfig.dts", "w") as f:
+            f.write(kconfig)
+
+        (Path(td) / 'soc').mkdir(exist_ok=True)
+        root_args = argparse.Namespace(**{'soc_roots': [Path(ZEPHYR_BASE)]})
+        v2_systems = list_hardware.find_v2_systems(root_args)
+
+        soc_folders = {soc.folder[0] for soc in v2_systems.get_socs()}
+        with open(Path(td) / "soc" / "Kconfig.defconfig", "w") as f:
+            f.write('')
+
+        with open(Path(td) / "soc" / "Kconfig.soc", "w") as f:
+            for folder in soc_folders:
+                f.write('source "' + (Path(folder) / 'Kconfig.soc').as_posix() + '"\n')
+
+                if "nordic" in folder:
+                    f.write('osource "' + (Path(folder) / 'Kconfig.sysbuild').as_posix() + '"\n')
+
+        with open(Path(td) / "soc" / "Kconfig", "w") as f:
+            for folder in soc_folders:
+                f.write('osource "' + (Path(folder) / 'Kconfig').as_posix() + '"\n')
+
+        (Path(td) / 'arch').mkdir(exist_ok=True)
+        root_args = argparse.Namespace(**{'arch_roots': [Path(ZEPHYR_BASE)], 'arch': None})
+        v2_archs = list_hardware.find_v2_archs(root_args)
+        kconfig = ""
+        for arch in v2_archs['archs']:
+            kconfig += 'source "' + (Path(arch['path']) / 'Kconfig').as_posix() + '"\n'
+        with open(Path(td) / "arch" / "Kconfig", "w") as f:
+            f.write(kconfig)
+
+        (Path(td) / 'boards').mkdir(exist_ok=True)
+        root_args = argparse.Namespace(
+            **{
+                'board_roots': [Path(ZEPHYR_BASE)],
+                'soc_roots': [Path(ZEPHYR_BASE)],
+                'board': None,
+                'board_dir': [],
+            }
+        )
+        v2_boards = list_boards.find_v2_boards(root_args).values()
+
+        with open(Path(td) / "boards" / "Kconfig.boards", "w") as f:
+            for board in v2_boards:
+                board_str = 'BOARD_' + re.sub(r"[^a-zA-Z0-9_]", "_", board.name).upper()
+                f.write('config  ' + board_str + '\n')
+                f.write('\t bool\n')
+                for qualifier in list_boards.board_v2_qualifiers(board):
+                    board_str = 'BOARD_' + re.sub(r"[^a-zA-Z0-9_]", "_", qualifier).upper()
+                    f.write('config  ' + board_str + '\n')
+                    f.write('\t bool\n')
+                f.write('source "' + (board.dir / ('Kconfig.' + board.name)).as_posix() + '"\n\n')
+
+        # base environment
+        os.environ["ZEPHYR_BASE"] = str(ZEPHYR_BASE)
+        os.environ["srctree"] = str(ZEPHYR_BASE)  # noqa: SIM112
+        os.environ["KCONFIG_DOC_MODE"] = "1"
+        os.environ["KCONFIG_BINARY_DIR"] = td
+
+        # include all archs and boards
+        os.environ["ARCH_DIR"] = "arch"
+        os.environ["ARCH"] = "[!v][!2]*"
+        os.environ["HWM_SCHEME"] = "v2"
+
+        os.environ["BOARD"] = "boards"
+        os.environ["KCONFIG_BOARD_DIR"] = str(Path(td) / "boards")
+        load_dotenv(str(Path(td) / "kconfig_module_dirs.env"))
+
+        # Sysbuild runs first
+        os.environ["CONFIG_"] = "SB_CONFIG_"
+        sysbuild_output = kconfiglib.Kconfig(ZEPHYR_BASE / "share" / "sysbuild" / "Kconfig")
+
+        # Normal Kconfig runs second
+        os.environ["CONFIG_"] = "CONFIG_"
+
+        # insert external Kconfigs to the environment
+        module_paths = dict()
+        for module in modules:
+            name = module.meta["name"]
+            name_var = module.meta["name-sanitized"].upper()
+            module_paths[name] = module.project
+
+            build_conf = module.meta.get("build")
+            if not build_conf:
+                continue
+
+            # Module Kconfig file has already been specified
+            if f"ZEPHYR_{name_var}_KCONFIG" in os.environ:
+                continue
+
+            if build_conf.get("kconfig"):
+                kconfig = Path(module.project) / build_conf["kconfig"]
+                os.environ[f"ZEPHYR_{name_var}_KCONFIG"] = str(kconfig)
+            elif build_conf.get("kconfig-ext"):
+                for path in ext_kconfigs:
+                    # Assume that the kconfig file exists at this path.
+                    # Technically the cmake variable can be constructed arbitarily
+                    # by "{ext_path}/modules/modules.cmake"
+                    kconfig = Path(path) / "modules" / name / "Kconfig"
+                    if kconfig.exists():
+                        os.environ[f"ZEPHYR_{name_var}_KCONFIG"] = str(kconfig)
+
+        return kconfiglib.Kconfig(ZEPHYR_BASE / "Kconfig"), sysbuild_output, module_paths
+
+
+def kconfig_node_generator(
+    kconfigs: list[kconfiglib.Kconfig],
+) -> Generator[tuple[kconfiglib.MenuNode, SC], None, None]:
+    for kconfig_obj in kconfigs:
+        os.environ["CONFIG_"] = kconfig_obj.config_prefix
+        for sc in sorted(
+            chain(kconfig_obj.unique_defined_syms, kconfig_obj.unique_choices),
+            key=lambda sc: sc.name if sc.name else "",
+        ):
+            if not sc.name:
+                continue
+
+            dedup: set[str] = set()
+            for node in filter(lambda node: node.prompt or node.help, sc.nodes):
+                if (path := f"{node.filename}:{node.linenr}") in dedup:
+                    continue
+                dedup.add(path)
+                yield node, sc
+
+
+def _entry_name(sc) -> str:
+    prefix = sc.kconfig.config_prefix if sc.kconfig else ""
+    return f"{prefix}{sc.name}"
+
+
+def sc_fmt(sc):
+    prefix = os.environ["CONFIG_"]
+
+    if isinstance(sc, kconfiglib.Symbol):
+        if sc.nodes:
+            return f'{prefix}{sc.name}'
+    elif isinstance(sc, kconfiglib.Choice):
+        if not sc.name:
+            return "&ltchoice&gt"
+        return f'&ltchoice {prefix}{sc.name}&gt'
+
+    return kconfiglib.standard_sc_expr_str(sc)
+
+
+class KconfigEntryProperties:
+    __slots__ = (
+        "_node",
+        "_sc",
+        "name",
+        "prompt",
+        "type",
+        "help",
+        "dependencies",
+        "defaults",
+        "selects",
+        "selected_by",
+        "implies",
+        "implied_by",
+        "ranges",
+        "choices",
+    )
+
+    def __init__(self, node: kconfiglib.MenuNode, sc: SC):
+        self._node = node
+        self._sc = sc
+
+        self.name = sc.name
+        self.prompt = node.prompt[0] if node.prompt else ""
+        self.type = kconfiglib.TYPE_TO_STR[sc.type]
+        self.help = node.help
+        self.dependencies = self._init_deps()
+        self.defaults = self._init_defaults()
+        self.selects = self._init_selects()
+        self.selected_by = self._init_selected_by()
+        self.implies = self._init_implies()
+        self.implied_by = self._init_implied_by()
+        self.ranges = self._init_ranges()
+        self.choices = self._init_choices()
+
+    def _init_deps(self) -> list[str]:
+        deps = []
+        if self._node.dep is not self._sc.kconfig.y:
+            deps = kconfiglib.expr_str(self._node.dep, sc_fmt)
+        return deps
+
+    def _init_defaults(self) -> list[str]:
+        defaults = []
+        for value, cond in self._node.orig_defaults:
+            fmt = kconfiglib.expr_str(value, sc_fmt)
+            if cond is not self._sc.kconfig.y:
+                fmt += f" if {kconfiglib.expr_str(cond, sc_fmt)}"
+            defaults.append(fmt)
+        return defaults
+
+    def _init_selects(self) -> list[str]:
+        selects = []
+        for value, cond in self._node.orig_selects:
+            fmt = kconfiglib.expr_str(value, sc_fmt)
+            if cond is not self._sc.kconfig.y:
+                fmt += f" if {kconfiglib.expr_str(cond, sc_fmt)}"
+            selects.append(fmt)
+        return selects
+
+    def _init_selected_by(self) -> list[str]:
+        selected_by = []
+        if isinstance(self._sc, kconfiglib.Symbol) and self._sc.rev_dep != self._sc.kconfig.n:
+            for select in kconfiglib.split_expr(self._sc.rev_dep, kconfiglib.OR):
+                sym = kconfiglib.split_expr(select, kconfiglib.AND)[0]
+                selected_by.append(f"{_entry_name(sym)}")
+        return selected_by
+
+    def _init_ranges(self) -> list[str]:
+        ranges = list()
+        for min_, max_, cond in self._node.orig_ranges:
+            fmt = f"[{kconfiglib.expr_str(min_, sc_fmt)}, {kconfiglib.expr_str(max_, sc_fmt)}]"
+            if cond is not self._sc.kconfig.y:
+                fmt += f" if {kconfiglib.expr_str(cond, sc_fmt)}"
+            ranges.append(fmt)
+        return ranges
+
+    def _init_choices(self) -> list[str]:
+        choices = []
+        if isinstance(self._sc, kconfiglib.Choice):
+            for sym in self._sc.syms:
+                choices.append(kconfiglib.expr_str(sym, sc_fmt))
+        return choices
+
+    def _init_implies(self) -> list[str]:
+        implies = []
+        for value, cond in self._node.orig_implies:
+            fmt = kconfiglib.expr_str(value, sc_fmt)
+            if cond is not self._sc.kconfig.y:
+                fmt += f" if {kconfiglib.expr_str(cond, sc_fmt)}"
+            implies.append(fmt)
+        return implies
+
+    def _init_implied_by(self) -> list[str]:
+        implied_by = []
+        if isinstance(self._sc, kconfiglib.Symbol) and self._sc.weak_rev_dep != self._sc.kconfig.n:
+            for select in kconfiglib.split_expr(self._sc.weak_rev_dep, kconfiglib.OR):
+                sym = kconfiglib.split_expr(select, kconfiglib.AND)[0]
+                implied_by.append(f"{_entry_name(sym)}")
+        return implied_by
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, KconfigEntryProperties):
+            raise NotImplementedError
+
+        return (
+            self.name == other.name
+            and self.prompt == other.prompt
+            and self.type == other.type
+            and self.help == other.help
+            and self.dependencies == other.dependencies
+            and set(self.defaults) == set(other.defaults)
+            and set(self.selects) == set(other.selects)
+            and set(self.selected_by) == set(other.selected_by)
+            and set(self.implies) == set(other.implies)
+            and set(self.implied_by) == set(other.implied_by)
+            and set(self.ranges) == set(other.ranges)
+            and set(self.choices) == set(other.choices)
+        )
+
+
+def diff_generator(
+    old: Path | str, new: Path | str
+) -> Generator[tuple[KconfigEntryProperties | None, KconfigEntryProperties | None], None, None]:
+    """Yield ``(old, new)`` pairs of :class:`KconfigEntryProperties`.
+
+    Either side may be ``None`` when an entry was added or removed.
+    """
+
+    def node_uid(node: kconfiglib.MenuNode, sc: SC) -> str:
+        return f"{_entry_name(sc)}/{node.filename}"
+
+    new_map: dict[str, list[tuple[kconfiglib.MenuNode, kconfiglib.Symbol | kconfiglib.Choice]]] = (
+        defaultdict(list)
+    )
+    kconfig_old_flat, sysbuild_kconfig_old_flat = pickler.load_file(old)
+    kconfig_old = pickler.unflatten_kconfig(kconfig_old_flat)
+    sysbuild_kconfig_old = pickler.unflatten_kconfig(sysbuild_kconfig_old_flat)
+
+    kconfig_flat, sysbuild_kconfig_flat = pickler.load_file(new)
+    kconfig = pickler.unflatten_kconfig(kconfig_flat)
+    sysbuild_kconfig = pickler.unflatten_kconfig(sysbuild_kconfig_flat)
+
+    for node, sc in kconfig_node_generator([kconfig, sysbuild_kconfig]):
+        new_map[node_uid(node, sc)].append((node, sc))
+
+    for node, sc in kconfig_node_generator([kconfig_old, sysbuild_kconfig_old]):
+        if new_items := new_map.get(node_uid(node, sc)):
+            to_del = None
+            if len(new_items) == 1:
+                to_del = 0
+            else:
+                for i, (new_node, _) in enumerate(new_items):
+                    if abs(new_node.linenr - node.linenr) < MAX_ENTRY_LINE_CHANGE:
+                        to_del = i
+                        break
+                else:
+                    yield KconfigEntryProperties(node, sc), None
+                    continue
+            new_node, new_sc = new_items.pop(to_del)
+            yield (
+                KconfigEntryProperties(node, sc),
+                KconfigEntryProperties(new_node, new_sc),
+            )
+            continue
+
+    for node, sc in chain(*new_map.values()):
+        yield None, KconfigEntryProperties(node, sc)

--- a/doc/_extensions/kconfigdiff/kconfig_utils.py
+++ b/doc/_extensions/kconfigdiff/kconfig_utils.py
@@ -6,7 +6,6 @@
 
 import argparse
 import io
-import json
 import logging
 import os
 import re
@@ -36,8 +35,6 @@ logger = logging.Logger(__name__)
 RESOURCES_DIR = Path(__file__).parent / "static"
 ZEPHYR_BASE = Path(__file__).parents[4] / "zephyr"
 NRF_BASE = Path(__file__).parents[3]
-
-VERSIONS_FILE = Path(__file__).parents[2] / "versions.json"
 
 KCONFIG_SAVE_FILE = "kconfig.zip"
 KCONFIG_URL = f"https://ncsdoc.z6.web.core.windows.net/ncs/{{version}}/kconfig/{KCONFIG_SAVE_FILE}"
@@ -352,15 +349,8 @@ class KconfigEntryProperties:
         )
 
 
-def get_prev_version() -> str:
-    with open(VERSIONS_FILE, "rb") as f:
-        versions = json.load(f)
-        # return first version that's a release (skip -preview and others)
-        return next(filter(lambda v: re.match(r"^\d+.\d+.\d+$", v), versions[1:]), "")
-
-
-def fetch_prev_kconfig_file() -> tuple[kconfiglib.Kconfig, kconfiglib.Kconfig, kconfiglib]:
-    url = KCONFIG_URL.format(version=get_prev_version())
+def fetch_prev_kconfig_file(version) -> tuple[kconfiglib.Kconfig, kconfiglib.Kconfig, kconfiglib]:
+    url = KCONFIG_URL.format(version=version)
     with progress_message(f"Fetching kconfig from previous build, {url=}"):
         res = requests.get(url)
         res.raise_for_status()
@@ -370,6 +360,7 @@ def fetch_prev_kconfig_file() -> tuple[kconfiglib.Kconfig, kconfiglib.Kconfig, k
 
 
 def diff_generator(
+    prev_version,
     outdir: Path,
 ) -> Generator[tuple[KconfigEntryProperties | None, KconfigEntryProperties | None], None, None]:
     """Yield ``(old, new)`` pairs of :class:`KconfigEntryProperties`.
@@ -385,7 +376,7 @@ def diff_generator(
     )
 
     try:
-        kconfig_old, sysbuild_kconfig_old, old_kconflib = fetch_prev_kconfig_file()
+        kconfig_old, sysbuild_kconfig_old, old_kconfiglib = fetch_prev_kconfig_file(prev_version)
     except requests.exceptions.RequestException:
         logger.error("Failed to fetch old kconfig")
         return
@@ -407,11 +398,11 @@ def diff_generator(
                             to_del = i
                             break
                     else:
-                        yield KconfigEntryProperties(node, sc, old_kconflib), None
+                        yield KconfigEntryProperties(node, sc, old_kconfiglib), None
                         continue
                 new_node, new_sc = new_items.pop(to_del)
                 yield (
-                    KconfigEntryProperties(node, sc, old_kconflib),
+                    KconfigEntryProperties(node, sc, old_kconfiglib),
                     KconfigEntryProperties(new_node, new_sc),
                 )
                 continue

--- a/doc/_extensions/kconfigdiff/kconfig_utils.py
+++ b/doc/_extensions/kconfigdiff/kconfig_utils.py
@@ -5,6 +5,8 @@
 #
 
 import argparse
+import io
+import logging
 import os
 import re
 import sys
@@ -15,7 +17,9 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TypeAlias
 
+import requests
 from dotenv import load_dotenv
+from sphinx.util.display import progress_message
 
 from . import pickler
 
@@ -27,9 +31,13 @@ import list_boards
 import list_hardware
 import zephyr_module
 
+logger = logging.Logger(__name__)
 RESOURCES_DIR = Path(__file__).parent / "static"
 ZEPHYR_BASE = Path(__file__).parents[4] / "zephyr"
 NRF_BASE = Path(__file__).parents[3]
+
+KCONFIG_SAVE_FILE = "kconfig.zip"
+KCONFIG_URL = f"https://ncsdoc.z6.web.core.windows.net/ncs/{{version}}/kconfig/{KCONFIG_SAVE_FILE}"
 
 MAX_ENTRY_LINE_CHANGE = 5
 
@@ -191,7 +199,7 @@ def kconfig_node_generator(
                 yield node, sc
 
 
-def _entry_name(sc) -> str:
+def entry_name(sc) -> str:
     prefix = sc.kconfig.config_prefix if sc.kconfig else ""
     return f"{prefix}{sc.name}"
 
@@ -232,7 +240,7 @@ class KconfigEntryProperties:
         self._node = node
         self._sc = sc
 
-        self.name = sc.name
+        self.name = entry_name(sc)
         self.prompt = node.prompt[0] if node.prompt else ""
         self.type = kconfiglib.TYPE_TO_STR[sc.type]
         self.help = node.help
@@ -274,7 +282,7 @@ class KconfigEntryProperties:
         if isinstance(self._sc, kconfiglib.Symbol) and self._sc.rev_dep != self._sc.kconfig.n:
             for select in kconfiglib.split_expr(self._sc.rev_dep, kconfiglib.OR):
                 sym = kconfiglib.split_expr(select, kconfiglib.AND)[0]
-                selected_by.append(f"{_entry_name(sym)}")
+                selected_by.append(f"{entry_name(sym)}")
         return selected_by
 
     def _init_ranges(self) -> list[str]:
@@ -307,7 +315,7 @@ class KconfigEntryProperties:
         if isinstance(self._sc, kconfiglib.Symbol) and self._sc.weak_rev_dep != self._sc.kconfig.n:
             for select in kconfiglib.split_expr(self._sc.weak_rev_dep, kconfiglib.OR):
                 sym = kconfiglib.split_expr(select, kconfiglib.AND)[0]
-                implied_by.append(f"{_entry_name(sym)}")
+                implied_by.append(f"{entry_name(sym)}")
         return implied_by
 
     def __eq__(self, other: object) -> bool:
@@ -330,8 +338,18 @@ class KconfigEntryProperties:
         )
 
 
+def fetch_prev_kconfig_file(version) -> tuple[kconfiglib.Kconfig, kconfiglib.Kconfig]:
+    url = KCONFIG_URL.format(version=version)
+    with progress_message(f"Fetching kconfig from previous build, {url=}"):
+        res = requests.get(url)
+        res.raise_for_status()
+
+        with io.BytesIO(res.content) as f:
+            return pickler.load_file(f)
+
+
 def diff_generator(
-    old: Path | str, new: Path | str
+    version: str, outdir: Path
 ) -> Generator[tuple[KconfigEntryProperties | None, KconfigEntryProperties | None], None, None]:
     """Yield ``(old, new)`` pairs of :class:`KconfigEntryProperties`.
 
@@ -339,41 +357,45 @@ def diff_generator(
     """
 
     def node_uid(node: kconfiglib.MenuNode, sc: SC) -> str:
-        return f"{_entry_name(sc)}/{node.filename}"
+        return f"{entry_name(sc)}/{node.filename}"
 
     new_map: dict[str, list[tuple[kconfiglib.MenuNode, kconfiglib.Symbol | kconfiglib.Choice]]] = (
         defaultdict(list)
     )
-    kconfig_old_flat, sysbuild_kconfig_old_flat = pickler.load_file(old)
-    kconfig_old = pickler.unflatten_kconfig(kconfig_old_flat)
-    sysbuild_kconfig_old = pickler.unflatten_kconfig(sysbuild_kconfig_old_flat)
 
-    kconfig_flat, sysbuild_kconfig_flat = pickler.load_file(new)
-    kconfig = pickler.unflatten_kconfig(kconfig_flat)
-    sysbuild_kconfig = pickler.unflatten_kconfig(sysbuild_kconfig_flat)
+    try:
+        kconfig_old, sysbuild_kconfig_old = fetch_prev_kconfig_file(version)
+    except requests.exceptions.RequestException:
+        logger.error("Failed to fetch old kconfig")
+        return
 
-    for node, sc in kconfig_node_generator([kconfig, sysbuild_kconfig]):
-        new_map[node_uid(node, sc)].append((node, sc))
+    with progress_message("Generating kconfig diff pairs"):
+        kconfig, sysbuild_kconfig, _ = kconfig_load([ZEPHYR_BASE, NRF_BASE])
 
-    for node, sc in kconfig_node_generator([kconfig_old, sysbuild_kconfig_old]):
-        if new_items := new_map.get(node_uid(node, sc)):
-            to_del = None
-            if len(new_items) == 1:
-                to_del = 0
-            else:
-                for i, (new_node, _) in enumerate(new_items):
-                    if abs(new_node.linenr - node.linenr) < MAX_ENTRY_LINE_CHANGE:
-                        to_del = i
-                        break
+        for node, sc in kconfig_node_generator([kconfig, sysbuild_kconfig]):
+            new_map[node_uid(node, sc)].append((node, sc))
+
+        for node, sc in kconfig_node_generator([kconfig_old, sysbuild_kconfig_old]):
+            if new_items := new_map.get(node_uid(node, sc)):
+                to_del = None
+                if len(new_items) == 1:
+                    to_del = 0
                 else:
-                    yield KconfigEntryProperties(node, sc), None
-                    continue
-            new_node, new_sc = new_items.pop(to_del)
-            yield (
-                KconfigEntryProperties(node, sc),
-                KconfigEntryProperties(new_node, new_sc),
-            )
-            continue
+                    for i, (new_node, _) in enumerate(new_items):
+                        if abs(new_node.linenr - node.linenr) < MAX_ENTRY_LINE_CHANGE:
+                            to_del = i
+                            break
+                    else:
+                        yield KconfigEntryProperties(node, sc), None
+                        continue
+                new_node, new_sc = new_items.pop(to_del)
+                yield (
+                    KconfigEntryProperties(node, sc),
+                    KconfigEntryProperties(new_node, new_sc),
+                )
+                continue
 
-    for node, sc in chain(*new_map.values()):
-        yield None, KconfigEntryProperties(node, sc)
+        for node, sc in chain(*new_map.values()):
+            yield None, KconfigEntryProperties(node, sc)
+
+        pickler.save_kconfig(outdir / KCONFIG_SAVE_FILE, kconfig, sysbuild_kconfig)

--- a/doc/_extensions/kconfigdiff/kconfig_utils.py
+++ b/doc/_extensions/kconfigdiff/kconfig_utils.py
@@ -6,6 +6,7 @@
 
 import argparse
 import io
+import json
 import logging
 import os
 import re
@@ -35,6 +36,8 @@ logger = logging.Logger(__name__)
 RESOURCES_DIR = Path(__file__).parent / "static"
 ZEPHYR_BASE = Path(__file__).parents[4] / "zephyr"
 NRF_BASE = Path(__file__).parents[3]
+
+VERSIONS_FILE = Path(__file__).parents[2] / "versions.json"
 
 KCONFIG_SAVE_FILE = "kconfig.zip"
 KCONFIG_URL = f"https://ncsdoc.z6.web.core.windows.net/ncs/{{version}}/kconfig/{KCONFIG_SAVE_FILE}"
@@ -293,8 +296,10 @@ class KconfigEntryProperties:
     def _init_ranges(self) -> list[str]:
         ranges = list()
         for min_, max_, cond in self._node.orig_ranges:
-            fmt = (f"[{self._kconfiglib.expr_str(min_, self.sc_fmt)}, "
-                   f"{self._kconfiglib.expr_str(max_, self.sc_fmt)}]")
+            fmt = (
+                f"[{self._kconfiglib.expr_str(min_, self.sc_fmt)}, "
+                f"{self._kconfiglib.expr_str(max_, self.sc_fmt)}]"
+            )
             if cond is not self._sc.kconfig.y:
                 fmt += f" if {self._kconfiglib.expr_str(cond, self.sc_fmt)}"
             ranges.append(fmt)
@@ -347,8 +352,15 @@ class KconfigEntryProperties:
         )
 
 
-def fetch_prev_kconfig_file(version) -> tuple[kconfiglib.Kconfig, kconfiglib.Kconfig, kconfiglib]:
-    url = KCONFIG_URL.format(version=version)
+def get_prev_version() -> str:
+    with open(VERSIONS_FILE, "rb") as f:
+        versions = json.load(f)
+        # return first version that's a release (skip -preview and others)
+        return next(filter(lambda v: re.match(r"^\d+.\d+.\d+$", v), versions[1:]), "")
+
+
+def fetch_prev_kconfig_file() -> tuple[kconfiglib.Kconfig, kconfiglib.Kconfig, kconfiglib]:
+    url = KCONFIG_URL.format(version=get_prev_version())
     with progress_message(f"Fetching kconfig from previous build, {url=}"):
         res = requests.get(url)
         res.raise_for_status()
@@ -358,7 +370,7 @@ def fetch_prev_kconfig_file(version) -> tuple[kconfiglib.Kconfig, kconfiglib.Kco
 
 
 def diff_generator(
-    version: str, outdir: Path
+    outdir: Path,
 ) -> Generator[tuple[KconfigEntryProperties | None, KconfigEntryProperties | None], None, None]:
     """Yield ``(old, new)`` pairs of :class:`KconfigEntryProperties`.
 
@@ -373,7 +385,7 @@ def diff_generator(
     )
 
     try:
-        kconfig_old, sysbuild_kconfig_old, old_kconflib = fetch_prev_kconfig_file(version)
+        kconfig_old, sysbuild_kconfig_old, old_kconflib = fetch_prev_kconfig_file()
     except requests.exceptions.RequestException:
         logger.error("Failed to fetch old kconfig")
         return

--- a/doc/_extensions/kconfigdiff/kconfig_utils.py
+++ b/doc/_extensions/kconfigdiff/kconfig_utils.py
@@ -204,24 +204,11 @@ def entry_name(sc) -> str:
     return f"{prefix}{sc.name}"
 
 
-def sc_fmt(sc):
-    prefix = os.environ["CONFIG_"]
-
-    if isinstance(sc, kconfiglib.Symbol):
-        if sc.nodes:
-            return f'{prefix}{sc.name}'
-    elif isinstance(sc, kconfiglib.Choice):
-        if not sc.name:
-            return "&ltchoice&gt"
-        return f'&ltchoice {prefix}{sc.name}&gt'
-
-    return kconfiglib.standard_sc_expr_str(sc)
-
-
 class KconfigEntryProperties:
     __slots__ = (
         "_node",
         "_sc",
+        "_kconfiglib",
         "name",
         "prompt",
         "type",
@@ -236,13 +223,18 @@ class KconfigEntryProperties:
         "choices",
     )
 
-    def __init__(self, node: kconfiglib.MenuNode, sc: SC):
+    def __init__(self, node: kconfiglib.MenuNode, sc: SC, kconfiglib_=None):
         self._node = node
         self._sc = sc
 
+        self._kconfiglib = kconfiglib
+
+        if kconfiglib_:
+            self._kconfiglib = kconfiglib_
+
         self.name = entry_name(sc)
         self.prompt = node.prompt[0] if node.prompt else ""
-        self.type = kconfiglib.TYPE_TO_STR[sc.type]
+        self.type = self._kconfiglib.TYPE_TO_STR[sc.type]
         self.help = node.help
         self.dependencies = self._init_deps()
         self.defaults = self._init_defaults()
@@ -253,68 +245,85 @@ class KconfigEntryProperties:
         self.ranges = self._init_ranges()
         self.choices = self._init_choices()
 
+    def sc_fmt(self, sc):
+        prefix = os.environ["CONFIG_"]
+
+        if isinstance(sc, self._kconfiglib.Symbol):
+            if sc.nodes:
+                return f'{prefix}{sc.name}'
+        elif isinstance(sc, self._kconfiglib.Choice):
+            if not sc.name:
+                return "&ltchoice&gt"
+            return f'&ltchoice {prefix}{sc.name}&gt'
+
+        return self._kconfiglib.standard_sc_expr_str(sc)
+
     def _init_deps(self) -> list[str]:
         deps = []
         if self._node.dep is not self._sc.kconfig.y:
-            deps = kconfiglib.expr_str(self._node.dep, sc_fmt)
+            deps = self._kconfiglib.expr_str(self._node.dep, self.sc_fmt)
         return deps
 
     def _init_defaults(self) -> list[str]:
         defaults = []
         for value, cond in self._node.orig_defaults:
-            fmt = kconfiglib.expr_str(value, sc_fmt)
+            fmt = self._kconfiglib.expr_str(value, self.sc_fmt)
             if cond is not self._sc.kconfig.y:
-                fmt += f" if {kconfiglib.expr_str(cond, sc_fmt)}"
+                fmt += f" if {self._kconfiglib.expr_str(cond, self.sc_fmt)}"
             defaults.append(fmt)
         return defaults
 
     def _init_selects(self) -> list[str]:
         selects = []
         for value, cond in self._node.orig_selects:
-            fmt = kconfiglib.expr_str(value, sc_fmt)
+            fmt = self._kconfiglib.expr_str(value, self.sc_fmt)
             if cond is not self._sc.kconfig.y:
-                fmt += f" if {kconfiglib.expr_str(cond, sc_fmt)}"
+                fmt += f" if {self._kconfiglib.expr_str(cond, self.sc_fmt)}"
             selects.append(fmt)
         return selects
 
     def _init_selected_by(self) -> list[str]:
         selected_by = []
-        if isinstance(self._sc, kconfiglib.Symbol) and self._sc.rev_dep != self._sc.kconfig.n:
-            for select in kconfiglib.split_expr(self._sc.rev_dep, kconfiglib.OR):
-                sym = kconfiglib.split_expr(select, kconfiglib.AND)[0]
+        if isinstance(self._sc, self._kconfiglib.Symbol) and self._sc.rev_dep != self._sc.kconfig.n:
+            for select in self._kconfiglib.split_expr(self._sc.rev_dep, self._kconfiglib.OR):
+                sym = self._kconfiglib.split_expr(select, self._kconfiglib.AND)[0]
                 selected_by.append(f"{entry_name(sym)}")
         return selected_by
 
     def _init_ranges(self) -> list[str]:
         ranges = list()
         for min_, max_, cond in self._node.orig_ranges:
-            fmt = f"[{kconfiglib.expr_str(min_, sc_fmt)}, {kconfiglib.expr_str(max_, sc_fmt)}]"
+            fmt = (f"[{self._kconfiglib.expr_str(min_, self.sc_fmt)}, "
+                   f"{self._kconfiglib.expr_str(max_, self.sc_fmt)}]")
             if cond is not self._sc.kconfig.y:
-                fmt += f" if {kconfiglib.expr_str(cond, sc_fmt)}"
+                fmt += f" if {self._kconfiglib.expr_str(cond, self.sc_fmt)}"
             ranges.append(fmt)
         return ranges
 
     def _init_choices(self) -> list[str]:
         choices = []
-        if isinstance(self._sc, kconfiglib.Choice):
+        if isinstance(self._sc, self._kconfiglib.Choice):
             for sym in self._sc.syms:
-                choices.append(kconfiglib.expr_str(sym, sc_fmt))
+                choices.append(self._kconfiglib.expr_str(sym, self.sc_fmt))
         return choices
 
     def _init_implies(self) -> list[str]:
         implies = []
         for value, cond in self._node.orig_implies:
-            fmt = kconfiglib.expr_str(value, sc_fmt)
+            fmt = self._kconfiglib.expr_str(value, self.sc_fmt)
             if cond is not self._sc.kconfig.y:
-                fmt += f" if {kconfiglib.expr_str(cond, sc_fmt)}"
+                fmt += f" if {self._kconfiglib.expr_str(cond, self.sc_fmt)}"
             implies.append(fmt)
         return implies
 
     def _init_implied_by(self) -> list[str]:
         implied_by = []
-        if isinstance(self._sc, kconfiglib.Symbol) and self._sc.weak_rev_dep != self._sc.kconfig.n:
-            for select in kconfiglib.split_expr(self._sc.weak_rev_dep, kconfiglib.OR):
-                sym = kconfiglib.split_expr(select, kconfiglib.AND)[0]
+        if (
+            isinstance(self._sc, self._kconfiglib.Symbol)
+            and self._sc.weak_rev_dep != self._sc.kconfig.n
+        ):
+            for select in self._kconfiglib.split_expr(self._sc.weak_rev_dep, self._kconfiglib.OR):
+                sym = self._kconfiglib.split_expr(select, self._kconfiglib.AND)[0]
                 implied_by.append(f"{entry_name(sym)}")
         return implied_by
 
@@ -338,7 +347,7 @@ class KconfigEntryProperties:
         )
 
 
-def fetch_prev_kconfig_file(version) -> tuple[kconfiglib.Kconfig, kconfiglib.Kconfig]:
+def fetch_prev_kconfig_file(version) -> tuple[kconfiglib.Kconfig, kconfiglib.Kconfig, kconfiglib]:
     url = KCONFIG_URL.format(version=version)
     with progress_message(f"Fetching kconfig from previous build, {url=}"):
         res = requests.get(url)
@@ -364,7 +373,7 @@ def diff_generator(
     )
 
     try:
-        kconfig_old, sysbuild_kconfig_old = fetch_prev_kconfig_file(version)
+        kconfig_old, sysbuild_kconfig_old, old_kconflib = fetch_prev_kconfig_file(version)
     except requests.exceptions.RequestException:
         logger.error("Failed to fetch old kconfig")
         return
@@ -386,11 +395,11 @@ def diff_generator(
                             to_del = i
                             break
                     else:
-                        yield KconfigEntryProperties(node, sc), None
+                        yield KconfigEntryProperties(node, sc, old_kconflib), None
                         continue
                 new_node, new_sc = new_items.pop(to_del)
                 yield (
-                    KconfigEntryProperties(node, sc),
+                    KconfigEntryProperties(node, sc, old_kconflib),
                     KconfigEntryProperties(new_node, new_sc),
                 )
                 continue

--- a/doc/_extensions/kconfigdiff/legend.py
+++ b/doc/_extensions/kconfigdiff/legend.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+
+
+class KconfigDiffLegendDirective(SphinxDirective):
+    """
+    Renders the legend describing how the extension shows comparison.
+
+    Usage::
+        .. kconfigdiff-legend
+    """
+
+    required_arguments = 0
+    optional_arguments = 0
+
+    @staticmethod
+    def sample(text: str, type_: str) -> nodes.Node:
+        return nodes.paragraph(text=text, classes=["kconfigdiff-line", f"kconfigdiff-{type_}"])
+
+    def run(self) -> list[nodes.Node]:
+        res = [
+            KconfigDiffLegendDirective.sample("This was added", "added"),
+            KconfigDiffLegendDirective.sample("This was removed", "removed"),
+            KconfigDiffLegendDirective.sample("This was changed", "changed"),
+        ]
+        return res

--- a/doc/_extensions/kconfigdiff/pickler.py
+++ b/doc/_extensions/kconfigdiff/pickler.py
@@ -191,7 +191,8 @@ def load_file(path: Path | str):
         ZipFile(path, "r", compression=ZIP_LZMA) as zip_file,
         zip_file.open("kconfig.pickle", "r") as f,
     ):
-        return _RefUnpickler(f).load()
+        kconfig, sysbuild_kconfig = _RefUnpickler(f).load()
+        return unflatten_kconfig(kconfig), unflatten_kconfig(sysbuild_kconfig)
 
 
 def save_kconfig(

--- a/doc/_extensions/kconfigdiff/pickler.py
+++ b/doc/_extensions/kconfigdiff/pickler.py
@@ -13,7 +13,8 @@ utilities for flattening the kconfig object so that it can be pickled.
 import pickle
 import sys
 from pathlib import Path
-from typing import Any
+from tempfile import TemporaryDirectory
+from typing import IO, Any
 from zipfile import ZIP_LZMA, ZipFile
 
 sys.path.insert(0, str(Path(__file__).parents[4] / "zephyr/scripts/kconfig"))
@@ -180,26 +181,46 @@ class _RefUnpickler(pickle.Unpickler):
     Sphinx build) those modules no longer define ``Ref``; redirect it here.
     """
 
+    def __init__(self, *k, kconfiglib_=None, **kw):
+        super().__init__(*k, **kw)
+
+        if kconfiglib_ is None:
+            self.kconfiglib = kconfiglib
+            return
+
+        self.kconfiglib = kconfiglib_
+
     def find_class(self, module: str, name: str):
+        if module == "kconfiglib":
+            return getattr(self.kconfiglib, name)
         if name == "Ref":
             return Ref
         return super().find_class(module, name)
 
 
-def load_file(path: Path | str):
+def load_file(path: Path | str | IO[bytes]):
     with (
         ZipFile(path, "r", compression=ZIP_LZMA) as zip_file,
-        zip_file.open("kconfig.pickle", "r") as f,
+        TemporaryDirectory() as td,
     ):
-        kconfig, sysbuild_kconfig = _RefUnpickler(f).load()
-        return unflatten_kconfig(kconfig), unflatten_kconfig(sysbuild_kconfig)
+        kconfiglib_path = Path(td) / "old_kconfiglib.py"
+        with open(kconfiglib_path, "wb") as f:
+            f.write(zip_file.read("kconfiglib.py"))
+
+        sys.path.insert(0, str(td))
+        import old_kconfiglib
+
+        with zip_file.open("kconfig.pickle", "r") as f:
+            kconfig, sys_kconfig = _RefUnpickler(f, kconfiglib_=old_kconfiglib).load()
+        return unflatten_kconfig(kconfig), unflatten_kconfig(sys_kconfig), old_kconfiglib
 
 
 def save_kconfig(
     path: Path | str, kconfig: kconfiglib.Kconfig, sysbuild_kconfig: kconfiglib.Kconfig
 ):
-    with (
-        ZipFile(path, "w", compression=ZIP_LZMA) as zip_file,
-        zip_file.open("kconfig.pickle", "w") as f,
-    ):
-        pickle.dump((flatten_kconfig(kconfig), flatten_kconfig(sysbuild_kconfig)), f)
+    with ZipFile(path, "w", compression=ZIP_LZMA) as zip_file:
+        with zip_file.open("kconfig.pickle", "w") as f:
+            pickle.dump((flatten_kconfig(kconfig), flatten_kconfig(sysbuild_kconfig)), f)
+        # store the kconfiglib.py file so that the pickle can be opened using
+        # the same version of kconfiglib
+        zip_file.write(kconfiglib.__file__, arcname="kconfiglib.py")

--- a/doc/_extensions/kconfigdiff/pickler.py
+++ b/doc/_extensions/kconfigdiff/pickler.py
@@ -14,6 +14,7 @@ import pickle
 import sys
 from pathlib import Path
 from typing import Any
+from zipfile import ZIP_LZMA, ZipFile
 
 sys.path.insert(0, str(Path(__file__).parents[4] / "zephyr/scripts/kconfig"))
 
@@ -186,12 +187,18 @@ class _RefUnpickler(pickle.Unpickler):
 
 
 def load_file(path: Path | str):
-    with open(path, "rb") as f:
+    with (
+        ZipFile(path, "r", compression=ZIP_LZMA) as zip_file,
+        zip_file.open("kconfig.pickle", "r") as f,
+    ):
         return _RefUnpickler(f).load()
 
 
 def save_kconfig(
     path: Path | str, kconfig: kconfiglib.Kconfig, sysbuild_kconfig: kconfiglib.Kconfig
 ):
-    with open(path, "wb") as f:
+    with (
+        ZipFile(path, "w", compression=ZIP_LZMA) as zip_file,
+        zip_file.open("kconfig.pickle", "w") as f,
+    ):
         pickle.dump((flatten_kconfig(kconfig), flatten_kconfig(sysbuild_kconfig)), f)

--- a/doc/_extensions/kconfigdiff/pickler.py
+++ b/doc/_extensions/kconfigdiff/pickler.py
@@ -1,0 +1,197 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+"""
+Kconfig objects from kconfiglib are deeply nested which would result in
+recursion errors if trying to pickle. Therefore this module introduces
+utilities for flattening the kconfig object so that it can be pickled.
+"""
+
+import pickle
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parents[4] / "zephyr/scripts/kconfig"))
+
+import kconfiglib
+
+KCONFIG_TYPES = (
+    kconfiglib.Symbol,
+    kconfiglib.Choice,
+    kconfiglib.MenuNode,
+    kconfiglib.Variable,
+    kconfiglib.Kconfig,
+)
+
+CONTAINER_TYPES = (tuple, list, set, frozenset, dict)
+
+SUPPORTED_TYPES = (str, bytes, bool, int, float, type(None), Path)
+
+
+class Ref:
+    """A placeholder standing in for a reference to another kconfig object.
+    Python's `id()` function is used for checking assuring unique identifiers
+    for each object.
+    """
+
+    __slots__ = ("id", "type")
+
+    def __init__(self, value: Any):
+        self.id = id(value)
+        self.type = type(value)
+
+
+def _all_slots(cls) -> list[str]:
+    """Collect ``__slots__`` across the full MRO"""
+    slots: list[str] = []
+    for klass in cls.__mro__:
+        slots.extend(getattr(klass, "__slots__", ()))
+    return slots
+
+
+def flatten_kconfig(kconfig: kconfiglib.Kconfig) -> dict:
+    """
+    Flattens a Kconfig object graph.
+    Returns a flattened object which can be pickled. Use
+    :func:`unflatten_kconfig` to retrieve the original object.
+    """
+    objects: dict[int, Any] = {}
+    queue: list = [kconfig]
+    seen: set[int] = {id(kconfig)}
+
+    def encode(value):
+        """Return a picklable stand-in for ``value`` and if value hasn't been
+        flattened yet appends it to queue.
+
+        Kconfig objects and containers become a :class:`Ref` (and are queued
+        for processing); plain data types from `SUPPORTED_TYPES` remain as is,
+        because the don't cause deep recursion; Any other types are dropped.
+        """
+        if isinstance(value, Ref):
+            return value
+        if type(value) in KCONFIG_TYPES or isinstance(value, CONTAINER_TYPES):
+            if id(value) not in seen:
+                seen.add(id(value))
+                queue.append(value)
+            return Ref(value)
+        if isinstance(value, SUPPORTED_TYPES):
+            return value
+        return None
+
+    while queue:
+        obj = queue.pop()
+        if type(obj) in KCONFIG_TYPES:
+            for slot in _all_slots(type(obj)):
+                try:
+                    value = getattr(obj, slot)
+                except AttributeError:
+                    # Slot was never assigned on this instance; leave it out.
+                    continue
+                setattr(obj, slot, encode(value))
+            objects[id(obj)] = obj
+        elif isinstance(obj, dict):
+            # Keys in kconfiglib containers are plain scalars (symbol names,
+            # ints); keep them as-is and only rewrite the values.
+            objects[id(obj)] = {k: encode(v) for k, v in obj.items()}
+        else:  # list, tuple, set or frozenset
+            objects[id(obj)] = type(obj)(encode(v) for v in obj)
+
+    return objects
+
+
+def resolve(value, immutable, flat, rebuilt):
+    if not isinstance(value, Ref):
+        return value
+    if value.id in immutable:
+        return rebuilt[value.id]
+    return flat[value.id]
+
+
+def rebuild_immutable(flat):
+    immutable = {oid for oid, obj in flat.items() if isinstance(obj, (tuple, set, frozenset))}
+
+    rebuilt: dict[int, Any] = {}
+    for start in immutable:
+        if start in rebuilt:
+            continue
+        stack = [start]
+        while stack:
+            oid = stack[-1]
+            if oid in rebuilt:
+                stack.pop()
+                continue
+            sub = flat[oid]
+            pending = [
+                v.id
+                for v in sub
+                if isinstance(v, Ref) and v.id in immutable and v.id not in rebuilt
+            ]
+            if pending:
+                stack.extend(pending)
+                continue
+            rebuilt[oid] = type(sub)(resolve(v, immutable, flat, rebuilt) for v in sub)
+            stack.pop()
+    return immutable, rebuilt
+
+
+def unflatten_kconfig(flat: dict) -> kconfiglib.Kconfig:
+    """Rebuild a Kconfig object graph produced by :func:`flatten_kconfig`.
+
+    Returns the reconstructed root :class:`kconfiglib.Kconfig`.
+    """
+    # Immutable containers cannot be patched in place, so they are rebuilt;
+    # everything else (kconfig objects, dicts, lists) keeps its identity and is
+    # patched in place. ``rebuilt`` maps the original id to its rebuilt value.
+
+    immutable, rebuilt = rebuild_immutable(flat)
+
+    for oid, obj in flat.items():
+        if oid in immutable:
+            continue
+        if isinstance(obj, dict):
+            for k in list(obj):
+                obj[k] = resolve(obj[k], immutable, flat, rebuilt)
+        elif isinstance(obj, list):
+            for i, value in enumerate(obj):
+                obj[i] = resolve(value, immutable, flat, rebuilt)
+        else:  # kconfig object
+            for slot in _all_slots(type(obj)):
+                try:
+                    value = getattr(obj, slot)
+                except AttributeError:
+                    continue
+                setattr(obj, slot, resolve(value, immutable, flat, rebuilt))
+
+    return next(iter(flat.values()))
+
+
+class _RefUnpickler(pickle.Unpickler):
+    """Unpickler that resolves :class:`Ref` regardless of the module it was
+    pickled from.
+
+    Snapshots may have been generated while this file was importable as a
+    top-level ``pickler`` module (or executed as ``__main__``). When the
+    extension is later imported as the ``kconfigdiff`` package (e.g. during a
+    Sphinx build) those modules no longer define ``Ref``; redirect it here.
+    """
+
+    def find_class(self, module: str, name: str):
+        if name == "Ref":
+            return Ref
+        return super().find_class(module, name)
+
+
+def load_file(path: Path | str):
+    with open(path, "rb") as f:
+        return _RefUnpickler(f).load()
+
+
+def save_kconfig(
+    path: Path | str, kconfig: kconfiglib.Kconfig, sysbuild_kconfig: kconfiglib.Kconfig
+):
+    with open(path, "wb") as f:
+        pickle.dump((flatten_kconfig(kconfig), flatten_kconfig(sysbuild_kconfig)), f)

--- a/doc/_extensions/kconfigdiff/rendering.py
+++ b/doc/_extensions/kconfigdiff/rendering.py
@@ -199,6 +199,10 @@ class KconfigDiffDirective(SphinxDirective):
         if not self.env.app.config.kconfigdiff_should_build:
             return []
 
+        if not (versions := self.env.app.config.kconfigdiff_versions):
+            return []
+        _, prev = versions
+
         root = nodes.container(classes=["kconfigdiff"])
 
         def ordering(old, new):
@@ -206,7 +210,7 @@ class KconfigDiffDirective(SphinxDirective):
 
         outdir = Path(self.env.app.outdir)
         for old, new in sorted(
-            diff_generator(outdir),
+            diff_generator(prev, outdir),
             key=lambda p: ordering(*p).name,
         ):
             node = ComparisonPair(old, new).render()

--- a/doc/_extensions/kconfigdiff/rendering.py
+++ b/doc/_extensions/kconfigdiff/rendering.py
@@ -201,6 +201,9 @@ class KconfigDiffDirective(SphinxDirective):
         return None
 
     def run(self) -> list[nodes.Node]:
+        if not self.env.app.config.kconfigdiff_should_build:
+            return []
+
         last_version = self._get_prev_version_num()
         if last_version is None:
             logger.error("Couldn't establish what was the previous build version")

--- a/doc/_extensions/kconfigdiff/rendering.py
+++ b/doc/_extensions/kconfigdiff/rendering.py
@@ -218,4 +218,4 @@ class KconfigDiffDirective(SphinxDirective):
                 root += node
 
         self.env.app.config.html_extra_path.append(outdir / KCONFIG_SAVE_FILE)
-        return [root]
+        return [nodes.transition(), root]

--- a/doc/_extensions/kconfigdiff/rendering.py
+++ b/doc/_extensions/kconfigdiff/rendering.py
@@ -11,14 +11,16 @@ Docutils rendering for the ``kconfigdiff`` directive.
 """
 
 import difflib
-import os
+import logging
 from dataclasses import dataclass
+from pathlib import Path
 
 from docutils import nodes
 from sphinx.util.docutils import SphinxDirective
 
-from .kconfig_utils import KconfigEntryProperties, diff_generator
+from .kconfig_utils import KCONFIG_SAVE_FILE, KconfigEntryProperties, diff_generator
 
+logger = logging.Logger(__name__)
 DIFFER = difflib.Differ()
 
 
@@ -186,30 +188,37 @@ class KconfigDiffDirective(SphinxDirective):
     Usage::
 
         .. kconfigdiff:: old.pickle new.pickle
-
-    The two arguments are paths to the pickle files produced by this extension,
-    resolved relative to the document that uses the directive.
     """
 
-    required_arguments = 2
+    required_arguments = 0
     optional_arguments = 0
     final_argument_whitespace = False
     has_content = False
 
-    def _resolve(self, arg: str) -> str:
-        # Absolute paths are used verbatim; relative ones are resolved against
-        # the document that uses the directive.
-        if os.path.isabs(arg):
-            return arg
-        return self.env.relfn2path(arg)[1]
+    def _get_prev_version_num(self) -> str | None:
+        if len(self.env.nrf_versions) >= 2:
+            return self.env.nrf_versions[-2].replace("-", ".")[1:]
+        return None
 
     def run(self) -> list[nodes.Node]:
-        old_path = self._resolve(self.arguments[0])
-        new_path = self._resolve(self.arguments[1])
+        last_version = self._get_prev_version_num()
+        if last_version is None:
+            logger.error("Couldn't establish what was the previous build version")
+            return []
 
         root = nodes.container(classes=["kconfigdiff"])
-        for old, new in diff_generator(old_path, new_path):
+
+        def ordering(old, new):
+            return max((old, new), key=lambda x: x is not None)
+
+        outdir = Path(self.env.app.outdir)
+        for old, new in sorted(
+            diff_generator(last_version, outdir),
+            key=lambda p: ordering(*p).name,
+        ):
             node = ComparisonPair(old, new).render()
             if node is not None:
                 root += node
+
+        self.env.app.config.html_extra_path.append(outdir / KCONFIG_SAVE_FILE)
         return [root]

--- a/doc/_extensions/kconfigdiff/rendering.py
+++ b/doc/_extensions/kconfigdiff/rendering.py
@@ -195,18 +195,8 @@ class KconfigDiffDirective(SphinxDirective):
     final_argument_whitespace = False
     has_content = False
 
-    def _get_prev_version_num(self) -> str | None:
-        if len(self.env.nrf_versions) >= 2:
-            return self.env.nrf_versions[-2].replace("-", ".")[1:]
-        return None
-
     def run(self) -> list[nodes.Node]:
         if not self.env.app.config.kconfigdiff_should_build:
-            return []
-
-        last_version = self._get_prev_version_num()
-        if last_version is None:
-            logger.error("Couldn't establish what was the previous build version")
             return []
 
         root = nodes.container(classes=["kconfigdiff"])
@@ -216,7 +206,7 @@ class KconfigDiffDirective(SphinxDirective):
 
         outdir = Path(self.env.app.outdir)
         for old, new in sorted(
-            diff_generator(last_version, outdir),
+            diff_generator(outdir),
             key=lambda p: ordering(*p).name,
         ):
             node = ComparisonPair(old, new).render()

--- a/doc/_extensions/kconfigdiff/rendering.py
+++ b/doc/_extensions/kconfigdiff/rendering.py
@@ -1,0 +1,215 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+"""
+Kconfig diff rendering
+
+Docutils rendering for the ``kconfigdiff`` directive.
+"""
+
+import difflib
+import os
+from dataclasses import dataclass
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+
+from .kconfig_utils import KconfigEntryProperties, diff_generator
+
+DIFFER = difflib.Differ()
+
+
+@dataclass
+class ComparisonPair:
+    old: KconfigEntryProperties | None
+    new: KconfigEntryProperties | None
+
+    def render_property(self, property_, value) -> nodes.field | None:
+        if not value:
+            return None
+        field = nodes.field()
+        field += nodes.field_name(text=property_)
+        body = nodes.field_body()
+        body += nodes.paragraph(text=value)
+        field += body
+        return field
+
+    def render_list_property(self, property_, values) -> nodes.field | None:
+        if not values:
+            return None
+
+        field = nodes.field()
+        field += nodes.field_name(text=property_)
+
+        body = nodes.field_body()
+        values_list = nodes.bullet_list()
+
+        for value in values:
+            item = nodes.list_item()
+            item += nodes.paragraph(text=value)
+            values_list += item
+
+        body += values_list
+        field += body
+
+        return field
+
+    def render_diff_property(self, property_, old_val, new_val) -> nodes.field | None:
+        if old_val == new_val:
+            return self.render_property(property_, new_val)
+        field = nodes.field()
+        field += nodes.field_name(text=property_)
+        body = nodes.field_body()
+        body += nodes.paragraph(text=old_val, classes=["kconfigdiff-removed", "kconfigdiff-line"])
+        body += nodes.paragraph(text=new_val, classes=["kconfigdiff-added", "kconfigdiff-line"])
+        field += body
+        return field
+
+    def render_list_diff_property(self, property_, old_values, new_values) -> nodes.field | None:
+        if set(old_values) == set(new_values):
+            return self.render_list_property(property_, new_values)
+
+        field = nodes.field()
+        field += nodes.field_name(text=property_)
+
+        body = nodes.field_body()
+        values_list = nodes.bullet_list()
+
+        diff = DIFFER.compare(old_values, new_values)
+
+        for value in diff:
+            if value.startswith("?"):
+                continue
+            item = nodes.list_item()
+            if value.startswith("+"):
+                item += nodes.paragraph(
+                    text=value[1:].strip(), classes=["kconfigdiff-added", "kconfigdiff-line"]
+                )
+            elif value.startswith("-"):
+                item += nodes.paragraph(
+                    text=value[1:].strip(), classes=["kconfigdiff-removed", "kconfigdiff-line"]
+                )
+            else:
+                item += nodes.paragraph(text=value.strip())
+            values_list += item
+
+        body += values_list
+        field += body
+
+        return field
+
+    def render_fields(self, props: KconfigEntryProperties) -> nodes.field_list:
+        fields = nodes.field_list()
+
+        fields += self.render_property("Prompt", props.prompt)
+        fields += self.render_property("Help", props.help)
+        fields += self.render_property("Type", props.type)
+        fields += self.render_property("Dependencies", props.dependencies)
+        fields += self.render_list_property("Defaults", props.defaults)
+        fields += self.render_list_property("Selects", props.selects)
+        fields += self.render_list_property("Selected by", props.selected_by)
+        fields += self.render_list_property("Implies", props.implies)
+        fields += self.render_list_property("Implied by", props.implied_by)
+        fields += self.render_list_property("Choices", props.choices)
+        fields += self.render_list_property("Ranges", props.ranges)
+
+        return fields
+
+    def render_diff_fileds(self) -> nodes.field_list:
+        fields = nodes.field_list()
+
+        fields += self.render_diff_property("Prompt", self.old.prompt, self.new.prompt)
+        fields += self.render_diff_property("Help", self.old.help, self.new.help)
+        fields += self.render_diff_property("Type", self.old.type, self.new.type)
+        fields += self.render_diff_property(
+            "Dependencies", self.old.dependencies, self.new.dependencies
+        )
+        fields += self.render_list_diff_property("Defaults", self.old.defaults, self.new.defaults)
+        fields += self.render_list_diff_property("Selects", self.old.selects, self.new.selects)
+        fields += self.render_list_diff_property(
+            "Selected by", self.old.selected_by, self.new.selected_by
+        )
+        fields += self.render_list_diff_property("Implies", self.old.implies, self.new.implies)
+        fields += self.render_list_diff_property(
+            "Implied by", self.old.implied_by, self.new.implied_by
+        )
+        fields += self.render_list_diff_property("Choices", self.old.choices, self.new.choices)
+        fields += self.render_list_diff_property("Ranges", self.old.ranges, self.new.ranges)
+
+        return fields
+
+    def render(self) -> nodes.container | None:
+        """Render a single :class:`ComparisonPair` as a docutils node.
+
+        Returns ``None`` for pairs whose properties are identical so the caller can
+        skip them.
+        """
+        if self.new is None:
+            # props = extract_properties(pair.old)
+            entry = nodes.container(classes=["kconfigdiff-entry", "kconfigdiff-entry-removed"])
+            entry += _entry_title(f"{self.old.name}", "removed")  # type: ignore[union-attr]
+
+            entry += self.render_fields(self.old)
+            return entry
+
+        if self.old is None:
+            # props = extract_properties(pair.new)
+            entry = nodes.container(classes=["kconfigdiff-entry", "kconfigdiff-entry-new"])
+            entry += _entry_title(f"{self.new.name}", "new")
+
+            entry += self.render_fields(self.new)
+            return entry
+
+        if self.old == self.new:
+            return None
+
+        entry = nodes.container(classes=["kconfigdiff-entry", "kconfigdiff-entry-changed"])
+        entry += _entry_title(f"{self.new.name}", "changed")
+
+        entry += self.render_diff_fileds()
+
+        return entry
+
+
+def _entry_title(text: str, css_kind: str) -> nodes.paragraph:
+    title = nodes.paragraph(classes=["kconfigdiff-entry-title", f"kconfigdiff-title-{css_kind}"])
+    title += nodes.strong(text=text)
+    return title
+
+
+class KconfigDiffDirective(SphinxDirective):
+    """Render the diff between two pickled Kconfig snapshots.
+
+    Usage::
+
+        .. kconfigdiff:: old.pickle new.pickle
+
+    The two arguments are paths to the pickle files produced by this extension,
+    resolved relative to the document that uses the directive.
+    """
+
+    required_arguments = 2
+    optional_arguments = 0
+    final_argument_whitespace = False
+    has_content = False
+
+    def _resolve(self, arg: str) -> str:
+        # Absolute paths are used verbatim; relative ones are resolved against
+        # the document that uses the directive.
+        if os.path.isabs(arg):
+            return arg
+        return self.env.relfn2path(arg)[1]
+
+    def run(self) -> list[nodes.Node]:
+        old_path = self._resolve(self.arguments[0])
+        new_path = self._resolve(self.arguments[1])
+
+        root = nodes.container(classes=["kconfigdiff"])
+        for old, new in diff_generator(old_path, new_path):
+            node = ComparisonPair(old, new).render()
+            if node is not None:
+                root += node
+        return [root]

--- a/doc/_extensions/kconfigdiff/static/kconfigdiff.css
+++ b/doc/_extensions/kconfigdiff/static/kconfigdiff.css
@@ -76,3 +76,9 @@
     background-color: #ffebe9;
     border-left-color: #cf222e;
 }
+
+/* Used only in legend */
+.kconfigdiff-changed {
+    background-color: #fff8c5;
+    border-left-color: #d4a72c;
+}

--- a/doc/_extensions/kconfigdiff/static/kconfigdiff.css
+++ b/doc/_extensions/kconfigdiff/static/kconfigdiff.css
@@ -1,0 +1,78 @@
+/*
+ *
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ */
+
+/*
+ * Styling for the Kconfig diff extension (kconfigdiff).
+ *
+ * Entries are rendered git-diff style: whole symbols that were added or
+ * removed are tinted green/red, and for symbols present in both snapshots only
+ * the changed lines of each property are highlighted.
+ */
+
+.kconfigdiff {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    font-size: 0.9rem;
+}
+
+.kconfigdiff-entry {
+    border: 1px solid #d0d7de;
+    border-left-width: 4px;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.kconfigdiff-entry-new {
+    border-left-color: #2da44e;
+}
+
+.kconfigdiff-entry-removed {
+    border-left-color: #cf222e;
+}
+
+.kconfigdiff-entry-changed {
+    border-left-color: #d4a72c;
+}
+
+.kconfigdiff-entry-title {
+    margin: 0;
+    padding: 0.4rem 0.6rem;
+    border-bottom: 1px solid #d0d7de;
+    max-width: 100% !important;
+}
+
+.kconfigdiff-title-new {
+    background-color: #dafbe1;
+}
+
+.kconfigdiff-title-removed {
+    background-color: #ffebe9;
+}
+
+.kconfigdiff-title-changed {
+    background-color: #fff8c5;
+}
+
+.kconfigdiff-line {
+    margin: 0;
+    padding: 0 0.4rem;
+    white-space: pre-wrap;
+    border-left: 3px solid transparent;
+    max-width: fit-content !important;
+}
+
+.kconfigdiff-added {
+    background-color: #e6ffec;
+    border-left-color: #2da44e;
+}
+
+.kconfigdiff-removed {
+    background-color: #ffebe9;
+    border-left-color: #cf222e;
+}

--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -58,6 +58,10 @@ external_content_contents = [
 kconfig_generate_db = True
 kconfig_ext_paths = [ZEPHYR_BASE, NRF_BASE]
 
+# Options for kconfigdiff
+
+kconfigdiff_should_build = False
+
 # Adding NCS_ specific entries. Can be removed when the NCSDK-14227 improvement
 # task has been completed.
 os.environ["NCS_MEMFAULT_FIRMWARE_SDK_KCONFIG"] = str(

--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -61,6 +61,7 @@ kconfig_ext_paths = [ZEPHYR_BASE, NRF_BASE]
 # Options for kconfigdiff
 
 kconfigdiff_should_build = False
+kconfigdiff_is_release = False
 
 # Adding NCS_ specific entries. Can be removed when the NCSDK-14227 improvement
 # task has been completed.

--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -62,6 +62,7 @@ kconfig_ext_paths = [ZEPHYR_BASE, NRF_BASE]
 
 kconfigdiff_should_build = False
 kconfigdiff_is_release = False
+kconfigdiff_versions = None
 
 # Adding NCS_ specific entries. Can be removed when the NCSDK-14227 improvement
 # task has been completed.

--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -30,7 +30,7 @@ version = "&nbsp;"
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))
 
-extensions = ["zephyr.kconfig", "zephyr.external_content"]
+extensions = ["zephyr.kconfig", "zephyr.external_content", "kconfigdiff"]
 
 # Options for HTML output ------------------------------------------------------
 

--- a/doc/kconfig/index.rst
+++ b/doc/kconfig/index.rst
@@ -22,3 +22,4 @@ The search results can be navigated page by page if the number of matches exceed
    :hidden:
 
    regex
+   kconfig_diff.rst

--- a/doc/kconfig/index.rst
+++ b/doc/kconfig/index.rst
@@ -21,5 +21,6 @@ The search results can be navigated page by page if the number of matches exceed
    :maxdepth: 1
    :hidden:
 
+   self
+   kconfig_diff
    regex
-   kconfig_diff.rst

--- a/doc/kconfig/kconfig_diff.rst
+++ b/doc/kconfig/kconfig_diff.rst
@@ -1,0 +1,13 @@
+.. _kconfig_diff:
+
+Kconfig diff
+############
+
+.. contents::
+   :local:
+   :depth: 2
+
+This page shows changes in available Kconfig options between two versions of
+nRF Connect SDK.
+
+.. kconfigdiff::

--- a/doc/kconfig/kconfig_diff.rst
+++ b/doc/kconfig/kconfig_diff.rst
@@ -1,7 +1,7 @@
 .. _kconfig_diff:
 
-Kconfig diff
-############
+Kconfig comparison: |kconfigdiff_previous| - |kconfigdiff_current|
+##############################################################
 
 .. contents::
    :local:

--- a/doc/kconfig/kconfig_diff.rst
+++ b/doc/kconfig/kconfig_diff.rst
@@ -1,13 +1,15 @@
 .. _kconfig_diff:
 
-Kconfig comparison: |kconfigdiff_previous| - |kconfigdiff_current|
-##############################################################
+Kconfig diff
+############
 
 .. contents::
    :local:
    :depth: 2
 
-This page shows changes in available Kconfig options between two versions of
-nRF Connect SDK.
+This page shows comparison between |kconfigdiff_previous| and |kconfigdiff_current|.
+The comparison is displayed using a format inspired by `git diff`:
+
+.. kconfigdiff-legend::
 
 .. kconfigdiff::

--- a/doc/nrf/dev_model_and_contributions/documentation/build.rst
+++ b/doc/nrf/dev_model_and_contributions/documentation/build.rst
@@ -134,6 +134,19 @@ These options are enabled in CI when building the documentation before it is pub
 
 You can try them locally by enabling ``-DDTS_BINDINGS=ON`` and ``-DHW_FEATURES=ON``.
 
+.. _building_kconfig_diff:
+
+Building the Kconfig diff
+*************************
+
+The Kconfig Reference documentation set can include a :ref:`kconfig:kconfig_diff` page that lists the changes in Kconfig configuration options between the current tree and the previous |NCS| release.
+Generating this diff is disabled by default, because it loads the complete Kconfig tree and downloads the Kconfig snapshot of the previous release over the network.
+To enable it, set the ``KCONFIGDIFF`` CMake option to ``ON`` when generating the build files:
+
+.. code-block:: console
+
+   cmake -GNinja -S. -B_build -DKCONFIGDIFF=ON
+
 .. _testing_versions:
 
 Testing locally

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -772,4 +772,5 @@ zcbor
 Documentation
 =============
 
-|no_changes_yet_note|
+* Added the :ref:`kconfig:kconfig_diff` page, displaying differences between available Kconfig options across releases.
+  To generate the new documentation page, set the ``KCONFIGDIFF`` CMake option to ``ON``.


### PR DESCRIPTION
Introduces a new extension which generates a visual diff of changes in available kconfig entries between releases.

All the kconfig entries are loaded, and then pickled so that the output of current  build can be used for reference in the next one. The pickling needs special handling (flattening) as kconfig entries are to deeply nested for pickle to handle.

The entries are built displaying changes in diff like format eg. green - added options, red - deleted options, yellow - modified options.