### PR TITLE
bluetooth: Allow using bt_conn_ctx_get to probe context allocation

### DIFF
--- a/include/bluetooth/conn_ctx.h
+++ b/include/bluetooth/conn_ctx.h
@@ -126,6 +126,9 @@ void bt_conn_ctx_free_all(struct bt_conn_ctx_lib *ctx_lib);
  * This function finds a connection's context data in the memory pool.
  * The link to find is identified by the connection object.
  *
+ * This function can also be used to check whether a context has been
+ * allocated for a connection.
+ *
  * This function should be used in conjunction with
  * @ref bt_conn_ctx_release to ensure proper operation.
  *
@@ -133,7 +136,8 @@ void bt_conn_ctx_free_all(struct bt_conn_ctx_lib *ctx_lib);
  * @param conn		Bluetooth connection.
  *
  * @return Pointer to the connection context data if the operation
- *         was successful. Otherwise NULL.
+ *         was successful.
+ *         NULL if no context was allocated for the connection.
  */
 void *bt_conn_ctx_get(struct bt_conn_ctx_lib *ctx_lib, struct bt_conn *conn);
 

--- a/subsys/bluetooth/conn_ctx.c
+++ b/subsys/bluetooth/conn_ctx.c
@@ -123,7 +123,7 @@ void *bt_conn_ctx_get(struct bt_conn_ctx_lib *ctx_lib, struct bt_conn *conn)
 		}
 	}
 
-	LOG_WRN("No memory block for connection");
+	LOG_DBG("No context allocated for connection");
 
 	k_mutex_unlock(ctx_lib->mutex);
 


### PR DESCRIPTION
bt_conn_ctx_get() may legitimately return NULL when no context has been
allocated for a connection, for example when checking whether allocation
is needed. Treat that as normal usage rather than a warning condition.

Downgrade the missing-context log from WRN to DBG and align the message
with the API semantics ("No context allocated for connection").

Document that NULL means no context was allocated and that the function
can be used to check allocation status.