### PR TITLE
applications: nrf_audio: Disable boot banners (printk issue)

### DIFF
--- a/applications/nrf_audio/prj.conf
+++ b/applications/nrf_audio/prj.conf
@@ -43,6 +43,11 @@ CONFIG_CONSOLE=y
 CONFIG_RTT_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 
+## Disable boot banner to get CPU load printks out on serial console.
+## See https://github.com/zephyrproject-rtos/zephyr/discussions/112416
+CONFIG_BOOT_BANNER=n
+CONFIG_NCS_BOOT_BANNER=n
+
 ## Shell related defines
 CONFIG_SHELL=y
 CONFIG_KERNEL_SHELL=y


### PR DESCRIPTION
By disabling boot banners, CONFIG_EARLY_CONSOLE is set to "n". Due to an issue in Zephyr, this is done to get printk()s from the CPU load callback printed to the serial console. See: https://github.com/zephyrproject-rtos/zephyr/discussions/112416

OCT-3762