### PR TITLE
Add new radio test commands for nrf71 and separate out code

### DIFF
--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/inc/radio_test/fmac_api.h
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/inc/radio_test/fmac_api.h
@@ -93,6 +93,8 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_prog_rx(struct nrf_wifi_fmac_dev_ctx *fmac
  * @param capture_timeout Capture timeout.
  * @param lna_gain LNA gain value.
  * @param bb_gain Baseband gain value.
+ * @param ed_thresh_ofdm OFDM energy detect threshold in dBm (-100..0).
+ * @param ed_thresh_dsss DSSS energy detect threshold in dBm (-100..0).
  * @param timeout_status Timeout status.
  *
  * This function is used to send a command to:
@@ -108,6 +110,8 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_rx_cap(struct nrf_wifi_fmac_dev_ct
 						     unsigned short int capture_timeout,
 						     unsigned char lna_gain,
 						     unsigned char bb_gain,
+						     unsigned char ed_thresh_ofdm,
+						     unsigned char ed_thresh_dsss,
 						     unsigned char *timeout_status);
 
 

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/inc/radio_test/fmac_api.h
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/inc/radio_test/fmac_api.h
@@ -117,6 +117,9 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_rx_cap(struct nrf_wifi_fmac_dev_ct
  * @param enable Enable/Disable TX tone test.
  * @param tone_freq Desired tone frequency in MHz in steps of 1 MHz from -10 MHz to +10 MHz.
  * @param tx_power Desired TX power in the range -16dBm to +24dBm.
+ * @param tone_type Tone type to be transmitted (0=complex, 1=real-only, 2=imag-only).
+ * @param dc_offset_i DC offset for the I channel.
+ * @param dc_offset_q DC offset for the Q channel.
  *
  * This function is used to send a command to:
  *	- The RPU firmware to start the RF TX tone test in radio test mode.
@@ -127,7 +130,10 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_rx_cap(struct nrf_wifi_fmac_dev_ct
 enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_tx_tone(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 						      unsigned char enable,
 						      signed char tone_freq,
-						      signed char tx_power);
+						      signed char tx_power,
+						      unsigned char tone_type,
+						      signed char dc_offset_i,
+						      signed char dc_offset_q);
 
 
 

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/inc/radio_test/fmac_api.h
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/inc/radio_test/fmac_api.h
@@ -141,12 +141,24 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_tx_tone(struct nrf_wifi_fmac_dev_c
  * @brief Get XO calibrated value.
  * @param fmac_dev_ctx Pointer to the UMAC IF context for a RPU WLAN device.
  *
- * This function is used to send a command to:
- *	- The RPU firmware wherein the RPU firmware estimates and
- *	  returns optimal XO value.
+ * This function is used to send a command to the RPU firmware, which
+ * estimates and returns the optimal XO value.
  *
- * @retval NRF_WIFI_STATUS_SUCCESS On Success
- * @retval NRF_WIFI_STATUS_FAIL On failure to execute command
+ * Once the firmware completes the XO tune, it reports a result status that
+ * indicates the outcome of the tuning procedure:
+ *	- 0: Success.
+ *	- 1: Tone not detected.
+ *	- 2: Gain failure (high).
+ *	- 3: Gain failure (low).
+ *	- 4: Gain failure (timeout).
+ *
+ * The detailed outcome is logged when the XO tune event is processed. Here,
+ * any non-success status (values 1 to 4) is mapped to @ref NRF_WIFI_STATUS_FAIL
+ * so that the caller can detect a failed tune from the return value.
+ *
+ * @retval NRF_WIFI_STATUS_SUCCESS On success (firmware reported status 0).
+ * @retval NRF_WIFI_STATUS_FAIL On failure to execute the command or when the
+ *	firmware reported a non-success XO tune status.
  */
 enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_compute_xo(
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx);

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/inc/radio_test/fmac_structs.h
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/inc/radio_test/fmac_structs.h
@@ -51,6 +51,12 @@ struct nrf_wifi_rt_fmac_dev_ctx {
 	enum nrf_wifi_cmd_status radio_cmd_status;
 	/** Firmware RF test RX capture event status */
 	unsigned char capture_status;
+	/** Firmware XO tune computed offset */
+	signed int xo_offset;
+	/** Firmware XO tune status (0=success, 1=tone not detected,
+	 *  2=gain fail (high), 3=gain fail (low), 4=gain fail (timeout))
+	 */
+	unsigned char xo_tune_status;
 };
 
 

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_api.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_api.c
@@ -419,6 +419,8 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_rx_cap(struct nrf_wifi_fmac_dev_ct
 						     unsigned short int capture_timeout,
 						     unsigned char lna_gain,
 						     unsigned char bb_gain,
+						     unsigned char ed_thresh_ofdm,
+						     unsigned char ed_thresh_dsss,
 						     unsigned char *capture_status)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -443,6 +445,8 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_rx_cap(struct nrf_wifi_fmac_dev_ct
 	rf_test_cap_params.cap_time = capture_timeout;
 	rf_test_cap_params.lna_gain = lna_gain;
 	rf_test_cap_params.bb_gain = bb_gain;
+	rf_test_cap_params.ed_thresh_ofdm = ed_thresh_ofdm;
+	rf_test_cap_params.ed_thresh_dsss = ed_thresh_dsss;
 	rf_test_cap_params.capture_addr = (unsigned int *)cap_data;
 
 	rt_dev_ctx->rf_test_type = rf_test_type;

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_api.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_api.c
@@ -601,6 +601,10 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_compute_xo(struct nrf_wifi_fmac_de
 		goto out;
 	}
 
+	if (rt_dev_ctx->xo_tune_status != 0) {
+		status = NRF_WIFI_STATUS_FAIL;
+	}
+
 out:
 	return status;
 }

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_api.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_api.c
@@ -19,7 +19,7 @@
 #include "util.h"
 
 #define RADIO_CMD_STATUS_TIMEOUT 5000
-
+#define RX_CAP_BYTES_PER_SAMPLE 4
 
 static enum nrf_wifi_status nrf_wifi_rt_fmac_fw_init(
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
@@ -447,7 +447,7 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_rx_cap(struct nrf_wifi_fmac_dev_ct
 
 	rt_dev_ctx->rf_test_type = rf_test_type;
 	rt_dev_ctx->rf_test_cap_data = cap_data;
-	rt_dev_ctx->rf_test_cap_sz = (num_samples * 3);
+	rt_dev_ctx->rf_test_cap_sz = (num_samples * RX_CAP_BYTES_PER_SAMPLE);
 	rt_dev_ctx->capture_status = 0;
 
 	status = umac_cmd_rt_prog_rf_test(fmac_dev_ctx,

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_api.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_api.c
@@ -485,7 +485,10 @@ out:
 enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_tx_tone(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 						      unsigned char enable,
 						      signed char tone_freq,
-						      signed char tx_power)
+						      signed char tx_power,
+						      unsigned char tone_type,
+						      signed char dc_offset_i,
+						      signed char dc_offset_q)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_rf_test_tx_params rf_test_tx_params;
@@ -508,6 +511,9 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_tx_tone(struct nrf_wifi_fmac_dev_c
 	rf_test_tx_params.tone_freq = tone_freq;
 	rf_test_tx_params.tx_pow = tx_power;
 	rf_test_tx_params.enabled = enable;
+	rf_test_tx_params.tone_type = tone_type;
+	rf_test_tx_params.dc_offset_i = dc_offset_i;
+	rf_test_tx_params.dc_offset_q = dc_offset_q;
 
 	rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_TX_TONE;
 	rt_dev_ctx->rf_test_cap_data = NULL;

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_event.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_event.c
@@ -97,9 +97,31 @@ static enum nrf_wifi_status umac_event_rt_rf_test_process(
 				(const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],
 				sizeof(rf_get_xo_value_params));
 
-		nrf_wifi_osal_log_info("Best XO value offset is = %d and status = %d",
-				rf_get_xo_value_params.xo_offset,
-				rf_get_xo_value_params.status);
+		def_dev_ctx->xo_offset = rf_get_xo_value_params.xo_offset;
+		def_dev_ctx->xo_tune_status = rf_get_xo_value_params.status;
+
+		switch (rf_get_xo_value_params.status) {
+		case 0:
+			nrf_wifi_osal_log_info("XO tune successful, optimal XO offset = %d",
+					       rf_get_xo_value_params.xo_offset);
+			break;
+		case 1:
+			nrf_wifi_osal_log_err("XO tune failed: tone not detected");
+			break;
+		case 2:
+			nrf_wifi_osal_log_err("XO tune failed: gain failure (high)");
+			break;
+		case 3:
+			nrf_wifi_osal_log_err("XO tune failed: gain failure (low)");
+			break;
+		case 4:
+			nrf_wifi_osal_log_err("XO tune failed: gain failure (timeout)");
+			break;
+		default:
+			nrf_wifi_osal_log_err("XO tune failed: unknown status (%d)",
+					      rf_get_xo_value_params.status);
+			break;
+		}
 		break;
 	default:
 		break;

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_event.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_event.c
@@ -92,7 +92,7 @@ static enum nrf_wifi_status umac_event_rt_rf_test_process(
 	case NRF_WIFI_RF_TEST_EVENT_TX_TONE_START:
 		break;
 
-	case NRF_WIFI_RF_TEST_XO_TUNE:
+	case NRF_WIFI_RF_TEST_EVENT_XO_TUNE:
 		nrf_wifi_osal_mem_cpy(&rf_get_xo_value_params,
 				(const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],
 				sizeof(rf_get_xo_value_params));

--- a/samples/wifi/radio_test/common/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/common/src/nrf_wifi_radio_test_shell.c
@@ -1228,10 +1228,10 @@ static int nrf_wifi_radio_test_set_tx(const struct shell *shell,
 
 	val = strtoul(argv[1], &ptr, 10);
 
-	if (val > 1) {
+	if (val != 0 && val != 1) {
 		shell_fprintf(shell,
 			      SHELL_ERROR,
-			      "Invalid value %lu\n",
+			      "Invalid value %lu (must be 0 or 1)\n",
 			      val);
 		shell_help(shell);
 		return -ENOEXEC;
@@ -1297,10 +1297,10 @@ static int nrf_wifi_radio_test_set_rx(const struct shell *shell,
 
 	val = strtoul(argv[1], &ptr, 10);
 
-	if (val > 1) {
+	if (val != 0 && val != 1) {
 		shell_fprintf(shell,
 			      SHELL_ERROR,
-			      "Invalid value %lu\n",
+			      "Invalid value %lu (must be 0 or 1)\n",
 			      val);
 		shell_help(shell);
 		return -ENOEXEC;

--- a/samples/wifi/radio_test/common/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/common/src/nrf_wifi_radio_test_shell.c
@@ -2482,6 +2482,31 @@ static int nrf_wifi_radio_test_set_rx_capture_ed_thresh(const struct shell *shel
 
 	return 0;
 }
+
+static int nrf_wifi_radio_test_set_rx_bss_check(const struct shell *shell,
+						size_t argc,
+						const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long rx_bss_check = 0;
+
+	rx_bss_check = strtoul(argv[1], &ptr, 10);
+
+	if ((rx_bss_check < 0) || (rx_bss_check > 1)) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "Invalid rx bss check setting\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(shell)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.bss_check_enable = rx_bss_check;
+
+	return 0;
+}
 #endif /* CONFIG_NRF71_RADIO_TEST */
 
 static int nrf_wifi_radio_test_show_cfg(const struct shell *shell,
@@ -2740,6 +2765,11 @@ static int nrf_wifi_radio_test_show_cfg(const struct shell *shell,
 		      SHELL_INFO,
 		      "ed_thresh_dsss = %d\n",
 		      conf_params->ed_thresh_dsss);
+
+	shell_fprintf(shell,
+		      SHELL_INFO,
+		      "rx_bss_check = %d\n",
+		      conf_params->bss_check_enable);
 #endif /* CONFIG_NRF71_RADIO_TEST */
 	return 0;
 }
@@ -3299,6 +3329,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "<ofdm> <dsss> - ED thresholds dynamic packet capture (-100..0)",
 		      nrf_wifi_radio_test_set_rx_capture_ed_thresh,
 		      3,
+		      0),
+	SHELL_CMD_ARG(rx_bss_check,
+		      NULL,
+		      "<val> - BSS check (0=disable, 1=enable)",
+		      nrf_wifi_radio_test_set_rx_bss_check,
+		      2,
 		      0),
 #endif /* CONFIG_NRF71_RADIO_TEST */
 	SHELL_SUBCMD_SET_END);

--- a/samples/wifi/radio_test/common/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/common/src/nrf_wifi_radio_test_shell.c
@@ -27,6 +27,16 @@ struct nrf_wifi_ctx_zep *ctx = &rpu_drv_priv_zep.rpu_ctx_zep;
 
 #define NRF_WIFI_RADIO_TEST_INIT_TIMEOUT_MS 5000
 
+#ifdef CONFIG_NRF71_RADIO_TEST
+#define rt_mem_alloc(size) k_malloc(size)
+#define rt_mem_free(ptr) k_free(ptr)
+#define RX_CAP_BYTES_PER_SAMPLE 4
+#else
+#define rt_mem_alloc(size) nrf_wifi_osal_mem_zalloc(size)
+#define rt_mem_free(ptr) nrf_wifi_osal_mem_free(ptr)
+#define RX_CAP_BYTES_PER_SAMPLE 3
+#endif
+
 static bool check_test_in_prog(const struct shell *shell)
 {
 	if (ctx->conf_params.rx) {
@@ -407,170 +417,6 @@ static int nrf_wifi_radio_test_set_defaults(const struct shell *shell,
 		return -ENOEXEC;
 	}
 
-	return 0;
-}
-
-
-static int nrf_wifi_radio_test_set_phy_calib_rxdc(const struct shell *shell,
-						  size_t argc,
-						  const char *argv[])
-{
-	char *ptr = NULL;
-	unsigned long phy_calib_rxdc = 0;
-
-	phy_calib_rxdc = strtoul(argv[1], &ptr, 10);
-
-	if (phy_calib_rxdc > 1) {
-		shell_fprintf(shell,
-			      SHELL_ERROR,
-			      "Invalid PHY RX DC calibration value(%lu).\n",
-			      phy_calib_rxdc);
-		shell_help(shell);
-		return -ENOEXEC;
-	}
-
-	if (!check_test_in_prog(shell)) {
-		return -ENOEXEC;
-	}
-
-	if (phy_calib_rxdc)
-		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
-					     NRF_WIFI_PHY_CALIB_FLAG_RXDC);
-	else
-		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
-					     ~(NRF_WIFI_PHY_CALIB_FLAG_RXDC));
-
-	return 0;
-}
-
-
-static int nrf_wifi_radio_test_set_phy_calib_txdc(const struct shell *shell,
-						  size_t argc,
-						  const char *argv[])
-{
-	char *ptr = NULL;
-	unsigned long phy_calib_txdc = 0;
-
-	phy_calib_txdc = strtoul(argv[1], &ptr, 10);
-
-	if (phy_calib_txdc > 1) {
-		shell_fprintf(shell,
-			      SHELL_ERROR,
-			      "Invalid PHY TX DC calibration value(%lu).\n",
-			      phy_calib_txdc);
-		shell_help(shell);
-		return -ENOEXEC;
-	}
-
-	if (!check_test_in_prog(shell)) {
-		return -ENOEXEC;
-	}
-
-	if (phy_calib_txdc)
-		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
-					     NRF_WIFI_PHY_CALIB_FLAG_TXDC);
-	else
-		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
-					     ~(NRF_WIFI_PHY_CALIB_FLAG_TXDC));
-
-	return 0;
-}
-
-
-static int nrf_wifi_radio_test_set_phy_calib_txpow(const struct shell *shell,
-						   size_t argc,
-						   const char *argv[])
-{
-	char *ptr = NULL;
-	unsigned long phy_calib_txpow = 0;
-
-	phy_calib_txpow = strtoul(argv[1], &ptr, 10);
-
-	if (phy_calib_txpow > 1) {
-		shell_fprintf(shell,
-			      SHELL_ERROR,
-			      "Invalid PHY TX power calibration value(%lu).\n",
-			      phy_calib_txpow);
-		shell_help(shell);
-		return -ENOEXEC;
-	}
-
-	if (!check_test_in_prog(shell)) {
-		return -ENOEXEC;
-	}
-
-	if (phy_calib_txpow)
-		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
-					     NRF_WIFI_PHY_CALIB_FLAG_TXPOW);
-	else
-		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
-					     ~(NRF_WIFI_PHY_CALIB_FLAG_TXPOW));
-
-	return 0;
-}
-
-
-static int nrf_wifi_radio_test_set_phy_calib_rxiq(const struct shell *shell,
-						  size_t argc,
-						  const char *argv[])
-{
-	char *ptr = NULL;
-	unsigned long phy_calib_rxiq = 0;
-
-	phy_calib_rxiq = strtoul(argv[1], &ptr, 10);
-
-	if (phy_calib_rxiq > 1) {
-		shell_fprintf(shell,
-			      SHELL_ERROR,
-			      "Invalid PHY RX IQ calibration value(%lu).\n",
-			      phy_calib_rxiq);
-		shell_help(shell);
-		return -ENOEXEC;
-	}
-
-	if (!check_test_in_prog(shell)) {
-		return -ENOEXEC;
-	}
-
-	if (phy_calib_rxiq)
-		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
-					     NRF_WIFI_PHY_CALIB_FLAG_RXIQ);
-	else
-		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
-					     ~(NRF_WIFI_PHY_CALIB_FLAG_RXIQ));
-
-	return 0;
-}
-
-
-static int nrf_wifi_radio_test_set_phy_calib_txiq(const struct shell *shell,
-						  size_t argc,
-						  const char *argv[])
-{
-	char *ptr = NULL;
-	unsigned long phy_calib_txiq = 0;
-
-	phy_calib_txiq = strtoul(argv[1], &ptr, 10);
-
-	if (phy_calib_txiq > 1) {
-		shell_fprintf(shell,
-			      SHELL_ERROR,
-			      "Invalid PHY TX IQ calibration value(%lu).\n",
-			      phy_calib_txiq);
-		shell_help(shell);
-		return -ENOEXEC;
-	}
-
-	if (!check_test_in_prog(shell)) {
-		return -ENOEXEC;
-	}
-
-	if (phy_calib_txiq)
-		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
-					     NRF_WIFI_PHY_CALIB_FLAG_TXIQ);
-	else
-		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
-					     ~(NRF_WIFI_PHY_CALIB_FLAG_TXIQ));
 	return 0;
 }
 
@@ -1494,7 +1340,7 @@ static int nrf_wifi_radio_test_sr_ant_switch_ctrl(const struct shell *shell,
 }
 #endif /* CONFIG_NRF70_SR_COEX_RF_SWITCH || CONFIG_NRF71_SR_COEX_RF_SWITCH */
 
-#if defined(CONFIG_NRF70_SR_COEX) || defined(CONFIG_NRF71_SR_COEX)
+#if defined(CONFIG_NRF70_SR_COEX)
 static int nrf_wifi_radio_test_config_pta(const struct shell *shell,
 					  size_t argc,
 					  const char *argv[])
@@ -1567,7 +1413,7 @@ static int nrf_wifi_radio_test_config_pta(const struct shell *shell,
 	result = result_non_pta & result_pta;
 	return result;
 }
-#endif /* CONFIG_NRF70_SR_COEX || CONFIG_NRF71_SR_COEX */
+#endif /* CONFIG_NRF70_SR_COEX */
 
 static int nrf_wifi_radio_test_rx_cap(const struct shell *shell,
 				      size_t argc,
@@ -1618,29 +1464,18 @@ static int nrf_wifi_radio_test_rx_cap(const struct shell *shell,
 		goto out;
 	}
 
-#ifdef CONFIG_NRF71_RADIO_TEST
-	rx_cap_buf = k_malloc((ctx->conf_params.capture_length * 3));
-	if (!rx_cap_buf) {
-		shell_fprintf(shell,
-			      SHELL_ERROR,
-			      "%s: Unable to allocate (%d) bytes for RX capture\n",
-			      __func__,
-			      (ctx->conf_params.capture_length * 3));
-		goto out;
-	}
-	memset(rx_cap_buf, 0, (ctx->conf_params.capture_length * 3));
-#else
-	rx_cap_buf = nrf_wifi_osal_mem_zalloc((ctx->conf_params.capture_length * 3));
+	rx_cap_buf = rt_mem_alloc(ctx->conf_params.capture_length *
+				  RX_CAP_BYTES_PER_SAMPLE);
 
 	if (!rx_cap_buf) {
 		shell_fprintf(shell,
 			      SHELL_ERROR,
 			      "%s: Unable to allocate (%d) bytes for RX capture\n",
 			      __func__,
-			      (ctx->conf_params.capture_length * 3));
+			      (ctx->conf_params.capture_length *
+			       RX_CAP_BYTES_PER_SAMPLE));
 		goto out;
 	}
-#endif /* CONFIG_NRF71_RADIO_TEST */
 
 	ctx->rf_test_run = true;
 	ctx->rf_test = NRF_WIFI_RF_TEST_RX_ADC_CAP;
@@ -1694,11 +1529,7 @@ static int nrf_wifi_radio_test_rx_cap(const struct shell *shell,
 	ret = 0;
 out:
 	if (rx_cap_buf) {
-#ifdef CONFIG_NRF71_RADIO_TEST
-		k_free(rx_cap_buf);
-#else
-		nrf_wifi_osal_mem_free(rx_cap_buf);
-#endif /* CONFIG_NRF71_RADIO_TEST */
+		rt_mem_free(rx_cap_buf);
 	}
 	ctx->rf_test_run = false;
 	ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
@@ -1762,6 +1593,171 @@ out:
 
 
 #ifndef CONFIG_NRF71_RADIO_TEST
+static int nrf_wifi_radio_test_set_phy_calib_rxdc(const struct shell *shell,
+						  size_t argc,
+						  const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long phy_calib_rxdc = 0;
+
+	phy_calib_rxdc = strtoul(argv[1], &ptr, 10);
+
+	if (phy_calib_rxdc > 1) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "Invalid PHY RX DC calibration value(%lu).\n",
+			      phy_calib_rxdc);
+		shell_help(shell);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(shell)) {
+		return -ENOEXEC;
+	}
+
+	if (phy_calib_rxdc) {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
+					     NRF_WIFI_PHY_CALIB_FLAG_RXDC);
+	} else {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
+					     ~(NRF_WIFI_PHY_CALIB_FLAG_RXDC));
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_phy_calib_txdc(const struct shell *shell,
+						  size_t argc,
+						  const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long phy_calib_txdc = 0;
+
+	phy_calib_txdc = strtoul(argv[1], &ptr, 10);
+
+	if (phy_calib_txdc > 1) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "Invalid PHY TX DC calibration value(%lu).\n",
+			      phy_calib_txdc);
+		shell_help(shell);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(shell)) {
+		return -ENOEXEC;
+	}
+
+	if (phy_calib_txdc) {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
+					     NRF_WIFI_PHY_CALIB_FLAG_TXDC);
+	} else {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
+					     ~(NRF_WIFI_PHY_CALIB_FLAG_TXDC));
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_phy_calib_txpow(const struct shell *shell,
+						   size_t argc,
+						   const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long phy_calib_txpow = 0;
+
+	phy_calib_txpow = strtoul(argv[1], &ptr, 10);
+
+	if (phy_calib_txpow > 1) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "Invalid PHY TX power calibration value(%lu).\n",
+			      phy_calib_txpow);
+		shell_help(shell);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(shell)) {
+		return -ENOEXEC;
+	}
+
+	if (phy_calib_txpow) {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
+					     NRF_WIFI_PHY_CALIB_FLAG_TXPOW);
+	} else {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
+					     ~(NRF_WIFI_PHY_CALIB_FLAG_TXPOW));
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_phy_calib_rxiq(const struct shell *shell,
+						  size_t argc,
+						  const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long phy_calib_rxiq = 0;
+
+	phy_calib_rxiq = strtoul(argv[1], &ptr, 10);
+
+	if (phy_calib_rxiq > 1) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "Invalid PHY RX IQ calibration value(%lu).\n",
+			      phy_calib_rxiq);
+		shell_help(shell);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(shell)) {
+		return -ENOEXEC;
+	}
+
+	if (phy_calib_rxiq) {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
+					     NRF_WIFI_PHY_CALIB_FLAG_RXIQ);
+	} else {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
+					     ~(NRF_WIFI_PHY_CALIB_FLAG_RXIQ));
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_phy_calib_txiq(const struct shell *shell,
+						  size_t argc,
+						  const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long phy_calib_txiq = 0;
+
+	phy_calib_txiq = strtoul(argv[1], &ptr, 10);
+
+	if (phy_calib_txiq > 1) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "Invalid PHY TX IQ calibration value(%lu).\n",
+			      phy_calib_txiq);
+		shell_help(shell);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(shell)) {
+		return -ENOEXEC;
+	}
+
+	if (phy_calib_txiq) {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
+					     NRF_WIFI_PHY_CALIB_FLAG_TXIQ);
+	} else {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
+					     ~(NRF_WIFI_PHY_CALIB_FLAG_TXIQ));
+	}
+
+	return 0;
+}
+
 static int nrf_wifi_radio_set_dpd(const struct shell *shell,
 				  size_t argc,
 				  const char *argv[])
@@ -1959,41 +1955,7 @@ out:
 
 	return ret;
 }
-#endif /* CONFIG_NRF71_RADIO_TEST */
 
-static int nrf_wifi_radio_comp_opt_xo_val(const struct shell *shell,
-					  size_t argc,
-					  const char *argv[])
-{
-	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
-
-	int ret = -ENOEXEC;
-
-	if (!check_test_in_prog(shell)) {
-		goto out;
-	}
-
-	ctx->rf_test_run = true;
-	ctx->rf_test = NRF_WIFI_RF_TEST_XO_TUNE;
-
-	status = nrf_wifi_rt_fmac_rf_test_compute_xo(ctx->rpu_ctx);
-
-	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		shell_fprintf(shell,
-			      SHELL_ERROR,
-			      "XO value computation failed\n");
-		goto out;
-	}
-
-	ret = 0;
-out:
-	ctx->rf_test_run = false;
-	ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
-
-	return ret;
-}
-
-#ifndef CONFIG_NRF71_RADIO_TEST
 static int nrf_wifi_radio_test_set_ant_gain(const struct shell *shell,
 					    size_t argc,
 					    const char *argv[])
@@ -2047,7 +2009,84 @@ static int nrf_wifi_radio_test_set_edge_bo(const struct shell *shell,
 
 	return 0;
 }
+
+/* See enum CD2CM_MSG_ID_T in RPU Coexistence Manager API */
+#define CD2CM_UPDATE_SWITCH_CONFIG 0x7
+static int nrf_wifi_radio_test_wlan_switch_ctrl(const struct shell *shell,
+						size_t argc,
+						const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	char *ptr = NULL;
+	struct coex_wlan_switch_ctrl params = { 0 };
+
+	if (argc < 2) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "Invalid number of parameters\n");
+		shell_help(shell);
+		return -ENOEXEC;
+	}
+
+	params.rpu_msg_id = CD2CM_UPDATE_SWITCH_CONFIG;
+	params.switch_A = strtoul(argv[1], &ptr, 10);
+
+	if (params.switch_A > 1) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "Invalid WLAN switch config (%d)\n",
+			      params.switch_A);
+		shell_help(shell);
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.wlan_ant_switch_ctrl = params.switch_A;
+
+	status = nrf_wifi_fmac_conf_srcoex(ctx->rpu_ctx,
+					   &params, sizeof(params));
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "WLAN switch configuration failed\n");
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
 #endif /* CONFIG_NRF71_RADIO_TEST */
+
+static int nrf_wifi_radio_comp_opt_xo_val(const struct shell *shell,
+					  size_t argc,
+					  const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+
+	int ret = -ENOEXEC;
+
+	if (!check_test_in_prog(shell)) {
+		goto out;
+	}
+
+	ctx->rf_test_run = true;
+	ctx->rf_test = NRF_WIFI_RF_TEST_XO_TUNE;
+
+	status = nrf_wifi_rt_fmac_rf_test_compute_xo(ctx->rpu_ctx);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "XO value computation failed\n");
+		goto out;
+	}
+
+	ret = 0;
+out:
+	ctx->rf_test_run = false;
+	ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
+
+	return ret;
+}
 
 #ifdef CONFIG_NRF71_RADIO_TEST
 static int nrf_wifi_radio_test_set_rx_bss_color(const struct shell *shell,
@@ -2371,6 +2410,32 @@ static int nrf_wifi_radio_test_show_cfg(const struct shell *shell,
 
 	shell_fprintf(shell,
 		      SHELL_INFO,
+		      "tx_pkt_num = %d\n",
+		      conf_params->tx_pkt_num);
+
+	shell_fprintf(shell,
+		      SHELL_INFO,
+		      "tx_pkt_len = %d\n",
+		      conf_params->tx_pkt_len);
+
+	shell_fprintf(shell,
+		      SHELL_INFO,
+		      "tx_power = %d\n",
+		      conf_params->tx_power);
+
+	shell_fprintf(shell,
+		      SHELL_INFO,
+		      "he_ltf = %d\n",
+		      conf_params->he_ltf);
+
+	shell_fprintf(shell,
+		      SHELL_INFO,
+		      "he_gi = %d\n",
+		      conf_params->he_gi);
+
+#ifndef CONFIG_NRF71_RADIO_TEST
+	shell_fprintf(shell,
+		      SHELL_INFO,
 		      "phy_calib_rxdc = %d\n",
 		      (conf_params->phy_calib &
 		       NRF_WIFI_PHY_CALIB_FLAG_RXDC) ? 1:0);
@@ -2401,34 +2466,13 @@ static int nrf_wifi_radio_test_show_cfg(const struct shell *shell,
 
 	shell_fprintf(shell,
 		      SHELL_INFO,
-		      "tx_pkt_num = %d\n",
-		      conf_params->tx_pkt_num);
-
-	shell_fprintf(shell,
-		      SHELL_INFO,
-		      "tx_pkt_len = %d\n",
-		      conf_params->tx_pkt_len);
-
-	shell_fprintf(shell,
-		      SHELL_INFO,
-		      "tx_power = %d\n",
-		      conf_params->tx_power);
-
-	shell_fprintf(shell,
-		      SHELL_INFO,
-		      "he_ltf = %d\n",
-		      conf_params->he_ltf);
-
-	shell_fprintf(shell,
-		      SHELL_INFO,
-		      "he_gi = %d\n",
-		      conf_params->he_gi);
-
-#ifndef CONFIG_NRF71_RADIO_TEST
-	shell_fprintf(shell,
-		      SHELL_INFO,
 		      "xo_val = %d\n",
 		      conf_params->rf_params[NRF_WIFI_XO_FREQ_BYTE_OFFSET]);
+
+	shell_fprintf(shell,
+		      SHELL_INFO,
+		      "wlan_ant_switch_ctrl = %d\n",
+		      conf_params->wlan_ant_switch_ctrl);
 #endif /* CONFIG_NRF71_RADIO_TEST */
 
 	shell_fprintf(shell,
@@ -2479,10 +2523,6 @@ static int nrf_wifi_radio_test_show_cfg(const struct shell *shell,
 		      conf_params->sr_ant_switch_ctrl);
 #endif /* CONFIG_BOARD_NRF7002DK_NRF5340_CPUAPP_NRF7001 || CONFIG_BOARD_NRF7002DK_NRF5340_CPUAPP */
 
-	shell_fprintf(shell,
-		      SHELL_INFO,
-		      "wlan_ant_switch_ctrl = %d\n",
-		      conf_params->wlan_ant_switch_ctrl);
 	shell_fprintf(shell,
 		      SHELL_INFO,
 		      "tx_pkt_cw = %d\n",
@@ -2608,52 +2648,6 @@ static int nrf_wifi_radio_test_get_stats(const struct shell *shell,
 	return 0;
 }
 
-/* See enum CD2CM_MSG_ID_T in RPU Coexistence Manager API */
-#define CD2CM_UPDATE_SWITCH_CONFIG 0x7
-static int nrf_wifi_radio_test_wlan_switch_ctrl(const struct shell *shell,
-						size_t argc,
-						const char *argv[])
-{
-	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
-	char *ptr = NULL;
-	struct coex_wlan_switch_ctrl params = { 0 };
-
-	if (argc < 2) {
-		shell_fprintf(shell,
-			      SHELL_ERROR,
-			      "Invalid number of parameters\n");
-		shell_help(shell);
-		return -ENOEXEC;
-	}
-
-	params.rpu_msg_id = CD2CM_UPDATE_SWITCH_CONFIG;
-	params.switch_A = strtoul(argv[1], &ptr, 10);
-
-	if (params.switch_A > 1) {
-		shell_fprintf(shell,
-			      SHELL_ERROR,
-			      "Invalid WLAN switch config (%d)\n",
-			      params.switch_A);
-		shell_help(shell);
-		return -ENOEXEC;
-	}
-
-	ctx->conf_params.wlan_ant_switch_ctrl = params.switch_A;
-
-	status = nrf_wifi_fmac_conf_srcoex(ctx->rpu_ctx,
-					   &params, sizeof(params));
-
-	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		shell_fprintf(shell,
-			      SHELL_ERROR,
-			      "WLAN switch configuration failed\n");
-		return -ENOEXEC;
-	}
-
-	return 0;
-}
-
-
 static int nrf_wifi_radio_test_set_reg_domain(const struct shell *shell,
 					      size_t argc,
 					      const char *argv[])
@@ -2737,41 +2731,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "Reset configuration parameter to their default values",
 		      nrf_wifi_radio_test_set_defaults,
 		      1,
-		      0),
-	SHELL_CMD_ARG(phy_calib_rxdc,
-		      NULL,
-		      "0 - Disable RX DC calibration\n"
-		      "1 - Enable RX DC calibration",
-		      nrf_wifi_radio_test_set_phy_calib_rxdc,
-		      2,
-		      0),
-	SHELL_CMD_ARG(phy_calib_txdc,
-		      NULL,
-		      "0 - Disable TX DC calibration\n"
-		      "1 - Enable TX DC calibration",
-		      nrf_wifi_radio_test_set_phy_calib_txdc,
-		      2,
-		      0),
-	SHELL_CMD_ARG(phy_calib_txpow,
-		      NULL,
-		      "0 - Disable TX power calibration\n"
-		      "1 - Enable TX power calibration",
-		      nrf_wifi_radio_test_set_phy_calib_txpow,
-		      2,
-		      0),
-	SHELL_CMD_ARG(phy_calib_rxiq,
-		      NULL,
-		      "0 - Disable RX IQ calibration\n"
-		      "1 - Enable RX IQ calibration",
-		      nrf_wifi_radio_test_set_phy_calib_rxiq,
-		      2,
-		      0),
-	SHELL_CMD_ARG(phy_calib_txiq,
-		      NULL,
-		      "0 - Disable TX IQ calibration\n"
-		      "1 - Enable TX IQ calibration",
-		      nrf_wifi_radio_test_set_phy_calib_txiq,
-		      2,
 		      0),
 	SHELL_CMD_ARG(he_ltf,
 		      NULL,
@@ -2913,7 +2872,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      0),
 #endif /* CONFIG_NRF70_SR_COEX_RF_SWITCH || CONFIG_NRF71_SR_COEX_RF_SWITCH */
 
-#if defined(CONFIG_NRF70_SR_COEX) || defined(CONFIG_NRF71_SR_COEX)
+#if defined(CONFIG_NRF70_SR_COEX)
 	SHELL_CMD_ARG(config_pta,
 		      NULL,
 		      " - <val> - Wi-Fi operating band 0: 2.4GHz, 1: 5GHz\n"
@@ -2922,7 +2881,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      nrf_wifi_radio_test_config_pta,
 		      4,
 		      0),
-#endif /* CONFIG_NRF70_SR_COEX || CONFIG_NRF71_SR_COEX */
+#endif /* CONFIG_NRF70_SR_COEX */
 
 	SHELL_CMD_ARG(rx_lna_gain,
 		      NULL,
@@ -2979,6 +2938,41 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      2,
 		      0),
 #ifndef CONFIG_NRF71_RADIO_TEST
+	SHELL_CMD_ARG(phy_calib_rxdc,
+		      NULL,
+		      "0 - Disable RX DC calibration\n"
+		      "1 - Enable RX DC calibration",
+		      nrf_wifi_radio_test_set_phy_calib_rxdc,
+		      2,
+		      0),
+	SHELL_CMD_ARG(phy_calib_txdc,
+		      NULL,
+		      "0 - Disable TX DC calibration\n"
+		      "1 - Enable TX DC calibration",
+		      nrf_wifi_radio_test_set_phy_calib_txdc,
+		      2,
+		      0),
+	SHELL_CMD_ARG(phy_calib_txpow,
+		      NULL,
+		      "0 - Disable TX power calibration\n"
+		      "1 - Enable TX power calibration",
+		      nrf_wifi_radio_test_set_phy_calib_txpow,
+		      2,
+		      0),
+	SHELL_CMD_ARG(phy_calib_rxiq,
+		      NULL,
+		      "0 - Disable RX IQ calibration\n"
+		      "1 - Enable RX IQ calibration",
+		      nrf_wifi_radio_test_set_phy_calib_rxiq,
+		      2,
+		      0),
+	SHELL_CMD_ARG(phy_calib_txiq,
+		      NULL,
+		      "0 - Disable TX IQ calibration\n"
+		      "1 - Enable TX IQ calibration",
+		      nrf_wifi_radio_test_set_phy_calib_txiq,
+		      2,
+		      0),
 	SHELL_CMD_ARG(dpd,
 		      NULL,
 		      "0 - Bypass DPD\n"
@@ -3010,6 +3004,24 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      nrf_wifi_radio_set_xo_val,
 		      2,
 		      0),
+	SHELL_CMD_ARG(set_ant_gain,
+		      NULL,
+		      "<val> - Antenna gain in dB (Min: 0, Max: 6)",
+		      nrf_wifi_radio_test_set_ant_gain,
+		      2,
+		      0),
+	SHELL_CMD_ARG(set_edge_bo,
+		      NULL,
+		      "<val> - Edge backoff in dB (Min: 0, Max: 10)",
+		      nrf_wifi_radio_test_set_edge_bo,
+		      2,
+		      0),
+	SHELL_CMD_ARG(wlan_ant_switch_ctrl,
+		      NULL,
+		      "Configure WLAN antenna switch (0-separate/1-shared)",
+		      nrf_wifi_radio_test_wlan_switch_ctrl,
+		      2,
+		      0),
 #endif /* CONFIG_NRF71_RADIO_TEST */
 	SHELL_CMD_ARG(compute_optimal_xo_val,
 		      NULL,
@@ -3028,12 +3040,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "Display statistics",
 		      nrf_wifi_radio_test_get_stats,
 		      1,
-		      0),
-	SHELL_CMD_ARG(wlan_ant_switch_ctrl,
-		      NULL,
-		      "Configure WLAN antenna switch (0-separate/1-shared)",
-		      nrf_wifi_radio_test_wlan_switch_ctrl,
-		      2,
 		      0),
 	SHELL_CMD_ARG(tx_pkt_cw,
 		      NULL,
@@ -3057,20 +3063,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      nrf_wifi_radio_test_set_bypass_reg,
 		      2,
 		      0),
-#ifndef CONFIG_NRF71_RADIO_TEST
-	SHELL_CMD_ARG(set_ant_gain,
-		      NULL,
-		      "<val> - Antenna gain in dB (Min: 0, Max: 6)",
-		      nrf_wifi_radio_test_set_ant_gain,
-		      2,
-		      0),
-	SHELL_CMD_ARG(set_edge_bo,
-		      NULL,
-		      "<val> - Edge backoff in dB (Min: 0, Max: 10)",
-		      nrf_wifi_radio_test_set_edge_bo,
-		      2,
-		      0),
-#endif /* CONFIG_NRF71_RADIO_TEST */
 #ifdef CONFIG_NRF71_RADIO_TEST
 	SHELL_CMD_ARG(rx_bss_color,
 		      NULL,

--- a/samples/wifi/radio_test/common/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/common/src/nrf_wifi_radio_test_shell.c
@@ -1134,7 +1134,14 @@ static int nrf_wifi_radio_test_init(const struct shell *shell,
 		status = nrf_wifi_rt_fmac_rf_test_tx_tone(ctx->rpu_ctx,
 						       0,
 						       ctx->conf_params.tx_tone_freq,
-						       ctx->conf_params.tx_power);
+						       ctx->conf_params.tx_power
+#ifdef CONFIG_NRF71_RADIO_TEST
+						       ,
+						       ctx->conf_params.tx_tone_type,
+						       ctx->conf_params.tx_tone_dc_offset_i,
+						       ctx->conf_params.tx_tone_dc_offset_q
+#endif /* CONFIG_NRF71_RADIO_TEST */
+						       );
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			shell_fprintf(shell,
@@ -1569,7 +1576,14 @@ static int nrf_wifi_radio_test_tx_tone(const struct shell *shell,
 	status = nrf_wifi_rt_fmac_rf_test_tx_tone(ctx->rpu_ctx,
 					       (unsigned char)val,
 					       ctx->conf_params.tx_tone_freq,
-					       ctx->conf_params.tx_power);
+					       ctx->conf_params.tx_power
+#ifdef CONFIG_NRF71_RADIO_TEST
+					       ,
+					       ctx->conf_params.tx_tone_type,
+					       ctx->conf_params.tx_tone_dc_offset_i,
+					       ctx->conf_params.tx_tone_dc_offset_q
+#endif /* CONFIG_NRF71_RADIO_TEST */
+					       );
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		shell_fprintf(shell,
@@ -2356,6 +2370,80 @@ static int nrf_wifi_radio_test_set_tx_fec_coding(const struct shell *shell,
 
 	return 0;
 }
+
+static int nrf_wifi_radio_test_set_tx_tone_type(const struct shell *shell,
+						size_t argc,
+						const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val > 2) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "'tx_tone_type' has to be 0 (complex), "
+			      "1 (real-only), or 2 (imag-only)\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(shell)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.tx_tone_type = (unsigned char)val;
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_tx_tone_dc_offset(const struct shell *shell,
+						     size_t argc,
+						     const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long mode = 0;
+	long i_val = 0;
+	long q_val = 0;
+
+	mode = strtoul(argv[1], &ptr, 10);
+	if (mode > 3) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "'mode' must be 0 (no offsets), 1 (I only), 2 (Q only), 3 (both)\n");
+		return -ENOEXEC;
+	}
+
+	i_val = strtol(argv[2], &ptr, 10);
+	q_val = strtol(argv[3], &ptr, 10);
+
+	if ((i_val > 2047) || (i_val < -2048) || (q_val > 2047) || (q_val < -2048)) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "DC offset values must be in Q.11 range -2048 to 2047\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(shell)) {
+		return -ENOEXEC;
+	}
+
+	if (mode == 0) {
+		ctx->conf_params.tx_tone_dc_offset_i = 0;
+		ctx->conf_params.tx_tone_dc_offset_q = 0;
+	} else if (mode == 1) {
+		ctx->conf_params.tx_tone_dc_offset_i = (signed short int)i_val;
+		ctx->conf_params.tx_tone_dc_offset_q = 0;
+	} else if (mode == 2) {
+		ctx->conf_params.tx_tone_dc_offset_i = 0;
+		ctx->conf_params.tx_tone_dc_offset_q = (signed short int)q_val;
+	} else {
+		ctx->conf_params.tx_tone_dc_offset_i = (signed short int)i_val;
+		ctx->conf_params.tx_tone_dc_offset_q = (signed short int)q_val;
+	}
+
+	return 0;
+}
 #endif /* CONFIG_NRF71_RADIO_TEST */
 
 static int nrf_wifi_radio_test_show_cfg(const struct shell *shell,
@@ -2589,6 +2677,21 @@ static int nrf_wifi_radio_test_show_cfg(const struct shell *shell,
 		      SHELL_INFO,
 		      "tx_fec_padd_factor = %d\n",
 		      conf_params->tx_fec_padd_factor);
+
+	shell_fprintf(shell,
+		      SHELL_INFO,
+		      "tx_tone_type = %d\n",
+		      conf_params->tx_tone_type);
+
+	shell_fprintf(shell,
+		      SHELL_INFO,
+		      "tx_tone_dc_offset_i = %d\n",
+		      conf_params->tx_tone_dc_offset_i);
+
+	shell_fprintf(shell,
+		      SHELL_INFO,
+		      "tx_tone_dc_offset_q = %d\n",
+		      conf_params->tx_tone_dc_offset_q);
 #endif /* CONFIG_NRF71_RADIO_TEST */
 	return 0;
 }
@@ -3123,6 +3226,25 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "<val> -Set TX FEC coding (0=BCC, 1=LDPC)",
 		      nrf_wifi_radio_test_set_tx_fec_coding,
 		      2,
+		      0),
+	SHELL_CMD_ARG(tx_tone_type,
+		      NULL,
+		      "<val> - Tone type\n"
+		      "0 = Complex\n"
+		      "1 = Real-only\n"
+		      "2 = Imag-only",
+		      nrf_wifi_radio_test_set_tx_tone_type,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx_tone_dc_offset,
+		      NULL,
+		      "<mode> <DC_offset_i> <DC_offset_q>\n"
+		      "0 0 0 - No DC offsets\n"
+		      "1 <DC_offset_i> 0 - I only\n"
+		      "2 0 <DC_offset_q> - Q only\n"
+		      "3 <DC_offset_i> <DC_offset_q> - Both",
+		      nrf_wifi_radio_test_set_tx_tone_dc_offset,
+		      4,
 		      0),
 #endif /* CONFIG_NRF71_RADIO_TEST */
 	SHELL_SUBCMD_SET_END);

--- a/samples/wifi/radio_test/common/src/nrf_wifi_radio_test_shell.c
+++ b/samples/wifi/radio_test/common/src/nrf_wifi_radio_test_shell.c
@@ -1494,6 +1494,10 @@ static int nrf_wifi_radio_test_rx_cap(const struct shell *shell,
 					      ctx->conf_params.capture_timeout,
 					      ctx->conf_params.lna_gain,
 					      ctx->conf_params.bb_gain,
+#ifdef CONFIG_NRF71_RADIO_TEST
+					      ctx->conf_params.ed_thresh_ofdm,
+					      ctx->conf_params.ed_thresh_dsss,
+#endif /* CONFIG_NRF71_RADIO_TEST */
 					      &capture_status);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
@@ -2444,6 +2448,40 @@ static int nrf_wifi_radio_test_set_tx_tone_dc_offset(const struct shell *shell,
 
 	return 0;
 }
+
+static int nrf_wifi_radio_test_set_rx_capture_ed_thresh(const struct shell *shell,
+							size_t argc,
+							const char *argv[])
+{
+	char *ptr = NULL;
+	long ofdm = 0;
+	long dsss = 0;
+
+	ofdm = strtol(argv[1], &ptr, 10);
+	if (ofdm < -100 || ofdm > 0) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "'ed_thresh_ofdm' must be in -100..0\n");
+		return -ENOEXEC;
+	}
+
+	dsss = strtol(argv[2], &ptr, 10);
+	if (dsss < -100 || dsss > 0) {
+		shell_fprintf(shell,
+			      SHELL_ERROR,
+			      "'ed_thresh_dsss' must be in -100..0\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(shell)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.ed_thresh_ofdm = (unsigned char)((signed char)ofdm);
+	ctx->conf_params.ed_thresh_dsss = (unsigned char)((signed char)dsss);
+
+	return 0;
+}
 #endif /* CONFIG_NRF71_RADIO_TEST */
 
 static int nrf_wifi_radio_test_show_cfg(const struct shell *shell,
@@ -2692,6 +2730,16 @@ static int nrf_wifi_radio_test_show_cfg(const struct shell *shell,
 		      SHELL_INFO,
 		      "tx_tone_dc_offset_q = %d\n",
 		      conf_params->tx_tone_dc_offset_q);
+
+	shell_fprintf(shell,
+		      SHELL_INFO,
+		      "ed_thresh_ofdm = %d\n",
+		      conf_params->ed_thresh_ofdm);
+
+	shell_fprintf(shell,
+		      SHELL_INFO,
+		      "ed_thresh_dsss = %d\n",
+		      conf_params->ed_thresh_dsss);
 #endif /* CONFIG_NRF71_RADIO_TEST */
 	return 0;
 }
@@ -3245,6 +3293,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "3 <DC_offset_i> <DC_offset_q> - Both",
 		      nrf_wifi_radio_test_set_tx_tone_dc_offset,
 		      4,
+		      0),
+	SHELL_CMD_ARG(rx_capture_ed_thresh,
+		      NULL,
+		      "<ofdm> <dsss> - ED thresholds dynamic packet capture (-100..0)",
+		      nrf_wifi_radio_test_set_rx_capture_ed_thresh,
+		      3,
 		      0),
 #endif /* CONFIG_NRF71_RADIO_TEST */
 	SHELL_SUBCMD_SET_END);


### PR DESCRIPTION
[CAL-7228]
- Add separate file for nrf71
- Add new radio test shell commands and driver support for nrf71

[CAL-7228]: https://nordicsemi.atlassian.net/browse/CAL-7228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ