### PR TITLE
bluetooth: controller: Add sdc_support fem and coex functions

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -1003,6 +1003,14 @@ static void configure_supported_features(void)
 	if (IS_ENABLED(CONFIG_BT_CTLR_DTM)) {
 		sdc_support_direct_test_mode();
 	}
+
+	if (IS_ENABLED(CONFIG_MPSL_FEM)) {
+		sdc_support_mpsl_fem();
+	}
+
+	if (IS_ENABLED(CONFIG_MPSL_CX)) {
+		sdc_support_mpsl_coex();
+	}
 }
 
 static int configure_memory_usage(void)


### PR DESCRIPTION
These are going to be added to SDC so we can improve linking of fem and coex functionality only when required.