### PR TITLE
doc: bluetooth: mesh: rework DFU over Bluetooth Mesh guide and samples

### DIFF
--- a/doc/nrf/protocols/bt/bt_mesh/dfu_over_bt_mesh.rst
+++ b/doc/nrf/protocols/bt/bt_mesh/dfu_over_bt_mesh.rst
@@ -27,6 +27,55 @@ You can use either the nRF Mesh app or the shell commands to configure and contr
 .. note::
    The Mesh DFU feature in the nRF Mesh app is currently supported only on iOS.
 
+.. _dfu_over_bt_mesh_roles_and_transport:
+
+DFU roles and image transport
+*****************************
+
+The Bluetooth Mesh DFU Model specification defines four DFU roles:
+
+* **Target** - A node that receives a firmware image and applies it.
+  A Target instantiates the Firmware Update Server and BLOB Transfer Server models.
+* **Initiator** - An entity that selects the firmware image to distribute and drives the distribution on the Distributor.
+  An Initiator instantiates the Firmware Distribution Client, Firmware Update Client and BLOB Transfer Client models.
+* **Distributor** - An intermediary node that stores the firmware image and delivers it to the Target nodes over the mesh network.
+  A Distributor instantiates the Firmware Distribution Server, Firmware Update Client, BLOB Transfer Client and BLOB Transfer Server models.
+* **Standalone Updater** - An entity that delivers firmware images to Target nodes directly, without an intermediary Distributor.
+
+Roles of the nRF Mesh mobile app
+================================
+
+When used with the samples provided by the |NCS|, the nRF Mesh mobile app has the following roles:
+
+* Provisioner and Configuration Client, used to provision the devices and to bind the application key to the mesh models involved in the DFU procedure.
+* Initiator, used to select the firmware image, register it on the Distributor, and start the distribution to the Target nodes.
+
+The mobile app is not a Distributor or a Standalone Updater.
+The :ref:`ble_mesh_dfu_distributor` sample (or an equivalent device on the mesh network) always has the intermediary Distributor role.
+
+How the firmware image reaches the Distributor
+==============================================
+
+The Bluetooth Mesh DFU Model specification defines two Upload Types on the Firmware Distribution Server:
+
+* In-band upload - The Initiator pushes the firmware image to the Distributor over the mesh network using the BLOB Transfer models.
+* Out-of-band upload - The firmware image reaches the Distributor through a channel outside the mesh network.
+
+For out-of-band upload, the specification describes one concrete mechanism, the Store Firmware OOB procedure on the Firmware Distribution Server, driven by an Upload Firmware OOB procedure on a Firmware Distribution Client.
+This procedure carries an Upload OOB URI that the Distributor uses to retrieve (pull) the image itself, for example over HTTPS.
+
+The |NCS| supports a different out-of-band mechanism in the :ref:`ble_mesh_dfu_distributor` sample.
+The nRF Mesh mobile app uploads (pushes) the image to the Distributor's storage slot over the Simple Management Protocol (SMP) provided by the :ref:`zephyr:mcu_mgr` (mcumgr Image Management over a GATT connection), then registers the resulting firmware in a DFU slot and starts the distribution using the Firmware Distribution Client model.
+Unlike the Store Firmware OOB procedure described in the specification, the SMP-based upload is not driven through the Firmware Distribution Server's Upload procedures, so it does not update the server's Upload Type or Upload Phase states.
+From the Firmware Distribution Server's point of view, the subsequent distribution to the Target nodes runs identically to a distribution triggered after a spec-defined upload.
+
+For alternatives (in-band BLOB Transfer upload from another Initiator, or out-of-band SMP upload driven from a workstation), see :ref:`ble_mesh_dfu_distributor_fw_image_upload` in the :ref:`ble_mesh_dfu_distributor` sample documentation.
+
+The transfer from the Distributor to the Target nodes always uses in-band BLOB Transfer over the mesh network, regardless of how the image was loaded onto the Distributor.
+
+Connecting to the Distributor
+=============================
+
 .. tabs::
 
    .. group-tab:: nRF Mesh app (iOS)

--- a/samples/bluetooth/mesh/dfu/distributor/README.rst
+++ b/samples/bluetooth/mesh/dfu/distributor/README.rst
@@ -8,7 +8,8 @@ Bluetooth Mesh: Device Firmware Update (DFU) distributor
    :depth: 2
 
 The Bluetooth® Mesh DFU distributor sample demonstrates how device firmware can be distributed over a Bluetooth Mesh network.
-The sample implements the Firmware Distribution role of the :ref:`Bluetooth Mesh DFU subsystem <zephyr:bluetooth_mesh_dfu>`.
+The sample implements the Distributor role of the Bluetooth Mesh DFU architecture.
+Refer to :ref:`dfu_over_bt_mesh` for an introduction to the feature and links to the Zephyr :ref:`Bluetooth Mesh DFU subsystem <zephyr:bluetooth_mesh_dfu>`.
 
 Requirements
 ************
@@ -141,39 +142,56 @@ Configure the Firmware Update Server and BLOB Transfer Server models on the seco
 Performing a Device Firmware Update
 -----------------------------------
 
-The Bluetooth Mesh defines the Firmware update Initiator role to control the firmware distribution.
-This sample supports, but does not require an external Initiator to control the DFU procedure.
+The end-to-end procedure for performing a Device Firmware Update over Bluetooth Mesh (uploading the image to the Distributor, populating the receivers list, initiating the distribution, and applying the image on the Target nodes) is described in :ref:`dfu_over_bt_mesh`.
+Follow the steps in the guide to run a DFU with this sample.
 
-To activate the new firmware image on the Target node, the new image to be distributed must satisfy acceptance crieria for the target (for example: see Target sample requirements stated in :ref:`ble_mesh_dfu_target_upgrade`).
+The Bluetooth Mesh DFU Model specification defines the Firmware Update Initiator's role of controlling the firmware distribution.
+This sample supports, but does not require, an external Initiator to control the DFU procedure.
+You can drive the procedure in the following ways:
 
-There are two ways to perform a Device Firmware Update on a mesh network using the Distributor sample:
+* Using the nRF Mesh mobile app as an Initiator (recommended, and covered step-by-step in :ref:`dfu_over_bt_mesh`).
+* Using the shell commands provided by the Bluetooth Mesh DFU subsystem in Zephyr instead of an Initiator.
+  You can execute the shell commands using either the shell management subsystem of the MCU manager (for example, using the `nRF Connect Device Manager`_ application, or :ref:`Mcumgr command-line tool <dfu_tools_mcumgr_cli>`), or the :ref:`zephyr:shell_api` module over RTT.
 
-* Through the shell management subsystem of MCU manager.
-* Through the nRF Mesh mobile application.
+To activate the new firmware image on the Target node, the image must satisfy the acceptance criteria for the target (for example, see the Target sample requirements described in :ref:`ble_mesh_dfu_target_upgrade`).
 
-.. tabs::
+Expected distribution duration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   .. group-tab:: nRF Mesh app (iOS)
+The time required to distribute a firmware image to the Target nodes depends on the following factors:
 
-      .. note::
-         If you plan to use the nRF Mesh app, the Mesh DFU feature is currently supported only in the nRF Mesh app for iOS.
+* The number of Target nodes
+* The distribution addressing (multicast group address versus per-target unicast address)
+* The image size
+* The network topology
+* The network quality
 
-      Obtain the firmware image archive for the target node from the build directory and copy it to your mobile device.
-      Then follow the steps in the :ref:`dfu_over_bt_mesh` guide to perform the firmware distribution.
+The following figures are indicative reference numbers observed with the |NCS| Bluetooth Mesh DFU samples (target sample build: 324.40 KB) and are provided as an order-of-magnitude estimate only.
 
-   .. group-tab:: Shell
+.. table::
+   :align: left
 
-      The Bluetooth Mesh DFU subsystem also provides a set of shell commands that you can use instead of the Initiator.
-      Follow the instructions in the :ref:`dfu_over_bt_mesh` guide on how to perform the firmware distribution without the Initiator.
-      You can execute the commands in the following two ways:
+   +----------------+---------------------+-----------------------+
+   | Distribution   | Small deployment    | Large deployment      |
+   | addressing     |                     |                       |
+   +================+=====================+=======================+
+   | Multicast      | ~2 hours (2 nodes)  | ~2 h 15 min           |
+   |                |                     | (~135 min, 100 nodes) |
+   +----------------+---------------------+-----------------------+
+   | Unicast        | ~34 minutes         | ~3400 minutes         |
+   |                | (1 node)            | (~57 h, 100 nodes)    |
+   +----------------+---------------------+-----------------------+
 
-      * Through the shell management subsystem of MCU manager (for example, using the `nRF Connect Device Manager`_ application for Android, or :ref:`Mcumgr command-line tool <dfu_tools_mcumgr_cli>`).
-      * Using the :ref:`zephyr:shell_api` module over RTT.
+With multicast addressing, the Distributor sends the image once and all receivers pick it up in parallel, so the total duration grows only moderately with the number of Target nodes.
+With per-target unicast addressing, the Distributor sends the image sequentially to each Target node, so the total duration grows roughly linearly with the number of Target nodes.
 
 .. _ble_mesh_dfu_distributor_fw_image_upload:
 
-Uploading a firmware image
---------------------------
+Alternative ways of uploading a firmware image
+----------------------------------------------
+
+The main procedure for uploading a firmware image to the Distributor is the phone-based flow described in :ref:`dfu_over_bt_mesh`.
+You can use the alternatives documented in this section when the phone-based flow is not applicable, for example, in automated setups or when the image is provided by another Initiator device on the mesh network.
 
 A firmware image can be uploaded to the device in two ways:
 

--- a/samples/bluetooth/mesh/dfu/distributor/README.rst
+++ b/samples/bluetooth/mesh/dfu/distributor/README.rst
@@ -8,7 +8,8 @@ Bluetooth Mesh: Device Firmware Update (DFU) distributor
    :depth: 2
 
 The Bluetooth® Mesh DFU distributor sample demonstrates how device firmware can be distributed over a Bluetooth Mesh network.
-The sample implements the Firmware Distribution role of the :ref:`Bluetooth Mesh DFU subsystem <zephyr:bluetooth_mesh_dfu>`.
+The sample implements the Distributor role of the Bluetooth Mesh DFU architecture.
+Refer to :ref:`dfu_over_bt_mesh` for an introduction to the feature and links to the Zephyr :ref:`Bluetooth Mesh DFU subsystem <zephyr:bluetooth_mesh_dfu>`.
 
 Requirements
 ************
@@ -141,39 +142,56 @@ Configure the Firmware Update Server and BLOB Transfer Server models on the seco
 Performing a Device Firmware Update
 -----------------------------------
 
-The Bluetooth Mesh defines the Firmware update Initiator role to control the firmware distribution.
-This sample supports, but does not require an external Initiator to control the DFU procedure.
+The end-to-end procedure for performing a Device Firmware Update over Bluetooth Mesh (uploading the image to the Distributor, populating the receivers list, initiating the distribution, and applying the image on the Target nodes) is described in :ref:`dfu_over_bt_mesh`.
+Follow the steps in the guide to run a DFU with this sample.
 
-To activate the new firmware image on the Target node, the new image to be distributed must satisfy acceptance crieria for the target (for example: see Target sample requirements stated in :ref:`ble_mesh_dfu_target_upgrade`).
+The Bluetooth Mesh DFU Model specification defines the Firmware Update Initiator's role of controlling the firmware distribution.
+This sample supports, but does not require, an external Initiator to control the DFU procedure.
+You can drive the procedure in the following ways:
 
-There are two ways to perform a Device Firmware Update on a mesh network using the Distributor sample:
+* Using the nRF Mesh mobile app as an Initiator (recommended, and covered step-by-step in :ref:`dfu_over_bt_mesh`).
+* Using the shell commands provided by the Bluetooth Mesh DFU subsystem in Zephyr instead of an Initiator.
+  You can execute the shell commands using either the shell management subsystem of the MCU manager (for example, using the `nRF Connect Device Manager`_ application, or :ref:`Mcumgr command-line tool <dfu_tools_mcumgr_cli>`), or the :ref:`zephyr:shell_api` module over RTT.
 
-* Through the shell management subsystem of MCU manager.
-* Through the nRF Mesh mobile application.
+To activate the new firmware image on the Target node, the image must satisfy the acceptance criteria for the target (for example, see the Target sample requirements described in :ref:`ble_mesh_dfu_target_upgrade`).
 
-.. tabs::
+Expected distribution duration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   .. group-tab:: nRF Mesh app (iOS)
+The time required to distribute a firmware image to the Target nodes depends on the following factors:
 
-      .. note::
-         If you plan to use the nRF Mesh app, the Mesh DFU feature is currently supported only in the nRF Mesh app for iOS.
+* The number of Target nodes
+* The distribution addressing (multicast group address versus per-target unicast address)
+* The image size
+* The network topology
+* The network quality
 
-      Obtain the firmware image archive for the target node from the build directory and copy it to your mobile device.
-      Then follow the steps in the :ref:`dfu_over_bt_mesh` guide to perform the firmware distribution.
+The following figures are indicative reference numbers observed with the |NCS| Bluetooth Mesh DFU samples and are provided as an order-of-magnitude estimate only.
 
-   .. group-tab:: Shell
+.. table::
+   :align: left
 
-      The Bluetooth Mesh DFU subsystem also provides a set of shell commands that you can use instead of the Initiator.
-      Follow the instructions in the :ref:`dfu_over_bt_mesh` guide on how to perform the firmware distribution without the Initiator.
-      You can execute the commands in the following two ways:
+   +----------------+---------------------+-----------------------+
+   | Distribution   | Small deployment    | Large deployment      |
+   | addressing     |                     |                       |
+   +================+=====================+=======================+
+   | Multicast      | ~2 hours (2 nodes)  | ~2 h 15 min           |
+   |                |                     | (~135 min, 100 nodes) |
+   +----------------+---------------------+-----------------------+
+   | Unicast        | ~34 minutes         | ~3400 minutes         |
+   |                | (1 node)            | (~57 h, 100 nodes)    |
+   +----------------+---------------------+-----------------------+
 
-      * Through the shell management subsystem of MCU manager (for example, using the `nRF Connect Device Manager`_ application for Android, or :ref:`Mcumgr command-line tool <dfu_tools_mcumgr_cli>`).
-      * Using the :ref:`zephyr:shell_api` module over RTT.
+With multicast addressing, the Distributor sends the image once and all receivers pick it up in parallel, so the total duration grows only moderately with the number of Target nodes.
+With per-target unicast addressing, the Distributor sends the image sequentially to each Target node, so the total duration grows roughly linearly with the number of Target nodes.
 
 .. _ble_mesh_dfu_distributor_fw_image_upload:
 
-Uploading a firmware image
---------------------------
+Alternative ways of uploading a firmware image
+----------------------------------------------
+
+The main procedure for uploading a firmware image to the Distributor is the phone-based flow described in :ref:`dfu_over_bt_mesh`.
+You can use the alternatives documented in this section when the phone-based flow is not applicable, for example, in automated setups or when the image is provided by another Initiator device on the mesh network.
 
 A firmware image can be uploaded to the device in two ways:
 

--- a/samples/bluetooth/mesh/dfu/target/README.rst
+++ b/samples/bluetooth/mesh/dfu/target/README.rst
@@ -8,7 +8,8 @@ Bluetooth Mesh: Device Firmware Update (DFU) target
    :depth: 2
 
 The Bluetooth® Mesh DFU target sample demonstrates how to update device firmware over Bluetooth Mesh network.
-The sample implements the Target role of the :ref:`Bluetooth Mesh DFU subsystem <zephyr:bluetooth_mesh_dfu>`.
+The sample implements the Target role of the Bluetooth Mesh DFU architecture.
+Refer to :ref:`dfu_over_bt_mesh` for an introduction to the feature and links to the Zephyr :ref:`Bluetooth Mesh DFU subsystem <zephyr:bluetooth_mesh_dfu>`.
 
 Requirements
 ************
@@ -138,6 +139,9 @@ Once the models are bound to the application key, together they implement all th
 
 Performing a Device Firmware Update
 -----------------------------------
+
+The end-to-end procedure for performing a Device Firmware Update over Bluetooth Mesh is described in :ref:`dfu_over_bt_mesh`.
+This section focuses on the Target-specific aspects: how to build a new image that this sample will accept, the firmware ID and metadata formats used, and how the sample behaves when the image is applied.
 
 This sample can be transferred as a DFU over a mesh network to update the existing nodes.
 The sample can also be the Target node updated by any firmware image that is compiled as the MCUboot application and transferred over the mesh network.


### PR DESCRIPTION
Improve discoverability of the "DFU over Bluetooth Mesh" user guide and align the mesh DFU sample READMEs with it.

Sample READMEs:
- Point the opening line of the target and distributor READMEs to the user guide as the primary entry point.
- Defer the end-to-end DFU procedure in both samples to the user guide and narrow each section to sample-specific aspects.
- Add an "Expected distribution duration" subsection with reference numbers to the distributor README.
- Rename the distributor's "Uploading a firmware image" section to "Alternative ways of uploading a firmware image".

User guide:
- Add a "DFU roles and image transport" section describing the four DFU roles from the Bluetooth Mesh DFU Model specification, the roles played by the nRF Mesh mobile app, and how in-band vs out-of-band upload (spec Store Firmware OOB versus the SMP/mcumgr push used by the app) reach the Distributor.