### PR TITLE
tests: subsys: event_manager_proxy: Use ICMsg session handshake

### DIFF
--- a/tests/subsys/event_manager_proxy/boards/nrf54lv10dk_nrf54lv10a_cpuapp_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/boards/nrf54lv10dk_nrf54lv10a_cpuapp_icmsg.overlay
@@ -31,6 +31,13 @@
 			rx-region = <&sram_rx>;
 			mboxes = <&cpuapp_vevif_rx 20>, <&cpuapp_vevif_tx 21>;
 			mbox-names = "rx", "tx";
+			/* Session-ID handshake so a warm restart of one core
+			 * forces a fresh rebind instead of trusting stale
+			 * shared-memory magic, which otherwise causes
+			 * intermittent IPC bind timeouts. Must match the remote
+			 * overlay.
+			 */
+			unbound = "enable";
 			status = "okay";
 		};
 	};

--- a/tests/subsys/event_manager_proxy/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/remote/boards/nrf54lv10dk_nrf54lv10a_cpuflpr_icmsg.overlay
@@ -27,6 +27,12 @@
 			rx-region = <&sram_rx>;
 			mboxes = <&cpuflpr_vevif_rx 21>, <&cpuflpr_vevif_tx 20>;
 			mbox-names = "rx", "tx";
+			/* Must match the application-core overlay: session-ID
+			 * handshake so a warm restart of one core forces a fresh
+			 * rebind instead of trusting stale shared-memory magic
+			 * (avoids intermittent IPC bind timeouts).
+			 */
+			unbound = "enable";
 			status = "okay";
 		};
 	};


### PR DESCRIPTION
The nrf54lv10 ipc0 instance did not set the "unbound" property, so it defaulted to "disable" (magic-only ICMsg handshake). In that mode the handshake relies on a constant magic value in the shared memory and cannot distinguish a peer that has just rebooted from stale contents left in the (non-cleared) shared RAM by the previous run.

On a warm restart this occasionally left the two cores with inconsistent pbuf state, so the endpoint never reported "bound" within the event manager proxy bind timeout. The application core then failed the very first REMOTE_EVENT_SUBSCRIBE with -EPIPE, resulting in an intermittent assert/kernel panic during test start.

Set "unbound = enable" on both the cpuapp and cpuflpr ipc0 overlays so a fresh session id is negotiated on every boot. Stale shared-memory state can no longer masquerade as a valid handshake, making bind deterministic.

Both sides must use the same mode; enable is available by default via IPC_SERVICE_ICMSG_UNBOUND_ENABLED_ALLOWED and dcache-alignment is 32.