### PR TITLE
scripts: license_allow_list: Fix regex for new types

### DIFF
--- a/scripts/ci/license_allow_list.yaml
+++ b/scripts/ci/license_allow_list.yaml
@@ -41,10 +41,10 @@ none: |
   !\.cpp$
   !\.a$
   !\.py$
-  !\.hpp
-  !\.cxx
-  !\.hxx
-  !\.rs
+  !\.hpp$
+  !\.cxx$
+  !\.hxx$
+  !\.rs$
 
 # Any license information is allowed in Python scripts, but it will generate a warning.
 -any: |


### PR DESCRIPTION
The new types added recently did not add a `$` terminator so the regex matched more than it should (e.g. it matches `.rst` because of the `!\.rs` regex.