### PR TITLE
tests: drivers: spi: spim_instances: add gpio okay for nrf9251

### DIFF
--- a/tests/drivers/spi/spim_instances/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/drivers/spi/spim_instances/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -89,6 +89,18 @@
 	nfct-pins-as-gpios;
 };
 
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio5 {
+	status = "okay";
+};
+
 &spi120 {
 	status = "okay";
 	pinctrl-0 = <&spi120_default_test>;


### PR DESCRIPTION
Missing gpio okays for nrf92.