### PR TITLE
Enable ram retention for nrf7120

### DIFF
--- a/lib/ram_pwrdn/Kconfig
+++ b/lib/ram_pwrdn/Kconfig
@@ -6,11 +6,11 @@
 
 menuconfig RAM_POWER_DOWN_LIBRARY
 	bool "API for turning off unused RAM segments"
-	depends on SOC_NRF52840 || SOC_NRF52833 || SOC_NRF5340_CPUAPP || SOC_SERIES_NRF54L
+	depends on SOC_NRF52840 || SOC_NRF52833 || SOC_NRF5340_CPUAPP || \
+		SOC_SERIES_NRF54L || SOC_NRF7120_ENGA_CPUAPP
 	# Powering down RAM blocks can only be done from the secure domain
-	# for security reasons. If necessary, this limitation could be
-	# addressed by a secure service in the future.
-	depends on ! BUILD_WITH_TFM
+	depends on !TRUSTED_EXECUTION_NONSECURE || \
+		(SOC_NRF7120_ENGA_CPUAPP && SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE)
 	imply NRF_FORCE_RAM_ON_REBOOT
 	help
 	  This allows application to call API for disabling unused RAM segments

--- a/lib/ram_pwrdn/Kconfig
+++ b/lib/ram_pwrdn/Kconfig
@@ -6,11 +6,9 @@
 
 menuconfig RAM_POWER_DOWN_LIBRARY
 	bool "API for turning off unused RAM segments"
-	depends on SOC_NRF52840 || SOC_NRF52833 || SOC_NRF5340_CPUAPP || SOC_SERIES_NRF54L
+	depends on SOC_NRF52840 || SOC_NRF52833 || SOC_NRF5340_CPUAPP || SOC_SERIES_NRF54L || SOC_NRF7120_ENGA_CPUAPP
 	# Powering down RAM blocks can only be done from the secure domain
-	# for security reasons. If necessary, this limitation could be
-	# addressed by a secure service in the future.
-	depends on ! BUILD_WITH_TFM
+	depends on !TRUSTED_EXECUTION_NONSECURE || (SOC_NRF7120_ENGA_CPUAPP && SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE)
 	imply NRF_FORCE_RAM_ON_REBOOT
 	help
 	  This allows application to call API for disabling unused RAM segments

--- a/lib/ram_pwrdn/ram_pwrdn.c
+++ b/lib/ram_pwrdn/ram_pwrdn.c
@@ -14,8 +14,12 @@
 #include <hal/nrf_power.h>
 #elif defined(CONFIG_SOC_NRF5340_CPUAPP)
 #include <hal/nrf_vmc.h>
-#elif defined(CONFIG_SOC_SERIES_NRF54L)
+#elif defined(CONFIG_SOC_SERIES_NRF54L) ||                                                         \
+	(defined(CONFIG_SOC_NRF7120_ENGA_CPUAPP) &&                                                \
+	 !defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE))
 #include <hal/nrf_memconf.h>
+#elif defined(CONFIG_SOC_NRF7120_ENGA_CPUAPP)
+#include "tfm_ioctl_core_api.h"
 #else
 #error "RAM power-down library is not supported on the current platform"
 #endif
@@ -52,6 +56,12 @@ static const struct ram_bank banks[] = {
 	{ .start = 0x20000000UL, .section_count = 3, .section_size = 0x8000 },
 #elif defined(CONFIG_SOC_NRF54LM20A_CPUAPP) || defined(CONFIG_SOC_NRF54LM20B_CPUAPP)
 	{ .start = 0x20000000UL, .section_count = 16, .section_size = 0x8000 },
+#elif defined(CONFIG_SOC_NRF7120_ENGA_CPUAPP)
+	/*
+	 * MEMCONF controls nRF7120 RAM in 32 KiB sections. Section 31 is
+	 * intentionally excluded because it cannot be powered down.
+	 */
+	{ .start = 0x20000000UL, .section_count = 31, .section_size = 0x8000 },
 #elif defined(CONFIG_SOC_NRF52840) || defined(CONFIG_SOC_NRF52833)
 	{ .start = 0x20000000UL, .section_count = 2, .section_size = 0x1000 },
 	{ .start = 0x20002000UL, .section_count = 2, .section_size = 0x1000 },
@@ -91,10 +101,20 @@ static void ram_bank_power_down(uint8_t bank_id, uint8_t first_section_id, uint8
 	uint32_t mask = GENMASK(VMC_RAM_POWER_S0POWER_Pos + last_section_id,
 				VMC_RAM_POWER_S0POWER_Pos + first_section_id);
 	nrf_vmc_ram_block_power_clear(NRF_VMC, bank_id, mask);
-#elif defined(CONFIG_SOC_SERIES_NRF54L)
+#elif defined(CONFIG_SOC_SERIES_NRF54L) ||                                                         \
+	(defined(CONFIG_SOC_NRF7120_ENGA_CPUAPP) &&                                                \
+	 !defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE))
 	uint32_t mask = GENMASK(MEMCONF_POWER_CONTROL_MEM0_Pos + last_section_id,
 				MEMCONF_POWER_CONTROL_MEM0_Pos + first_section_id);
 	nrf_memconf_ramblock_control_mask_enable_set(NRF_MEMCONF, bank_id, mask, false);
+#elif defined(CONFIG_SOC_NRF7120_ENGA_CPUAPP)
+	const struct ram_bank *bank = &banks[bank_id];
+	uint32_t addr = bank->start + first_section_id * bank->section_size;
+	uint32_t len = (last_section_id - first_section_id + 1U) * bank->section_size;
+
+	if (tfm_platform_ram_ctrl_power_set(addr, len, false) != TFM_PLATFORM_ERR_SUCCESS) {
+		LOG_ERR("TF-M rejected RAM power-down range 0x%08x..0x%08x", addr, addr + len);
+	}
 #endif
 }
 
@@ -111,10 +131,20 @@ static void ram_bank_power_up(uint8_t bank_id, uint8_t first_section_id, uint8_t
 	uint32_t mask = GENMASK(VMC_RAM_POWER_S0POWER_Pos + last_section_id,
 				VMC_RAM_POWER_S0POWER_Pos + first_section_id);
 	nrf_vmc_ram_block_power_set(NRF_VMC, bank_id, mask);
-#elif defined(CONFIG_SOC_SERIES_NRF54L)
+#elif defined(CONFIG_SOC_SERIES_NRF54L) ||                                                         \
+	(defined(CONFIG_SOC_NRF7120_ENGA_CPUAPP) &&                                                \
+	 !defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE))
 	uint32_t mask = GENMASK(MEMCONF_POWER_CONTROL_MEM0_Pos + last_section_id,
 				MEMCONF_POWER_CONTROL_MEM0_Pos + first_section_id);
 	nrf_memconf_ramblock_control_mask_enable_set(NRF_MEMCONF, bank_id, mask, true);
+#elif defined(CONFIG_SOC_NRF7120_ENGA_CPUAPP)
+	const struct ram_bank *bank = &banks[bank_id];
+	uint32_t addr = bank->start + first_section_id * bank->section_size;
+	uint32_t len = (last_section_id - first_section_id + 1U) * bank->section_size;
+
+	if (tfm_platform_ram_ctrl_power_set(addr, len, true) != TFM_PLATFORM_ERR_SUCCESS) {
+		LOG_ERR("TF-M rejected RAM power-up range 0x%08x..0x%08x", addr, addr + len);
+	}
 #endif
 }
 

--- a/lib/ram_pwrdn/ram_pwrdn.c
+++ b/lib/ram_pwrdn/ram_pwrdn.c
@@ -11,13 +11,17 @@
 
 #include <helpers/nrfx_ram_ctrl.h>
 
+#if defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE)
+#include "tfm_ioctl_core_api.h"
+#endif
+
 #if !defined(NRF_MEMORY_RAM_BASE) && defined(NRF_MEMORY_RAM0_BASE)
 #define NRF_MEMORY_RAM_BASE NRF_MEMORY_RAM0_BASE
 #endif
 
 #define RAM_IMAGE_END_ADDR ((uintptr_t)_image_ram_end)
 
-#define RAM_UNIFORM_REGION_SIZE \
+#define RAM_UNIFORM_REGION_SIZE                                                                    \
 	((uintptr_t)RAM_UNIFORM_SECTIONS_TOTAL * (uintptr_t)RAM_SECTION_UNIT_SIZE)
 
 LOG_MODULE_REGISTER(ram_pwrdn, CONFIG_RAM_POWERDOWN_LOG_LEVEL);
@@ -78,8 +82,18 @@ static void ram_sections_power_set(uintptr_t start_address, uintptr_t end_addres
 			LOG_DBG("%s RAM 0x%08lx-0x%08lx",
 				power_up ? "Powering up" : "Powering down",
 				(unsigned long)section_start, (unsigned long)section_end);
+#if defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE)
+			if (tfm_platform_ram_ctrl_power_set((uint32_t)section_start,
+							    (uint32_t)(section_end - section_start),
+							    power_up) != TFM_PLATFORM_ERR_SUCCESS) {
+				LOG_ERR("TF-M rejected RAM power-%s range 0x%08lx-0x%08lx",
+					power_up ? "up" : "down", (unsigned long)section_start,
+					(unsigned long)section_end);
+			}
+#else
 			nrfx_ram_ctrl_power_enable_set((void const *)section_start,
 						       section_end - section_start, power_up);
+#endif
 		}
 	}
 }

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -561,14 +561,14 @@ config TFM_NRF_SYSTEM_OFF_SERVICE
 	depends on TFM_ISOLATION_LEVEL = 1
 	depends on TFM_SFN
 	depends on SOC_SERIES_NRF54L || SOC_SERIES_NRF71
-	depends on !RETAINED_MEM_NRF_RAM_CTRL
+	depends on !RETAINED_MEM_NRF_RAM_CTRL || SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE
 	select EXPERIMENTAL
 	help
-	  Provide a System OFF service for the nRF54L Series SoCs.
+	  Provide a System OFF service for the nRF54L and nRF71 Series SoCs.
 	  This service allows the non-secure application to request
 	  the system to enter the System OFF mode using a secure service call.
-	  This service disables RAM retention for all RAM blocks
-	  before entering the System OFF mode.
+	  Unless the RAM-control service is enabled, this service disables RAM
+	  retention for all RAM blocks before entering the System OFF mode.
 
 config TFM_HAS_B0N
 	bool "Network core bootloader present (informative only, do not change)"

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -562,14 +562,14 @@ config TFM_NRF_SYSTEM_OFF_SERVICE
 	depends on TFM_ISOLATION_LEVEL = 1
 	depends on TFM_SFN
 	depends on SOC_SERIES_NRF54L || SOC_SERIES_NRF71
-	depends on !RETAINED_MEM_NRF_RAM_CTRL
+	depends on !RETAINED_MEM_NRF_RAM_CTRL || SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE
 	select EXPERIMENTAL
 	help
-	  Provide a System OFF service for the nRF54L Series SoCs.
+	  Provide a System OFF service for the nRF54L and nRF71 Series SoCs.
 	  This service allows the non-secure application to request
 	  the system to enter the System OFF mode using a secure service call.
-	  This service disables RAM retention for all RAM blocks
-	  before entering the System OFF mode.
+	  Unless the RAM-control service is enabled, this service disables RAM
+	  retention for all RAM blocks before entering the System OFF mode.
 
 config TFM_HAS_B0N
 	bool "Network core bootloader present (informative only, do not change)"

--- a/modules/trusted-firmware-m/tfm_boards/src/tfm_platform_system.c
+++ b/modules/trusted-firmware-m/tfm_boards/src/tfm_platform_system.c
@@ -37,7 +37,9 @@ enum tfm_platform_err_t tfm_platform_hal_system_off(void)
 {
 	__disable_irq();
 
+#if !defined(TFM_NRF_RAM_CTRL_SERVICE)
 	nrfx_ram_ctrl_retention_enable_all_set(false);
+#endif
 
 	nrf_regulators_system_off(NRF_REGULATORS);
 

--- a/modules/trusted-firmware-m/tfm_boards/src/tfm_platform_system.c
+++ b/modules/trusted-firmware-m/tfm_boards/src/tfm_platform_system.c
@@ -12,6 +12,7 @@
 #include <arm_cmse.h>
 
 #include "tfm_ioctl_api.h"
+#include "tfm_ioctl_core_api.h"
 #include "tfm_platform_hal_ioctl.h"
 #include <tfm_hal_isolation.h>
 
@@ -156,6 +157,10 @@ enum tfm_platform_err_t tfm_platform_hal_ioctl(tfm_platform_ioctl_req_t request,
 		return tfm_platform_hal_mramc_init_service();
 	case TFM_PLATFORM_IOCTL_MRAMC_SET_WEN_SERVICE:
 		return tfm_platform_hal_mramc_set_wen_service(in_vec);
+#endif
+#if defined(TFM_NRF_RAM_CTRL_SERVICE)
+	case TFM_PLATFORM_IOCTL_RAM_CTRL_SERVICE:
+		return tfm_platform_hal_ram_ctrl_service(in_vec, out_vec);
 #endif
 
 		/* Board specific IOCTL services */

--- a/modules/trusted-firmware-m/tfm_boards/src/tfm_platform_system.c
+++ b/modules/trusted-firmware-m/tfm_boards/src/tfm_platform_system.c
@@ -12,6 +12,7 @@
 #include <arm_cmse.h>
 
 #include "tfm_ioctl_api.h"
+#include "tfm_ioctl_core_api.h"
 #include "tfm_platform_hal_ioctl.h"
 #include <tfm_hal_isolation.h>
 
@@ -162,6 +163,10 @@ enum tfm_platform_err_t tfm_platform_hal_ioctl(tfm_platform_ioctl_req_t request,
 		return tfm_platform_hal_wifi_kmu_write_key_service(in_vec);
 	case TFM_PLATFORM_IOCTL_WIFI_KMU_ERASE_KEYS_SERVICE:
 		return tfm_platform_hal_wifi_kmu_erase_keys_service();
+#endif
+#if defined(TFM_NRF_RAM_CTRL_SERVICE)
+	case TFM_PLATFORM_IOCTL_RAM_CTRL_SERVICE:
+		return tfm_platform_hal_ram_ctrl_service(in_vec, out_vec);
 #endif
 
 		/* Board specific IOCTL services */

--- a/tests/lib/ram_pwrdn/src/main.c
+++ b/tests/lib/ram_pwrdn/src/main.c
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <hal/nrf_power.h>
+#include <stdint.h>
+
 #include <ram_pwrdn.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/ztest.h>
@@ -13,6 +14,17 @@
 #include <stdlib.h>
 #include <malloc.h>
 
+#if defined(CONFIG_SOC_NRF52840)
+#include <hal/nrf_power.h>
+#elif defined(CONFIG_SOC_NRF7120_ENGA_CPUAPP)
+#if defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE)
+#include "tfm_ioctl_core_api.h"
+#else
+#include <hal/nrf_memconf.h>
+#endif
+#endif
+
+#if defined(CONFIG_SOC_NRF52840)
 /* ===== Test helpers ===== */
 
 struct bank_section {
@@ -22,7 +34,7 @@ struct bank_section {
 
 static struct bank_section bank_section(uint8_t bank_id, uint8_t section_id)
 {
-	struct bank_section ret = { .bank_id = bank_id, .sect_id = section_id };
+	struct bank_section ret = {.bank_id = bank_id, .sect_id = section_id};
 
 	return ret;
 }
@@ -127,3 +139,63 @@ ZTEST(ram_pwrdn, test_manual_power_control)
 }
 
 ZTEST_SUITE(ram_pwrdn, NULL, NULL, NULL, teardown, NULL);
+#elif defined(CONFIG_SOC_NRF7120_ENGA_CPUAPP)
+
+#define RAM_SECTION_SIZE  0x8000UL
+#define TEST_SECTION_ID	  30U
+#define TEST_SECTION_ADDR (0x20000000UL + TEST_SECTION_ID * RAM_SECTION_SIZE)
+
+static uint32_t control_get(void)
+{
+#if defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE)
+	uint32_t control;
+	enum tfm_platform_err_t err;
+
+	err = tfm_platform_ram_ctrl_read_status(&control, NULL, NULL);
+	zassert_equal(err, TFM_PLATFORM_ERR_SUCCESS, "Reading MEMCONF CONTROL through TF-M");
+
+	return control;
+#else
+	return NRF_MEMCONF->POWER[0].CONTROL;
+#endif
+}
+
+static void teardown(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	power_up_ram(TEST_SECTION_ADDR, TEST_SECTION_ADDR + RAM_SECTION_SIZE);
+}
+
+ZTEST(ram_pwrdn, test_nrf7120_power_control)
+{
+	uint32_t control;
+	uint32_t section31_before;
+
+	power_up_ram(TEST_SECTION_ADDR, TEST_SECTION_ADDR + RAM_SECTION_SIZE);
+	control = control_get();
+	zassert_true(control & BIT(TEST_SECTION_ID), "Test section is not powered up");
+	section31_before = control & BIT(31);
+
+	/* A section is powered down only when the complete section is requested. */
+	power_down_ram(TEST_SECTION_ADDR + 1U, TEST_SECTION_ADDR + RAM_SECTION_SIZE);
+	control = control_get();
+	zassert_true(control & BIT(TEST_SECTION_ID), "A partial section was powered down");
+	zassert_equal(control & BIT(31), section31_before, "Section 31 changed");
+
+	power_down_ram(TEST_SECTION_ADDR, TEST_SECTION_ADDR + RAM_SECTION_SIZE);
+	control = control_get();
+	zassert_false(control & BIT(TEST_SECTION_ID), "A complete section was not powered down");
+	zassert_equal(control & BIT(31), section31_before, "Section 31 changed");
+
+	/* Any overlap powers the complete section back up. */
+	power_up_ram(TEST_SECTION_ADDR, TEST_SECTION_ADDR + 1U);
+	control = control_get();
+	zassert_true(control & BIT(TEST_SECTION_ID), "The section was not powered up");
+	zassert_equal(control & BIT(31), section31_before, "Section 31 changed");
+}
+
+ZTEST_SUITE(ram_pwrdn, NULL, NULL, NULL, teardown, NULL);
+#else
+#error "RAM power-down test is not supported on the current platform"
+#endif

--- a/tests/lib/ram_pwrdn/testcase.yaml
+++ b/tests/lib/ram_pwrdn/testcase.yaml
@@ -8,3 +8,21 @@ tests:
       - ram_pwrdn
       - sysbuild
       - ci_tests_lib_ram_pwrdn
+  ram_pwrdn.nrf7120_secure:
+    sysbuild: true
+    platform_allow: nrf7120dk/nrf7120/cpuapp
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp
+    tags:
+      - ram_pwrdn
+      - sysbuild
+      - ci_tests_lib_ram_pwrdn
+  ram_pwrdn.nrf7120_tfm:
+    sysbuild: true
+    platform_allow: nrf7120dk/nrf7120/cpuapp/ns
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp/ns
+    tags:
+      - ram_pwrdn
+      - sysbuild
+      - ci_tests_lib_ram_pwrdn

--- a/tests/lib/ram_pwrdn/testcase.yaml
+++ b/tests/lib/ram_pwrdn/testcase.yaml
@@ -19,8 +19,12 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf52840dk/nrf52840
+      - nrf7120dk/nrf7120/cpuapp
+      - nrf7120dk/nrf7120/cpuapp/ns
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
+      - nrf7120dk/nrf7120/cpuapp/ns
     tags:
       - ram_pwrdn
       - ci_tests_lib_ram_pwrdn

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 7b5e299bd8a0772715b152c32f6520bb776b55e1
+      revision: pull/4293/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -154,7 +154,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 74c58c82a89cc739cd1b003c70a90e0f9d843039
+      revision: pull/263/head
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0c2615717b6beeb413fdae8348afb55735ff0531
+      revision: 56ce996672b5acd5c8f76d14dc568cf53a075bdc
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -154,7 +154,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: e7c7581eba02c2f8e3efe9f18cf2e4d3270fa321
+      revision: b2dc08d416bef316c7464356be96699e9a6f24c1
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
This PR adds

- `ram_pwrdwn` support to nRF7120 and nRF7120/ns variant
- Enables ram retention via TF-M for nRF7120/ns targets.

Depends on:
- upstream trusted-firmware changes (https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/52584)
- nrfx release
Raised the PR so that I can get early reviews