### PR TITLE
quarantine_windows: Remove carrier sample from quarantine

### DIFF
--- a/scripts/quarantine_windows_mac.yaml
+++ b/scripts/quarantine_windows_mac.yaml
@@ -27,9 +27,3 @@
     - thingy53/nrf5340/cpuapp/ns
     - thingy53/nrf5340/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/SHEL-3161"
-
-- scenarios:
-    - sample.cellular.lwm2m_carrier.shell
-  platforms:
-    - nrf9151dk/nrf9151/ns
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39639"


### PR DESCRIPTION
This build failure has not been reproduced. As the build failure was related to partition manager which has since been disabled in the sample, it seems unlikely that this issue will reappear.