### PR TITLE
tests: drivers: timer: enable GRTC support for FLPR core

### DIFF
--- a/tests/drivers/timer/grtc_multiple_access/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
+++ b/tests/drivers/timer/grtc_multiple_access/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: LicenseRef-Nordic-5-Clause */
+
+&grtc {
+	owned-channels = <5 6>;
+};

--- a/tests/drivers/timer/grtc_multiple_access/testcase.yaml
+++ b/tests/drivers/timer/grtc_multiple_access/testcase.yaml
@@ -9,6 +9,7 @@ tests:
   drivers.timer.grtc_multiple_access:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpuflpr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp


### PR DESCRIPTION
Add corresponding test overlays so that the GRTC
tests run correctly under Twister for the FLPR core.