### PR TITLE
doc: kconfig: fix formatting of kconfig_diff page description

### DIFF
--- a/doc/kconfig/kconfig_diff.rst
+++ b/doc/kconfig/kconfig_diff.rst
@@ -7,8 +7,9 @@ Kconfig diff
    :local:
    :depth: 2
 
-This page shows comparison between |kconfigdiff_previous| and |kconfigdiff_current|.
-The comparison is displayed using a format inspired by `git diff`:
+This page shows a comparison between |kconfigdiff_previous| and |kconfigdiff_current|.
+
+The comparison is displayed in a format inspired by ``git diff``:
 
 .. kconfigdiff-legend::
 


### PR DESCRIPTION
Add a new line to fix the formatting.