### PR TITLE
doc: samples: zephyr: net: Update Zephyr Wi-Fi samples documentation

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -486,7 +486,29 @@ Thread samples
 Wi-Fi samples
 -------------
 
-|no_changes_yet_note|
+* Removed support from the following Zephyr samples:
+
+  * :zephyr:code-sample:`dns-resolve`
+  * :zephyr:code-sample:`ipv4-autoconf`
+  * :zephyr:code-sample:`mdns-responder`
+  * :zephyr:code-sample:`mqtt-publisher`
+  * :zephyr:code-sample:`async-sockets-echo`
+  * :zephyr:code-sample:`sockets-echo-client`
+  * :zephyr:code-sample:`sockets-echo-server`
+  * :zephyr:code-sample:`sockets-http-get`
+  * :zephyr:code-sample:`sntp-client`
+  * :zephyr:code-sample:`syslog-net`
+  * :zephyr:code-sample:`telnet-console`
+
+* Removed support for the ``nrf5340dk/nrf5340/cpuapp`` board target with the nRF7002 EK shield from the following Zephyr samples:
+
+  * :zephyr:code-sample:`mqtt-sn-publisher`
+  * :zephyr:code-sample:`coap-server`
+
+* Added support for the ``nrf7120dk/nrf7120/cpuapp`` board target in the following Zephyr samples:
+
+  * :zephyr:code-sample:`mqtt-sn-publisher`
+  * :zephyr:code-sample:`coap-server`
 
 Other samples
 -------------

--- a/doc/nrf/samples/wifi_zephyr.rst
+++ b/doc/nrf/samples/wifi_zephyr.rst
@@ -8,21 +8,10 @@ Wi-Fi: Zephyr networking samples
    :depth: 2
 
 In addition to |NCS| samples, it is possible to run selected networking samples with Wi-Fi®, provided and maintained as part of the upstream Zephyr project.
-The following list specifies samples that are currently supported with the Wi-Fi driver:
+The following list specifies samples that are currently supported on :zephyr:board:`nrf7002dk` and :zephyr:board:`nrf7120dk`:
 
-* :zephyr:code-sample:`dns-resolve`
-* :zephyr:code-sample:`ipv4-autoconf`
-* :zephyr:code-sample:`mdns-responder`
-* :zephyr:code-sample:`mqtt-publisher`
 * :zephyr:code-sample:`mqtt-sn-publisher`
 * :zephyr:code-sample:`coap-server`
-* :zephyr:code-sample:`async-sockets-echo`
-* :zephyr:code-sample:`sockets-echo-client`
-* :zephyr:code-sample:`sockets-echo-server`
-* :zephyr:code-sample:`sockets-http-get`
-* :zephyr:code-sample:`sntp-client`
-* :zephyr:code-sample:`syslog-net`
-* :zephyr:code-sample:`telnet-console`
 
 Building and running
 ********************
@@ -32,18 +21,15 @@ See :ref:`building` for other building scenarios, :ref:`programming` for program
 
 A :ref:`Wi-Fi snippet <zephyr:snippet-wifi-ipv4>` configuration is provided to all Zephyr samples, which configures the sample to run with the Wi-Fi driver.
 
-To build Zephyr samples for the nRF7002 DK, use the ``nrf7002dk/nrf5340/cpuapp`` board target.
+To build Zephyr samples, use the ``nrf7002dk/nrf5340/cpuapp`` or ``nrf7120dk/nrf7120/cpuapp`` board target, and ``wifi-ipv4`` snippet.
 The following is an example of the CLI command:
 
 .. code-block:: console
 
+   # nRF7002 DK
    west build -b nrf7002dk/nrf5340/cpuapp -S wifi-ipv4
 
-To build for the nRF7002 EK with nRF5340 DK, use the ``nrf5340dk/nrf5340/cpuapp`` board target with the ``SHIELD`` CMake option set to ``nrf7002ek``.
-The following is an example of the CLI command:
-
-.. code-block:: console
-
-   west build -b nrf5340dk/nrf5340/cpuapp -S wifi-ipv4 -- -DSHIELD=nrf7002ek -DSB_CONFIG_WIFI_NRF70=y
+   # nRF7120 DK
+   west build -b nrf7120dk/nrf7120/cpuapp -S wifi-ipv4
 
 For additional details about running a sample, refer to the respective sample in Zephyr’s :zephyr:code-sample-category:`samples`.


### PR DESCRIPTION
Updated the Zephyr networking samples documentation to reflect that support has been dropped for all upstream Zephyr Wi-Fi samples except the CoAP Server and MQTT-SN Publisher samples.

Changes:
- Trimmed the list of supported samples to CoAP Server and MQTT-SN Publisher.
- Updated the supported board targets to the nRF7002 DK and nRF7120 DK.
- Removed the nRF5340 DK with nRF7002 EK build instructions, as this combination is no longer maintained.

The actual sample support was removed in: https://github.com/nrfconnect/sdk-nrf/pull/29951#pullrequestreview-4607664438

JIRA: NCSDK-40011