### PR TITLE
bluetooth: hids: support for HID SCI mode parameter customization

### DIFF
--- a/doc/nrf/libraries/bluetooth/services/hids.rst
+++ b/doc/nrf/libraries/bluetooth/services/hids.rst
@@ -88,7 +88,14 @@ This starts the SCI mode change process, which consists of the following steps:
    The library invokes this callback with the matching :c:enum:`bt_hids_cp_evt` event and the connection object when the HID host writes an SCI mode request to the Control Point characteristic.
    The deprecated :c:member:`bt_hids_init_param.cp_evt_handler` callback is not invoked for SCI mode requests.
 #. Inside the callback, the application can perform any additional necessary actions, such as performing Frame Space Update.
-#. Call the :c:func:`bt_hids_sci_mode_change_request` function to request connection parameters for the target :c:enum:`bt_hids_sci_mode_value`.
+#. Request connection parameters for the target :c:enum:`bt_hids_sci_mode_value` using one of the following approaches:
+
+   * Call the :c:func:`bt_hids_sci_mode_change_request` function to automatically request the parameter values specified by the Kconfig options.
+   * Call the :c:func:`bt_hids_sci_mode_conn_rate_param_get` function to obtain the parameters for the mode.
+     Optionally adjust them to select a subset of the allowed values for the mode.
+     You can use the :c:func:`bt_hids_sci_mode_validate` API to check if the updated parameters are still valid for the selected HID SCI mode.
+     Then call :c:func:`bt_conn_le_conn_rate_request` manually.
+
    The application should track the pending mode (for example, in per-connection context data) until the connection rate change completes.
 #. In the :c:member:`bt_conn_cb.conn_rate_changed` callback, call the :c:func:`bt_hids_sci_mode_validate` function with the pending mode and the new connection parameters.
    If the validation succeeds, call the :c:func:`bt_hids_sci_mode_updated` function to update the cached SCI mode and notify the subscribed HID hosts.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -582,6 +582,10 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
+* :ref:`hids_readme` library:
+
+  * Added support for runtime customization of connection parameters for a given HID SCI mode through the newly added :c:func:`bt_hids_sci_mode_conn_rate_param_get` API.
+
 * :ref:`bt_fast_pair_readme` library:
 
   * Removed the nRF52 and nRF53 Series support.

--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -725,6 +725,16 @@ int bt_hids_boot_kb_inp_rep_send(struct bt_hids *hids_obj, struct bt_conn *conn,
  */
 int bt_hids_sci_mode_get(struct bt_conn *conn, enum bt_hids_sci_mode_value *mode);
 
+/** @brief Get connection rate parameters for the given SCI mode.
+ *         The parameters are configured by using Kconfig options.
+ *
+ *  @param mode SCI mode.
+ *
+ *  @return Pointer to the connection rate parameters for @p mode, or NULL if @p mode is invalid.
+ */
+const struct bt_conn_le_conn_rate_param *bt_hids_sci_mode_conn_rate_param_get(
+	enum bt_hids_sci_mode_value mode);
+
 /** @brief Request a new HID SCI mode.
  *         This function will request connection parameters for the mode.
  *         To actually change the mode @ref bt_hids_sci_mode_updated needs to be called

--- a/subsys/bluetooth/services/hids.c
+++ b/subsys/bluetooth/services/hids.c
@@ -887,26 +887,6 @@ static void hids_sci_mode_ccc_changed(struct bt_gatt_attr const *attr, uint16_t 
 	}
 }
 
-static const struct bt_conn_le_conn_rate_param *get_sci_conn_rate_param_for_mode(
-	enum bt_hids_sci_mode_value mode)
-{
-	switch (mode) {
-	case BT_HIDS_SCI_MODE_DEFAULT:
-		return &hids_sci_conn_rate_default;
-	case BT_HIDS_SCI_MODE_FAST:
-		return &hids_sci_conn_rate_fast;
-#if defined(CONFIG_BT_HIDS_SCI_LOW_POWER_MODE)
-	case BT_HIDS_SCI_MODE_LOW_POWER:
-		return &hids_sci_conn_rate_low_power;
-#endif
-	case BT_HIDS_SCI_MODE_FULL_RANGE:
-		return &hids_sci_conn_rate_full_range;
-	default:
-		LOG_ERR("Invalid SCI mode: %d", mode);
-		return NULL;
-	}
-}
-
 int bt_hids_sci_mode_get(struct bt_conn *conn, enum bt_hids_sci_mode_value *mode)
 {
 	if (conn == NULL || mode == NULL) {
@@ -932,6 +912,26 @@ int bt_hids_sci_mode_get(struct bt_conn *conn, enum bt_hids_sci_mode_value *mode
 	return 0;
 }
 
+const struct bt_conn_le_conn_rate_param *bt_hids_sci_mode_conn_rate_param_get(
+	enum bt_hids_sci_mode_value mode)
+{
+	switch (mode) {
+	case BT_HIDS_SCI_MODE_DEFAULT:
+		return &hids_sci_conn_rate_default;
+	case BT_HIDS_SCI_MODE_FAST:
+		return &hids_sci_conn_rate_fast;
+#if defined(CONFIG_BT_HIDS_SCI_LOW_POWER_MODE)
+	case BT_HIDS_SCI_MODE_LOW_POWER:
+		return &hids_sci_conn_rate_low_power;
+#endif
+	case BT_HIDS_SCI_MODE_FULL_RANGE:
+		return &hids_sci_conn_rate_full_range;
+	default:
+		LOG_ERR("Invalid SCI mode: %d", mode);
+		return NULL;
+	}
+}
+
 int bt_hids_sci_mode_change_request(struct bt_conn *conn,
 				 enum bt_hids_sci_mode_value mode)
 {
@@ -954,7 +954,7 @@ int bt_hids_sci_mode_change_request(struct bt_conn *conn,
 		return -ENOENT;
 	}
 
-	params = get_sci_conn_rate_param_for_mode(mode);
+	params = bt_hids_sci_mode_conn_rate_param_get(mode);
 	if (params == NULL) {
 		bt_conn_ctx_release(sci_mode_hids_obj->conn_ctx, (void *)conn_data);
 		return -EINVAL;
@@ -975,7 +975,7 @@ bool bt_hids_sci_mode_validate(enum bt_hids_sci_mode_value mode,
 			       const struct bt_conn_le_conn_rate_changed *params)
 {
 	const struct bt_conn_le_conn_rate_param *mode_params =
-		get_sci_conn_rate_param_for_mode(mode);
+		bt_hids_sci_mode_conn_rate_param_get(mode);
 
 	if (params == NULL || mode_params == NULL) {
 		return false;


### PR DESCRIPTION
The customization is achieved by adding an API for getting parameters for a given HID SCI mode.
The user of the API can then manually request the connection parameters.

The main trigger for this change is allowing an nrf_desktop peripheral to switch between "low latency" and "high latency" while remaining in HID SCI fast mode