### PR TITLE
tests: benchmarks: Add missing snippet in 'grtc_idle.ldo'

### DIFF
--- a/tests/benchmarks/current_consumption/grtc_idle/testcase.yaml
+++ b/tests/benchmarks/current_consumption/grtc_idle/testcase.yaml
@@ -36,6 +36,8 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp/ns
+    required_snippets:
+      - nordic-vregmain-ldo
     harness_config:
       fixture: ppk_power_measure
       pytest_root:

--- a/tests/benchmarks/current_consumption/uart_idle/testcase.yaml
+++ b/tests/benchmarks/current_consumption/uart_idle/testcase.yaml
@@ -40,6 +40,8 @@ tests:
       - nrf54lc10dk/nrf54lc10a/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
+    required_snippets:
+      - nordic-vregmain-ldo
 
   benchmarks.current_consumption.uart_idle_uart30:
     platform_allow:

--- a/tests/benchmarks/current_consumption/uarte_suspend/testcase.yaml
+++ b/tests/benchmarks/current_consumption/uarte_suspend/testcase.yaml
@@ -38,6 +38,8 @@ tests:
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+    required_snippets:
+      - nordic-vregmain-ldo
     harness_config:
       fixture: gpio_loopback
       pytest_root:


### PR DESCRIPTION
This test case requires 'nordic-vregmain-ldo' snippet