### PR TITLE
samples: bluetooth: fix nRF53/ns after PM to DTS migration

### DIFF
--- a/samples/bluetooth/central_and_peripheral_hrs/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/central_and_peripheral_hrs/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/central_bas/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/central_bas/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/central_uart/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/central_uart/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/multiple_adv_sets/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/multiple_adv_sets/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/peripheral_ams_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_ams_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/peripheral_ancs_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_ancs_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/peripheral_cgms/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_cgms/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/peripheral_cts_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_cts_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/peripheral_gatt_dm/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_gatt_dm/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/peripheral_mds/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_mds/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/peripheral_nfc_pairing/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_nfc_pairing/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/peripheral_rscs/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_rscs/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/peripheral_status/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_status/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/shell_bt_nus/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/shell_bt_nus/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};

--- a/samples/bluetooth/throughput/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/throughput/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x20000>;
+		};
+
+		slot0_ns_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x20000 0xd2000>;
+		};
+
+		nonsecure_storage: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xf2000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xf2000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};
+
+&sram0_s {
+	reg = <0x0 0xc000>;
+};
+
+&sram0_ns {
+	reg = <0xc000 0x74000>;
+	ranges = <0x0 0xc000 0x74000>;
+};
+
+&sram0_ns_app {
+	reg = <0x0 0x64000>;
+};


### PR DESCRIPTION
The default partition layout on nRF53 assumes the bootloader is enabled which is not the case for most BLE samples.