### PR TITLE
scripts: quarantine_zephyr: clear drivers.i2c.ram.rtio

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -193,12 +193,6 @@
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-37574"
 
 - scenarios:
-    - drivers.i2c.ram.rtio
-  platforms:
-    - nrf52840dk/nrf52840
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-37791"
-
-- scenarios:
     - bluetooth.general.tester_le_audio
     - sample.bluetooth.audio_unicast_client
     - sample.bluetooth.audio_unicast_server


### PR DESCRIPTION
Fixed.