### PR TITLE
tests: benchmarks: Add missing harness to vpr_context test

### DIFF
--- a/tests/benchmarks/vpr_context/testcase.yaml
+++ b/tests/benchmarks/vpr_context/testcase.yaml
@@ -14,3 +14,9 @@ tests:
       - nrf54l15dk/nrf54l15/cpuflpr
     extra_args:
       - vpr_launcher_CONFIG_SERIAL=n
+    harness: console
+    harness_config:
+      type: one_line
+      ordered: true
+      regex:
+        - "Test PASS"


### PR DESCRIPTION
Add missing harness definition to 'benchmarks.vpr_context'