### PR TITLE
net: tls: Add support for retreiving certificate expiry from the nRF Modem

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -594,6 +594,8 @@ Libraries for networking
 
   * Fixed an issue with parsing invalid payloads.
 
+* Added :ref:`TLS Credentials Subsystem <zephyr:sockets_tls_credentials_subsys>` support for TLS credential expiry retrieval when using the modem as TLS credentials storage.
+
 Libraries for NFC
 -----------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -574,6 +574,10 @@ Modem libraries
 
   * Updated the library to always use the chosen ``zephyr,wifi`` node instead of ``ncs,location-wifi`` to find the used Wi-Fi device.
 
+* :ref:`modem_key_mgmt` library:
+
+  * Added the :c:func:`modem_key_mgmt_certexpiry` function that would retrieve the expiry date of a credential from the modem.
+
 Multiprotocol Service Layer libraries
 -------------------------------------
 

--- a/include/modem/modem_key_mgmt.h
+++ b/include/modem/modem_key_mgmt.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include <nrf_socket.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -164,6 +165,22 @@ int modem_key_mgmt_cmp(nrf_sec_tag_t sec_tag,
 int modem_key_mgmt_digest(nrf_sec_tag_t sec_tag,
 			  enum modem_key_mgmt_cred_type cred_type,
 			  void *buf, size_t len);
+
+/**
+ * @brief Read the expiry time of a certificate from persistent storage.
+ *
+ * @param[in]           sec_tag         The security tag of the credential.
+ * @param[in]           cred_type       The credential type.
+ * @param[out]          expiry          Pointer to store the expiry time.
+ *
+ * @retval 0            On success.
+ * @retval -EINVAL      Invalid parameters.
+ * @retval -ENOENT      No credential associated with the given
+ *                      @p sec_tag and @p cred_type.
+ */
+int modem_key_mgmt_certexpiry(nrf_sec_tag_t sec_tag,
+			      enum modem_key_mgmt_cred_type cred_type,
+			      time_t *expiry);
 
 /**
  * @brief Check if a credential exists in persistent storage.

--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -293,7 +293,8 @@ int modem_key_mgmt_digest(nrf_sec_tag_t sec_tag,
 			  enum modem_key_mgmt_cred_type cred_type,
 			  void *buf, size_t len)
 {
-	char cmd[sizeof("AT%CMNG=1,##########,##")];
+	/* Use half the scratch buffer for the hex string command output */
+	char *hex_str = scratch_buf + sizeof(scratch_buf) / 2;
 	bool cmee_was_enabled;
 	int ret;
 
@@ -305,49 +306,52 @@ int modem_key_mgmt_digest(nrf_sec_tag_t sec_tag,
 		return -ENOMEM;
 	}
 
-	snprintk(cmd, sizeof(cmd), "AT%%CMNG=1,%u,%u", sec_tag, cred_type);
-
 	k_mutex_lock(&key_mgmt_mutex, K_FOREVER);
 
 	cmee_enable(&cmee_was_enabled);
 
-	ret = nrf_modem_at_scanf(
-		cmd,
-		"%%CMNG: "
-		"%*u," /* Ignore tag. */
-		"%*u," /* Ignore type. */
-		"\"%" STRINGIFY(MODEM_KEY_MGMT_DIGEST_STR_SIZE_WITHOUT_NULL_TERM) "s\"",
-		scratch_buf);
+	ret = nrf_modem_at_cmd(scratch_buf, sizeof(scratch_buf) / 2,
+			       "AT%%CMNG=1,%u,%u", sec_tag, cred_type);
 
 	if (!cmee_was_enabled) {
 		cmee_disable();
 	}
 
-	switch (ret) {
-	case 1:
-		len = hex2bin(scratch_buf, strlen(scratch_buf), buf, len);
-
-		if (len != MODEM_KEY_MGMT_DIGEST_SIZE) {
-			ret = -EINVAL;
-			break;
-		}
-
-		ret = 0;
-		break;
-	case 0:
-		ret = -ENOENT;
-	default:
-		break;
+	if (ret) {
+		ret = translate_error(ret);
+		goto out;
 	}
 
+	if (strcmp(scratch_buf, "OK\r\n") == 0) {
+		ret = -ENOENT;
+		goto out;
+	}
+
+	ret = sscanf(
+		scratch_buf,
+		"%%CMNG: "
+		"%*u,"
+		"%*u,"
+		"\"%" STRINGIFY(MODEM_KEY_MGMT_DIGEST_STR_SIZE_WITHOUT_NULL_TERM) "[^\"]\"",
+		hex_str);
+
+	if (ret != 1) {
+		ret = -EBADMSG;
+		goto out;
+	}
+
+	len = hex2bin(hex_str, strlen(hex_str), buf, len);
+	if (len != MODEM_KEY_MGMT_DIGEST_SIZE) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	ret = 0;
+
+out:
 	k_mutex_unlock(&key_mgmt_mutex);
 
-	if (ret) {
-		return translate_error(ret);
-	}
-
-	return 0;
-
+	return ret;
 }
 
 int modem_key_mgmt_delete(nrf_sec_tag_t sec_tag,

--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/timeutil.h>
 #include <nrf_modem_at.h>
 #include <modem/modem_key_mgmt.h>
 #include <zephyr/logging/log.h>
@@ -346,6 +347,72 @@ int modem_key_mgmt_digest(nrf_sec_tag_t sec_tag,
 		goto out;
 	}
 
+	ret = 0;
+
+out:
+	k_mutex_unlock(&key_mgmt_mutex);
+
+	return ret;
+}
+
+int modem_key_mgmt_certexpiry(nrf_sec_tag_t sec_tag,
+			    enum modem_key_mgmt_cred_type cred_type,
+			    time_t *expiry)
+{
+	bool cmee_was_enabled;
+	struct tm not_after;
+	time_t expiry_time;
+	int ret;
+
+	if (expiry == NULL) {
+		return -EINVAL;
+	}
+
+	if (cred_type != MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN &&
+	    cred_type != MODEM_KEY_MGMT_CRED_TYPE_PUBLIC_CERT) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&key_mgmt_mutex, K_FOREVER);
+
+	cmee_enable(&cmee_was_enabled);
+
+	ret = nrf_modem_at_cmd(scratch_buf, sizeof(scratch_buf),
+			       "AT%%CERTEXPIRY=%d,%d", sec_tag, cred_type);
+
+	if (!cmee_was_enabled) {
+		cmee_disable();
+	}
+
+	if (ret) {
+		ret = translate_error(ret);
+		goto out;
+	}
+
+	ret = sscanf(scratch_buf,
+		"%%CERTEXPIRY: "
+		"%*[^,],"
+		"%*[^,],"
+		"%4u%2u%2u%2u%2u%2uZ", /* YYYYMMDDHHMMSSZ */
+		&not_after.tm_year, &not_after.tm_mon, &not_after.tm_mday,
+		&not_after.tm_hour, &not_after.tm_min, &not_after.tm_sec);
+
+	if (ret != 6) {
+		ret = -EBADMSG;
+		goto out;
+	}
+
+	not_after.tm_year -= 1900; /* Adjust year to be years since 1900 */
+	not_after.tm_mon -= 1;     /* Adjust month to be 0-11 */
+
+	errno = 0;
+	expiry_time = timeutil_timegm(&not_after);
+	if (expiry_time == -1 && errno != 0) {
+		ret = -errno;
+		goto out;
+	}
+
+	*expiry = expiry_time;
 	ret = 0;
 
 out:

--- a/subsys/net/lib/tls_credentials/tls_credentials_nrf_modem.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_nrf_modem.c
@@ -323,6 +323,39 @@ exit:
 	return ret;
 }
 
+int tls_credential_expiry(sec_tag_t tag, enum tls_credential_type type, time_t *expiry)
+{
+	struct tls_credential *credential;
+	int ret = 0;
+
+	if (expiry == NULL) {
+		return -EINVAL;
+	}
+
+	if (type != TLS_CREDENTIAL_CA_CERTIFICATE &&
+	    type != TLS_CREDENTIAL_PUBLIC_CERTIFICATE) {
+		/* Only CA and server certificates have expiry information. */
+		return -EINVAL;
+	}
+
+	credentials_lock();
+
+	credential = credential_get(tag, type);
+
+	if (!credential) {
+		ret = -ENOENT;
+		goto exit;
+	}
+
+	ret = modem_key_mgmt_certexpiry(credential->tag, modem_key_mgmt_type_get(type), expiry);
+
+exit:
+	credentials_unlock();
+
+	return ret;
+}
+
+
 static void credential_entry_init_callback(nrf_sec_tag_t sec_tag,
 					   enum modem_key_mgmt_cred_type cred_type)
 {

--- a/tests/lib/modem_key_mgmt/src/main.c
+++ b/tests/lib/modem_key_mgmt/src/main.c
@@ -4,10 +4,14 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* Required for gmtime_r */
+
 #include <zephyr/ztest.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 
@@ -254,6 +258,79 @@ ZTEST(suite_modem_key_mgmt, test_list_multiple_entries)
 
 	zassert_equal(key_list_cb_fake.arg0_history[4], 16842753);
 	zassert_equal(key_list_cb_fake.arg1_history[4], MODEM_KEY_MGMT_CRED_TYPE_PRIVATE_CERT);
+}
+
+static int nrf_modem_at_cmd_test_expiry_error(void *buf, size_t len, const char *fmt, va_list args)
+{
+	char buffer[256 + 1];
+
+	vsnprintf(buffer, sizeof(buffer), fmt, args);
+
+	switch (nrf_modem_at_cmd_fake.call_count) {
+	case 1:
+		zassert_equal(0, strcmp("AT%CERTEXPIRY=13,0", buffer));
+		return 513; /* CME ERROR: 513 - Not found */
+	default:
+		zassert_true(false);
+	}
+
+	return 0;
+}
+
+ZTEST(suite_modem_key_mgmt, test_expiry_not_exists)
+{
+	time_t expiry;
+	int err;
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_cmee_enabled;
+	nrf_modem_at_cmd_fake.custom_fake = nrf_modem_at_cmd_test_expiry_error;
+
+	err = modem_key_mgmt_certexpiry(13, MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN, &expiry);
+	zassert_equal(err, -ENOENT);
+}
+
+static const char *test_data_expiry_valid =
+"%CERTEXPIRY: 15E1A419ADF6FAA5B2E8770C5DED39319F982EF2,20260121100755Z,20310120100755Z\r\n";
+
+
+static int nrf_modem_at_cmd_test_expiry_valid(void *buf, size_t len, const char *fmt, va_list args)
+{
+	char buffer[256 + 1];
+
+	vsnprintf(buffer, sizeof(buffer), fmt, args);
+
+	switch (nrf_modem_at_cmd_fake.call_count) {
+	case 1:
+		zassert_equal(0, strcmp("AT%CERTEXPIRY=3,1", buffer));
+		strncpy(buf, test_data_expiry_valid, len);
+		return 0;
+	default:
+		zassert_true(false);
+	}
+
+	return 0;
+}
+
+ZTEST(suite_modem_key_mgmt, test_expiry_valid)
+{
+	time_t expiry;
+	struct tm tm;
+	int err;
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_cmee_enabled;
+	nrf_modem_at_cmd_fake.custom_fake = nrf_modem_at_cmd_test_expiry_valid;
+
+	err = modem_key_mgmt_certexpiry(3, MODEM_KEY_MGMT_CRED_TYPE_PUBLIC_CERT, &expiry);
+	zassert_equal(err, 0);
+
+	gmtime_r(&expiry, &tm);
+
+	zassert_equal(tm.tm_year + 1900, 2031);
+	zassert_equal(tm.tm_mon + 1, 1);
+	zassert_equal(tm.tm_mday, 20);
+	zassert_equal(tm.tm_hour, 10);
+	zassert_equal(tm.tm_min, 07);
+	zassert_equal(tm.tm_sec, 55);
 }
 
 static void _test_setup(void *fixture)

--- a/tests/lib/modem_key_mgmt/src/main.c
+++ b/tests/lib/modem_key_mgmt/src/main.c
@@ -28,15 +28,30 @@ FAKE_VALUE_FUNC_VARARG(int, nrf_modem_at_cmd, void *, size_t, const char *, ...)
 static const char test_cmee_enabled[] = "+CMEE: 1";
 static const char *test_data_empty_list = "OK\r\n";
 
-static int nrf_modem_at_scanf_test_digest_empty(const char *cmd, const char *fmt, va_list args)
+static int nrf_modem_at_scanf_cmee_enabled(const char *cmd, const char *fmt, va_list args)
 {
 	switch (nrf_modem_at_scanf_fake.call_count) {
 	case 1:
-		/* For the purpose of this test, simplify by having the cmee already enabled. */
+		/* For the purpose of these tests, simplify by having the cmee already enabled. */
 		return vsscanf(test_cmee_enabled, fmt, args);
-	case 2:
-		zassert_equal(0, strcmp("AT%CMNG=1,0,0", cmd));
-		return vsscanf(test_data_empty_list, fmt, args);
+	default:
+		zassert_true(false);
+	}
+
+	return 0;
+}
+
+static int nrf_modem_at_cmd_test_digest_empty(void *buf, size_t len, const char *fmt, va_list args)
+{
+	char buffer[256 + 1];
+
+	vsnprintf(buffer, sizeof(buffer), fmt, args);
+
+	switch (nrf_modem_at_cmd_fake.call_count) {
+	case 1:
+		zassert_equal(0, strcmp("AT%CMNG=1,0,0", buffer));
+		strncpy(buf, test_data_empty_list, len);
+		return 0;
 	default:
 		zassert_true(false);
 	}
@@ -49,7 +64,8 @@ ZTEST(suite_modem_key_mgmt, test_digest_no_entry)
 	char digest_buf[32];
 	int err;
 
-	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_test_digest_empty;
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_cmee_enabled;
+	nrf_modem_at_cmd_fake.custom_fake = nrf_modem_at_cmd_test_digest_empty;
 
 	err = modem_key_mgmt_digest(0, MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN,
 				    digest_buf, sizeof(digest_buf));
@@ -77,15 +93,17 @@ static const uint8_t expected_digest[] = {
 	0x59, 0x77, 0x43, 0x7E,  0xA3, 0x5F, 0x7A, 0x45
 };
 
-static int nrf_modem_at_scanf_test_digest(const char *cmd, const char *fmt, va_list args)
+static int nrf_modem_at_cmd_test_digest(void *buf, size_t len, const char *fmt, va_list args)
 {
-	switch (nrf_modem_at_scanf_fake.call_count) {
+	char buffer[256 + 1];
+
+	vsnprintf(buffer, sizeof(buffer), fmt, args);
+
+	switch (nrf_modem_at_cmd_fake.call_count) {
 	case 1:
-		/* For the purpose of this test, simplify by having the cmee already enabled. */
-		return vsscanf(test_cmee_enabled, fmt, args);
-	case 2:
-		zassert_equal(0, strcmp("AT%CMNG=1,16842753,1", cmd));
-		return vsscanf(test_data_digest, fmt, args);
+		zassert_equal(0, strcmp("AT%CMNG=1,16842753,1", buffer));
+		strncpy(buf, test_data_digest, len);
+		return 0;
 	default:
 		zassert_true(false);
 	}
@@ -98,7 +116,8 @@ ZTEST(suite_modem_key_mgmt, test_digest_public_cert)
 	char digest_buf[32];
 	int err;
 
-	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_test_digest;
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_cmee_enabled;
+	nrf_modem_at_cmd_fake.custom_fake = nrf_modem_at_cmd_test_digest;
 
 	err = modem_key_mgmt_digest(16842753, MODEM_KEY_MGMT_CRED_TYPE_PUBLIC_CERT,
 				    digest_buf, sizeof(digest_buf));
@@ -111,15 +130,18 @@ static const char *test_data_invalid_digest =
 "%CMNG: 16842753,1,\"B9BAC15641653CAE2B5151DCBD0C40DDCDF19125950FA2475977437EA35F7A\"\r\n"
 "OK\r\n";
 
-static int nrf_modem_at_scanf_test_invalid_digest(const char *cmd, const char *fmt, va_list args)
+static int nrf_modem_at_cmd_test_invalid_digest(void *buf, size_t len, const char *fmt,
+						va_list args)
 {
-	switch (nrf_modem_at_scanf_fake.call_count) {
+	char buffer[256 + 1];
+
+	vsnprintf(buffer, sizeof(buffer), fmt, args);
+
+	switch (nrf_modem_at_cmd_fake.call_count) {
 	case 1:
-		/* For the purpose of this test, simplify by having the cmee already enabled. */
-		return vsscanf(test_cmee_enabled, fmt, args);
-	case 2:
-		zassert_equal(0, strcmp("AT%CMNG=1,16842753,1", cmd));
-		return vsscanf(test_data_invalid_digest, fmt, args);
+		zassert_equal(0, strcmp("AT%CMNG=1,16842753,1", buffer));
+		strncpy(buf, test_data_invalid_digest, len);
+		return 0;
 	default:
 		zassert_true(false);
 	}
@@ -132,7 +154,8 @@ ZTEST(suite_modem_key_mgmt, test_digest_invalid_response)
 	char digest_buf[32];
 	int err;
 
-	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_test_invalid_digest;
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_cmee_enabled;
+	nrf_modem_at_cmd_fake.custom_fake = nrf_modem_at_cmd_test_invalid_digest;
 
 	err = modem_key_mgmt_digest(16842753, MODEM_KEY_MGMT_CRED_TYPE_PUBLIC_CERT,
 				    digest_buf, sizeof(digest_buf));

--- a/tests/subsys/net/lib/tls_credentials_nrf_modem/main.c
+++ b/tests/subsys/net/lib/tls_credentials_nrf_modem/main.c
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* Required for gmtime_r */
+
 #include <zephyr/ztest.h>
 #include <zephyr/fff.h>
 
@@ -24,6 +27,8 @@ FAKE_VALUE_FUNC(int, modem_key_mgmt_cmp, nrf_sec_tag_t, enum modem_key_mgmt_cred
 					 const void *, size_t);
 FAKE_VALUE_FUNC(int, modem_key_mgmt_digest, nrf_sec_tag_t, enum modem_key_mgmt_cred_type,
 					    void *, size_t);
+FAKE_VALUE_FUNC(int, modem_key_mgmt_certexpiry, nrf_sec_tag_t, enum modem_key_mgmt_cred_type,
+						time_t *);
 FAKE_VALUE_FUNC(int, modem_key_mgmt_exists, nrf_sec_tag_t, enum modem_key_mgmt_cred_type,
 					    bool *);
 FAKE_VALUE_FUNC(int, modem_key_mgmt_list, modem_key_mgmt_list_cb_t);
@@ -225,6 +230,63 @@ ZTEST(tls_credentials, test_tls_credential_add_existing_but_not_existing)
 	zassert_equal(modem_key_mgmt_write_fake.arg3_val, len);
 }
 
+int modem_key_mgmt_certexpiry_custom(nrf_sec_tag_t sec_tag, enum modem_key_mgmt_cred_type cred_type,
+				     time_t *expiry)
+{
+	zassert_equal(sec_tag, 100);
+	zassert_equal(cred_type, MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN);
+
+	/* Timestamp: 1782486440
+	 * Timestamp in ms: 1782486440000
+	 * UTC: Friday, June 26, 2026 at 3:07:20 PM
+	 */
+	*expiry = 1782486440;
+
+	return 0;
+}
+
+ZTEST(tls_credentials, test_tls_credential_expiry)
+{
+	time_t expiry;
+	struct tm tm;
+	int ret;
+
+	modem_key_mgmt_certexpiry_fake.return_val = 0;
+	modem_key_mgmt_certexpiry_fake.custom_fake = modem_key_mgmt_certexpiry_custom;
+
+	ret = tls_credential_expiry(100, TLS_CREDENTIAL_CA_CERTIFICATE, &expiry);
+	zassert_equal(ret, 0);
+
+	gmtime_r(&expiry, &tm);
+
+	zassert_equal(tm.tm_year + 1900, 2026);
+	zassert_equal(tm.tm_mon + 1, 6);
+	zassert_equal(tm.tm_mday, 26);
+	zassert_equal(tm.tm_hour, 15);
+	zassert_equal(tm.tm_min, 7);
+	zassert_equal(tm.tm_sec, 20);
+}
+
+ZTEST(tls_credentials, test_tls_credential_invalid_type)
+{
+	time_t expiry;
+	int ret;
+
+	modem_key_mgmt_certexpiry_fake.return_val = 0;
+	modem_key_mgmt_certexpiry_fake.custom_fake = modem_key_mgmt_certexpiry_custom;
+
+	ret = tls_credential_expiry(100, TLS_CREDENTIAL_PRIVATE_KEY, &expiry);
+	zassert_equal(ret, -EINVAL);
+}
+
+ZTEST(tls_credentials, test_tls_credential_not_exists)
+{
+	time_t expiry;
+	int ret;
+
+	ret = tls_credential_expiry(109, TLS_CREDENTIAL_PUBLIC_CERTIFICATE, &expiry);
+	zassert_equal(ret, -ENOENT);
+}
 
 static void _reset_fake(const struct ztest_unit_test *test, void *fixture)
 {
@@ -232,6 +294,8 @@ static void _reset_fake(const struct ztest_unit_test *test, void *fixture)
 	RESET_FAKE(modem_key_mgmt_read);
 	RESET_FAKE(modem_key_mgmt_cmp);
 	RESET_FAKE(modem_key_mgmt_exists);
+	RESET_FAKE(modem_key_mgmt_digest);
+	RESET_FAKE(modem_key_mgmt_certexpiry);
 	RESET_FAKE(modem_key_mgmt_delete);
 	RESET_FAKE(modem_key_mgmt_list);
 }


### PR DESCRIPTION
Add support for retrieving the TLS certificate expiration date from the nRF modem using the AT%CERTEXPIRY command.
Add both the modem_key_mgmt library functionality as well as a TLS credential API for generic TLS support.

Note: requires TLS credential expiry API support in zephyr.
Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/112096