### PR TITLE
scripts: align find my CI entries and memory thresholds

### DIFF
--- a/scripts/ci/pm_legacy.txt
+++ b/scripts/ci/pm_legacy.txt
@@ -30,8 +30,6 @@ applications.nrf_desktop.zdebug_partition_manager_mcuboot_direct_xip.uart
 applications.nrf_desktop.zdebug_partition_manager_mcuboot_single_app
 applications.nrf_desktop.zdebug_partition_manager_single_image.uart
 sample.find_my.locator_tag.pm_legacy.boot_max_img_sectors
-sample.find_my.locator_tag.pm_legacy
 sample.find_my.switchable_networks.pm_legacy.boot_max_img_sectors
-sample.find_my.switchable_networks.pm_legacy
 sample.bluetooth.fast_pair.input_device.pm_legacy
 test.bluetooth.fast_pair.locator_tag_legacy.fast_pair_api_legacy.pm_legacy

--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -2,6 +2,7 @@
     - sample.bluetooth.fast_pair.locator_tag.release
   platforms: # configuration for small memory devices
     - nrf54l15dk/nrf54l05/cpuapp
+    - nrf54ls05dk/nrf54ls05b/cpuapp
   rom_increase: 512
   ram_increase: 512
   codeowners:
@@ -12,6 +13,7 @@
   platforms: # configuration for large memory devices
     - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54l15tag/nrf54l15/cpuapp
     - nrf54lm20dk/nrf54lm20a/cpuapp
   rom_increase: 1024
   ram_increase: 1024
@@ -22,6 +24,7 @@
     - sample.find_my.locator_tag.release
   platforms: # configuration for small memory devices
     - nrf54l15dk/nrf54l05/cpuapp
+    - nrf54ls05dk/nrf54ls05b/cpuapp
   rom_increase: 512
   ram_increase: 512
   codeowners:
@@ -53,6 +56,15 @@
     - all
   rom_increase: 512
   ram_increase: 512
+  codeowners:
+    - nrfconnect/ncs-si-bluebagel
+
+- scenarios:
+    - application.find_my.tag.release
+  platforms:
+    - nrf54l15tag/nrf54l15/cpuapp
+  rom_increase: 1024
+  ram_increase: 1024
   codeowners:
     - nrfconnect/ncs-si-bluebagel
 

--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -21,8 +21,6 @@
 - scenarios:
     - sample.find_my.locator_tag.release
   platforms: # configuration for small memory devices
-    - nrf52dk/nrf52832
-    - nrf52833dk/nrf52833
     - nrf54l15dk/nrf54l05/cpuapp
   rom_increase: 512
   ram_increase: 512
@@ -32,9 +30,6 @@
 - scenarios:
     - sample.find_my.locator_tag.release
   platforms: # configuration for large memory devices
-    - nrf52840dk/nrf52840
-    - nrf5340dk/nrf5340/cpuapp
-    - nrf5340dk/nrf5340/cpuapp/ns
     - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54lm20dk/nrf54lm20a/cpuapp


### PR DESCRIPTION
## Summary

This PR aligns the sdk-nrf CI infrastructure with the removal of the nRF52 and nRF53 Series support from the Apple Find My samples in the sdk-find-my repository, and adds memory threshold coverage for recently introduced board targets.

- Removed the deleted `nrf52dk/nrf52832`, `nrf52833dk/nrf52833`, `nrf52840dk/nrf52840`, `nrf5340dk/nrf5340/cpuapp`, and `nrf5340dk/nrf5340/cpuapp/ns` board targets from the `sample.find_my.locator_tag.release` entries in the memory threshold list.
- Removed the orphaned `sample.find_my.locator_tag.pm_legacy` and `sample.find_my.switchable_networks.pm_legacy` patterns from the legacy Partition Manager list, as these scenarios no longer exist (only the `boot_max_img_sectors` variants remain on the nRF54L15 DK).
- Added the missing nRF54L15 TAG (`nrf54l15tag/nrf54l15/cpuapp`) and nRF54LS05 B (`nrf54ls05dk/nrf54ls05b/cpuapp`) targets to the memory threshold list for the Google Fast Pair Locator Tag sample and the Apple Find My sample and Tag application.

Ref: NCSDK-39959 (nRF52 and nRF53 removal alignment; the memory threshold additions for the new targets have no associated ticket)

## Test plan

- [x] CI: memory threshold checks pass with the updated `scripts/memory-threshold-list.yaml`.
- [x] CI: legacy Partition Manager list (`scripts/ci/pm_legacy.txt`) no longer references removed Find My scenarios.
