### PR TITLE
samples: bluetooth: central_uart: increase UDC pool size

### DIFF
--- a/samples/bluetooth/central_uart/boards/nrf54lm20dongle_nrf54lm20b_cpuapp.conf
+++ b/samples/bluetooth/central_uart/boards/nrf54lm20dongle_nrf54lm20b_cpuapp.conf
@@ -11,6 +11,7 @@ CONFIG_LOG_BACKEND_UART=y
 # Allow defining multiple USB CDC ACM interfaces.
 CONFIG_CDC_ACM_SERIAL_MULTIPLE_INSTANCES=y
 CONFIG_UDC_DRIVER_LOG_LEVEL_WRN=y
+CONFIG_UDC_BUF_POOL_SIZE=8192
 
 # The sample requires UART async API that is not supported by the USB CDC ACM UART driver yet.
 # Hence we need the UART async adapter as the intermediate layer.


### PR DESCRIPTION
On a single Windows host, the sample run on nRF54LM20 Dongle would log errors about failed net_buf allocations.