### PR TITLE
scripts: ci: Expand manifest imports in module license check

### DIFF
--- a/scripts/ci/check_license.py
+++ b/scripts/ci/check_license.py
@@ -10,7 +10,8 @@ Check for allowed licenses in a "sdk-nrf" pull request.
 For the "sdk-nrf" repository it checks the files changed by the pull request. In addition, when the
 pull request modifies the west manifest (west.yml) it also checks the new files brought in by the
 modules:
-  1. Parses the manifest at the base and at the PR head.
+  1. Parses and fully expands the manifest (including projects brought in through imports, such as
+     modules imported via the "zephyr" project) at the base and at the PR head.
   2. Classifies which manifest projects were updated or added considering only projects in the
      "nrfconnect" org (classify_project_changes).
   3. Collects the files to check:
@@ -312,10 +313,12 @@ class PatchLicenseChecker:
 
     def load_projects(self, manifest_data: str) -> 'dict':
         '''
-        parses one west.yml manifest and returns only the relevant projects keeping only
-        active projects hosted under the NRFCONNECT_URL_PREFIX org.
+        Parse one west.yml manifest, expanding its imports, and return only the active projects
+        hosted under the NRFCONNECT_URL_PREFIX org. Projects pulled in indirectly through manifest
+        imports (for example modules imported via the "zephyr" project) are included as well.
         '''
-        manifest = Manifest.from_data(manifest_data, import_flags=ImportFlag.IGNORE)
+        manifest = Manifest.from_data(manifest_data, importer=self.import_manifest,
+                                      import_flags=ImportFlag.FORCE_PROJECTS)
         projects = {}
         for project in manifest.projects:
             url = (project.url or '').lower().removesuffix('.git')
@@ -325,6 +328,23 @@ class PatchLicenseChecker:
                 continue
             projects[project.name] = project
         return projects
+
+    def import_manifest(self, project, file: str) -> str:
+        '''
+        Importer callback for "Manifest.from_data". Return the manifest content read from Git
+        at the revision pinned in the importing manifest.
+        This is what makes indirectly imported modules (for example the projects pulled
+        in via "zephyr") appear in the resolved project list.
+        '''
+        project_dir = self.west_workspace / project.path
+        self.ensure_revision(project_dir, project.revision)
+        data = yaml.safe_load(self.run('git', 'show', f'{project.revision}:{file}',
+                                       cwd=project_dir))
+        #cleanup for 'self: import: manifest' string
+        self_section = (data or {}).get('manifest', {}).get('self')
+        if isinstance(self_section, dict):
+            self_section.pop('import', None)
+        return yaml.safe_dump(data)
 
     def ensure_revision(self, project_dir: Path, revision: str) -> bool:
         '''Make sure a revision is available locally, fetching it if necessary.'''

--- a/scripts/ci/check_license.py
+++ b/scripts/ci/check_license.py
@@ -10,7 +10,8 @@ Check for allowed licenses in a "sdk-nrf" pull request.
 For the "sdk-nrf" repository it checks the files changed by the pull request. In addition, when the
 pull request modifies the west manifest (west.yml) it also checks the new files brought in by the
 modules:
-  1. Parses the manifest at the base and at the PR head.
+  1. Parses and fully expands the manifest (including projects brought in through imports, such as
+     modules imported via the "zephyr" project) at the base and at the PR head.
   2. Classifies which manifest projects were updated or added considering only projects in the
      "nrfconnect" org (classify_project_changes).
   3. Collects the files to check:
@@ -33,7 +34,7 @@ from pathlib import Path
 
 import junit_xml
 import yaml
-from west.manifest import ImportFlag, Manifest
+from west.manifest import ImportFlag, ImportedContentType, Manifest, Project
 
 NRFCONNECT_URL_PREFIX = 'https://github.com/nrfconnect/'
 
@@ -310,12 +311,45 @@ class PatchLicenseChecker:
         head = parts[1] if len(parts) > 1 and parts[1] else 'HEAD'
         return base, head
 
-    def load_projects(self, manifest_data: str) -> 'dict':
+    def manifests_from_tree(self) -> 'tuple[Manifest, Manifest]':
         '''
-        parses one west.yml manifest and returns only the relevant projects keeping only
-        active projects hosted under the NRFCONNECT_URL_PREFIX org.
+        Expand the manifest at the base and at the head of the commit range.
         '''
-        manifest = Manifest.from_data(manifest_data, import_flags=ImportFlag.IGNORE)
+        base, head = (self.run('git', 'rev-parse', rev, cwd=self.git_top)
+                      for rev in self.commit_range())
+        mfile = (self.git_top / self.args.manifest).resolve()
+
+        def manifest_at_rev(rev: str) -> Manifest:
+            # Use --quiet to avoid Git writing a warning about a commit left behind in stderr
+            self.run('git', 'checkout', '--quiet', '--detach', rev, cwd=self.git_top)
+            return Manifest.from_file(mfile, importer=self.import_manifest,
+                                      import_flags=ImportFlag.FORCE_PROJECTS)
+
+        old_manifest = manifest_at_rev(base)
+        new_manifest = manifest_at_rev(head)
+
+        return (old_manifest, new_manifest)
+
+    def import_manifest(self, project: Project, file: str) -> ImportedContentType:
+        '''
+        Return an imported manifest file, such as "zephyr/west.yml", read from Git at the
+        revision the importing manifest pins.
+        '''
+        rev = self.ensure_revision(project, project.revision)
+        if rev is None:
+            return None
+        try:
+            content = project.read_at(file, rev=rev, cwd=self.west_workspace / project.path)
+        except subprocess.CalledProcessError:
+            return None
+        return content.decode(Manifest.encoding)
+
+    def load_projects(self, manifest: Manifest) -> 'dict':
+        '''
+        Return the relevant projects of a manifest keeping only projects hosted
+        under the NRFCONNECT_URL_PREFIX org. Projects pulled in indirectly through manifest imports
+        (for example modules imported via the "zephyr" project) are included as well.
+        '''
         projects = {}
         for project in manifest.projects:
             url = (project.url or '').lower().removesuffix('.git')
@@ -326,22 +360,21 @@ class PatchLicenseChecker:
             projects[project.name] = project
         return projects
 
-    def ensure_revision(self, project_dir: Path, revision: str) -> bool:
-        '''Make sure a revision is available locally, fetching it if necessary.'''
-        if (
-            self.try_run(
-                'git', 'cat-file', '-e', f'{revision}^{{commit}}', cwd=project_dir
-            ).returncode
-            == 0
-        ):
-            return True
-        self.try_run('git', 'fetch', '--no-tags', 'origin', revision, cwd=project_dir)
-        return (
-            self.try_run(
-                'git', 'cat-file', '-e', f'{revision}^{{commit}}', cwd=project_dir
-            ).returncode
-            == 0
-        )
+    def ensure_revision(self, project: Project, revision: str) -> 'str|None':
+        '''
+        Return a revision of a project that git can read locally. A revision that like
+        "pull/1234/head" is fetched from the project URL and returned as the commit it points to.
+        '''
+        project_dir = self.west_workspace / project.path
+        if not project_dir.is_dir():
+            return None
+        if self.try_run('git', 'cat-file', '-e', f'{revision}^{{commit}}',
+                        cwd=project_dir).returncode == 0:
+            return revision
+        if self.try_run('git', 'fetch', '--no-tags', project.url, revision,
+                        cwd=project_dir).returncode != 0:
+            return None
+        return self.run('git', 'rev-parse', 'FETCH_HEAD', cwd=project_dir)
 
     def prefix(self, project_path: str, git_output: str) -> 'list[str]':
         '''Prefix each git output line with the project path to make it workspace relative.'''
@@ -352,10 +385,9 @@ class PatchLicenseChecker:
     def added_files(self, project, old_rev: str, new_rev: str) -> 'list[str]':
         '''Return the workspace relative paths of files added between old_rev and new_rev.'''
         project_dir = self.west_workspace / project.path
-        if not (
-            self.ensure_revision(project_dir, old_rev)
-            and self.ensure_revision(project_dir, new_rev)
-        ):
+        old_rev = self.ensure_revision(project, old_rev)
+        new_rev = self.ensure_revision(project, new_rev)
+        if not (old_rev and new_rev):
             return []
         out = self.run(
             'git',
@@ -370,7 +402,8 @@ class PatchLicenseChecker:
     def all_files(self, project, new_rev: str) -> 'list[str]':
         '''Return the workspace relative paths of all files at new_rev (newly added project).'''
         project_dir = self.west_workspace / project.path
-        if not self.ensure_revision(project_dir, new_rev):
+        new_rev = self.ensure_revision(project, new_rev)
+        if not new_rev:
             return []
         out = self.run('git', 'ls-tree', '-r', '--name-only', new_rev, cwd=project_dir)
         return self.prefix(project.path, out)
@@ -386,9 +419,9 @@ class PatchLicenseChecker:
             print(f'"{manifest_path}" was not modified; skipping module license checks.')
             return []
 
-        base, head = self.commit_range()
-        old_projects = self.load_projects(self.run('git', 'show', f'{base}:{manifest_path}'))
-        new_projects = self.load_projects(self.run('git', 'show', f'{head}:{manifest_path}'))
+        (old_manifest, new_manifest) = self.manifests_from_tree()
+        old_projects = self.load_projects(old_manifest)
+        new_projects = self.load_projects(new_manifest)
 
         old_set = {(p.name, p.revision) for p in old_projects.values()}
         new_set = {(p.name, p.revision) for p in new_projects.values()}


### PR DESCRIPTION
The manifest license check only looked at the projects listed directly in sdk-nrf's west.yml; Manifest.from_data() was called with ImportFlag.IGNORE.

Resolve the manifest with its imports fully expanded so indirectly imported projects are classified and diffed as well.