### PR TITLE
tests: drivers: mspi: controller_periph: disable spi00 for nrf54l15dk

### DIFF
--- a/tests/zephyr/drivers/mspi/controller_peripheral/boards/nrf54l15dk_spis.overlay
+++ b/tests/zephyr/drivers/mspi/controller_peripheral/boards/nrf54l15dk_spis.overlay
@@ -57,6 +57,10 @@
 	};
 };
 
+&spi00 {
+	status = "disabled";
+};
+
 /delete-node/ &mx25r64;
 
 &hpf_mspi {


### PR DESCRIPTION
The nrf54l15dk has spi00 enabled by default along with the mx25r64, however only the mx25r64 is disabled/removed by the board specific overlay. Since the spi00 instance pinctrl conflicts with the hpf mspi, it must be disabled.