### PR TITLE
net: lib: nrf70_fw_ext: Fix build ordering for nrf70.bin.inc generation

### DIFF
--- a/subsys/net/lib/nrf70_fw_ext/CMakeLists.txt
+++ b/subsys/net/lib/nrf70_fw_ext/CMakeLists.txt
@@ -51,4 +51,10 @@ if(DEFINED CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_DISABLED OR
     ${NRF70_PATCH}
     ${gen_dir}/nrf70.bin.inc
   )
+  # fw_load.c is added to the zephyr library via zephyr_library_sources(), so the
+  # zephyr library must also depend on the generated nrf70.bin.inc file to ensure
+  # correct build ordering (otherwise fw_load.c may be compiled before the .inc
+  # file is generated).
+  generate_unique_target_name_from_filename(${gen_dir}/nrf70.bin.inc _nrf70_gen_target)
+  add_dependencies(zephyr ${_nrf70_gen_target})
 endif()


### PR DESCRIPTION
When CONFIG_NRF_WIFI_PATCHES_EXT_FLASH_DISABLED=y, fw_load.c is added to the zephyr library via zephyr_library_sources(). The .inc file is generated by a custom target created with generate_inc_file_for_target(), which sets up the dependency on the 'nrf_wifi' CMake target — but not on the 'zephyr' target that actually compiles fw_load.c.

This causes a race condition where fw_load.c can be compiled before nrf70_fw_patch/nrf70.bin.inc is generated, resulting in:

  fatal error: nrf70_fw_patch/nrf70.bin.inc: No such file or directory

Fix by calling generate_unique_target_name_from_filename() with the same path used in generate_inc_file_for_target() to get the custom target name, then adding it as a dependency of the zephyr library.


Assisted-by: Copilot:Auto