### PR TITLE
samples: dfu: smp_svr: Increase timeout to 30 seconds from 15 seconds

### DIFF
--- a/samples/dfu/smp_svr/sample.yaml
+++ b/samples/dfu/smp_svr/sample.yaml
@@ -11,7 +11,7 @@ common:
       - "Starting .*bootloader"
       - "Jumping to the .*image slot"
       - "build time"
-  timeout: 15
+  timeout: 30
   tags:
     - ci_samples_zephyr_subsys_mgmt_mcumgr_smp_svr
 


### PR DESCRIPTION
Increase the timeout to 30 seconds.

nRF7120 takes around 20.5 seconds to run the test.