### PR TITLE
Add DTS overlay files and disable Partition Manager in decompression tests

### DIFF
--- a/tests/subsys/nrf_compress/decompression/arm_thumb/Kconfig.sysbuild
+++ b/tests/subsys/nrf_compress/decompression/arm_thumb/Kconfig.sysbuild
@@ -1,4 +1,0 @@
-config PARTITION_MANAGER
-	default n if !BOARD_IS_NON_SECURE
-
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"

--- a/tests/subsys/nrf_compress/decompression/arm_thumb/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/tests/subsys/nrf_compress/decompression/arm_thumb/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,50 @@
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x40000>;
+		};
+
+		slot0_ns_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x40000 0xb4000>;
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};

--- a/tests/subsys/nrf_compress/decompression/lzma/Kconfig.sysbuild
+++ b/tests/subsys/nrf_compress/decompression/lzma/Kconfig.sysbuild
@@ -1,4 +1,0 @@
-config PARTITION_MANAGER
-	default n if !BOARD_IS_NON_SECURE
-
-source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"

--- a/tests/subsys/nrf_compress/decompression/lzma/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/tests/subsys/nrf_compress/decompression/lzma/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,50 @@
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &tfm_ps_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x40000>;
+		};
+
+		slot0_ns_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x40000 0xb4000>;
+		};
+
+		tfm_storage_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0xf4000 DT_SIZE_K(48)>;
+			ranges = <0x0 0xf4000 DT_SIZE_K(48)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@8000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x8000 DT_SIZE_K(16)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Porting arm_thumb and lzma decompression tests from Partition Manager to DTS for nrf5340_ns.

Ref: NCSDK-40050