### PR TITLE
cmake: sysbuild: Fix downgrade  prevention UICR provisioning

### DIFF
--- a/cmake/sysbuild/provision_hex.cmake
+++ b/cmake/sysbuild/provision_hex.cmake
@@ -105,24 +105,21 @@ function(provision application prefix_name)
       set(provision_address $<TARGET_PROPERTY:partition_manager,PM_PROVISION_ADDRESS>)
     endif()
   else()
-    if(cpunet_target)
-      dt_partition_addr(s0_slot_address LABEL "s0_partition" TARGET b0n ABSOLUTE REQUIRED)
-      set(s0_arg --s0-addr ${s0_slot_address})
-      set(s1_arg)
-    else()
-      # We can pick all of these from MCUboot image, as DTS partitions come from common
-      # DTS and image header size is the same for all images for a given platform.
-      dt_partition_addr(s0_slot_address LABEL "s0_partition" TARGET ${DEFAULT_IMAGE} ABSOLUTE REQUIRED)
-      dt_partition_addr(s1_slot_address LABEL "s1_partition" TARGET ${DEFAULT_IMAGE} ABSOLUTE REQUIRED)
-      set(s0_arg --s0-addr ${s0_slot_address})
-      set(s1_arg --s1-addr ${s1_slot_address})
-    endif()
-
     if(CONFIG_SECURE_BOOT)
       if(cpunet_target)
+        dt_partition_addr(s0_slot_address LABEL "s0_partition" TARGET b0n ABSOLUTE REQUIRED)
+        set(s0_arg --s0-addr ${s0_slot_address})
+        set(s1_arg)
         # B0 is secure bootloader and we pick the address from its configuration.
         set(bl_storage_target b0n)
       else()
+        # We can pick all of these from MCUboot image, as DTS partitions come from common
+        # DTS and image header size is the same for all images for a given platform.
+        dt_partition_addr(s0_slot_address LABEL "s0_partition" TARGET ${DEFAULT_IMAGE} ABSOLUTE REQUIRED)
+        dt_partition_addr(s1_slot_address LABEL "s1_partition" TARGET ${DEFAULT_IMAGE} ABSOLUTE REQUIRED)
+        set(s0_arg --s0-addr ${s0_slot_address})
+        set(s1_arg --s1-addr ${s1_slot_address})
+
         set(bl_storage_target b0)
       endif()
     else(SB_CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION)
@@ -245,7 +242,9 @@ function(provision application prefix_name)
   endif()
 endfunction()
 
-b0_gen_keys()
+if(SB_CONFIG_SECURE_BOOT)
+  b0_gen_keys()
+endif()
 
 # Get the main app of the domain that secure boot should handle.
 if(SB_CONFIG_SECURE_BOOT AND SB_CONFIG_SECURE_BOOT_APPCORE)

--- a/sysbuild/mcuboot.cmake
+++ b/sysbuild/mcuboot.cmake
@@ -40,3 +40,10 @@ if(SB_CONFIG_MCUBOOT_BUILD_DIRECT_XIP_VARIANT)
 
   endforeach()
 endif()
+
+if(NOT SB_CONFIG_PARTITION_MANAGER AND SB_CONFIG_BOOTLOADER_MCUBOOT AND SB_CONFIG_MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION)
+  # Downgrade prevention in MCUboot requires provisioning UICR with prepared counter structures.
+  include(image_flasher.cmake)
+  add_image_flasher(NAME app_provision HEX_FILE "${CMAKE_BINARY_DIR}/app_provision.hex" BASE_IMAGE mcuboot)
+  sysbuild_add_dependencies(FLASH mcuboot app_provision)
+endif()


### PR DESCRIPTION
Fix for provisioning UICR for MCUboot downgrade preventions. The counters, in UICR, have not been provisioning for MCUboot, as only bootloader, configuration after switching to DTS partitions.
The PR also fixes pointless NSIB UICR configuration when NSIB was not part of a build.

Update: Removed release notes (https://github.com/nrfconnect/sdk-nrf/pull/29864#discussion_r3482270741)