### PR TITLE
workflows: Fix west commands workflow

### DIFF
--- a/.github/workflows/west-commands.yml
+++ b/.github/workflows/west-commands.yml
@@ -8,6 +8,7 @@ on:
       - scripts/west_commands/**
       - scripts/requirements-west-ncs-sbom.txt
       - scripts/requirements-extra.txt
+      - scripts/requirements-fixed.txt
 
 permissions:
   contents: read
@@ -60,7 +61,8 @@ jobs:
       - name: Install requirements
         shell: bash
         run: |
-          pip3 install -r nrf/scripts/requirements-fixed.txt -r nrf/scripts/requirements-west-ncs-sbom.txt
+          pip3 install -r nrf/scripts/requirements-fixed.txt
+          pip3 install -r nrf/scripts/requirements-west-ncs-sbom.txt
       - name: Smoke test ncs-loot & ncs-compare
         shell: bash
         run: |


### PR DESCRIPTION
scancode-toolkit package from requirements-west-ncs-sbom.txt has hardcoded dependency on spdx-tools==0.8.2.
We use spdx-tools==0.8.5 in toolchain bundle.
Ignore the conflict while installing scancode-toolkit package.