### PR TITLE
drivers: nrf71: Fix TX tone DC offset truncation in rf_test API

### DIFF
--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/inc/radio_test/fmac_api.h
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/inc/radio_test/fmac_api.h
@@ -136,8 +136,8 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_tx_tone(struct nrf_wifi_fmac_dev_c
 						      signed char tone_freq,
 						      signed char tx_power,
 						      unsigned char tone_type,
-						      signed char dc_offset_i,
-						      signed char dc_offset_q);
+						      signed short int dc_offset_i,
+						      signed short int dc_offset_q);
 
 
 

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_api.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/radio_test/fmac_api.c
@@ -491,8 +491,8 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_rf_test_tx_tone(struct nrf_wifi_fmac_dev_c
 						      signed char tone_freq,
 						      signed char tx_power,
 						      unsigned char tone_type,
-						      signed char dc_offset_i,
-						      signed char dc_offset_q)
+						      signed short int dc_offset_i,
+						      signed short int dc_offset_q)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_rf_test_tx_params rf_test_tx_params;


### PR DESCRIPTION
Change dc_offset_i and dc_offset_q in nrf_wifi_rt_fmac_rf_test_tx_tone() from signed char to signed short int so full Q.11 values (-2048 to 2047) are passed correctly to the FW command struct.