### PR TITLE
tests: drivers: gpio: hpf_gpio_basic_api: fix support for FLPR

### DIFF
--- a/tests/drivers/gpio/hpf_gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
+++ b/tests/drivers/gpio/hpf_gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# FLPR does not support GPIO interrupts. Disabling interrupt support removes
+# the driver's dependency on the (disabled-by-default) GPIOTE130 peripheral,
+CONFIG_GPIO_NRFX_INTERRUPT=n

--- a/tests/drivers/gpio/hpf_gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
+++ b/tests/drivers/gpio/hpf_gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
@@ -8,6 +8,10 @@
 	};
 };
 
+&gpio0 {
+	status = "okay";
+};
+
 &cpuflpr_code_partition {
 	reg = <0xf4000 DT_SIZE_K(64)>;
 };


### PR DESCRIPTION
Remove implicit usage of GPIOTE130 which forces
interrupts, because hese are unsupported on FLPR.