### PR TITLE
samples: esb: Add nRF54LS05A board support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -391,7 +391,7 @@ DECT NR+ samples
 Enhanced ShockBurst samples
 ---------------------------
 
-* Added support for the ``nrf54lc10dk/nrf54lc10a/cpuapp`` board target in all samples.
+* Added support for the ``nrf54lc10dk/nrf54lc10a/cpuapp`` and ``nrf54ls05dk/nrf54ls05a/cpuapp`` board targets in all samples.
 
 Gazell samples
 --------------

--- a/samples/esb/esb_monitor/sample.yaml
+++ b/samples/esb/esb_monitor/sample.yaml
@@ -23,7 +23,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
@@ -34,6 +34,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
     tags:
@@ -56,7 +57,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
     platform_allow:
       - nrf5340dk/nrf5340/cpunet
@@ -66,6 +67,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
     tags:

--- a/samples/esb/esb_prx/sample.yaml
+++ b/samples/esb/esb_prx/sample.yaml
@@ -40,7 +40,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
     platform_allow:
@@ -56,6 +56,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp

--- a/samples/esb/esb_prx_ble/sample.yaml
+++ b/samples/esb/esb_prx_ble/sample.yaml
@@ -26,7 +26,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
     platform_allow:
@@ -39,6 +39,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp

--- a/samples/esb/esb_ptx/sample.yaml
+++ b/samples/esb/esb_ptx/sample.yaml
@@ -40,7 +40,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
     platform_allow:
@@ -56,6 +56,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp

--- a/samples/esb/esb_ptx_ble/sample.yaml
+++ b/samples/esb/esb_ptx_ble/sample.yaml
@@ -25,7 +25,7 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
     platform_allow:
@@ -38,6 +38,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp


### PR DESCRIPTION
Add the nrf54ls05dk/nrf54ls05a/cpuapp board target to all ESB samples.
