### PR TITLE
samples: dect: dect_shell: remove deprecated PM reference

### DIFF
--- a/samples/dect/dect_shell/nrf_cloud_coap.conf
+++ b/samples/dect/dect_shell/nrf_cloud_coap.conf
@@ -87,13 +87,6 @@ CONFIG_PSA_CRYPTO=y
 # TF-M crypto configuration
 CONFIG_TFM_PROFILE_TYPE_NOT_SET=y
 CONFIG_TFM_SFN=y
-# Reduce the TFM SRAM partition. It's 0x16000 by default for the nRF91 when TFM profile is not
-# set, but that much does not seem to be needed.
-CONFIG_PM_PARTITION_SIZE_TFM_SRAM=0xe000
-
-# Reduce the TFM flash partition. It's 0x40000 by default which is almost double of what is
-# actually needed.
-CONFIG_PM_PARTITION_SIZE_TFM=0x28000
 
 # MBEDTLS core
 CONFIG_MBEDTLS=y


### PR DESCRIPTION
Partition size is no longer set using Partition Manager so removed from conf.