### PR TITLE
[DNM] manifest: temporarily switch hal_nordic and nrfx to allow testing

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -7,6 +7,9 @@ set(SOC_DIR ${NRFX_DIR}/bsp/stable)
 set(MDK_DIR ${SOC_DIR}/mdk)
 set(helpers_dir ${NRFX_DIR}/helpers)
 
+zephyr_compile_definitions_ifdef(CONFIG_NRF_PLATFORM_LUMOS LUMOS_XXAA)
+zephyr_compile_definitions_ifdef(CONFIG_NRF_PLATFORM_HALTIUM HALTIUM_XXAA)
+
 # Add definitions for products which are yet to be upstreamed.
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LC10A NRF54LC10A_XXAA)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LC10A_CPUAPP NRF_APPLICATION)

--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -28,7 +28,7 @@ zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9251_CPUPPR NRF_PPR)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9251_CPUFLPR NRF_FLPR)
 
 zephyr_library_sources_ifdef(CONFIG_SOC_NRF7120_ENGA
-                             ${MDK_DIR}/nrf71/nrf7120_enga/system_nrf7120_enga.c)
+                             ${MDK_DIR}/nrf71/system_nrf71.c)
 
 mdk_svd_ifdef(CONFIG_SOC_NRF54LC10A_CPUAPP nrf54l/nrf54lc10a/nrf54lc10a_application.svd)
 mdk_svd_ifdef(CONFIG_SOC_NRF54LC10A_CPUFLPR nrf54l/nrf54lc10a/nrf54lc10a_flpr.svd)

--- a/subsys/mpsl/hwres/mpsl_hwres.c
+++ b/subsys/mpsl/hwres/mpsl_hwres.c
@@ -7,7 +7,7 @@
 #include <mpsl_hwres_ppi.h>
 #include <helpers/nrfx_gppi.h>
 
-#if defined(DPPI_PRESENT) || defined(LUMOS_XXAA)
+#if defined(DPPI_PRESENT) || defined(CONFIG_SOC_SERIES_NRF54L) || defined(CONFIG_SOC_SERIES_NRF71)
 static bool mpsl_hwres_channel_alloc(uint32_t node_id, uint8_t *p_ch)
 {
 	int ch = nrfx_gppi_channel_alloc(node_id);
@@ -31,7 +31,7 @@ bool mpsl_hwres_dppi_channel_alloc(NRF_DPPIC_Type *p_dppic, uint8_t *p_dppi_ch)
 
 #if defined(PPIB_PRESENT)
 
-#if defined(LUMOS_XXAA)
+#if defined(CONFIG_SOC_SERIES_NRF54L) || defined(CONFIG_SOC_SERIES_NRF71)
 #include <soc/interconnect/nrfx_gppi_d2ppi.h>
 static uint32_t ppib_get_domain(NRF_PPIB_Type *p_ppib)
 {
@@ -56,7 +56,7 @@ static uint32_t ppib_get_domain(NRF_PPIB_Type *p_ppib)
 
 bool mpsl_hwres_ppib_channel_alloc(NRF_PPIB_Type *p_ppib, uint8_t *p_ppib_ch)
 {
-#if defined(LUMOS_XXAA)
+#if defined(CONFIG_SOC_SERIES_NRF54L) || defined(CONFIG_SOC_SERIES_NRF71)
 	return mpsl_hwres_channel_alloc(ppib_get_domain(p_ppib), p_ppib_ch);
 #else
 	(void)p_ppib;

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: bd565d8fbbd6e11b3b6528735e889239649deb9f
+      revision: pull/4299/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above

--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,6 @@ manifest:
           - dhara
           - edtt
           - fatfs
-          - hal_nordic
           - hal_st # required for ST sensors (unrelated to STM32 MCUs)
           - hal_tdk # required for Invensense sensors such as ICM42670
           - hal_wurthelektronik
@@ -118,6 +117,13 @@ manifest:
     #
     # Some of these are also Zephyr modules which have NCS-specific
     # changes.
+    - name: hal_nordic
+      revision: nrfx-removed
+      remote: zephyrproject
+      path: modules/hal/nor
+    - name: nrfx
+      revision: pull/1292/head
+      path: modules/hal/nor/nrfx
     - name: wfa-qt-control-app
       repo-path: sdk-wi-fiquicktrack-controlappc
       path: modules/lib/wfa-qt-control-app

--- a/west.yml
+++ b/west.yml
@@ -160,7 +160,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 48be4db2d52d873436103b6865e222e21380a565
+      revision: pull/262/head
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
Use pre-release nrfx revision.

Analogously to https://github.com/nrfconnect/sdk-nrf/pull/29098