### PR TITLE
drivers: wifi: nrf71: Read connect scan results from GDRAM database

### DIFF
--- a/drivers/wifi/nrf71/Kconfig
+++ b/drivers/wifi/nrf71/Kconfig
@@ -584,6 +584,13 @@ config HEAP_MEM_POOL_ADD_SIZE_NRF71
 	def_int 25000 if NRF71_SCAN_ONLY
 	def_int 150000
 
+config HEAP_MEM_POOL_ADD_SIZE_NRF71_CONNECT_SCAN
+	# Connect scan database; summed into the system heap automatically. Kconfig
+	# can't subtract the display scan budget here, so reserve the full size.
+	int
+	depends on NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM
+	default NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM_SIZE
+
 endif # NRF_WIFI_GLOBAL_HEAP
 
 if !NRF_WIFI_GLOBAL_HEAP
@@ -926,6 +933,25 @@ config NRF_WIFI_DISPLAY_SCAN_BSS_LIMIT
 	def_int 150
 	help
 	  Number of BSS entries in scan result.
+
+config NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM
+	bool "Read connect scan results from the scan results database"
+	depends on NRF71_STA_MODE
+	default y
+	help
+	  Read connect scan results from the database the firmware builds in
+	  GDRAM instead of the NRF_WIFI_UMAC_CMD_GET_SCAN_RESULTS command. This
+	  lifts the per-SSID result limit and is mainly useful for roaming.
+
+config NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM_SIZE
+	int "Connect scan results database buffer size"
+	depends on NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM
+	range 1024 65535
+	default 8192
+	help
+	  Size in bytes of the connect scan results database buffer. The default
+	  holds around ten results, enough for roaming. The control plane heap it
+	  is allocated from grows with this, so it is safe to increase.
 
 config NRF_WIFI_COEX_DISABLE_PRIORITY_WINDOW_FOR_SCAN
 	bool "Force disable priority window for scan in the case of coexistence with Short Range radio"

--- a/drivers/wifi/nrf71/inc/fmac_main.h
+++ b/drivers/wifi/nrf71/inc/fmac_main.h
@@ -102,6 +102,13 @@ struct nrf_wifi_vif_ctx_zep {
 #endif /* CONFIG_NRF71_DATA_TX */
 	unsigned long rssi_record_timestamp_us;
 	signed short rssi;
+#ifdef CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM
+	/* Connect scan results database cached from the scan done event, read
+	 * on the supplicant's get scan results call and freed right after.
+	 */
+	unsigned int connect_scan_db_addr;
+	unsigned int connect_scan_res_cnt;
+#endif /* CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM */
 #endif /* CONFIG_NRF71_STA_MODE */
 #ifdef CONFIG_NRF71_AP_MODE
 	int inactive_time_sec;

--- a/drivers/wifi/nrf71/os/shim.c
+++ b/drivers/wifi/nrf71/os/shim.c
@@ -27,6 +27,7 @@
 #include "timer.h"
 #include "osal_ops.h"
 #include "common/hal_structs_common.h"
+#include <nrf71_wifi_ctrl.h> /* struct umac_display_results, for heap sizing */
 
 LOG_MODULE_REGISTER(wifi_nrf, CONFIG_WIFI_NRF71_LOG_LEVEL);
 
@@ -38,11 +39,25 @@ static struct k_heap * const wifi_ctrl_pool = &_system_heap;
 static struct k_heap * const wifi_data_pool = &_system_heap;
 #else
 /* Use dedicated heaps */
+#if defined(CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM)
+/* Connect and display scan databases share the control pool but never run at
+ * once, so only reserve what the connect one needs beyond the display one.
+ */
+#define NRF_WIFI_DISP_SCAN_DB (CONFIG_NRF_WIFI_SCAN_MAX_BSS_CNT * \
+			       sizeof(struct umac_display_results))
+#define NRF_WIFI_CONN_SCAN_DB CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM_SIZE
+#define NRF_WIFI_CTRL_HEAP_EXTRA (NRF_WIFI_CONN_SCAN_DB > NRF_WIFI_DISP_SCAN_DB ? \
+				  NRF_WIFI_CONN_SCAN_DB - NRF_WIFI_DISP_SCAN_DB : 0)
+#else
+#define NRF_WIFI_CTRL_HEAP_EXTRA 0
+#endif
 #if defined(CONFIG_NOCACHE_MEMORY)
-K_HEAP_DEFINE_NOCACHE(wifi_drv_ctrl_mem_pool, CONFIG_NRF_WIFI_CTRL_HEAP_SIZE);
+K_HEAP_DEFINE_NOCACHE(wifi_drv_ctrl_mem_pool,
+		      CONFIG_NRF_WIFI_CTRL_HEAP_SIZE + NRF_WIFI_CTRL_HEAP_EXTRA);
 K_HEAP_DEFINE_NOCACHE(wifi_drv_data_mem_pool, CONFIG_NRF_WIFI_DATA_HEAP_SIZE);
 #else
-K_HEAP_DEFINE(wifi_drv_ctrl_mem_pool, CONFIG_NRF_WIFI_CTRL_HEAP_SIZE);
+K_HEAP_DEFINE(wifi_drv_ctrl_mem_pool,
+	      CONFIG_NRF_WIFI_CTRL_HEAP_SIZE + NRF_WIFI_CTRL_HEAP_EXTRA);
 K_HEAP_DEFINE(wifi_drv_data_mem_pool, CONFIG_NRF_WIFI_DATA_HEAP_SIZE);
 #endif /* CONFIG_NOCACHE_MEMORY */
 static struct k_heap * const wifi_ctrl_pool = &wifi_drv_ctrl_mem_pool;

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/system/fmac_api.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/system/fmac_api.c
@@ -634,7 +634,11 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_scan(void *dev_ctx,
 		goto out;
 	}
 
-	if (scan_info->scan_reason == SCAN_DISPLAY) {
+	/* The firmware fills the scan results database into this buffer, both
+	 * for display scan and (when the host asks for it) connect scan. Any
+	 * scan that provides a non-zero database length gets a buffer.
+	 */
+	if (scan_info->scan_db_len) {
 		nrf_wifi_osal_log_dbg("%s: scan_db_len = %d",
 				      __func__,
 				      scan_info->scan_db_len);
@@ -661,6 +665,12 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_scan(void *dev_ctx,
 out:
 	if (scan_cmd) {
 		nrf_wifi_osal_mem_free(scan_cmd);
+	}
+
+	/* Free the database buffer if the scan did not start. */
+	if ((status != NRF_WIFI_STATUS_SUCCESS) && scan_info->scan_db_addr) {
+		nrf_wifi_osal_mem_free((void *)(unsigned long)scan_info->scan_db_addr);
+		scan_info->scan_db_addr = 0;
 	}
 
 	return status;

--- a/drivers/wifi/nrf71/src/fmac_main.c
+++ b/drivers/wifi/nrf71/src/fmac_main.c
@@ -187,6 +187,19 @@ void nrf_wifi_event_proc_scan_done_zep(void *vif_ctx,
 #endif /* CONFIG_NET_L2_WIFI_MGMT */
 #ifdef CONFIG_NRF71_STA_MODE
 	case SCAN_CONNECT:
+#ifdef CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM
+		/* Cache for the get scan results call, under vif_lock as the
+		 * supplicant path reads and frees it; free any unread previous one.
+		 */
+		k_mutex_lock(&vif_ctx_zep->vif_lock, K_FOREVER);
+		if (vif_ctx_zep->connect_scan_db_addr) {
+			nrf_wifi_osal_mem_free(
+				(void *)(uintptr_t)vif_ctx_zep->connect_scan_db_addr);
+		}
+		vif_ctx_zep->connect_scan_db_addr = scan_done_event->scan_db_addr;
+		vif_ctx_zep->connect_scan_res_cnt = scan_done_event->scan_results_cnt;
+		k_mutex_unlock(&vif_ctx_zep->vif_lock);
+#endif /* CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM */
 		nrf_wifi_wpa_supp_event_proc_scan_done(vif_ctx_zep,
 						       scan_done_event,
 						       event_len,

--- a/drivers/wifi/nrf71/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf71/src/wpa_supp_if.c
@@ -580,6 +580,18 @@ int nrf_wifi_wpa_supp_scan2(void *if_priv, struct wpa_driver_scan_params *params
 
 	scan_info->scan_reason = SCAN_CONNECT;
 
+#ifdef CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM
+	/* Free any database left unread from a previous scan. */
+	if (vif_ctx_zep->connect_scan_db_addr) {
+		nrf_wifi_osal_mem_free((void *)(uintptr_t)vif_ctx_zep->connect_scan_db_addr);
+		vif_ctx_zep->connect_scan_db_addr = 0;
+		vif_ctx_zep->connect_scan_res_cnt = 0;
+	}
+
+	/* Firmware builds the results database in a buffer of this size. */
+	scan_info->scan_db_len = CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM_SIZE;
+#endif /* CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM */
+
 	/* Copy extra_ies */
 	if (params->extra_ies_len && params->extra_ies_len <= NRF_WIFI_MAX_IE_LEN) {
 		memcpy(scan_info->scan_params.ie.ie, params->extra_ies, params->extra_ies_len);
@@ -662,12 +674,78 @@ out:
 	return status;
 }
 
+#ifdef CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM
+/* Relay the cached connect scan database to the supplicant and free it. With
+ * no results, send one empty result to end the supplicant's wait.
+ */
+static void nrf_wifi_wpa_supp_scan_res_relay(struct nrf_wifi_vif_ctx_zep *vif_ctx_zep)
+{
+	struct nrf_wifi_umac_event_new_scan_results *db = NULL;
+	struct nrf_wifi_umac_event_new_scan_results *prev = NULL;
+	unsigned int cnt = vif_ctx_zep->connect_scan_res_cnt;
+	unsigned char *end = NULL;
+	unsigned int i;
+
+	db = (struct nrf_wifi_umac_event_new_scan_results *)
+		(uintptr_t)vif_ctx_zep->connect_scan_db_addr;
+	end = (unsigned char *)db + CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM_SIZE;
+
+	/* Deliver each entry once the next is known valid, so the walk stays
+	 * bounded and the last result carries more_res = false.
+	 */
+	for (i = 0; db && i < cnt; i++) {
+		size_t avail = end - (unsigned char *)db;
+		unsigned int entry_len;
+
+		/* Bound each length against the space left so the firmware
+		 * provided lengths cannot overflow the walk.
+		 */
+		if (avail < sizeof(*db)) {
+			break;
+		}
+		if ((db->ies_len > avail - sizeof(*db)) ||
+		    (db->beacon_ies_len > avail - sizeof(*db) - db->ies_len)) {
+			break;
+		}
+
+		entry_len = sizeof(*db) + db->ies_len + db->beacon_ies_len;
+
+		if (prev) {
+			nrf_wifi_wpa_supp_event_proc_scan_res(vif_ctx_zep, prev,
+							      sizeof(*prev), true);
+		}
+		prev = db;
+		db = (struct nrf_wifi_umac_event_new_scan_results *)
+			((unsigned char *)db + entry_len);
+	}
+
+	if (prev) {
+		nrf_wifi_wpa_supp_event_proc_scan_res(vif_ctx_zep, prev,
+						      sizeof(*prev), false);
+	} else {
+		struct nrf_wifi_umac_event_new_scan_results empty;
+
+		memset(&empty, 0, sizeof(empty));
+		nrf_wifi_wpa_supp_event_proc_scan_res(vif_ctx_zep, &empty,
+						      sizeof(empty), false);
+	}
+
+	if (vif_ctx_zep->connect_scan_db_addr) {
+		nrf_wifi_osal_mem_free((void *)(uintptr_t)vif_ctx_zep->connect_scan_db_addr);
+	}
+	vif_ctx_zep->connect_scan_db_addr = 0;
+	vif_ctx_zep->connect_scan_res_cnt = 0;
+}
+#endif /* CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM */
+
 int nrf_wifi_wpa_supp_scan_results_get(void *if_priv)
 {
-	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
 	int ret = -1;
+#ifndef CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+#endif /* CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM */
 
 	if (!if_priv) {
 		LOG_ERR("%s: Invalid params", __func__);
@@ -687,6 +765,10 @@ int nrf_wifi_wpa_supp_scan_results_get(void *if_priv)
 		goto out;
 	}
 
+#ifdef CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM
+	nrf_wifi_wpa_supp_scan_res_relay(vif_ctx_zep);
+	ret = 0;
+#else
 	status = nrf_wifi_sys_fmac_scan_res_get(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx,
 					    SCAN_CONNECT);
 
@@ -696,6 +778,7 @@ int nrf_wifi_wpa_supp_scan_results_get(void *if_priv)
 	}
 
 	ret = 0;
+#endif /* CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM */
 out:
 	k_mutex_unlock(&vif_ctx_zep->vif_lock);
 	return ret;


### PR DESCRIPTION
Jira: WZN-9252

### What

Read connect scan results directly from the scan results database the
firmware builds in GDRAM, instead of pulling them back one BSS at a time
with `NRF_WIFI_UMAC_CMD_GET_SCAN_RESULTS`.

The command based path caps the number of results the firmware keeps per
SSID (four), too few for roaming where we scan a single SSID and want
every candidate. The firmware already builds the full database during
the scan (as for display scan), so the host now hands it a buffer,
caches the database address/count from the scan done event, and relays
each entry to the supplicant on the get scan results call. Each entry is
a `nrf_wifi_umac_event_new_scan_results` followed by its IEs, so the
existing per-BSS relay is reused as is. The buffer is freed once read.

### Details

- New `NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM` (default y for nRF71 STA),
  with the command based path kept as fallback when disabled.
- Buffer size `NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM_SIZE` (default 8192).
  The control plane heap grows only for buffers larger than the display
  scan database, which the two share (they never run at once).
- `fmac` scan DB allocation is generalized to key off `scan_db_len`.
- Walk is bounded to the buffer; last entry relayed with `more_res`
  false; stale/unread databases are freed on the next scan.

### Testing

- Builds: `samples/wifi/shell` on `nrf7120dk/nrf7120/cpuapp`, default and
  large buffer (heap grows by exactly the excess over the display DB),
  and with the feature disabled.
- Compliance: Checkpatch, Gitlint, Nits, Identity, KconfigBasic pass.
