### PR TITLE
test: benchmarks: Add missing fixture to XSPI performance test

### DIFF
--- a/tests/benchmarks/xspi_performance/testcase.yaml
+++ b/tests/benchmarks/xspi_performance/testcase.yaml
@@ -83,6 +83,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     harness: pytest
     harness_config: &spi_perf_harness_cfg
+      fixture: ppk_power_measure
       pytest_root:
         - "${CUSTOM_ROOT_TEST_DIR}/test_measure_power_consumption.py::test_measure_xspi_performance"
 


### PR DESCRIPTION
This test requires the 'fixture: ppk_power_measure'