### PR TITLE
quarantine: unquarantine BLE samples

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -295,13 +295,3 @@
     - nrf9160dk@0.14.0/nrf9160
     - nrf9161dk@0.9.0/nrf9161
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39943 - PM-DTS migration"
-
-- scenarios:
-    - sample.bluetooth.peripheral_mds
-    - sample.bluetooth.peripheral_nsms
-    - sample.bluetooth.peripheral_nsms_no_security
-  platforms:
-    - nrf5340dk/nrf5340/cpuapp/ns
-    - thingy53/nrf5340/cpuapp
-    - thingy53/nrf5340/cpuapp/ns
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39947 - PM-DTS migration"


### PR DESCRIPTION
BLE samples have been fixed after PM to DTS migration.