### PR TITLE
samples: matter: custom clusters: unified app zap dir configuration

### DIFF
--- a/doc/nrf/protocols/matter/getting_started/custom_clusters.rst
+++ b/doc/nrf/protocols/matter/getting_started/custom_clusters.rst
@@ -723,8 +723,7 @@ Align the configuration with the new cluster
 
 Generating the :file:`.zap` files with the ``--full`` option creates new source files under :file:`zap-generated/app-common`.
 They need to override the default files located in the Matter SDK in the :file:`zzz_generated/app-common` directory.
-To override the path, set the :kconfig:option:`CONFIG_CHIP_APP_ZAP_DIR` option in the :file:`prj.conf` file to the ``"${APPLICATION_CONFIG_DIR}/src/default_zap/zap-generated"`` value, pointing to the parent of the generated :file:`app-common` directory, and set the ``CHIP_APP_ZAP_DIR`` variable in the :file:`CMakeLists.txt` file.
-
+To override the path, set the :kconfig:option:`CONFIG_CHIP_APP_ZAP_DIR` Kconfig option in the :file:`prj.conf` file to the ``"${APPLICATION_CONFIG_DIR}/src/default_zap/zap-generated"`` value, pointing to the parent of the generated :file:`app-common` directory.
 As custom clusters are not part of the default Matter SDK, you need to additionally pass a list of all new cluster names in an ``EXTERNAL_CLUSTERS`` argument when calling ``ncs_configure_data_model``.
 
 The following code snippet shows how to modify the Matter template :file:`CMakeLists.txt` file with the new cluster:
@@ -733,13 +732,7 @@ The following code snippet shows how to modify the Matter template :file:`CMakeL
 
       project(matter-template)
 
-      # Override zap-generated directory.
-      include(${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/cmake/zap_helpers.cmake)
-      ncs_get_zap_parent_dir(ZAP_PARENT_DIR)
-
-      get_filename_component(CHIP_APP_ZAP_DIR ${ZAP_PARENT_DIR}/zap-generated REALPATH CACHE)
-
-      # Existing code in CMakeList.txt
+      # Existing code in CMakeLists.txt
 
       ncs_configure_data_model(
          EXTERNAL_CLUSTERS "MY_NEW_CLUSTER" # Add EXTERNAL_CLUSTERS flag

--- a/samples/matter/common/cmake/data_model.cmake
+++ b/samples/matter/common/cmake/data_model.cmake
@@ -17,6 +17,11 @@ function(ncs_configure_data_model)
     ${zap_parent_dir}
   )
 
+  if(CONFIG_CHIP_APP_ZAP_DIR)
+    string(CONFIGURE "${CONFIG_CHIP_APP_ZAP_DIR}" app_zap_dir)
+    get_filename_component(CHIP_APP_ZAP_DIR ${app_zap_dir} REALPATH)
+  endif()
+
   chip_configure_data_model(matter-data-model
     BYPASS_IDL
     GEN_DIR ${zap_parent_dir}/zap-generated

--- a/samples/matter/manufacturer_specific/CMakeLists.txt
+++ b/samples/matter/manufacturer_specific/CMakeLists.txt
@@ -13,9 +13,6 @@ project(matter-manufacturer_specific)
 include(${ZEPHYR_NRF_MODULE_DIR}/samples/matter/common/cmake/zap_helpers.cmake)
 ncs_get_zap_parent_dir(ZAP_PARENT_DIR)
 
-# Override zap-generated directory.
-get_filename_component(CHIP_APP_ZAP_DIR ${ZAP_PARENT_DIR}/zap-generated REALPATH CACHE)
-
 # Enable GNU STD support.
 include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/config/nrfconnect/app/enable-gnu-std.cmake)
 


### PR DESCRIPTION
When user wanted to set a custom app zap dir, a change in two places was needed.
Now it is enough to set a single Kconfig.