### PR TITLE
tests: Apply formatting cleanups in subsystem test scripts

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -666,50 +666,15 @@
     "UP012",    # https://docs.astral.sh/ruff/rules/unnecessary-encode-utf8
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
 ]
-"./tests/lib/hw_unique_key_tfm/create_test_vector.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./tests/lib/hw_unique_key_tfm/write_kmu.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./tests/subsys/bluetooth/mesh/metadata_extraction/verify_metadata.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
 ]
-"./tests/subsys/bootloader/bl_crypto/test_generator.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "F821",     # https://docs.astral.sh/ruff/rules/undefined-name
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-    "W191",     # https://docs.astral.sh/ruff/rules/tab-indentation
-    "W291",     # https://docs.astral.sh/ruff/rules/trailing-whitespace
-]
 "./tests/subsys/bootloader/bl_validation_ff_key/generate_ff_key.py" = [
     "B007",     # https://docs.astral.sh/ruff/rules/unused-loop-control-variable
     "B905",     # https://docs.astral.sh/ruff/rules/zip-without-explicit-strict
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./tests/subsys/kmu/pytest/conftest.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-]
-"./tests/subsys/kmu/pytest/test_kmu_provision.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./tests/subsys/kmu/pytest/test_kmu_verify_keys_in_app.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./tests/subsys/rtt/pytest/test_rtt.py" = [
-    "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./tests/subsys/swo/pytest/test_swo.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./tests/subsys/usb/negotiated_speed/pytest/test_usb_speed.py" = [
-    "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
-    "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
 ]
 [format]
 exclude = [
@@ -836,14 +801,6 @@ exclude = [
     "./scripts/west_commands/utils/__init__.py",
     "./subsys/net/lib/wifi_prov_core/proto/generate_wifi_prov_config.py",
     "./subsys/net/lib/wifi_prov_core/proto/test_auth_modes.py",
-    "./tests/drivers/grtc/grtc_reset/pytest/tests.py",
     "./tests/lib/hw_unique_key_tfm/create_test_vector.py",
     "./tests/lib/hw_unique_key_tfm/write_kmu.py",
-    "./tests/subsys/bluetooth/mesh/metadata_extraction/verify_metadata.py",
-    "./tests/subsys/bootloader/bl_crypto/test_generator.py",
-    "./tests/subsys/bootloader/bl_validation_ff_key/generate_ff_key.py",
-    "./tests/subsys/kmu/pytest/test_kmu_provision.py",
-    "./tests/subsys/kmu/pytest/test_kmu_verify_keys_in_app.py",
-    "./tests/subsys/rtt/pytest/test_rtt.py",
-    "./tests/subsys/usb/negotiated_speed/pytest/test_usb_speed.py",
 ]

--- a/tests/subsys/bluetooth/mesh/metadata_extraction/verify_metadata.py
+++ b/tests/subsys/bluetooth/mesh/metadata_extraction/verify_metadata.py
@@ -58,12 +58,10 @@ def expected_metadata(size):
                 'vid': 3,
                 'crpl': 64,
                 'features': 5,
-                'elements': [
-                    {'location': 1, 'sig_models': [0, 2], 'vendor_models': [0x56781234]}
-                ]
+                'elements': [{'location': 1, 'sig_models': [0, 2], 'vendor_models': [0x56781234]}],
             },
             'composition_hash': 1829016033,
-            'encoded_metadata': f'0102030004000000{encoded_size}01e191046d0100'
+            'encoded_metadata': f'0102030004000000{encoded_size}01e191046d0100',
         },
         {
             'sign_version': {'major': 1, 'minor': 2, 'revision': 3, 'build_number': 4},
@@ -77,12 +75,12 @@ def expected_metadata(size):
                 'features': 5,
                 'elements': [
                     {'location': 1, 'sig_models': [0, 2], 'vendor_models': [0x56781234]},
-                    {'location': 2, 'sig_models': [4097, 4099], 'vendor_models': []}
-                ]
+                    {'location': 2, 'sig_models': [4097, 4099], 'vendor_models': []},
+                ],
             },
             'composition_hash': 214185805,
-            'encoded_metadata': f'0102030004000000{encoded_size}014d37c40c0200'
-        }
+            'encoded_metadata': f'0102030004000000{encoded_size}014d37c40c0200',
+        },
     ]
 
 
@@ -92,7 +90,9 @@ if __name__ == '__main__':
     fwid = sys.argv[3]
 
     zip_path = os.path.join(bin_dir, "dfu_application.zip")
-    binary_size = os.path.getsize(os.path.join(bin_dir, "metadata_extraction", "zephyr", "zephyr.signed.bin"))
+    binary_size = os.path.getsize(
+        os.path.join(bin_dir, "metadata_extraction", "zephyr", "zephyr.signed.bin")
+    )
 
     expected = expected_metadata(binary_size)
 
@@ -112,8 +112,9 @@ if __name__ == '__main__':
         assert_metadata_equal(json_data, expected[0])
     elif comp_data_layout == '--multiple':
         assert not isinstance(json_data, dict), "Expected multiple metadata but got one."
-        assert len(json_data) == len(expected), (f"Expected {len(expected)} metadatas "
-                                                          f"but got {len(json_data)}")
+        assert len(json_data) == len(expected), (
+            f"Expected {len(expected)} metadatas but got {len(json_data)}"
+        )
         for i, data in enumerate(json_data):
             assert_metadata_equal(data, expected[i], f"Metadata[{i}] not equal to expected")
     else:

--- a/tests/subsys/bootloader/bl_validation_ff_key/generate_ff_key.py
+++ b/tests/subsys/bootloader/bl_validation_ff_key/generate_ff_key.py
@@ -17,7 +17,7 @@ for _i in range(100000):
 
     # Search for aligned 0xFFFF.
     for u16 in zip(vk_hash[::2], vk_hash[1::2], strict=False):
-        if u16 == (0xff, 0xff):
+        if u16 == (0xFF, 0xFF):
             print(vk_hash)
             with open('ff.pem', 'wb') as f:
                 f.write(sk.to_pem())

--- a/tests/subsys/kmu/pytest/test_kmu_provision.py
+++ b/tests/subsys/kmu/pytest/test_kmu_provision.py
@@ -7,14 +7,14 @@ import logging
 from pathlib import Path
 
 import pytest
+from constant import APP_KEYS_FOR_KMU
 from twister_harness import DeviceAdapter
 from twister_harness.helpers.utils import find_in_config, match_lines
+from twister_harness_ext.utils.common import reset_board
 from twister_harness_ext.utils.key_provisioning import (
     get_keyname_for_mcuboot,
     provision_keys_for_kmu,
 )
-from twister_harness_ext.utils.common import reset_board
-from constant import APP_KEYS_FOR_KMU
 
 logger = logging.getLogger(__name__)
 
@@ -36,31 +36,33 @@ def test_kmu_use_key_from_config(dut: DeviceAdapter, test_option):
         keys = [
             APP_KEYS_FOR_KMU / 'root-ed25519-1.pem',
             key_file,
-            APP_KEYS_FOR_KMU / 'root-ed25519-2.pem'
+            APP_KEYS_FOR_KMU / 'root-ed25519-2.pem',
         ]
     elif test_option == 'three_keys_last_used':
         keys = [
             APP_KEYS_FOR_KMU / 'root-ed25519-1.pem',
             APP_KEYS_FOR_KMU / 'root-ed25519-2.pem',
-            key_file
+            key_file,
         ]
     else:
         keys = [key_file]
 
     provision_keys_for_kmu(
-        keys=keys,
-        keyname=get_keyname_for_mcuboot(sysbuild_config),
-        dev_id=dut.device_config.id
+        keys=keys, keyname=get_keyname_for_mcuboot(sysbuild_config), dev_id=dut.device_config.id
     )
     dut.clear_buffer()
     reset_board(dut.device_config.id)
 
     lines = dut.readlines_until(
         regex='Unable to find bootable image|Jumping to the first image slot',
-        print_output=True, timeout=20)
+        print_output=True,
+        timeout=20,
+    )
 
     match_lines(lines, ['Jumping to the first image slot'])
-    logger.info("Passed: Booted successfully after provisioning the same key that was used during building")
+    logger.info(
+        "Passed: Booted successfully after provisioning the same key that was used during building"
+    )
 
 
 @pytest.mark.usefixtures("no_reset")
@@ -75,10 +77,10 @@ def test_kmu_use_wrong_key(dut: DeviceAdapter):
         keys=[
             APP_KEYS_FOR_KMU / 'root-ed25519-1.pem',
             APP_KEYS_FOR_KMU / 'root-ed25519-2.pem',
-            APP_KEYS_FOR_KMU / 'root-ed25519-w.pem'
+            APP_KEYS_FOR_KMU / 'root-ed25519-w.pem',
         ],
         keyname=get_keyname_for_mcuboot(sysbuild_config),
-        dev_id=dut.device_config.id
+        dev_id=dut.device_config.id,
     )
 
     dut.clear_buffer()
@@ -86,11 +88,16 @@ def test_kmu_use_wrong_key(dut: DeviceAdapter):
 
     lines = dut.readlines_until(
         regex='Unable to find bootable image|Jumping to the first image slot',
-        print_output=True, timeout=20)
+        print_output=True,
+        timeout=20,
+    )
 
-    match_lines(lines, [
-        'ED25519 signature verification failed',
-        'Image in the primary slot is not valid',
-        'Unable to find bootable image'
-    ])
+    match_lines(
+        lines,
+        [
+            'ED25519 signature verification failed',
+            'Image in the primary slot is not valid',
+            'Unable to find bootable image',
+        ],
+    )
     logger.info("Passed: Not booted when used wrong keys")

--- a/tests/subsys/kmu/pytest/test_kmu_verify_keys_in_app.py
+++ b/tests/subsys/kmu/pytest/test_kmu_verify_keys_in_app.py
@@ -7,12 +7,11 @@ import logging
 from pathlib import Path
 
 import pytest
+from constant import APP_KEYS_FOR_KMU
 from twister_harness import DeviceAdapter
 from twister_harness.helpers.utils import find_in_config, match_lines
-from twister_harness_ext.utils.key_provisioning import provision_keys_for_kmu
 from twister_harness_ext.utils.common import reset_board
-from constant import APP_KEYS_FOR_KMU
-
+from twister_harness_ext.utils.key_provisioning import provision_keys_for_kmu
 
 logger = logging.getLogger(__name__)
 
@@ -26,10 +25,12 @@ def test_kmu_correct_keys_uploaded(dut: DeviceAdapter):
     zephyr_base = find_in_config(dut.device_config.build_dir / 'CMakeCache.txt', 'ZEPHYR_BASE:PATH')
     default_key = Path(zephyr_base).parent / 'bootloader' / 'mcuboot' / 'root-ed25519.pem'
     provision_keys_for_kmu(
-        keys=[default_key,
-              APP_KEYS_FOR_KMU / 'root-ed25519-1.pem',
-              APP_KEYS_FOR_KMU / 'root-ed25519-2.pem'],
-        dev_id=dut.device_config.id
+        keys=[
+            default_key,
+            APP_KEYS_FOR_KMU / 'root-ed25519-1.pem',
+            APP_KEYS_FOR_KMU / 'root-ed25519-2.pem',
+        ],
+        dev_id=dut.device_config.id,
     )
 
     logger.info("Reset the board once again and check if keys are verified")
@@ -37,14 +38,10 @@ def test_kmu_correct_keys_uploaded(dut: DeviceAdapter):
     reset_board(dut.device_config.id)
 
     lines = dut.readlines_until(
-        regex='Key 2 failed|Key 2 verified|PSA crypto init failed',
-        print_output=True, timeout=20)
+        regex='Key 2 failed|Key 2 verified|PSA crypto init failed', print_output=True, timeout=20
+    )
 
-    match_lines(lines, [
-        'Default key verified',
-        'Key 1 verified',
-        'Key 2 verified'
-    ])
+    match_lines(lines, ['Default key verified', 'Key 1 verified', 'Key 2 verified'])
 
 
 @pytest.mark.usefixtures("no_reset")
@@ -54,10 +51,12 @@ def test_kmu_wrong_keys_uploaded(dut: DeviceAdapter):
     and verify it in application.
     """
     provision_keys_for_kmu(
-        keys=[APP_KEYS_FOR_KMU / 'root-ed25519-w.pem',
-              APP_KEYS_FOR_KMU / 'root-ed25519-1.pem',
-              APP_KEYS_FOR_KMU / 'root-ed25519-w.pem'],
-        dev_id=dut.device_config.id
+        keys=[
+            APP_KEYS_FOR_KMU / 'root-ed25519-w.pem',
+            APP_KEYS_FOR_KMU / 'root-ed25519-1.pem',
+            APP_KEYS_FOR_KMU / 'root-ed25519-w.pem',
+        ],
+        dev_id=dut.device_config.id,
     )
 
     logger.info("Reset the board once again and check if keys are verified")
@@ -65,11 +64,7 @@ def test_kmu_wrong_keys_uploaded(dut: DeviceAdapter):
     reset_board(dut.device_config.id)
 
     lines = dut.readlines_until(
-        regex='Key 2 failed|Key 2 verified|PSA crypto init failed',
-        print_output=True, timeout=20)
+        regex='Key 2 failed|Key 2 verified|PSA crypto init failed', print_output=True, timeout=20
+    )
 
-    match_lines(lines, [
-        'Default key failed',
-        'Key 1 verified',
-        'Key 2 failed'
-    ])
+    match_lines(lines, ['Default key failed', 'Key 1 verified', 'Key 2 failed'])

--- a/tests/subsys/rtt/pytest/test_rtt.py
+++ b/tests/subsys/rtt/pytest/test_rtt.py
@@ -15,6 +15,7 @@ from twister_harness import DeviceAdapter
 
 logger = logging.getLogger(__name__)
 
+
 # Kill parent process and all child processes (if started)
 def _kill(proc):
     try:
@@ -116,7 +117,7 @@ def test_rtt_logging(dut: DeviceAdapter):
         # Using nRF54L15_M33 as the device because its RAM region closely matches nRF7120.
         # This enables automatic SEGGER RTT symbol detection by JLinkRTTLogger.
         # Update to the official nRF7120 device name when SEGGER adds support.
-        'nrf7120dk/nrf7120/cpuapp' : {
+        'nrf7120dk/nrf7120/cpuapp': {
             'device': 'nRF54L15_M33',
         },
     }
@@ -178,9 +179,7 @@ def test_rtt_logging(dut: DeviceAdapter):
         raise exc
 
     # if nothing in log_file, stop test
-    assert(
-        len(log_file_content) > 0
-    ), f"File {log_filename} is empty"
+    assert len(log_file_content) > 0, f"File {log_filename} is empty"
 
     # Check if log file contains expected string
     expected_str = re.search(EXPECTED, log_file_content)

--- a/tests/subsys/usb/negotiated_speed/pytest/test_usb_speed.py
+++ b/tests/subsys/usb/negotiated_speed/pytest/test_usb_speed.py
@@ -51,15 +51,10 @@ def test_usb_negotaited_speed(dut: DeviceAdapter):
 
     assert USB_SAMPLE_ID in usb_devices, failure_info
 
-    vendor_and_dev_id: str = (
-        usb_devices.split(USB_SAMPLE_ID)[0].split("ID ")[-1].strip(" ")
-    )
+    vendor_and_dev_id: str = usb_devices.split(USB_SAMPLE_ID)[0].split("ID ")[-1].strip(" ")
     usb_device_info: str = excute_command(f"lsusb -d {vendor_and_dev_id} -v")
     max_packet_size: int = int(
-        usb_device_info.split("wMaxPacketSize")[-1]
-        .split("bytes")[0]
-        .split("1x ")[-1]
-        .strip(" ")
+        usb_device_info.split("wMaxPacketSize")[-1].split("bytes")[0].split("1x ")[-1].strip(" ")
     )
     negotiated_speed: str = packet_size_vs_speed[max_packet_size]
 


### PR DESCRIPTION
Formatted python files with ruff and removed from .ruff-excludes.toml.