### PR TITLE
samples: fast_pair: Add nRF54LC10 support for input_device

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -344,7 +344,7 @@ Bluetooth Fast Pair samples
 
 * :ref:`fast_pair_input_device` sample:
 
-  * Added support for the ``nrf54ls05dk/nrf54ls05a/cpuapp`` and ``nrf54ls05dk/nrf54ls05b/cpuapp`` board targets.
+    * Added support for the ``nrf54ls05dk/nrf54ls05a/cpuapp``, ``nrf54ls05dk/nrf54ls05b/cpuapp``, and ``nrf54lc10dk/nrf54lc10a/cpuapp`` board targets.
 
 Cellular samples
 ----------------

--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Align the advertised TX power with Fast Pair expectations.
+CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-11

--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuapp_rram {
+	/* Redefine the "partitions" DTS node. */
+	/delete-node/ partitions;
+
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x0 DT_SIZE_K(988)>;
+		};
+
+		bt_fast_pair_partition: partition@f7000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0xf7000 DT_SIZE_K(4)>;
+		};
+
+		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0xf8000 DT_SIZE_K(20)>;
+		};
+	};
+};

--- a/samples/bluetooth/fast_pair/input_device/sample.yaml
+++ b/samples/bluetooth/fast_pair/input_device/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     platform_allow:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
@@ -19,6 +20,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     tags:
       - bluetooth
       - ci_build


### PR DESCRIPTION
Add nRF54LC10 support for input_device fast_pair sample.
