### PR TITLE
[Backport v3.4-branch] tests: drivers: mspi: controller_periph: disable spi00 for nrf54l15dk

### DIFF
--- a/tests/zephyr/drivers/mspi/controller_peripheral/boards/nrf54l15dk_spis.overlay
+++ b/tests/zephyr/drivers/mspi/controller_peripheral/boards/nrf54l15dk_spis.overlay
@@ -57,6 +57,10 @@
 	};
 };
 
+&spi00 {
+	status = "disabled";
+};
+
 /delete-node/ &mx25r64;
 
 &hpf_mspi {


### PR DESCRIPTION
Backport 28f3c723d11eb25fbb6b4f50ed84201e0c6ab408 from #29829.

Fix for NCSDK-39998