### PR TITLE
[v3.4-branch] scripts: memory threshold: add nRF54L15 TAG and nRF54LS05 B targets

### DIFF
--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -4,6 +4,7 @@
     - nrf52dk/nrf52832
     - nrf52833dk/nrf52833
     - nrf54l15dk/nrf54l05/cpuapp
+    - nrf54ls05dk/nrf54ls05b/cpuapp
   rom_increase: 512
   ram_increase: 512
   codeowners:
@@ -17,6 +18,7 @@
     - nrf5340dk/nrf5340/cpuapp/ns
     - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54l15tag/nrf54l15/cpuapp
     - nrf54lm20dk/nrf54lm20a/cpuapp
     - thingy53/nrf5340/cpuapp
     - thingy53/nrf5340/cpuapp/ns
@@ -31,6 +33,7 @@
     - nrf52dk/nrf52832
     - nrf52833dk/nrf52833
     - nrf54l15dk/nrf54l05/cpuapp
+    - nrf54ls05dk/nrf54ls05b/cpuapp
   rom_increase: 512
   ram_increase: 512
   codeowners:
@@ -65,6 +68,15 @@
     - all
   rom_increase: 512
   ram_increase: 512
+  codeowners:
+    - nrfconnect/ncs-si-bluebagel
+
+- scenarios:
+    - application.find_my.tag.release
+  platforms:
+    - nrf54l15tag/nrf54l15/cpuapp
+  rom_increase: 1024
+  ram_increase: 1024
   codeowners:
     - nrfconnect/ncs-si-bluebagel
 


### PR DESCRIPTION
## Summary

Backport of commit fa9e06959471a41b8b8149604353fa7c0650feee to `v3.4-branch`.

Adds the missing nRF54L15 TAG (`nrf54l15tag/nrf54l15/cpuapp`) and nRF54LS05 B (`nrf54ls05dk/nrf54ls05b/cpuapp`) board targets to the memory threshold list, aligning it with the platforms already built by the Google Fast Pair Locator Tag sample and the Apple Find My sample and Tag application.

- Added `nrf54ls05dk/nrf54ls05b/cpuapp` (small memory) to the `sample.bluetooth.fast_pair.locator_tag.release` and `sample.find_my.locator_tag.release` entries.
- Added `nrf54l15tag/nrf54l15/cpuapp` (large memory) to the `sample.bluetooth.fast_pair.locator_tag.release` entry.
- Added a new `application.find_my.tag.release` entry for the `nrf54l15tag/nrf54l15/cpuapp` target, which was not covered before.

The nRF52 and nRF53 Series (and Thingy:53) entries are intentionally kept, as `v3.4-branch` still supports these targets.

## Test plan

- [ ] CI: memory threshold checks pass with the updated `scripts/memory-threshold-list.yaml`.
