### PR TITLE
caf: add support for the BLE conn rate change event

### DIFF
--- a/doc/nrf/libraries/caf/ble_state.rst
+++ b/doc/nrf/libraries/caf/ble_state.rst
@@ -64,10 +64,33 @@ The application module can submit a :c:struct:`ble_peer_event` with :c:member:`b
 Connection parameter change
 ===========================
 
+Connection parameter changes are handled differently depending on whether Shorter Connection Intervals (SCI) are used for a given Bluetooth LE connection.
+SCI support is controlled by the :kconfig:option:`CONFIG_BT_SHORTER_CONNECTION_INTERVALS` Kconfig option.
+The peer must also support SCI for it to be used on a connection.
+
+Shorter Connection Intervals unused
+-----------------------------------
+
 The module submits a :c:struct:`ble_peer_conn_params_event` to inform other application modules about connection parameter update requests and connection parameter updates.
 
 The |ble_state| rejects the connection parameter update request in Zephyr's callback.
 An application module can handle the :c:struct:`ble_peer_conn_params_event` and update the connection parameters.
+
+Shorter Connection Intervals used
+---------------------------------
+
+If you are using SCI, update the connection parameters with the connection *rate* API (:c:func:`bt_conn_le_conn_rate_request`).
+The module submits a :c:struct:`ble_peer_sci_conn_rate_event` to inform other application modules about connection rate changes.
+The event is also emitted when a connection rate update request fails.
+In this case, it contains the status code of the failed request.
+No event is emitted when a connection rate update request is made, because the Bluetooth stack does not provide a callback for this when SCI is enabled.
+
+A Bluetooth LE Central can use the :c:func:`bt_conn_le_conn_rate_set_defaults` API to limit the accepted connection rate range.
+
+.. note::
+   When the :kconfig:option:`CONFIG_BT_SHORTER_CONNECTION_INTERVALS` Kconfig option is enabled, the non-SCI callbacks remain available.
+   They are called if you use the non-SCI (connection parameter update) API to update the connection parameters.
+   However, do not use the non-SCI API if both the device and peer support the SCI.
 
 Connection references
 =====================

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -583,7 +583,9 @@ Bluetooth libraries and services
 Common Application Framework
 ----------------------------
 
-|no_changes_yet_note|
+* :ref:`caf_ble_state`:
+
+  * Added the :c:struct:`ble_peer_sci_conn_rate_event` event to report connection rate changes or failed connection rate change requests when shorter connection intervals are enabled.
 
 Debug libraries
 ---------------

--- a/include/caf/events/ble_common_event.h
+++ b/include/caf/events/ble_common_event.h
@@ -184,6 +184,27 @@ struct ble_peer_conn_params_event {
 	bool updated;
 };
 
+/** @brief Bluetooth LE peer SCI connection rate event.
+ *
+ * The Bluetooth LE peer SCI connection rate event is submitted to inform that connection rate
+ * parameters (including both connection interval and subrating) have changed or that a
+ * connection rate change request failed.
+ * The params field is valid only if status is BT_HCI_ERR_SUCCESS and must be ignored otherwise.
+ */
+struct ble_peer_sci_conn_rate_event {
+	/** Event header. */
+	struct app_event_header header;
+
+	/** ID used to identify Bluetooth connection - pointer to the bt_conn. */
+	void *id;
+
+	/** HCI Status from LE Connection Rate Change event. */
+	uint8_t status;
+
+	/** New connection rate parameters. Valid only if status is BT_HCI_ERR_SUCCESS. */
+	struct bt_conn_le_conn_rate_changed params;
+};
+
 /** @brief Bluetooth LE peer search event.
  *
  * The Bluetooth LE peer search event is submitted to inform if application is currently looking for
@@ -222,6 +243,7 @@ extern "C" {
 APP_EVENT_TYPE_DECLARE(ble_peer_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_operation_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_conn_params_event);
+APP_EVENT_TYPE_DECLARE(ble_peer_sci_conn_rate_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_search_event);
 APP_EVENT_TYPE_DECLARE(ble_adv_data_update_event);
 

--- a/subsys/caf/events/Kconfig
+++ b/subsys/caf/events/Kconfig
@@ -35,6 +35,14 @@ config CAF_BLE_COMMON_EVENTS
 	help
 	  Enable support for BLE common events.
 
+config CAF_BLE_SCI_CONN_RATE_EVENTS
+	bool "BLE SCI connection rate events"
+	depends on CAF_BLE_COMMON_EVENTS
+	depends on BT_SHORTER_CONNECTION_INTERVALS
+	default y
+	help
+	  Enable support for BLE connection rate events.
+
 config CAF_INIT_LOG_BLE_PEER_EVENTS
 	bool "Log BLE peer events"
 	depends on CAF_BLE_COMMON_EVENTS
@@ -62,6 +70,12 @@ config CAF_INIT_LOG_BLE_PEER_OPERATION_EVENTS
 config CAF_INIT_LOG_BLE_PEER_CONN_PARAMS_EVENTS
 	bool "Log BLE peer connection parameters events"
 	depends on CAF_BLE_COMMON_EVENTS
+	depends on LOG
+	default y
+
+config CAF_INIT_LOG_BLE_SCI_CONN_RATE_EVENTS
+	bool "Log BLE peer connection rate events"
+	depends on CAF_BLE_SCI_CONN_RATE_EVENTS
 	depends on LOG
 	default y
 

--- a/subsys/caf/events/ble_common_event.c
+++ b/subsys/caf/events/ble_common_event.c
@@ -160,3 +160,33 @@ APP_EVENT_TYPE_DEFINE(ble_peer_conn_params_event,
 		  APP_EVENT_FLAGS_CREATE(
 			IF_ENABLED(CONFIG_CAF_INIT_LOG_BLE_PEER_CONN_PARAMS_EVENTS,
 				(APP_EVENT_TYPE_FLAGS_INIT_LOG_ENABLE))));
+
+#if CONFIG_CAF_BLE_SCI_CONN_RATE_EVENTS
+
+static void log_ble_peer_sci_conn_rate_event(const struct app_event_header *aeh)
+{
+	const struct ble_peer_sci_conn_rate_event *event =
+		cast_ble_peer_sci_conn_rate_event(aeh);
+
+	if (event->status == BT_HCI_ERR_SUCCESS) {
+		APP_EVENT_MANAGER_LOG(aeh, "peer=%p interval_us=%" PRIu32
+				" subrate=%" PRIu16 " lat=%" PRIu16
+				" continuation num=%" PRIu16 " timeout=%" PRIu16,
+				event->id, event->params.interval_us,
+				event->params.subrate_factor,
+				event->params.peripheral_latency,
+				event->params.continuation_number,
+				event->params.supervision_timeout_10ms);
+	} else {
+		APP_EVENT_MANAGER_LOG(aeh, "peer=%p status=0x%02x", event->id, event->status);
+	}
+}
+
+APP_EVENT_TYPE_DEFINE(ble_peer_sci_conn_rate_event,
+		  log_ble_peer_sci_conn_rate_event,
+		  NULL,
+		  APP_EVENT_FLAGS_CREATE(
+			IF_ENABLED(CONFIG_CAF_INIT_LOG_BLE_SCI_CONN_RATE_EVENTS,
+				(APP_EVENT_TYPE_FLAGS_INIT_LOG_ENABLE))));
+
+#endif /* CONFIG_CAF_BLE_SCI_CONN_RATE_EVENTS */

--- a/subsys/caf/modules/ble_state.c
+++ b/subsys/caf/modules/ble_state.c
@@ -269,6 +269,26 @@ static void le_param_updated(struct bt_conn *conn, uint16_t interval,
 	APP_EVENT_SUBMIT(event);
 }
 
+#if CONFIG_CAF_BLE_SCI_CONN_RATE_EVENTS
+static void conn_rate_changed(struct bt_conn *conn, uint8_t status,
+			      const struct bt_conn_le_conn_rate_changed *params)
+{
+	struct ble_peer_sci_conn_rate_event *event = new_ble_peer_sci_conn_rate_event();
+
+	event->id = conn;
+	event->status = status;
+
+	if (status == BT_HCI_ERR_SUCCESS) {
+		__ASSERT(params != NULL,
+			 "params pointer is NULL for successful conn rate change");
+
+		event->params = *params;
+	}
+
+	APP_EVENT_SUBMIT(event);
+}
+#endif /* CONFIG_CAF_BLE_SCI_CONN_RATE_EVENTS */
+
 static void bt_ready(int err)
 {
 	if (err) {
@@ -302,6 +322,9 @@ static int ble_state_init(void)
 		.security_changed = security_changed,
 		.le_param_req = le_param_req,
 		.le_param_updated = le_param_updated,
+#if CONFIG_CAF_BLE_SCI_CONN_RATE_EVENTS
+		.conn_rate_changed = conn_rate_changed,
+#endif /* CONFIG_CAF_BLE_SCI_CONN_RATE_EVENTS */
 	};
 	bt_conn_cb_register(&conn_callbacks);
 


### PR DESCRIPTION
The event is issued when the Bluetooth SCI specific conn_rate_changed callback arrives.