### PR TITLE
tests: benchmarks: multicore: idle_stm: idle case

### DIFF
--- a/tests/benchmarks/multicore/idle_stm/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_stm/testcase.yaml
@@ -31,31 +31,6 @@ tests:
         - "rad/idle_stm: Run 2"
         - "ppr/idle_stm: Run 2"
 
-  benchmarks.multicore.idle_stm.nrf54h20dk_cpuapp_cpurad_cpuppr.idle:
-    extra_args:
-      - idle_stm_CONF_FILE=prj_s2ram.conf
-      - remote_rad_CONF_FILE=prj_s2ram.conf
-      - idle_stm_CONFIG_TEST_SLEEP_DURATION_MS=500
-      - remote_rad_CONFIG_TEST_SLEEP_DURATION_MS=500
-      - remote_ppr_CONFIG_TEST_SLEEP_DURATION_MS=500
-    harness: console
-    harness_config:
-      type: multi_line
-      ordered: false
-      regex:
-        - "Main sleeps for 500 ms"
-        - "Multicore idle_stm test on"
-        - "app/idle_stm: Run 0"
-        - "rad/idle_stm: Run 0"
-        - "ppr/idle_stm: Run 0"
-        - "app/idle_stm: Run 1"
-        - "rad/idle_stm: Run 1"
-        - "ppr/idle_stm: Run 1"
-        - "app/idle_stm: Run 2"
-        - "rad/idle_stm: Run 2"
-        - "ppr/idle_stm: Run 2"
-        - "ppr/power_off: Wait Sleep State"
-
   benchmarks.multicore.idle_stm.nrf54h20dk_cpuapp_cpurad_cpuppr.s2ram:
     extra_args:
       - idle_stm_CONF_FILE=prj_s2ram.conf
@@ -76,4 +51,3 @@ tests:
         - "app/idle_stm: Run 2"
         - "rad/idle_stm: Run 2"
         - "ppr/idle_stm: Run 2"
-        - "ppr/power_off: Hibernate Sleep State"


### PR DESCRIPTION
Since custom power management for VPR has been removed, PPR will always enter the same power state in sleep mode. Separate test cases for idle and S2RAM are no longer necessary.