### PR TITLE
lib: hw_id: support UUID on nRF53, nRF54

### DIFF
--- a/doc/nrf/libraries/others/hw_id.rst
+++ b/doc/nrf/libraries/others/hw_id.rst
@@ -20,7 +20,7 @@ To enable the library, set the :kconfig:option:`CONFIG_HW_ID_LIBRARY` Kconfig op
 You can configure one of the following Kconfig options to choose the hardware ID:
 
 * :kconfig:option:`CONFIG_HW_ID_LIBRARY_SOURCE_IMEI` - This option specifies the :term:`International Mobile (Station) Equipment Identity (IMEI)` of the modem.
-* :kconfig:option:`CONFIG_HW_ID_LIBRARY_SOURCE_UUID` - This option specifies the UUID of the modem.
+* :kconfig:option:`CONFIG_HW_ID_LIBRARY_SOURCE_UUID` - This option specifies the UUID of the modem on nRF91 Series devices and read from FICR otherwise.
 * :kconfig:option:`CONFIG_HW_ID_LIBRARY_SOURCE_BT_DEVICE_ADDRESS` - This option specifies the Bluetooth® Device Address.
 * :kconfig:option:`CONFIG_HW_ID_LIBRARY_SOURCE_NET_MAC` - This option specifies the MAC address of the default network interface.
 * :kconfig:option:`CONFIG_HW_ID_LIBRARY_SOURCE_DEVICE_ID` - This option specifies a serial number provided by Zephyr's HW Info API.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -666,6 +666,10 @@ Other libraries
 
   * Added support for the nRF54LC10A SoC.
 
+* :ref:`lib_hw_id` library:
+
+  * Added UUID support for the nRF54L Series and the nRF5340 SoC.
+
 Shell libraries
 ---------------
 

--- a/lib/hw_id/Kconfig
+++ b/lib/hw_id/Kconfig
@@ -22,9 +22,9 @@ config HW_ID_LIBRARY_SOURCE_IMEI
 
 config HW_ID_LIBRARY_SOURCE_UUID
 	bool "UUID"
-	depends on MODEM_JWT
+	depends on (MODEM_JWT || !SOC_SERIES_NRF91)
 	help
-	  This option requires modem firmware v1.3.0 or higher.
+	  On nRF9160, this option requires modem firmware v1.3.0 or higher.
 
 config HW_ID_LIBRARY_SOURCE_BT_DEVICE_ADDRESS
 	bool "Bluetooth Device Address"

--- a/lib/hw_id/hw_id.c
+++ b/lib/hw_id/hw_id.c
@@ -7,6 +7,10 @@
 #include <hw_id.h>
 #include <zephyr/kernel.h>
 
+#if !defined(CONFIG_BOARD_NATIVE_SIM)
+#include <nrfx.h>
+#endif
+
 /* includes for the different HW ID sources */
 #if defined(CONFIG_HW_ID_LIBRARY_SOURCE_BT_DEVICE_ADDRESS)
 #include <zephyr/bluetooth/bluetooth.h>
@@ -15,7 +19,9 @@
 #include <zephyr/drivers/hwinfo.h>
 #endif /* defined(CONFIG_HW_ID_LIBRARY_SOURCE_DEVICE_ID) */
 #if defined(CONFIG_HW_ID_LIBRARY_SOURCE_UUID)
+#if defined(CONFIG_SOC_SERIES_NRF91)
 #include <modem/modem_jwt.h>
+#endif /* defined(CONFIG_SOC_SERIES_NRF91) */
 #endif /* defined(CONFIG_HW_ID_LIBRARY_SOURCE_UUID) */
 #if defined(CONFIG_HW_ID_LIBRARY_SOURCE_IMEI)
 #include <nrf_modem_at.h>
@@ -87,6 +93,7 @@ int hw_id_get(char *buf, size_t buf_len)
 #if defined(CONFIG_HW_ID_LIBRARY_SOURCE_UUID)
 /* Request a UUID from the modem */
 
+#if defined(CONFIG_SOC_SERIES_NRF91)
 int hw_id_get(char *buf, size_t buf_len)
 {
 	if (buf == NULL || buf_len < HW_ID_LEN) {
@@ -104,6 +111,35 @@ int hw_id_get(char *buf, size_t buf_len)
 	snprintk(buf, buf_len, "%s", dev.str);
 	return 0;
 }
+#else
+int hw_id_get(char *buf, size_t buf_len)
+{
+	uint32_t uuid_words[4] = { 0 };
+	uint8_t *uuid_bytes = (uint8_t *)uuid_words;
+
+	if (buf == NULL || buf_len < HW_ID_LEN) {
+		return -EINVAL;
+	}
+#if defined(CONFIG_SOC_SERIES_NRF53)
+	uuid_words[0] = NRF_FICR_NS->INFO.PART;
+	uuid_words[1] = NRF_FICR_NS->INFO.VARIANT;
+	uuid_words[2] = NRF_FICR_NS->INFO.DEVICEID[0];
+	uuid_words[3] = NRF_FICR_NS->INFO.DEVICEID[1];
+#else
+	for (int i = 0; i < 4; i++) {
+		uuid_words[i] = NRF_FICR_NS->INFO.UUID[i];
+	}
+#endif /* defined(CONFIG_SOC_SERIES_NRF53) */
+
+	snprintk(buf, buf_len,
+		"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+		uuid_bytes[0], uuid_bytes[1], uuid_bytes[2], uuid_bytes[3],
+		uuid_bytes[4], uuid_bytes[5], uuid_bytes[6], uuid_bytes[7],
+		uuid_bytes[8], uuid_bytes[9], uuid_bytes[10], uuid_bytes[11],
+		uuid_bytes[12], uuid_bytes[13], uuid_bytes[14], uuid_bytes[15]);
+	return 0;
+}
+#endif /* defined(CONFIG_SOC_SERIES_NRF91) */
 #endif /* defined(CONFIG_HW_ID_LIBRARY_SOURCE_UUID) */
 
 #if defined(CONFIG_HW_ID_LIBRARY_SOURCE_IMEI)

--- a/tests/lib/hw_id/CMakeLists.txt
+++ b/tests/lib/hw_id/CMakeLists.txt
@@ -25,7 +25,6 @@ zephyr_include_directories(${ZEPHYR_NRF_MODULE_DIR}/include/net)
 zephyr_include_directories(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include/)
 zephyr_include_directories(${ZEPHYR_BASE}/include/zephyr/)
 zephyr_include_directories(${ZEPHYR_BASE}/subsys/testsuite/include)
-
 if(KCONFIG_OVERRIDE_FILE)
   add_definitions(-include ${KCONFIG_OVERRIDE_FILE})
 elseif(CONFIG_HW_ID_OVERRIDE_FILE)

--- a/tests/lib/hw_id/src/kconfig_override_uuid.h
+++ b/tests/lib/hw_id/src/kconfig_override_uuid.h
@@ -5,3 +5,4 @@
  */
 
 #define CONFIG_HW_ID_LIBRARY_SOURCE_UUID y
+#define CONFIG_SOC_SERIES_NRF91 y


### PR DESCRIPTION
Extend the HW ID library to support UUID on
all major platforms.
Modern nRF54 chips have a UUID in FICR that can
be read on the non-secure domain.
For nRF5340, a workaround is implemented using
the shorter DEVICEID registers.