### PR TITLE
ci: Exclude Matter repository from license checking

### DIFF
--- a/scripts/ci/license_allow_list.yaml
+++ b/scripts/ci/license_allow_list.yaml
@@ -21,6 +21,7 @@ exclude:
   # - nrf/tests
   # - nrfxlib/blocked_dir
   # - modules/crypto/mbedtls
+  - modules/lib/matter
   files:
   # - modules/crypto/oberon-psa-crypto/a_new_file.h
   patterns:


### PR DESCRIPTION
Matter reposiotory has own license checker, so it is redundant to check it twice.