### PR TITLE
tests: bootloadres: quarantine update

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -63,11 +63,16 @@
 
 - scenarios:
     - bootloader.ppi_config_leftovers.nsib
+  platforms:
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf54l15dk/nrf54l15/cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39901 - PM-DTS migration"
+
+- scenarios:
     - mcuboot.external_flash.upgrade.netcore
     - nsib.mcuboot.external_flash.upgrade.netcore_and_mcuboot
   platforms:
     - nrf5340dk/nrf5340/cpuapp
-    - nrf54l15dk/nrf54l15/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39901 - PM-DTS migration"
 
 - scenarios:


### PR DESCRIPTION
Narrow the two netcore update scenarios in quarantine to nrf5340dk only.