### PR TITLE
samples: bluetooth: ipt_reflector: add ios support

### DIFF
--- a/samples/bluetooth/channel_sounding/ipt_reflector/README.rst
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/README.rst
@@ -128,6 +128,20 @@ After programming the sample to your development kit, test it together with a de
       - maximum procedure length: 12
 
 
+Building for testing with iOS 27 Beta 2 devices
+===============================================
+
+To enable the Bluetooth configurations required for testing Channel Sounding with iOS 27 Beta 2 devices that support Channel Sounding, apply the ``ios_ranging.conf`` fragment.
+For example, use the following command:
+
+.. parsed-literal::
+   :class: highlight
+
+   west build -bnrf54l15dk/nrf54l15/cpuapp -- -DEXTRA_CONF_FILE="ios_ranging.conf"
+
+.. note::
+   When ``ios_ranging.conf`` is applied, the sample may not be compatible with the :ref:`channel_sounding_ipt_initiator` sample.
+
 Dependencies
 ************
 

--- a/samples/bluetooth/channel_sounding/ipt_reflector/ios_ranging.conf
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/ios_ranging.conf
@@ -1,0 +1,11 @@
+# KConfig fragment file with the settings
+# required to run CS Ranging with iOS 27 beta 2 devices
+
+# Required for bonding
+CONFIG_BT_BONDABLE=y
+CONFIG_BT_SETTINGS=y
+CONFIG_SETTINGS=y
+CONFIG_FLASH=y
+CONFIG_FLASH_PAGE_LAYOUT=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y

--- a/samples/bluetooth/channel_sounding/ipt_reflector/src/main.c
+++ b/samples/bluetooth/channel_sounding/ipt_reflector/src/main.c
@@ -16,6 +16,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/cs.h>
+#include <zephyr/settings/settings.h>
 #include <dk_buttons_and_leds.h>
 
 #include <zephyr/logging/log.h>
@@ -23,12 +24,18 @@ LOG_MODULE_REGISTER(app_main, LOG_LEVEL_INF);
 
 #define CON_STATUS_LED DK_LED1
 
+#define BT_UUID_RAS_WORKAROUND (0x185B)
+
 static K_SEM_DEFINE(sem_connected, 0, 1);
 
 static struct bt_conn *connection;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+	/* Note: RAS is disabled in IPT sample but it seems some devices require
+	 * RAS UUID to be presented in adv data to be able to connect.
+	 */
+	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_RAS_WORKAROUND)),
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
@@ -199,6 +206,10 @@ int main(void)
 	if (err) {
 		LOG_ERR("Bluetooth init failed (err %d)", err);
 		return 0;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		settings_load();
 	}
 
 	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), NULL, 0);


### PR DESCRIPTION
Added .conf file and added changes required
to run CS with iOS devices.
Note: current support was tested with iOS 27 beta 2 and may change in the future when newer versions of iOS are released.