### PR TITLE
scripts: sbom: Simplify non-git directory warning

### DIFF
--- a/scripts/west_commands/sbom/common.py
+++ b/scripts/west_commands/sbom/common.py
@@ -23,7 +23,8 @@ from sbom_exceptions import SbomException
 
 def command_execute(*cmd_args: 'tuple[str|Path]', cwd: 'str|Path|None' = None,
                     return_path: bool = False, allow_stderr: bool = False,
-                    return_error_code: bool = False, shell: bool = False) -> 'Path|str':
+                    return_error_code: bool = False, shell: bool = False,
+                    log_stderr: bool = True) -> 'Path|str':
     '''Execute subprocess wrapper that handles errors and output redirections.'''
     cmd_args = tuple(str(x) for x in cmd_args)
     if cwd is not None:
@@ -47,7 +48,8 @@ def command_execute(*cmd_args: 'tuple[str|Path]', cwd: 'str|Path|None' = None,
 
         if len(err.strip()) > 0:
             if allow_stderr:
-                log.wrn(f'Command "{cmd_args[0]}" reported errors:\n{err}')
+                if log_stderr:
+                    log.wrn(f'Command "{cmd_args[0]}" reported errors:\n{err}')
             else:
                 log.err(f'Command "{cmd_args[0]}" reported errors:\n{err}')
                 if (cp.returncode == 0) or return_error_code:

--- a/scripts/west_commands/sbom/git_info_detector.py
+++ b/scripts/west_commands/sbom/git_info_detector.py
@@ -135,7 +135,7 @@ def get_toplevel(absolute_path: Path) -> 'Path|None':
     '''Returns the resolved git toplevel directory at `absolute_path`.'''
     output, error_code = command_execute(args.git, 'rev-parse', '--show-toplevel',
                                          cwd=absolute_path, return_error_code=True,
-                                         allow_stderr=True)
+                                         allow_stderr=True, log_stderr=False)
     if error_code != 0:
         return None
     line = output.strip()
@@ -216,9 +216,15 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
     untracked_files = set()
     absolute_path = Path(files_to_assign[0].file_path).parent
     relative_path = Path(files_to_assign[0].file_rel_path).parent
-    git_sha = get_sha(absolute_path)
-    git_origin = get_origin(absolute_path, relative_path)
     repo = get_toplevel(absolute_path)
+    if repo is None:
+        log.wrn(f'Directory "{relative_path}" is not a git repository. '
+                'Files will be included without git-info detector information.')
+        git_sha = None
+        git_origin = None
+    else:
+        git_sha = get_sha(absolute_path)
+        git_origin = get_origin(absolute_path, relative_path)
     project = _manifest_projects.get(repo) if repo is not None else None
     if project is not None:
         git_origin = project.url


### PR DESCRIPTION
Check whether an input directory belongs to a git repository before fetching git information when using git-info detector.

Suppress the expected git stderr and emit one clear warning while keeping the files in the sbom report.