### PR TITLE
dts: nordic: nrf54lv10: Fix bl_storage partition UICR

### DIFF
--- a/dts/common/nordic/nrf54lv10a.dtsi
+++ b/dts/common/nordic/nrf54lv10a.dtsi
@@ -84,8 +84,11 @@
 		/* intentionally empty because UICR is hardware fixed to Secure */
  #else
 		uicr: uicr@ffd000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
 			compatible = "nordic,nrf-uicr";
 			reg = <0xffd000 0x1000>;
+			ranges = <0x0 0xffd000 0x1000>;
 		};
  #endif
 


### PR DESCRIPTION
Missing rages and regs have rendered different addressing then expected and caused failure when accessing bl_storage.