### PR TITLE
lib: ram_pwrdn: use nrfx RAM control helper 

### DIFF
--- a/lib/ram_pwrdn/ram_pwrdn.c
+++ b/lib/ram_pwrdn/ram_pwrdn.c
@@ -7,217 +7,96 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/kernel.h>
 #include <stdint.h>
 
-#if defined(CONFIG_SOC_NRF52840) || defined(CONFIG_SOC_NRF52833)
-#include <hal/nrf_power.h>
-#elif defined(CONFIG_SOC_NRF5340_CPUAPP)
-#include <hal/nrf_vmc.h>
-#elif defined(CONFIG_SOC_SERIES_NRF54L)
-#include <hal/nrf_memconf.h>
-#else
-#error "RAM power-down library is not supported on the current platform"
-#endif
+#include <helpers/nrfx_ram_ctrl.h>
 
-#if defined(CONFIG_PARTITION_MANAGER_ENABLED)
-#include <pm_config.h>
+#if !defined(NRF_MEMORY_RAM_BASE) && defined(NRF_MEMORY_RAM0_BASE)
+#define NRF_MEMORY_RAM_BASE NRF_MEMORY_RAM0_BASE
 #endif
 
 #define RAM_IMAGE_END_ADDR ((uintptr_t)_image_ram_end)
-#define RAM_BANK_COUNT ARRAY_SIZE(banks)
+
+#define RAM_UNIFORM_REGION_SIZE \
+	((uintptr_t)RAM_UNIFORM_SECTIONS_TOTAL * (uintptr_t)RAM_SECTION_UNIT_SIZE)
 
 LOG_MODULE_REGISTER(ram_pwrdn, CONFIG_RAM_POWERDOWN_LOG_LEVEL);
 
-struct ram_bank {
-	uintptr_t start;
-	uint8_t section_count;
-	uint16_t section_size;
-};
-
 extern char _image_ram_end[];
 
-static const struct ram_bank banks[] = {
-#if defined(CONFIG_SOC_NRF54L15_CPUAPP)
-	/* Section numbers for RAM00 are 0-3 and for RAM01 are 4-7 within
-	 * the same bank.
-	 */
-	{ .start = 0x20000000UL, .section_count = 8, .section_size = 0x8000 },
-#elif defined(CONFIG_SOC_NRF54L10_CPUAPP) || defined(CONFIG_SOC_NRF54LC10A_CPUAPP)
-	/* Section numbers for RAM00 are 0-3 and for RAM01 are 4-5 within
-	 * the same bank.
-	 */
-	{ .start = 0x20000000UL, .section_count = 6, .section_size = 0x8000 },
-#elif defined(CONFIG_SOC_NRF54L05_CPUAPP)
-	{ .start = 0x20000000UL, .section_count = 3, .section_size = 0x8000 },
-#elif defined(CONFIG_SOC_NRF54LM20A_CPUAPP) || defined(CONFIG_SOC_NRF54LM20B_CPUAPP)
-	{ .start = 0x20000000UL, .section_count = 16, .section_size = 0x8000 },
-#elif defined(CONFIG_SOC_NRF52840) || defined(CONFIG_SOC_NRF52833)
-	{ .start = 0x20000000UL, .section_count = 2, .section_size = 0x1000 },
-	{ .start = 0x20002000UL, .section_count = 2, .section_size = 0x1000 },
-	{ .start = 0x20004000UL, .section_count = 2, .section_size = 0x1000 },
-	{ .start = 0x20006000UL, .section_count = 2, .section_size = 0x1000 },
-	{ .start = 0x20008000UL, .section_count = 2, .section_size = 0x1000 },
-	{ .start = 0x2000A000UL, .section_count = 2, .section_size = 0x1000 },
-	{ .start = 0x2000C000UL, .section_count = 2, .section_size = 0x1000 },
-	{ .start = 0x2000E000UL, .section_count = 2, .section_size = 0x1000 },
-#if CONFIG_SOC_NRF52833
-	{ .start = 0x20010000UL, .section_count = 2, .section_size = 0x8000 },
-#else
-	{ .start = 0x20010000UL, .section_count = 6, .section_size = 0x8000 },
-#endif
-#elif defined(CONFIG_SOC_NRF5340_CPUAPP)
-	{ .start = 0x20000000UL, .section_count = 16, .section_size = 0x1000 },
-	{ .start = 0x20010000UL, .section_count = 16, .section_size = 0x1000 },
-	{ .start = 0x20020000UL, .section_count = 16, .section_size = 0x1000 },
-	{ .start = 0x20030000UL, .section_count = 16, .section_size = 0x1000 },
-	{ .start = 0x20040000UL, .section_count = 16, .section_size = 0x1000 },
-	{ .start = 0x20050000UL, .section_count = 16, .section_size = 0x1000 },
-	{ .start = 0x20060000UL, .section_count = 16, .section_size = 0x1000 },
-	{ .start = 0x20070000UL, .section_count = 16, .section_size = 0x1000 },
+/* Contiguous RAM range in which every power-controllable section has the same size. */
+struct ram_region {
+	uintptr_t start;
+	uintptr_t size;
+	uintptr_t section_size;
+};
+
+static const struct ram_region ram_regions[] = {
+	{
+		.start = NRF_MEMORY_RAM_BASE,
+		.size = RAM_UNIFORM_REGION_SIZE,
+		.section_size = RAM_SECTION_UNIT_SIZE,
+	},
+#if defined(RAM_NON_UNIFORM_SECTIONS)
+	{
+		.start = NRF_MEMORY_RAM_BASE + RAM_UNIFORM_REGION_SIZE,
+		.size = (uintptr_t)NRF_MEMORY_RAM_SIZE - RAM_UNIFORM_REGION_SIZE,
+		.section_size =
+			(uintptr_t)RAM_NON_UNIFORM_BLOCK_UNITS * (uintptr_t)RAM_SECTION_UNIT_SIZE,
+	},
 #endif
 };
 
 /*
- * Power down selected RAM sections of the given bank.
+ * When powering down, only sections that fall entirely within the range are affected, so that
+ * a section still holding part of the application image is never turned off. When powering up,
+ * every section that overlaps the range is affected.
  */
-static void ram_bank_power_down(uint8_t bank_id, uint8_t first_section_id, uint8_t last_section_id)
+static void ram_sections_power_set(uintptr_t start_address, uintptr_t end_address, bool power_up)
 {
-#if defined(CONFIG_SOC_NRF52840) || defined(CONFIG_SOC_NRF52833)
-	uint32_t mask = GENMASK(NRF_POWER_RAMPOWER_S0POWER_POS + last_section_id,
-				NRF_POWER_RAMPOWER_S0POWER_POS + first_section_id);
-	nrf_power_rampower_mask_off(NRF_POWER, bank_id, mask);
-#elif defined(CONFIG_SOC_NRF5340_CPUAPP)
-	uint32_t mask = GENMASK(VMC_RAM_POWER_S0POWER_Pos + last_section_id,
-				VMC_RAM_POWER_S0POWER_Pos + first_section_id);
-	nrf_vmc_ram_block_power_clear(NRF_VMC, bank_id, mask);
-#elif defined(CONFIG_SOC_SERIES_NRF54L)
-	uint32_t mask = GENMASK(MEMCONF_POWER_CONTROL_MEM0_Pos + last_section_id,
-				MEMCONF_POWER_CONTROL_MEM0_Pos + first_section_id);
-	nrf_memconf_ramblock_control_mask_enable_set(NRF_MEMCONF, bank_id, mask, false);
-#endif
-}
+	for (size_t i = 0; i < ARRAY_SIZE(ram_regions); ++i) {
+		const struct ram_region *region = &ram_regions[i];
+		uintptr_t region_end = region->start + region->size;
+		uintptr_t range_start = MAX(start_address, region->start);
+		uintptr_t range_end = MIN(end_address, region_end);
+		uintptr_t section_start;
+		uintptr_t section_end;
 
-/*
- * Power up selected RAM sections of the given bank.
- */
-static void ram_bank_power_up(uint8_t bank_id, uint8_t first_section_id, uint8_t last_section_id)
-{
-#if defined(CONFIG_SOC_NRF52840) || defined(CONFIG_SOC_NRF52833)
-	uint32_t mask = GENMASK(NRF_POWER_RAMPOWER_S0POWER_POS + last_section_id,
-				NRF_POWER_RAMPOWER_S0POWER_POS + first_section_id);
-	nrf_power_rampower_mask_on(NRF_POWER, bank_id, mask);
-#elif defined(CONFIG_SOC_NRF5340_CPUAPP)
-	uint32_t mask = GENMASK(VMC_RAM_POWER_S0POWER_Pos + last_section_id,
-				VMC_RAM_POWER_S0POWER_Pos + first_section_id);
-	nrf_vmc_ram_block_power_set(NRF_VMC, bank_id, mask);
-#elif defined(CONFIG_SOC_SERIES_NRF54L)
-	uint32_t mask = GENMASK(MEMCONF_POWER_CONTROL_MEM0_Pos + last_section_id,
-				MEMCONF_POWER_CONTROL_MEM0_Pos + first_section_id);
-	nrf_memconf_ramblock_control_mask_enable_set(NRF_MEMCONF, bank_id, mask, true);
-#endif
-}
+		if (range_start >= range_end) {
+			continue;
+		}
 
-/*
- * Calculate size of the RAM bank.
- */
-static uintptr_t ram_bank_size(const struct ram_bank *bank)
-{
-	return (uintptr_t)bank->section_count * (uintptr_t)bank->section_size;
-}
+		if (power_up) {
+			section_start = ROUND_DOWN(range_start, region->section_size);
+			section_end = ROUND_UP(range_end, region->section_size);
+		} else {
+			section_start = ROUND_UP(range_start, region->section_size);
+			section_end = ROUND_DOWN(range_end, region->section_size);
+		}
 
-/*
- * Return ID of the nearest RAM section with start address less or equal to the given address.
- *
- * If the address points before or after the RAM bank then 0 or the number of bank sections
- * is returned, respectively.
- */
-static uint8_t ram_bank_section_id_floor(uintptr_t address, const struct ram_bank *bank)
-{
-	if (address < bank->start) {
-		return 0;
+		if (section_start < section_end) {
+			LOG_DBG("%s RAM 0x%08lx-0x%08lx",
+				power_up ? "Powering up" : "Powering down",
+				(unsigned long)section_start, (unsigned long)section_end);
+			nrfx_ram_ctrl_power_enable_set((void const *)section_start,
+						       section_end - section_start, power_up);
+		}
 	}
-
-	if (address >= bank->start + ram_bank_size(bank)) {
-		return bank->section_count;
-	}
-
-	return (uint8_t)((address - bank->start) / bank->section_size);
 }
 
-/*
- * Returns ID of the nearest RAM section with start address greater or equal to the given address.
- *
- * If the address points before or after the RAM bank then 0 or the number of bank sections
- * is returned, respectively.
- */
-static uint8_t ram_bank_section_id_ceil(uintptr_t address, const struct ram_bank *bank)
-{
-	if (address < bank->start) {
-		return 0;
-	}
-
-	if (address >= bank->start + ram_bank_size(bank)) {
-		return bank->section_count;
-	}
-
-	return (uint8_t)(ROUND_UP(address - bank->start, bank->section_size) / bank->section_size);
-}
-
-/*
- * Returns end address of RAM managed by the Power Down library
- */
 static uintptr_t ram_end_addr(void)
 {
-#if !defined(CONFIG_PARTITION_MANAGER_ENABLED)
-	const struct ram_bank *last_bank = &banks[RAM_BANK_COUNT - 1];
-	uintptr_t bank_table_end = last_bank->start + ram_bank_size(last_bank);
-
-#if DT_HAS_CHOSEN(zephyr_sram)
-	uintptr_t sram_chosen_end =
-		DT_REG_ADDR(DT_CHOSEN(zephyr_sram)) + DT_REG_SIZE(DT_CHOSEN(zephyr_sram));
-
-	return MIN(bank_table_end, sram_chosen_end);
-#else
-	return bank_table_end;
-#endif
-#else
-	return PM_SRAM_PRIMARY_END_ADDRESS;
-#endif
+	return DT_REG_ADDR(DT_CHOSEN(zephyr_sram)) + DT_REG_SIZE(DT_CHOSEN(zephyr_sram));
 }
 
 void power_down_ram(uintptr_t start_address, uintptr_t end_address)
 {
-	for (uint8_t bank_id = 0; bank_id < RAM_BANK_COUNT; ++bank_id) {
-		const struct ram_bank *bank = &banks[bank_id];
-
-		/* Determine bank sections which fully fall within the input address range */
-		uint8_t section_begin = ram_bank_section_id_ceil(start_address, bank);
-		uint8_t section_end = ram_bank_section_id_floor(end_address, bank);
-
-		if (section_begin < section_end) {
-			LOG_DBG("Powering down sections %u-%u of bank %u", section_begin,
-				section_end - 1, bank_id);
-			ram_bank_power_down(bank_id, section_begin, section_end - 1);
-		}
-	}
+	ram_sections_power_set(start_address, end_address, false);
 }
 
 void power_up_ram(uintptr_t start_address, uintptr_t end_address)
 {
-	for (uint8_t bank_id = 0; bank_id < RAM_BANK_COUNT; ++bank_id) {
-		const struct ram_bank *bank = &banks[bank_id];
-
-		/* Determine bank sections which overlap with the input address range */
-		uint8_t section_begin = ram_bank_section_id_floor(start_address, bank);
-		uint8_t section_end = ram_bank_section_id_ceil(end_address, bank);
-
-		if (section_begin < section_end) {
-			LOG_DBG("Powering up sections %u-%u of bank %u", section_begin,
-				section_end - 1, bank_id);
-			ram_bank_power_up(bank_id, section_begin, section_end - 1);
-		}
-	}
+	ram_sections_power_set(start_address, end_address, true);
 }
 
 void power_down_unused_ram(void)

--- a/tests/lib/ram_pwrdn/CMakeLists.txt
+++ b/tests/lib/ram_pwrdn/CMakeLists.txt
@@ -9,5 +9,4 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ram_pwrdn)
 
-FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+target_sources(app PRIVATE src/main.c)

--- a/tests/lib/ram_pwrdn/prj.conf
+++ b/tests/lib/ram_pwrdn/prj.conf
@@ -1,8 +1,10 @@
 #
-# Copyright (c) 2022-2023 Nordic Semiconductor ASA
+# Copyright (c) 2022-2026 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-CONFIG_ZTEST=y
 CONFIG_RAM_POWER_DOWN_LIBRARY=y
+CONFIG_NRF_FORCE_RAM_ON_REBOOT=y
+CONFIG_REBOOT=y
+CONFIG_PM=y

--- a/tests/lib/ram_pwrdn/src/main.c
+++ b/tests/lib/ram_pwrdn/src/main.c
@@ -1,129 +1,139 @@
 /*
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <hal/nrf_power.h>
-#include <ram_pwrdn.h>
+/*
+ * On-hardware test for the RAM power-down library, written against the public
+ * API only so it runs on any supported family.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/reboot.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/ztest.h>
 
-#include <inttypes.h>
-#include <stdlib.h>
-#include <malloc.h>
+#include <ram_pwrdn.h>
 
-/* ===== Test helpers ===== */
+#define REBOOT_MARKER 0x5A11EDA7u
+#define PROBE_PATTERN 0xCAFEBABEu
+#define RESTORE_PATTERN 0xA5A5A5A5u
 
-struct bank_section {
-	uint8_t bank_id;
-	uint8_t sect_id;
-};
+/* Lives inside the application image, so it is always powered. */
+static volatile uint32_t work_buf[256];
 
-static struct bank_section bank_section(uint8_t bank_id, uint8_t section_id)
+/* Kept across the software reset (a warm reset does not clear RAM). */
+static __noinit uint32_t reboot_marker;
+
+static void exercise_ram(void)
 {
-	struct bank_section ret = { .bank_id = bank_id, .sect_id = section_id };
+	uint32_t sum = 0;
 
-	return ret;
-}
-
-static bool check_section_up(uint8_t bank_id, uint8_t section_id)
-{
-	uint32_t mask = nrf_power_rampower_mask_get(NRF_POWER, bank_id);
-
-	return mask & (NRF_POWER_RAMPOWER_S0POWER_MASK << section_id);
-}
-
-static bool check_section_range(struct bank_section first, struct bank_section last, bool up)
-{
-	for (uint8_t bank_id = first.bank_id; bank_id <= last.bank_id; ++bank_id) {
-		uint8_t first_sect_id = bank_id == first.bank_id ? first.sect_id : 0;
-		uint8_t last_sect_id = bank_id == last.bank_id ? last.sect_id : 1;
-
-		for (uint8_t sect_id = first_sect_id; sect_id <= last_sect_id; ++sect_id) {
-			if (check_section_up(bank_id, sect_id) != up) {
-				return false;
-			}
-		}
+	for (size_t i = 0; i < ARRAY_SIZE(work_buf); ++i) {
+		work_buf[i] = (uint32_t)(i * 7u + 1u);
 	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(work_buf); ++i) {
+		sum += work_buf[i];
+	}
+
+	printk("ram_pwrdn: RAM check sum=%u\n", sum);
+}
+
+/* Word at the top of RAM, which the library powers down (the image never
+ * reaches this far).
+ */
+static volatile uint32_t *unused_ram_word(void)
+{
+	uintptr_t ram_end = DT_REG_ADDR(DT_CHOSEN(zephyr_sram)) +
+			    DT_REG_SIZE(DT_CHOSEN(zephyr_sram));
+
+	return (volatile uint32_t *)(ram_end - sizeof(uint32_t));
+}
+
+/* Returns true if the unused RAM was confirmed to be powered down. */
+static bool verify_power_down(void)
+{
+	volatile uint32_t *unused_ram = unused_ram_word();
+
+	*unused_ram = PROBE_PATTERN;
+	work_buf[0] = PROBE_PATTERN;
+
+	power_down_unused_ram();
+	printk("ram_pwrdn: powered down unused RAM\n");
+
+	/* Some families gate the RAM only once the SoC enters System ON idle. */
+	printk("ram_pwrdn: entering System ON idle\n");
+	k_msleep(1000);
+	printk("ram_pwrdn: woke from idle\n");
+
+	power_up_unused_ram();
+	printk("ram_pwrdn: powered up unused RAM\n");
+
+	/* Read only after power-up: on some families accessing powered-down RAM
+	 * faults. Losing the pattern proves the RAM lost power.
+	 */
+	if (*unused_ram == PROBE_PATTERN) {
+		printk("ram_pwrdn: ERROR unused RAM kept its content (still powered)\n");
+		return false;
+	}
+	printk("ram_pwrdn: unused RAM lost content (powered down)\n");
+
+	if (work_buf[0] != PROBE_PATTERN) {
+		printk("ram_pwrdn: ERROR used RAM lost its content\n");
+		return false;
+	}
+	printk("ram_pwrdn: used RAM retained content\n");
 
 	return true;
 }
 
-static void teardown(void *f)
+/* Returns true if unused RAM is accessible again (power restored on reboot). */
+static bool verify_unused_ram_accessible(void)
 {
-	const uintptr_t RAM_START_ADDR = 0x20000000UL;
-	const uintptr_t RAM_END_ADDR = 0x20040000UL;
+	volatile uint32_t *unused_ram = unused_ram_word();
 
-	power_up_ram(RAM_START_ADDR, RAM_END_ADDR);
+	*unused_ram = RESTORE_PATTERN;
+	if (*unused_ram != RESTORE_PATTERN) {
+		printk("ram_pwrdn: ERROR unused RAM not accessible after reboot\n");
+		return false;
+	}
+	printk("ram_pwrdn: unused RAM accessible after reboot\n");
+
+	return true;
 }
 
-/* ===== Test cases ===== */
-
-ZTEST(ram_pwrdn, test_manual_power_control)
+int main(void)
 {
-	const uintptr_t RAM_START_ADDR = 0x20000000UL;
-	const uintptr_t RAM_END_ADDR = 0x20040000UL;
-	const uintptr_t RAM_BANK_SECTION_SIZE = 0x1000UL;
-	const uintptr_t RAM_BANK8_ADDR = 0x20010000UL;
-	const uintptr_t RAM_BANK8_SECTION_SIZE = 0x8000UL;
+	if (reboot_marker == REBOOT_MARKER) {
+		reboot_marker = 0;
+		printk("ram_pwrdn: boot after reboot\n");
+		exercise_ram();
+		if (!verify_unused_ram_accessible()) {
+			return 0;
+		}
+		printk("ram_pwrdn: RAM access after reboot OK\n");
+		printk("ram_pwrdn: TEST PASS\n");
+		return 0;
+	}
 
-	/* Power up all sections */
-	power_up_ram(RAM_START_ADDR, RAM_END_ADDR);
-	zassert_true(check_section_range(bank_section(0, 0), bank_section(8, 5), true),
-		     "Enabling all RAM sections");
+	printk("ram_pwrdn: initial boot\n");
+	exercise_ram();
 
-	/* Verify that powering down part of RAM section is not effective */
-	power_down_ram(RAM_END_ADDR - RAM_BANK8_SECTION_SIZE + 1, RAM_END_ADDR);
-	zassert_true(check_section_range(bank_section(0, 0), bank_section(8, 5), true),
-		     "Disabling part of RAM section");
+	if (!verify_power_down()) {
+		return 0;
+	}
 
-	/* Verify that powering down entire RAM section works */
-	power_down_ram(RAM_END_ADDR - RAM_BANK8_SECTION_SIZE, RAM_END_ADDR);
-	zassert_true(check_section_range(bank_section(0, 0), bank_section(8, 4), true),
-		     "Disabling single RAM section (disabled too much)");
-	zassert_true(check_section_range(bank_section(8, 5), bank_section(8, 5), false),
-		     "Disabling single RAM section (failed)");
+	exercise_ram();
+	printk("ram_pwrdn: RAM access after power cycle OK\n");
 
-	/* Verify that powering down RAM section plus one byte has the same effect */
-	power_down_ram(RAM_END_ADDR - RAM_BANK8_SECTION_SIZE, RAM_END_ADDR);
-	zassert_true(check_section_range(bank_section(0, 0), bank_section(8, 4), true),
-		     "Disabling more than RAM section (disabled too much)");
-	zassert_true(check_section_range(bank_section(8, 5), bank_section(8, 5), false),
-		     "Disabling more than RAM section (failed)");
+	/* Reboot with unused RAM powered down; it must be restored before reset. */
+	reboot_marker = REBOOT_MARKER;
+	power_down_unused_ram();
+	printk("ram_pwrdn: rebooting with RAM powered down\n");
+	k_msleep(100);
+	sys_reboot(SYS_REBOOT_COLD);
 
-	/* Power down last three sections */
-	power_down_ram(RAM_END_ADDR - RAM_BANK8_SECTION_SIZE * 3, RAM_END_ADDR);
-	zassert_true(check_section_range(bank_section(0, 0), bank_section(8, 2), true),
-		     "Disabling three RAM sections (disabled too much)");
-	zassert_true(check_section_range(bank_section(8, 3), bank_section(8, 5), false),
-		     "Disabling three RAM sections (failed)");
-
-	/* Verify that powering up one byte is enough to enable entire RAM section */
-	power_up_ram(RAM_END_ADDR - RAM_BANK8_SECTION_SIZE * 3,
-		     RAM_END_ADDR - RAM_BANK8_SECTION_SIZE * 3 + 1);
-	zassert_true(check_section_range(bank_section(0, 0), bank_section(8, 3), true),
-		     "Enabling one byte (failed)");
-	zassert_true(check_section_range(bank_section(8, 4), bank_section(8, 5), false),
-		     "Enabling one byte (enabled too much)");
-
-	/* Verify that powering up entire RAM section has the same effect */
-	power_up_ram(RAM_END_ADDR - RAM_BANK8_SECTION_SIZE * 3,
-		     RAM_END_ADDR - RAM_BANK8_SECTION_SIZE * 2);
-	zassert_true(check_section_range(bank_section(0, 0), bank_section(8, 3), true),
-		     "Enabling single RAM section (failed)");
-	zassert_true(check_section_range(bank_section(8, 4), bank_section(8, 5), false),
-		     "Enabling single RAM section (enabled too much)");
-
-	/* Power down sections on the border between two banks */
-	power_down_ram(RAM_BANK8_ADDR - RAM_BANK_SECTION_SIZE - 1,
-		       RAM_BANK8_ADDR + RAM_BANK8_SECTION_SIZE);
-	zassert_true(check_section_range(bank_section(0, 0), bank_section(7, 0), true),
-		     "Disabling sections on two banks (disabled too much)");
-	zassert_true(check_section_range(bank_section(7, 1), bank_section(8, 0), false),
-		     "Disabling sections on two banks (failed)");
-	zassert_true(check_section_range(bank_section(8, 1), bank_section(8, 3), true),
-		     "Disabling sections on two banks (disabled too much)");
+	return 0;
 }
-
-ZTEST_SUITE(ram_pwrdn, NULL, NULL, NULL, teardown, NULL);

--- a/tests/lib/ram_pwrdn/testcase.yaml
+++ b/tests/lib/ram_pwrdn/testcase.yaml
@@ -1,10 +1,26 @@
 tests:
   ram_pwrdn.functionality_test:
-    sysbuild: true
-    platform_allow: nrf52840dk/nrf52840
-    integration_platforms:
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "ram_pwrdn: initial boot"
+        - "ram_pwrdn: powered down unused RAM"
+        - "ram_pwrdn: powered up unused RAM"
+        - "ram_pwrdn: unused RAM lost content .powered down."
+        - "ram_pwrdn: used RAM retained content"
+        - "ram_pwrdn: RAM access after power cycle OK"
+        - "ram_pwrdn: rebooting with RAM powered down"
+        - "ram_pwrdn: boot after reboot"
+        - "ram_pwrdn: unused RAM accessible after reboot"
+        - "ram_pwrdn: RAM access after reboot OK"
+        - "ram_pwrdn: TEST PASS"
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
       - nrf52840dk/nrf52840
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
     tags:
       - ram_pwrdn
-      - sysbuild
       - ci_tests_lib_ram_pwrdn


### PR DESCRIPTION
Rework the library on top of the nrfx RAM control helper
(nrfx_ram_ctrl) instead of accessing the POWER, VMC and MEMCONF
registers directly. The RAM section layout is now derived from the
nrfx SoC description instead of hardcoded bank tables, so the code no
longer needs per-SoC register handling.

Add an on-hardware test for the RAM power-down library that are nRF
family agnostic. The responsibility of turning off/on certain sections is
verified in nrfx instead.