### PR TITLE
test: benchmarks: Fix missing overlays for system_off gpio wakeup

### DIFF
--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l05_cpuapp_gpio_wakeup.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l05_cpuapp_gpio_wakeup.overlay
@@ -1,0 +1,1 @@
+#include "nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup.overlay"

--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l05_cpuapp_lpcomp_wakeup.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l05_cpuapp_lpcomp_wakeup.overlay
@@ -1,0 +1,1 @@
+#include "nrf54l15dk_nrf54l15_cpuapp_lpcomp_wakeup.overlay"

--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l10_cpuapp_gpio_wakeup.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l10_cpuapp_gpio_wakeup.overlay
@@ -1,0 +1,1 @@
+#include "nrf54l15dk_nrf54l15_cpuapp_gpio_wakeup.overlay"

--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l10_cpuapp_lpcomp_wakeup.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54l15dk_nrf54l10_cpuapp_lpcomp_wakeup.overlay
@@ -1,0 +1,1 @@
+#include "nrf54l15dk_nrf54l15_cpuapp_lpcomp_wakeup.overlay"


### PR DESCRIPTION
Missing overlays for l05 and l10