### PR TITLE
applications: nrf_audio: Fix deadlock between MCS and streaming state

### DIFF
--- a/applications/nrf_audio/src/bluetooth/bt_content_control/bt_content_ctrl.c
+++ b/applications/nrf_audio/src/bluetooth/bt_content_control/bt_content_ctrl.c
@@ -131,6 +131,13 @@ int bt_content_ctrl_uuid_populate(struct net_buf_simple *uuid_buf)
 	return 0;
 }
 
+void bt_content_ctrl_state_override(bool playing)
+{
+	if (IS_ENABLED(CONFIG_BT_MCS)) {
+		bt_content_ctrl_media_state_override(playing);
+	}
+}
+
 int bt_content_ctrl_init(void)
 {
 	int ret;

--- a/applications/nrf_audio/src/bluetooth/bt_content_control/bt_content_ctrl.h
+++ b/applications/nrf_audio/src/bluetooth/bt_content_control/bt_content_ctrl.h
@@ -71,6 +71,13 @@ int bt_content_ctrl_uuid_populate(struct net_buf_simple *uuid_buf);
 bool bt_content_ctlr_media_state_playing(void);
 
 /**
+ * @brief	Override the current state of the media player.
+ *
+ * @param[in]	playing	Indicate whether the content should be in the playing state.
+ */
+void bt_content_ctrl_state_override(bool playing);
+
+/**
  * @brief	Initialize the content control module.
  *
  * @return	0 for success, error otherwise.

--- a/applications/nrf_audio/src/bluetooth/bt_content_control/bt_content_ctrl.h
+++ b/applications/nrf_audio/src/bluetooth/bt_content_control/bt_content_ctrl.h
@@ -71,6 +71,17 @@ int bt_content_ctrl_uuid_populate(struct net_buf_simple *uuid_buf);
 bool bt_content_ctlr_media_state_playing(void);
 
 /**
+ * @brief	Override the current state of the media player.
+ *
+ * @note	This is needed if the media player state is not in sync with the actual state of
+ *		stream. This can happen if a device disconnects at the same time as a play/pause
+ *		command is sent.
+ *
+ * @param[in]	playing	Indicate whether the content should be in the playing state.
+ */
+void bt_content_ctrl_state_override(bool playing);
+
+/**
  * @brief	Initialize the content control module.
  *
  * @return	0 for success, error otherwise.

--- a/applications/nrf_audio/src/bluetooth/bt_content_control/media/bt_content_ctrl_media.c
+++ b/applications/nrf_audio/src/bluetooth/bt_content_control/media/bt_content_ctrl_media.c
@@ -332,6 +332,17 @@ static int mpl_cmd_send(struct bt_conn *conn, struct mpl_cmd *cmd)
 	return 0;
 }
 
+void bt_content_ctrl_media_state_override(bool playing)
+{
+	if (IS_ENABLED(CONFIG_BT_MCS)) {
+		if (playing) {
+			media_player_state = BT_MCS_MEDIA_STATE_PLAYING;
+		} else {
+			media_player_state = BT_MCS_MEDIA_STATE_PAUSED;
+		}
+	}
+}
+
 int bt_content_ctrl_media_discover(struct bt_conn *conn)
 {
 	int ret;

--- a/applications/nrf_audio/src/bluetooth/bt_content_control/media/bt_content_ctrl_media_internal.h
+++ b/applications/nrf_audio/src/bluetooth/bt_content_control/media/bt_content_ctrl_media_internal.h
@@ -17,6 +17,13 @@
 typedef void (*bt_content_ctrl_media_play_pause_cb)(bool play);
 
 /**
+ * @brief	Override the current state of the media player.
+ *
+ * @param[in]	playing	Indicate whether the media player should be in the playing state.
+ */
+void bt_content_ctrl_media_state_override(bool playing);
+
+/**
  * @brief	Discover Media Control Service and the included services.
  *
  * @note	Only valid for client.

--- a/applications/nrf_audio/src/bluetooth/bt_content_control/media/bt_content_ctrl_media_internal.h
+++ b/applications/nrf_audio/src/bluetooth/bt_content_control/media/bt_content_ctrl_media_internal.h
@@ -17,6 +17,17 @@
 typedef void (*bt_content_ctrl_media_play_pause_cb)(bool play);
 
 /**
+ * @brief	Override the current state of the media player.
+ *
+ * @note	This is needed if the media player state is not in sync with the actual state of
+ *		stream. This can happen if a device disconnects at the same time as a play/pause
+ *		command is sent.
+ *
+ * @param[in]	playing	Indicate whether the media player should be in the playing state.
+ */
+void bt_content_ctrl_media_state_override(bool playing);
+
+/**
  * @brief	Discover Media Control Service and the included services.
  *
  * @note	Only valid for client.

--- a/applications/nrf_audio/src/bluetooth/bt_stream/unicast/server_store.c
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/unicast/server_store.c
@@ -1107,6 +1107,7 @@ int srv_store_all_ep_state_count(enum bt_bap_ep_state state, enum bt_audio_dir d
 				srv_idx, count);
 			return count;
 		}
+
 		count_total += count;
 	}
 

--- a/applications/nrf_audio/src/bluetooth/bt_stream/unicast/server_store.c
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/unicast/server_store.c
@@ -1151,6 +1151,7 @@ int srv_store_all_ep_state_count(enum bt_bap_ep_state state, enum bt_audio_dir d
 				srv_idx, count);
 			return count;
 		}
+
 		count_total += count;
 	}
 

--- a/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -36,6 +36,34 @@ ZBUS_CHAN_DEFINE(le_audio_chan, struct le_audio_msg, NULL, NULL, ZBUS_OBSERVERS_
 #define CAP_PROCED_SEM_WAIT_TIME_MS K_MSEC(500)
 K_SEM_DEFINE(sem_cap_procedure_proceed, 1, 1);
 
+#define CAP_PROC_SEM_WATCHDOG_TIMEOUT_MS K_SECONDS(5)
+
+static void cap_proc_sem_watchdog_cb(struct k_timer *timer)
+{
+	LOG_WRN("sem_cap_procedure_proceed watchdog expired, giving semaphore back");
+	k_sem_give(&sem_cap_procedure_proceed);
+}
+
+K_TIMER_DEFINE(cap_proc_sem_watchdog, cap_proc_sem_watchdog_cb, NULL);
+
+static int cap_sem_take(void)
+{
+	int ret = k_sem_take(&sem_cap_procedure_proceed, K_NO_WAIT);
+
+	if (ret == 0) {
+		k_timer_start(&cap_proc_sem_watchdog, CAP_PROC_SEM_WATCHDOG_TIMEOUT_MS, K_NO_WAIT);
+	}
+
+	return ret;
+}
+
+static void cap_sem_give(void)
+{
+	k_timer_stop(&cap_proc_sem_watchdog);
+	bt_cap_initiator_unicast_audio_cancel();
+	k_sem_give(&sem_cap_procedure_proceed);
+}
+
 enum cap_procedure_type {
 	CAP_PROCEDURE_START = 1,
 	CAP_PROCEDURE_UPDATE,
@@ -111,7 +139,7 @@ static void cap_proc_waiting_check(void)
 	if (ret == -ENOMSG) {
 		/* No procedure waiting */
 		return;
-	} else if (ret) {
+	} else if (ret != 0) {
 		LOG_ERR("Failed to get message from cap_proc_q: %d", ret);
 		return;
 	}
@@ -330,7 +358,7 @@ static void unicast_group_create(void)
 	}
 
 	ret = bt_cap_unicast_group_create(&group_param, &unicast_group);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to create unicast group: %d", ret);
 	} else {
 		LOG_INF("Created unicast group");
@@ -381,7 +409,7 @@ static bool server_stream_in_unicast_group_check(struct server_store *server, vo
 	struct bt_conn_info info;
 
 	ret = bt_conn_get_info(server->conn, &info);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to get connection info for conn: %p", (void *)server->conn);
 		return true;
 	}
@@ -436,7 +464,7 @@ static void cap_start_worker(struct k_work *work)
 	uint8_t group_length = 0;
 
 	ret = bt_cap_unicast_group_get_info(unicast_group, &info);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to get unicast group info: %d", ret);
 		return;
 	}
@@ -514,7 +542,7 @@ static void unicast_client_location_cb(struct bt_conn *conn, enum bt_audio_dir d
 	}
 
 	ret = srv_store_from_conn_get(conn, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Unknown connection, should not reach here", __func__);
 		srv_store_unlock();
 		return;
@@ -526,7 +554,7 @@ static void unicast_client_location_cb(struct bt_conn *conn, enum bt_audio_dir d
 
 		ret = srv_store_location_set(
 			conn, dir, BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to set location for conn %p, dir %d, loc %d: %d",
 				(void *)conn, dir, loc, ret);
 			srv_store_unlock();
@@ -546,7 +574,7 @@ static void unicast_client_location_cb(struct bt_conn *conn, enum bt_audio_dir d
 	    (loc & BT_AUDIO_LOCATION_FRONT_LEFT_WIDE) || (loc & BT_AUDIO_LOCATION_LEFT_SURROUND) ||
 	    (loc == BT_AUDIO_LOCATION_MONO_AUDIO)) {
 		ret = srv_store_location_set(conn, dir, BT_AUDIO_LOCATION_FRONT_LEFT);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to set location for conn %p, dir %d, loc %d: %d",
 				(void *)conn, dir, loc, ret);
 			srv_store_unlock();
@@ -565,7 +593,7 @@ static void unicast_client_location_cb(struct bt_conn *conn, enum bt_audio_dir d
 		   (loc & BT_AUDIO_LOCATION_FRONT_RIGHT_WIDE) ||
 		   (loc & BT_AUDIO_LOCATION_RIGHT_SURROUND)) {
 		ret = srv_store_location_set(conn, dir, BT_AUDIO_LOCATION_FRONT_RIGHT);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to set location for conn %p, dir %d, loc %d: %d",
 				(void *)conn, dir, loc, ret);
 			srv_store_unlock();
@@ -605,7 +633,7 @@ static void available_contexts_cb(struct bt_conn *conn, enum bt_audio_context sn
 	}
 
 	ret = srv_store_avail_context_set(conn, snk_ctx, src_ctx);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to set available contexts for conn %p, snk ctx %d src ctx %d: %d",
 			(void *)conn, snk_ctx, src_ctx, ret);
 	}
@@ -640,7 +668,7 @@ static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 	}
 
 	ret = srv_store_codec_cap_set(conn, dir, codec);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to set codec capability: %d", ret);
 	}
 
@@ -668,7 +696,7 @@ static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_b
 	struct server_store *server = NULL;
 
 	ret = srv_store_from_conn_get(conn, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Unknown connection, should not reach here", __func__);
 		srv_store_unlock();
 		return;
@@ -747,7 +775,7 @@ static void discover_cb_sink(struct bt_conn *conn, int err, struct server_store 
 	uint32_t valid_sink_caps = 0;
 
 	ret = srv_store_valid_codec_cap_check(conn, BT_AUDIO_DIR_SINK, &valid_sink_caps, NULL, 0);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to check for valid codec capabilities: %d", ret);
 		return;
 	}
@@ -878,7 +906,7 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 	struct server_store *server = NULL;
 
 	ret = srv_store_from_conn_get(conn, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Unknown connection, should not reach here", __func__);
 		srv_store_unlock();
 		return;
@@ -898,16 +926,10 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 
 	if (server->src.waiting_for_disc) {
 		ret = bt_bap_unicast_client_discover(conn, BT_AUDIO_DIR_SOURCE);
-		if (ret) {
+		if (ret != 0) {
 			LOG_WRN("Failed to start source discovery: %d", ret);
 		}
 
-		srv_store_unlock();
-		return;
-	}
-
-	if (!playing_state) {
-		/* Since we are not in a playing state we return before starting the new streams */
 		srv_store_unlock();
 		return;
 	}
@@ -925,6 +947,12 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 	le_audio_event_publish(LE_AUDIO_EVT_DISCOVERY_COMPLETE, conn, NULL, dir);
 
 	srv_store_unlock();
+
+	if (!playing_state) {
+		/* Since we are not in a playing state we return before starting the new streams */
+		return;
+	}
+
 	k_work_submit(&cap_start_work);
 }
 
@@ -936,14 +964,14 @@ static void stream_sent_cb(struct bt_bap_stream *stream)
 	uint8_t state;
 
 	ret = le_audio_ep_state_get(stream->ep, &state);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to get endpoint state: %d", ret);
 		return;
 	}
 
 	if (state == BT_BAP_EP_STATE_STREAMING) {
 		ret = stream_idx_get(stream, &idx);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("%s: Failed to get stream index: %d", __func__, ret);
 			return;
 		}
@@ -979,7 +1007,7 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 	struct server_store *server = NULL;
 
 	ret = srv_store_from_stream_get(stream, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Unknown stream, should not reach here");
 		srv_store_unlock();
 		return;
@@ -1011,7 +1039,7 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 
 	ret = srv_store_pres_dly_find(stream, &new_pres_dly_us, &existing_pres_dly_us, server_pref,
 				      &group_reconfigure_needed, unicast_group);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Cannot get a valid presentation delay");
 		srv_store_unlock();
 		return;
@@ -1031,7 +1059,7 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 			existing_pres_dly_us, new_pres_dly_us);
 		ret = bt_cap_unicast_group_foreach_stream(unicast_group, new_pres_dly_us_set,
 							  &new_pres_dly_us);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to update presentation delay for unicast group: %d", ret);
 			return;
 		}
@@ -1064,7 +1092,7 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 	struct stream_index idx = {0};
 
 	ret = stream_idx_get(stream, &idx);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Failed to get stream index: %d", __func__, ret);
 		return;
 	}
@@ -1161,7 +1189,7 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 		}
 
 		ret = bt_cap_unicast_group_delete(unicast_group);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to delete unicast group: %d", ret);
 		}
 
@@ -1183,7 +1211,7 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 	}
 
 	ret = le_audio_metadata_populate(&meta, stream, info, audio_frame);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to populate meta data: %d", ret);
 		return;
 	}
@@ -1191,7 +1219,7 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 	struct stream_index idx;
 
 	ret = stream_idx_get(stream, &idx);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Failed to get stream index: %d", __func__, ret);
 		return;
 	}
@@ -1240,7 +1268,7 @@ static void unicast_discovery_complete_cb(struct bt_conn *conn, int err,
 	}
 
 	ret = srv_store_from_conn_get(conn, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Unknown connection, should not reach here", __func__);
 		srv_store_unlock();
 		return;
@@ -1272,11 +1300,13 @@ static void unicast_discovery_complete_cb(struct bt_conn *conn, int err,
 	ERR_CHK(ret);
 
 	srv_store_unlock();
+
+	cap_proc_waiting_check();
 }
 
 static void unicast_start_complete_cb(int err, struct bt_conn *conn)
 {
-	k_sem_give(&sem_cap_procedure_proceed);
+	cap_sem_give();
 
 	if (err) {
 		LOG_WRN("Failed start_complete for conn: %p, err: %d", (void *)conn, err);
@@ -1290,7 +1320,7 @@ static void unicast_start_complete_cb(int err, struct bt_conn *conn)
 
 static void unicast_update_complete_cb(int err, struct bt_conn *conn)
 {
-	k_sem_give(&sem_cap_procedure_proceed);
+	cap_sem_give();
 
 	if (err) {
 		LOG_WRN("Failed update_complete for conn: %p, err: %d", (void *)conn, err);
@@ -1301,7 +1331,7 @@ static void unicast_update_complete_cb(int err, struct bt_conn *conn)
 
 static void unicast_stop_complete_cb(int err, struct bt_conn *conn)
 {
-	k_sem_give(&sem_cap_procedure_proceed);
+	cap_sem_give();
 
 	if (err) {
 		LOG_WRN("Failed stop_complete for conn: %p, err: %d", (void *)conn, err);
@@ -1336,7 +1366,7 @@ static bool first_source_location_get(struct bt_cap_stream *stream, void *user_d
 	dir = le_audio_stream_dir_get(&stream->bap_stream);
 
 	ret = stream_idx_get(&stream->bap_stream, &idx);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to get stream index: %d", ret);
 		return ret;
 	}
@@ -1348,7 +1378,7 @@ static bool first_source_location_get(struct bt_cap_stream *stream, void *user_d
 
 	ret = bt_audio_codec_cfg_get_chan_allocation(stream->bap_stream.codec_cfg, locations,
 						     false);
-	if (ret) {
+	if (ret != 0) {
 		LOG_WRN("Failed to get channel allocation");
 		return ret;
 	}
@@ -1378,6 +1408,25 @@ int le_audio_concurrent_sync_num_get(uint8_t *num_streams, enum bt_audio_locatio
 	return 0;
 }
 
+bool unicast_client_is_streaming(void)
+{
+	int ret;
+	bool is_streaming = false;
+
+	ret = srv_store_lock(CAP_PROCED_SEM_WAIT_TIME_MS);
+	if (ret < 0) {
+		LOG_ERR("%s: Failed to lock server store: %d", __func__, ret);
+		return false;
+	}
+
+	is_streaming = srv_store_all_ep_state_count(BT_BAP_EP_STATE_STREAMING, BT_AUDIO_DIR_SINK) ||
+		       srv_store_all_ep_state_count(BT_BAP_EP_STATE_STREAMING, BT_AUDIO_DIR_SOURCE);
+
+	srv_store_unlock();
+
+	return is_streaming;
+}
+
 int unicast_client_config_get(struct bt_bap_stream *stream, uint32_t *bitrate,
 			      uint32_t *sampling_rate_hz)
 {
@@ -1400,7 +1449,7 @@ int unicast_client_config_get(struct bt_bap_stream *stream, uint32_t *bitrate,
 
 	if (sampling_rate_hz != NULL) {
 		ret = le_audio_freq_hz_get(stream->codec_cfg, sampling_rate_hz);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Invalid sampling frequency: %d", ret);
 			return -ENXIO;
 		}
@@ -1408,7 +1457,7 @@ int unicast_client_config_get(struct bt_bap_stream *stream, uint32_t *bitrate,
 
 	if (bitrate != NULL) {
 		ret = le_audio_bitrate_get(stream->codec_cfg, bitrate);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Unable to calculate bitrate: %d", ret);
 			return -ENXIO;
 		}
@@ -1459,14 +1508,14 @@ int unicast_client_locations_get(uint32_t *locations, enum bt_audio_dir dir)
 
 	if (dir == BT_AUDIO_DIR_SINK) {
 		ret = srv_store_foreach_server(sink_locations_get, locations);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to get locations: %d", ret);
 			srv_store_unlock();
 			return ret;
 		}
 	} else if (dir == BT_AUDIO_DIR_SOURCE) {
 		ret = srv_store_foreach_server(source_locations_get, locations);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to get locations: %d", ret);
 			srv_store_unlock();
 			return ret;
@@ -1489,7 +1538,7 @@ void unicast_client_conn_disconnected(struct bt_conn *conn)
 	}
 
 	ret = srv_store_clear_by_conn(conn);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to clear server store for conn %p: %d", (void *)conn, ret);
 	}
 
@@ -1509,7 +1558,7 @@ int unicast_client_discover(struct bt_conn *conn, enum unicast_discover_dir dir)
 	struct server_store *server = NULL;
 
 	ret = srv_store_from_conn_get(conn, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Unknown connection, should not reach here", __func__);
 		srv_store_unlock();
 		return ret;
@@ -1525,7 +1574,7 @@ int unicast_client_discover(struct bt_conn *conn, enum unicast_discover_dir dir)
 	}
 
 	ret = bt_cap_initiator_unicast_discover(conn);
-	if (ret) {
+	if (ret != 0) {
 		LOG_WRN("Failed to start cap discover: %d", ret);
 		srv_store_unlock();
 		return ret;
@@ -1547,7 +1596,7 @@ int unicast_client_discover(struct bt_conn *conn, enum unicast_discover_dir dir)
 	}
 
 	ret = bt_bap_unicast_client_discover(conn, dir);
-	if (ret) {
+	if (ret != 0) {
 		LOG_WRN("Failed to discover %d", ret);
 		srv_store_unlock();
 		return ret;
@@ -1571,7 +1620,7 @@ static bool is_connected(struct bt_conn const *const conn)
 	}
 
 	ret = bt_conn_get_info(conn, &info);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to get connection info for conn %p: %d", (void *)conn, ret);
 		return false;
 	}
@@ -1634,27 +1683,30 @@ int unicast_client_start(uint8_t cig_index)
 {
 	int ret;
 
-	ret = k_sem_take(&sem_cap_procedure_proceed, K_NO_WAIT);
+	ret = cap_sem_take();
 	if (ret == -EBUSY) {
+		LOG_DBG("Cannot start unicast client, another procedure is ongoing");
 		/* Ongoing procedure, try again later */
 		enum cap_procedure_type proc_type;
 
 		proc_type = CAP_PROCEDURE_START;
 
 		ret = k_msgq_put(&cap_proc_q, &proc_type, K_NO_WAIT);
-		if (ret) {
+		if (ret != 0) {
 			LOG_WRN("Failed to put start procedure in queue: %d", ret);
 		}
 
 		return ret;
-	} else if (ret) {
+	} else if (ret != 0) {
 		LOG_ERR("Failed to take sem_cap_procedure_proceed: %d", ret);
+
 		return ret;
 	}
 
 	if (unicast_group == NULL) {
 		LOG_WRN("No unicast group to start");
-		k_sem_give(&sem_cap_procedure_proceed);
+		cap_sem_give();
+
 		return -EIO;
 	}
 
@@ -1676,25 +1728,31 @@ int unicast_client_start(uint8_t cig_index)
 	}
 
 	ret = srv_store_foreach_server(add_to_start_params, &param);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to add streams to start params: %d", ret);
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_sem_give();
 		srv_store_unlock();
+
 		return ret;
 	}
 
 	if (param.count == 0) {
 		LOG_DBG("No streams to start");
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_sem_give();
 		srv_store_unlock();
+
 		return -EIO;
 	}
 
 	ret = bt_cap_initiator_unicast_audio_start(&param);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to start unicast sink audio: %d", ret);
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_sem_give();
 		srv_store_unlock();
+
 		return ret;
 	}
 
@@ -1724,7 +1782,7 @@ static bool server_connected_check(struct bt_cap_stream *stream, void *user_data
 	bool *connected_server_found = (bool *)user_data;
 
 	ret = srv_store_from_stream_get(&stream->bap_stream, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to get server from stream: %d", ret);
 		return true;
 	}
@@ -1746,20 +1804,20 @@ int unicast_client_stop(uint8_t cig_index)
 				      CONFIG_BT_MAX_CONN];
 	static struct bt_cap_unicast_audio_stop_param param;
 
-	ret = k_sem_take(&sem_cap_procedure_proceed, K_NO_WAIT);
+	ret = cap_sem_take();
 	if (ret == -EBUSY) {
 		enum cap_procedure_type proc_type;
 
 		proc_type = CAP_PROCEDURE_STOP;
 
 		ret = k_msgq_put(&cap_proc_q, &proc_type, K_NO_WAIT);
-		if (ret) {
+		if (ret != 0) {
 			LOG_WRN("Failed to put stop procedure in queue: %d", ret);
 		}
 
 		return ret;
 
-	} else if (ret) {
+	} else if (ret != 0) {
 		LOG_ERR("Failed to take sem_cap_procedure_proceed: %d", ret);
 		return ret;
 	}
@@ -1771,7 +1829,9 @@ int unicast_client_stop(uint8_t cig_index)
 
 	if (unicast_group == NULL) {
 		LOG_WRN("No unicast group to stop");
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_sem_give();
+
 		return -EIO;
 	}
 
@@ -1781,15 +1841,18 @@ int unicast_client_stop(uint8_t cig_index)
 	param.release = true;
 
 	ret = bt_cap_unicast_group_foreach_stream(unicast_group, add_to_stop_params, &param);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to add streams to stop params: %d", ret);
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_sem_give();
+
 		return ret;
 	}
 
 	if (param.count == 0) {
 		LOG_DBG("No streams to stop");
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_sem_give();
 
 		/* No streams found. Check if devices are connected, if no, delete the group */
 		bool connected_server_found = false;
@@ -1807,7 +1870,7 @@ int unicast_client_stop(uint8_t cig_index)
 			/* If cancelled a connected server has been found */
 			srv_store_unlock();
 			return ret;
-		} else if (ret) {
+		} else if (ret != 0) {
 			LOG_ERR("Failed to check if servers are connected: %d", ret);
 			srv_store_unlock();
 			return ret;
@@ -1818,7 +1881,7 @@ int unicast_client_stop(uint8_t cig_index)
 		if (!connected_server_found) {
 			LOG_DBG("No connected servers found, deleting unicast group");
 			ret = bt_cap_unicast_group_delete(unicast_group);
-			if (ret) {
+			if (ret != 0) {
 				LOG_ERR("Failed to delete unicast group: %d", ret);
 			}
 
@@ -1832,9 +1895,11 @@ int unicast_client_stop(uint8_t cig_index)
 	}
 
 	ret = bt_cap_initiator_unicast_audio_stop(&param);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to stop unicast audio: %d", ret);
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_sem_give();
+
 		return ret;
 	}
 
@@ -1864,7 +1929,7 @@ static bool unicast_send_info_populate(struct server_store *server, void *user_d
 		/* Set index */
 		ret = stream_idx_get(&server->snk.cap_streams[i].bap_stream,
 				     &info->tx[info->num_active_streams].idx);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("%s: Failed to get stream index: %d", __func__, ret);
 			return false;
 		}
@@ -1916,7 +1981,7 @@ int unicast_client_send(struct net_buf const *const audio_frame, uint8_t cig_ind
 
 	/* Populate tx struct */
 	ret = srv_store_foreach_server(unicast_send_info_populate, &info);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to populate send info: %d", ret);
 		srv_store_unlock();
 		return ret;
@@ -1930,7 +1995,7 @@ int unicast_client_send(struct net_buf const *const audio_frame, uint8_t cig_ind
 	}
 
 	ret = bt_le_audio_tx_send(bt_le_audio_tx, audio_frame, info.tx, info.num_active_streams);
-	if (ret) {
+	if (ret != 0) {
 		srv_store_unlock();
 		return ret;
 	}
@@ -1965,7 +2030,7 @@ int unicast_client_enable(uint8_t cig_index, le_audio_receive_cb recv_cb)
 	}
 
 	ret = srv_store_init();
-	if (ret) {
+	if (ret != 0) {
 		srv_store_unlock();
 		return ret;
 	}
@@ -1979,14 +2044,14 @@ int unicast_client_enable(uint8_t cig_index, le_audio_receive_cb recv_cb)
 	receive_cb = recv_cb;
 
 	ret = bt_bap_unicast_client_register_cb(&unicast_client_cbs);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to register client callbacks: %d", ret);
 		srv_store_unlock();
 		return ret;
 	}
 
 	ret = bt_cap_initiator_register_cb(&cap_cbs);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to register cap callbacks: %d", ret);
 		srv_store_unlock();
 		return ret;
@@ -1995,7 +2060,7 @@ int unicast_client_enable(uint8_t cig_index, le_audio_receive_cb recv_cb)
 	if (IS_ENABLED(CONFIG_BT_AUDIO_TX)) {
 		/* A unicast client is the Bluetooth central device */
 		ret = bt_le_audio_tx_init(bt_le_audio_tx, true);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to initialize LE Audio TX: %d", ret);
 			srv_store_unlock();
 			return ret;

--- a/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -28,6 +28,7 @@
 #include "zbus_common.h"
 #include "bt_le_audio_tx.h"
 #include "le_audio.h"
+#include "bt_mgmt.h"
 #include "server_store.h"
 
 #include <zephyr/logging/log.h>
@@ -39,6 +40,116 @@ ZBUS_CHAN_DEFINE(le_audio_chan, struct le_audio_msg, NULL, NULL, ZBUS_OBSERVERS_
 #define CAP_PROCED_SEM_WAIT_TIME_MS K_MSEC(500)
 K_SEM_DEFINE(sem_cap_procedure_proceed, 1, 1);
 
+#define CAP_PROC_SEM_WATCHDOG_TIMEOUT_PER_CONN_SEC 2U
+#define CAP_CANCEL_PROC_WAIT_TIME_MS		   K_MSEC(500)
+
+static void cap_proc_waiting_check(void);
+
+static void cap_sem_give_delayed_work_cb(struct k_work *work)
+{
+	k_sem_give(&sem_cap_procedure_proceed);
+	cap_proc_waiting_check();
+}
+
+K_WORK_DELAYABLE_DEFINE(cap_sem_give_delayed_work, cap_sem_give_delayed_work_cb);
+
+/**
+ * @brief	Function to cancel the CAP procedure and give the semaphore back after a timeout.
+ *
+ * @note	This function is used as a watchdog to ensure that the CAP procedure does not block
+ *		indefinitely. The timeout is based on the number of connected devices, as
+ *		a CAP procedure can take longer with more devices.
+ */
+static void cap_cancel_delayed(struct k_work *work)
+{
+	int ret;
+
+	LOG_DBG("CAP procedure aborted, cancelling CAP procedure and giving semaphore");
+
+	ret = bt_cap_initiator_unicast_audio_cancel();
+	if (ret == -EALREADY) {
+		LOG_DBG("CAP procedure not running");
+		int count = k_sem_count_get(&sem_cap_procedure_proceed);
+
+		if (count == 0) {
+			LOG_DBG("CAP procedure semaphore not available, giving it back");
+			k_sem_give(&sem_cap_procedure_proceed);
+		}
+
+		cap_proc_waiting_check();
+
+		return;
+	}
+
+	if (ret != 0) {
+		LOG_ERR("Failed to cancel CAP procedure: %d", ret);
+	}
+
+	ret = k_work_schedule(&cap_sem_give_delayed_work, CAP_CANCEL_PROC_WAIT_TIME_MS);
+
+	if (ret != 1) {
+		LOG_ERR("Failed to schedule CAP sem give: %d", ret);
+	}
+}
+
+K_WORK_DELAYABLE_DEFINE(cap_cancel_delayed_work, cap_cancel_delayed);
+
+/**
+ * @brief	Function to mark the CAP procedure as active.
+ *
+ * @note	This function will schedule a delayed work to give the semaphore back after a
+ *		timeout, as a sort of a watchdog. The timeout is based on the number of connected
+ *		devices, as a CAP procedure can take longer with more devices.
+ *
+ * @return	0 if the semaphore was taken, -EBUSY if the semaphore was not available.
+ */
+static int cap_set_proc_active(void)
+{
+	int ret;
+	uint8_t num_connected = 0;
+
+	ret = k_sem_take(&sem_cap_procedure_proceed, K_NO_WAIT);
+	if (ret != 0) {
+		LOG_DBG("CAP procedure semaphore not available, cannot start CAP procedure");
+		return -EBUSY;
+	}
+
+	bt_mgmt_num_conn_get(&num_connected);
+
+	ret = k_work_schedule(
+		&cap_cancel_delayed_work,
+		K_SECONDS(CAP_PROC_SEM_WATCHDOG_TIMEOUT_PER_CONN_SEC * MAX(num_connected, 1)));
+
+	if (ret != 1) {
+		LOG_ERR("Failed to schedule CAP procedure watchdog: %d", ret);
+		k_sem_give(&sem_cap_procedure_proceed);
+		return -EBUSY;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief	Function to mark the CAP procedure as inactive.
+ *
+ * @note	This function will cancel the delayed work that was scheduled to give the
+ *		semaphore back after a timeout.
+ */
+static void cap_set_proc_inactive(void)
+{
+	struct k_work_sync sync;
+
+	/**
+	 * If either of the two delayable works were in the middle of executing, the semaphore will
+	 * be given back by them. It is not a problem if the semaphore is given back twice, as the
+	 * max count for the semaphore is 1.
+	 */
+	LOG_DBG("Cancelling CAP procedure watchdog and giving semaphore back");
+	(void)k_work_cancel_delayable_sync(&cap_cancel_delayed_work, &sync);
+	(void)k_work_cancel_delayable_sync(&cap_sem_give_delayed_work, &sync);
+	k_sem_give(&sem_cap_procedure_proceed);
+}
+
 enum cap_procedure_type {
 	CAP_PROCEDURE_START = 1,
 	CAP_PROCEDURE_UPDATE,
@@ -48,7 +159,7 @@ enum cap_procedure_type {
 K_MSGQ_DEFINE(cap_proc_q, sizeof(enum cap_procedure_type), CONFIG_BT_ISO_MAX_CHAN, sizeof(void *));
 
 /* For unicast (as opposed to broadcast) level 2/subgroup is not defined in the specification */
-#define LVL2 0
+#define LVL2		 0
 /* Will return 1 if x == 0, due to how locations are defined in LE Audio */
 #define POPCOUNT_ZERO(x) ((x) == 0 ? 1 : POPCOUNT(x))
 
@@ -67,7 +178,7 @@ BT_LE_AUDIO_TX_DEFINE(bt_le_audio_tx);
 static struct bt_cap_unicast_group *unicast_group;
 static bool unicast_group_created;
 
-static bool playing_state = true;
+static bool in_playing_state = true;
 
 static void le_audio_event_publish(enum le_audio_evt_type event, struct bt_conn *conn,
 				   struct bt_bap_stream *stream, enum bt_audio_dir dir)
@@ -114,7 +225,7 @@ static void cap_proc_waiting_check(void)
 	if (ret == -ENOMSG) {
 		/* No procedure waiting */
 		return;
-	} else if (ret) {
+	} else if (ret != 0) {
 		LOG_ERR("Failed to get message from cap_proc_q: %d", ret);
 		return;
 	}
@@ -333,7 +444,7 @@ static void unicast_group_create(void)
 	}
 
 	ret = bt_cap_unicast_group_create(&group_param, &unicast_group);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to create unicast group: %d", ret);
 	} else {
 		LOG_INF("Created unicast group");
@@ -384,7 +495,7 @@ static bool server_stream_in_unicast_group_check(struct server_store *server, vo
 	struct bt_conn_info info;
 
 	ret = bt_conn_get_info(server->conn, &info);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to get connection info for conn: %p", (void *)server->conn);
 		return true;
 	}
@@ -439,7 +550,7 @@ static void cap_start_worker(struct k_work *work)
 	uint8_t group_length = 0;
 
 	ret = bt_cap_unicast_group_get_info(unicast_group, &info);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to get unicast group info: %d", ret);
 		return;
 	}
@@ -517,7 +628,7 @@ static void unicast_client_location_cb(struct bt_conn *conn, enum bt_audio_dir d
 	}
 
 	ret = srv_store_from_conn_get(conn, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Unknown connection, should not reach here", __func__);
 		srv_store_unlock();
 		return;
@@ -529,7 +640,7 @@ static void unicast_client_location_cb(struct bt_conn *conn, enum bt_audio_dir d
 
 		ret = srv_store_location_set(
 			conn, dir, BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to set location for conn %p, dir %d, loc %d: %d",
 				(void *)conn, dir, loc, ret);
 			srv_store_unlock();
@@ -549,7 +660,7 @@ static void unicast_client_location_cb(struct bt_conn *conn, enum bt_audio_dir d
 	    (loc & BT_AUDIO_LOCATION_FRONT_LEFT_WIDE) || (loc & BT_AUDIO_LOCATION_LEFT_SURROUND) ||
 	    (loc == BT_AUDIO_LOCATION_MONO_AUDIO)) {
 		ret = srv_store_location_set(conn, dir, BT_AUDIO_LOCATION_FRONT_LEFT);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to set location for conn %p, dir %d, loc %d: %d",
 				(void *)conn, dir, loc, ret);
 			srv_store_unlock();
@@ -568,7 +679,7 @@ static void unicast_client_location_cb(struct bt_conn *conn, enum bt_audio_dir d
 		   (loc & BT_AUDIO_LOCATION_FRONT_RIGHT_WIDE) ||
 		   (loc & BT_AUDIO_LOCATION_RIGHT_SURROUND)) {
 		ret = srv_store_location_set(conn, dir, BT_AUDIO_LOCATION_FRONT_RIGHT);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to set location for conn %p, dir %d, loc %d: %d",
 				(void *)conn, dir, loc, ret);
 			srv_store_unlock();
@@ -608,7 +719,7 @@ static void available_contexts_cb(struct bt_conn *conn, enum bt_audio_context sn
 	}
 
 	ret = srv_store_avail_context_set(conn, snk_ctx, src_ctx);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to set available contexts for conn %p, snk ctx %d src ctx %d: %d",
 			(void *)conn, snk_ctx, src_ctx, ret);
 	}
@@ -643,7 +754,7 @@ static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 	}
 
 	ret = srv_store_codec_cap_set(conn, dir, codec);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to set codec capability: %d", ret);
 	}
 
@@ -671,7 +782,7 @@ static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_b
 	struct server_store *server = NULL;
 
 	ret = srv_store_from_conn_get(conn, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Unknown connection, should not reach here", __func__);
 		srv_store_unlock();
 		return;
@@ -750,7 +861,7 @@ static void discover_cb_sink(struct bt_conn *conn, int err, struct server_store 
 	uint32_t valid_sink_caps = 0;
 
 	ret = srv_store_valid_codec_cap_check(conn, BT_AUDIO_DIR_SINK, &valid_sink_caps, NULL, 0);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to check for valid codec capabilities: %d", ret);
 		return;
 	}
@@ -881,7 +992,7 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 	struct server_store *server = NULL;
 
 	ret = srv_store_from_conn_get(conn, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Unknown connection, should not reach here", __func__);
 		srv_store_unlock();
 		return;
@@ -901,16 +1012,10 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 
 	if (server->src.waiting_for_disc) {
 		ret = bt_bap_unicast_client_discover(conn, BT_AUDIO_DIR_SOURCE);
-		if (ret) {
+		if (ret != 0) {
 			LOG_WRN("Failed to start source discovery: %d", ret);
 		}
 
-		srv_store_unlock();
-		return;
-	}
-
-	if (!playing_state) {
-		/* Since we are not in a playing state we return before starting the new streams */
 		srv_store_unlock();
 		return;
 	}
@@ -928,6 +1033,12 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 	le_audio_event_publish(LE_AUDIO_EVT_DISCOVERY_COMPLETE, conn, NULL, dir);
 
 	srv_store_unlock();
+
+	if (!in_playing_state) {
+		/* Since we are not in a playing state we return before starting the new streams */
+		return;
+	}
+
 	k_work_submit(&cap_start_work);
 }
 
@@ -939,14 +1050,14 @@ static void stream_sent_cb(struct bt_bap_stream *stream)
 	uint8_t state;
 
 	ret = le_audio_ep_state_get(stream->ep, &state);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to get endpoint state: %d", ret);
 		return;
 	}
 
 	if (state == BT_BAP_EP_STATE_STREAMING) {
 		ret = stream_idx_get(stream, &idx);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("%s: Failed to get stream index: %d", __func__, ret);
 			return;
 		}
@@ -956,7 +1067,6 @@ static void stream_sent_cb(struct bt_bap_stream *stream)
 	}
 }
 #endif /* CONFIG_BT_AUDIO_TX */
-
 
 static void stream_configured_cb(struct bt_bap_stream *stream,
 				 const struct bt_bap_qos_cfg_pref *server_pref)
@@ -974,7 +1084,7 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 	struct server_store *server = NULL;
 
 	ret = srv_store_from_stream_get(stream, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Unknown stream, should not reach here");
 		srv_store_unlock();
 		return;
@@ -1006,7 +1116,7 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 
 	ret = srv_store_pres_dly_find(stream, &new_pres_dly_us, &existing_pres_dly_us, server_pref,
 				      &group_reconfigure_needed, unicast_group);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Cannot get a valid presentation delay");
 		srv_store_unlock();
 		return;
@@ -1025,9 +1135,9 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 	/* TODO: This part is temporary, see OCT-3787. It only works for PD as this is not part of
 	 * the CIG, and relies on the internal headers.
 	 */
-	uint32_t group_pres_dly_us = (dir == BT_AUDIO_DIR_SINK) ?
-		unicast_group->bap_unicast_group->sink_pd :
-		unicast_group->bap_unicast_group->source_pd;
+	uint32_t group_pres_dly_us = (dir == BT_AUDIO_DIR_SINK)
+					     ? unicast_group->bap_unicast_group->sink_pd
+					     : unicast_group->bap_unicast_group->source_pd;
 
 	if ((new_pres_dly_us != group_pres_dly_us) || group_reconfigure_needed) {
 		LOG_INF("Stream QoS PD: %d, prev group PD: %d, new PD %d", stream->qos->pd,
@@ -1068,7 +1178,7 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 	struct stream_index idx = {0};
 
 	ret = stream_idx_get(stream, &idx);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Failed to get stream index: %d", __func__, ret);
 		return;
 	}
@@ -1165,7 +1275,7 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 		}
 
 		ret = bt_cap_unicast_group_delete(unicast_group);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to delete unicast group: %d", ret);
 		}
 
@@ -1187,7 +1297,7 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 	}
 
 	ret = le_audio_metadata_populate(&meta, stream, info, audio_frame);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to populate meta data: %d", ret);
 		return;
 	}
@@ -1195,7 +1305,7 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 	struct stream_index idx;
 
 	ret = stream_idx_get(stream, &idx);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Failed to get stream index: %d", __func__, ret);
 		return;
 	}
@@ -1244,7 +1354,7 @@ static void unicast_discovery_complete_cb(struct bt_conn *conn, int err,
 	}
 
 	ret = srv_store_from_conn_get(conn, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Unknown connection, should not reach here", __func__);
 		srv_store_unlock();
 		return;
@@ -1276,43 +1386,48 @@ static void unicast_discovery_complete_cb(struct bt_conn *conn, int err,
 	ERR_CHK(ret);
 
 	srv_store_unlock();
+
+	cap_proc_waiting_check();
 }
 
 static void unicast_start_complete_cb(int err, struct bt_conn *conn)
 {
-	k_sem_give(&sem_cap_procedure_proceed);
-
 	if (err) {
 		LOG_WRN("Failed start_complete for conn: %p, err: %d", (void *)conn, err);
+		return;
 	}
 
+	cap_set_proc_inactive();
+
 	LOG_DBG("Unicast start complete cb");
-	playing_state = true;
+	in_playing_state = true;
 
 	cap_proc_waiting_check();
 }
 
 static void unicast_update_complete_cb(int err, struct bt_conn *conn)
 {
-	k_sem_give(&sem_cap_procedure_proceed);
-
 	if (err) {
 		LOG_WRN("Failed update_complete for conn: %p, err: %d", (void *)conn, err);
+		return;
 	}
+
+	cap_set_proc_inactive();
 
 	LOG_DBG("Unicast update complete cb");
 }
 
 static void unicast_stop_complete_cb(int err, struct bt_conn *conn)
 {
-	k_sem_give(&sem_cap_procedure_proceed);
-
 	if (err) {
 		LOG_WRN("Failed stop_complete for conn: %p, err: %d", (void *)conn, err);
+		return;
 	}
 
+	cap_set_proc_inactive();
+
 	LOG_DBG("Unicast stop complete cb");
-	playing_state = false;
+	in_playing_state = false;
 
 	cap_proc_waiting_check();
 }
@@ -1340,7 +1455,7 @@ static bool first_source_location_get(struct bt_cap_stream *stream, void *user_d
 	dir = le_audio_stream_dir_get(&stream->bap_stream);
 
 	ret = stream_idx_get(&stream->bap_stream, &idx);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to get stream index: %d", ret);
 		return ret;
 	}
@@ -1352,7 +1467,7 @@ static bool first_source_location_get(struct bt_cap_stream *stream, void *user_d
 
 	ret = bt_audio_codec_cfg_get_chan_allocation(stream->bap_stream.codec_cfg, locations,
 						     false);
-	if (ret) {
+	if (ret != 0) {
 		LOG_WRN("Failed to get channel allocation");
 		return ret;
 	}
@@ -1382,6 +1497,37 @@ int le_audio_concurrent_sync_num_get(uint8_t *num_streams, enum bt_audio_locatio
 	return 0;
 }
 
+int unicast_client_is_streaming(bool *is_streaming)
+{
+	int ret;
+	int snk_count;
+	int src_count;
+
+	if (is_streaming == NULL) {
+		return -EINVAL;
+	}
+
+	ret = srv_store_lock(CAP_PROCED_SEM_WAIT_TIME_MS);
+	if (ret < 0) {
+		LOG_ERR("%s: Failed to lock server store: %d", __func__, ret);
+		return -EINVAL;
+	}
+
+	snk_count = srv_store_all_ep_state_count(BT_BAP_EP_STATE_STREAMING, BT_AUDIO_DIR_SINK);
+	src_count = srv_store_all_ep_state_count(BT_BAP_EP_STATE_STREAMING, BT_AUDIO_DIR_SOURCE);
+
+	srv_store_unlock();
+
+	if (snk_count < 0 || src_count < 0) {
+		LOG_ERR("Failed to get streaming count: snk %d, src %d", snk_count, src_count);
+		return -EACCES;
+	}
+
+	*is_streaming = (snk_count > 0 || src_count > 0);
+
+	return 0;
+}
+
 int unicast_client_config_get(struct bt_bap_stream *stream, uint32_t *bitrate,
 			      uint32_t *sampling_rate_hz)
 {
@@ -1404,7 +1550,7 @@ int unicast_client_config_get(struct bt_bap_stream *stream, uint32_t *bitrate,
 
 	if (sampling_rate_hz != NULL) {
 		ret = le_audio_freq_hz_get(stream->codec_cfg, sampling_rate_hz);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Invalid sampling frequency: %d", ret);
 			return -ENXIO;
 		}
@@ -1412,7 +1558,7 @@ int unicast_client_config_get(struct bt_bap_stream *stream, uint32_t *bitrate,
 
 	if (bitrate != NULL) {
 		ret = le_audio_bitrate_get(stream->codec_cfg, bitrate);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Unable to calculate bitrate: %d", ret);
 			return -ENXIO;
 		}
@@ -1463,14 +1609,14 @@ int unicast_client_locations_get(uint32_t *locations, enum bt_audio_dir dir)
 
 	if (dir == BT_AUDIO_DIR_SINK) {
 		ret = srv_store_foreach_server(sink_locations_get, locations);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to get locations: %d", ret);
 			srv_store_unlock();
 			return ret;
 		}
 	} else if (dir == BT_AUDIO_DIR_SOURCE) {
 		ret = srv_store_foreach_server(source_locations_get, locations);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to get locations: %d", ret);
 			srv_store_unlock();
 			return ret;
@@ -1493,7 +1639,7 @@ void unicast_client_conn_disconnected(struct bt_conn *conn)
 	}
 
 	ret = srv_store_clear_by_conn(conn);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to clear server store for conn %p: %d", (void *)conn, ret);
 	}
 
@@ -1513,7 +1659,7 @@ int unicast_client_discover(struct bt_conn *conn, enum unicast_discover_dir dir)
 	struct server_store *server = NULL;
 
 	ret = srv_store_from_conn_get(conn, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("%s: Unknown connection, should not reach here", __func__);
 		srv_store_unlock();
 		return ret;
@@ -1529,7 +1675,7 @@ int unicast_client_discover(struct bt_conn *conn, enum unicast_discover_dir dir)
 	}
 
 	ret = bt_cap_initiator_unicast_discover(conn);
-	if (ret) {
+	if (ret != 0) {
 		LOG_WRN("Failed to start cap discover: %d", ret);
 		srv_store_unlock();
 		return ret;
@@ -1551,7 +1697,7 @@ int unicast_client_discover(struct bt_conn *conn, enum unicast_discover_dir dir)
 	}
 
 	ret = bt_bap_unicast_client_discover(conn, dir);
-	if (ret) {
+	if (ret != 0) {
 		LOG_WRN("Failed to discover %d", ret);
 		srv_store_unlock();
 		return ret;
@@ -1575,7 +1721,7 @@ static bool is_connected(struct bt_conn const *const conn)
 	}
 
 	ret = bt_conn_get_info(conn, &info);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to get connection info for conn %p: %d", (void *)conn, ret);
 		return false;
 	}
@@ -1638,28 +1784,29 @@ int unicast_client_start(uint8_t cig_index)
 {
 	int ret;
 
-	ret = k_sem_take(&sem_cap_procedure_proceed, K_NO_WAIT);
+	if (unicast_group == NULL) {
+		LOG_WRN("No unicast group to start");
+		return -EIO;
+	}
+
+	ret = cap_set_proc_active();
 	if (ret == -EBUSY) {
+		LOG_DBG("Cannot start unicast client, another procedure is ongoing");
 		/* Ongoing procedure, try again later */
 		enum cap_procedure_type proc_type;
 
 		proc_type = CAP_PROCEDURE_START;
 
 		ret = k_msgq_put(&cap_proc_q, &proc_type, K_NO_WAIT);
-		if (ret) {
+		if (ret != 0) {
 			LOG_WRN("Failed to put start procedure in queue: %d", ret);
 		}
 
 		return ret;
-	} else if (ret) {
+	} else if (ret != 0) {
 		LOG_ERR("Failed to take sem_cap_procedure_proceed: %d", ret);
-		return ret;
-	}
 
-	if (unicast_group == NULL) {
-		LOG_WRN("No unicast group to start");
-		k_sem_give(&sem_cap_procedure_proceed);
-		return -EIO;
+		return ret;
 	}
 
 	/* Start all unicast_servers with valid endpoints */
@@ -1676,29 +1823,38 @@ int unicast_client_start(uint8_t cig_index)
 	ret = srv_store_lock(CAP_PROCED_SEM_WAIT_TIME_MS);
 	if (ret < 0) {
 		LOG_ERR("%s: Failed to lock server store: %d", __func__, ret);
+		cap_set_proc_inactive();
+
 		return ret;
 	}
 
 	ret = srv_store_foreach_server(add_to_start_params, &param);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to add streams to start params: %d", ret);
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_set_proc_inactive();
 		srv_store_unlock();
+
 		return ret;
 	}
 
 	if (param.count == 0) {
 		LOG_DBG("No streams to start");
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_set_proc_inactive();
 		srv_store_unlock();
+
 		return -EIO;
 	}
 
 	ret = bt_cap_initiator_unicast_audio_start(&param);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to start unicast sink audio: %d", ret);
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_set_proc_inactive();
+
 		srv_store_unlock();
+
 		return ret;
 	}
 
@@ -1728,7 +1884,7 @@ static bool server_connected_check(struct bt_cap_stream *stream, void *user_data
 	bool *connected_server_found = (bool *)user_data;
 
 	ret = srv_store_from_stream_get(&stream->bap_stream, &server);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to get server from stream: %d", ret);
 		return true;
 	}
@@ -1750,20 +1906,20 @@ int unicast_client_stop(uint8_t cig_index)
 				      CONFIG_BT_MAX_CONN];
 	static struct bt_cap_unicast_audio_stop_param param;
 
-	ret = k_sem_take(&sem_cap_procedure_proceed, K_NO_WAIT);
+	ret = cap_set_proc_active();
 	if (ret == -EBUSY) {
 		enum cap_procedure_type proc_type;
 
 		proc_type = CAP_PROCEDURE_STOP;
 
 		ret = k_msgq_put(&cap_proc_q, &proc_type, K_NO_WAIT);
-		if (ret) {
+		if (ret != 0) {
 			LOG_WRN("Failed to put stop procedure in queue: %d", ret);
 		}
 
 		return ret;
 
-	} else if (ret) {
+	} else if (ret != 0) {
 		LOG_ERR("Failed to take sem_cap_procedure_proceed: %d", ret);
 		return ret;
 	}
@@ -1775,7 +1931,9 @@ int unicast_client_stop(uint8_t cig_index)
 
 	if (unicast_group == NULL) {
 		LOG_WRN("No unicast group to stop");
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_set_proc_inactive();
+
 		return -EIO;
 	}
 
@@ -1785,15 +1943,18 @@ int unicast_client_stop(uint8_t cig_index)
 	param.release = true;
 
 	ret = bt_cap_unicast_group_foreach_stream(unicast_group, add_to_stop_params, &param);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to add streams to stop params: %d", ret);
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_set_proc_inactive();
+
 		return ret;
 	}
 
 	if (param.count == 0) {
 		LOG_DBG("No streams to stop");
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_set_proc_inactive();
 
 		/* No streams found. Check if devices are connected, if no, delete the group */
 		bool connected_server_found = false;
@@ -1811,7 +1972,7 @@ int unicast_client_stop(uint8_t cig_index)
 			/* If cancelled a connected server has been found */
 			srv_store_unlock();
 			return ret;
-		} else if (ret) {
+		} else if (ret != 0) {
 			LOG_ERR("Failed to check if servers are connected: %d", ret);
 			srv_store_unlock();
 			return ret;
@@ -1822,7 +1983,7 @@ int unicast_client_stop(uint8_t cig_index)
 		if (!connected_server_found) {
 			LOG_DBG("No connected servers found, deleting unicast group");
 			ret = bt_cap_unicast_group_delete(unicast_group);
-			if (ret) {
+			if (ret != 0) {
 				LOG_ERR("Failed to delete unicast group: %d", ret);
 			}
 
@@ -1836,9 +1997,11 @@ int unicast_client_stop(uint8_t cig_index)
 	}
 
 	ret = bt_cap_initiator_unicast_audio_stop(&param);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to stop unicast audio: %d", ret);
-		k_sem_give(&sem_cap_procedure_proceed);
+
+		cap_set_proc_inactive();
+
 		return ret;
 	}
 
@@ -1868,7 +2031,7 @@ static bool unicast_send_info_populate(struct server_store *server, void *user_d
 		/* Set index */
 		ret = stream_idx_get(&server->snk.cap_streams[i].bap_stream,
 				     &info->tx[info->num_active_streams].idx);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("%s: Failed to get stream index: %d", __func__, ret);
 			return false;
 		}
@@ -1920,7 +2083,7 @@ int unicast_client_send(struct net_buf const *const audio_frame, uint8_t cig_ind
 
 	/* Populate tx struct */
 	ret = srv_store_foreach_server(unicast_send_info_populate, &info);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to populate send info: %d", ret);
 		srv_store_unlock();
 		return ret;
@@ -1934,7 +2097,7 @@ int unicast_client_send(struct net_buf const *const audio_frame, uint8_t cig_ind
 	}
 
 	ret = bt_le_audio_tx_send(bt_le_audio_tx, audio_frame, info.tx, info.num_active_streams);
-	if (ret) {
+	if (ret != 0) {
 		srv_store_unlock();
 		return ret;
 	}
@@ -1969,7 +2132,7 @@ int unicast_client_enable(uint8_t cig_index, le_audio_receive_cb recv_cb)
 	}
 
 	ret = srv_store_init();
-	if (ret) {
+	if (ret != 0) {
 		srv_store_unlock();
 		return ret;
 	}
@@ -1983,14 +2146,14 @@ int unicast_client_enable(uint8_t cig_index, le_audio_receive_cb recv_cb)
 	receive_cb = recv_cb;
 
 	ret = bt_bap_unicast_client_register_cb(&unicast_client_cbs);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to register client callbacks: %d", ret);
 		srv_store_unlock();
 		return ret;
 	}
 
 	ret = bt_cap_initiator_register_cb(&cap_cbs);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to register cap callbacks: %d", ret);
 		srv_store_unlock();
 		return ret;
@@ -1999,7 +2162,7 @@ int unicast_client_enable(uint8_t cig_index, le_audio_receive_cb recv_cb)
 	if (IS_ENABLED(CONFIG_BT_AUDIO_TX)) {
 		/* A unicast client is the Bluetooth central device */
 		ret = bt_le_audio_tx_init(bt_le_audio_tx, true);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to initialize LE Audio TX: %d", ret);
 			srv_store_unlock();
 			return ret;

--- a/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_client.h
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_client.h
@@ -57,6 +57,14 @@ enum unicast_discover_dir {
 #endif /* CONFIG_BT_BAP_UNICAST_16_2_1 */
 
 /**
+ * @brief Check if the unicast client is currently streaming.
+ *
+ * @retval	true	The unicast client is streaming.
+ * @retval	false	The unicast client is not streaming.
+ */
+bool unicast_client_is_streaming(void);
+
+/**
  * @brief	Get configuration for the audio stream.
  *
  * @param[in]	stream			Pointer to the stream to get the configuration for.

--- a/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_client.h
+++ b/applications/nrf_audio/src/bluetooth/bt_stream/unicast/unicast_client.h
@@ -57,6 +57,16 @@ enum unicast_discover_dir {
 #endif /* CONFIG_BT_BAP_UNICAST_16_2_1 */
 
 /**
+ * @brief Check if the unicast client is currently streaming.
+ *
+ * @param[out]	is_streaming	Pointer to a boolean that will be set to true if streaming, false
+ *				otherwise.
+ *
+ * @return	0 for success, error otherwise.
+ */
+int unicast_client_is_streaming(bool *is_streaming);
+
+/**
  * @brief	Get configuration for the audio stream.
  *
  * @param[in]	stream			Pointer to the stream to get the configuration for.

--- a/applications/nrf_audio/unicast_client/main.c
+++ b/applications/nrf_audio/unicast_client/main.c
@@ -136,27 +136,38 @@ static void button_msg_sub_thread(void)
 				break;
 			}
 
-			if (strm_state == STATE_STREAMING) {
+			if (unicast_client_is_streaming()) {
 				ret = bt_content_ctrl_stop(NULL);
-				if (ret) {
+				if (ret == -EAGAIN) {
+					bt_content_ctrl_state_override(true);
+
+					ret = bt_content_ctrl_stop(NULL);
+					if (ret != 0) {
+						LOG_ERR("Could not stop: %d", ret);
+					}
+				} else if (ret != 0) {
 					LOG_WRN("Could not stop: %d", ret);
 				}
 
-			} else if (strm_state == STATE_PAUSED) {
+			} else {
 				ret = bt_content_ctrl_start(NULL);
-				if (ret) {
+				if (ret == -EAGAIN) {
+					bt_content_ctrl_state_override(false);
+
+					ret = bt_content_ctrl_start(NULL);
+					if (ret != 0) {
+						LOG_ERR("Could not start: %d", ret);
+					}
+				} else if (ret != 0) {
 					LOG_WRN("Could not start: %d", ret);
 				}
-
-			} else {
-				LOG_WRN("In invalid state: %d", strm_state);
 			}
 
 			break;
 
 		case BUTTON_VOLUME_UP:
 			ret = bt_r_and_c_volume_up();
-			if (ret) {
+			if (ret != 0) {
 				LOG_WRN("Failed to increase volume: %d", ret);
 			}
 
@@ -164,7 +175,7 @@ static void button_msg_sub_thread(void)
 
 		case BUTTON_VOLUME_DOWN:
 			ret = bt_r_and_c_volume_down();
-			if (ret) {
+			if (ret != 0) {
 				LOG_WRN("Failed to decrease volume: %d", ret);
 			}
 
@@ -177,13 +188,13 @@ static void button_msg_sub_thread(void)
 					break;
 				}
 
-				if (strm_state != STATE_STREAMING) {
+				if (!unicast_client_is_streaming()) {
 					LOG_WRN("Not in streaming state");
 					break;
 				}
 
 				ret = audio_system_encode_test_tone_step();
-				if (ret) {
+				if (ret != 0) {
 					LOG_WRN("Failed to play test tone, ret: %d", ret);
 				}
 
@@ -195,7 +206,7 @@ static void button_msg_sub_thread(void)
 		case BUTTON_5:
 			if (IS_ENABLED(CONFIG_AUDIO_MUTE)) {
 				ret = bt_r_and_c_volume_mute(false);
-				if (ret) {
+				if (ret != 0) {
 					LOG_WRN("Failed to mute, ret: %d", ret);
 				}
 
@@ -274,7 +285,7 @@ static void le_audio_msg_sub_thread(void)
 				"disconnect");
 
 			ret = bt_mgmt_conn_disconnect(msg.conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-			if (ret) {
+			if (ret != 0) {
 				LOG_ERR("Failed to disconnect: %d", ret);
 			}
 
@@ -285,7 +296,7 @@ static void le_audio_msg_sub_thread(void)
 
 			ret = unicast_client_config_get(msg.stream, &bitrate_bps,
 							&sampling_rate_hz);
-			if (ret) {
+			if (ret != 0) {
 				LOG_WRN("Failed to get config: %d", ret);
 				break;
 			}
@@ -339,7 +350,7 @@ static void le_audio_msg_sub_thread(void)
 				/* Room for more connections, start scanning again */
 				ret = bt_mgmt_scan_start(0, 0, BT_MGMT_SCAN_TYPE_CONN, NULL,
 							 BRDCAST_ID_NOT_USED);
-				if (ret) {
+				if (ret != 0) {
 					LOG_ERR("Failed to resume scanning: %d", ret);
 				}
 			}
@@ -358,7 +369,7 @@ static void le_audio_msg_sub_thread(void)
 			uint16_t interval = 0;
 
 			ret = bt_conn_get_info(msg.conn, &conn_info);
-			if (ret) {
+			if (ret != 0) {
 				LOG_ERR("Failed to get conn info");
 			} else {
 				interval = BT_GAP_US_TO_CONN_INTERVAL(conn_info.le.interval_us);
@@ -376,7 +387,7 @@ static void le_audio_msg_sub_thread(void)
 				param.timeout = CONFIG_BLE_ACL_SUP_TIMEOUT;
 
 				ret = bt_conn_le_param_update(msg.conn, &param);
-				if (ret) {
+				if (ret != 0) {
 					LOG_WRN("Failed to update conn parameters: %d", ret);
 				}
 
@@ -400,7 +411,7 @@ static void discovery_process_start(struct bt_conn *conn)
 	int ret;
 
 	ret = bt_r_and_c_discover(conn);
-	if (ret) {
+	if (ret != 0) {
 		LOG_WRN("Failed to discover rendering services");
 	}
 
@@ -410,7 +421,7 @@ static void discovery_process_start(struct bt_conn *conn)
 		ret = unicast_client_discover(conn, UNICAST_SERVER_SINK);
 	}
 
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to handle unicast client discover: %d", ret);
 	}
 }
@@ -451,7 +462,7 @@ static void bt_mgmt_evt_handler(const struct zbus_channel *chan)
 			 */
 
 			ret = srv_store_conn_update(msg->conn, &msg->addr);
-			if (ret) {
+			if (ret != 0) {
 				LOG_ERR("Failed to update conn in store: %d", ret);
 				srv_store_unlock();
 				return;
@@ -472,7 +483,7 @@ static void bt_mgmt_evt_handler(const struct zbus_channel *chan)
 		ERR_CHK_MSG(ret, "Failed to lock server store");
 
 		ret = srv_store_add_by_conn(msg->conn);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to add server to store: %d", ret);
 			srv_store_unlock();
 			return;
@@ -516,7 +527,7 @@ static void bt_mgmt_evt_handler(const struct zbus_channel *chan)
 		ERR_CHK_MSG(ret, "Failed to lock server store");
 
 		ret = srv_store_remove_by_addr(&msg->addr);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to remove server from store: %d", ret);
 		}
 
@@ -548,7 +559,7 @@ static int zbus_subscribers_create(void)
 		NULL, NULL, K_PRIO_PREEMPT(CONFIG_BUTTON_MSG_SUB_THREAD_PRIO), 0, K_NO_WAIT);
 
 	ret = k_thread_name_set(button_msg_sub_thread_id, "Msg_sub_btn");
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to create button_msg thread");
 		return ret;
 	}
@@ -559,7 +570,7 @@ static int zbus_subscribers_create(void)
 		NULL, NULL, K_PRIO_PREEMPT(CONFIG_LE_AUDIO_MSG_SUB_THREAD_PRIO), 0, K_NO_WAIT);
 
 	ret = k_thread_name_set(le_audio_msg_sub_thread_id, "Msg_sub_LE_Audio");
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to create le_audio_msg thread");
 		return ret;
 	}
@@ -571,12 +582,12 @@ static int zbus_subscribers_create(void)
 		K_PRIO_PREEMPT(CONFIG_CONTENT_CONTROL_MSG_SUB_THREAD_PRIO), 0, K_NO_WAIT);
 
 	ret = k_thread_name_set(content_control_thread_id, "Msg_sub_content_ctrl");
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = zbus_chan_add_obs(&sdu_ref_chan, &sdu_ref_msg_listen, ZBUS_ADD_OBS_TIMEOUT_MS);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to add timestamp listener");
 		return ret;
 	}
@@ -598,19 +609,19 @@ static int zbus_link_producers_observers(void)
 	}
 
 	ret = zbus_chan_add_obs(&button_chan, &button_evt_sub, ZBUS_ADD_OBS_TIMEOUT_MS);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to add button sub");
 		return ret;
 	}
 
 	ret = zbus_chan_add_obs(&le_audio_chan, &le_audio_evt_sub, ZBUS_ADD_OBS_TIMEOUT_MS);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to add le_audio sub");
 		return ret;
 	}
 
 	ret = zbus_chan_add_obs(&bt_mgmt_chan, &bt_mgmt_evt_listen, ZBUS_ADD_OBS_TIMEOUT_MS);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to add bt_mgmt listener");
 		return ret;
 	}
@@ -705,7 +716,7 @@ int main(void)
 
 	ret = bt_mgmt_scan_start(0, 0, BT_MGMT_SCAN_TYPE_CONN, CONFIG_BT_DEVICE_NAME,
 				 BRDCAST_ID_NOT_USED);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to start scanning");
 		return ret;
 	}

--- a/applications/nrf_audio/unicast_client/main.c
+++ b/applications/nrf_audio/unicast_client/main.c
@@ -33,6 +33,9 @@ BUILD_ASSERT(CONFIG_BT_AUDIO_CONCURRENT_TX_STREAMS_MAX <= CONFIG_AUDIO_ENCODE_CH
 
 static enum stream_state strm_state = STATE_PAUSED;
 
+#define CONTENT_CTRL_STATE_PLAYING true
+#define CONTENT_CTRL_STATE_PAUSED  false
+
 ZBUS_SUBSCRIBER_DEFINE(button_evt_sub, CONFIG_BUTTON_MSG_SUB_QUEUE_SIZE);
 ZBUS_SUBSCRIBER_DEFINE(content_control_evt_sub, CONFIG_CONTENT_CONTROL_MSG_SUB_QUEUE_SIZE);
 
@@ -136,27 +139,48 @@ static void button_msg_sub_thread(void)
 				break;
 			}
 
-			if (strm_state == STATE_STREAMING) {
+			bool is_streaming;
+
+			ret = unicast_client_is_streaming(&is_streaming);
+			if (ret != 0) {
+				LOG_WRN("Failed to get streaming state: %d", ret);
+				break;
+			}
+
+			if (is_streaming) {
 				ret = bt_content_ctrl_stop(NULL);
-				if (ret) {
+				if (ret == -EAGAIN) {
+					/* Override and try again  [flesh out]*/
+					bt_content_ctrl_state_override(CONTENT_CTRL_STATE_PLAYING);
+
+					ret = bt_content_ctrl_stop(NULL);
+					if (ret != 0) {
+						LOG_ERR("Could not stop: %d", ret);
+					}
+				} else if (ret != 0) {
 					LOG_WRN("Could not stop: %d", ret);
 				}
 
-			} else if (strm_state == STATE_PAUSED) {
+			} else {
 				ret = bt_content_ctrl_start(NULL);
-				if (ret) {
+				if (ret == -EAGAIN) {
+					/* Override and try again */
+					bt_content_ctrl_state_override(CONTENT_CTRL_STATE_PAUSED);
+
+					ret = bt_content_ctrl_start(NULL);
+					if (ret != 0) {
+						LOG_ERR("Could not start: %d", ret);
+					}
+				} else if (ret != 0) {
 					LOG_WRN("Could not start: %d", ret);
 				}
-
-			} else {
-				LOG_WRN("In invalid state: %d", strm_state);
 			}
 
 			break;
 
 		case BUTTON_VOLUME_UP:
 			ret = bt_r_and_c_volume_up();
-			if (ret) {
+			if (ret != 0) {
 				LOG_WRN("Failed to increase volume: %d", ret);
 			}
 
@@ -164,7 +188,7 @@ static void button_msg_sub_thread(void)
 
 		case BUTTON_VOLUME_DOWN:
 			ret = bt_r_and_c_volume_down();
-			if (ret) {
+			if (ret != 0) {
 				LOG_WRN("Failed to decrease volume: %d", ret);
 			}
 
@@ -177,13 +201,21 @@ static void button_msg_sub_thread(void)
 					break;
 				}
 
-				if (strm_state != STATE_STREAMING) {
+				bool is_streaming;
+
+				ret = unicast_client_is_streaming(&is_streaming);
+				if (ret != 0) {
+					LOG_WRN("Failed to get streaming state: %d", ret);
+					break;
+				}
+
+				if (!is_streaming) {
 					LOG_WRN("Not in streaming state");
 					break;
 				}
 
 				ret = audio_system_encode_test_tone_step();
-				if (ret) {
+				if (ret != 0) {
 					LOG_WRN("Failed to play test tone, ret: %d", ret);
 				}
 
@@ -195,7 +227,7 @@ static void button_msg_sub_thread(void)
 		case BUTTON_5:
 			if (IS_ENABLED(CONFIG_AUDIO_MUTE)) {
 				ret = bt_r_and_c_volume_mute(false);
-				if (ret) {
+				if (ret != 0) {
 					LOG_WRN("Failed to mute, ret: %d", ret);
 				}
 
@@ -274,7 +306,7 @@ static void le_audio_msg_sub_thread(void)
 				"disconnect");
 
 			ret = bt_mgmt_conn_disconnect(msg.conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-			if (ret) {
+			if (ret != 0) {
 				LOG_ERR("Failed to disconnect: %d", ret);
 			}
 
@@ -285,7 +317,7 @@ static void le_audio_msg_sub_thread(void)
 
 			ret = unicast_client_config_get(msg.stream, &bitrate_bps,
 							&sampling_rate_hz);
-			if (ret) {
+			if (ret != 0) {
 				LOG_WRN("Failed to get config: %d", ret);
 				break;
 			}
@@ -339,7 +371,7 @@ static void le_audio_msg_sub_thread(void)
 				/* Room for more connections, start scanning again */
 				ret = bt_mgmt_scan_start(0, 0, BT_MGMT_SCAN_TYPE_CONN, NULL,
 							 BRDCAST_ID_NOT_USED);
-				if (ret) {
+				if (ret != 0) {
 					LOG_ERR("Failed to resume scanning: %d", ret);
 				}
 			}
@@ -358,7 +390,7 @@ static void le_audio_msg_sub_thread(void)
 			uint16_t interval = 0;
 
 			ret = bt_conn_get_info(msg.conn, &conn_info);
-			if (ret) {
+			if (ret != 0) {
 				LOG_ERR("Failed to get conn info");
 			} else {
 				interval = BT_GAP_US_TO_CONN_INTERVAL(conn_info.le.interval_us);
@@ -376,7 +408,7 @@ static void le_audio_msg_sub_thread(void)
 				param.timeout = CONFIG_BLE_ACL_SUP_TIMEOUT;
 
 				ret = bt_conn_le_param_update(msg.conn, &param);
-				if (ret) {
+				if (ret != 0) {
 					LOG_WRN("Failed to update conn parameters: %d", ret);
 				}
 
@@ -400,7 +432,7 @@ static void discovery_process_start(struct bt_conn *conn)
 	int ret;
 
 	ret = bt_r_and_c_discover(conn);
-	if (ret) {
+	if (ret != 0) {
 		LOG_WRN("Failed to discover rendering services");
 	}
 
@@ -410,7 +442,7 @@ static void discovery_process_start(struct bt_conn *conn)
 		ret = unicast_client_discover(conn, UNICAST_SERVER_SINK);
 	}
 
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to handle unicast client discover: %d", ret);
 	}
 }
@@ -451,7 +483,7 @@ static void bt_mgmt_evt_handler(const struct zbus_channel *chan)
 			 */
 
 			ret = srv_store_conn_update(msg->conn, &msg->addr);
-			if (ret) {
+			if (ret != 0) {
 				LOG_ERR("Failed to update conn in store: %d", ret);
 				srv_store_unlock();
 				return;
@@ -472,7 +504,7 @@ static void bt_mgmt_evt_handler(const struct zbus_channel *chan)
 		ERR_CHK_MSG(ret, "Failed to lock server store");
 
 		ret = srv_store_add_by_conn(msg->conn);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to add server to store: %d", ret);
 			srv_store_unlock();
 			return;
@@ -516,7 +548,7 @@ static void bt_mgmt_evt_handler(const struct zbus_channel *chan)
 		ERR_CHK_MSG(ret, "Failed to lock server store");
 
 		ret = srv_store_remove_by_addr(&msg->addr);
-		if (ret) {
+		if (ret != 0) {
 			LOG_ERR("Failed to remove server from store: %d", ret);
 		}
 
@@ -548,7 +580,7 @@ static int zbus_subscribers_create(void)
 		NULL, NULL, K_PRIO_PREEMPT(CONFIG_BUTTON_MSG_SUB_THREAD_PRIO), 0, K_NO_WAIT);
 
 	ret = k_thread_name_set(button_msg_sub_thread_id, "Msg_sub_btn");
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to create button_msg thread");
 		return ret;
 	}
@@ -559,7 +591,7 @@ static int zbus_subscribers_create(void)
 		NULL, NULL, K_PRIO_PREEMPT(CONFIG_LE_AUDIO_MSG_SUB_THREAD_PRIO), 0, K_NO_WAIT);
 
 	ret = k_thread_name_set(le_audio_msg_sub_thread_id, "Msg_sub_LE_Audio");
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to create le_audio_msg thread");
 		return ret;
 	}
@@ -571,12 +603,12 @@ static int zbus_subscribers_create(void)
 		K_PRIO_PREEMPT(CONFIG_CONTENT_CONTROL_MSG_SUB_THREAD_PRIO), 0, K_NO_WAIT);
 
 	ret = k_thread_name_set(content_control_thread_id, "Msg_sub_content_ctrl");
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = zbus_chan_add_obs(&sdu_ref_chan, &sdu_ref_msg_listen, ZBUS_ADD_OBS_TIMEOUT_MS);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to add timestamp listener");
 		return ret;
 	}
@@ -598,19 +630,19 @@ static int zbus_link_producers_observers(void)
 	}
 
 	ret = zbus_chan_add_obs(&button_chan, &button_evt_sub, ZBUS_ADD_OBS_TIMEOUT_MS);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to add button sub");
 		return ret;
 	}
 
 	ret = zbus_chan_add_obs(&le_audio_chan, &le_audio_evt_sub, ZBUS_ADD_OBS_TIMEOUT_MS);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to add le_audio sub");
 		return ret;
 	}
 
 	ret = zbus_chan_add_obs(&bt_mgmt_chan, &bt_mgmt_evt_listen, ZBUS_ADD_OBS_TIMEOUT_MS);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to add bt_mgmt listener");
 		return ret;
 	}
@@ -705,7 +737,7 @@ int main(void)
 
 	ret = bt_mgmt_scan_start(0, 0, BT_MGMT_SCAN_TYPE_CONN, CONFIG_BT_DEVICE_NAME,
 				 BRDCAST_ID_NOT_USED);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to start scanning");
 		return ret;
 	}

--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -2904,6 +2904,13 @@ OCT-3248: A race condition between capturing timers and the RTC tick resetting t
 
   **Affected platforms:** nRF5340 Audio DK
 
+.. rst-class:: v3-4-0 v3-3-4 v3-3-3 v3-3-2 v3-3-1 v3-3-0 v3-2-5 v3-2-4 v3-2-3 v3-2-2 v3-2-1 v3-2-0
+
+OCT-3775: Deadlock on the unicast client when a unicast server is reset at the same time as a pause command is sent
+  This is because the unicast client is waiting for a response from the unicast server, which is reset and cannot respond.
+
+  **Affected platforms:** nRF5340 Audio DK
+
 Controller subsystem for nRF Audio
 ----------------------------------
 


### PR DESCRIPTION
- Override MCS state if it doesn't match current streaming state
- Add timeout to CAP procedures to capture disconnects during proc
- OCT-3775