### PR TITLE
tests: bootloader: Align log messages

### DIFF
--- a/tests/subsys/bootloader/upgrade/pytest/test_upgrade_mcuboot_nsib.py
+++ b/tests/subsys/bootloader/upgrade/pytest/test_upgrade_mcuboot_nsib.py
@@ -63,7 +63,7 @@ def test_upgrade_of_mcuboot_with_nsib(dut: DeviceAdapter, shell: Shell, mcumgr: 
         lines=[
             f"Image index: {tm.image_index}, Swap type: perm",
         ],
-        no_lines=["insufficient version in secondary slot"],
+        no_lines=["Insufficient version in secondary slot"],
     )
     assert shell.wait_for_prompt(timeout=10.0), "No shell prompt after upgrade"
     logger.info(

--- a/tests/subsys/bootloader/upgrade/pytest/test_upgrade_netcore.py
+++ b/tests/subsys/bootloader/upgrade/pytest/test_upgrade_netcore.py
@@ -55,7 +55,7 @@ def test_upgrade_with_netcore(dut: DeviceAdapter, shell: Shell, mcumgr: MCUmgr):
             "Image 0 copying the secondary slot",
             "Image 1 copying the secondary slot",
         ],
-        no_lines=["Swap type: none", "insufficient version in secondary slot"],
+        no_lines=["Swap type: none", "Insufficient version in secondary slot"],
     )
     tm.check_with_shell_command()
     logger.info("APP and NETCORE upgraded successfully")
@@ -90,7 +90,7 @@ def test_sw_downgrade_prevention_with_netcore(dut: DeviceAdapter, shell: Shell, 
         lines=[
             "Image index: 0, Swap type: perm",
             "Image index: 1, Swap type: perm",
-            "insufficient version in secondary slot",
+            "Insufficient version in secondary slot",
         ],
         no_lines=["copying the secondary slot"],
     )
@@ -134,7 +134,7 @@ def test_upgrade_netcore_only(dut: DeviceAdapter, shell: Shell, mcumgr: MCUmgr):
             "Image 1 copying the secondary slot to the primary slot:",
             "Image version: v1.1.1",
         ],
-        no_lines=["insufficient version in secondary slot"],
+        no_lines=["Insufficient version in secondary slot"],
     )
     logger.info("NETCORE upgraded successfully")
 
@@ -167,7 +167,7 @@ def test_sw_downgrade_prevention_with_netcore_only(
         lines=[
             "Image index: 0, Swap type: none",
             "Image index: 1, Swap type: perm",
-            "insufficient version in secondary slot",
+            "Insufficient version in secondary slot",
         ],
         no_lines=["copying the secondary slot"],
     )

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 9ca3dd0e39bd3ce12ee2fd7d5fa022bf93c4b463
+      revision: 8414450633ac0b902256e58216fe4f3c6c3039d7
       path: bootloader/mcuboot
     - name: qcbor
       repo-path: sdk-qcbor


### PR DESCRIPTION
Align log messages with upstream MCUboot and Zephyr tests.

Ref: NCSDK-39513