### PR TITLE
Bluetooth: Mesh: Fix model message decoding bugs

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1012,6 +1012,9 @@ static int handle_sensor_status(const struct bt_mesh_model *model, struct bt_mes
 		}
 
 		if (!type) {
+			if (len > buf->len) {
+				return -EINVAL;
+			}
 			net_buf_simple_pull(buf, len);
 			continue;
 		}

--- a/subsys/bluetooth/mesh/sensor_cli.c
+++ b/subsys/bluetooth/mesh/sensor_cli.c
@@ -162,7 +162,7 @@ static int handle_status(const struct bt_mesh_model *model, struct bt_mesh_msg_c
 			cli->cb->data(cli, ctx, type, value);
 		}
 
-		if (rsp && count <= rsp->count) {
+		if (rsp && count < rsp->count) {
 			memcpy(rsp->sensors[count].value, value,
 			       sizeof(struct bt_mesh_sensor_value) * type->channel_count);
 


### PR DESCRIPTION
This fixes two problems where an incoming message would be decoded or handled incorrectly in the sensor client and light ctrl server models.