### PR TITLE
samples: zephyr: bluetooth: Enable for nrf54lc10a.

### DIFF
--- a/samples/zephyr/bluetooth/beacon/README.txt
+++ b/samples/zephyr/bluetooth/beacon/README.txt
@@ -1,4 +1,4 @@
-This sample extends the same-named Zephyr sample to verify it with Nordic nRF54lv10 development kit.
+This sample extends the same-named Zephyr sample to verify it with Nordic nRF54lv10/lc10 development kit.
 
 Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/bluetooth/beacon.
 

--- a/samples/zephyr/bluetooth/beacon/sample.yaml
+++ b/samples/zephyr/bluetooth/beacon/sample.yaml
@@ -8,6 +8,8 @@ tests:
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
+      - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp/ns
     integration_platforms:
       - nrf54lv10dk/nrf54lv10a/cpuapp
     harness: console

--- a/samples/zephyr/bluetooth/hci_uart/README.txt
+++ b/samples/zephyr/bluetooth/hci_uart/README.txt
@@ -1,4 +1,4 @@
-This sample extends the same-named Zephyr sample to verify it with Nordic nRF54lv10 development kit.
+This sample extends the same-named Zephyr sample to verify it with Nordic nRF54lv10/lc10 development kit.
 
 Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/bluetooth/hci_uart.
 

--- a/samples/zephyr/bluetooth/hci_uart/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/zephyr/bluetooth/hci_uart/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,6 @@
+&uart30 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <1000000>;
+	status = "okay";
+	hw-flow-control;
+};

--- a/samples/zephyr/bluetooth/hci_uart/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns.overlay
+++ b/samples/zephyr/bluetooth/hci_uart/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns.overlay
@@ -1,0 +1,1 @@
+#include "nrf54lc10dk_nrf54lc10a_cpuapp.overlay"

--- a/samples/zephyr/bluetooth/hci_uart/sample.yaml
+++ b/samples/zephyr/bluetooth/hci_uart/sample.yaml
@@ -9,6 +9,8 @@ tests:
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
+      - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp/ns
     integration_platforms:
       - nrf54lv10dk/nrf54lv10a/cpuapp
     build_only: true

--- a/samples/zephyr/bluetooth/peripheral_hr/README.txt
+++ b/samples/zephyr/bluetooth/peripheral_hr/README.txt
@@ -1,4 +1,4 @@
-This sample extends the same-named Zephyr sample to verify it with Nordic nRF54lv10 development kit.
+This sample extends the same-named Zephyr sample to verify it with Nordic nRF54lv10/lc10 development kit.
 
 Source code and basic configuration files can be found in the corresponding folder structure in zephyr/samples/bluetooth/peripheral_hr.
 

--- a/samples/zephyr/bluetooth/peripheral_hr/sample.yaml
+++ b/samples/zephyr/bluetooth/peripheral_hr/sample.yaml
@@ -9,6 +9,8 @@ tests:
     platform_allow:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
+      - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp/ns
     integration_platforms:
       - nrf54lv10dk/nrf54lv10a/cpuapp
     harness: console


### PR DESCRIPTION
Add neccessary overlay and testcase.yaml entries.