### PR TITLE
tests: drivers: watchdog: Extend test timeout

### DIFF
--- a/tests/drivers/watchdog/uicr_wdtstart/testcase.yaml
+++ b/tests/drivers/watchdog/uicr_wdtstart/testcase.yaml
@@ -15,7 +15,7 @@ common:
       - "3: Watchdog was feed"
       - "WATCHDOG was disabled"
       - "Test is completed"
-  timeout: 6
+  timeout: 30
   platform_allow:
     - nrf54h20dk/nrf54h20/cpuapp
   integration_platforms:


### PR DESCRIPTION
extend timeout for gswdt test, current one is not enough to collect complete logs.