### PR TITLE
[Backport v3.4-branch] doc: sml: Mark Channel Sounding as unsupported on nRF54H20

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -744,7 +744,7 @@ The following table indicates the software maturity levels of the support for ea
            * - **Connection Subrating**
              - Supported
            * - **Channel Sounding**
-             - Experimental
+             - --
            * - **GATT Database Hash**
              - Supported
            * - **Enhanced ATT**


### PR DESCRIPTION
Backport 34703f276657e151473b4cdd7679462048680d33 from #29810.