### PR TITLE
[Backport v3.4-branch] net: lib: fota_download: close DFU session after downloader stops

### DIFF
--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -772,14 +772,18 @@ int fota_download_cancel(void)
 		return err;
 	}
 
+	/* Wait for the downloader to stop before closing the DFU session, so an
+	 * in-flight fragment write cannot race dfu_target_done().
+	 */
+	while (atomic_test_bit(&flags, FLAG_DOWNLOADING)) {
+		k_msleep(10);
+	}
+
 	err = dfu_target_done(false);
 	if (err && err != -EACCES) {
 		LOG_ERR("%s failed to clean up: %d", __func__, err);
 	}
 
-	while (atomic_test_bit(&flags, FLAG_DOWNLOADING)) {
-		k_msleep(10);
-	}
 	return err;
 }
 


### PR DESCRIPTION
Backport db959aebfe8d29062c0961e0ae592b1381f4ef27 from #29796.