### PR TITLE
samples: peripheral: 802154_phy_test: Enable sample on nrf54lc10dk

### DIFF
--- a/samples/peripheral/802154_phy_test/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
+++ b/samples/peripheral/802154_phy_test/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SHELL_PROMPT_UART=">"
+
+# currently unsupported for nRF54LC10
+CONFIG_PTT_CACHE_MGMT=n
+
+# nrfx drivers configuration:
+CONFIG_NRFX_TIMER=y  # enable TIMER support
+# enable DPPIC
+CONFIG_NRFX_GPPI=y
+
+# Set temperature sensor update period in ms
+CONFIG_NRF_802154_TEMPERATURE_UPDATE_PERIOD=10000

--- a/samples/peripheral/802154_phy_test/sample.yaml
+++ b/samples/peripheral/802154_phy_test/sample.yaml
@@ -14,6 +14,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     platform_allow:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
@@ -23,6 +24,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     tags:
       - ci_build
       - ci_rs_build


### PR DESCRIPTION
and add board configuration required to run the sample on nrf54lc10dk target.