### PR TITLE
tests: benchmarks: Clean up system off test

### DIFF
--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l05_cpuapp_gpio_wakeup_retain_4k.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l05_cpuapp_gpio_wakeup_retain_4k.overlay
@@ -1,0 +1,2 @@
+#include "nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup.overlay"
+#include "nrf54l15dk_nrf54l05_cpuapp_retain_4k.overlay"

--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l10_cpuapp_gpio_wakeup_retain_4k.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l10_cpuapp_gpio_wakeup_retain_4k.overlay
@@ -1,0 +1,2 @@
+#include "nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup.overlay"
+#include "nrf54l15dk_nrf54l10_cpuapp_retain_4k.overlay"

--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup_retain_4k.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup_retain_4k.overlay
@@ -1,0 +1,2 @@
+#include "nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup.overlay"
+#include "nrf54l15dk_nrf54l15_cpuapp_retain_4k.overlay"

--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54lc10dk_nrf54lc10a_cpuapp_gpio_wakeup_retain_4k.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54lc10dk_nrf54lc10a_cpuapp_gpio_wakeup_retain_4k.overlay
@@ -1,0 +1,2 @@
+#include "nrf54lc10dk_nrf54lc10a_cpuapp_gpio_wakeup.overlay"
+#include "nrf54lc10dk_nrf54lc10a_cpuapp_retain_4k.overlay"

--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54lm20dk_nrf54lm20a_cpuapp_gpio_wakeup_retain_4k.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54lm20dk_nrf54lm20a_cpuapp_gpio_wakeup_retain_4k.overlay
@@ -1,0 +1,2 @@
+#include "nrf54lm20dk_nrf54lm20a_cpuapp_gpio_wakeup.overlay"
+#include "nrf54lm20dk_nrf54lm20a_cpuapp_retain_4k.overlay"

--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54lm20dk_nrf54lm20b_cpuapp_gpio_wakeup_retain_4k.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54lm20dk_nrf54lm20b_cpuapp_gpio_wakeup_retain_4k.overlay
@@ -1,0 +1,2 @@
+#include "nrf54lm20dk_nrf54lm20b_cpuapp_gpio_wakeup.overlay"
+#include "nrf54lm20dk_nrf54lm20b_cpuapp_retain_4k.overlay"

--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54ls05dk_nrf54ls05a_cpuapp_gpio_wakeup_retain_4k.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54ls05dk_nrf54ls05a_cpuapp_gpio_wakeup_retain_4k.overlay
@@ -1,0 +1,2 @@
+#include "nrf54ls05dk_nrf54ls05b_cpuapp_gpio_wakeup.overlay"
+#include "nrf54ls05dk_nrf54ls05a_cpuapp_retain_4k.overlay"

--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54ls05dk_nrf54ls05b_cpuapp_gpio_wakeup_retain_4k.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54ls05dk_nrf54ls05b_cpuapp_gpio_wakeup_retain_4k.overlay
@@ -1,0 +1,2 @@
+#include "nrf54ls05dk_nrf54ls05b_cpuapp_gpio_wakeup.overlay"
+#include "nrf54ls05dk_nrf54ls05b_cpuapp_retain_4k.overlay"

--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54lv10dk_nrf54lv10a_cpuapp_gpio_wakeup_retain_4k.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54lv10dk_nrf54lv10a_cpuapp_gpio_wakeup_retain_4k.overlay
@@ -1,0 +1,2 @@
+#include "nrf54lv10dk_nrf54lv10a_cpuapp_gpio_wakeup.overlay"
+#include "nrf54lv10dk_nrf54lv10a_cpuapp_retain_4k.overlay"

--- a/tests/benchmarks/current_consumption/system_off/testcase.yaml
+++ b/tests/benchmarks/current_consumption/system_off/testcase.yaml
@@ -21,21 +21,7 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
-      - platform:nrf54l15dk/nrf54l15/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54l15dk/nrf54l10/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54l15dk/nrf54l05/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lm20dk/nrf54lm20a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lm20dk_nrf54lm20a_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lm20dk/nrf54lm20b/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lm20dk_nrf54lm20b_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lv10dk/nrf54lv10a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lv10dk_nrf54lv10a_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lv10dk@0.7.0/nrf54lv10a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lv10dk_nrf54lv10a_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lv10dk/nrf54lv10a/cpuapp/ns:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lv10dk_nrf54lv10a_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lv10dk@0.7.0/nrf54lv10a/cpuapp/ns:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lv10dk_nrf54lv10a_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lc10dk/nrf54lc10a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lc10dk_nrf54lc10a_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lc10dk@0.8.0/nrf54lc10a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lc10dk_nrf54lc10a_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54ls05dk/nrf54ls05a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54ls05dk_nrf54ls05b_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54ls05dk/nrf54ls05b/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54ls05dk_nrf54ls05b_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54ls05dk@0.2.0/nrf54ls05a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54ls05dk_nrf54ls05b_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54ls05dk@0.2.0/nrf54ls05b/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54ls05dk_nrf54ls05b_cpuapp_gpio_wakeup.overlay"
+      - FILE_SUFFIX=gpio_wakeup
     harness: pytest
     harness_config:
       fixture: ppk_power_measure
@@ -56,20 +42,7 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
-      - platform:nrf54l15dk/nrf54l15/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54l15dk/nrf54l10/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54l15dk/nrf54l05/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lm20dk/nrf54lm20a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lm20dk_nrf54lm20a_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lm20dk/nrf54lm20b/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lm20dk_nrf54lm20b_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lv10dk/nrf54lv10a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lv10dk_nrf54lv10a_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lv10dk@0.7.0/nrf54lv10a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lv10dk_nrf54lv10a_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lc10dk/nrf54lc10a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lc10dk_nrf54lc10a_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54lc10dk@0.8.0/nrf54lc10a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lc10dk_nrf54lc10a_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54ls05dk/nrf54ls05a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54ls05dk_nrf54ls05b_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54ls05dk/nrf54ls05b/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54ls05dk_nrf54ls05b_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54ls05dk@0.2.0/nrf54ls05a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54ls05dk_nrf54ls05b_cpuapp_gpio_wakeup.overlay"
-      - platform:nrf54ls05dk@0.2.0/nrf54ls05b/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54ls05dk_nrf54ls05b_cpuapp_gpio_wakeup.overlay"
-      - FILE_SUFFIX=retain_4k
+      - FILE_SUFFIX=gpio_wakeup_retain_4k
     extra_configs:
       - CONFIG_APP_USE_RETAINED_MEM=y
     harness: pytest
@@ -349,15 +322,7 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
-      - platform:nrf54l15dk/nrf54l15/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15dk_nrf54l15_cpuapp_lpcomp_wakeup.overlay"
-      - platform:nrf54l15dk/nrf54l10/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15dk_nrf54l15_cpuapp_lpcomp_wakeup.overlay"
-      - platform:nrf54l15dk/nrf54l05/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54l15dk_nrf54l15_cpuapp_lpcomp_wakeup.overlay"
-      - platform:nrf54lm20dk/nrf54lm20a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lm20dk_nrf54lm20a_cpuapp_lpcomp_wakeup.overlay"
-      - platform:nrf54lm20dk/nrf54lm20b/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lm20dk_nrf54lm20b_cpuapp_lpcomp_wakeup.overlay"
-      - platform:nrf54lv10dk/nrf54lv10a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lv10dk_nrf54lv10a_cpuapp_lpcomp_wakeup.overlay"
-      - platform:nrf54lv10dk@0.7.0/nrf54lv10a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lv10dk_nrf54lv10a_cpuapp_lpcomp_wakeup.overlay"
-      - platform:nrf54lc10dk/nrf54lc10a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lc10dk_nrf54lc10a_cpuapp_lpcomp_wakeup.overlay"
-      - platform:nrf54lc10dk@0.8.0/nrf54lc10a/cpuapp:"EXTRA_DTC_OVERLAY_FILE=boards/nrf54lc10dk_nrf54lc10a_cpuapp_lpcomp_wakeup.overlay"
+      - FILE_SUFFIX=lpcomp_wakeup
     extra_configs:
       - CONFIG_LPCOMP_WAKEUP_ENABLE=y
       - CONFIG_COMPARATOR=y


### PR DESCRIPTION
Remove the per-platform overlay assignment
Use FILE SUFFIX instead