### PR TITLE
boards: nordic: nrf9251dk: Add external flash

### DIFF
--- a/boards/nordic/nrf9251dk/nrf9251dk_nrf9251_cpuapp.dts
+++ b/boards/nordic/nrf9251dk/nrf9251dk_nrf9251_cpuapp.dts
@@ -163,6 +163,32 @@
 	memory-regions = <&cpuapp_dma_region>;
 };
 
+&spi120 {
+	pinctrl-0 = <&spi120_default>;
+	pinctrl-1 = <&spi120_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+	cs-gpios = <&gpio5 5 GPIO_ACTIVE_LOW>;
+
+	gd25le255e: gd25le255e@0 {
+		compatible = "jedec,spi-nor";
+		status = "disabled";
+		reg = <0>;
+		spi-max-frequency = <8000000>;
+		size = <DT_SIZE_M(256)>;
+		has-dpd;
+		t-enter-dpd = <3000>;
+		t-exit-dpd = <20000>;
+		jedec-id = [c8 60 19];
+		sfdp-bfp = [e5 20 f3 ff ff ff ff 0f 44 eb 08 6b 08 3b 42 bb
+			    fe ff ff ff ff ff 00 ff ff ff 42 eb 0c 20 0f 52
+			    10 d8 00 ff d4 31 a5 fe 84 df 14 4f ec 62 16 33
+			    7a 75 7a 75 04 b3 d5 5c 19 06 14 00 08 50 00 01];
+		reset-gpios = <&gpio5 0 GPIO_ACTIVE_LOW>;
+		wp-gpios = <&gpio5 3 GPIO_ACTIVE_LOW>;
+	};
+};
+
 &adc {
 	status = "okay";
 	memory-regions = <&cpuapp_dma_region>;

--- a/dts/common/nordic/nrf9251dk_nrf9251-pinctrl.dtsi
+++ b/dts/common/nordic/nrf9251dk_nrf9251-pinctrl.dtsi
@@ -100,4 +100,22 @@
 			nordic,drive-mode = <NRF_DRIVE_E0E1>;
 		};
 	};
+
+	/omit-if-no-ref/  spi120_default: spi120_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 5, 1)>,
+				<NRF_PSEL(SPIM_MISO, 5, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 5, 2)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
+		};
+	};
+
+	/omit-if-no-ref/ spi120_sleep: spi120_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 5, 1)>,
+				<NRF_PSEL(SPIM_MISO, 5, 4)>,
+				<NRF_PSEL(SPIM_MOSI, 5, 2)>;
+			low-power-enable;
+		};
+	};
 };

--- a/samples/cellular/modem_shell/nrf9251dk_ext_flash.overlay
+++ b/samples/cellular/modem_shell/nrf9251dk_ext_flash.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&spi120 {
+	status = "okay";
+};
+
+&gpio5 {
+	status = "okay";
+};
+
+&gd25le255e {
+	status = "okay";
+};


### PR DESCRIPTION
Added external flash to the nRF9251 DK board configuration.

Added a devicetree overlay to modem_shell for enabling the external flash.