### PR TITLE
doc: matter: Fix wrong Matter SDK version

### DIFF
--- a/doc/nrf/protocols/matter/index.rst
+++ b/doc/nrf/protocols/matter/index.rst
@@ -25,7 +25,7 @@ For a full list of |NCS| and Matter versions, view the following table:
    +--------------------------+-----------------------------------------------------+------------------------+
    | nRF Connect SDK version  | Matter specification version                        | Matter SDK version     |
    +==========================+=====================================================+========================+
-   | v3.4.99 (latest)         | :ref:`1.6.0 <ug_matter_overview_dev_model_support>` | 1.6.0.0                |
+   | v3.4.99 (latest)         | :ref:`1.5.0 <ug_matter_overview_dev_model_support>` | 1.5.0.0                |
    +--------------------------+-----------------------------------------------------+------------------------+
    | |release|                | :ref:`1.5.0 <ug_matter_overview_dev_model_support>` | 1.5.0.0                |
    +--------------------------+                                                     |                        |


### PR DESCRIPTION
The Matter SDK version should be set to 1.5.0.0 instead of 1.6.0.0.