### PR TITLE
doc: extensions: handling of new tests.yaml file naming

### DIFF
--- a/doc/_extensions/table_from_rows.py
+++ b/doc/_extensions/table_from_rows.py
@@ -5,6 +5,7 @@
 import os
 import re
 from pathlib import Path
+from itertools import chain
 
 import yaml
 from docutils import io, statemachine
@@ -139,6 +140,7 @@ class TableFromRows(SphinxDirective):
         return []
 
 class TableFromSampleYaml(TableFromRows):
+    _excepted_file_names = ["sample.yaml", "tests.yaml"]
 
     option_spec = {}
     required_arguments = 0
@@ -220,15 +222,14 @@ class TableFromSampleYaml(TableFromRows):
         # Path to the origin of the rst-file outside the build folder
         dir_path = Path(self.config.table_from_rows_base_dir) / rel_path
 
-        sample_yamls = []
-        if (dir_path / 'sample.yaml').exists():
-            sample_yamls.append(dir_path / 'sample.yaml')
-        elif rel_path.endswith('doc'):
-            parent_path = dir_path.parent / 'sample.yaml'
-            if parent_path.exists():
-                sample_yamls.append(parent_path)
-        else:
-            sample_yamls += list(dir_path.glob('**/sample.yaml'))
+        sample_yamls = list(
+                chain(*(dir_path.glob(f'**/{name}') for name in self._excepted_file_names))
+            )
+        if rel_path.endswith("doc"):
+            sample_yamls += [
+                    dir_path.parent / name for name in self._excepted_file_names
+                    if (dir_path.parent / name).exists()
+                ]
 
         if not sample_yamls:
             raise self.severe(f'"{path}" not found')


### PR DESCRIPTION
Allow the extension to handle both sample.yaml and tests.yaml files, in case we want to rename sample.yaml files into tests.yaml as in upstream zephyr.