### PR TITLE
drivers: ppi_seq: allow attaching notifier to external connection 

### DIFF
--- a/drivers/ppi_seq/ppi_seq.c
+++ b/drivers/ppi_seq/ppi_seq.c
@@ -273,11 +273,39 @@ static int ppi_seq_notifier_init(struct ppi_seq *seq)
 
 	if (IS_ENABLED(CONFIG_NRFX_GPPI)) {
 		rv = nrfx_gppi_ep_channel_get(notifier->nrfx_timer.end_seq_event);
-		if ((rv >= 0) &&
-		    (nrfx_gppi_domain_id_get(notifier->nrfx_timer.end_seq_event) ==
-		     nrfx_gppi_domain_id_get(cnt_task))) {
-			/* Channel is already in use */
-			nrfx_gppi_ep_to_ch_attach(cnt_task, rv);
+		if (rv >= 0) {
+			/* Channel already attached to the event. Attach another task to it. */
+			uint32_t producer =
+				nrfx_gppi_domain_id_get(notifier->nrfx_timer.end_seq_event);
+			uint32_t consumer = nrfx_gppi_domain_id_get(cnt_task);
+
+			if (producer == consumer) {
+				/* Same domain - attach endpoint to existing channel. */
+				nrfx_gppi_ep_to_ch_attach(cnt_task, rv);
+			} else {
+				/* Different domain - attach endpoint to external connection. */
+				nrfx_gppi_resource_t resource = {
+					.domain_id = producer,
+					.channel = rv,
+				};
+				nrfx_gppi_handle_t ext_handle;
+
+				rv = nrfx_gppi_ext_conn_alloc(producer, consumer,
+							      &ext_handle, &resource);
+				if (rv < 0) {
+					return rv;
+				}
+
+				rv = nrfx_gppi_ep_attach(cnt_task, ext_handle);
+				if (rv < 0) {
+					nrfx_gppi_domain_conn_free(ext_handle);
+					return rv;
+				}
+
+				seq->ppi_pool[seq->ppi_cnt++] = ext_handle;
+				nrfx_gppi_conn_enable(ext_handle);
+			}
+
 			notifier->nrfx_timer.attached = true;
 			return 0;
 		}

--- a/tests/drivers/ppi_seq/ppi_seq_with_spi/src/main.c
+++ b/tests/drivers/ppi_seq/ppi_seq_with_spi/src/main.c
@@ -409,8 +409,8 @@ static void ppi_seq_cb(struct ppi_seq *ppi_seq, bool last)
 	uint8_t *rx_buf = prim ? spim_data.rx_buf0 : spim_data.rx_buf1;
 	uint32_t batch_bytes = XFER_CNT * XFER_LEN;
 
-	spim_data.spim.p_reg->DMA.RX.PTR = (uint32_t)(prim ? spim_data.tx_buf1 : spim_data.tx_buf0);
-	spim_data.spim.p_reg->DMA.TX.PTR = (uint32_t)(prim ? spim_data.rx_buf1 : spim_data.rx_buf0);
+	nrf_spim_rx_ptr_set(spim_data.spim.p_reg, prim ? spim_data.tx_buf1 : spim_data.tx_buf0);
+	nrf_spim_tx_ptr_set(spim_data.spim.p_reg, prim ? spim_data.rx_buf1 : spim_data.rx_buf0);
 	spim_data.primary_buf = !spim_data.primary_buf;
 
 	spim_data.t_cb = k_cycle_get_32();


### PR DESCRIPTION
Allow attaching end sequence event from a domain different than the used timer. This becomes useful with devices with single timer per domain (e.g. nRF54LS05), where TIMER cannot be used for both triggering and counting sequences.

This solves ppi_seq_with_spi bug for nRF54LS05, where SPIM20 required two timers from same domain. nRF54LS05B only has one timer per domain - TIMER00, TIMER10 and TIMER20.