### PR TITLE
subsys: esb: improve resource cleanup on init error paths

### DIFF
--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -2326,6 +2326,8 @@ static void esb_irq_disable(void)
 int esb_init(const struct esb_config *config)
 {
 	int err;
+	bool esb_clock_initialized = false;
+	bool sys_timer_initialized = false;
 
 	if (!config) {
 		return -EINVAL;
@@ -2341,6 +2343,7 @@ int esb_init(const struct esb_config *config)
 			LOG_ERR("Failed to start clocks: %d", err);
 			return err;
 		}
+		esb_clock_initialized = true;
 	}
 
 	event_handler = config->event_handler;
@@ -2353,7 +2356,8 @@ int esb_init(const struct esb_config *config)
 
 	if (fast_switching) {
 		if (!esb_cfg.use_fast_ramp_up) {
-			return -EINVAL;
+			err = -EINVAL;
+			goto error_cleanup;
 		}
 	}
 
@@ -2368,13 +2372,15 @@ int esb_init(const struct esb_config *config)
 		LOG_ERR("Configured retransmission delay is below the required minimum of %d us",
 			RETRANSMIT_DELAY_MIN);
 
-		return -EINVAL;
+		err = -EINVAL;
+		goto error_cleanup;
 	}
 
 	if (!IS_ENABLED(CONFIG_ESB_MPSL_TIMESLOT)) {
 		if (!update_radio_parameters()) {
 			LOG_ERR("Failed to update radio parameters");
-			return -EINVAL;
+			err = -EINVAL;
+			goto error_cleanup;
 		}
 
 		/* Configure radio address registers according to ESB default values */
@@ -2386,13 +2392,14 @@ int esb_init(const struct esb_config *config)
 		err = sys_timer_init();
 		if (err) {
 			LOG_ERR("Failed to initialize ESB system timer");
-			return err;
+			goto error_cleanup;
 		}
+		sys_timer_initialized = true;
 
 		err = esb_ppi_init();
 		if (err) {
 			LOG_ERR("Failed to initialize PPI");
-			return err;
+			goto error_cleanup;
 		}
 
 		disable_event.event.generic.event = esb_ppi_radio_disabled_get();
@@ -2411,13 +2418,15 @@ int esb_init(const struct esb_config *config)
 	} else { /* IS_ENABLED(CONFIG_ESB_MPSL_TIMESLOT) */
 		if (esb_cfg.mode == ESB_MODE_MONITOR) {
 			LOG_ERR("Primary monitor mode is not supported in Timeslots");
-			return -EPERM;
+			err = -EPERM;
+			goto error_cleanup;
 		}
 
 		if (!(update_radio_bitrate(esb_cfg.bitrate) && verify_radio_protocol() &&
 		      verify_radio_crc())) {
 			LOG_ERR("Failed to update radio parameters");
-			return -EINVAL;
+			err = -EINVAL;
+			goto error_cleanup;
 		}
 
 		multithreading_lock_acquire(K_FOREVER);
@@ -2425,7 +2434,7 @@ int esb_init(const struct esb_config *config)
 		multithreading_lock_release();
 		if (err) {
 			LOG_ERR("Failed to open MPSL Timeslot session (%u)", err);
-			return err;
+			goto error_cleanup;
 		}
 
 		update_ts_duration_params();
@@ -2480,6 +2489,25 @@ int esb_init(const struct esb_config *config)
 	}
 
 	return 0;
+
+error_cleanup:
+	/* Undo partial init tracked by the flags above. esb_disable() cannot be
+	 * used here because it returns immediately while esb_state is still
+	 * ESB_STATE_UNINITIALIZED.
+	 */
+	if (sys_timer_initialized) {
+		sys_timer_deinit();
+	}
+
+	if (esb_clock_initialized) {
+		int stop_err = esb_clocks_stop();
+
+		if (stop_err) {
+			LOG_ERR("Failed to stop clocks: %d", stop_err);
+		}
+	}
+
+	return err;
 }
 
 int esb_suspend(void)

--- a/subsys/esb/esb_dppi.c
+++ b/subsys/esb/esb_dppi.c
@@ -218,56 +218,36 @@ uint32_t esb_ppi_radio_disabled_get(void)
 int esb_ppi_init(void)
 {
 	int ch;
+	int err = -ENODEV;
 	uint32_t domain_id = nrfx_gppi_domain_id_get((uint32_t)ESB_DPPIC);
+	uint8_t *const channels[] = {
+		&radio_address_timer_stop,
+		&timer_compare0_radio_disable,
+		&timer_compare1_radio_txen,
+		&disabled_phy_end_egu,
+		&egu_timer_start,
+		&egu_ramp_up,
+#if defined(CONFIG_ESB_NEVER_DISABLE_TX)
+		&radio_end_timer_start,
+#endif
+	};
+	size_t allocated = 0;
 
-	ch = nrfx_gppi_channel_alloc(domain_id);
-	if (ch < 0) {
-		goto error;
-	}
-	radio_address_timer_stop = (uint8_t)ch;
-
-	ch = nrfx_gppi_channel_alloc(domain_id);
-	if (ch < 0) {
-		goto error;
-	}
-	timer_compare0_radio_disable = (uint8_t)ch;
-
-	ch = nrfx_gppi_channel_alloc(domain_id);
-	if (ch < 0) {
-		goto error;
-	}
-	timer_compare1_radio_txen = (uint8_t)ch;
-
-	ch = nrfx_gppi_channel_alloc(domain_id);
-	if (ch < 0) {
-		goto error;
-	}
-	disabled_phy_end_egu = (uint8_t)ch;
-
-	ch = nrfx_gppi_channel_alloc(domain_id);
-	if (ch < 0) {
-		goto error;
-	}
-	egu_timer_start = (uint8_t)ch;
-
-	ch = nrfx_gppi_channel_alloc(domain_id);
-	if (ch < 0) {
-		goto error;
-	}
-	egu_ramp_up = (uint8_t)ch;
-
-	if (IS_ENABLED(CONFIG_ESB_NEVER_DISABLE_TX)) {
+	for (allocated = 0; allocated < ARRAY_SIZE(channels); allocated++) {
 		ch = nrfx_gppi_channel_alloc(domain_id);
 		if (ch < 0) {
+			LOG_ERR("gppi_channel_alloc failed with: %d\n", ch);
+			err = -ENODEV;
 			goto error;
 		}
-		radio_end_timer_start = (uint8_t)ch;
+		*channels[allocated] = (uint8_t)ch;
 	}
 
 	ch = nrfx_gppi_group_channel_alloc(domain_id);
 	if (ch < 0) {
 		LOG_ERR("gppi_group_alloc failed with: %d\n", ch);
-		return ch;
+		err = ch;
+		goto error;
 	}
 	ramp_up_dppi_group = (uint8_t)ch;
 
@@ -280,8 +260,12 @@ int esb_ppi_init(void)
 	return 0;
 
 error:
-	LOG_ERR("gppi_channel_alloc failed with: %d\n", ch);
-	return -ENODEV;
+	/* Free the channels already allocated. */
+	for (size_t i = 0; i < allocated; i++) {
+		nrfx_gppi_channel_free(domain_id, *channels[i]);
+	}
+
+	return err;
 }
 
 void esb_ppi_disable_all(void)

--- a/subsys/esb/esb_ppi.c
+++ b/subsys/esb/esb_ppi.c
@@ -193,63 +193,47 @@ void esb_ppi_for_wait_for_rx_clear(void)
 int esb_ppi_init(void)
 {
 	int ch;
+	int err = -ENODEV;
+	nrf_ppi_channel_t *const channels[] = {
+		&egu_ramp_up,
+		&disabled_egu,
+		&egu_timer_start,
+		&radio_address_timer_stop,
+		&timer_compare0_radio_disable,
+		&timer_compare1_radio_txen,
+#if defined(CONFIG_ESB_NEVER_DISABLE_TX)
+		&radio_end_timer_start,
+#endif
+	};
+	size_t allocated = 0;
 
-	ch = nrfx_gppi_channel_alloc(0);
-	if (ch < 0) {
-		goto error;
-	}
-	egu_ramp_up = (nrf_ppi_channel_t)ch;
-
-	ch = nrfx_gppi_channel_alloc(0);
-	if (ch < 0) {
-		goto error;
-	}
-	disabled_egu = (nrf_ppi_channel_t)ch;
-
-	ch = nrfx_gppi_channel_alloc(0);
-	if (ch < 0) {
-		goto error;
-	}
-	egu_timer_start = (nrf_ppi_channel_t)ch;
-
-	ch = nrfx_gppi_channel_alloc(0);
-	if (ch < 0) {
-		goto error;
-	}
-	radio_address_timer_stop = (nrf_ppi_channel_t)ch;
-
-	ch = nrfx_gppi_channel_alloc(0);
-	if (ch < 0) {
-		goto error;
-	}
-	timer_compare0_radio_disable = (nrf_ppi_channel_t)ch;
-
-	ch = nrfx_gppi_channel_alloc(0);
-	if (ch < 0) {
-		goto error;
-	}
-	timer_compare1_radio_txen = (nrf_ppi_channel_t)ch;
-
-	if (IS_ENABLED(CONFIG_ESB_NEVER_DISABLE_TX)) {
+	for (allocated = 0; allocated < ARRAY_SIZE(channels); allocated++) {
 		ch = nrfx_gppi_channel_alloc(0);
 		if (ch < 0) {
+			LOG_ERR("gppi_channel_alloc failed with: %d\n", ch);
+			err = -ENODEV;
 			goto error;
 		}
-		radio_end_timer_start = (nrf_ppi_channel_t)ch;
+		*channels[allocated] = (nrf_ppi_channel_t)ch;
 	}
 
 	ch = nrfx_gppi_group_channel_alloc(0);
 	if (ch < 0) {
 		LOG_ERR("gppi_group_alloc failed with: %d\n", ch);
-		return ch;
+		err = ch;
+		goto error;
 	}
 	ramp_up_ppi_group = (nrf_ppi_channel_group_t)ch;
 
 	return 0;
 
 error:
-	LOG_ERR("gppi_channel_alloc failed with: %d\n", ch);
-	return -ENODEV;
+	/* Free the channels already allocated. */
+	for (size_t i = 0; i < allocated; i++) {
+		nrfx_gppi_channel_free(0, (uint8_t)*channels[i]);
+	}
+
+	return err;
 }
 
 uint32_t esb_ppi_radio_disabled_get(void)


### PR DESCRIPTION
A failed initialization after `esb_clocks_start()` left the HF clock
requested (`esb_disable()` skips clock stop while state is
`UNINITIALIZED`) and a failure after `sys_timer_init()`
left the nrfx timer reserved.
Also improve `esb_ppi_init()` to free already-allocated (D)PPI channels
on partial allocation failure.
