### PR TITLE
[Backport v3.4-branch] workflows: doc build: Switch to self-hosted runners

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -27,7 +27,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - runner=16cpu-linux-x64
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -63,7 +65,8 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get install -y wget python3-pip git ninja-build graphviz lcov mscgen plantuml
-          sudo snap install yq
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
           DOXYGEN_VERSION=$(yq ".doxygen.version" nrf/scripts/tools-versions-linux.yml)
           wget --no-verbose "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
           tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz


### PR DESCRIPTION
Move from GitHub's runners to self-hosted ones to speed up the doc build.
More info in https://nordicsemi.atlassian.net/browse/NCSDK-38365, test PR in https://github.com/nrfconnect/sdk-nrf/pull/29655.

Backport of https://github.com/nrfconnect/sdk-nrf/pull/29676