### PR TITLE
tests: subsys: esb: Add ESB sample integration test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1017,6 +1017,7 @@
 /tests/subsys/dfu/                        @nrfconnect/ncs-eris
 /tests/subsys/dfu/dfu_multi_image/        @Damian-Nordic
 /tests/subsys/emds/                       @nrfconnect/ncs-paladin
+/tests/subsys/esb/                        @nrfconnect/ncs-si-xcake
 /tests/subsys/event_manager_proxy/        @nrfconnect/ncs-si-bluebagel @nrfconnect/ncs-si-muffin @nrfconnect/ncs-si-xcake
 /tests/subsys/fw_info/                    @nrfconnect/ncs-eris
 /tests/subsys/ipc/                        @nrfconnect/ncs-low-level-test @anangl

--- a/tests/subsys/esb/esb_samples/pytest/test_esb_sample.py
+++ b/tests/subsys/esb/esb_samples/pytest/test_esb_sample.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+import logging
+
+import pytest
+from twister_harness import DeviceAdapter
+
+logger = logging.getLogger(__name__)
+
+
+def test_basic(duts: list[DeviceAdapter]):
+    """Verify ESB prx and ptx samples communicate over the air.
+
+    Boot both DUTs, check that each sample reports initialization
+    complete, then confirm the prx receives packets and the ptx gets
+    TX success events.
+    """
+    assert len(duts) > 1, "This test requires at least two DUTs, ESB PTX and ESB PRX"
+    dut_rx = duts[0]
+    dut_tx = duts[1]
+
+    logger.info("Waiting for initialization complete messages...")
+    lines = dut_rx.readlines_until(regex="Initialization complete", timeout=10)
+    pytest.LineMatcher(lines).fnmatch_lines(
+        ["*Enhanced ShockBurst prx sample", "*Initialization complete"]
+    )
+    lines = dut_tx.readlines_until(regex="Initialization complete", timeout=10)
+    pytest.LineMatcher(lines).fnmatch_lines(
+        ["*Enhanced ShockBurst ptx sample", "*Initialization complete"]
+    )
+
+    logger.info("Waiting for packets to be received and TX success events...")
+    dut_rx.readlines_until(regex="Packet received", timeout=10)
+    logger.info("Waiting for TX success events...")
+    dut_tx.readlines_until(regex="TX SUCCESS EVENT", timeout=10)

--- a/tests/subsys/esb/esb_samples/testcase.yaml
+++ b/tests/subsys/esb/esb_samples/testcase.yaml
@@ -1,0 +1,77 @@
+common:
+  tags:
+    - esb
+    - ci_tests_subsys_esb
+  harness: pytest
+  build: false
+
+tests:
+  test.sample.esb.same_boards_connected:
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    platform_allow: &platform_allow_basic
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpunet
+      - nrf54h20dk/nrf54h20/cpurad
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+    required_applications:
+      - application: sample.esb.prx.build
+        path: $ZEPHYR_BASE/../nrf/samples/esb/esb_prx
+    harness_config:
+      required_devices:
+        - application: sample.esb.ptx.build
+          path: $ZEPHYR_BASE/../nrf/samples/esb/esb_ptx
+
+  test.sample.esb.nrf54h20_with_other_board:
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+    platform_allow: *platform_allow_basic
+    platform_exclude:
+      - nrf54h20dk/nrf54h20/cpurad
+    required_applications:
+      - application: sample.esb.prx.build
+        path: $ZEPHYR_BASE/../nrf/samples/esb/esb_prx
+    harness_config:
+      required_devices:
+        - application: sample.esb.ptx.build
+          path: $ZEPHYR_BASE/../nrf/samples/esb/esb_ptx
+          platform: nrf54h20dk/nrf54h20/cpurad
+
+  test.sample.esb.dynamic_irq:
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpunet
+      - nrf54h20dk/nrf54h20/cpurad
+    platform_allow:
+      - nrf5340dk/nrf5340/cpunet
+      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+    required_applications:
+      - application: sample.esb.prx.dynamic_irq
+        path: $ZEPHYR_BASE/../nrf/samples/esb/esb_prx
+    harness_config:
+      required_devices:
+        - application: sample.esb.ptx.dynamic_irq
+          path: $ZEPHYR_BASE/../nrf/samples/esb/esb_ptx
+
+  test.sample.esb.fast_switching:
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpurad
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpurad
+    required_applications:
+      - application: sample.esb.prx.fast_switching
+        path: $ZEPHYR_BASE/../nrf/samples/esb/esb_prx
+    harness_config:
+      required_devices:
+        - application: sample.esb.ptx.fast_switching
+          path: $ZEPHYR_BASE/../nrf/samples/esb/esb_ptx


### PR DESCRIPTION
Add a pytest-based Twister test that verifies the ESB ptx and prx samples communicate correctly on connected hardware. The test boots both DUTs, checks the initialization output, and confirms packets are received on the prx side and acknowledged on the ptx side.

The testcase covers same-board pairs, mixing an nRF54H20 with another board, and the fast switching configuration.

---
connect boards, then generate the hardware map
`west twister --no-clean --generate-hardware-map ~/hwmap.yaml`
update hwmap if new board were added

run tests
`west twister --no-clean -vv -ll debug -T tests/subsys/esb/esb_samples --west-flash=--erase --device-testing --hardware-map ~/hwmap.yaml`
