### PR TITLE
manifest: Update bsim to version v3.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
     - name: bsim
       repo-path: bsim_west
       remote: babblesim
-      revision: a88d3353451387ca490a6a7f7c478a90c4ee05b7
+      revision: 9fce3723520edcdfddcfa0f1162b45c80d3da527
       import:
         path-prefix: tools
     - name: bme68x


### PR DESCRIPTION
Main changes since v2.5:
* ext_2G4_modem_BLE_simple: Added initial HDT support
* libUtilv1: dump_files: Fix in file access macros
* Phy-device v2.1 API introduced
* Phy update to use internally this v2.1 API, so channel and modem IF are updated accordingly
* ext_2G4_phy_v1: Runtime performance optimizations
* ext_2G4_libPhyComv1: Add BT LE HDT support
* ext_2G4_channel_Indoorv1: Add BT LE HDT support
* ext_2G4_phy_v1: Now supports DISCONNECTS during abort re-evaluations
* ext_2G4_phy_v1: Also support bitrates multiple of 250Kbps and 333Kbps

Note: Like before, bsim remains fully backwards compatible