### PR TITLE
workflows: doc build: Increase storage capacity for AWS instances

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on:
       - runs-on=${{ github.run_id }}
       - runner=16cpu-linux-x64
+      - volume=120gb
+      - family=c6id+m6id+r6id
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
Changes the following:

- Increase the default 40GB root EBS volume (volume=)
- Use NVMe-equipped instances (family=)

Assisted-by: Claude:claude-opus-4.8