### PR TITLE
tools: bump ncs-build docker versions

### DIFF
--- a/scripts/ncs-docker-version.txt
+++ b/scripts/ncs-docker-version.txt
@@ -1,1 +1,1 @@
-5ea73affbf
+a140d687bb

--- a/scripts/pip-audit-whitelist.yml
+++ b/scripts/pip-audit-whitelist.yml
@@ -7,3 +7,4 @@ py:
   - PYSEC-2024-311
   - PYSEC-2026-151
   - GHSA-537c-gmf6-5ccf
+  - PYSEC-2026-3447

--- a/scripts/requirements-extra.txt
+++ b/scripts/requirements-extra.txt
@@ -12,3 +12,4 @@ idna>=3.7 # https://github.com/advisories/GHSA-jjg7-2v4v-x38h
 libusb>=1.0.26
 matter_idl
 python-path>=0.1.3
+pyasn1>=0.6.4


### PR DESCRIPTION
add PYSEC-2026-3447 to pip whitelist
* Setuptools cannot be updated atm due to conflict with spsdk package