### PR TITLE
manifest: Update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b8e6b9b3ed1f2c00a32e03975d189b5050e10c31
+      revision: pull/4274/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Use sdk-zephyr revision with fix for
cmake-only build on Thingy:53.

Ref: NCSDK-39372