### PR TITLE
gitignore: ignore AI assistant tool directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,18 @@ tags
 .xxproject
 .envrc
 .vscode
+
+# AI assistant / IDE tool directories
+.cursor
+.claude
+.nordic-skills-library
+.aider*
+.continue
+.windsurf
+.codex
+.cline
+.roo
+
 sanity-out*
 twister-out*
 


### PR DESCRIPTION
Add entries for .cursor, .claude, .nordic-skills-library, and other common AI coding assistant configuration directories.