### PR TITLE
doc: extensions: introducing ncs-file role

### DIFF
--- a/doc/_extensions/ncs_file.py
+++ b/doc/_extensions/ncs_file.py
@@ -1,0 +1,159 @@
+"""
+Copyright (c) 2026 Nordic Semiconductor ASA
+
+SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+A sphinx extension for referencing files inside of NCS workspace.
+
+Usage:
+    Reference a file directly by an absolute path from sdk-nrf root.
+    :ncs-file:`/doc/versions.json`
+
+    Reference a file relative to current file in sdk-nrf part of workspace.
+    :ncs-file:`../../samples/Kconfig`
+
+    Reference a file in one of the projects inside the workspace by using
+    project name from west.yaml specification. (Only absolute paths allowed
+    for references outside of sdk-nrf)
+    :ncs-file:`zephyr:/.checkpatch.conf`
+
+    Reference a file with an alias:
+    :ncs-file:`sample-alias <zephyr:.checkpatch.conf>`
+    :ncs-file:`sample-alias <../../samples/Kconfig>`
+
+    The alias can be quoted if it contgains "<" or ">" characters.
+    :ncs-file:`"sample-alias with < character" <zephyr:.checkpatch.conf>`
+
+    Quotes and "<>" characters can be escaped by repeating them.
+"""
+
+import os
+import re
+from pathlib import Path
+from typing import Any, override
+
+import utils
+from docutils import nodes
+from sphinx.application import Sphinx
+from sphinx.util.docutils import SphinxRole
+from west.manifest import Project
+
+__version__ = "0.0.1"
+
+NRF_BASE = Path(__file__).absolute().parents[2]
+
+
+class NcsFile(SphinxRole):
+    _default_repo = "sdk-nrf"
+    _link_re = re.compile(
+        r"^(?P<alias>(?:(?:\"(?:[^\"]|\"\")*\")|(?:'(?:[^']|'')*')|(?:[^\"'].*))\s*(?=<))?"
+        # match either quoted string using '' or "" as escapes or unquoted string
+        r"(?P<path>(?:<(?:[^<>]|<<|>>)*>)|(?:[^<]+))$"
+        # match eithere a string in <> using << and >> as escapes or any string without <
+    )
+
+    @staticmethod
+    def format_alias(raw: str) -> str:
+        res = raw.strip()
+        if res.startswith('"') or res.startswith("'"):
+            res = res[1:-1]
+        return res.replace('""', '"').replace("''", "'")
+
+    @staticmethod
+    def format_path(raw: str) -> str:
+        res = raw.strip()
+        if res.startswith("<"):
+            res = res[1:-1]
+        return res.replace("<<", "<").replace(">>", ">")
+
+    def get_page_prefix(self, path: str) -> str | None:
+        found_prefix = None
+        for pattern, prefix in self.env.app.config.gh_link_prefixes.items():
+            if re.match(pattern, path):
+                found_prefix = prefix
+                break
+        return found_prefix
+
+    def gh_link_get_url(self, path: str, mode: str = "blob") -> str:
+        page_prefix = self.get_page_prefix(path)
+        if page_prefix is None:
+            raise FileNotFoundError
+
+        if not (NRF_BASE / page_prefix / path).exists():
+            raise FileNotFoundError
+
+        return "/".join(
+            [
+                self.env.app.config.gh_link_base_url,
+                mode,
+                self.env.app.config.gh_link_version,
+                page_prefix,
+                path,
+            ]
+        )
+
+    def error(self, info: str) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+        msg = self.inliner.reporter.error(info, line=self.lineno)
+        prb = self.inliner.problematic(self.rawtext, self.rawtext, msg)
+        return [prb], [msg]
+
+    def get_url_non_nrf(self, project: Project, path: str | os.PathLike) -> str:
+        path = Path(path)
+        revision = project.revision
+        url = project.url
+        path = path.relative_to(path.anchor)
+        if not os.path.exists(os.path.join(project.abspath, path)):
+            raise FileNotFoundError
+        return os.path.join(url, "blob", revision, path)
+
+    def parse_path(self, path: str) -> tuple[str, str]:
+        colon = path.find(":")
+
+        if colon != -1:
+            selected_proj = path[:colon].strip()
+            path = path[colon + 1 :]
+            if selected_proj != self._default_repo:
+                proj = utils.MANIFEST.get_projects([selected_proj])[0]
+                return os.path.basename(path), self.get_url_non_nrf(proj, path)
+
+        if os.path.isabs(path):
+            tmp = Path(path)
+            path = tmp.relative_to(tmp.anchor).as_posix()
+            if not (NRF_BASE / path).exists():
+                raise FileNotFoundError
+            return os.path.basename(path), os.path.join(
+                self.config.gh_link_base_url, "blob", self.config.gh_link_version, path
+            )
+
+        path = (
+            self.env.doc2path(self.env.docname).relative_to(self.env.app.srcdir).parent / path
+        ).as_posix()
+        return os.path.basename(path), self.gh_link_get_url(path)
+
+    @override
+    def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+        match = self._link_re.match(self.text)
+        if not match:
+            return self.error("Failed to parse ncs-file content")
+
+        if not (path := match.group("path")):
+            return self.error("Failed to parse path out of ncs-file content")
+
+        try:
+            alias, url = self.parse_path(self.format_path(path))
+        except FileNotFoundError:
+            return self.error(f"Failed to locate file {path} in directive {self.text}")
+
+        if match.group("alias"):
+            alias = self.format_alias(match.group("alias"))
+        return [nodes.reference(self.text, alias, refuri=url)], []
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    app.add_role("ncs-file", NcsFile())
+    return {
+        "version": __version__,
+        "env_version": 1,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/_extensions/ncs_file.py
+++ b/doc/_extensions/ncs_file.py
@@ -1,0 +1,172 @@
+"""
+Copyright (c) 2026 Nordic Semiconductor ASA
+
+SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+A sphinx extension for referencing files inside of NCS workspace.
+
+Usage:
+    Reference a file directly by an absolute path from sdk-nrf root.
+    :ncs-file:`/doc/versions.json`
+
+    Reference a file relative to current file in sdk-nrf part of workspace.
+    :ncs-file:`../../samples/Kconfig`
+
+    Reference a file in one of the projects inside the workspace by using
+    project name from west.yaml specification. (Only absolute paths allowed
+    for references outside of sdk-nrf)
+    :ncs-file:`zephyr:/.checkpatch.conf`
+
+    Reference a file with an alias:
+    :ncs-file:`sample-alias <zephyr:.checkpatch.conf>`
+    :ncs-file:`sample-alias <../../samples/Kconfig>`
+
+    The alias can be quoted if it contgains "<" or ">" characters.
+    :ncs-file:`"sample-alias with < character" <zephyr:.checkpatch.conf>`
+
+    Quotes and "<>" characters can be escaped by repeating them.
+"""
+
+import os
+import re
+import subprocess
+from functools import cached_property
+from pathlib import Path
+from typing import Any, override
+
+import utils
+from docutils import nodes
+from sphinx.application import Sphinx
+from sphinx.util.docutils import SphinxRole
+from west.manifest import Project
+
+__version__ = "0.0.1"
+
+NRF_BASE = Path(__file__).absolute().parents[2]
+
+
+class NcsFile(SphinxRole):
+    _default_repo = "sdk-nrf"
+    _default_repo_path = Path(__file__).parents[1]
+    _link_re = re.compile(
+        r"^(?P<alias>(?:(?:\"(?:[^\"]|\"\")*\")|(?:'(?:[^']|'')*')|(?:[^\"'].*))\s*(?=<))?"
+        # match either quoted string using '' or "" as escapes or unquoted string
+        r"(?P<path>(?:<(?:[^<>]|<<|>>)*>)|(?:[^<]+))$"
+        # match eithere a string in <> using << and >> as escapes or any string without <
+    )
+
+    @staticmethod
+    def format_alias(raw: str) -> str:
+        res = raw.strip()
+        if res.startswith('"') or res.startswith("'"):
+            res = res[1:-1]
+        return res.replace('""', '"').replace("''", "'")
+
+    @staticmethod
+    def format_path(raw: str) -> str:
+        res = raw.strip()
+        if res.startswith("<"):
+            res = res[1:-1]
+        return res.replace("<<", "<").replace(">>", ">")
+
+    def get_page_prefix(self, path: str) -> str | None:
+        found_prefix = None
+        for pattern, prefix in self.env.app.config.gh_link_prefixes.items():
+            if re.match(pattern, path):
+                found_prefix = prefix
+                break
+        return found_prefix
+
+    def gh_link_get_url(self, path: str, mode: str = "blob") -> str:
+        page_prefix = self.get_page_prefix(path)
+        if page_prefix is None:
+            raise FileNotFoundError
+
+        if not (NRF_BASE / page_prefix / path).exists():
+            raise FileNotFoundError
+
+        return "/".join(
+            [
+                self.env.app.config.gh_link_base_url,
+                mode,
+                self.manifest_repo_sha,
+                page_prefix,
+                path,
+            ]
+        )
+
+    def error(self, info: str) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+        msg = self.inliner.reporter.error(info, line=self.lineno)
+        prb = self.inliner.problematic(self.rawtext, self.rawtext, msg)
+        return [prb], [msg]
+
+    def get_url_non_nrf(self, project: Project, path: str | os.PathLike) -> str:
+        path = Path(path)
+        revision = project.revision
+        url = project.url
+        path = path.relative_to(path.anchor)
+        if not project.abspath:
+            raise FileNotFoundError
+        if not (Path(project.abspath) / path).is_file():
+            raise FileNotFoundError
+        return os.path.join(url, "blob", revision, path)
+
+    @cached_property
+    def manifest_repo_sha(self) -> str:
+        return (
+            subprocess.check_output(["git", "-C", self._default_repo_path, "rev-parse", "HEAD"])
+            .decode()
+            .strip()
+        )
+
+    def parse_path(self, path: str) -> tuple[str, str]:
+        colon = path.find(":")
+
+        if colon != -1:
+            selected_proj = path[:colon].strip()
+            path = path[colon + 1 :]
+            if selected_proj != self._default_repo:
+                proj = utils.MANIFEST.get_projects([selected_proj])[0]
+                return os.path.basename(path), self.get_url_non_nrf(proj, path)
+
+        if os.path.isabs(path):
+            tmp = Path(path)
+            path = tmp.relative_to(tmp.anchor).as_posix()
+            if not (NRF_BASE / path).exists():
+                raise FileNotFoundError
+            return os.path.basename(path), os.path.join(
+                self.config.gh_link_base_url, "blob", self.manifest_repo_sha, path
+            )
+
+        path = (
+            self.env.doc2path(self.env.docname).relative_to(self.env.app.srcdir).parent / path
+        ).as_posix()
+        return os.path.basename(path), self.gh_link_get_url(path)
+
+    @override
+    def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+        match = self._link_re.match(self.text)
+        if not match:
+            return self.error("Failed to parse ncs-file content")
+
+        if not (path := match.group("path")):
+            return self.error("Failed to parse path out of ncs-file content")
+
+        try:
+            alias, url = self.parse_path(self.format_path(path))
+        except FileNotFoundError:
+            return self.error(f"Failed to locate file {path} in directive {self.text}")
+
+        if match.group("alias"):
+            alias = self.format_alias(match.group("alias"))
+        return [nodes.reference(self.text, alias, refuri=url)], []
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    app.add_role("ncs-file", NcsFile())
+    return {
+        "version": __version__,
+        "env_version": 1,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/_utils/utils.py
+++ b/doc/_utils/utils.py
@@ -14,7 +14,7 @@ from west.manifest import Manifest
 _NRF_BASE = Path(__file__).parents[2]
 """NCS Repository root"""
 
-_MANIFEST = Manifest.from_file(_NRF_BASE / "west.yml")
+MANIFEST = Manifest.from_file(_NRF_BASE / "west.yml")
 """Manifest instance"""
 
 ALL_DOCSETS = {
@@ -36,7 +36,7 @@ OPTIONAL_DOCSETS = {
 
 # append optional docsets if they exist
 for docset, props in OPTIONAL_DOCSETS.items():
-    for p in _MANIFEST.projects:
+    for p in MANIFEST.projects:
         if p.name != props[2] or not (Path(p.topdir) / Path(p.path)).exists():
             continue
 
@@ -57,7 +57,7 @@ def get_projdir(docset: str) -> Path:
     if not name:
         raise ValueError("Given docset has no associated project")
 
-    p = next((p for p in _MANIFEST.projects if p.name == name), None)
+    p = next((p for p in MANIFEST.projects if p.name == name), None)
     assert p, f"Project {name} not in manifest"
 
     return Path(p.topdir) / Path(p.path)

--- a/doc/_utils/utils.py
+++ b/doc/_utils/utils.py
@@ -15,7 +15,7 @@ from west.manifest import Manifest
 _NRF_BASE = Path(__file__).parents[2]
 """NCS Repository root"""
 
-_MANIFEST = Manifest.from_file(_NRF_BASE / "west.yml")
+MANIFEST = Manifest.from_file(_NRF_BASE / "west.yml")
 """Manifest instance"""
 
 _DOCS_BASEURL = "https://nrfconnectdocs.nordicsemi.com/ncs/{version}/{docset}/"
@@ -40,7 +40,7 @@ OPTIONAL_DOCSETS = {
 
 # append optional docsets if they exist
 for docset, props in OPTIONAL_DOCSETS.items():
-    for p in _MANIFEST.projects:
+    for p in MANIFEST.projects:
         if p.name != props[2] or not (Path(p.topdir) / Path(p.path)).exists():
             continue
 
@@ -61,7 +61,7 @@ def get_projdir(docset: str) -> Path:
     if not name:
         raise ValueError("Given docset has no associated project")
 
-    p = next((p for p in _MANIFEST.projects if p.name == name), None)
+    p = next((p for p in MANIFEST.projects if p.name == name), None)
     assert p, f"Project {name} not in manifest"
 
     return Path(p.topdir) / Path(p.path)

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -63,7 +63,8 @@ extensions = [
     "memory_table",
     "sphinxcontrib.plantuml",
     "sphinxcontrib.programoutput",
-    "sphinxcontrib.jquery"
+    "sphinxcontrib.jquery",
+    "ncs_file",
 ]
 
 linkcheck_ignore = [

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -61,6 +61,7 @@ extensions = [
     "samples",
     "sphinx_sitemap",
     "external_sw_versions",
+    "ncs_file",
 ]
 
 linkcheck_ignore = [

--- a/doc/nrf/dev_model_and_contributions/documentation/styleguide.rst
+++ b/doc/nrf/dev_model_and_contributions/documentation/styleguide.rst
@@ -91,6 +91,56 @@ If you want to change the link text::
 
    :ref:`Zephyr coding style <zephyr:coding_style>`
 
+Files in the |NCS| repositories
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To link to a file in the |NCS| west workspace, use the ``:ncs-file:`` role.
+Do not define these links in the :file:`links.txt` file and do not type the GitHub URL manually.
+The role builds the URL from the documentation version, and, for files in other repositories, from the revision specified in the :file:`west.yml` file.
+This keeps the links valid in each release.
+
+The role also checks that the file exists when the documentation is built.
+If the file is missing, the documentation build fails.
+
+Use one of the following forms:
+
+* A path from the root of the ``sdk-nrf`` repository, starting with a slash::
+
+     :ncs-file:`/doc/versions.json`
+
+* A path relative to the file you are editing, for files in the same directory::
+
+     :ncs-file:`prj.conf`
+
+* A path from the root of another repository in the workspace, where the prefix is the project name from the :file:`west.yml` file::
+
+     :ncs-file:`zephyr:/.checkpatch.conf`
+
+The above examples render as follows:
+
+* :ncs-file:`/doc/versions.json`
+* :ncs-file:`styleguide.rst`
+* :ncs-file:`zephyr:/.checkpatch.conf`
+
+By default, the link text is the name of the file, without the path.
+To use a different link text, place the path in angle brackets::
+
+   :ncs-file:`configuration file <prj.conf>`
+
+For example, :ncs-file:`documentation style guide <styleguide.rst>` links to the source file of this page.
+
+.. note::
+   The ``:ncs-file:`` role is only available in the |NCS| documentation set.
+   Do not use it in files that are also included in other documentation sets.
+
+If you want to show a file path without linking to it, use the ``:file:`` role instead.
+
+.. note::
+   The |NCS| documentation set also provides the ``:zephyr_file:`` and ``:module_file:`` roles, which come from the Zephyr documentation extensions.
+   Do not use them in new content.
+   In the |NCS| documentation set, these roles do not verify that the file exists, so the links break silently when a file is moved or renamed.
+   Use ``:ncs-file:`` instead.
+
 Replacements
 ------------
 


### PR DESCRIPTION
A new role is introduced in order to allow referencing files inside of west workspace without providing full github urls.

Usage:
```rst
    Reference a file directly by an absolute path from sdk-nrf root.
    :ncs-file:`/doc/versions.json`
    Reference a file relative to current file in sdk-nrf part of workspace.
    :ncs-file:`../../samples/Kconfig`
    Reference a file in one of the projects inside the workspace by using
    project name from west.yaml specification. (Only absolute paths allowed
    for references outside of sdk-nrf)
    :ncs-file:`zephyr:/.checkpatch.conf`
    Reference a file with an alias:
    :ncs-file:`sample-alias <zephyr:.checkpatch.conf>`
    :ncs-file:`sample-alias <../../samples/Kconfig>`
    The alias can be quoted if it contgains "<" or ">" characters.
    :ncs-file:`"sample-alias with < character" <zephyr:.checkpatch.conf>`
    Quotes and "<>" characters can be escaped by repeating them.
```