### PR TITLE
doc/nrf/app_dev/bootloaders: update about Mcuboot's LOAD_ADDRESS_CHECK

### DIFF
--- a/doc/nrf/app_dev/bootloaders_dfu/mcuboot_image_compression.rst
+++ b/doc/nrf/app_dev/bootloaders_dfu/mcuboot_image_compression.rst
@@ -12,12 +12,12 @@ MCUboot image compression
 The system includes the following features and limitation:
 
 * Allows slot ``1`` to be approximately 70% the size of slot ``0``.
-* Supports a single-image only.
-  It does not support network core updates for the nRF5340 SoC or :ref:`bootloader` updates.
+* Supports single-image mode.
+  It can be used experimentally for network core updates on the nRF5340 SoC or :ref:`bootloader` updates, provided that the active instance of MCUboot uses image matching based on explicit image address (:kconfig:option:`CONFIG_MCUBOOT_CHECK_HEADER_LOAD_ADDRESS=y`) or vendor and class UUID-based matching.
+
 * Does not support reverting to previous versions.
   MCUboot must be configured for upgrade-only mode.
-* Validates the compressed image during the update process before the main image is erased, ensuring the update does not lead to a bricked module due to un-loadable firmware.
-* Does not support image encryption.
+* Validates the compressed image during the update process before the main image is erased, ensuring the update does not lead to a bricked module due to unloadable firmware.
 * Uses LZMA2 compression with ARM thumb filter for compressed images.
 * Must use :ref:`configuration_system_overview_sysbuild`.
 

--- a/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_main_config.rst
+++ b/doc/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader_main_config.rst
@@ -25,6 +25,44 @@ This configuration allows for more complex update scenarios and greater flexibil
 * ``CONFIG_UPDATEABLE_IMAGE_NUMBER`` - Specifies the number of images that MCUboot can handle.
 * :kconfig:option:`SB_CONFIG_MCUBOOT_UPDATEABLE_IMAGES` - Configures the number of images supported by MCUboot at the sysbuild level.
 
+Supported image matching modes
+******************************
+
+MCUboot supports various *image matching modes* that determine how it identifies the target partition for a given image candidate.
+
+This feature is particularly useful when MCUboot updates multiple images from a single incoming image slot, as is the case for S0/S1 MCUboot instance updates.
+
+The selected mode determines which bootloader operations are available for the images managed by a given MCUboot instance:
+
+.. list-table:: MCUboot image matching modes
+    :header-rows: 1
+    :widths: auto
+
+    * - **Mode**
+      - **Description**
+      - **Configuration Option**
+      - **Notes**
+    * - Cortex-M reset handler-based (heuristic)
+      - Matches the image by comparing the Cortex-M reset handler address in the image's vector table against the partition address.
+        Because this approach is a heuristic, it is deprecated and cannot be used with encrypted or compressed images.
+      - ``CONFIG_MCUBOOT_VERIFY_IMG_ADDRESS``
+      - Deprecated; not compatible with encryption or compression.
+    * - Explicit image address in header
+      - Matches using an explicit image address encoded in the image header, set by the signing script. All executable slot addresses must be non-overlapping.
+      - ``CONFIG_MCUBOOT_CHECK_HEADER_LOAD_ADDRESS``
+      - Preferred for multi-image and updateable bootloader configurations such as s0/s1.
+    * - Vendor and class UUID-based
+      - Matches images by the vendor and class UUIDs, which are stored in the image header.
+        This approach allows reliable identification of images across devices and variants and is suitable for flexible multi-image systems.
+        The configuration is provided in the devicetree by a node with compatible ``nordic,mcuboot``.
+        This node includes the ``uuid-vid-required`` and ``uuid-cid-required`` properties along with boot chain descriptions.
+      - Devicetree: node with ``nordic,mcuboot`` compatible
+      - Enables advanced matching via devicetree properties for precise control across complex update scenarios.
+    * - None
+      - The system does not perform image matching or verify whether the candidate image is expected to update the given image slot.
+      - No matching option configured
+      - Supports the basic update scheme of a multi-image dual-bank bootloader.
+
 Operational modes of MCUboot
 ****************************
 

--- a/doc/nrf/app_dev/device_guides/nrf54l/ecies_x25519.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54l/ecies_x25519.rst
@@ -22,8 +22,11 @@ The current implementation has the following limitations:
   This is the default configuration.
 * Encryption is not supported when using MCUboot in direct-xip mode.
 * Storing the ECIES-X25519 device private key in the Key Management Unit (KMU) is currently not supported.
-* HMAC and HKDF tools currently use the SHA-256 hash algorithm.
-* Encryption is not supported with immutable and upgradable bootloader configuration.
+* Encryption of MCUboot updates is supported with an immutable and upgradable bootloader configuration, with the following limitations:
+
+  * The active instance of MCUboot must use image matching based on explicit image address (:kconfig:option:`CONFIG_MCUBOOT_CHECK_HEADER_LOAD_ADDRESS=y`) or vendor and class UUID-based matching.
+  * You must use the same key encryption for both MCUboot updates and the application image.
+  * You must sign the image manually, since the NCS signing process for s0/s1 images has not yet been updated to support encryption.
 
 HMAC and HKDF impact on TLV and key exchange
 ********************************************


### PR DESCRIPTION
Added update for describe mcuboot image matching metchods. Updated encryption and compression limitation notes about informations that these feture are now possible to be use with new matching metchod.

Also removed limitation on HMAC/HDFK for nRF54l ecies encryption.