### PR TITLE
samples: benchmarks: coremark: Align to nrf9251

### DIFF
--- a/samples/benchmarks/coremark/boards/nrf9251dk_nrf9251_cpuapp.conf
+++ b/samples/benchmarks/coremark/boards/nrf9251dk_nrf9251_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_COREMARK_ITERATIONS=10000
+
+CONFIG_LOG_MODE_IMMEDIATE=y

--- a/samples/benchmarks/coremark/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/samples/benchmarks/coremark/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "app_aliases_common.dtsi"
+
+&button0 {
+	label = "Push button 0";
+};
+
+&gpiote130 {
+	/* Select the only free channel. */
+	owned-channels = <7>;
+	status = "okay";
+};
+
+/* Disable the UART instance used by the PPR core for its own logging to avoid
+ * two cores accessing the same peripheral. The application core logs over uart133.
+ */
+&uart132 {
+	status = "disabled";
+};
+
+/* DTS node required to run the cpuppr target. */
+&cpuppr_vpr {
+	status = "okay";
+};

--- a/samples/benchmarks/coremark/boards/nrf9251dk_nrf9251_cpuppr.conf
+++ b/samples/benchmarks/coremark/boards/nrf9251dk_nrf9251_cpuppr.conf
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# The PPR core runs at a lower clock frequency, so fewer iterations are needed
+# to reach the minimum run time required for valid results.
+CONFIG_COREMARK_ITERATIONS=500
+
+# The PPR core has no dedicated button and LED, so run the benchmark on start up.
+CONFIG_APP_MODE_FLASH_AND_RUN=y
+
+CONFIG_LOG_MODE_IMMEDIATE=y
+
+# The application core is responsible for printing the boot banner.
+CONFIG_NCS_BOOT_BANNER=n
+CONFIG_BOOT_BANNER=n
+
+# Reduce speed optimizations to fit the sample into the PPR core TCM.
+# Removed the following options from the default configuration (prj.conf):
+# -funroll-loops
+CONFIG_COMPILER_OPT="-O3 -fno-lto"

--- a/samples/benchmarks/coremark/boards/nrf9251dk_nrf9251_cpuppr.overlay
+++ b/samples/benchmarks/coremark/boards/nrf9251dk_nrf9251_cpuppr.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &cpuapp_cpuppr_ipc;
+/delete-node/ &cpuapp_cpuppr_ipc_shm;
+/delete-node/ &cpuppr_cpuapp_ipc_shm;
+/delete-node/ &cpuapp_dma_region;
+
+&cpuppr_tcm_sram {
+	reg = <0x2fc00000 DT_SIZE_K(79)>;
+	ranges = <0x0 0x2fc00000 0x13c00>;
+};

--- a/samples/benchmarks/coremark/sample.yaml
+++ b/samples/benchmarks/coremark/sample.yaml
@@ -31,6 +31,7 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf7120dk/nrf7120/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
     integration_platforms: *coremark_platforms
 
   sample.benchmark.coremark.flash_and_run:


### PR DESCRIPTION
Add neccessary overlays, .conf files and extend platform_allow entries.