### PR TITLE
modules: memfault: upgrade to 1.42.0

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -645,6 +645,9 @@ Google Fast Pair integration
 Memfault integration
 --------------------
 
+* Updated Memfault to version 1.42.0.
+  See the `Memfault firmware SDK changelog`_ for details.
+
 * Removed the ``CONFIG_MEMFAULT_NCS_PROVISION_CERTIFICATES`` Kconfig option from nRF91x targets.
   Certificate provisioning for nRF91x targets is now handled automatically by the `Memfault firmware SDK`_.
   The option remains available for nRF7002 targets, which do not have automatic certificate provisioning.

--- a/west.yml
+++ b/west.yml
@@ -254,7 +254,7 @@ manifest:
       remote: throwtheswitch
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 1.40.0
+      revision: 1.42.0
       remote: memfault
     - name: bsim
       repo-path: bsim_west


### PR DESCRIPTION
Bump the Memfault firmware SDK version, which notably includes support for runtime-setting of app and modem project keys.