### PR TITLE
tests: drivers: timer: Update lfclk_accuracy result assessment

### DIFF
--- a/tests/drivers/timer/lfclk_accuracy/src/main.c
+++ b/tests/drivers/timer/lfclk_accuracy/src/main.c
@@ -92,6 +92,11 @@ int check_timing(void)
 	printk("Minimal interval [us]: %llu\n", min_interval);
 	printk("Maximal interval [us]: %llu\n", max_interval);
 
+	if (total_intervals == 0) {
+		printk("No intervals measured !\n");
+		status = -2;
+	}
+
 	return status;
 }
 


### PR DESCRIPTION
Fail the tests if there are no measured intervals