### PR TITLE
doc: security: deprecate trusted storage

### DIFF
--- a/doc/nrf/libraries/security/trusted_storage.rst
+++ b/doc/nrf/libraries/security/trusted_storage.rst
@@ -10,6 +10,11 @@ Trusted storage
 The trusted storage library enables its users to provide integrity, confidentiality and authenticity of stored data using Authenticated Encryption with Associated Data (AEAD) algorithms or cryptographic hash, without the use of TF-M Platform Root of Trust (PRoT).
 The library implements the :ref:`PSA Certified Secure Storage API <ug_psa_certified_api_overview_secstorage>` for use on builds without TF-M (no :ref:`security by separation <ug_tfm_security_by_separation>`).
 
+.. note::
+   The trusted storage library is deprecated and will be removed in a future release.
+   Use the :ref:`Secure storage subsystem <secure_storage>` instead (:kconfig:option:`CONFIG_SECURE_STORAGE`).
+   If you have an existing installation that uses the Trusted Storage library with entries stored in non-volatile memory, you can switch to using Secure Storage without losing any data by enabling the :kconfig:option:`CONFIG_SECURE_STORAGE_TRUSTED_STORAGE_COMPATIBILITY` Kconfig option.
+
 See also :ref:`secure_storage_in_ncs` for an overview of the PSA Secure Storage API implementation in the |NCS|.
 
 Overview

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -158,6 +158,11 @@ Security libraries
   * Removed the configuration page for the deprecated legacy crypto backend (:file:`libraries/security/nrf_security/doc/backend_config`).
     Configure cryptographic features using :ref:`psa_crypto_support` and :ref:`ug_crypto_supported_features` instead.
 
+* :ref:`trusted_storage_readme` library:
+
+  * Added the deprecation note in the library documentation.
+    The library has been replaced by Zephyr's :ref:`Secure storage subsystem <secure_storage>` (:kconfig:option:`CONFIG_SECURE_STORAGE`).
+
 Mbed TLS
 --------
 

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -3055,10 +3055,10 @@ Hardware Unique Key
 
 .. _software_maturity_security_features_ts:
 
-Trusted storage
+Secure storage
 ===============
 
-Trusted storage implements the PSA Certified Secure Storage APIs without TF-M.
+Zephyr's Secure storage module implements the PSA Certified Secure Storage APIs without TF-M.
 
 .. toggle::
 
@@ -3066,7 +3066,7 @@ Trusted storage implements the PSA Certified Secure Storage APIs without TF-M.
 
       .. tab:: nRF52 Series
 
-         .. list-table:: Trusted storage support
+         .. list-table:: Secure storage support
             :header-rows: 1
             :widths: auto
 
@@ -3077,7 +3077,7 @@ Trusted storage implements the PSA Certified Secure Storage APIs without TF-M.
               - nRF52832
               - nRF52833
               - nRF52840
-            * - **Trusted storage**
+            * - **Secure storage**
               - --
               - --
               - --
@@ -3087,29 +3087,29 @@ Trusted storage implements the PSA Certified Secure Storage APIs without TF-M.
 
       .. tab:: nRF53 Series
 
-         .. list-table:: Trusted storage support
+         .. list-table:: Secure storage support
             :header-rows: 1
             :widths: auto
 
             * - Feature
               - nRF5340
-            * - **Trusted storage**
+            * - **Secure storage**
               - Supported
 
       .. tab:: nRF54H Series
 
-         .. list-table:: Trusted storage support
+         .. list-table:: Secure storage support
             :header-rows: 1
             :widths: auto
 
             * - Feature
               - nRF54H20
-            * - **Trusted storage**
+            * - **Secure storage**
               - Experimental
 
       .. tab:: nRF54L Series
 
-         .. list-table:: Trusted storage support
+         .. list-table:: Secure storage support
             :header-rows: 1
             :widths: auto
 
@@ -3122,7 +3122,7 @@ Trusted storage implements the PSA Certified Secure Storage APIs without TF-M.
               - nRF54LV10A
               - nRF54LS05A
               - nRF54LS05B
-            * - **Trusted storage**
+            * - **Secure storage**
               - Supported
               - Supported
               - Supported
@@ -3134,7 +3134,7 @@ Trusted storage implements the PSA Certified Secure Storage APIs without TF-M.
 
       .. tab:: nRF91 Series
 
-         .. list-table:: Trusted storage support
+         .. list-table:: Secure storage support
             :header-rows: 1
             :widths: auto
 
@@ -3143,7 +3143,7 @@ Trusted storage implements the PSA Certified Secure Storage APIs without TF-M.
               - nRF9151
               - nRF9160
               - nRF9161
-            * - **Trusted storage**
+            * - **Secure storage**
               - --
               - Supported
               - Supported

--- a/doc/nrf/security.rst
+++ b/doc/nrf/security.rst
@@ -156,7 +156,7 @@ Some of them are documented in detail in other parts of this documentation, whil
   * - Secure storage
     - Secure storage enables you to provide features like integrity, confidentiality and authenticity of the stored data, with or without TF-M.
     - See :ref:`secure_storage_in_ncs`.
-    - | - :ref:`trusted_storage_readme` library
+    - | - Zephyr's :ref:`Secure storage subsystem <secure_storage>`
       | - TF-M's :ref:`ug_tfm_services_its`
       | - TF-M's :ref:`tfm_partition_ps`
   * - Hardware unique key (HUK)

--- a/doc/nrf/security/crypto/crypto_architecture.rst
+++ b/doc/nrf/security/crypto/crypto_architecture.rst
@@ -110,11 +110,7 @@ For more information about the driver selection, see :ref:`crypto_drivers`.
 Storage integration for the Oberon PSA Crypto implementation
 ------------------------------------------------------------
 
-When using the Oberon PSA Crypto implementation, persistent keys from the PSA Crypto API can be stored in the |NCS| using one of the following storage mechanisms:
-
-* Zephyr's :ref:`Secure storage <zephyr:secure_storage>` subsystem - Zephyr-specific implementation of the functions defined in the `PSA Certified Secure Storage API`_.
-* |NCS|'s :ref:`trusted_storage_readme` library - which provides features like integrity, confidentiality, and authenticity of the stored data without using the TF-M Platform Root of Trust (PRoT).
-
+When using the Oberon PSA Crypto implementation, persistent keys from the PSA Crypto API can be stored in the |NCS| using Zephyr's :ref:`Secure storage <zephyr:secure_storage>` subsystem, which is a Zephyr-specific implementation of the functions defined in the `PSA Certified Secure Storage API`_, valid also for the |NCS|.
 For more information, see :ref:`secure_storage_in_ncs`.
 
 .. _ug_crypto_architecture_implementation_standards_tfm:

--- a/doc/nrf/security/key_storage.rst
+++ b/doc/nrf/security/key_storage.rst
@@ -106,7 +106,7 @@ Usage
 You cannot use HUKs directly.
 You can however use the :ref:`lib_hw_unique_key` library to derive keys from HUKs using known labels.
 
-You can use HUKs indirectly through PSA Secure Storage without TF-M, for example through the :ref:`trusted_storage_readme` library.
+You can use HUKs indirectly through PSA Secure Storage without TF-M, for example through Zephyr's :ref:`Secure storage <zephyr:secure_storage>` subsystem.
 In such case, the HUK library will be used to derive keys that are then used to encrypt storage entries.
 This is done to prevent the application from accessing the HUK directly.
 

--- a/doc/nrf/security/secure_storage.rst
+++ b/doc/nrf/security/secure_storage.rst
@@ -17,7 +17,7 @@ The following implementations of the PSA Secure Storage API are available:
 * TF-M's :ref:`ug_tfm_services_its` and :ref:`tfm_partition_ps` services - This option can only be used when :ref:`building with TF-M <ug_tfm_building>` and if the `ARM TrustZone`_ technology and hardware-accelerated firmware isolation are supported by the hardware platform in use.
   Using this option, the Internal Trusted Storage and the Protected Storage are working :ref:`with security by separation <ug_tfm_security_by_separation>`.
 
-* The :ref:`Trusted storage library <trusted_storage_readme>` - This option enables you to provide features like integrity, confidentiality, and authenticity of the stored data when building without TF-M.
+* Zephyr's :ref:`Secure storage subsystem <secure_storage>` - This option enables you to provide features like integrity, confidentiality, and authenticity of the stored data when building without TF-M.
   Using this option, you can use the PSA Secure Storage API without TF-M.
 
 .. note::
@@ -45,7 +45,7 @@ The table below gives an overview of the secure storage support for the products
      - Yes
      - Yes
    * - nRF91 Series without TF-M
-     - Trusted storage library
+     - Zephyr's :ref:`Secure storage subsystem <secure_storage>`
      - Partial [1]_
      - Yes
      - Yes
@@ -59,11 +59,11 @@ The table below gives an overview of the secure storage support for the products
      - Yes
    * - | - nRF54L15 without TF-M
        | - nRF54L10 without TF-M
-     - Trusted storage library
+     - Zephyr's :ref:`Secure storage subsystem <secure_storage>`
      - Partial [1]_
      - Yes
      - Yes
-     - Yes
+     - No
    * - nRF5340 with TF-M
      - TF-M's :ref:`ug_tfm_services_its` and :ref:`tfm_partition_ps`
      - Yes
@@ -71,34 +71,34 @@ The table below gives an overview of the secure storage support for the products
      - Yes
      - Yes
    * - nRF5340 without TF-M
-     - Trusted storage library
+     - Zephyr's :ref:`Secure storage subsystem <secure_storage>`
      - Partial [1]_
      - Yes
      - Yes
      - No
    * - nRF52840
-     - Trusted storage library
+     - Zephyr's :ref:`Secure storage subsystem <secure_storage>`
      - Partial [1]_
      - Yes
      - Yes
      - No
    * - nRF52833
-     - Trusted storage library
+     - Zephyr's :ref:`Secure storage subsystem <secure_storage>`
      - Partial [2]_
      - Yes
      - Yes
      - No
    * - nRF52832
-     - Trusted storage library
+     - Zephyr's :ref:`Secure storage subsystem <secure_storage>`
      - Partial [2]_
      - Yes
      - Yes
      - No
 
 Notes for confidentiality partial support
-  .. [1] On systems without the isolation feature, the confidentiality is limited to protection of data at rest in a non-volatile internal or external memory.
+  .. [1] On SoCs without the isolation feature, the confidentiality is limited to protection of data at rest in a non-volatile internal or external memory.
          This partial confidentiality is based on a CPU-inaccessible master key used for data encryption.
          When the data is decrypted for usage, there is no mechanism providing access control and protecting its visibility.
-         Using a TrustZone-enabled system provides stronger protection, and is recommended if available.
+         Using an SoC with security by separation (that is, without support for TF-M and ARM TrustZone) provides stronger protection, and is recommended if available.
   .. [2] The use of Hardware Unique Key (HUK) to provide the AEAD key is not available on nRF52833 and nRF52832 devices.
-         The trusted storage library offers the use of SHA-256 to generate the key, which does not guarantee security beyond the integrity check of the encrypted data.
+         The Secure storage subsystem offers the use of SHA-256 to generate the key, which does not guarantee security beyond the integrity check of the encrypted data.

--- a/samples/crypto/persistent_key_usage/README.rst
+++ b/samples/crypto/persistent_key_usage/README.rst
@@ -11,7 +11,7 @@ The persistent key sample demonstrates how to use the :ref:`PSA Crypto API <ug_p
 The implementation of the PSA ITS API is provided in one of the following ways, depending on your configuration:
 
 * Through TF-M using Internal Trusted Storage and Protected Storage services.
-* When building without TF-M: using either Zephyr's :ref:`secure_storage` subsystem or the :ref:`trusted_storage_readme` library.
+* When building without TF-M: using Zephyr's :ref:`secure_storage` subsystem.
 
 A persistent key becomes unusable when the ``psa_destroy_key`` function is called.
 


### PR DESCRIPTION
Edited documentation to reflect the deprecation of the trusted storage library as per PR #28996. NCSDK-29983 and TECHDOC-4623.