### PR TITLE
[Backport v3.4-branch] manifest: sdk-mcuboot: [nrf noup] boot/zephyr/kconfig: MCUBOOT_CHECK_HEADER_LOAD_ADDRESS=y

### DIFF
--- a/cmake/sysbuild/b0_mcuboot_signing.cmake
+++ b/cmake/sysbuild/b0_mcuboot_signing.cmake
@@ -38,7 +38,18 @@ function(ncs_secure_boot_mcuboot_sign application bin_files signed_targets prefi
     # Get the partition node and pick size from it.
     dt_chosen(code_partition_path PROPERTY "zephyr,code-partition" TARGET ${application})
     dt_partition_size(slot_size PATH "${code_partition_path}" TARGET ${application} REQUIRED)
-    dt_partition_addr(slot_address PATH "${code_partition_path}" TARGET ${application} REQUIRED ABSOLUTE)
+    if(SB_CONFIG_SECURE_BOOT_APPCORE AND SB_CONFIG_BOOTLOADER_MCUBOOT)
+      b0_image_name(s1_variant_name)
+      if("${application}" STREQUAL "mcuboot")
+        dt_partition_addr(slot_address LABEL "s0_partition" TARGET ${application} ABSOLUTE REQUIRED)
+      elseif("${application}" STREQUAL "s1_image" OR "${application}" STREQUAL "${s1_variant_name}")
+        dt_partition_addr(slot_address LABEL "s1_partition" TARGET ${application} ABSOLUTE REQUIRED)
+      else()
+        dt_partition_addr(slot_address PATH "${code_partition_path}" TARGET ${application} REQUIRED ABSOLUTE)
+      endif()
+    else()
+      dt_partition_addr(slot_address PATH "${code_partition_path}" TARGET ${application} REQUIRED ABSOLUTE)
+    endif()
     # Header size is picked from the image that is being signed.
     sysbuild_get(header_size IMAGE ${DEFAULT_IMAGE} VAR CONFIG_ROM_START_OFFSET KCONFIG)
 

--- a/cmake/sysbuild/sign_nrf54h20.cmake
+++ b/cmake/sysbuild/sign_nrf54h20.cmake
@@ -275,6 +275,8 @@ function(mcuboot_sign_merged_nrf54h20 merged_hex main_image merged_images)
       math(EXPR start_offset "${start_offset} + ${start_offset_dts}")
       set(pad_header "--pad-header")
     endif()
+    # For nRF54H20 in a direct-xip mode use relative bounds due to backwards compatibility
+    # This is ensured by fetching component which determines `slot_addr` as relative values.
     set(imgtool_rom_command --rom-fixed ${slot_addr})
   elseif(SB_CONFIG_MCUBOOT_MODE_FIRMWARE_UPDATER)
     if(CONFIG_MCUBOOT_APPLICATION_FIRMWARE_UPDATER)


### PR DESCRIPTION
Backport f83ae967a796da6c40ca52c6092836baf9768541~2..f83ae967a796da6c40ca52c6092836baf9768541 from #29319.