### PR TITLE
doc: fix a small issue with github links

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -237,6 +237,7 @@ gh_link_prefixes = {
     "samples/.*": "",
     "scripts/.*": "",
     "tests/.*": "",
+    "boards/.*": "",
     ".*": "doc/nrf",
 }
 

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -227,6 +227,7 @@ gh_link_prefixes = {
     "samples/.*": "",
     "scripts/.*": "",
     "tests/.*": "",
+    "boards/.*": "",
     ".*": "doc/nrf",
 }
 


### PR DESCRIPTION
The 'Open in Github' button linked to 404 when used on pages for Nordic boards in the sdk-nrf repo.