### PR TITLE
net: nrf_provisioning: Add bounds check

### DIFF
--- a/subsys/net/lib/nrf_provisioning/nrf_provisioning_cbor.cddl
+++ b/subsys/net/lib/nrf_provisioning/nrf_provisioning_cbor.cddl
@@ -29,7 +29,7 @@ command_with_nonce = [at_command / config / finished, nonce]
 
 ;============================;
 
-correlation = (correlation_id: tstr)
+correlation = (correlation_id: tstr .size (0..45))
 
 command = [correlation, at_command / config / finished]
 

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_cbor_decode.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_cbor_decode.c
@@ -108,10 +108,14 @@ static bool decode_command(zcbor_state_t *state, struct command *result)
 
 	bool res = ((
 		(zcbor_list_start_decode(state) &&
-		 ((((zcbor_tstr_decode(state, (&(*result).command_correlation_m)))) &&
+		 ((((zcbor_tstr_decode(state, (&(*result).command_correlation_m))) &&
+		    ((((((*result).command_correlation_m.len >= 0) &&
+			((*result).command_correlation_m.len <= 45)) ||
+		       (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))) ||
+		     (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))) &&
 		   ((zcbor_union_start_code(state) &&
-		     (int_res = ((((decode_at_command(state,
-						      (&(*result).command_union_at_command_m)))) &&
+		     (int_res = ((((decode_at_command(
+					  state, (&(*result).command_union_at_command_m)))) &&
 				  (((*result).command_union_choice = command_union_at_command_m_c),
 				   true)) ||
 				 (zcbor_union_elem_code(state) &&

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_cbor_encode.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_cbor_encode.c
@@ -65,7 +65,11 @@ static bool encode_response(zcbor_state_t *state, const struct response *input)
 
 	bool res = ((
 		(zcbor_list_start_encode(state, 4) &&
-		 ((((zcbor_tstr_encode(state, (&(*input).response_correlation_m)))) &&
+		 (((((((((*input).response_correlation_m.len >= 0) &&
+			((*input).response_correlation_m.len <= 45)) ||
+		       (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))) ||
+		     (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false)) &&
+		    (zcbor_tstr_encode(state, (&(*input).response_correlation_m)))) &&
 		   ((((*input).response_union_choice == response_union_error_response_m_c)
 			     ? ((encode_error_response(
 				       state, (&(*input).response_union_error_response_m))))

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
@@ -295,7 +295,8 @@ static void coap_callback(const struct coap_client_response_data *data, void *us
 				coap_ctx->response_len = 0;
 			}
 
-			if (coap_ctx->response_len + data->payload_len > coap_ctx->rx_buf_len) {
+			if (data->offset > coap_ctx->rx_buf_len ||
+			    data->payload_len > coap_ctx->rx_buf_len - data->offset) {
 				LOG_ERR("RX buffer too small");
 				coap_ctx->code = -ENOMEM;
 				k_sem_give(&coap_response);
@@ -304,7 +305,8 @@ static void coap_callback(const struct coap_client_response_data *data, void *us
 
 			memcpy(coap_ctx->rx_buf + data->offset, data->payload, data->payload_len);
 			coap_ctx->response = coap_ctx->rx_buf;
-			coap_ctx->response_len += data->payload_len;
+			coap_ctx->response_len = MAX(coap_ctx->response_len,
+						     data->offset + data->payload_len);
 		} else {
 			LOG_DBG("Operation successful");
 			coap_ctx->response_len = 0;

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
@@ -527,11 +527,18 @@ int nrf_provisioning_codec_process_commands(void)
 		}
 
 		/* Mark as the latest successful provisioning command */
+		size_t corr_id_len = CDC_IFMT_CMD_I_GET(cctx, i)->command_correlation_m.len;
+
+		if (corr_id_len >= sizeof(nrf_provisioning_latest_corr_id)) {
+			LOG_ERR("Correlation ID too long: %zu bytes", corr_id_len);
+			ret = -ENOMEM;
+			goto stop_provisioning;
+		}
+
 		memcpy(nrf_provisioning_latest_corr_id,
 			CDC_IFMT_CMD_I_GET(cctx, i)->command_correlation_m.value,
-			CDC_IFMT_CMD_I_GET(cctx, i)->command_correlation_m.len);
-		nrf_provisioning_latest_corr_id[
-			CDC_IFMT_CMD_I_GET(cctx, i)->command_correlation_m.len] = '\0';
+			corr_id_len);
+		nrf_provisioning_latest_corr_id[corr_id_len] = '\0';
 	}
 
 stop_provisioning:


### PR DESCRIPTION
* codec: the correlation ID from decoded CBOR was copied into nrf_provisioning_latest_corr_id (plus a NUL terminator) without checking that it fits, allowing an overflow of the fixed buffer. Reject correlation IDs that do not fit and abort provisioning.

* coap: the block-wise receive path bounds-checked response_len + payload_len but wrote to rx_buf + offset. Since offset is an independent transport-controlled value, a block with a large offset and small payload could pass the check and still write past rx_buf. Validate offset + payload_len against rx_buf_len instead.

Limit correlation ID size in CBOR schema and regenerate the encoder/decoder sources from the updated schema.

Jira: SI-651