### PR TITLE
scripts: west_commands: create_board: Add model info to nRF91

### DIFF
--- a/scripts/west_commands/create_board/templates/nrf91/board.dts.jinja2
+++ b/scripts/west_commands/create_board/templates/nrf91/board.dts.jinja2
@@ -6,6 +6,9 @@
 #include "{{ board }}-partitioning.dtsi"
 
 / {
+	model = "{{ board_desc }} (non-secure)";
+	compatible = "{{ vendor }},{{ board | replace("_", "-") }}-ns";
+
 	chosen {
 		zephyr,flash = &flash0;
 		zephyr,sram = &sram0_ns_app;
@@ -20,6 +23,9 @@
 #include "{{ board }}-partitioning.dtsi"
 
 / {
+	model = "{{ board_desc }}";
+	compatible = "{{ vendor }},{{ board | replace("_", "-") }}";
+
 	chosen {
 		zephyr,sram = &sram0_s;
 		zephyr,flash = &flash0;


### PR DESCRIPTION
Seemingly this was missing from this one board template