### PR TITLE
ci: fix links.txt check for docs.nordicsemi.com

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -123,20 +123,22 @@ jobs:
         run: |
           RE='.. _`(.*)`: (.*)'
           LINKS=$(git diff --unified=0 "${{ github.event.pull_request.base.sha }}..HEAD" -- "doc/nrf/links.txt" | \
-                  grep "^+" || true | \
-                  grep -Ev "^(---|\+\+\+)" || true)
+                  grep "^+" | grep -Ev "^\+\+\+" || true)
 
           while IFS= read -r link; do
+            link="${link#+}"
             if [[ $link =~ $RE ]]; then
               NAME=${BASH_REMATCH[1]}
               URL=${BASH_REMATCH[2]}
 
               echo -n "Checking URL for '$NAME' ($URL)... "
-              if [[ "$URL" == *"files.nordicsemi.com"* ]]; then
-                # files.nordicsemi.com server does not allow downloading only headers
-                status=$(curl --write-out "%{http_code}" --output /dev/null --silent "$URL" || true)
+              if [[ "$URL" == *"nordicsemi.com"* ]]; then
+                # Nordic hosts often reject HEAD from CI; /bundle/ URLs redirect to /r/
+                status=$(curl --write-out "%{http_code}" --output /dev/null --silent --location \
+                  --user-agent "NCS-compliance-link-check" "$URL" || true)
               else
-                status=$(curl --write-out "%{http_code}" --output /dev/null --silent --head "$URL" || true)
+                status=$(curl --write-out "%{http_code}" --output /dev/null --silent --location --head \
+                  "$URL" || true)
               fi
 
               if [[ "$status" -ne 200 ]]; then


### PR DESCRIPTION
Follow redirects and use GET for Nordic hosts so added PS links pass when /bundle/ URLs redirect and HEAD returns 403 or 301 in CI:
used `--loacation` so `curl` repeats request on redirections.

Additionally fixed small bug in the diff pipeline

`grep "^+" || true | grep -Ev "^(---|\+\+\+)" || true`

Because of ||, when grep "^+" matches, the second grep never runs, so +++ b/doc/nrf/links.txt lines can end up in LINKS. That does not cause 403 by itself, but it is worth fixing.

Instead used : `git diff ... | grep "^+" | grep -Ev "^(---|\+\+\+)" || true`

fixes issue like this one:
https://github.com/nrfconnect/sdk-nrf/actions/runs/29824762021/job/88876235273?pr=28821

<img width="1173" height="112" alt="image" src="https://github.com/user-attachments/assets/3ebb839a-0d66-4e49-9db0-b4d4cc5fcad4" />

