### PR TITLE
doc: release notes: add Fast Pair Locator Tag TX power changelog entry

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -312,7 +312,11 @@ Bluetooth Fast Pair samples
 
 * :ref:`fast_pair_locator_tag` sample:
 
-  * Updated the references to the deleted ``CONFIG_CRACEN_LIB_KMU`` Kconfig option with the :kconfig:option:`CONFIG_CRACEN_KMU` replacement.
+  * Updated:
+
+    * The references to the deleted ``CONFIG_CRACEN_LIB_KMU`` Kconfig option to use the :kconfig:option:`CONFIG_CRACEN_KMU` replacement.
+    * The TX power calibration for the ``nrf54l15tag/nrf54l15/cpuapp`` board target.
+      The :kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` and :kconfig:option:`CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL` Kconfig options were changed from ``-13`` dBm to ``-11`` dBm to meet the Fast Pair distance certification requirements.
 
 * :ref:`fast_pair_input_device` sample:
 


### PR DESCRIPTION
## Summary

Adds a changelog entry documenting the TX power calibration alignment of the :ref:`fast_pair_locator_tag` sample for the nRF54L15 Tag board target (`nrf54l15tag/nrf54l15/cpuapp`).

- Documents that `CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` and `CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL` were recalibrated from `-13` dBm to `-11` dBm to meet the [Fast Pair distance certification requirements](https://developers.google.com/nearby/fast-pair/fast-pair-certification-guideline#24_certification_specification_for_distance).
- Follow-up documentation for the code change already merged in [nrfconnect/sdk-nrf#30073](https://github.com/nrfconnect/sdk-nrf/pull/30073).

Ref: NCSDK-38845

## Test plan

- [ ] Documentation builds without RST warnings for the release notes changelog page.