### PR TITLE
scripts: nrf_profiler: Add -o float offset to merge_data

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -887,6 +887,12 @@ This section provides detailed lists of changes by :ref:`script <scripts>`.
 
   * The SPDX output format from ``SPDX-2.2`` to ``SPDX-2.3``.
 
+* :ref:`nrf_profiler_script` script:
+
+  * Added the ``-o <float>`` / ``--offset`` argument to the :file:`merge_data.py` script.
+    The argument accepts a floating-point peripheral synchronization event offset in microseconds and is applied before clock drift compensation.
+    This allows tuning merged results for the repeatable, constant delays.
+
 Integrations
 ============
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -652,6 +652,12 @@ This section provides detailed lists of changes by :ref:`script <scripts>`.
 
   * The SPDX output format from ``SPDX-2.2`` to ``SPDX-2.3``.
 
+* :ref:`nrf_profiler_script` script:
+
+  * Added the ``-o <float>`` / ``--offset`` argument to the :file:`merge_data.py` script.
+    The argument accepts a floating-point peripheral synchronization event offset in microseconds and is applied before clock drift compensation.
+    This allows tuning merged results for the repeatable, constant delays.
+
 Integrations
 ============
 

--- a/scripts/nrf_profiler/README.rst
+++ b/scripts/nrf_profiler/README.rst
@@ -138,6 +138,16 @@ For example:
 
    python3 merge_data.py test_p sync_event_p test_c sync_event_c test_merged
 
+Optionally, use the ``-o <float>`` (``--offset``) argument to add a fixed time correction value to peripheral synchronization event timestamps before clock drift compensation.
+The offset is a floating-point value specified in microseconds.
+A positive value shifts peripheral sync timestamps forward on the time axis.
+When using GPIO for synchronization (Central: GPIO OUT → Peripheral: GPIO IRQ on edge), ``-3.6`` is the recommended offset value.
+For example:
+
+.. code-block:: console
+
+   python3 merge_data.py test_p sync_event_p test_c sync_event_c test_merged -o -3.6
+
 The newly created dataset (``test_merged``) contains the nRF Profiler events registered by both devices with compensated clock drift.
 You can use it  for visualization or calculating statistics.
 

--- a/scripts/nrf_profiler/merge_data.py
+++ b/scripts/nrf_profiler/merge_data.py
@@ -31,6 +31,13 @@ def sync_peripheral_ts(ts_peripheral, sync_ts_peripheral, sync_ts_central):
                          sync_ts_peripheral, sync_ts_central,
                          left=INTERP_OUT_OF_RANGE_VAL, right=INTERP_OUT_OF_RANGE_VAL)
 
+def apply_peripheral_sync_offset(sync_ts, offset_us):
+    if offset_us == 0:
+        return sync_ts
+    # µs -> s (timestamps from CSV - seconds)
+    offset_s = offset_us * 1e-6
+    print(f'Applied peripheral sync offset: {offset_us} us')
+    return [t + offset_s for t in sync_ts]
 
 def main():
     descr = "Merge data from Peripheral and Central. Synchronization events" \
@@ -44,6 +51,16 @@ def main():
     parser.add_argument("central_sync_event",
                         help="Event used for synchronization - Central")
     parser.add_argument("result_dataset", help="Name for result dataset")
+    parser.add_argument(
+        '-o', '--offset',
+        type=float,
+        default=0.0,
+        help=(
+            "Floating-point peripheral sync-event time offset in microseconds (optional)."
+            "A positive value shifts peripheral sync timestamps forward before clock alignment."
+        )
+    )
+
     args = parser.parse_args()
 
     evt_peripheral = ProcessedEvents()
@@ -87,6 +104,8 @@ def main():
         sync_ts_peripheral = sync_ts_peripheral[:len(sync_ts_central)]
     elif len(sync_ts_peripheral) < len(sync_ts_central):
         sync_ts_central = sync_ts_central[:len(sync_ts_peripheral)]
+
+    sync_ts_peripheral = apply_peripheral_sync_offset(sync_ts_peripheral, args.offset)
 
     new_ts_peripheral = ts_peripheral.copy()
     new_ts_peripheral[list(list(elem is not None for elem in row) for row in new_ts_peripheral)] = \


### PR DESCRIPTION
Add optional floating-point offset (us) applied to peripheral sync events before clock drift compensation.

Jira: NCSDK-39449