### PR TITLE
[Backport v3.4-branch] samples: matter: added support for nRF54LC10

### DIFF
--- a/doc/nrf/includes/matter/configuration/advanced/dfu.txt
+++ b/doc/nrf/includes/matter/configuration/advanced/dfu.txt
@@ -23,9 +23,18 @@ Device firmware upgrade support
    * nRF52840 DK
    * nRF5340 DK
    * nRF54L10 DK
+   * nRF54LC10A SoC
 
    You can run DFU without external flash memory on the nRF54L15 and nRF54LM20 DKs using the :ref:`mcuboot_image_compression` feature.
    To see if the |matter_type| supports this feature, check whether the ``internal`` build configuration is available in the build configuration table.
+
+   .. note::
+      DFU is not supported on the nRF54LC10 DK.
+      It is supported for the nRF54LC10A SoC, but the nRF54LC10 DK lacks external flash.
+      Without external flash there is not enough space to fit two application images required for any type of DFU.
+      If you want to support DFU on nRF54LC10A SoC, you need to add external flash and configure the additional partitions needed for image swap.
+      For an example of how to configure such partitions, see the nRF54L10 devicetree files (:file:`nrf54l10_cpuapp_partitions.dtsi`), since the nRF54L10 SoC is similar to nRF54LC10A and can be used as a reference design.
+      See :ref:`ug_matter_hw_requirements_external_flash` for more information.
 
    .. tabs::
 

--- a/doc/nrf/includes/matter/interface/nfc.txt
+++ b/doc/nrf/includes/matter/interface/nfc.txt
@@ -1,3 +1,6 @@
 NFC port with antenna attached:
     Optionally used for obtaining the onboarding information from the Matter accessory device to start the commissioning the device procedure while using a commercial ecosystem.
     See the `Testing with commercial ecosystem`_ section.
+
+    .. note::
+       The nRF54LC10A SoC does not have an NFC peripheral, thus this feature is not supported on the nRF54LC10 DK.

--- a/doc/nrf/protocols/matter/getting_started/ecosystem_compatibility_testing.rst
+++ b/doc/nrf/protocols/matter/getting_started/ecosystem_compatibility_testing.rst
@@ -19,7 +19,7 @@ Prerequisites
 
 At the very least, you need the following pieces of hardware to set up and test the interoperability scenario from the tutorial:
 
-* Matter over Thread development kit: 1x nRF52840 DK, 1x nRF5340 DK, 1x nRF54L15 DK, or 1x nRF54LM20 DK
+* Matter over Thread development kit: one of the following devices - nRF52840 DK, nRF5340 DK, nRF54L15 DK, nRF54LC10 DK, or nRF54LM20 DK
 * Matter over Wi-Fi development kit: 1x nRF54LM20 DK with nRF7002 EB-II
 * Devices from at least one of commercial ecosystems compatible with the official Matter implementation, for example:
 

--- a/doc/nrf/protocols/matter/getting_started/hw_requirements.rst
+++ b/doc/nrf/protocols/matter/getting_started/hw_requirements.rst
@@ -20,6 +20,7 @@ Currently the following SoCs from Nordic Semiconductor are supported for use wit
 * :ref:`nRF52840 <programming_board_names>` (Matter over Thread)
 * :ref:`nRF54L15 <programming_board_names>` (Matter over Thread)
 * :ref:`nRF54L10 <programming_board_names>` (Matter over Thread)
+* :ref:`nRF54LC10 <programming_board_names>` (Matter over Thread)
 * :ref:`nRF54LM20 <programming_board_names>` (Matter over Thread and Matter over Wi-Fi through the ``nrf7002eb2`` shield)
 
 Front-End Modules
@@ -43,6 +44,11 @@ This is required to perform the DFU operation.
 The development kits for the supported SoCs from Nordic Semiconductor are supplied with the MX25R64 type of external flash that meets these memory requirements.
 However, it is possible to configure the SoCs with different QSPI or SPI memory if it is supported by Zephyr.
 For this purpose, check the reference design for Nordic DKs for information about how to connect the external memory with SoC, specifically whether the pins are designed for the QSPI or the high-speed SPIM operations.
+
+.. note::
+   The nRF54LC10 DK does not come with external memory by default.
+   It cannot fit two slots in its internal memory, which is required for DFU.
+   Connecting and configuring an external flash is required to perform any type of DFU.
 
 .. _ug_matter_hw_requirements_ram_flash:
 

--- a/doc/nrf/protocols/matter/overview/integration.rst
+++ b/doc/nrf/protocols/matter/overview/integration.rst
@@ -56,12 +56,12 @@ This platform design is suitable for the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf5340dk_nrf5340_cpuapp, nrf54l15dk_nrf54l15_cpuapp_and_cpuapp_ns, nrf54lm20dk_nrf54lm20a_cpuapp, nrf54lm20dk_nrf54lm20b_cpuapp
+   :rows: nrf52840dk_nrf52840, nrf5340dk_nrf5340_cpuapp, nrf54l15dk_nrf54l15_cpuapp_and_cpuapp_ns, nrf54lc10dk_nrf54lc10a_cpuapp, nrf54lm20dk_nrf54lm20a_cpuapp, nrf54lm20dk_nrf54lm20b_cpuapp
 
 The design differences between the supported SoCs are the following:
 
 * On the nRF5340, SoC the network core runs both the Bluetooth LE Controller and the 802.15.4 IEEE Radio Driver.
-* On the nRF52840, nRF54L15 and nRF54LM20 SoCs, all components are located on the application core.
+* On the nRF52840, nRF54L15, nRF54LC10, and nRF54LM20 SoCs, all components are located on the application core.
 
 .. figure:: ../../thread/overview/images/thread_platform_design_multi.svg
    :alt: Multiprotocol Thread and Bluetooth LE architecture (nRF52, nRF54L)

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -303,7 +303,13 @@ Keys samples
 Matter samples
 --------------
 
-|no_changes_yet_note|
+* Added support for the ``nrf54lc10dk/nrf54lc10a/cpuapp`` board target for the following samples:
+
+  * :ref:`matter_template_sample`
+  * :ref:`matter_temperature_sensor_sample`
+
+  DFU is not supported on this board target, as the nRF54LC10 DK is not equipped with external flash.
+  See :ref:`ug_matter_hw_requirements_external_flash` for more information.
 
 Networking samples
 ------------------

--- a/dts/samples/matter/nrf54lc10_cpuapp_partitions.dtsi
+++ b/dts/samples/matter/nrf54lc10_cpuapp_partitions.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+&cpuapp_rram {
+	partitions {
+		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(52)>;
+		};
+
+		slot0_partition: partition@d000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x0000d000 DT_SIZE_K(904)>;
+		};
+
+		factory_data_partition: partition@f2000 {
+			compatible = "zephyr,mapped-partition";
+			label = "factory-data";
+			reg = <0x000f2000 DT_SIZE_K(4)>;
+		};
+
+		storage_partition: partition@f3000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x000f3000 DT_SIZE_K(40)>;
+		};
+	};
+};

--- a/samples/matter/temperature_sensor/Kconfig.sysbuild
+++ b/samples/matter/temperature_sensor/Kconfig.sysbuild
@@ -23,6 +23,12 @@ choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
 
+# The nRF54LC10 DK keeps MCUboot but uses a single application slot:
+# it has no external flash and its RRAM cannot hold two Matter-sized slots.
+# DFU can be added by introducing external flash.
+config MATTER_OTA
+	default n if BOARD_NRF54LC10DK
+
 if BOOTLOADER_MCUBOOT
 
 #### DFU multi-image support
@@ -80,6 +86,15 @@ endchoice
 
 config MCUBOOT_COMPRESSED_IMAGE_SUPPORT
 	default y
+
+endif
+
+# Disable Secondary slot for nRF54LC10 DK since it lacks memory to support it.
+if BOARD_NRF54LC10DK
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_SINGLE_APP
+endchoice
 
 endif
 

--- a/samples/matter/temperature_sensor/README.rst
+++ b/samples/matter/temperature_sensor/README.rst
@@ -1,6 +1,6 @@
 .. |matter_name| replace:: Temperature Sensor
 .. |matter_type| replace:: sample
-.. |matter_dks_thread| replace:: ``nrf52840dk/nrf52840``, ``nrf5340dk/nrf5340/cpuapp``, ``nrf54l15dk/nrf54l15/cpuapp``, ``nrf54l15tag/nrf54l15/cpuapp``, ``nrf54lm20dk/nrf54lm20b/cpuapp`` and ``nrf54lm20dk/nrf54lm20a/cpuapp`` board targets
+.. |matter_dks_thread| replace:: ``nrf52840dk/nrf52840``, ``nrf5340dk/nrf5340/cpuapp``, ``nrf54l15dk/nrf54l15/cpuapp``, ``nrf54l15tag/nrf54l15/cpuapp``, ``nrf54lm20dk/nrf54lm20b/cpuapp``, ``nrf54lm20dk/nrf54lm20a/cpuapp``, and ``nrf54lc10dk/nrf54lc10a/cpuapp`` board targets
 .. |matter_dks_internal| replace:: nRF54LM20 DK
 .. |sample path| replace:: :file:`samples/matter/temperature_sensor`
 .. |matter_qr_code_payload| replace:: MT:K.K9042C00KA0648G00

--- a/samples/matter/temperature_sensor/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
+++ b/samples/matter/temperature_sensor/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# No NFC hardware
+CONFIG_CHIP_NFC_ONBOARDING_PAYLOAD=n
+
+# CHIP_BOOTLOADER_MCUBOOT selects IMG_MANAGER, which depends on STREAM_FLASH.
+# Matter OTA is disabled on this board (single slot), so OTA defaults do not enable it.
+CONFIG_STREAM_FLASH=y

--- a/samples/matter/temperature_sensor/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/matter/temperature_sensor/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/matter/nrf54lc10_cpuapp_partitions.dtsi>
+
+/ {
+	aliases {
+		/* Use watchdog wdt31 as the application watchdog */
+		watchdog0 = &wdt31;
+	};
+};
+
+&wdt31 {
+	status = "okay";
+};

--- a/samples/matter/temperature_sensor/sample.yaml
+++ b/samples/matter/temperature_sensor/sample.yaml
@@ -16,6 +16,7 @@ tests:
       - nrf54l15tag/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -23,6 +24,7 @@ tests:
       - nrf54l15tag/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
   sample.matter.temperature_sensor.release:
     sysbuild: true
     build_only: true
@@ -31,6 +33,7 @@ tests:
     integration_platforms:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -38,3 +41,4 @@ tests:
       - nrf54l15tag/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp

--- a/samples/matter/temperature_sensor/sysbuild/mcuboot/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
+++ b/samples/matter/temperature_sensor/sysbuild/mcuboot/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TODO: Workaround, disable memory guard to avoid false faults in application after boot
+CONFIG_HW_STACK_PROTECTION=n
+
+CONFIG_BOOT_WATCHDOG_FEED=n
+
+# Currently, without tickless kernel, the SYSCOUNTER value after the software
+# reset is not set properly, and due to that, the first system interrupt is not called
+# in the proper time - the SYSCOUNTER value is set to the value from before
+# reset + 1. Hence, the reboot time increases more and more.
+# To avoid it, enable tickless kernel for MCUboot.
+CONFIG_TICKLESS_KERNEL=y

--- a/samples/matter/temperature_sensor/sysbuild/mcuboot/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/matter/temperature_sensor/sysbuild/mcuboot/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/matter/nrf54lc10_cpuapp_partitions.dtsi>
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/samples/matter/template/Kconfig.sysbuild
+++ b/samples/matter/template/Kconfig.sysbuild
@@ -23,6 +23,12 @@ choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT if !BOARD_NRF21540DK
 endchoice
 
+# The nRF54LC10 DK keeps MCUboot but uses a single application slot:
+# it has no external flash and its RRAM cannot hold two Matter-sized slots.
+# DFU can be added by introducing external flash.
+config MATTER_OTA
+	default n if BOARD_NRF54LC10DK
+
 if BOOTLOADER_MCUBOOT
 
 #### DFU multi-image support
@@ -69,6 +75,15 @@ endchoice
 
 config MCUBOOT_COMPRESSED_IMAGE_SUPPORT
 	default y
+
+endif
+
+# Disable Secondary slot for nRF54LC10 DK since it lacks memory to support it.
+if BOARD_NRF54LC10DK
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_SINGLE_APP
+endchoice
 
 endif
 

--- a/samples/matter/template/README.rst
+++ b/samples/matter/template/README.rst
@@ -1,6 +1,6 @@
 .. |matter_name| replace:: Template
 .. |matter_type| replace:: sample
-.. |matter_dks_thread| replace:: ``nrf52840dk/nrf52840``, ``nrf5340dk/nrf5340/cpuapp``, ``nrf54l15dk/nrf54l15/cpuapp``, ``nrf54l15tag/nrf54l15/cpuapp``, ``nrf54lm20dk/nrf54lm20b/cpuapp``, and ``nrf54lm20dk/nrf54lm20a/cpuapp`` board targets
+.. |matter_dks_thread| replace:: ``nrf52840dk/nrf52840``, ``nrf5340dk/nrf5340/cpuapp``, ``nrf54l15dk/nrf54l15/cpuapp``, ``nrf54l15tag/nrf54l15/cpuapp``, ``nrf54lm20dk/nrf54lm20b/cpuapp``, ``nrf54lm20dk/nrf54lm20a/cpuapp``, and ``nrf54lc10dk/nrf54lc10a/cpuapp`` board targets
 .. |matter_dks_wifi| replace:: ``nrf54lm20dk/nrf54lm20b/cpuapp`` and ``nrf54lm20dk/nrf54lm20a/cpuapp`` board targets with the ``nrf7002eb2`` shield attached
 .. |matter_dks_internal| replace:: nRF54LM20 DK and nRF54L15 DK
 .. |matter_dks_tfm| replace:: ``nrf54l15dk/nrf54l15/cpuapp`` board target

--- a/samples/matter/template/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
+++ b/samples/matter/template/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# CHIP_BOOTLOADER_MCUBOOT selects IMG_MANAGER, which depends on STREAM_FLASH.
+# Matter OTA is disabled on this board (single slot), so OTA defaults do not enable it.
+CONFIG_STREAM_FLASH=y

--- a/samples/matter/template/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/matter/template/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/matter/nrf54lc10_cpuapp_partitions.dtsi>
+
+/ {
+	aliases {
+		/* Use watchdog wdt31 as the application watchdog */
+		watchdog0 = &wdt31;
+	};
+};
+
+&wdt31 {
+	status = "okay";
+};

--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -19,6 +19,7 @@ tests:
       - nrf54l15tag/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -27,6 +28,7 @@ tests:
       - nrf54l15tag/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
   sample.matter.template.nrf7002eb2.debug:
     sysbuild: true
     build_only: true
@@ -53,6 +55,7 @@ tests:
       - nrf54l15tag/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -61,6 +64,7 @@ tests:
       - nrf54l15tag/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
   sample.matter.template.nrf7002eb2.release:
     sysbuild: true
     build_only: true

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TODO: Workaround, disable memory guard to avoid false faults in application after boot
+CONFIG_HW_STACK_PROTECTION=n
+
+CONFIG_BOOT_WATCHDOG_FEED=n
+
+# Currently, without tickless kernel, the SYSCOUNTER value after the software
+# reset is not set properly, and due to that, the first system interrupt is not called
+# in the proper time - the SYSCOUNTER value is set to the value from before
+# reset + 1. Hence, the reboot time increases more and more.
+# To avoid it, enable tickless kernel for MCUboot.
+CONFIG_TICKLESS_KERNEL=y

--- a/samples/matter/template/sysbuild/mcuboot/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/matter/template/sysbuild/mcuboot/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <samples/matter/nrf54lc10_cpuapp_partitions.dtsi>
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};


### PR DESCRIPTION
Backport 1f82c58170ad5a03fba0688431387699199be3c9 from #30038.