### PR TITLE
tests: drivers: ppi_seq: i2c_spi: Change pins for nrf9251dk

### DIFF
--- a/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp_i2c_timer_notifier_counter.overlay
+++ b/tests/drivers/ppi_seq/ppi_seq_i2c_spi/boards/nrf9251dk_nrf9251_cpuapp_i2c_timer_notifier_counter.overlay
@@ -5,22 +5,22 @@
  */
 
 /* Test requires loopbacks:
- * - between P2.03 and P2.09
- * - between P2.01 and P2.02
+ * - between P1.04 and P1.11
+ * - between P1.00 and P1.01
  */
 
 &pinctrl {
 	i2c130_default_alt: i2c130_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 2, 3)>,
-				<NRF_PSEL(TWIM_SCL, 2, 1)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
+				<NRF_PSEL(TWIM_SCL, 1, 1)>;
 		};
 	};
 
 	i2c130_sleep_alt: i2c130_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 2, 3)>,
-				<NRF_PSEL(TWIM_SCL, 2, 1)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 4)>,
+				<NRF_PSEL(TWIM_SCL, 1, 1)>;
 			low-power-enable;
 		};
 	};
@@ -30,16 +30,16 @@
 			/* Temporary workaround as it is currently not possible
 			 * to configure pins for TWIS with pinctrl.
 			 */
-			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
-				<NRF_PSEL(TWIM_SCL, 2, 2)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+				<NRF_PSEL(TWIM_SCL, 1, 0)>;
 			bias-pull-up;
 		};
 	};
 
 	i2c131_sleep_alt: i2c131_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
-				<NRF_PSEL(TWIM_SCL, 2, 2)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+				<NRF_PSEL(TWIM_SCL, 1, 0)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
For i2c configuration use pins which are not connected to board LEDs. Board LEDs has additional resistors that impact the I2C transfer.