### PR TITLE
tests: drivers: i2c: Update i2c latency test

### DIFF
--- a/tests/drivers/i2c/i2c_latency/Kconfig
+++ b/tests/drivers/i2c/i2c_latency/Kconfig
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config TEST_TWI_1MBPS_SUPPORT
+	bool "Test with 1Mbps rate - DUT HW dependent"
+	default y if SOC_NRF5340
+	default y if SOC_NRF54H20
+	default y if SOC_NRF9251
+
+source "Kconfig.zephyr"

--- a/tests/drivers/i2c/i2c_latency/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_latency/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,1 @@
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"

--- a/tests/drivers/i2c/i2c_latency/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_latency/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,1 @@
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"

--- a/tests/drivers/i2c/i2c_latency/src/main.c
+++ b/tests/drivers/i2c/i2c_latency/src/main.c
@@ -313,8 +313,7 @@ ZTEST(i2c_transmission_latency, test_i2c_read_call_latency_fast_speed)
 
 ZTEST(i2c_transmission_latency, test_i2c_read_call_latency_fast_plus_speed)
 {
-	Z_TEST_SKIP_IFDEF(CONFIG_SOC_NRF54L15_CPUAPP);
-	Z_TEST_SKIP_IFDEF(CONFIG_SOC_NRF52840);
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_TWI_1MBPS_SUPPORT);
 
 	test_i2c_read_latency(1, I2C_SPEED_FAST_PLUS);
 	test_i2c_read_latency(10, I2C_SPEED_FAST_PLUS);
@@ -340,8 +339,7 @@ ZTEST(i2c_transmission_latency, test_i2c_write_call_latency_fast_speed)
 
 ZTEST(i2c_transmission_latency, test_i2c_write_call_latency_fast_plus_speed)
 {
-	Z_TEST_SKIP_IFDEF(CONFIG_SOC_NRF54L15_CPUAPP);
-	Z_TEST_SKIP_IFDEF(CONFIG_SOC_NRF52840);
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_TWI_1MBPS_SUPPORT);
 
 	test_i2c_write_latency(1, I2C_SPEED_FAST_PLUS);
 	test_i2c_write_latency(10, I2C_SPEED_FAST_PLUS);

--- a/tests/drivers/i2c/i2c_latency/testcase.yaml
+++ b/tests/drivers/i2c/i2c_latency/testcase.yaml
@@ -14,6 +14,8 @@ common:
     - nrf54h20dk/nrf54h20/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54lc10dk/nrf54lc10a/cpuapp
+    - nrf54lm20dk/nrf54lm20a/cpuapp
+    - nrf54lm20dk/nrf54lm20b/cpuapp
     - nrf9251dk/nrf9251/cpuapp
   integration_platforms:
     - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Make 1Mbps capable DUT selection more generic
Add nrf54lm20 to supported platforms