### PR TITLE
[Backport v3.4-branch] lib: Added support for nRF54LC10A in ram power down library

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -445,7 +445,9 @@ nRF RPC libraries
 Other libraries
 ---------------
 
-|no_changes_yet_note|
+* :ref:`lib_ram_pwrdn` library:
+
+  * Added support for the nRF54LC10A SoC.
 
 Shell libraries
 ---------------

--- a/lib/ram_pwrdn/ram_pwrdn.c
+++ b/lib/ram_pwrdn/ram_pwrdn.c
@@ -43,7 +43,7 @@ static const struct ram_bank banks[] = {
 	 * the same bank.
 	 */
 	{ .start = 0x20000000UL, .section_count = 8, .section_size = 0x8000 },
-#elif defined(CONFIG_SOC_NRF54L10_CPUAPP)
+#elif defined(CONFIG_SOC_NRF54L10_CPUAPP) || defined(CONFIG_SOC_NRF54LC10A_CPUAPP)
 	/* Section numbers for RAM00 are 0-3 and for RAM01 are 4-5 within
 	 * the same bank.
 	 */


### PR DESCRIPTION
Backport 08b4ce719a0e6b4f434769948356c16a9ae60b95 from #30031.