### PR TITLE
doc: nrf: app_dev: device_guides: PM deprecation updates

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf91/index.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/index.rst
@@ -68,6 +68,7 @@ If you want to go through a hands-on online training to familiarize yourself wit
 
    nrf91_features
    nrf91_board_controllers
+   nrf91_dt_partitions
    nrf91_cloud_connecting
    nrf91_dk_updating_fw_programmer
    nrf91_building

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf9160_external_flash.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf9160_external_flash.rst
@@ -37,7 +37,6 @@ To use external flash, you also need to enable configuration and devicetree opti
    * :kconfig:option:`CONFIG_SPI`
    * :kconfig:option:`CONFIG_SPI_NOR`
    * :kconfig:option:`CONFIG_SPI_NOR_SFDP_DEVICETREE`
-   * :kconfig:option:`CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK`
 
 #. Specify the board revision parameter when :ref:`building` to automatically include the devicetree overlay with the external flash.
    The board revision is printed on the label of your DK, just below the PCA number.
@@ -46,43 +45,44 @@ To use external flash, you also need to enable configuration and devicetree opti
 
    .. code-block:: devicetree
 
-      /* Enable the external flash device (required) */
       &mx25r64 {
+	   /* Enable the external flash device (required) */
 	   status = "okay";
-      };
 
-      /* Configure partition manager to use mx25r64 as the external flash device */
-      / {
-          chosen {
-              nordic,pm-ext-flash = &mx25r64;
-          };
-      };
+	   /* Enable high performance mode to increase write/erase performance */
+	   mxicy,mx25r-power-mode = "high-performance";
 
-      /* Enable high performance mode to increase write/erase performance */
-      &mx25r64 {
-          mxicy,mx25r-power-mode = "high-performance";
+	   /* Add partitions as required */
+	   partitions {
+	      compatible = "fixed-partitions";
+	      #address-cells = <1>;
+	      #size-cells = <1>;
+
+	      fmfu_storage_partition: partition@0 {
+		   label = "fmfu_storage";
+		   reg = <0x00000000 0x400000>;
+	      };
+
+	      modem_trace: partition@400000 {
+		   label = "modem_trace";
+		   reg = <0x00400000 0x400000>;
+	      };
+
+	      pgps_partition: partition@800000 {
+		   label = "pgps";
+		   reg = <0x00800000 0x14000>;
+	      };
+
+	      settings_storage_partition: partition@814000 {
+		   label = "settings_storage";
+		   reg = <0x00814000 0x2000>;
+	      };
+
+	      external_flash_partition: partition@816000 {
+		   label = "external_flash";
+		   reg = <0x00816000 0x17ea000>;
+	      };
+	   };
       };
 
    For more information about devicetree overlays, see :ref:`zephyr:use-dt-overlays`.
-
-Using Partition Manager
-***********************
-
-.. include:: ../../../includes/pm_deprecation.txt
-
-If your application was built using the |NCS|, you must define partitions using :ref:`partition_manager`.
-The built-in partition definitions can be found in the :file:`nrf/subsys/partition_manager` folder, and the file names start with ``pm.yml``.
-The files that have ``external_flash`` as their region support storing partitions in the external flash.
-You can also find the configuration option required to place the partition in the external flash region in those files.
-For example, the :file:`pm.yml.pgps` file has an option (:kconfig:option:`CONFIG_PM_PARTITION_REGION_PGPS_EXTERNAL`) to place the P-GPS partition in external flash:
-
-.. code-block:: c
-
-   #ifdef CONFIG_PM_PARTITION_REGION_PGPS_EXTERNAL
-     region: external_flash
-   #else
-     inside: [nonsecure_storage]
-   #endif
-     size: CONFIG_NRF_CLOUD_PGPS_PARTITION_SIZE
-
-You can also change the size of the partition with the :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_PARTITION_SIZE` Kconfig option.

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_dt_partitions.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_dt_partitions.rst
@@ -1,0 +1,61 @@
+.. _nrf91_dt_partitions:
+
+Configuring partitions on an nRF91 Series device
+################################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The default SRAM and Flash partition layouts in Zephyr allocate space for all Trusted Firmware-M (TF-M) features and require you to enable MCUboot.
+As MCUboot is disabled by default in |NCS|, and the modem handles the security requirements, all applications are expected to set the partition tables using a devicetree overlay.
+This ensures that the partitions match the actual requirements and maximizes the available memory for your application.
+
+Including default partition layouts
+***********************************
+
+The easiest way is to include two of the ``.dtsi`` files from the :file:`nrf/dts/samples/cellular` folder to your board's :file:`.overlay` file.
+
+.. code-block:: devicetree
+
+   #include <samples/cellular/nrf91_no_bootloader_partitions.dtsi>
+
+   #include <samples/cellular/nrf91_sram_partitions.dtsi>
+
+* There are four sample flash layouts:
+
+   * ``nrf91_no_bootloader_partitions.dtsi`` - This layout works with minimal TF-M configurations without a bootloader.
+     This layout is used by most samples.
+   * ``nrf91_bootloader_partitions.dtsi`` - This layout works with minimal TF-M setups that include MCUboot.
+   * ``nrf91_immutable_bootloader_partitions.dtsi`` - This layout works with minimal TF-M and both an :ref:`bootloader` and an updatable MCUboot.
+     Both the b0 and MCUboot are built separately and must also know about these partitions.
+     You need to add a ``b0`` and ``mcuboot`` folder inside a ``sysbuild`` folder with a :file:`prj.conf` and the required overlay in a ``boards`` folder.
+   * ``nrf91_crypto_partitions.dtsi`` - This layout works  for the full TF-M features without a bootloader.
+     You can use it to test TF-M functionalities.
+
+* There are two sample SRAM layouts:
+
+   * ``nrf91_sram_partitions.dtsi`` - This layout works with minimal TF-M configurations.
+     This layout is used by most samples.
+   * ``nrf91_sram_crypto_partitions.dtsi``- This layout works for the full TF-M features.
+     You can use it to test TF-M functionalities.
+
+Creating a custom partition layout
+**********************************
+
+Instead of including these ``.dtsi`` files, you can copy their contents and modify them as required.
+
+The flash memory uses 4 KB pages, so each partition must start on a 4 KB boundary.
+The flash memory has 32 KB blocks that can be marked as secure or non-secure.
+Any 32 KB block that contains a ``slot0_ns_partition``, ``slot1_ns_partition``, or ``storage_partition`` will be marked as non-secure.
+Secure partitions must not share a 32 KB block with any non-secure partition.
+In addition, the ``storage_partition`` must not share a 32 KB block with the ``slot0_ns_partition``.
+Any partitions that need to be accessed by the application must be part of (or included within) the storage partition.
+
+The SRAM has 8 KB blocks that can be marked as secure or non-secure.
+You need to add a specific block of non-secure memory that is shared with the modem as described in :ref:`devicetree_integration`.
+
+References
+**********
+
+See `Migrating from Partition Manager to devicetree (DTS)`_ for instructions on how to migrate your project to devicetree in general.

--- a/doc/nrf/app_dev/device_guides/nrf91/nrf91_snippet.rst
+++ b/doc/nrf/app_dev/device_guides/nrf91/nrf91_snippet.rst
@@ -32,13 +32,17 @@ On nRF91 Series devices, you can enable the following functionalities using snip
      - ``tfm-enable-share-uart``
      - :ref:`All nRF91 Series board targets <ug_nrf91>`
 
+You can only use the four trace snippets with applications that use the RAM layout defined in :file:`nrf/dts/samples/cellular/nrf91_sram_partitions.dtsi`.
+If you are using a different RAM layout, for example, to use more TF-M functionalities, you need to add the ``cpucell_cpuapp_ipc_shm_trace`` partition yourself and copy the configurations from the :file:`.conf` file in the snippet.
+See :ref:`devicetree_integration` for more information.
+
 .. _nrf91_modem_trace_ext_flash_snippet:
 
 nRF91 modem traces with flash backend using snippets
 ****************************************************
 
 The ``nrf91-modem-trace-ext-flash`` snippet enables modem tracing, the flash backend, and external flash and configures them to store modem traces to a dedicated partition on the external flash for supported boards.
-To change the partition size, the project needs to configure the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH_PARTITION_SIZE` Kconfig option.
+If you want to use the external flash for other purposes, you need to define your own external flash partitions, including one named `modem_trace`.
 
 To enable modem traces with the flash backend, add the ``nrf91-modem-trace-ext-flash`` snippet to the :term:`build configuration`.
 You can do this in one of the following ways:


### PR DESCRIPTION
- Add documentation section about devicetree partitions.
- Update nRF9160 external flash documentation.
- Update snippet documentation.
