### PR TITLE
applications: nrf_audio: Remove CONFIG_BT_AUDIO_BITRATE_UNICAST_SINK

### DIFF
--- a/applications/nrf_audio/src/bluetooth/bt_stream/unicast/Kconfig
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/unicast/Kconfig
@@ -11,17 +11,11 @@ menu "Unicast"
 choice BT_BAP_UNICAST_BAP_CONFIGURATION
 	prompt "Unicast codec configuration"
 	depends on TRANSPORT_CIS
-	default BT_BAP_UNICAST_CONFIGURABLE
+	default BT_BAP_UNICAST_48_4_1
 	help
 	  Select the unicast codec configuration as given in
 	  Table 5.2 of the Bluetooth Audio Profile Specification.
 	  USB only supports 48 kHz samplig rate.
-
-config BT_BAP_UNICAST_CONFIGURABLE
-	bool "Configurable unicast settings"
-	depends on TRANSPORT_CIS
-	help
-	  Configurable option that doesn't follow any preset. Allows for more flexibility.
 
 config BT_BAP_UNICAST_16_2_1
 	bool "16_2_1"
@@ -108,25 +102,6 @@ config BT_AUDIO_PREFERRED_MAX_PRES_DLY_US
 	help
 	  The preferred maximum presentation delay in microseconds. This can not
 	  be less than the absolute maximum presentation delay.
-
-config BT_AUDIO_BITRATE_UNICAST_SINK
-	int "ISO stream bitrate"
-	depends on TRANSPORT_CIS
-	default 64000 if BT_BAP_UNICAST_CONFIGURABLE && STREAM_BIDIRECTIONAL
-	default 96000 if BT_BAP_UNICAST_CONFIGURABLE
-	default 32000 if BT_BAP_UNICAST_16_2_1
-	default 48000 if BT_BAP_UNICAST_24_2_1
-	help
-	  Bitrate for the unicast sink ISO stream.
-
-config BT_AUDIO_BITRATE_UNICAST_SRC
-	int "ISO stream bitrate"
-	depends on TRANSPORT_CIS
-	default 32000 if BT_BAP_UNICAST_16_2_1
-	default 48000 if BT_BAP_UNICAST_24_2_1
-	default 64000
-	help
-	  Bitrate for the unicast source ISO stream.
 
 config BT_SET_IDENTITY_RESOLVING_KEY_DEFAULT
 	string

--- a/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_client.h
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_client.h
@@ -29,18 +29,7 @@ enum unicast_discover_dir {
 	UNICAST_SERVER_BIDIR = (BT_AUDIO_DIR_SINK | BT_AUDIO_DIR_SOURCE)
 };
 
-#if CONFIG_BT_BAP_UNICAST_CONFIGURABLE
-#define BT_BAP_LC3_UNICAST_PRESET_NRF_AUDIO_SINK                                                   \
-	BT_BAP_LC3_PRESET_CONFIGURABLE(BT_AUDIO_LOCATION_FRONT_LEFT,                               \
-				       BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED,                          \
-				       CONFIG_BT_AUDIO_BITRATE_UNICAST_SINK)
-
-#define BT_BAP_LC3_UNICAST_PRESET_NRF_AUDIO_SOURCE                                                 \
-	BT_BAP_LC3_PRESET_CONFIGURABLE(BT_AUDIO_LOCATION_FRONT_LEFT,                               \
-				       BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED,                          \
-				       CONFIG_BT_AUDIO_BITRATE_UNICAST_SRC)
-
-#elif CONFIG_BT_BAP_UNICAST_16_2_1
+#if CONFIG_BT_BAP_UNICAST_16_2_1
 #define BT_BAP_LC3_UNICAST_PRESET_NRF_AUDIO_SINK                                                   \
 	BT_BAP_LC3_UNICAST_PRESET_16_2_1(BT_AUDIO_LOCATION_FRONT_LEFT,                             \
 					 BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED)
@@ -65,7 +54,7 @@ enum unicast_discover_dir {
 	BT_BAP_LC3_UNICAST_PRESET_48_4_1(BT_AUDIO_LOCATION_ANY, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED)
 #else
 #error Unsupported LC3 codec preset for unicast
-#endif /* CONFIG_BT_BAP_UNICAST_CONFIGURABLE */
+#endif /* CONFIG_BT_BAP_UNICAST_16_2_1 */
 
 /**
  * @brief	Get configuration for the audio stream.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -284,9 +284,13 @@ nRF Audio (formerly nRF5340 Audio)
     The support is limited to the :ref:`unicast client app<nrf_audio_unicast_client_app>` application with USB as audio source, which can be built for the ``nrf54lm20dk/nrf54lm20a/cpuapp`` board target.
     The support is experimental and not yet fully tested, so it is not recommended for production use.
 
-* Removed :file:`prj_release.conf` files from all nRF Audio applications, and the buildprog tool.
-  Users must specify themselves which configurations are desired in a release build.
-  See :ref:`nrf_audio_app_configuration_select_build` for more information.
+* Removed:
+
+  * :file:`prj_release.conf` files from all nRF Audio applications and from the buildprog tool.
+    You must now explicitly specify which configurations to include in a release build.
+    See :ref:`nrf_audio_app_configuration_select_build` for more information.
+  * The :kconfig:option:`CONFIG_BT_BAP_UNICAST_CONFIGURABLE` option from the unicast client and server applications.
+    This option was not useful because the unicast server range settings overwrite the bitrate configuration.
 
 nRF Desktop
 -----------


### PR DESCRIPTION
The BAP presets are covering enough. It’s not really up to the unicast client to decide, as the server needs to have the specific bitrate in its PAC records anyway.
Hence removing references to CONFIG_BT_AUDIO_BITRATE_UNICAST_SINK.
 OCT-3006