### PR TITLE
workflows: add LTS tag to src mirror packages

### DIFF
--- a/.github/workflows/src-mirror.yml
+++ b/.github/workflows/src-mirror.yml
@@ -41,3 +41,4 @@ jobs:
           artifactory-pass: ${{ secrets.COM_NORDICSEMI_FILES_PASSWORD }}
           stable: ${{ env.STABLE }}
           repository-type: 'nrf'
+          tags: 'LTS'


### PR DESCRIPTION
Add LTS tag to src mirror packages built from v3.4-branch