### PR TITLE
drivers: wifi: nrf71 boot gate on driver

### DIFF
--- a/drivers/wifi/nrf71/Kconfig
+++ b/drivers/wifi/nrf71/Kconfig
@@ -14,7 +14,7 @@ menuconfig WIFI_NRF71
 	select IPC_SERVICE
 	select MBOX
 	select SPSC_PBUF
-	select SOC_NRF71_WIFI_BOOT if BUILD_WITH_TFM
+	select SOC_NRF71_WIFI_BOOT
 	default y
 	depends on DT_HAS_NORDIC_NRF7120_WIFI_ENABLED
 	help

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a8d9f5e138572ae55ac33f3b88b3a8954272de30
+      revision: b312f8a8dcf8ba941a28c2ce457f9bbe83c25efd
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix the Wi-Fi core boot only when driver is enabled.