### PR TITLE
drivers: ppi_seq: Add support for reusing PPI connection for the counter

### DIFF
--- a/drivers/ppi_seq/ppi_seq.c
+++ b/drivers/ppi_seq/ppi_seq.c
@@ -271,6 +271,18 @@ static int ppi_seq_notifier_init(struct ppi_seq *seq)
 		return rv;
 	}
 
+	if (IS_ENABLED(CONFIG_NRFX_GPPI)) {
+		rv = nrfx_gppi_ep_channel_get(notifier->nrfx_timer.end_seq_event);
+		if ((rv >= 0) &&
+		    (nrfx_gppi_domain_id_get(notifier->nrfx_timer.end_seq_event) ==
+		     nrfx_gppi_domain_id_get(cnt_task))) {
+			/* Channel is already in use */
+			nrfx_gppi_ep_to_ch_attach(cnt_task, rv);
+			notifier->nrfx_timer.attached = true;
+			return 0;
+		}
+	}
+
 	rv = ppi_alloc(seq, notifier->nrfx_timer.end_seq_event, cnt_task, true);
 	if (rv < 0) {
 		return rv;
@@ -291,7 +303,9 @@ static void ppi_seq_notifier_uninit(struct ppi_seq *seq)
 
 	cnt_task = nrfx_timer_task_address_get(&notifier->nrfx_timer.timer, NRF_TIMER_TASK_COUNT);
 	nrfx_timer_uninit(&notifier->nrfx_timer.timer);
-	nrfx_gppi_ep_clear(notifier->nrfx_timer.end_seq_event);
+	if (IS_ENABLED(CONFIG_NRFX_GPPI) && !notifier->nrfx_timer.attached) {
+		nrfx_gppi_ep_clear(notifier->nrfx_timer.end_seq_event);
+	}
 	nrfx_gppi_ep_clear(cnt_task);
 }
 

--- a/include/drivers/ppi_seq/ppi_seq.h
+++ b/include/drivers/ppi_seq/ppi_seq.h
@@ -99,6 +99,9 @@ struct ppi_seq_notifier_nrfx_timer {
 	 * are 2 SPI transfers in each cycle then it should be set to 1.
 	 */
 	uint16_t extra_main_ops;
+
+	/** If set, it indicates that event is already used and channel is just attached. */
+	bool attached;
 };
 
 /** @brief Notifier structure. */

--- a/tests/drivers/ppi_seq/ppi_seq_with_spi/src/main.c
+++ b/tests/drivers/ppi_seq/ppi_seq_with_spi/src/main.c
@@ -86,6 +86,7 @@ struct spim_test_data {
 
 	nrfx_gpiote_t *gpiote;
 	uint8_t gpiote_task_ch;
+	nrfx_gppi_handle_t gpiote_cs_handle;
 	uint32_t ss_pin;
 	uint32_t ss_task;
 
@@ -208,8 +209,10 @@ static void spis_check_time(void)
 static void spis_event_handler(nrfx_spis_event_t const *event, void *context)
 {
 	if ((event->evt_type == NRFX_SPIS_XFER_DONE) && (spis_data.stop == false)) {
-		zassert_equal(spis_data.exp_len, event->rx_amount);
-		zassert_equal(spis_data.exp_len, event->tx_amount);
+		zassert_equal(spis_data.exp_len, event->rx_amount, "Expected:%d got:%d",
+				spis_data.exp_len, event->rx_amount);
+		zassert_equal(spis_data.exp_len, event->tx_amount, "Expected:%d got:%d",
+				spis_data.exp_len, event->tx_amount);
 
 		spis_check_time();
 
@@ -256,6 +259,8 @@ static void spim_init(bool use_hw_ss)
 		nrf_gpio_cfg_output(ss_pin);
 		spim_data.ss_task = 0;
 	} else {
+		uint32_t cs_task;
+		uint32_t spim_end_event;
 		const struct device *cs_port = DEVICE_DT_GET(DT_GPIO_CTLR(SPIM_NODE, cs_gpios));
 		nrfx_gpiote_t *gpiote = gpio_nrf_gpiote_by_port_get(cs_port);
 		nrfx_gpiote_output_config_t out_config = {.drive = NRF_GPIO_PIN_S0S1,
@@ -274,9 +279,18 @@ static void spim_init(bool use_hw_ss)
 		zassert_ok(rv, "Unexpected error:%d", rv);
 		nrfx_gpiote_out_task_enable(gpiote, ss_pin);
 
-		spim_data.ss_task = nrfx_gpiote_out_task_address_get(gpiote, ss_pin);
+		spim_data.ss_task = nrfx_gpiote_clr_task_address_get(gpiote, ss_pin);
 		spim_data.ss_pin = ss_pin;
 		spim_data.gpiote = gpiote;
+
+		spim_end_event = nrf_spim_event_address_get(spim_data.spim.p_reg,
+							    NRF_SPIM_EVENT_END);
+		cs_task = nrfx_gpiote_set_task_address_get(gpiote, ss_pin);
+
+		rv = nrfx_gppi_conn_alloc(spim_end_event, cs_task, &spim_data.gpiote_cs_handle);
+		zassert_ok(rv, "Unexpected error:%d", rv);
+
+		nrfx_gppi_conn_enable(spim_data.gpiote_cs_handle);
 	}
 
 	config.ss_pin = NRF_SPIM_PIN_NOT_CONNECTED;
@@ -443,11 +457,10 @@ static void seq_spim_init(enum test_ppi_seq_mode mode, enum test_ppi_seq_op op,
 	memset(&config, 0, sizeof(config));
 	if (op == TEST_OP_SINGLE_GPIOTE_SS) {
 		config.task = spim_data.ss_task;
-		ops[0].task = task, ops[0].offset = 2;
-		ops[1].task = spim_data.ss_task;
-		ops[1].offset = 14;
+		ops[0].task = task;
+		ops[0].offset = 2;
 		config.extra_ops = ops;
-		config.extra_ops_count = 2;
+		config.extra_ops_count = 1;
 	} else if (op == TEST_OP_DOUBLE) {
 		ops[0].task = task;
 		ops[0].offset = SEQ_OFFSET;
@@ -490,6 +503,7 @@ static void seq_spim_init(enum test_ppi_seq_mode mode, enum test_ppi_seq_op op,
 		notifier.nrfx_timer.end_seq_event =
 			nrfx_spim_end_event_address_get(&spim_data.spim);
 		notifier.nrfx_timer.extra_main_ops = (op == TEST_OP_DOUBLE) ? 1 : 0;
+		notifier.nrfx_timer.attached = false;
 	}
 	config.notifier = &notifier;
 	config.callback = ppi_seq_cb;
@@ -872,6 +886,20 @@ static void after(void *not_used)
 	spis_uninit();
 	if (spim_data.init_done) {
 		if (spim_data.ss_task) {
+			uint32_t cs_task;
+			uint32_t spim_end_event;
+			const struct device *cs_port;
+			nrfx_gpiote_t *gpiote;
+
+			cs_port = DEVICE_DT_GET(DT_GPIO_CTLR(SPIM_NODE, cs_gpios));
+			gpiote = gpio_nrf_gpiote_by_port_get(cs_port);
+
+			cs_task = nrfx_gpiote_set_task_address_get(gpiote, spim_data.ss_pin);
+			spim_end_event = nrf_spim_event_address_get(spim_data.spim.p_reg,
+								    NRF_SPIM_EVENT_END);
+			nrfx_gppi_conn_disable(spim_data.gpiote_cs_handle);
+			nrfx_gppi_conn_free(spim_end_event, cs_task, spim_data.gpiote_cs_handle);
+
 			nrfx_gpiote_pin_uninit(spim_data.gpiote, spim_data.ss_pin);
 			nrfx_gpiote_channel_free(spim_data.gpiote, spim_data.gpiote_task_ch);
 		}

--- a/tests/drivers/ppi_seq/ppi_seq_with_spi/src/main.c
+++ b/tests/drivers/ppi_seq/ppi_seq_with_spi/src/main.c
@@ -48,8 +48,16 @@ enum test_ppi_seq_mode {
 };
 
 enum test_ppi_seq_op {
+	/* PPI sequencer is starting a single SPI transfer per period. HW SS is used. */
 	TEST_OP_SINGLE_HW_SS,
+
+	/* PPI sequencer is starting a single SPI transfer per period but GPIOTE is used
+	 * to assert SS pin, SS pin is deasserted by PPI connection between SPI END event
+	 * and GPIOTE.
+	 */
 	TEST_OP_SINGLE_GPIOTE_SS,
+
+	/* Two SPI transfers per PPI sequencer period. HW SS is used. */
 	TEST_OP_DOUBLE,
 };
 
@@ -760,34 +768,30 @@ ZTEST(ppi_seq_spi, test_single_run_with_grtc_interval_and_cnt_timer)
 
 ZTEST(ppi_seq_spi, test_single_run_with_cnt_timer_gpiote_ss)
 {
-	if (!IS_ENABLED(TEST_MULTI_OP)) {
-		ztest_test_skip();
-	}
+	Z_TEST_SKIP_IFNDEF(TEST_MULTI_OP);
+
 	test_single_run(TEST_MODE_GRTC_TIMER, TEST_OP_SINGLE_GPIOTE_SS,
 			PPI_SEQ_NOTIFIER_NRFX_TIMER);
 }
 
 ZTEST(ppi_seq_spi, test_single_run_with_sys_timer_gpiote_ss)
 {
-	if (!IS_ENABLED(TEST_MULTI_OP)) {
-		ztest_test_skip();
-	}
+	Z_TEST_SKIP_IFNDEF(TEST_MULTI_OP);
+
 	test_single_run(TEST_MODE_GRTC_TIMER, TEST_OP_SINGLE_GPIOTE_SS, PPI_SEQ_NOTIFIER_SYS_TIMER);
 }
 
 ZTEST(ppi_seq_spi, test_single_run_with_trig_timer_and_sys_timer_two_ops)
 {
-	if (!IS_ENABLED(TEST_MULTI_OP)) {
-		ztest_test_skip();
-	}
+	Z_TEST_SKIP_IFNDEF(TEST_MULTI_OP);
+
 	test_single_run(TEST_MODE_GRTC_TIMER, TEST_OP_DOUBLE, PPI_SEQ_NOTIFIER_SYS_TIMER);
 }
 
 ZTEST(ppi_seq_spi, test_single_run_with_trig_timer_and_cnt_timer_two_ops)
 {
-	if (!IS_ENABLED(TEST_MULTI_OP)) {
-		ztest_test_skip();
-	}
+	Z_TEST_SKIP_IFNDEF(TEST_MULTI_OP);
+
 	test_single_run(TEST_MODE_GRTC_TIMER, TEST_OP_DOUBLE, PPI_SEQ_NOTIFIER_NRFX_TIMER);
 }
 
@@ -803,17 +807,14 @@ ZTEST(ppi_seq_spi, test_multi_run_with_trig_timer_and_cnt_timer)
 
 ZTEST(ppi_seq_spi, test_multi_run_with_trig_timer_and_cnt_timer_two_ops)
 {
-	if (!IS_ENABLED(TEST_MULTI_OP)) {
-		ztest_test_skip();
-	}
+	Z_TEST_SKIP_IFNDEF(TEST_MULTI_OP);
+
 	test_multi_run(TEST_MODE_GRTC_TIMER, TEST_OP_DOUBLE, PPI_SEQ_NOTIFIER_NRFX_TIMER);
 }
 
 ZTEST(ppi_seq_spi, test_multi_run_with_trig_timer_and_sys_timer_two_ops)
 {
-	if (!IS_ENABLED(TEST_MULTI_OP)) {
-		ztest_test_skip();
-	}
+	Z_TEST_SKIP_IFNDEF(TEST_MULTI_OP);
 
 	test_multi_run(TEST_MODE_GRTC_TIMER, TEST_OP_DOUBLE, PPI_SEQ_NOTIFIER_SYS_TIMER);
 }


### PR DESCRIPTION
When TIMER is used for counting events in the sequence, it is possible that PPI event that TIMER intends to count is already in use. So far ppi_seq was returning an error during the initialization but it is possible to attach to the channel if counting (notifying) TIMER is in the same domain as the event that is being counted. In that case TIMER COUNT task can be attached to the existing connection.

Updated test to use PPI sequencer only to assert GPIOTE SS pin and deassertion is done by the external PPI connection between SPIM END event and GPIOTE task. This connection is setup in the test.
