### PR TITLE
doc: Replace m2r2 with myst-parser

### DIFF
--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -260,8 +260,8 @@ They can all be installed using the ``doc/requirements.txt`` file using ``pip``.
      - Version
    * - azure-storage-blob
      - :ncs-tool-version:`AZURE_STORAGE_BLOB_VERSION`
-   * - m2r2
-     - :ncs-tool-version:`M2R2_VERSION`
+   * - myst-parser
+     - :ncs-tool-version:`MYST_PARSER_VERSION`
    * - PyYAML
      - :ncs-tool-version:`PYYAML_VERSION`
    * - pykwalify

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -33,7 +33,8 @@ The following sections provide detailed lists of changes by component.
 IDE, OS, and tool support
 =========================
 
-|no_changes_yet_note|
+* Updated documentation build requirements to replace ``m2r2`` with ``myst-parser``.
+  See the :ref:`gs_recommended_versions` page for the updated tool list.
 
 Board support
 =============

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -10,7 +10,7 @@ anytree                         # |     |         |        |         |         |
 azure-storage-blob              # |  X  |         |        |         |         |      |        |
 beautifulsoup4                  # |     |         |        |         |         |      |        |
 doxmlparser                     # |     |         |        |         |         |      |   X    |
-m2r2                            # |     |         |        |         |         |      |        |
+myst-parser>=4,<5               # |     |         |        |         |         |  X   |        |
 natsort                         # |     |         |        |         |         |      |   x    |
 PyYAML                          # |  X  |         |        |         |         |      |   X    |
 pykwalify                       # |     |         |        |         |         |      |   X    |

--- a/doc/tfm/conf.py
+++ b/doc/tfm/conf.py
@@ -31,7 +31,7 @@ sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))
 
 extensions = [
-    "m2r2",
+    "myst_parser",
     "warnings_filter",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.intersphinx",


### PR DESCRIPTION
Follow upstream trusted-firmware-m
(1c8f9f8a2ae51fa06cd4330f42097df089ecaf37) and switch to myst-parser instead of m2r2 due to it being unmaintained.