### PR TITLE
[Backport v3.4-branch] scripts: sbom: Remove .git from sbom output

### DIFF
--- a/scripts/west_commands/sbom/ninja_build_extractor.py
+++ b/scripts/west_commands/sbom/ninja_build_extractor.py
@@ -111,7 +111,9 @@ class NinjaBuildExtractor:
         Ignore targets which pollute the SBOM with unrelated headers.
         '''
         normalized = str(target).replace('\\', '/').lower()
-        return normalized.endswith(IGNORE_TARGETS)
+        if normalized.endswith(IGNORE_TARGETS):
+            return True
+        return '.git' in normalized.split('/')
 
     def detect_file_type(self, file: Path) -> FileType:
         '''


### PR DESCRIPTION
Backport 878c9ab264ca66d48a1b9a5661f0359d81752e13 from #29637.