### PR TITLE
[Backport v3.4-branch] samples: peripheral: radio_test: Enable sample on nrf54lc10dk

### DIFF
--- a/samples/peripheral/radio_test/sample.yaml
+++ b/samples/peripheral/radio_test/sample.yaml
@@ -15,6 +15,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf7120dk/nrf7120/cpuapp
     platform_allow:
@@ -29,6 +30,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf7120dk/nrf7120/cpuapp
     tags:


### PR DESCRIPTION
Backport 04fbd2a3b58071f72387178bde8b93ba733f7c0e from #29691.