### PR TITLE
manifest: Update sdk-zephyr and nrf_wifi revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 56ce996672b5acd5c8f76d14dc568cf53a075bdc
+      revision: aa605a14b6fe5f2d988babeb56990a46d1d18d01
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -224,7 +224,7 @@ manifest:
       groups:
         - doc-internal
     - name: nrf_wifi
-      revision: 3fb784e4f908beea7c942063e4333d27b15be83c
+      revision: 4def032de959a5dcf6f804739ca67aef3b6bb187
       path: modules/lib/nrf_wifi
 
     # Other third-party repositories.

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a8d9f5e138572ae55ac33f3b88b3a8954272de30
+      revision: pull/4252/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -224,7 +224,7 @@ manifest:
       groups:
         - doc-internal
     - name: nrf_wifi
-      revision: 7c26fb42f2b4265790ff2b401017a33dd046df29
+      revision: pull/4/head
       path: modules/lib/nrf_wifi
 
     # Other third-party repositories.


### PR DESCRIPTION
[SHEL-4260] Update revision for extended sleep interval support.

[SHEL-4260]: https://nordicsemi.atlassian.net/browse/SHEL-4260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ