### PR TITLE
[Backport v3.4-branch] samples: dfu: dfu_multi_image: adjust IMG_MAX_SECTORS

### DIFF
--- a/samples/dfu/dfu_multi_image/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/dfu/dfu_multi_image/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -42,7 +42,7 @@
 		slot3_partition: partition@78000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-3";
-			reg = <0x78000 DT_SIZE_K(256)>;
+			reg = <0x78000 DT_SIZE_K(208)>;
 		};
 
 		dfu_multi_image_helper_partition: partition@b8000 {

--- a/samples/dfu/dfu_multi_image/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/dfu/dfu_multi_image/sysbuild/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BOOT_MAX_IMG_SECTORS_AUTO=n
+CONFIG_BOOT_MAX_IMG_SECTORS=128


### PR DESCRIPTION
Backport 610f31e67498a750f3022b4b19a17aa1e791db98 from #29624.