### PR TITLE
scripts: sbom: Populate fields LicenseInfoInFile and FileCopyrightText

### DIFF
--- a/scripts/west_commands/sbom/README.rst
+++ b/scripts/west_commands/sbom/README.rst
@@ -305,7 +305,7 @@ The ``ncs-sbom`` command includes the following detectors:
 
   The database is part of the ``ncs-sbom`` command. Enabled by default.
 
-* ``scancode-toolkit`` - License detection by the `Scancode-Toolkit`_. Enabled and optional by default.
+* ``scancode-toolkit`` - License and copyright detection by the `Scancode-Toolkit`_. Enabled and optional by default.
 
   If the ``scancode`` command is not on your ``PATH``, you can use the ``--scancode`` option to provide it, for example:
 
@@ -350,8 +350,12 @@ The ``ncs-sbom`` command includes the following detectors:
 
      --input-cache-database *cache-database.json*
 
-  Each database entry has a path relative to the west workspace directory, a hash, and a list of detected licenses.
-  If the file under detection has the same path and hash, the list of licenses from the database is used.
+  Each version 2 database entry has a path relative to the west workspace directory, a hash,
+  concluded license evidence, license information detected in the file, and copyright notices.
+  If the file under detection has the same path and hash, the cached information is merged with
+  results from earlier detectors.
+
+  Version 1 databases containing only the merged license list remain supported.
 
   .. note::
      To generate the database based on, for example the ``scancode-toolkit`` detector, run the following command:

--- a/scripts/west_commands/sbom/args.py
+++ b/scripts/west_commands/sbom/args.py
@@ -30,11 +30,11 @@ full-text
   Compare the contents of the license with the references that are stored in the database.
 
 scancode-toolkit
-  License detection by scancode-toolkit.
+  License and copyright detection by scancode-toolkit.
   For more details see: https://scancode-toolkit.readthedocs.io/en/stable/
 
 cache-databese
-  License detection is based on a predefined database.
+  License and copyright information is obtained from a predefined database.
   The license type is obtained from the database.
 
 git-info
@@ -120,7 +120,7 @@ def add_arguments(parser: argparse.ArgumentParser):
     parser.add_argument('--output-spdx', default=None,
                         help='Generate output SPDX report.')
     parser.add_argument('--output-cache-database', default=None,
-                        help='Generate a license database for the files using scancode-toolkit')
+                        help='Generate a license and copyright database for the files.')
     parser.add_argument('--input-cache-database', default=None,
                         help='Input license database. The database is passed to the "cache-databe" '
                              'detector')

--- a/scripts/west_commands/sbom/cache_database_detector.py
+++ b/scripts/west_commands/sbom/cache_database_detector.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
 '''
-Detector that detect license using provided cache database file.
+Detector that retrieves license and copyright information from a cache database.
 '''
 
 import json
@@ -14,22 +14,42 @@ from common import SbomException
 from data_structure import Data
 from west import log
 
+CACHE_SCHEMA_VERSION = 2
+
 
 def detect(data: Data, optional: bool):
-    '''Retrieve the license from the provided database.'''
+    '''Retrieve license and copyright information from the provided database.'''
     if args.input_cache_database is None:
         raise SbomException('No input cache database file.')
 
     with open(args.input_cache_database) as fd:
         log.dbg(f'Loading cache database from {args.input_cache_database}')
         db = json.load(fd)
+    schema_version = db.get('schema_version', 1)
+    if schema_version not in (1, CACHE_SCHEMA_VERSION):
+        raise SbomException(f'Unsupported cache database schema version: {schema_version}')
 
     for file in data.files:
-        if optional and file.licenses:
-            continue
         key = str(file.file_rel_path)
         if key not in db['files']:
             continue
-        if file.sha1 == db['files'][key]['sha1']:
-            file.licenses = db['files'][key]['license']
-        file.detectors.add('cache-database')
+        entry = db['files'][key]
+        if file.sha1 != entry['sha1']:
+            continue
+
+        licenses = set(entry.get('license', []))
+        licenses_in_file = set(entry.get('license_in_file', []))
+        copyright_texts = {
+            text.strip()
+            for text in entry.get('copyright', [])
+            if isinstance(text, str) and text.strip()
+        }
+
+        # Legacy cache files have no license_in_file field. Their merged
+        # license evidence cannot safely be classified as originating in-file.
+        file.licenses.update(licenses)
+        file.licenses.update(licenses_in_file)
+        file.licenses_in_file.update(licenses_in_file)
+        file.copyright_texts.update(copyright_texts)
+        if licenses or licenses_in_file or copyright_texts:
+            file.detectors.add('cache-database')

--- a/scripts/west_commands/sbom/data_structure.py
+++ b/scripts/west_commands/sbom/data_structure.py
@@ -28,18 +28,24 @@ class FileInfo(DataBaseClass):
         file_path           File path
         file_rel_path       Path relative to west workspace
         licenses            Set of detected SPDX license IDs and expressions
+        licenses_in_file    Subset of licenses detected in the file itself
         license_expr        Contains SPDX license expression that covers all detected licesens
+        infile_lics         Friendly SPDX entries for licenses detected in the file itself
+        copyright_texts     Copyright notices detected in the file
         package             Package ID of this file
         local_modifications The file was modified and does not match version of this package
         sha1                SHA-1 of the file
-        detectors           Set of detectors that contributed to the list of licenses
-                             for the file
+        detectors           Set of detectors that contributed license or copyright
+                            information for the file
     '''
     file_path: Path
     file_rel_path: Path
     licenses: 'set[str]' = set()
+    licenses_in_file: 'set[str]' = set()
     license_expr: str
     license_expr_friendly: str = ''
+    infile_lics: 'list[str]' = list()
+    copyright_texts: 'set[str]' = set()
     package: 'str' = ''
     local_modifications: bool = False
     sha1: str

--- a/scripts/west_commands/sbom/full_text_detector.py
+++ b/scripts/west_commands/sbom/full_text_detector.py
@@ -95,4 +95,5 @@ def detect(data: Data, optional: bool):
     for results, file, _ in concurrent_pool_iter(detect_file, filtered, True, 2048):
         if len(results) > 0:
             file.licenses.update(results)
+            file.licenses_in_file.update(results)
             file.detectors.add('full-text')

--- a/scripts/west_commands/sbom/output_pre_process.py
+++ b/scripts/west_commands/sbom/output_pre_process.py
@@ -13,71 +13,86 @@ from license_utils import get_license, get_spdx_license_expr_info, is_spdx_licen
 DEPENDENCY_PLACEHOLDER_ID = 'DEPENDENCY-INFORMATION-UNAVAILABLE'
 
 
+def make_license_expression(licenses: 'set[str]') -> str:
+    '''Convert a set of licenses to a single SPDX license expression.'''
+    if len(licenses) == 0:
+        return ''
+    simple_expr_items = set()
+    or_expr_items = set()
+    repeated_expr_items = set()
+    for license in licenses:
+        license = license.upper()
+        info = get_spdx_license_expr_info(license)
+        if info.valid and not info.is_id_only and len(info.licenses) > 1:
+            repeated_expr_items.update(info.licenses)
+        if not info.valid or info.or_present:
+            or_expr_items.add(license)
+        else:
+            simple_expr_items.add(license)
+    simple_expr_items -= repeated_expr_items
+    if len(or_expr_items) > 1 or len(simple_expr_items) > 0:
+        or_expr_items = {f'({x})' for x in or_expr_items}
+    return ' AND '.join(sorted(simple_expr_items.union(or_expr_items)))
+
+
 def pre_process(data: Data, built_date: 'str|None' = None):
     '''Do pre-processing of data for simpler usage by the output modules.
     built_date (UTC ISO 8601 or None) is stamped on application packages.
     '''
     # Sort files
     data.files.sort(key=lambda f: f.file_path)
-    # Convert list of licenses to license expression for each file
+    # Convert concluded licenses to a single SPDX license expression for each file.
     for file in data.files:
-        licenses = file.licenses if len(file.licenses) > 0 else ['']
-        simple_expr_items = set()
-        or_expr_items = set()
-        repeated_expr_items = set()
-        for license in licenses:
-            license = license.upper()
-            info = get_spdx_license_expr_info(license)
-            if info.valid and not info.is_id_only and len(info.licenses) > 1:
-                repeated_expr_items.update(info.licenses)
-            if not info.valid or info.or_present:
-                or_expr_items.add(license)
-            else:
-                simple_expr_items.add(license)
-        simple_expr_items -= repeated_expr_items
-        if len(or_expr_items) > 1 or len(simple_expr_items) > 0:
-            or_expr_items = { f'({x})' for x in or_expr_items }
-        file.license_expr = ' AND '.join(sorted(simple_expr_items.union(or_expr_items)))
+        file.license_expr = make_license_expression(file.licenses)
     # Collect all used detectors
     for file in data.files:
         data.detectors.update(file.detectors)
     # Collect all used licenses and license expressions and put them into data.licenses
     used_licenses = dict()
     for file in data.files:
-        if file.license_expr in used_licenses:
-            continue
-        info = get_spdx_license_expr_info(file.license_expr)
-        if not info.valid or not info.is_id_only:
-            expr = LicenseExpr()
-            expr.valid = info.valid
-            expr.id = file.license_expr
-            expr.friendly_id = info.friendly_expr
-            expr.licenses = sorted(info.licenses)
-            expr.custom = not info.valid
-            for id in expr.licenses:
-                if not is_spdx_license(id):
-                    expr.custom = True
-                    break
-            used_licenses[file.license_expr] = expr
-        for id in info.licenses:
-            if id in used_licenses:
+        expressions = [file.license_expr, *file.licenses_in_file]
+        for license_expr in expressions:
+            if license_expr in used_licenses:
                 continue
-            elif is_spdx_license(id):
-                used_licenses[id] = get_license(id)
-            elif id in data.licenses:
-                used_licenses[id] = data.licenses[id]
-            else:
-                lic = get_license(id)
-                if lic is None:
-                    lic = License()
-                    lic.id = id
-                    lic.friendly_id = id
-                used_licenses[id] = lic
+            info = get_spdx_license_expr_info(license_expr)
+            if not info.valid or not info.is_id_only:
+                expr = LicenseExpr()
+                expr.valid = info.valid
+                expr.id = license_expr
+                expr.friendly_id = info.friendly_expr
+                expr.licenses = sorted(info.licenses)
+                expr.custom = not info.valid
+                for id in expr.licenses:
+                    if not is_spdx_license(id):
+                        expr.custom = True
+                        break
+                used_licenses[license_expr] = expr
+            for id in info.licenses:
+                if id in used_licenses:
+                    continue
+                if is_spdx_license(id):
+                    used_licenses[id] = get_license(id)
+                elif id in data.licenses:
+                    used_licenses[id] = data.licenses[id]
+                else:
+                    lic = get_license(id)
+                    if lic is None:
+                        lic = License()
+                        lic.id = id
+                        lic.friendly_id = id
+                    used_licenses[id] = lic
     data.licenses = used_licenses
     # Pre-compute friendly-cased license expression so the SPDX LicenseConcluded matches the casing
     for file in data.files:
         lic = data.licenses.get(file.license_expr)
         file.license_expr_friendly = lic.friendly_id if lic is not None else file.license_expr
+        file.infile_lics = list()
+        for license_expr in file.licenses_in_file:
+            lic = data.licenses.get(license_expr)
+            file.infile_lics.append(
+                lic.friendly_id if lic is not None else license_expr
+            )
+        file.infile_lics.sort()
     # Sort licenses
     def lic_reorder(id: str):
         lic: License | LicenseExpr = data.licenses[id]

--- a/scripts/west_commands/sbom/output_template.py
+++ b/scripts/west_commands/sbom/output_template.py
@@ -40,8 +40,14 @@ def adjust_identifier(license: str) -> str:
     return license.replace('LICENSEREF', 'LicenseRef')
 
 
+def sanitize_tagvalue_text(value: str) -> str:
+    '''Prevent copyright text from terminating an SPDX tag-value text block.'''
+    return str(value).replace('</text>', '&lt;/text&gt;')
+
+
 filters.FILTERS['verification_code'] = verification_code
 filters.FILTERS['adjust_identifier'] = adjust_identifier
+filters.FILTERS['sanitize_tagvalue_text'] = sanitize_tagvalue_text
 
 
 def group_by(files: 'list[FileInfo]', attr_name: str) -> 'dict[list[FileInfo]]':

--- a/scripts/west_commands/sbom/scancode_toolkit_detector.py
+++ b/scripts/west_commands/sbom/scancode_toolkit_detector.py
@@ -98,37 +98,29 @@ def run_scancode(file: FileInfo) -> 'dict|None':
 def apply_scancode_result(data: Data, file: FileInfo, result: dict):
     '''Parse one ScanCode result and update file/license structures.'''
     current = result['files'][0]
-    if 'licenses' in current:
-        licenses = current['licenses']
-    elif 'license_detections' in current:
-        licenses = current['license_detections']
-    else:
-        print('No license information for {}'.format(current['path']))
-        return
+    licenses = current.get('license_detections')
+    if licenses is None:
+        licenses = current.get('licenses', [])
 
-    for i in licenses:
-
-        friendly_id = ''
-        if 'spdx_license_key' in i and i['spdx_license_key'] != '':
-            friendly_id = i['spdx_license_key']
-        elif 'key' in i and i['key'] != '':
-            friendly_id = i['key']
-        elif 'license_expression_spdx' in i and i['license_expression_spdx'] != '':
-            friendly_id = i['license_expression_spdx']
-        elif 'license_expression' in i and i['license_expression'] != '':
-            friendly_id = i['license_expression']
+    for item in licenses:
+        friendly_id = next((item.get(key) for key in (
+            'spdx_license_key',
+            'key',
+            'license_expression_spdx',
+            'license_expression',
+        ) if item.get(key)), '')
         id = friendly_id.upper()
         if id in ('UNKNOWN-SPDX', 'LICENSEREF-SCANCODE-UNKNOWN-SPDX') or id == '':
-            matched_text = None
-            if 'matched_text' in i:
-                matched_text = i['matched_text']
-            elif 'matches' in i and isinstance(i['matches'], list):
-                matched_text = next((match.get('matched_text')
-                                     for match in i['matches']
-                                     if match.get('matched_text') is not None), None)
+            matched_text = item.get('matched_text')
+            if matched_text is None:
+                matched_text = next((
+                    match.get('matched_text') for match in item.get('matches', [])
+                    if isinstance(match, dict) and match.get('matched_text') is not None
+                ), None)
             if matched_text:
-                friendly_id = re.sub(r'SPDX-License-Identifier:', '', matched_text,
-                                     flags=re.I).strip()
+                friendly_id = re.sub(
+                    r'SPDX-License-Identifier:', '', matched_text, flags=re.I
+                ).strip()
                 friendly_id = friendly_id.rstrip('*/').strip()
                 friendly_id = friendly_id.lstrip('/*').strip()
                 id = friendly_id.upper()
@@ -137,25 +129,16 @@ def apply_scancode_result(data: Data, file: FileInfo, result: dict):
             continue
 
         file.licenses.add(id)
+        file.licenses_in_file.add(id)
         file.detectors.add('scancode-toolkit')
 
         if not is_spdx_license(id):
-            if 'name' in i:
-                name = i['name']
-            elif 'short_name' in i:
-                name = i['short_name']
-            else:
-                name = None
-
-            if 'spdx_url' in i:
-                url = i['spdx_url']
-            elif 'reference_url' in i:
-                url = i['reference_url']
-            elif 'scancode_text_url' in i:
-                url = i['scancode_text_url']
-            else:
-                url = None
-
+            name = item.get('name') or item.get('short_name')
+            url = (
+                item.get('spdx_url')
+                or item.get('reference_url')
+                or item.get('scancode_text_url')
+            )
             if id in data.licenses:
                 license = data.licenses[id]
                 if license.is_expr:
@@ -171,12 +154,21 @@ def apply_scancode_result(data: Data, file: FileInfo, result: dict):
                 license.url = url
             license.detectors.add('scancode-toolkit')
 
+    for item in current.get('copyrights', []):
+        if not isinstance(item, dict):
+            log.wrn(f'Invalid copyright response from scancode-toolkit, file: {file.file_path}')
+            continue
+        copyright_text = (item.get('copyright') or item.get('value') or '').strip()
+        if copyright_text:
+            file.copyright_texts.add(copyright_text)
+            file.detectors.add('scancode-toolkit')
+
 
 def detect(data: Data, optional: bool):
     '''License detection using scancode-toolkit.'''
 
     if optional:
-        filtered = tuple(filter(lambda file: len(file.licenses) == 0, data.files))
+        filtered = tuple(filter(lambda file: len(file.licenses_in_file) == 0, data.files))
     else:
         filtered = tuple(data.files)
 

--- a/scripts/west_commands/sbom/spdx_tag_detector.py
+++ b/scripts/west_commands/sbom/spdx_tag_detector.py
@@ -46,4 +46,5 @@ def detect(data: Data, optional: bool):
     for results, file, _ in concurrent_pool_iter(detect_file, filtered, True, 4096):
         if len(results) > 0:
             file.licenses.update(results)
+            file.licenses_in_file.update(results)
             file.detectors.add('spdx-tag')

--- a/scripts/west_commands/sbom/templates/cache.database.jinja
+++ b/scripts/west_commands/sbom/templates/cache.database.jinja
@@ -1,9 +1,16 @@
 {
+	"schema_version": 2,
 	"files": {
-		{% for file in files %}"{{file.file_rel_path}}": {
-				"sha1": "{{file.sha1}}",
+		{% for file in files %}{{ file.file_rel_path | string | tojson }}: {
+				"sha1": {{ file.sha1 | tojson }},
 				"license": [
-					{% for license in file.licenses %} "{{license}}"{{ ", " if not loop.last else "" }}
+					{% for license in file.licenses | sort(case_sensitive=true) %} {{ license | tojson }}{{ ", " if not loop.last else "" }}
+				{% endfor %}],
+				"license_in_file": [
+					{% for license in file.licenses_in_file | sort(case_sensitive=true) %} {{ license | tojson }}{{ ", " if not loop.last else "" }}
+				{% endfor %}],
+				"copyright": [
+					{% for copyright in file.copyright_texts | sort(case_sensitive=true) %} {{ copyright | tojson }}{{ ", " if not loop.last else "" }}
 				{% endfor %}]
 		}{{ ", " if not loop.last else "" }}
 		{% endfor %}

--- a/scripts/west_commands/sbom/templates/raport.spdx.jinja
+++ b/scripts/west_commands/sbom/templates/raport.spdx.jinja
@@ -78,9 +78,18 @@ FileChecksum: SHA1: {{file.sha1}}
 FileComment: <text>This file is modified locally.</text>
 {% endif -%}
 LicenseConcluded: {{ file.license_expr_friendly if file.license_expr_friendly != '' else 'NOASSERTION' }}
+{% if file.infile_lics -%}
+{% for license in file.infile_lics -%}
+LicenseInfoInFile: {{ license }}
+{% endfor -%}
+{% else -%}
 LicenseInfoInFile: NOASSERTION
+{% endif -%}
+{% if file.copyright_texts -%}
+FileCopyrightText: <text>{{ file.copyright_texts | sort(case_sensitive=true) | join('\n') | sanitize_tagvalue_text }}</text>
+{% else -%}
 FileCopyrightText: NOASSERTION
-
+{% endif %}
 {% endfor -%}
 
 {% endfor -%}

--- a/scripts/west_commands/sbom/templates/report.html.jinja
+++ b/scripts/west_commands/sbom/templates/report.html.jinja
@@ -233,7 +233,7 @@
 		<span class="-icon-exclamation"></span>&nbsp; Note
 	</div>
 	<div class="note-content">
-		Some of the licenses were detected by an external tool <a href="https://github.com/nexB/scancode-toolkit">ScanCode Toolkit</a>.
+		Some of the license or copyright information was detected by an external tool <a href="https://github.com/nexB/scancode-toolkit">ScanCode Toolkit</a>.
 		You can read more about it in the <a href="https://scancode-toolkit.readthedocs.io/">ScanCode Toolkit Documentation</a>.
 	</div>
 	{% endif %}


### PR DESCRIPTION
`LicenseInfoInFile` and `FileCopyrightText` are now determined from the scanned file.
Only ScanCode currently populates `FileCopyrightText` while `LicenseInfoInFile` is determined by either, SPDX detector, ScanCode, full-text detector or from the cache-database

Previously only LicenseConcluded was generated dynamically. LicenseInfoInFile and FileCopyrightText were always hardcoded to NOASSERTION.