### PR TITLE
bootloader: Fix variant image detection

### DIFF
--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -246,10 +246,14 @@ DT_NODELABEL_SLOT1_PARTITION := slot1_partition
 config NCS_IS_VARIANT_IMAGE
 	bool
 	default y if "$(dt_nodelabel_exists,$(DT_NODELABEL_SECONDARY_PARTITION))" && \
+			"$(dt_partition_mtd,$(dt_nodelabel_path,$(DT_NODELABEL_SECONDARY_PARTITION)))" = \
+				"$(dt_partition_mtd,$(dt_chosen_path,$(DT_CHOSEN_Z_CODE_PARTITION)))" && \
 			"$(sub, \
 				$(dt_nodelabel_reg_addr_int,$(DT_NODELABEL_SECONDARY_PARTITION)), \
 				$(dt_chosen_reg_addr_int,$(DT_CHOSEN_Z_CODE_PARTITION)))" = 0
 	default y if "$(dt_nodelabel_exists,$(DT_NODELABEL_SLOT1_PARTITION))" && \
+			"$(dt_partition_mtd,$(dt_nodelabel_path,$(DT_NODELABEL_SLOT1_PARTITION)))" = \
+				"$(dt_partition_mtd,$(dt_chosen_path,$(DT_CHOSEN_Z_CODE_PARTITION)))" && \
 			"$(sub, \
 				$(dt_nodelabel_reg_addr_int,$(DT_NODELABEL_SLOT1_PARTITION)), \
 				$(dt_chosen_reg_addr_int,$(DT_CHOSEN_Z_CODE_PARTITION)))" = 0

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c1a3e0d06b747de46f48a036908a1f730e88eef0
+      revision: 934e0c6aded9bf8e998279c2e2479007cb83080a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix a variant image detection if an external mamory with overlapping address space is used.
Fixed MCUboot updates on nRF5340 with external memory attached.