### PR TITLE
net: lib: downloader: coap: bound retries on server errors

### DIFF
--- a/include/net/downloader.h
+++ b/include/net/downloader.h
@@ -44,7 +44,9 @@ enum downloader_evt_id {
 	 *
 	 * Error reason may be one of the following:
 	 * - -ECONNRESET: Socket error, peer closed connection.
-	 * - -ECONNREFUSED: Socket error, connection refused by server.
+	 * - -ECONNREFUSED: Socket error, connection refused by server, or (CoAP)
+	 *   the server returned an error response (e.g. 4.01 Unauthorized).
+	 * - -ECONNABORTED: (CoAP) reconnect attempts exhausted, download aborted.
 	 * - -ENETDOWN: Socket error, network down.
 	 * - -ETIMEDOUT: Socket error, connection timed out.
 	 * - -EHOSTDOWN: Host went down during download.
@@ -58,11 +60,13 @@ enum downloader_evt_id {
 	 * - -EMSGSIZE: TLS packet is larger than the nRF91 Modem can handle.
 	 * - -EMLINK: Maximum number of redirects reached.
 	 *
-	 * In case of @c ECONNRESET errors, returning zero from the callback will let the
-	 * library attempt to reconnect to the server and download the last fragment again.
-	 * Otherwise, the application may return any non-zero value to stop the download.
-	 * On any other error code than @c ECONNRESET, the downloader will not attempt to reconnect
-	 * and will ignore the return value.
+	 * How the downloader reacts depends on the error:
+	 * - @c -ECONNRESET: the downloader automatically closes the connection, reconnects,
+	 *   and resumes the download without invoking the callback. The
+	 *   @c DOWNLOADER_EVT_ERROR event is only generated if the reconnection itself fails.
+	 * - Any other error (including the CoAP @c -ECONNREFUSED and @c -ECONNABORTED above):
+	 *   the @c DOWNLOADER_EVT_ERROR event is generated. Return a non-zero value from the
+	 *   callback to stop the download, or zero to let the downloader reconnect and resume.
 	 *
 	 * In case the download is stopped or completed, and the
 	 * @c downloader_host_cfg.keep_connection flag is set, the downloader will stay
@@ -115,13 +119,11 @@ struct downloader_evt {
  * Through this callback, the application receives events, such as
  * download of a fragment, download completion, or errors.
  *
- * On a @c DOWNLOADER_EVT_ERROR event with error @c ECONNRESET,
- * returning zero from the callback will let the library attempt
- * to reconnect to the server and continue the download.
- * Otherwise, the callback may return any non-zero value
- * to stop the download. On any other error code than @c ECONNRESET, the downloader
- * will not attempt to reconnect and will ignore the return value.
- * To resume the download, use @ref downloader_get().
+ * When a @c DOWNLOADER_EVT_ERROR event is received, the return value controls
+ * whether the download is resumed: return a non-zero value to stop it, or zero to
+ * let the downloader reconnect and resume. On @c -ECONNRESET the downloader
+ * reconnects automatically and the event is only generated if that reconnection
+ * fails. To resume a stopped download later, use @ref downloader_get().
  *
  * @param[in] event	The event.
  *

--- a/include/net/downloader_transport_coap.h
+++ b/include/net/downloader_transport_coap.h
@@ -27,6 +27,14 @@ struct downloader_transport_coap_cfg {
 	enum coap_block_size block_size;
 	/** Max retransmission requests. */
 	uint8_t max_retransmission;
+	/** Maximum number of reconnect attempts before the download is aborted.
+	 *
+	 *  This bounds how many times the downloader retries the transfer when
+	 *  recovery (retransmission or reconnection) does not make progress,
+	 *  preventing indefinite retry loops. The counter is reset every time a
+	 *  block is received successfully. A value of 0 selects the default.
+	 */
+	uint8_t max_reconnects;
 };
 
 /**

--- a/subsys/net/lib/downloader/src/transports/coap.c
+++ b/subsys/net/lib/downloader/src/transports/coap.c
@@ -35,6 +35,9 @@ LOG_MODULE_DECLARE(downloader, CONFIG_DOWNLOADER_LOG_LEVEL);
 #define COAP "coap://"
 #define COAPS "coaps://"
 
+#define COAP_DEFAULT_MAX_RETRANSMISSION 4
+#define COAP_DEFAULT_MAX_RECONNECTS	3
+
 struct transport_params_coap {
 	/** Flag whether config is set */
 	bool cfg_set;
@@ -64,6 +67,11 @@ struct transport_params_coap {
 	bool new_data_req;
 	/** Request retransmission */
 	bool retransmission_req;
+	/** Number of reconnect attempts since the last forward progress.
+	 *  Reset whenever a block is received successfully. Bounds the number
+	 *  of times the download is retried when recovery does not succeed.
+	 */
+	uint8_t reconnects;
 	/* Proxy-URI option value */
 	const char *proxy_uri;
 	/* Client auth callback */
@@ -243,8 +251,16 @@ static int coap_parse(struct downloader *dl, size_t len)
 
 	response_code = coap_header_get_code(&response);
 	if (response_code != COAP_RESPONSE_CODE_CONTENT) {
+		/* The server returned a valid response, but not the expected
+		 * content (e.g. a 4.xx/5.xx such as 4.01 Unauthorized). This is a
+		 * definitive answer from the server; retransmitting the same
+		 * request will not change it, so report a fatal error instead of
+		 * requesting the block again. -ECONNREFUSED is used (as opposed to
+		 * the -EBADMSG returned for malformed/unexpected packets) so the
+		 * caller can tell the two apart and stop the download.
+		 */
 		LOG_ERR("Server responded with code 0x%x", response_code);
-		return -EBADMSG;
+		return -ECONNREFUSED;
 	}
 
 	err = coap_block_update(dl, &response, &blk_off, &more);
@@ -261,6 +277,9 @@ static int coap_parse(struct downloader *dl, size_t len)
 	/* Accumulate buffer offset */
 	dl->progress += payload_len;
 	dl->buf_offset = 0;
+
+	/* Forward progress was made, reset the reconnect budget. */
+	coap->reconnects = 0;
 
 	dl_transport_evt_data(dl, (void *)payload, payload_len);
 
@@ -394,7 +413,14 @@ static int dl_coap_init(struct downloader *dl, struct downloader_host_cfg *dl_ho
 		coap->cfg_set = cfg_set;
 	} else {
 		coap->cfg.block_size = COAP_BLOCK_1024;
-		coap->cfg.max_retransmission = 4;
+		coap->cfg.max_retransmission = COAP_DEFAULT_MAX_RETRANSMISSION;
+	}
+
+	/* A value of 0 (e.g. from a config that predates this field) selects the
+	 * default so that there is always an upper bound on retries.
+	 */
+	if (coap->cfg.max_reconnects == 0) {
+		coap->cfg.max_reconnects = COAP_DEFAULT_MAX_RECONNECTS;
 	}
 
 	coap->sock.proto = NET_IPPROTO_UDP;
@@ -454,6 +480,23 @@ static int dl_coap_connect(struct downloader *dl)
 	struct transport_params_coap *coap;
 
 	coap = (struct transport_params_coap *)dl->transport_internal;
+
+	/* coap->initialized is only set after the first successful connection of
+	 * a download, so if it is set here this call is a reconnect attempt.
+	 * Bound the number of reconnects that do not lead to forward progress to
+	 * avoid retrying indefinitely (the counter is reset in coap_parse() when
+	 * a block is received).
+	 */
+	if (coap->initialized) {
+		if (coap->reconnects >= coap->cfg.max_reconnects) {
+			LOG_ERR("Reconnect limit (%u) reached, aborting download",
+				coap->cfg.max_reconnects);
+			return -ECONNABORTED;
+		}
+		coap->reconnects++;
+		LOG_DBG("Reconnect attempt %u/%u", coap->reconnects,
+			coap->cfg.max_reconnects);
+	}
 
 	err = -1;
 
@@ -562,9 +605,20 @@ static int dl_coap_download(struct downloader *dl)
 
 	ret = coap_parse(dl, len);
 	if (ret < 0) {
-		/* Request data again */
-		coap->retransmission_req = true;
-		return 0;
+		if (ret == -EBADMSG) {
+			/* Malformed or unexpected packet, likely transient.
+			 * Request the same block again.
+			 */
+			coap->retransmission_req = true;
+			return 0;
+		}
+
+		/* Any other error (e.g. a 4.xx/5.xx server response) is
+		 * definitive. Propagate it so the download is stopped and the
+		 * error is reported to the application instead of retrying
+		 * indefinitely.
+		 */
+		return ret;
 	}
 
 	if (dl->progress == dl->file_size) {

--- a/tests/subsys/net/lib/downloader/src/main.c
+++ b/tests/subsys/net/lib/downloader/src/main.c
@@ -1159,6 +1159,17 @@ static ssize_t z_impl_zsock_recvfrom_coap_timeout_then_data(int sock, void *buf,
 	return z_impl_zsock_recvfrom_coap(sock, buf, max_len, flags, src_addr, addrlen);
 }
 
+static ssize_t z_impl_zsock_recvfrom_coap_econnreset(int sock, void *buf, size_t max_len,
+						     int flags, struct net_sockaddr *src_addr,
+						     net_socklen_t *addrlen)
+{
+	/* Connection reset on every receive, forcing the downloader to reconnect
+	 * repeatedly without ever making progress.
+	 */
+	errno = ECONNRESET;
+	return -1;
+}
+
 int coap_get_option_int_ok(const struct coap_packet *cpkt, uint16_t code)
 {
 	return 0;
@@ -1241,6 +1252,12 @@ uint8_t coap_header_get_code_bad_then_ok(const struct coap_packet *cpkt)
 uint8_t coap_header_get_code_bad(const struct coap_packet *cpkt)
 {
 	return 0xba;
+}
+
+uint8_t coap_header_get_code_unauthorized(const struct coap_packet *cpkt)
+{
+	/* 4.01 Unauthorized, wire code 0x81. See NCSDK-38508. */
+	return COAP_RESPONSE_CODE_UNAUTHORIZED;
 }
 
 #define COAP_PAYLOAD "This is the payload"
@@ -2105,7 +2122,12 @@ void test_downloader_get_coap_one_bad_header_code(void)
 	err = downloader_get(&dl, &dl_host_cfg, COAP_URL, 0);
 	TEST_ASSERT_EQUAL(0, err);
 
-	evt = dl_wait_for_event(DOWNLOADER_EVT_DONE, K_SECONDS(3));
+	/* A non-CONTENT CoAP response code is a definitive answer from the server
+	 * (e.g. 4.01 Unauthorized). The downloader must not retransmit the request
+	 * indefinitely; it reports the error and stops. See NCSDK-38508.
+	 */
+	evt = dl_wait_for_event(DOWNLOADER_EVT_ERROR, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(-ECONNREFUSED, evt.error);
 
 	downloader_deinit(&dl);
 	dl_wait_for_event(DOWNLOADER_EVT_DEINITIALIZED, K_SECONDS(1));
@@ -2211,6 +2233,86 @@ void test_downloader_get_coap_retransmission_recovery(void)
 
 	TEST_ASSERT_EQUAL(2, coap_pending_cycle_fake.call_count);
 	TEST_ASSERT_EQUAL(2, z_impl_zsock_recvfrom_fake.call_count);
+
+	downloader_deinit(&dl);
+	dl_wait_for_event(DOWNLOADER_EVT_DEINITIALIZED, K_SECONDS(1));
+}
+
+/* A CoAP transfer that never makes progress must not reconnect forever. After
+ * the reconnect budget is exhausted, the download is aborted with -ECONNABORTED
+ * instead of looping indefinitely. See NCSDK-38508.
+ */
+void test_downloader_get_coap_reconnect_limit(void)
+{
+	int err;
+	struct downloader_evt evt;
+
+	err = downloader_init(&dl, &dl_cfg_cb_abort);
+	TEST_ASSERT_EQUAL(0, err);
+
+	zsock_getaddrinfo_fake.custom_fake = zsock_getaddrinfo_server_ok;
+	zsock_freeaddrinfo_fake.custom_fake = zsock_freeaddrinfo_server_ipv6;
+	z_impl_zsock_socket_fake.custom_fake = z_impl_zsock_socket_coap_ipv6_ok;
+	z_impl_zsock_connect_fake.custom_fake = z_impl_zsock_connect_ipv6_ok;
+	z_impl_zsock_setsockopt_fake.custom_fake = z_impl_zsock_setsockopt_coap_ok;
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_ok;
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_coap_econnreset;
+
+	coap_get_transmission_parameters_fake.custom_fake = coap_get_transmission_parameters_ok;
+	coap_pending_cycle_fake.custom_fake = coap_pending_cycle_ok;
+	coap_header_get_type_fake.custom_fake = coap_header_get_type_ack;
+	coap_header_get_code_fake.custom_fake = coap_header_get_code_ok;
+	coap_packet_get_payload_fake.custom_fake = coap_packet_get_payload_ok;
+
+	err = downloader_get(&dl, &dl_host_cfg, COAP_URL, 0);
+	TEST_ASSERT_EQUAL(0, err);
+
+	evt = dl_wait_for_event(DOWNLOADER_EVT_ERROR, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(-ECONNABORTED, evt.error);
+
+	downloader_deinit(&dl);
+	dl_wait_for_event(DOWNLOADER_EVT_DEINITIALIZED, K_SECONDS(1));
+}
+
+/* Exact scenario from NCSDK-38508: the server answers the block request with a
+ * 4.01 Unauthorized (wire code 0x81). This is a definitive response, so the
+ * downloader must report an error and stop, not retransmit the request forever.
+ * The request is expected to be sent exactly once (no retransmission/reconnect
+ * loop).
+ */
+void test_downloader_get_coap_unauthorized_response(void)
+{
+	int err;
+	struct downloader_evt evt;
+
+	err = downloader_init(&dl, &dl_cfg_cb_abort);
+	TEST_ASSERT_EQUAL(0, err);
+
+	zsock_getaddrinfo_fake.custom_fake = zsock_getaddrinfo_server_ok;
+	zsock_freeaddrinfo_fake.custom_fake = zsock_freeaddrinfo_server_ipv6;
+	z_impl_zsock_socket_fake.custom_fake = z_impl_zsock_socket_coap_ipv6_ok;
+	z_impl_zsock_connect_fake.custom_fake = z_impl_zsock_connect_ipv6_ok;
+	z_impl_zsock_setsockopt_fake.custom_fake = z_impl_zsock_setsockopt_coap_ok;
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_ok;
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_coap;
+
+	coap_get_transmission_parameters_fake.custom_fake = coap_get_transmission_parameters_ok;
+	coap_pending_cycle_fake.custom_fake = coap_pending_cycle_ok;
+	coap_header_get_type_fake.custom_fake = coap_header_get_type_ack;
+	coap_header_get_code_fake.custom_fake = coap_header_get_code_unauthorized;
+	coap_packet_get_payload_fake.custom_fake = coap_packet_get_payload_ok;
+
+	err = downloader_get(&dl, &dl_host_cfg, COAP_URL, 0);
+	TEST_ASSERT_EQUAL(0, err);
+
+	evt = dl_wait_for_event(DOWNLOADER_EVT_ERROR, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(-ECONNREFUSED, evt.error);
+
+	/* The request must have been sent exactly once: the 4.01 response is not
+	 * retransmitted.
+	 */
+	TEST_ASSERT_EQUAL(1, z_impl_zsock_sendto_fake.call_count);
+	TEST_ASSERT_EQUAL(1, z_impl_zsock_recvfrom_fake.call_count);
 
 	downloader_deinit(&dl);
 	dl_wait_for_event(DOWNLOADER_EVT_DEINITIALIZED, K_SECONDS(1));


### PR DESCRIPTION
## Description

The CoAP transport in the downloader library retried indefinitely when a block request received a definitive server response.

When the server answered a block request with a non-`Content` response code (e.g. **4.01 Unauthorized**, wire code `0x81`), `coap_parse()` returned an error which `dl_coap_download()` treated as a transient event: it requested a retransmission and returned success to the download thread. Because `coap_parse()` had already cleared the pending object, the retransmission failed with `-EINVAL`, was converted to `-ECONNRESET`, and the thread reconnected and reissued the identical request — looping forever and never reporting an error to the application (the `-ECONNRESET` reconnect path emits no error event).

## Fix

Addressed on two levels:

- **Classify the parse result.** A non-`Content` response code is a definitive answer from the server and is now reported as `-ECONNREFUSED` so the download stops. Malformed/unexpected packets keep returning `-EBADMSG` and are retransmitted as before.
- **Add an overall bound.** A new `max_reconnects` config option (default `3`) limits how many times the transfer is retried without making progress; the counter resets whenever a block is received. `dl_coap_connect()` aborts with `-ECONNABORTED` once the budget is spent, guaranteeing an upper bound on retries regardless of cause.

Documented the new `-ECONNREFUSED` / `-ECONNABORTED` error reasons in `downloader.h`.

## Test coverage

Added / updated unit tests (`tests/subsys/net/lib/downloader`):

- `test_downloader_get_coap_unauthorized_response` — **exact JIRA scenario**: server returns 4.01 (`0x81`); verifies the download stops with `-ECONNREFUSED` and the request is sent exactly once (no retry loop).
- `test_downloader_get_coap_reconnect_limit` — a never-progressing transfer aborts with `-ECONNABORTED` after the reconnect budget.
- `test_downloader_get_coap_one_bad_header_code` — updated to reflect that a non-`Content` code now stops with an error instead of being retransmitted.

All 55 tests pass on `native_sim`.

## Note / possible follow-up

For non-`ECONNRESET` errors, the generic `download_thread` only halts if the application returns non-zero from the error callback; on a `0` return it re-enters the (now bounded) reconnect path. This fall-through also contradicts the `downloader.h` documentation ("on any other error code than `ECONNRESET`, the downloader will not attempt to reconnect"). Worth a separate ticket if we want the library to stop unconditionally without relying on the callback return value.

Ref: NCSDK-38508