### PR TITLE
tests/fprotect/negative: Enable nRF54L series

### DIFF
--- a/tests/drivers/fprotect/negative/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"

--- a/tests/drivers/fprotect/negative/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"

--- a/tests/drivers/fprotect/negative/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuapp_rram {
+	/delete-node/ partitions;
+
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		b0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		s0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x10000 DT_SIZE_K(128)>;
+		};
+
+		s1_partition: partition@30000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x30000 DT_SIZE_K(128)>;
+		};
+	};
+};
+
+/ {
+	chosen {
+		zephyr,code-partition = &s0_partition;
+	};
+};

--- a/tests/drivers/fprotect/negative/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuapp_rram {
+	/delete-node/ partitions;
+
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		b0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x0 DT_SIZE_K(32)>;
+		};
+
+		s0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x8000 DT_SIZE_K(124)>;
+		};
+
+		s1_partition: partition@27000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x27000 DT_SIZE_K(124)>;
+		};
+	};
+};
+
+/ {
+	chosen {
+		zephyr,code-partition = &s0_partition;
+	};
+};

--- a/tests/drivers/fprotect/negative/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuapp_rram {
+	/delete-node/ partitions;
+
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		b0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		s0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x10000 DT_SIZE_K(984)>;
+		};
+
+		s1_partition: partition@f6000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0xf6000 DT_SIZE_K(984)>;
+		};
+	};
+};
+
+/ {
+	chosen {
+		zephyr,code-partition = &s0_partition;
+	};
+};

--- a/tests/drivers/fprotect/negative/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54lm20dk_nrf54lm20a_cpuapp.overlay"

--- a/tests/drivers/fprotect/negative/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuapp_rram {
+	/delete-node/ partitions;
+
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		b0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x0 DT_SIZE_K(32)>;
+		};
+
+		s0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x8000 DT_SIZE_K(124)>;
+		};
+
+		s1_partition: partition@27000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x27000 DT_SIZE_K(124)>;
+		};
+	};
+};
+
+/ {
+	chosen {
+		zephyr,code-partition = &s0_partition;
+	};
+};

--- a/tests/drivers/fprotect/negative/socs/nrf54l05_cpuapp.conf
+++ b/tests/drivers/fprotect/negative/socs/nrf54l05_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This should be not required as tests does not use Flash API, but
+# RRAM protection parameters are unfortunately dependent on Flash API
+# being enabled.
+CONFIG_FLASH=y

--- a/tests/drivers/fprotect/negative/socs/nrf54l10_cpuapp.conf
+++ b/tests/drivers/fprotect/negative/socs/nrf54l10_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This should be not required as tests does not use Flash API, but
+# RRAM protection parameters are unfortunately dependent on Flash API
+# being enabled.
+CONFIG_FLASH=y

--- a/tests/drivers/fprotect/negative/socs/nrf54l15_cpuapp.conf
+++ b/tests/drivers/fprotect/negative/socs/nrf54l15_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This should be not required as tests does not use Flash API, but
+# RRAM protection parameters are unfortunately dependent on Flash API
+# being enabled.
+CONFIG_FLASH=y

--- a/tests/drivers/fprotect/negative/socs/nrf54lc10a_cpuapp.conf
+++ b/tests/drivers/fprotect/negative/socs/nrf54lc10a_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This should be not required as tests does not use Flash API, but
+# RRAM protection parameters are unfortunately dependent on Flash API
+# being enabled.
+CONFIG_FLASH=y

--- a/tests/drivers/fprotect/negative/socs/nrf54lm20a_cpuapp.conf
+++ b/tests/drivers/fprotect/negative/socs/nrf54lm20a_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This should be not required as tests does not use Flash API, but
+# RRAM protection parameters are unfortunately dependent on Flash API
+# being enabled.
+CONFIG_FLASH=y

--- a/tests/drivers/fprotect/negative/socs/nrf54lm20b_cpuapp.conf
+++ b/tests/drivers/fprotect/negative/socs/nrf54lm20b_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This should be not required as tests does not use Flash API, but
+# RRAM protection parameters are unfortunately dependent on Flash API
+# being enabled.
+CONFIG_FLASH=y

--- a/tests/drivers/fprotect/negative/socs/nrf54lv10a_cpuapp.conf
+++ b/tests/drivers/fprotect/negative/socs/nrf54lv10a_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This should be not required as tests does not use Flash API, but
+# RRAM protection parameters are unfortunately dependent on Flash API
+# being enabled.
+CONFIG_FLASH=y

--- a/tests/drivers/fprotect/negative/src/main.c
+++ b/tests/drivers/fprotect/negative/src/main.c
@@ -13,7 +13,13 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/device.h>
+#if defined(CONFIG_NRFX_NVMC)
 #include <nrfx_nvmc.h>
+#elif defined(CONFIG_NRFX_RRAMC)
+#include <nrfx_rramc.h>
+#else
+#error Could not determine type of NVM
+#endif
 #include <zephyr/sys/util.h>
 #include <fprotect.h>
 #include <zephyr/linker/linker-defs.h>
@@ -44,6 +50,15 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
 	actual_fatal++;
 }
 
+static inline void test_write_bytes(uint32_t addr, const uint8_t *buf, size_t len)
+{
+#if defined(CONFIG_NRFX_NVMC)
+	nrfx_nvmc_bytes_write(addr, buf, len);
+#elif defined(CONFIG_NRFX_RRAMC)
+	nrfx_rramc_bytes_write(addr, buf, len);
+#endif
+}
+
 static void flash_write_protected_fails(uint32_t addr, bool backup)
 {
 	uint8_t buf[BUF_SIZE];
@@ -61,7 +76,7 @@ static void flash_write_protected_fails(uint32_t addr, bool backup)
 		" means the test passed!\n");
 	zassert_equal(expected_fatal, actual_fatal, "An unexpected fatal error has occurred.\n");
 	expected_fatal++;
-	nrfx_nvmc_bytes_write(addr, buf, sizeof(buf));
+	test_write_bytes(addr, buf, sizeof(buf));
 	zassert_unreachable("Should have BUS FAULTed before coming here.");
 }
 
@@ -78,7 +93,7 @@ ZTEST(test_fprotect_negative, test_flash_write_protected_fails)
 	uint8_t buf[BUF_SIZE];
 
 	(void)memset(buf, 0x5a, sizeof(buf));
-	nrfx_nvmc_bytes_write(TEST_FPROTECT_WRITE_ADDR, buf, sizeof(buf));
+	test_write_bytes(TEST_FPROTECT_WRITE_ADDR, buf, sizeof(buf));
 
 #ifdef CONFIG_HAS_HW_NRF_ACL
 	zassert_equal(0, fprotect_is_protected(TEST_FPROTECT_WRITE_ADDR), NULL);

--- a/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf54l15dk_nrf54l05_cpuapp.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &b0_partition;
+	};
+};

--- a/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf54l15dk_nrf54l10_cpuapp.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &b0_partition;
+	};
+};

--- a/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf54l15dk_nrf54l15_cpuapp.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &b0_partition;
+	};
+};

--- a/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &b0_partition;
+	};
+};

--- a/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &b0_partition;
+	};
+};

--- a/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &b0_partition;
+	};
+};

--- a/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
+++ b/tests/drivers/fprotect/negative/sysbuild/b0/boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf54lv10dk_nrf54lv10a_cpuapp.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &b0_partition;
+	};
+};

--- a/tests/drivers/fprotect/negative/testcase.yaml
+++ b/tests/drivers/fprotect/negative/testcase.yaml
@@ -5,6 +5,13 @@ common:
     - nrf52dk/nrf52832
     - nrf5340dk/nrf5340/cpuapp
     - nrf52840dk/nrf52840
+    - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54l15dk/nrf54l10/cpuapp
+    - nrf54l15dk/nrf54l05/cpuapp
+    - nrf54lc10dk/nrf54lc10a/cpuapp
+    - nrf54lv10dk/nrf54lv10a/cpuapp
+    - nrf54lm20dk/nrf54lm20a/cpuapp
+    - nrf54lm20dk/nrf54lm20b/cpuapp
   tags:
     - b0
     - fprotect


### PR DESCRIPTION
Add to allow list but not integration platforms.
Add overlays and required configs.