### PR TITLE
[Backport v3.4-branch] workflows: doc build: Ensure enough RAM available in main builds

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -32,6 +32,7 @@ jobs:
       - runner=16cpu-linux-x64
       - volume=120gb
       - family=c6id+m6id+r6id
+      - ram=${{ github.event_name == 'pull_request' && '32+128' || '64+128' }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
When building the doc on main, we enable doc build features that trigger a twister run to generate metadata. Twister is very aggressive when sizing its RAM usage based on cores, so the combination of 16 cores and 32GB of RAM was causing OOM (showing as a cancellation) errors.

Ensure that for builds to main we use instances with at least 64GB of RAM.

Assisted-by: Claude:claude-opus-4.8