### PR TITLE
Add IPC sample/tests support for nRF7120

### DIFF
--- a/samples/event_manager_proxy/Kconfig.sysbuild
+++ b/samples/event_manager_proxy/Kconfig.sysbuild
@@ -17,6 +17,7 @@ config REMOTE_BOARD
 	default "nrf54lm20dk/nrf54lm20b/cpuflpr" if BOARD_NRF54LM20DK_NRF54LM20B_CPUAPP
 	default "nrf54lv10dk/nrf54lv10a/cpuflpr" if BOARD_NRF54LV10DK_NRF54LV10A_CPUAPP
 	default "nrf54lc10dk/nrf54lc10a/cpuflpr" if BOARD_NRF54LC10DK_NRF54LC10A_CPUAPP
+	default "nrf7120dk/nrf7120/cpuflpr" if BOARD_NRF7120DK_NRF7120_CPUAPP
 	default "nrf9251dk/nrf9251/cpuppr" if BOARD_NRF9251DK_NRF9251_CPUAPP
 
 source "share/sysbuild/Kconfig"

--- a/samples/event_manager_proxy/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/samples/event_manager_proxy/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		/delete-property/ zephyr,bt-hci;
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram_rx: memory@20080000 {
+			reg = <0x20080000 0x8000>;
+		};
+
+		sram_tx: memory@20088000 {
+			reg = <0x20088000 0x8000>;
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			dcache-alignment = <32>;
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			mboxes = <&cpuapp_vevif_rx 20>, <&cpuapp_vevif_tx 21>;
+			mbox-names = "rx", "tx";
+			status = "okay";
+		};
+	};
+};
+
+&cpuapp_vevif_rx {
+	status = "okay";
+};
+
+&cpuapp_vevif_tx {
+	status = "okay";
+};

--- a/samples/event_manager_proxy/remote/boards/nrf7120dk_nrf7120_cpuflpr.overlay
+++ b/samples/event_manager_proxy/remote/boards/nrf7120dk_nrf7120_cpuflpr.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram_tx: memory@20080000 {
+			reg = <0x20080000 0x8000>;
+		};
+
+		sram_rx: memory@20088000 {
+			reg = <0x20088000 0x8000>;
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			dcache-alignment = <32>;
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			mboxes = <&cpuflpr_vevif_rx 21>, <&cpuflpr_vevif_tx 20>;
+			mbox-names = "rx", "tx";
+			status = "okay";
+		};
+	};
+};
+
+&cpuflpr_vevif_rx {
+	status = "okay";
+};
+
+&cpuflpr_vevif_tx {
+	status = "okay";
+};

--- a/samples/event_manager_proxy/sample.yaml
+++ b/samples/event_manager_proxy/sample.yaml
@@ -51,10 +51,12 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
   sample.event_manager_proxy.nrf9251dk_cpuapp_cpuppr:
     platform_allow:
       - nrf9251dk/nrf9251/cpuapp

--- a/tests/subsys/event_manager_proxy/Kconfig.sysbuild
+++ b/tests/subsys/event_manager_proxy/Kconfig.sysbuild
@@ -16,6 +16,7 @@ config REMOTE_BOARD
 	default "nrf54lm20dk/nrf54lm20b/cpuflpr" if BOARD_NRF54LM20DK_NRF54LM20B_CPUAPP
 	default "nrf54lv10dk/nrf54lv10a/cpuflpr" if BOARD_NRF54LV10DK_NRF54LV10A_CPUAPP
 	default "nrf54lc10dk/nrf54lc10a/cpuflpr" if BOARD_NRF54LC10DK_NRF54LC10A_CPUAPP
+	default "nrf7120dk/nrf7120/cpuflpr" if BOARD_NRF7120DK_NRF7120_CPUAPP
 	default "nrf9251dk/nrf9251/cpuppr" if BOARD_NRF9251DK_NRF9251_CPUAPP
 
 source "share/sysbuild/Kconfig"

--- a/tests/subsys/event_manager_proxy/boards/nrf7120dk_nrf7120_cpuapp_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/boards/nrf7120dk_nrf7120_cpuapp_icmsg.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		/delete-property/ zephyr,bt-hci;
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram_rx: memory@20080000 {
+			reg = <0x20080000 0x8000>;
+		};
+
+		sram_tx: memory@20088000 {
+			reg = <0x20088000 0x8000>;
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			dcache-alignment = <32>;
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			mboxes = <&cpuapp_vevif_rx 20>, <&cpuapp_vevif_tx 21>;
+			mbox-names = "rx", "tx";
+			status = "okay";
+		};
+	};
+};
+
+&cpuapp_vevif_rx {
+	status = "okay";
+};
+
+&cpuapp_vevif_tx {
+	status = "okay";
+};

--- a/tests/subsys/event_manager_proxy/remote/boards/nrf7120dk_nrf7120_cpuflpr_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/remote/boards/nrf7120dk_nrf7120_cpuflpr_icmsg.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram_tx: memory@20080000 {
+			reg = <0x20080000 0x8000>;
+		};
+
+		sram_rx: memory@20088000 {
+			reg = <0x20088000 0x8000>;
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			dcache-alignment = <32>;
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			mboxes = <&cpuflpr_vevif_rx 21>, <&cpuflpr_vevif_tx 20>;
+			mbox-names = "rx", "tx";
+			status = "okay";
+		};
+	};
+};
+
+&cpuflpr_vevif_rx {
+	status = "okay";
+};
+
+&cpuflpr_vevif_tx {
+	status = "okay";
+};

--- a/tests/subsys/event_manager_proxy/testcase.yaml
+++ b/tests/subsys/event_manager_proxy/testcase.yaml
@@ -37,7 +37,9 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp

--- a/tests/subsys/ipc/ipc_reconnect/Kconfig.sysbuild
+++ b/tests/subsys/ipc/ipc_reconnect/Kconfig.sysbuild
@@ -14,5 +14,6 @@ config REMOTE_BOARD
 	default "$(BOARD)/nrf54lm20b/cpuflpr" if SOC_NRF54LM20B_CPUAPP
 	default "$(BOARD)/nrf54lv10a/cpuflpr" if SOC_NRF54LV10A_CPUAPP
 	default "$(BOARD)/nrf54lc10a/cpuflpr" if SOC_NRF54LC10A_CPUAPP
+	default "$(BOARD)/nrf7120/cpuflpr" if SOC_NRF7120_ENGA_CPUAPP
 
 source "share/sysbuild/Kconfig"

--- a/tests/subsys/ipc/ipc_reconnect/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/subsys/ipc/ipc_reconnect/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		/delete-property/ zephyr,bt-hci;
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram_rx: memory@20080000 {
+			reg = <0x20080000 0x8000>;
+		};
+
+		sram_tx: memory@20088000 {
+			reg = <0x20088000 0x8000>;
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			dcache-alignment = <32>;
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			mboxes = <&cpuapp_vevif_rx 20>, <&cpuapp_vevif_tx 21>;
+			mbox-names = "rx", "tx";
+			unbound = "enable";
+			status = "okay";
+		};
+	};
+};
+
+&cpuapp_vevif_rx {
+	status = "okay";
+};
+
+&cpuapp_vevif_tx {
+	status = "okay";
+};

--- a/tests/subsys/ipc/ipc_reconnect/boards/nrf7120dk_nrf7120_cpuapp_icbmsg.overlay
+++ b/tests/subsys/ipc/ipc_reconnect/boards/nrf7120dk_nrf7120_cpuapp_icbmsg.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf7120dk_nrf7120_cpuapp.overlay"
+
+&ipc0 {
+	compatible = "zephyr,ipc-icbmsg";
+	tx-blocks = <16>;
+	rx-blocks = <18>;
+};

--- a/tests/subsys/ipc/ipc_reconnect/remote/boards/nrf7120dk_nrf7120_cpuflpr.overlay
+++ b/tests/subsys/ipc/ipc_reconnect/remote/boards/nrf7120dk_nrf7120_cpuflpr.overlay
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram_tx: memory@20080000 {
+			reg = <0x20080000 0x8000>;
+		};
+
+		sram_rx: memory@20088000 {
+			reg = <0x20088000 0x8000>;
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			dcache-alignment = <32>;
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			mboxes = <&cpuflpr_vevif_rx 21>, <&cpuflpr_vevif_tx 20>;
+			mbox-names = "rx", "tx";
+			unbound = "enable";
+			status = "okay";
+		};
+	};
+};
+
+&cpuflpr_vevif_rx {
+	status = "okay";
+};
+
+&cpuflpr_vevif_tx {
+	status = "okay";
+};

--- a/tests/subsys/ipc/ipc_reconnect/remote/boards/nrf7120dk_nrf7120_cpuflpr_icbmsg.overlay
+++ b/tests/subsys/ipc/ipc_reconnect/remote/boards/nrf7120dk_nrf7120_cpuflpr_icbmsg.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf7120dk_nrf7120_cpuflpr.overlay"
+
+&ipc0 {
+	compatible = "zephyr,ipc-icbmsg";
+	tx-blocks = <18>;
+	rx-blocks = <16>;
+};

--- a/tests/subsys/ipc/ipc_reconnect/testcase.yaml
+++ b/tests/subsys/ipc/ipc_reconnect/testcase.yaml
@@ -64,6 +64,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:


### PR DESCRIPTION
Support for IPC sample and tests for nRF7120. Using RAM01 for FLPR and ARM IPC memory.