### PR TITLE
nrf_security: cracen: Make KMU Protected RAM scheme support configurable

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/Kconfig
+++ b/subsys/nrf_security/src/drivers/cracen/Kconfig
@@ -72,6 +72,17 @@ config CRACEN_KMU
 	help
 	  Activate CRACEN Key Management Unit (KMU) functionality for the PSA layer.
 
+config CRACEN_KMU_PROTECTED_RAM
+	bool "KMU protected RAM key usage scheme"
+	depends on CRACEN_KMU
+	default y
+	help
+	  Enable driver support for the KMU Protected RAM key usage scheme. This
+	  scheme relies on two reserved KMU slots (248 and 249) holding invalidation data
+	  that is pushed to protected RAM after use.
+
+if CRACEN_KMU_PROTECTED_RAM
+
 config CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS
 	bool "Provision protected RAM invalidation slots with nrfutil (informative only, do not change)"
 	help
@@ -86,7 +97,6 @@ if !CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS
 
 config CRACEN_PROVISION_PROT_RAM_INV_SLOTS_ON_INIT
 	bool "Provision protected RAM invalidation slots on boot"
-	depends on CRACEN_KMU
 	default y
 	help
 	  Provision the protected RAM invalidation data in the KMU. This will generate random
@@ -97,7 +107,6 @@ config CRACEN_PROVISION_PROT_RAM_INV_SLOTS_ON_INIT
 
 config CRACEN_PROVISION_PROT_RAM_INV_SLOTS_WITH_IMPORT
 	bool "Provision protected RAM invalidation slots using psa_import_key"
-	depends on CRACEN_KMU
 	help
 	  Provision the protected RAM invalidation KMU slots (248,249) in the KMU using a
 	  psa_import_key call. The application is required to call psa_import_key with the
@@ -107,6 +116,8 @@ config CRACEN_PROVISION_PROT_RAM_INV_SLOTS_WITH_IMPORT
 	  image is flashed. This is not meant to be used by user applications.
 
 endif # CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS
+
+endif # CRACEN_KMU_PROTECTED_RAM
 
 config CRACEN_IKG
 	bool "CRACEN IKG"

--- a/subsys/nrf_security/src/drivers/cracen/common/src/cracen/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/common/src/cracen/common.c
@@ -248,12 +248,13 @@ psa_status_t cracen_load_keyref(const psa_key_attributes_t *attributes, const ui
 			k->key = kmu_push_area;
 
 			return PSA_SUCCESS;
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 		case CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED:
 			k->sz = PSA_BITS_TO_BYTES(psa_get_key_bits(attributes));
 			k->key = (const uint8_t *)CRACEN_PROTECTED_RAM_AES_KEY0;
 
 			return PSA_SUCCESS;
-
+#endif
 		default:
 			return PSA_ERROR_NOT_PERMITTED;
 		}
@@ -275,24 +276,24 @@ psa_status_t cracen_load_keyref(const psa_key_attributes_t *attributes, const ui
 		k->prepare_key = NULL;
 		k->clean_key = NULL;
 
-		switch (MBEDTLS_SVC_KEY_ID_GET_KEY_ID(psa_get_key_id(attributes))) {
-		case CRACEN_PROTECTED_RAM_AES_KEY0_ID:
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
+		uint32_t key_id = MBEDTLS_SVC_KEY_ID_GET_KEY_ID(psa_get_key_id(attributes));
+
+		if (key_id == CRACEN_PROTECTED_RAM_AES_KEY0_ID) {
 			k->sz = 32;
 			k->key = (const uint8_t *)CRACEN_PROTECTED_RAM_AES_KEY0;
-			break;
-		default:
-			if (key_buffer_size == 0) {
-				return PSA_ERROR_CORRUPTION_DETECTED;
-			}
 
-			/* Normal transparent key. */
-			k->key = key_buffer;
-			k->sz = key_buffer_size;
+			return PSA_SUCCESS;
 		}
-	} else {
-		k->key = key_buffer;
-		k->sz = key_buffer_size;
+#endif
+
+		if (key_buffer_size == 0) {
+			return PSA_ERROR_CORRUPTION_DETECTED;
+		}
 	}
+
+	k->key = key_buffer;
+	k->sz = key_buffer_size;
 
 	return PSA_SUCCESS;
 }

--- a/subsys/nrf_security/src/drivers/cracen/common/src/cracen/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/common/src/cracen/common.c
@@ -248,12 +248,13 @@ psa_status_t cracen_load_keyref(const psa_key_attributes_t *attributes, const ui
 			k->key = kmu_push_area;
 
 			return PSA_SUCCESS;
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 		case CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED:
 			k->sz = PSA_BITS_TO_BYTES(psa_get_key_bits(attributes));
 			k->key = (const uint8_t *)CRACEN_PROTECTED_RAM_AES_KEY0;
 
 			return PSA_SUCCESS;
-
+#endif
 		default:
 			return PSA_ERROR_NOT_PERMITTED;
 		}
@@ -275,20 +276,24 @@ psa_status_t cracen_load_keyref(const psa_key_attributes_t *attributes, const ui
 		k->prepare_key = NULL;
 		k->clean_key = NULL;
 
-		switch (MBEDTLS_SVC_KEY_ID_GET_KEY_ID(psa_get_key_id(attributes))) {
-		case CRACEN_PROTECTED_RAM_AES_KEY0_ID:
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
+		uint32_t key_id = MBEDTLS_SVC_KEY_ID_GET_KEY_ID(psa_get_key_id(attributes));
+
+		if (key_id == CRACEN_PROTECTED_RAM_AES_KEY0_ID) {
 			k->sz = 32;
 			k->key = (const uint8_t *)CRACEN_PROTECTED_RAM_AES_KEY0;
-			break;
-		default:
-			if (key_buffer_size == 0) {
-				return PSA_ERROR_CORRUPTION_DETECTED;
-			}
 
-			/* Normal transparent key. */
-			k->key = key_buffer;
-			k->sz = key_buffer_size;
+			return PSA_SUCCESS;
 		}
+#endif
+
+		if (key_buffer_size == 0) {
+			return PSA_ERROR_CORRUPTION_DETECTED;
+		}
+
+		/* Normal transparent key. */
+		k->key = key_buffer;
+		k->sz = key_buffer_size;
 	} else {
 		k->key = key_buffer;
 		k->sz = key_buffer_size;

--- a/subsys/nrf_security/src/drivers/cracen/common/src/cracen/hardware/hardware.c
+++ b/subsys/nrf_security/src/drivers/cracen/common/src/cracen/hardware/hardware.c
@@ -163,6 +163,7 @@ int cracen_init(void)
 		}
 	}
 
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 #if defined(CONFIG_CRACEN_PROVISION_PROT_RAM_INV_SLOTS_ON_INIT)
 	status = cracen_provision_prot_ram_inv_slots();
 	if (status != PSA_SUCCESS) {
@@ -170,9 +171,8 @@ int cracen_init(void)
 	}
 #endif /* CONFIG_CRACEN_PROVISION_PROT_RAM_INV_SLOTS_ON_INIT */
 
-#if defined(CONFIG_PSA_NEED_CRACEN_KMU_DRIVER)
 	status = cracen_push_prot_ram_inv_slots();
-#endif
+#endif /* CONFIG_CRACEN_KMU_PROTECTED_RAM */
 
 exit:
 	cracen_release();

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_kmu.c
@@ -362,7 +362,9 @@ int cracen_kmu_prepare_key(const uint8_t *user_data)
 
 	switch (key->key_usage_scheme) {
 	case CRACEN_KMU_KEY_USAGE_SCHEME_RAW:
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 	case CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED:
+#endif /* CONFIG_CRACEN_KMU_PROTECTED_RAM */
 		if (nrfx_kmu_key_slots_push(key->slot_id, key->number_of_slots) != 0) {
 			return SX_ERR_UNKNOWN_ERROR;
 		}
@@ -397,6 +399,7 @@ int cracen_kmu_prepare_key(const uint8_t *user_data)
 	return SX_OK;
 }
 
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 psa_status_t cracen_push_prot_ram_inv_slots(void)
 {
 	bool any_slot_empty;
@@ -417,16 +420,21 @@ psa_status_t cracen_push_prot_ram_inv_slots(void)
 	}
 	return PSA_SUCCESS;
 }
+#endif /* CONFIG_CRACEN_KMU_PROTECTED_RAM */
 
 int cracen_kmu_clean_key(const uint8_t *user_data)
 {
 	const kmu_opaque_key_buffer *key = (const kmu_opaque_key_buffer *)user_data;
 
+	ARG_UNUSED(key);
+
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 	if (key->key_usage_scheme == CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED) {
 		if (cracen_push_prot_ram_inv_slots() != PSA_SUCCESS) {
 			return SX_ERR_UNKNOWN_ERROR;
 		}
 	}
+#endif /* CONFIG_CRACEN_KMU_PROTECTED_RAM */
 
 	safe_memzero(kmu_push_area, sizeof(kmu_push_area));
 
@@ -879,6 +887,7 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 		return PSA_ERROR_DATA_INVALID;
 	}
 
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 	if (metadata->key_usage_scheme == CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED) {
 		/* Only AES keys are supported. */
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
@@ -893,6 +902,7 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 			return PSA_ERROR_CORRUPTION_DETECTED;
 		}
 	}
+#endif
 
 	return PSA_SUCCESS;
 }
@@ -912,6 +922,9 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 
 	switch (metadata->key_usage_scheme) {
 	case CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED:
+#if !defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
+		return PSA_ERROR_NOT_SUPPORTED;
+#endif
 	case CRACEN_KMU_KEY_USAGE_SCHEME_SEED:
 	case CRACEN_KMU_KEY_USAGE_SCHEME_ENCRYPTED:
 	case CRACEN_KMU_KEY_USAGE_SCHEME_RAW:
@@ -920,6 +933,7 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 	if (metadata->key_usage_scheme == CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED) {
 		if (psa_get_key_usage_flags(key_attr) & PSA_KEY_USAGE_EXPORT) {
 			return PSA_ERROR_INVALID_ARGUMENT;
@@ -928,6 +942,7 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 			return PSA_ERROR_INVALID_ARGUMENT;
 		}
 	}
+#endif
 
 	if (metadata->key_usage_scheme == CRACEN_KMU_KEY_USAGE_SCHEME_SEED) {
 		metadata->rpolicy = NRFX_KMU_RPOLICY_LOCKED;
@@ -1094,6 +1109,7 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		break;
 #endif /* PSA_NEED_CRACEN_ECDH */
 	default:
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 		/* Ignore the algorithm for the protected ram invalidation kmu slot because
 		 * it will never be used for crypto operations.
 		 */
@@ -1102,6 +1118,9 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		if (kmu_slot != PROTECTED_RAM_INVALIDATION_DATA_SLOT1) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
+#else
+		return PSA_ERROR_NOT_SUPPORTED;
+#endif
 	}
 
 	psa_key_usage_t resulting_usage = 0;
@@ -1140,6 +1159,7 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 	metadata->key_usage_scheme = CRACEN_PSA_GET_KEY_USAGE_SCHEME(
 		MBEDTLS_SVC_KEY_ID_GET_KEY_ID(psa_get_key_id(key_attr)));
 
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 	if (metadata->key_usage_scheme == CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED) {
 		if (psa_get_key_usage_flags(key_attr) & PSA_KEY_USAGE_EXPORT) {
 			return PSA_ERROR_INVALID_ARGUMENT;
@@ -1148,6 +1168,7 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 			return PSA_ERROR_INVALID_ARGUMENT;
 		}
 	}
+#endif
 
 	switch (PSA_KEY_LIFETIME_GET_PERSISTENCE(psa_get_key_lifetime(key_attr))) {
 	case PSA_KEY_PERSISTENCE_READ_ONLY:
@@ -1194,6 +1215,7 @@ psa_status_t cracen_kmu_provision(const psa_key_attributes_t *key_attr, int slot
 	}
 
 	switch (metadata.key_usage_scheme) {
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 	case CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED:
 		/* Only AES keys are supported. */
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
@@ -1207,6 +1229,7 @@ psa_status_t cracen_kmu_provision(const psa_key_attributes_t *key_attr, int slot
 			return PSA_ERROR_INVALID_ARGUMENT;
 		}
 		break;
+#endif /* CONFIG_CRACEN_KMU_PROTECTED_RAM */
 #ifdef PSA_NEED_CRACEN_KMU_ENCRYPTED_KEYS
 	case CRACEN_KMU_KEY_USAGE_SCHEME_ENCRYPTED:
 		if (key_buffer_size > CRACEN_KMU_PUSH_AREA_SIZE) {

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_kmu.c
@@ -362,7 +362,9 @@ int cracen_kmu_prepare_key(const uint8_t *user_data)
 
 	switch (key->key_usage_scheme) {
 	case CRACEN_KMU_KEY_USAGE_SCHEME_RAW:
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 	case CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED:
+#endif /* CONFIG_CRACEN_KMU_PROTECTED_RAM */
 		if (nrfx_kmu_key_slots_push(key->slot_id, key->number_of_slots) != 0) {
 			return SX_ERR_UNKNOWN_ERROR;
 		}
@@ -397,6 +399,7 @@ int cracen_kmu_prepare_key(const uint8_t *user_data)
 	return SX_OK;
 }
 
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 psa_status_t cracen_push_prot_ram_inv_slots(void)
 {
 	bool any_slot_empty;
@@ -417,9 +420,13 @@ psa_status_t cracen_push_prot_ram_inv_slots(void)
 	}
 	return PSA_SUCCESS;
 }
+#endif /* CONFIG_CRACEN_KMU_PROTECTED_RAM */
 
 int cracen_kmu_clean_key(const uint8_t *user_data)
 {
+	ARG_UNUSED(user_data);
+
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 	const kmu_opaque_key_buffer *key = (const kmu_opaque_key_buffer *)user_data;
 
 	if (key->key_usage_scheme == CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED) {
@@ -427,6 +434,7 @@ int cracen_kmu_clean_key(const uint8_t *user_data)
 			return SX_ERR_UNKNOWN_ERROR;
 		}
 	}
+#endif /* CONFIG_CRACEN_KMU_PROTECTED_RAM */
 
 	safe_memzero(kmu_push_area, sizeof(kmu_push_area));
 
@@ -879,6 +887,7 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 		return PSA_ERROR_DATA_INVALID;
 	}
 
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 	if (metadata->key_usage_scheme == CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED) {
 		/* Only AES keys are supported. */
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
@@ -893,6 +902,7 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 			return PSA_ERROR_CORRUPTION_DETECTED;
 		}
 	}
+#endif
 
 	return PSA_SUCCESS;
 }
@@ -912,6 +922,9 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 
 	switch (metadata->key_usage_scheme) {
 	case CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED:
+#if !defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
+		return PSA_ERROR_NOT_SUPPORTED;
+#endif
 	case CRACEN_KMU_KEY_USAGE_SCHEME_SEED:
 	case CRACEN_KMU_KEY_USAGE_SCHEME_ENCRYPTED:
 	case CRACEN_KMU_KEY_USAGE_SCHEME_RAW:
@@ -920,6 +933,7 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 	if (metadata->key_usage_scheme == CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED) {
 		if (psa_get_key_usage_flags(key_attr) & PSA_KEY_USAGE_EXPORT) {
 			return PSA_ERROR_INVALID_ARGUMENT;
@@ -928,6 +942,7 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 			return PSA_ERROR_INVALID_ARGUMENT;
 		}
 	}
+#endif
 
 	if (metadata->key_usage_scheme == CRACEN_KMU_KEY_USAGE_SCHEME_SEED) {
 		metadata->rpolicy = NRFX_KMU_RPOLICY_LOCKED;
@@ -1094,6 +1109,7 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		break;
 #endif /* PSA_NEED_CRACEN_ECDH */
 	default:
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 		/* Ignore the algorithm for the protected ram invalidation kmu slot because
 		 * it will never be used for crypto operations.
 		 */
@@ -1102,6 +1118,9 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		if (kmu_slot != PROTECTED_RAM_INVALIDATION_DATA_SLOT1) {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
+#else
+		return PSA_ERROR_NOT_SUPPORTED;
+#endif
 	}
 
 	psa_key_usage_t resulting_usage = 0;
@@ -1140,6 +1159,7 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 	metadata->key_usage_scheme = CRACEN_PSA_GET_KEY_USAGE_SCHEME(
 		MBEDTLS_SVC_KEY_ID_GET_KEY_ID(psa_get_key_id(key_attr)));
 
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 	if (metadata->key_usage_scheme == CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED) {
 		if (psa_get_key_usage_flags(key_attr) & PSA_KEY_USAGE_EXPORT) {
 			return PSA_ERROR_INVALID_ARGUMENT;
@@ -1148,6 +1168,7 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 			return PSA_ERROR_INVALID_ARGUMENT;
 		}
 	}
+#endif
 
 	switch (PSA_KEY_LIFETIME_GET_PERSISTENCE(psa_get_key_lifetime(key_attr))) {
 	case PSA_KEY_PERSISTENCE_READ_ONLY:
@@ -1194,6 +1215,7 @@ psa_status_t cracen_kmu_provision(const psa_key_attributes_t *key_attr, int slot
 	}
 
 	switch (metadata.key_usage_scheme) {
+#if defined(CONFIG_CRACEN_KMU_PROTECTED_RAM)
 	case CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED:
 		/* Only AES keys are supported. */
 		if (psa_get_key_type(key_attr) != PSA_KEY_TYPE_AES) {
@@ -1207,6 +1229,7 @@ psa_status_t cracen_kmu_provision(const psa_key_attributes_t *key_attr, int slot
 			return PSA_ERROR_INVALID_ARGUMENT;
 		}
 		break;
+#endif /* CONFIG_CRACEN_KMU_PROTECTED_RAM */
 #ifdef PSA_NEED_CRACEN_KMU_ENCRYPTED_KEYS
 	case CRACEN_KMU_KEY_USAGE_SCHEME_ENCRYPTED:
 		if (key_buffer_size > CRACEN_KMU_PUSH_AREA_SIZE) {


### PR DESCRIPTION
Add CONFIG_CRACEN_KMU_PROTECTED_RAM (default y) to make CRACEN KMU
support for the Protected RAM key scheme itself configurable, nesting
the existing slot-provisioning options under it instead of always
compiling the scheme in.

This benefits users that don't use Protected RAM keys in the following ways:

300 bytes reduced code size.
No need to provision or push an invalidation key (on every cracen init), which improves runtime.
Reduced attack surface, compiling out unused features prevents accidental and/or malicous use of the feature.