### PR TITLE
nrf_security: allow disabling `CONFIG_MBEDTLS_PLATFORM_MEMORY`

### DIFF
--- a/subsys/nrf_security/Kconfig.tf-psa-crypto
+++ b/subsys/nrf_security/Kconfig.tf-psa-crypto
@@ -29,16 +29,21 @@ config MBEDTLS_THREADING_ALT
 
 endif # MBEDTLS_THREADING_C
 
-config MBEDTLS_PLATFORM_MEMORY
-	bool
-	default y
-
 config MBEDTLS_PLATFORM_C
 	bool
 	default y
 
+config MBEDTLS_ENABLE_HEAP
+	select MBEDTLS_PLATFORM_MEMORY
+
+config MBEDTLS_PLATFORM_MEMORY
+	bool "Memory allocation layer"
+	depends on MBEDTLS_PLATFORM_C
+	default y
+
 config MBEDTLS_MEMORY_BUFFER_ALLOC_C
 	bool
+	depends on MBEDTLS_PLATFORM_MEMORY
 	default y
 
 config MBEDTLS_ASN1_WRITE_C

--- a/subsys/nrf_security/src/zephyr/CMakeLists.txt
+++ b/subsys/nrf_security/src/zephyr/CMakeLists.txt
@@ -19,7 +19,6 @@ if(CONFIG_MBEDTLS_DEBUG)
   zephyr_library_sources(debug_init.c)
 endif()
 
-# Add mbed TLS heap library - Not for TF-M build
 if(CONFIG_MBEDTLS_ENABLE_HEAP)
   list(APPEND src_zephyr
     mbedtls_heap.c


### PR DESCRIPTION
Give it a prompt so it can be disabled by users that want to make use of the libc heap.

Make `CONFIG_MBEDTLS_ENABLE_HEAP` select it so that we don't end up in a scenario where the former is enabled without the latter.

Supersedes https://github.com/nrfconnect/sdk-nrf/pull/24173 which was never followed up with.