### PR TITLE
doc: sml: Mark Channel Sounding as unsupported on nRF54H20

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -744,7 +744,7 @@ The following table indicates the software maturity levels of the support for ea
            * - **Connection Subrating**
              - Supported
            * - **Channel Sounding**
-             - Experimental
+             - --
            * - **GATT Database Hash**
              - Supported
            * - **Enhanced ATT**


### PR DESCRIPTION
Channel Sounding is not supported on nRF54H20. Update the software maturity table to reflect the current support status.