### PR TITLE
tests: subsys: swo: Select compatible setups with fixture

### DIFF
--- a/tests/subsys/swo/testcase.yaml
+++ b/tests/subsys/swo/testcase.yaml
@@ -3,6 +3,7 @@ tests:
     tags: ci_tests_subsys_swo
     harness: pytest
     harness_config:
+      fixture: swo_enabled
       pytest_dut_scope: session
       pytest_root:
         - "pytest/test_swo.py::test_swo_logging"


### PR DESCRIPTION
Run the SWO test on compatible DKs.
Select them by requiring fixture "swo_enabled".