### PR TITLE
samples: matter: allow for upstream's build-time zap generation

### DIFF
--- a/samples/matter/common/cmake/data_model.cmake
+++ b/samples/matter/common/cmake/data_model.cmake
@@ -4,7 +4,17 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/chip_data_model.cmake)
+# The upsteram chip_data_model.cmake needs the CHIP_ROOT variable set at include time
+# Adding a guard here to make sure it will build properly
+if(NOT CHIP_ROOT)
+  set(CHIP_ROOT ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR})
+endif()
+
+if(CONFIG_NCS_SAMPLE_MATTER_ZAP_GENERATION_BUILD_TIME)
+  include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/chip_data_model.cmake)
+elseif(CONFIG_NCS_SAMPLE_MATTER_ZAP_GENERATION_STATIC)
+  include(${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/chip_data_model_static.cmake)
+endif()
 
 function(ncs_configure_data_model)
   string(CONFIGURE "${CONFIG_NCS_SAMPLE_MATTER_ZAP_FILE_PATH}" zap_file_path)
@@ -17,10 +27,29 @@ function(ncs_configure_data_model)
     ${zap_parent_dir}
   )
 
-  chip_configure_data_model(matter-data-model
-    BYPASS_IDL
-    GEN_DIR ${zap_parent_dir}/zap-generated
-    ZAP_FILE ${zap_file_path}
-    EXTERNAL_CLUSTERS ${ARG_EXTERNAL_CLUSTERS}
-  )
+  if(CONFIG_NCS_SAMPLE_MATTER_ZAP_GENERATION_BUILD_TIME)
+    # Use the build-time generation implemented in upstream.
+    # ZCL_PATH is passed explicitly so generation does not depend on the
+    # relative zcl.json path stored inside the .zap file.
+    chip_configure_data_model(matter-data-model
+      ZAP_FILE ${zap_file_path}
+      ZCL_PATH ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/zap-templates/zcl/zcl.json
+      EXTERNAL_CLUSTERS ${ARG_EXTERNAL_CLUSTERS}
+    )
+    # Forward matter-data-model's include directories added by
+    # chip_configure_data_model above to 'app'.
+    target_include_directories(app PRIVATE
+      $<TARGET_PROPERTY:matter-data-model,INCLUDE_DIRECTORIES>
+    )
+  elseif(CONFIG_NCS_SAMPLE_MATTER_ZAP_GENERATION_STATIC)
+    # Use the pre-generated files.
+    chip_configure_data_model_static(matter-data-model
+      BYPASS_IDL
+      GEN_DIR ${zap_parent_dir}/zap-generated
+      ZAP_FILE ${zap_file_path}
+      EXTERNAL_CLUSTERS ${ARG_EXTERNAL_CLUSTERS}
+    )
+  else()
+    message(WARNING "Unsupported ZAP generation type")
+  endif()
 endfunction()

--- a/samples/matter/common/src/Kconfig
+++ b/samples/matter/common/src/Kconfig
@@ -107,6 +107,26 @@ config NCS_SAMPLE_MATTER_ZAP_FILE_PATH
 	  Absolute path to location under which ZAP file is located.
 	  It shall contain the file name and .zap extension.
 
+choice NCS_SAMPLE_MATTER_ZAP_GENERATION
+	prompt "Matter data model (ZAP) files source"
+	default NCS_SAMPLE_MATTER_ZAP_GENERATION_STATIC
+	help
+	  Selects how the Matter data model C++ files are provided to the build.
+
+config NCS_SAMPLE_MATTER_ZAP_GENERATION_STATIC
+	bool "Use pre-generated (static) ZAP files"
+	help
+	  Use the pre-generated files.
+
+config NCS_SAMPLE_MATTER_ZAP_GENERATION_BUILD_TIME
+	bool "Generate ZAP files at build time"
+	help
+	  Generate the Matter data model C++ files from the .zap file at build
+	  time using the ZAP tool. Requires the ZAP tool to be available in the build environment through
+	  the ZAP_INSTALL_PATH environment variable.
+
+endchoice
+
 config NCS_SAMPLE_MATTER_CERTIFICATION
 	bool "Patches for Matter platform certification"
 	help

--- a/west.yml
+++ b/west.yml
@@ -162,7 +162,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 9895b2bdb4c43b48426930f03e3c05502babd2f0
+      revision: 6add52db053a9050f91604acc356b9dfba0ffbce
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio


### PR DESCRIPTION
Added a new Kconfig choice that enables the upstream's way of zap generation. The old static way, using the pregenerated files is still the default.

Chip pr:
https://github.com/nrfconnect/sdk-connectedhomeip/pull/727