### PR TITLE
doc: Update nRF54H20 user guide

### DIFF
--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_mcuboot_dfu.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_mcuboot_dfu.rst
@@ -162,12 +162,9 @@ You can test BLE-based FOTA samples with the `nRF Connect Device Manager`_.
 For DFU over a serial connection, use the :ref:`dfu_tools_mcumgr_cli`.
 
 .. note::
-   On the nRF54H20 SoC, Direct-xip mode uses a merged image slot that combines both application and radio core images.
+   On the nRF54H20 SoC, Direct-xip mode uses a merged image slot that combines both application and radio core images or manifest-based image dependencies.
    Refer to the sample's DTS overlay files to understand the partition layout.
    In contrast, Swap modes place application and radio images in separate MCUboot slots, enabling multi-image updates.
 
    Direct-xip (merged) build artifacts are generated in the :file:`build` directory.
    Swap-mode artifacts reside in subdirectories of the applications build folders under the :file:`build/<application>/zephyr` directory path (for example, :file:`build/smp_svr/zephyr` or :file:`build/ipc_radio/zephyr`).
-
-.. note::
-   DFU from external flash is currently not supported on the nRF54H20 SoC.


### PR DESCRIPTION
Updates from the external memory as well as manifest-based Direct XIP modes are available on nRF54h20 platform.