### PR TITLE
Manual Backport: doc: Updated abi compatibility to ISE +33

### DIFF
--- a/doc/nrf/releases_and_maturity/abi_compatibility.rst
+++ b/doc/nrf/releases_and_maturity/abi_compatibility.rst
@@ -46,6 +46,22 @@ nRF54H20 IronSide SE binaries changelog
 
 The following sections provide detailed lists of changes by component.
 
+IronSide Secure Enclave (IronSide SE) v23.8.0+33
+================================================
+
+Added
+-----
+
+* Support for the Nordic nRF Global Software Watchdog Timer (GSWDT).
+  You can enable this feature through the Zephyr driver using the ``cpuapp_gswdt`` devicetree node.
+
+Fixed
+-----
+
+* An issue where using the LFRC would break the System Controller's monitoring of stalled MRAM transactions.
+* Decoupled the TEMPERATURE and MRAM handlers to prevent the MRAM monitor from timing out and skipping MRAM checks.
+  The MRAM monitor now triggers every 11 s.
+
 IronSide Secure Enclave (IronSide SE) v23.7.0+30
 ================================================
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -10,7 +10,7 @@
 
 .. |54H_nrfutil_device_ver| replace:: 2.17.1
 .. |54H_nrfutil_trace_ver| replace:: 4.4.0
-.. |ironside_se_ver| replace:: v23.7.0+30
+.. |ironside_se_ver| replace:: v23.8.0+33
 
 .. ### Config shortcuts
 


### PR DESCRIPTION
Manual backport: Update abi compatibility docs to IronSide Secure Enclave (IronSide SE) v23.8.0+33 for NCS v3.2.5