### PR TITLE
Revert ext adv discard handling (NCSDK-39888)

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -24,9 +24,4 @@ zephyr_library_sources_ifdef(
 
 zephyr_library_link_libraries(subsys__bluetooth)
 
-zephyr_library_include_directories_ifdef(
-  CONFIG_BT_EXT_ADV
-  ${ZEPHYR_BASE}/drivers/bluetooth/hci
-)
-
 zephyr_include_directories(.)

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -31,9 +31,6 @@
 #include "hci_internal.h"
 #include "radio_nrf5_txp.h"
 #include "cs_antenna_switch.h"
-#if defined(CONFIG_BT_EXT_ADV)
-#include "util_hci_evt.h"
-#endif
 
 #define DT_DRV_COMPAT nordic_bt_hci_sdc
 
@@ -361,10 +358,6 @@ void sdc_assertion_handler(const char *const file, const uint32_t line)
 #endif /* IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER) */
 
 static struct k_work receive_work;
-#if defined(CONFIG_BT_EXT_ADV)
-static struct hci_ext_adv_discard_ctx ext_adv_discard;
-#endif
-
 static inline void receive_signal_raise(void)
 {
 	mpsl_work_submit(&receive_work);
@@ -606,7 +599,7 @@ static int event_packet_process(const struct device *dev, uint8_t *hci_buf)
 {
 	bool discardable = event_packet_is_discardable(hci_buf);
 	struct bt_hci_evt_hdr *hdr = (void *)hci_buf;
-	struct net_buf *evt_buf = NULL;
+	struct net_buf *evt_buf;
 
 	if (hdr->len + sizeof(*hdr) > HCI_RX_BUF_SIZE) {
 		LOG_ERR("Event buffer too small. %zu > %u",
@@ -614,18 +607,6 @@ static int event_packet_process(const struct device *dev, uint8_t *hci_buf)
 			HCI_RX_BUF_SIZE);
 		return -ENOMEM;
 	}
-
-#if defined(CONFIG_BT_EXT_ADV)
-	if (hci_ext_adv_report_process(&ext_adv_discard, hci_buf, hdr->len + sizeof(*hdr),
-						&evt_buf)) {
-		if (evt_buf != NULL) {
-			struct hci_driver_data *driver_data = dev->data;
-
-			(void)driver_data->recv_func(dev, evt_buf);
-		}
-		return 0;
-	}
-#endif
 
 	if (hdr->evt == BT_HCI_EVT_LE_META_EVENT) {
 		struct bt_hci_evt_le_meta_event *me = (void *)&hci_buf[2];
@@ -1309,10 +1290,6 @@ static int hci_driver_open(const struct device *dev, bt_hci_recv_t recv_func)
 	LOG_DBG("Open");
 
 	k_work_init(&receive_work, receive_work_handler);
-
-#if defined(CONFIG_BT_EXT_ADV)
-	ext_adv_discard = (struct hci_ext_adv_discard_ctx){0};
-#endif
 
 	uint8_t build_revision[SDC_BUILD_REVISION_SIZE];
 

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0855feffc94b4bd74a48226b16c9937c6608345b
+      revision: c89ea87cd944e6ccb60707d5280d6bc5446460df
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
## Summary

Backport of [#29708](https://github.com/nrfconnect/sdk-nrf/pull/29708) for `v3.4-branch`.

Revert the extended advertising report discard feature to avoid corrupted LE Extended Advertising Report HCI events under buffer pressure (NCSDK-39888, upstream zephyr#111388).

- Revert SDC HCI driver integration (`6ae884407d5`, cherry-pick of `4361459c61c`)
- Bump sdk-zephyr to `c89ea87cd944e6ccb60707d5280d6bc5446460df` ([sdk-zephyr#4225](https://github.com/nrfconnect/sdk-zephyr/pull/4225), merged 2026-06-22)

Keep DNM until CI is green on the final manifest SHA.

## west.yml

Pins zephyr to merge commit `c89ea87cd944e6ccb60707d5280d6bc5446460df` from sdk-zephyr#4225 on `ncs-v3.4-branch`. Supersedes auto-manifest [sdk-nrf#29759](https://github.com/nrfconnect/sdk-nrf/pull/29759) and the stale auto-manifest bump to pre-revert `0855feffc94`.

## Zephyr commit format (paired PR)

sdk-zephyr#4225 is a `[nrf noup]` manual revert backport of sdk-zephyr#4216. See that PR for the commit-tags / `scan.c` replay rationale.

## SonarCloud

SonarCloud may report c:S859 on a pre-existing cast in `event_packet_is_discardable()` (re-flagged because this revert touches `hci_driver.c`).

## Test plan

- [x] Compliance CI
- [ ] Manifest CI
- [ ] Jenkins toolchain / twister / integration
- [ ] OSS history

## Related PRs

- sdk-zephyr backport: https://github.com/nrfconnect/sdk-zephyr/pull/4225
- sdk-nrf main: https://github.com/nrfconnect/sdk-nrf/pull/29708
- sdk-zephyr main: https://github.com/nrfconnect/sdk-zephyr/pull/4216