### PR TITLE
tests: benchmarks: system_off: gpio_wakeup lv10/ns

### DIFF
--- a/tests/benchmarks/current_consumption/system_off/boards/nrf54lv10dk_nrf54lv10a_cpuapp_ns_gpio_wakeup.overlay
+++ b/tests/benchmarks/current_consumption/system_off/boards/nrf54lv10dk_nrf54lv10a_cpuapp_ns_gpio_wakeup.overlay
@@ -1,0 +1,1 @@
+#include "nrf54lv10dk_nrf54lv10a_cpuapp_gpio_wakeup.overlay"


### PR DESCRIPTION
Missing overlay.