### PR TITLE
WZN-9900: nRF7120 support TFM-MCUboot integration and add ns support to DFU sample 

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -28,7 +28,7 @@ endif
 
 config TFM_MCUBOOT_HEADER_SIZE
 	hex "MCUboot header size for the TF-M combined slot"
-	default 0x800 if BOOTLOADER_MCUBOOT && SOC_SERIES_NRF54L
+	default 0x800 if BOOTLOADER_MCUBOOT && (SOC_SERIES_NRF54L || SOC_SERIES_NRF71)
 	default 0x200 if BOOTLOADER_MCUBOOT
 	default 0
 	help

--- a/samples/dfu/smp_svr/boards/nrf7120dk_nrf7120_cpuapp_ns.overlay
+++ b/samples/dfu/smp_svr/boards/nrf7120dk_nrf7120_cpuapp_ns.overlay
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuapp_mram {
+	/delete-node/ partitions;
+};
+
+&cpuapp_mram {
+	/*
+	 * Default NVM layout on NRF7120 NS Application MCU with MCUBoot:
+	 *
+	 * 0x0000_0000 Boot Partition (64 KB)
+	 *
+	 * 0x0001_0000 Primary image area (1952 KB):
+	 *   - 0x0001_0000 Secure image primary (192 KB)
+	 *   - 0x0004_0000 Non-secure image primary (1760 KB)
+	 *
+	 * 0x001F_8000 Secondary image area (1952 KB):
+	 *   - 0x001F_8000 Secure image secondary (192 KB)
+	 *   - 0x0022_8000 Non-secure image secondary (1760 KB)
+	 *
+	 * 0x003E_0000 Protected Storage Area (16 KB)
+	 * 0x003E_4000 Internal Trusted Storage Area (16 KB)
+	 * 0x003E_8000 OTP / NV counters area (8 KB)
+	 *
+	 * 0x003E_A000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
+	 *             otherwise unused (68 KB)
+	 */
+	partitions {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(1952)>;
+			ranges = <0x0 0x00010000 DT_SIZE_K(1952)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_s_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-secure";
+				reg = <0x0 DT_SIZE_K(192)>;
+			};
+
+			slot0_ns_partition: partition@30000 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0-nonsecure";
+				reg = <0x30000 DT_SIZE_K(1760)>;
+			};
+		};
+
+		slot1_partition: partition@1f8000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
+			reg = <0x001f8000 DT_SIZE_K(1952)>;
+			ranges = <0x0 0x001f8000 DT_SIZE_K(1952)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot1_s_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-1-secure";
+				reg = <0x0 DT_SIZE_K(192)>;
+			};
+
+			slot1_ns_partition: partition@30000 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-1-nonsecure";
+				reg = <0x30000 DT_SIZE_K(1760)>;
+			};
+		};
+
+		tfm_ps_partition: partition@3e0000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-ps";
+			reg = <0x003e1000 DT_SIZE_K(16)>;
+		};
+
+		tfm_its_partition: partition@3e4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-its";
+			reg = <0x003e5000 DT_SIZE_K(16)>;
+		};
+
+		tfm_otp_partition: partition@3e8000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-otp";
+			reg = <0x003e9000 DT_SIZE_K(8)>;
+		};
+
+		storage_partition: partition@3ea000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x003eb000 DT_SIZE_K(68)>;
+		};
+	};
+};
+
+/ {
+	chosen {
+		zephyr,code-partition = &slot0_ns_partition;
+	};
+};

--- a/samples/dfu/smp_svr/sample.yaml
+++ b/samples/dfu/smp_svr/sample.yaml
@@ -56,6 +56,14 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+
+  sample.dfu.smp_svr.serial.tfm_mcuboot:
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp/ns
+    sysbuild: true
+    extra_args:
+      - FILE_SUFFIX=tfm_mcuboot
+
   sample.dfu.smp_svr.mcuboot_flags.direct_xip_withrevert:
     extra_args:
       - SB_CONFIG_MCUBOOT_MODE_DIRECT_XIP_WITH_REVERT=y

--- a/samples/dfu/smp_svr/sysbuild/mcuboot/boards/nrf7120dk_nrf7120_cpuapp_tfm_mcuboot.overlay
+++ b/samples/dfu/smp_svr/sysbuild/mcuboot/boards/nrf7120dk_nrf7120_cpuapp_tfm_mcuboot.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf7120dk_nrf7120_cpuapp_ns.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -121,7 +121,7 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
   string(REPLACE "/" ";" split_board_qualifiers ";${BOARD_QUALIFIERS}")
   list(GET split_board_qualifiers 1 target_soc)
 
-  if(SB_CONFIG_SOC_SERIES_NRF53 OR SB_CONFIG_SOC_SERIES_NRF54L)
+  if(SB_CONFIG_SOC_SERIES_NRF53 OR SB_CONFIG_SOC_SERIES_NRF54L OR SB_CONFIG_SOC_SERIES_NRF71)
     list(LENGTH split_board_qualifiers target_length)
 
     if("${target_length}" GREATER "3")
@@ -494,7 +494,9 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
        # Do not use the upstream mcuboot.cmake on new platforms.
        OR SB_CONFIG_SOC_SERIES_NRF53
        OR SB_CONFIG_SOC_SERIES_NRF54L
-       OR SB_CONFIG_SOC_SERIES_NRF54H OR SB_CONFIG_QSPI_XIP_SPLIT_IMAGE
+       OR SB_CONFIG_SOC_SERIES_NRF54H
+       OR SB_CONFIG_SOC_SERIES_NRF71
+       OR SB_CONFIG_QSPI_XIP_SPLIT_IMAGE
        OR ((SB_CONFIG_SOC_SERIES_NRF52 OR SB_CONFIG_SOC_SERIES_NRF91) AND NOT
        SB_CONFIG_PARTITION_MANAGER)
        # TF-M NS builds require signing tfm_merged.hex, not zephyr.hex.
@@ -620,7 +622,7 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
     endforeach()
 
     if(NOT DEFINED mcuboot_BOARD AND DEFINED board_target_secure)
-      # MCUboot must run in secure mode on the nRF9160/nRF5340
+      # MCUboot must run in secure mode
       set_target_properties(mcuboot PROPERTIES BOARD ${board_target_secure})
     endif()
 

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: afae26a112cf0ee75e2f7a084fb2d2d1ddbde8d2
+      revision: pull/4232/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -154,7 +154,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: c435c364ffdf4a26eaf1164e04872932a6f1e1c4
+      revision: 0287e435067334db021469da413ced0406c4cfb8
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: pull/4232/head
+      revision: c76c5621f4f2083be82b5c8acbff9b0c3a80b67c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
1. nrf7120dk/nrf7120/cpuapp/ns need to build with default secure image for
Mcuboot, so that it picks up nrf7120dk/nrf7120/cpuapp defconfig.

2. Add nrf7120-ns tfm-mcuboot integrated sample to smpsvr, the overlay file
added in smp_svr contains full flash layout for a MCUBoot sample
integrated with tfm.
Where flash layout is includes boot partition, slot0, slot1, secure
storage, non-secure storage. Slot 1 ad non secure storage are set as
non secure.

Related manifest:
https://github.com/nrfconnect/sdk-trusted-firmware-m/pull/259
https://github.com/nrfconnect/sdk-zephyr/pull/4232