### PR TITLE
tests: bootloader: quarantine update

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -83,9 +83,7 @@
 - scenarios:
     - mgmt.mcumgr.fs.mgmt.hash.supported.sha256
   platforms:
-    - nrf54h20dk@0.9.0/nrf54h20/cpuapp
     - nrf54h20dk@0.9.0/nrf54h20/cpurad
-    - nrf54l15dk/nrf54l15/cpuapp
     - nrf54lm20dk/nrf54lm20a/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-34575 and NCSDK-35492"
 


### PR DESCRIPTION
mgmt.mcumgr.fs.mgmt.hash.supported.sha256 now pass on two platforms.