### PR TITLE
mpsl, sdc: Update signature for assert ids

### DIFF
--- a/include/mpsl/mpsl_assert.h
+++ b/include/mpsl/mpsl_assert.h
@@ -20,6 +20,16 @@
 extern "C" {
 #endif
 
+#include <mpsl.h>
+
+#ifdef MPSL_ASSERT_ID
+/**
+ * @brief Application-defined sink for the MPSL assertion mechanism.
+ *
+ * @param assert_id The ID of the assertion that occurred.
+ */
+void mpsl_assert_handle(uint16_t assert_id);
+#else
 /**
  * @brief Application-defined sink for the MPSL assertion mechanism.
  *
@@ -27,6 +37,7 @@ extern "C" {
  * @param line  The line number where the assertion occurred.
  */
 void mpsl_assert_handle(char *file, uint32_t line);
+#endif
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -329,14 +329,34 @@ static __aligned(8) uint8_t sdc_mempool[MEMPOOL_SIZE];
 #if IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER)
 extern void bt_ctlr_assert_handle(char *file, uint32_t line);
 
+#ifdef SDC_ASSERT_ID
+void sdc_assertion_handler(const uint16_t assert_id)
+{
+	bt_ctlr_assert_handle("sdc.a", assert_id);
+}
+
+#else
 void sdc_assertion_handler(const char *const file, const uint32_t line)
 {
 	bt_ctlr_assert_handle((char *) file, line);
 }
+#endif
 
 #else /* !IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER) */
 
 #if defined(CONFIG_LOG)
+#ifdef SDC_ASSERT_ID
+const char *sdc_get_assertion_message(const uint16_t assert_id)
+{
+	for (uint32_t i = 0; i < ARRAY_SIZE(sdc_assert_messages); i++) {
+		if (sdc_assert_messages[i].assert_id == assert_id) {
+			return sdc_assert_messages[i].assert_msg;
+		}
+	}
+
+	return NULL;
+}
+#else
 const char *sdc_get_assertion_message(const char *const file, const uint32_t line)
 {
 	uint32_t file_id = atoi(file);
@@ -350,8 +370,34 @@ const char *sdc_get_assertion_message(const char *const file, const uint32_t lin
 
 	return NULL;
 }
+#endif
 #endif /* CONFIG_LOG */
 
+#ifdef SDC_ASSERT_ID
+void sdc_assertion_handler(const uint16_t id)
+{
+	volatile uint16_t assert_id = id;
+
+#if defined(CONFIG_ASSERT) && defined(CONFIG_ASSERT_VERBOSE) && !defined(CONFIG_ASSERT_NO_MSG_INFO)
+	__ASSERT(false, "SoftDevice Controller ASSERT: 0x%04x\n", assert_id);
+#elif defined(CONFIG_LOG)
+	LOG_ERR("SoftDevice Controller ASSERT: 0x%04x", assert_id);
+	const char *failure_reason_msg = sdc_get_assertion_message(assert_id);
+
+	if (failure_reason_msg) {
+		LOG_ERR("ASSERT REASON: %s", failure_reason_msg);
+	}
+	k_oops();
+#elif defined(CONFIG_PRINTK)
+	printk("SoftDevice Controller ASSERT: 0x%04x\n", assert_id);
+	printk("\n");
+	k_oops();
+#else
+	(void)assert_id;
+	k_oops();
+#endif
+}
+#else
 void sdc_assertion_handler(const char *const file, const uint32_t line)
 {
 	volatile char assert_file_id[11] = { 0 };
@@ -379,6 +425,7 @@ void sdc_assertion_handler(const char *const file, const uint32_t line)
 	k_oops();
 #endif
 }
+#endif
 #endif /* IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER) */
 
 static struct k_work receive_work;

--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -312,14 +312,32 @@ ISR_DIRECT_DECLARE(mpsl_radio_isr_wrapper)
 #endif /* IS_ENABLED(CONFIG_MPSL_DYNAMIC_INTERRUPTS) */
 
 #if IS_ENABLED(CONFIG_MPSL_ASSERT_HANDLER)
+#ifdef MPSL_ASSERT_ID
+void m_assert_handler(const uint16_t assert_id)
+{
+	mpsl_assert_handle(assert_id);
+}
+#else
 void m_assert_handler(const char *const file, const uint32_t line)
 {
 	mpsl_assert_handle((char *) file, line);
 }
-
+#endif
 #else /* !IS_ENABLED(CONFIG_MPSL_ASSERT_HANDLER) */
 
 #if defined(CONFIG_LOG)
+#ifdef MPSL_ASSERT_ID
+const char *mpsl_get_assertion_message(const uint16_t assert_id)
+{
+	for (uint32_t i = 0; i < ARRAY_SIZE(mpsl_assert_messages); i++) {
+		if (mpsl_assert_messages[i].assert_id == assert_id) {
+			return mpsl_assert_messages[i].assert_msg;
+		}
+	}
+
+	return NULL;
+}
+#else
 const char *mpsl_get_assertion_message(const char *const file, const uint32_t line)
 {
 	uint32_t file_id = atoi(file);
@@ -333,8 +351,34 @@ const char *mpsl_get_assertion_message(const char *const file, const uint32_t li
 
 	return NULL;
 }
+#endif
 #endif /* CONFIG_LOG */
 
+#ifdef MPSL_ASSERT_ID
+static void m_assert_handler(const uint16_t id)
+{
+	volatile uint16_t assert_id = id;
+
+#if defined(CONFIG_ASSERT) && defined(CONFIG_ASSERT_VERBOSE) && !defined(CONFIG_ASSERT_NO_MSG_INFO)
+	__ASSERT(false, "MPSL ASSERT: 0x%04x\n", assert_id);
+#elif defined(CONFIG_LOG)
+	LOG_ERR("MPSL ASSERT: 0x%04x", assert_id);
+	const char *failure_reason_msg = mpsl_get_assertion_message(assert_id);
+
+	if (failure_reason_msg) {
+		LOG_ERR("ASSERT REASON: %s", failure_reason_msg);
+	}
+	k_oops();
+#elif defined(CONFIG_PRINTK)
+	printk("MPSL ASSERT: 0x%04x\n", assert_id);
+	printk("\n");
+	k_oops();
+#else
+	(void)assert_id;
+	k_oops();
+#endif
+}
+#else
 static void m_assert_handler(const char *const file, const uint32_t line)
 {
 	volatile char assert_file_id[11] = { 0 };
@@ -361,6 +405,7 @@ static void m_assert_handler(const char *const file, const uint32_t line)
 	k_oops();
 #endif
 }
+#endif
 #endif /* IS_ENABLED(CONFIG_MPSL_ASSERT_HANDLER) */
 
 #if !defined(CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL)


### PR DESCRIPTION
* mpsl: Update assertion handlers to take assert id

    MPSL will soon change to use a single assert id
    instead of a filename and line number.

* Bluetooth: Controller: Update assertion handler to take assert id

    SDC will soon  change to use a single assert id
    instead of a filename and line number.
