### PR TITLE
Revert ext adv discard handling (NCSDK-39888)

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -24,9 +24,4 @@ zephyr_library_sources_ifdef(
 
 zephyr_library_link_libraries(subsys__bluetooth)
 
-zephyr_library_include_directories_ifdef(
-  CONFIG_BT_EXT_ADV
-  ${ZEPHYR_BASE}/drivers/bluetooth/hci
-)
-
 zephyr_include_directories(.)

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -33,9 +33,6 @@
 #include "hci_internal.h"
 #include "radio_nrf5_txp.h"
 #include "cs_antenna_switch.h"
-#if defined(CONFIG_BT_EXT_ADV)
-#include "util_hci_evt.h"
-#endif
 
 #define DT_DRV_COMPAT nordic_bt_hci_sdc
 
@@ -385,10 +382,6 @@ void sdc_assertion_handler(const char *const file, const uint32_t line)
 #endif /* IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER) */
 
 static struct k_work receive_work;
-#if defined(CONFIG_BT_EXT_ADV)
-static struct hci_ext_adv_discard_ctx ext_adv_discard;
-#endif
-
 static inline void receive_signal_raise(void)
 {
 	mpsl_work_submit(&receive_work);
@@ -629,7 +622,7 @@ static int event_packet_process(const struct device *dev, uint8_t *hci_buf)
 {
 	bool discardable = event_packet_is_discardable(hci_buf);
 	struct bt_hci_evt_hdr *hdr = (void *)hci_buf;
-	struct net_buf *evt_buf = NULL;
+	struct net_buf *evt_buf;
 
 	if (hdr->len + sizeof(*hdr) > HCI_RX_BUF_SIZE) {
 		LOG_ERR("Event buffer too small. %zu > %u",
@@ -637,18 +630,6 @@ static int event_packet_process(const struct device *dev, uint8_t *hci_buf)
 			HCI_RX_BUF_SIZE);
 		return -ENOMEM;
 	}
-
-#if defined(CONFIG_BT_EXT_ADV)
-	if (hci_ext_adv_report_process(&ext_adv_discard, hci_buf, hdr->len + sizeof(*hdr),
-						&evt_buf)) {
-		if (evt_buf != NULL) {
-			struct hci_driver_data *driver_data = dev->data;
-
-			(void)driver_data->recv_func(dev, evt_buf);
-		}
-		return 0;
-	}
-#endif
 
 	if (hdr->evt == BT_HCI_EVT_LE_META_EVENT) {
 		struct bt_hci_evt_le_meta_event *me = (void *)&hci_buf[2];
@@ -1333,10 +1314,6 @@ static int hci_driver_open(const struct device *dev, bt_hci_recv_t recv_func)
 	LOG_DBG("Open");
 
 	k_work_init(&receive_work, receive_work_handler);
-
-#if defined(CONFIG_BT_EXT_ADV)
-	ext_adv_discard = (struct hci_ext_adv_discard_ctx){0};
-#endif
 
 	uint8_t build_revision[SDC_BUILD_REVISION_SIZE];
 

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: cbe0ba9bfb638f88caec1f262eed2fbecca730b8
+      revision: 7e13730f40a0717e56dd2f5b92e6d4fbeacd60cb
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
## Summary

Revert the extended advertising report discard feature to avoid corrupted LE Extended Advertising Report HCI events under buffer pressure (NCSDK-39888, upstream zephyr#111388).

- Revert SDC HCI driver integration (`4361459c61c`)
- Bump sdk-zephyr to `7e13730f40a0717e56dd2f5b92e6d4fbeacd60cb` ([sdk-zephyr#4216](https://github.com/nrfconnect/sdk-zephyr/pull/4216), merged 2026-06-20)

Target: NCS 3.4.0 RC2. Keep DNM until CI is green on the final manifest SHA.

## west.yml

sdk-zephyr#4216 merged first; this PR carries the paired SDC revert and pins zephyr to merge commit `7e13730f40a0717e56dd2f5b92e6d4fbeacd60cb`. sdk-nrf `main` still points at pre-revert zephyr until this lands.

## Zephyr commit format (paired PR)

sdk-zephyr#4216 uses a `[nrf noup]` manual revert instead of a `Revert "..."` / `git revert` replay, because commit-tags replay of the standard revert shape conflicts in `scan.c` after intervening changes. See that PR for the full rationale.

## SonarCloud

SonarCloud reports c:S859 on a pre-existing cast in `event_packet_is_discardable()` (2022 code; re-flagged because this revert touches `hci_driver.c`): `(void *)&hci_buf[3]` from `const uint8_t *` drops const in the intermediate `void *` cast; the result is stored in `const struct bt_hci_evt_le_ext_advertising_report *` and only read.

https://github.com/nrfconnect/sdk-nrf/blob/59af0208f842b0087029a82ae016127ea2d8f5ea/subsys/bluetooth/controller/hci_driver.c#L587-L588

## Test plan

- [x] Compliance CI
- [ ] Manifest CI (re-run after manifest SHA update)
- [ ] Jenkins toolchain / twister / integration
- [ ] OSS history
- [ ] SonarCloud (c:S859; see SonarCloud section)

## Related PRs

- sdk-zephyr: https://github.com/nrfconnect/sdk-zephyr/pull/4216