### PR TITLE
bluetooth: controller: Fix return of LE Read Supported States

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -792,7 +792,7 @@ static void le_read_supported_states(uint8_t *buf)
 #endif
 #if defined(CONFIG_BT_CENTRAL)
 	states1 |= ST_MAS;
-	states2 |= ST_MAS;
+	states2 |= ST_MAS2;
 #else
 	states1 &= ~ST_MAS;
 	states2 &= ~ST_MAS2;
@@ -803,9 +803,8 @@ static void le_read_supported_states(uint8_t *buf)
 #else
 	states1 &= ~ST_SCA_INI;
 #endif
-
-	*buf = states1;
-	*(buf + 4) = states2;
+	sys_put_le32(states1, &buf[0]);
+	sys_put_le32(states2, &buf[4]);
 }
 
 int hci_internal_user_cmd_handler_register(const hci_internal_user_cmd_handler_t handler)


### PR DESCRIPTION
This commit ensures that the returned parameters is matching the supported states. Previously only byte 0 and byte 4 were set, the remaining bytes contained undefined values.

The return parameters of this commands are currently only used by the zephyr host to use concurrent
scanning and initiating when supported by the controller and CONFIG_BT_SCAN_AND_INITIATE_IN_PARALLEL is enabled.

- Default: Application assumes it is not supported. No issue: The application stops scanner before starting connection establishment.
- Concurrent scanning and initiating used. In this scenario the host may reject starting connection establishment even if the controller supports it. The rejection will occur depending on the unitialized bits 22 and 23.

The implementation of this command had two issues:

- Only the first bits of states1  and states2 were applied. because buf was a pointer to uint8_t. The remaining bits were not set and therefore contained garbage values.
- There was a typo which resulted in the command not returning bits 32 to 41 as supported. Since these bits were anyways not applied, this issue was masked away.


(cherry picked from commit daa1a97b912b7e1e3c3ba986c14d32664f01242f)