### PR TITLE
tests: drivers: watchdog: Test GSWDT

### DIFF
--- a/tests/drivers/watchdog/uicr_wdtstart/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/watchdog/uicr_wdtstart/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -5,6 +5,12 @@
  */
 
 /* It must match with CONFIG_GEN_UICR_WDTSTART_INSTANCE_WDTx in sysbuild/uicr.conf */
+/ {
+	aliases {
+		wdt = &wdt011;
+	};
+};
+
 &wdt011 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/uicr_wdtstart/boards/nrf54h20dk_nrf54h20_cpuapp_nrf_gswdt.overlay
+++ b/tests/drivers/watchdog/uicr_wdtstart/boards/nrf54h20dk_nrf54h20_cpuapp_nrf_gswdt.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		wdt = &cpuapp_gswdt;
+	};
+};
+
+&cpuapp_gswdt {
+	status = "okay";
+};
+
+&cpuapp_cpusys_gswdt_mbox {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/uicr_wdtstart/src/main.c
+++ b/tests/drivers/watchdog/uicr_wdtstart/src/main.c
@@ -12,8 +12,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uicr_wdtstart, LOG_LEVEL_INF);
 
-static const struct device *const wdt_dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(wdt011));
+static const struct device *const wdt_dev = DEVICE_DT_GET_OR_NULL(DT_ALIAS(wdt));
 static int wdt_channel_id = -1;
+static uint32_t watchdog_window = 5000U;
 
 
 /* First call of configure_watchdog will:
@@ -29,7 +30,6 @@ static void configure_watchdog(void)
 	/* After reconfiguration, watchdog window will be
 	 * larger than the one set by the Ironside.
 	 */
-	uint32_t watchdog_window = 5000U;
 
 	if (!device_is_ready(wdt_dev)) {
 		LOG_ERR("WDT device %s is not ready", wdt_dev->name);
@@ -123,6 +123,7 @@ int main(void)
 	} else {
 		LOG_INF("FAIL: wdt_disable() returned %d", ret);
 	}
+	k_msleep(watchdog_window + 100);
 
 	print_bar();
 	LOG_INF("Test is completed");

--- a/tests/drivers/watchdog/uicr_wdtstart/testcase.yaml
+++ b/tests/drivers/watchdog/uicr_wdtstart/testcase.yaml
@@ -14,10 +14,15 @@ common:
       - "WATCHDOG was reconfigured"
       - "3: Watchdog was feed"
       - "WATCHDOG was disabled"
+      - "Test is completed"
+  timeout: 6
+  platform_allow:
+    - nrf54h20dk/nrf54h20/cpuapp
+  integration_platforms:
+    - nrf54h20dk/nrf54h20/cpuapp
 
 tests:
-  drivers.watchdog.uicr_wdtstart:
-    platform_allow:
-      - nrf54h20dk/nrf54h20/cpuapp
-    integration_platforms:
-      - nrf54h20dk/nrf54h20/cpuapp
+  drivers.watchdog.uicr_wdtstart: {}
+  drivers.watchdog.uicr_wdtstart.nrf_gswdt:
+    extra_args:
+      - FILE_SUFFIX=nrf_gswdt


### PR DESCRIPTION
Add a test case for the Global Software WDT. Additionally, add a sleep longer than the watchdog window after the WDT is disabled to verify that the WDT is actually disabled.