### PR TITLE
nrf_security: cracen: Validate completion of both PKE and IKG

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -80,7 +80,7 @@ bool is_busy(sx_pk_req *req)
 {
 #if defined(CONFIG_CRACEN_IKG)
 	if (sx_pk_is_ik_cmd(req)) {
-		return ik_is_busy(req);
+		return ik_is_busy(req) || ba414ep_is_busy(req);
 	}
 #endif
 


### PR DESCRIPTION
When interrupts are disabled for CRACEN there is the possibility of the IKG busy register being cleared before operation is completed.
Check both IKG and PKE register to ensure operation is fully completed.