### PR TITLE
tests: benchmarks: multicore: idle_rad: try different board

### DIFF
--- a/tests/benchmarks/multicore/idle_rad/testcase.yaml
+++ b/tests/benchmarks/multicore/idle_rad/testcase.yaml
@@ -13,7 +13,7 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpurad
     harness_config:
-      fixture: ppk_power_measure
+      fixture: gpio_loopback
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_and_data_dump_power_consumption_s2ram_outside_of_main"
     timeout: 120


### PR DESCRIPTION
Use board with loopbacks.