### PR TITLE
drivers: wifi: nrf71: Reserve TX tailroom for SW MIC

### DIFF
--- a/drivers/wifi/nrf71/os/shim.c
+++ b/drivers/wifi/nrf71/os/shim.c
@@ -18,6 +18,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/net/net_core.h>
 #include "ipc_if.h"
 #include <zephyr/sys/math_extras.h>
 
@@ -230,6 +231,7 @@ static int zep_shim_pr_err(const char *fmt, va_list args)
 struct nwb {
 	unsigned char *data;
 	unsigned char *tail;
+	unsigned char *end;
 	int len;
 	int headroom;
 	void *next;
@@ -269,6 +271,7 @@ static void *zep_shim_nbuf_alloc(unsigned int size)
 
 	nbuff->data = (unsigned char *)nbuff->priv;
 	nbuff->tail = nbuff->data;
+	nbuff->end = (unsigned char *)nbuff->priv + size;
 	nbuff->len = 0;
 	nbuff->headroom = 0;
 	nbuff->next = NULL;
@@ -320,6 +323,9 @@ static void *zep_shim_nbuf_data_put(void *nbuf, unsigned int size)
 {
 	struct nwb *nwb = (struct nwb *)nbuf;
 	unsigned char *data = nwb->tail;
+
+	NET_ASSERT(nwb->tail + size <= nwb->end,
+		   "nbuf data put (%u) overruns reserved tailroom", size);
 
 	nwb->tail += size;
 	nwb->len += size;
@@ -420,7 +426,6 @@ static bool zep_shim_nbuf_is_raw_tx(void *nbuf)
 
 
 #include <zephyr/net/ethernet.h>
-#include <zephyr/net/net_core.h>
 
 #ifdef CONFIG_NRF_WIFI_ZERO_COPY_TX
 void *net_pkt_to_nbuf_zc(struct net_pkt *pkt)

--- a/drivers/wifi/nrf71/os/shim.c
+++ b/drivers/wifi/nrf71/os/shim.c
@@ -51,6 +51,18 @@ static struct k_heap * const wifi_data_pool = &wifi_drv_data_mem_pool;
 
 #define WORD_SIZE 4
 
+/*
+ * Tailroom reserved after the payload in every copied TX data buffer.
+ *
+ * The Wi-Fi crypto hardware on nrf71 does not compute the TKIP Michael
+ * MIC, so once a TKIP key is installed UMAC generates the 8-byte MIC in
+ * software and writes it right after the payload. Host and firmware share
+ * the TX buffer and operate on it independently, so the firmware just
+ * needs the room to exist past the payload. CCMP/GCMP MICs are produced
+ * by the HW crypto engine and never land in this buffer.
+ */
+#define NRF71_TX_MIC_TAILROOM 8
+
 struct zep_shim_intr_priv *intr_priv;
 
 static void *zep_shim_mem_alloc(size_t size)
@@ -309,6 +321,16 @@ static unsigned int zep_shim_nbuf_headroom_get(void *nbuf)
 	return ((struct nwb *)nbuf)->headroom;
 }
 
+static void zep_shim_nbuf_tailroom_res(void *nbuf, unsigned int size)
+{
+	struct nwb *nwb = (struct nwb *)nbuf;
+
+	NET_ASSERT(nwb->end - nwb->tail >= (int)size,
+		   "nbuf tailroom reserve (%u) exceeds free space", size);
+
+	nwb->end -= size;
+}
+
 static unsigned int zep_shim_nbuf_data_size(void *nbuf)
 {
 	return ((struct nwb *)nbuf)->len;
@@ -485,13 +507,14 @@ void *net_pkt_to_nbuf(struct net_pkt *pkt)
 
 	len = net_pkt_get_len(pkt);
 
-	nbuff = zep_shim_nbuf_alloc(len + 100);
+	nbuff = zep_shim_nbuf_alloc(len + 100 + NRF71_TX_MIC_TAILROOM);
 
 	if (!nbuff) {
 		return NULL;
 	}
 
 	zep_shim_nbuf_headroom_res(nbuff, 100);
+	zep_shim_nbuf_tailroom_res(nbuff, NRF71_TX_MIC_TAILROOM);
 
 	data = zep_shim_nbuf_data_put(nbuff, len);
 


### PR DESCRIPTION
## Summary
nrf71's Wi-Fi crypto HW can't generate the MIC, so UMAC computes it in
software and writes it right after the payload (8B CCMP / 16B GCMP-256).
net_pkt_to_nbuf() reserved headroom but zero tailroom, so the MIC write
ran past the allocation - small frames (e.g. a 42B ARP after the 4-way
handshake in SoftAP) corrupted the neighbouring heap chunk (canary panic
with hardening on, silent metadata scribble otherwise).

Fix: reserve 16 bytes of tailroom per copied TX buffer, covering CCMP
and GCMP-256. nrf70 is unaffected (HW crypto appends the MIC, no host
memory needed).

## Test plan
- [x] SoftAP: associate a client, complete 4-way HS, pass traffic - no
      heap canary panic (CONFIG_SYS_HEAP_HARDENING_EXTREME=y)
- [x] STA: connect + ping, confirm no regression
- [x] WPA2 (CCMP) 