### PR TITLE
Unify access to version information in doc extensions

### DIFF
--- a/doc/_extensions/kconfigdiff/__init__.py
+++ b/doc/_extensions/kconfigdiff/__init__.py
@@ -9,13 +9,12 @@ Kconfigdiff extension for displaying changes in kconfig
 files between releases.
 """
 
-import json
 import logging
-import re
 from pathlib import Path
 
 from sphinx.application import Sphinx
 from sphinx.util.typing import ExtensionMetadata
+from versions import Versions, get_versions
 
 from .kconfig_utils import RESOURCES_DIR
 from .legend import KconfigDiffLegendDirective
@@ -27,55 +26,37 @@ logger = logging.Logger(__name__)
 
 __version__ = "0.1.0"
 
-VERSION_REGEX = re.compile(r"^\d+\.\d+\.\d+$")
-MAJOR_VERSION_REGEX = re.compile(r"^\d+\.\d+\.0$")
 
-
-def is_major(version: str):
-    return MAJOR_VERSION_REGEX.match(version)
-
-
-def get_major_version(versions: list[str]) -> str | None:
-    return next((v for v in versions if is_major(v)), None)
-
-
-def get_versions(app) -> tuple[str, str] | None:
+def get_kconfig_versions(app: Sphinx) -> tuple[str, str] | None:
     current = "latest"
 
-    with open(VERSIONS_FILE, "rb") as f:
-        versions = json.load(f)
-        if not versions:
-            logger.error("Ill formatted versions file")
+    versions = get_versions(app).normalized().patchlevel()
+    if not versions:
+        logger.error("Ill formatted versions file")
+        return None
+
+    minor_versions = versions.minor()
+    if app.config.kconfigdiff_is_release:
+        current = versions.latest()
+        if len(minor_versions) >= 2 and Versions.is_minor(current):
+            return current, minor_versions.all()[1]
+        elif len(versions) >= 2:
+            return current, versions.all()[1]
+        else:
+            logger.error("Not enough versions to generate comparison")
             return None
 
-        if versions[0].endswith("99"):
-            # skip the placeholder .99 version
-            versions.pop(0)
+    if prev := minor_versions.latest():
+        return current, prev
 
-        # Filter out preview versions (and other -addition versions)
-        versions = [v for v in versions if VERSION_REGEX.match(v)]
-
-        if app.config.kconfigdiff_is_release:
-            current = versions[0]
-            if is_major(current) and (prev := get_major_version(versions[1:])):
-                return current, prev
-            elif len(versions) >= 2:
-                return current, versions[1]
-            else:
-                logger.error("Not enough versions to generate comparison")
-                return None
-
-        if prev := get_major_version(versions):
-            return current, prev
-
-        logger.error("Not enough versions to generate comparison")
-        return None
+    logger.error("Not enough versions to generate comparison")
+    return None
 
 
 def kconfigdiff_install(app: Sphinx) -> None:
     app.config.html_static_path.append(RESOURCES_DIR.as_posix())
 
-    versions = get_versions(app)
+    versions = get_kconfig_versions(app)
     app.config.kconfigdiff_versions = versions
 
     if versions:

--- a/doc/_extensions/page_filter.py
+++ b/doc/_extensions/page_filter.py
@@ -59,7 +59,6 @@ Example of use:
   :container: dl/dt
 """
 
-import json
 import re
 from pathlib import Path
 
@@ -68,6 +67,7 @@ from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
+from versions import get_versions
 
 __version__ = "0.1.0"
 
@@ -75,9 +75,6 @@ logger = logging.getLogger(__name__)
 
 RESOURCES_DIR = Path(__file__).parent / "static"
 """Static resources"""
-
-VERSIONS_FILE = Path(__file__).parents[1] / "versions.json"
-"""Contains all versions to date"""
 
 
 class PageFilter(SphinxDirective):
@@ -106,16 +103,18 @@ class VersionFilter(PageFilter):
 
     has_content = False
 
-    def run(self):
+    def run(self) -> list[nodes.Node]:
         name = self.options.get("name", "versions")
         default = self.options.get("default", "all")
         container_element = self.options.get("container", None)
         tags = self.options.get("tags", [])
         tags = {classname: displayname for classname, displayname in tags}
         tags["versions"] = ""
-        def create_tuple(v):
-            return v, v.replace("-", ".")
-        versions = list(map(create_tuple, reversed(self.env.nrf_versions)))
+
+        def create_tuple(v: str) -> tuple[str, str]:
+            return f"v{v.replace('.', '-')}", f"v{v}"
+
+        versions = get_versions(self.env.app).matching(re.compile(r"\d+\.\d+\.\d+(?:-(?!preview\d+|rc\d+|dev\d+).*)?$")).all(create_tuple)
         return [FilterDropdown(name, versions, default, container_element, tags)]
 
 
@@ -214,34 +213,6 @@ def page_filter_install(
 
 def add_filter_resources(app: Sphinx):
     app.config.html_static_path.append(RESOURCES_DIR.as_posix())
-    read_versions(app)
-
-
-def read_versions(app: Sphinx) -> None:
-    """Get all NRF versions to date"""
-
-    if hasattr(app.env, "nrf_versions") and app.env.nrf_versions:
-        return
-
-    try:
-        with open(VERSIONS_FILE) as version_file:
-            nrf_versions = json.loads(version_file.read())
-            # Updated regex to match versions with optional segments
-            nrf_versions = list(
-                filter(
-                    lambda v: re.match(
-                        r"\d+\.\d+\.\d+(?:-(?!preview\d+|rc\d+|dev\d+).*)?$", v
-                    ),
-                    nrf_versions,
-                )
-            )
-            # Convert versions to a format suitable for class names
-            app.env.nrf_versions = [
-                f"v{version.replace('.', '-')}" for version in reversed(nrf_versions)
-            ]
-    except FileNotFoundError:
-        logger.error("Could not load version file")
-        app.env.nrf_versions = []
 
 
 def setup(app: Sphinx):

--- a/doc/_utils/versions.py
+++ b/doc/_utils/versions.py
@@ -1,0 +1,175 @@
+"""
+Copyright (c) 2026 Nordic Semiconductor ASA
+
+SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""
+
+import json
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar, overload
+
+from sphinx.application import Sphinx
+
+VERSIONS_FILE = (Path(__file__).parents[1] / "versions.json").as_posix()
+
+T = TypeVar("T")
+VersionFmt = Callable[[str], T]
+
+
+class Versions:
+    """
+    An object intended to use as a singleton for accessing version information.
+    Intended usage is through get_versions method for example:
+
+        get_versions(app).normalized().minor().all() # Get all minor versions as a list
+
+        get_versions(app).major().latest() # Get latest major version
+
+        get_versions(app).major().latest(lambda v: f"version {v}")
+        # Latest major version with custom format
+    """
+
+    _major_version_re = re.compile(r"^\d+\.0.0$")
+    _minor_version_re = re.compile(r"^\d+\.\d+\.0$")
+    _patchlevel_version_re = re.compile(r"^\d+\.\d+\.\d+$")
+
+    def __init__(self, versions: list[str]) -> None:
+        self._versions = versions
+
+    @staticmethod
+    def from_topdir() -> "Versions":
+        """
+        Creates the Versions object from doc/versions.json file
+        @return New Versions object
+        """
+        with open(VERSIONS_FILE, "rb") as f:
+            return Versions(json.load(f))
+
+    @staticmethod
+    def is_major(v: str) -> bool:
+        """
+        Checks if version is major.
+
+        @param v Version to check
+        @return True if version is major
+        """
+        return bool(Versions._major_version_re.match(v))
+
+    @staticmethod
+    def is_minor(v: str) -> bool:
+        """
+        Checks if version is minor.
+
+        A major version is considered minor but not the other way around.
+        @param v Version to check
+        @return True if version is minor
+        """
+        return bool(Versions._minor_version_re.match(v))
+
+    @staticmethod
+    def is_patchlevel(v: str) -> bool:
+        """
+        Checks if version is patchlevel.
+
+        A patchlevel version set here is considered to contain minor and major versions
+        @param v Version to check
+        @return True if version is minor
+        """
+        return bool(Versions._patchlevel_version_re.match(v))
+
+    @staticmethod
+    def is_placeholder(v: str) -> bool:
+        """
+        Checks if version is a placeholder for latest with the .99 suffix.
+
+        @param v Version to check
+        @return True if version is the placeholder.
+        """
+        return v.endswith(".99")
+
+    @overload
+    def latest(self) -> str | None: ...
+    @overload
+    def latest(self, fmt: VersionFmt[T]) -> T | None: ...
+    def latest(self, fmt: VersionFmt[Any] = lambda v: v) -> Any:
+        """
+        @return Latest version available, passed through fmt or None if Versions object is empty
+        """
+        if self._versions:
+            return fmt(self._versions[0])
+        return None
+
+    def vlatest(self) -> str | None:
+        """
+        @return Latest version formated with a ``v`` as in: ``v3.4.0``
+            or None if Versions object is empty
+        """
+        return self.latest(Versions._to_vformat)
+
+    @overload
+    def all(self) -> list[str]: ...
+    @overload
+    def all(self, fmt: VersionFmt[T]) -> list[T]: ...
+    def all(self, fmt: VersionFmt[Any] = lambda v: v) -> list[Any]:
+        """
+        @return List of all versions, passed through fmt if given
+        """
+        return [fmt(v) for v in self._versions]
+
+    def vall(self) -> list[str]:
+        """
+        @return List of all versions formatted as in ``vlatest``
+        """
+        return self.all(Versions._to_vformat)
+
+    def normalized(self) -> "Versions":
+        """
+        Filters versions removing the placeholder version if it's present.
+        """
+        if not self._versions:
+            return self
+
+        if Versions.is_placeholder(self._versions[0]):
+            return Versions(self._versions[1:])
+
+        return self
+
+    def matching(self, regex: re.Pattern[str]) -> "Versions":
+        """
+        Filters versions by regex.
+        """
+        return Versions([v for v in self._versions if regex.match(v)])
+
+    def major(self) -> "Versions":
+        """
+        Filters versions to only major versions.
+        """
+        return self.matching(Versions._major_version_re)
+
+    def minor(self) -> "Versions":
+        """
+        Filters versions to only minor version (filters out any -addition versions).
+        """
+        return self.matching(Versions._minor_version_re)
+
+    def patchlevel(self) -> "Versions":
+        """
+        Filters versions to only patchlevel version (filters out any -addition versions).
+        """
+        return self.matching(Versions._patchlevel_version_re)
+
+    @staticmethod
+    def _to_vformat(v: str) -> str:
+        return f"v{v}"
+
+    def __len__(self) -> int:
+        return len(self._versions)
+
+
+def get_versions(app: Sphinx) -> Versions:
+    if hasattr(app.env, "ncs_versions"):
+        return app.env.ncs_versions
+    app.env.ncs_versions = Versions.from_topdir()
+    return app.env.ncs_versions


### PR DESCRIPTION
Introduces a new object with utilities for filtering available version which is stored for all extensions to access in app.env.ncs_versions, and should be used through get_versions(app) function.