### PR TITLE
net: lib: downloader: coap: validate token and support separate responses

### DIFF
--- a/subsys/net/lib/downloader/src/transports/coap.c
+++ b/subsys/net/lib/downloader/src/transports/coap.c
@@ -49,6 +49,13 @@ struct transport_params_coap {
 	struct coap_block_context block_ctx;
 	/** CoAP pending object. */
 	struct coap_pending pending;
+	/** Token of the outstanding request. Stored so that the response token
+	 *  can be validated (RFC 7252 5.3.2) and reused across retransmissions
+	 *  of the same request.
+	 */
+	uint8_t token[COAP_TOKEN_MAX_LEN];
+	/** Length of the outstanding request token. */
+	uint8_t token_len;
 
 	struct {
 		/** Socket descriptor. */
@@ -100,6 +107,45 @@ static bool has_pending(struct downloader *dl)
 
 	coap = (struct transport_params_coap *)dl->transport_internal;
 	return coap->pending.timeout > 0;
+}
+
+/* Check that the token in the received response matches the one that was sent
+ * with the outstanding request (RFC 7252 5.3.2).
+ */
+static bool coap_tokens_match(const struct coap_packet *response,
+			      const struct transport_params_coap *coap)
+{
+	uint8_t token[COAP_TOKEN_MAX_LEN];
+	uint8_t token_len;
+
+	token_len = coap_header_get_token(response, token);
+
+	return (token_len == coap->token_len) &&
+	       (memcmp(token, coap->token, token_len) == 0);
+}
+
+/* Acknowledge a separate response that was sent as a confirmable message with
+ * an empty ACK (RFC 7252 5.2.2). A dedicated buffer is used so that the receive
+ * buffer holding the response payload is left untouched.
+ */
+static int coap_send_empty_ack(struct downloader *dl, uint16_t id)
+{
+	int err;
+	struct coap_packet ack;
+	struct transport_params_coap *coap;
+	/* An empty ACK is header-only: 4-byte header, no token/options/payload. */
+	uint8_t buf[4];
+
+	coap = (struct transport_params_coap *)dl->transport_internal;
+
+	err = coap_packet_init(&ack, buf, sizeof(buf), COAP_VER, COAP_TYPE_ACK, 0, NULL,
+			       COAP_CODE_EMPTY, id);
+	if (err) {
+		LOG_ERR("Failed to init empty ACK, err %d", err);
+		return err;
+	}
+
+	return dl_socket_send(coap->sock.fd, ack.data, ack.offset);
 }
 
 int coap_block_init(struct downloader *dl, size_t from)
@@ -219,6 +265,7 @@ static int coap_parse(struct downloader *dl, size_t len)
 	int err;
 	size_t blk_off;
 	uint8_t response_code;
+	uint8_t response_type;
 	uint16_t payload_len;
 	const uint8_t *payload;
 	struct coap_packet response;
@@ -237,19 +284,78 @@ static int coap_parse(struct downloader *dl, size_t len)
 		return -EBADMSG;
 	}
 
-	if (coap_header_get_id(&response) != coap->pending.id) {
-		LOG_ERR("Response is not pending");
+	response_type = coap_header_get_type(&response);
+	response_code = coap_header_get_code(&response);
+
+	/* RFC 7252 5.2.2: when the server cannot answer a confirmable request
+	 * immediately, it sends an empty ACK to stop the client retransmitting
+	 * and delivers the payload later in a separate CON/NON message. Consume
+	 * the empty ACK and keep waiting for that message; the pending object is
+	 * intentionally left untouched so the existing retransmission window
+	 * still bounds how long we wait.
+	 */
+	if (response_type == COAP_TYPE_ACK && response_code == COAP_CODE_EMPTY) {
+		if (coap_header_get_id(&response) != coap->pending.id) {
+			/* Empty ACK for a different exchange (e.g. a stale or
+			 * reordered ACK belonging to an already completed block).
+			 * Silently consume it and keep waiting; retransmitting in
+			 * response to it would be spurious. -EAGAIN is used rather
+			 * than -EBADMSG so dl_coap_download() does not request a
+			 * retransmission.
+			 */
+			LOG_DBG("Ignoring empty ACK with unexpected message ID");
+			return -EAGAIN;
+		}
+		LOG_DBG("Received empty ACK, awaiting separate response");
+		return -EAGAIN;
+	}
+
+	/* Match the response to the outstanding request. A piggybacked response
+	 * is an ACK carrying the request's message ID. A separate response
+	 * (RFC 7252 5.2.2) is a new CON/NON message whose message ID is chosen
+	 * by the server and thus unknown in advance, so it is matched by its
+	 * token below. UDP does not preserve ordering, so the separate response
+	 * may arrive before or after the empty ACK; both orderings are handled.
+	 */
+	switch (response_type) {
+	case COAP_TYPE_ACK:
+		if (coap_header_get_id(&response) != coap->pending.id) {
+			LOG_ERR("Response is not pending");
+			return -EBADMSG;
+		}
+		break;
+	case COAP_TYPE_CON:
+	case COAP_TYPE_NON_CON:
+		/* Separate response, matched by token below. */
+		break;
+	default:
+		LOG_ERR("Unexpected CoAP response type 0x%x", response_type);
 		return -EBADMSG;
+	}
+
+	/* RFC 7252 5.3.2: the response token must match the request token. The
+	 * downloader generates the token, so it cannot be treated as opaque and
+	 * must be verified. This is also what matches a separate response to its
+	 * request.
+	 */
+	if (!coap_tokens_match(&response, coap)) {
+		LOG_ERR("CoAP token mismatch");
+		return -EBADMSG;
+	}
+
+	/* A separate response delivered as a confirmable message must itself be
+	 * acknowledged with an empty ACK.
+	 */
+	if (response_type == COAP_TYPE_CON) {
+		err = coap_send_empty_ack(dl, coap_header_get_id(&response));
+		if (err) {
+			LOG_ERR("Failed to ACK separate response, err %d", err);
+			return err;
+		}
 	}
 
 	coap_pending_clear(&coap->pending);
 
-	if (coap_header_get_type(&response) != COAP_TYPE_ACK) {
-		LOG_ERR("Response must be of coap type ACK");
-		return -EBADMSG;
-	}
-
-	response_code = coap_header_get_code(&response);
 	if (response_code != COAP_RESPONSE_CODE_CONTENT) {
 		/* The server returned a valid response, but not the expected
 		 * content (e.g. a 4.xx/5.xx such as 4.01 Unauthorized). This is a
@@ -308,10 +414,17 @@ static int coap_request_send(struct downloader *dl)
 		id = coap->pending.id;
 	} else {
 		id = coap_next_id();
+		/* New request: generate a fresh token and remember it so the
+		 * response token can be validated (RFC 7252 5.3.2).
+		 * Retransmissions of the same request reuse the stored message
+		 * ID and token.
+		 */
+		memcpy(coap->token, coap_next_token(), COAP_TOKEN_MAX_LEN);
+		coap->token_len = COAP_TOKEN_MAX_LEN;
 	}
 
 	err = coap_packet_init(&request, dl->cfg.buf, dl->cfg.buf_size, COAP_VER,
-			       COAP_TYPE_CON, 8, coap_next_token(), COAP_METHOD_GET, id);
+			       COAP_TYPE_CON, coap->token_len, coap->token, COAP_METHOD_GET, id);
 	if (err) {
 		LOG_ERR("Failed to init CoAP message, err %d", err);
 		return err;
@@ -605,6 +718,14 @@ static int dl_coap_download(struct downloader *dl)
 
 	ret = coap_parse(dl, len);
 	if (ret < 0) {
+		if (ret == -EAGAIN) {
+			/* Empty ACK consumed (RFC 7252 5.2.2). Keep receiving
+			 * within the current retransmission window without
+			 * requesting new data or forcing a retransmission, so the
+			 * separate response can be received.
+			 */
+			return 0;
+		}
 		if (ret == -EBADMSG) {
 			/* Malformed or unexpected packet, likely transient.
 			 * Request the same block again.

--- a/tests/subsys/net/lib/downloader/src/main.c
+++ b/tests/subsys/net/lib/downloader/src/main.c
@@ -274,6 +274,7 @@ FAKE_VALUE_FUNC(int, coap_packet_parse, struct coap_packet *, uint8_t *, uint16_
 FAKE_VALUE_FUNC(uint16_t, coap_header_get_id, const struct coap_packet *);
 FAKE_VALUE_FUNC(uint8_t, coap_header_get_type, const struct coap_packet *);
 FAKE_VALUE_FUNC(uint8_t, coap_header_get_code, const struct coap_packet *);
+FAKE_VALUE_FUNC(uint8_t, coap_header_get_token, const struct coap_packet *, uint8_t *);
 FAKE_VALUE_FUNC(const uint8_t *, coap_packet_get_payload, const struct coap_packet *, uint16_t *);
 FAKE_VALUE_FUNC(int, coap_packet_init, struct coap_packet *, uint8_t *, uint16_t, uint8_t, uint8_t,
 		uint8_t, const uint8_t *, uint8_t, uint16_t);
@@ -1278,6 +1279,45 @@ uint8_t *coap_next_token_ok(void)
 	static uint8_t token[COAP_TOKEN_MAX_LEN];
 
 	return token;
+}
+
+uint8_t coap_header_get_token_ok(const struct coap_packet *cpkt, uint8_t *token)
+{
+	/* Return the same (zeroed) token that coap_next_token_ok() provided when
+	 * the request was built, so the transport's token validation passes.
+	 */
+	memset(token, 0, COAP_TOKEN_MAX_LEN);
+	return COAP_TOKEN_MAX_LEN;
+}
+
+uint8_t coap_header_get_type_separate(const struct coap_packet *cpkt)
+{
+	/* The first response is the empty ACK, the second is the separate
+	 * response delivered as a confirmable message (RFC 7252 5.2.2).
+	 */
+	return (coap_header_get_type_fake.call_count == 1) ? COAP_TYPE_ACK : COAP_TYPE_CON;
+}
+
+uint8_t coap_header_get_code_empty_then_content(const struct coap_packet *cpkt)
+{
+	/* Empty ACK first (code 0.00), then the actual content response. */
+	return (coap_header_get_code_fake.call_count == 1) ? COAP_CODE_EMPTY
+							   : COAP_RESPONSE_CODE_CONTENT;
+}
+
+/* Message ID chosen by the server for the separate response. Deliberately
+ * different from the request's (pending) message ID, which is 0 in these tests.
+ */
+#define COAP_SEPARATE_RESPONSE_MSG_ID 0x1234
+
+uint16_t coap_header_get_id_separate(const struct coap_packet *cpkt)
+{
+	/* First lookup is for the empty ACK, which must match the pending
+	 * request ID (0). The second is for the separate response, which
+	 * carries the server-chosen ID that the empty ACK back to the server
+	 * must echo.
+	 */
+	return (coap_header_get_id_fake.call_count == 1) ? 0 : COAP_SEPARATE_RESPONSE_MSG_ID;
 }
 int coap_packet_append_option_ok(struct coap_packet *cpkt, uint16_t code,
 			      const uint8_t *value, uint16_t len)
@@ -2318,6 +2358,66 @@ void test_downloader_get_coap_unauthorized_response(void)
 	dl_wait_for_event(DOWNLOADER_EVT_DEINITIALIZED, K_SECONDS(1));
 }
 
+/* RFC 7252 5.2.2: the server may answer a confirmable request with an empty
+ * ACK and deliver the payload later in a separate confirmable message. The
+ * downloader must wait for that separate response, acknowledge it, and complete
+ * the download. See NCSDK-25747.
+ */
+void test_downloader_get_coap_separate_response(void)
+{
+	int err;
+	struct downloader_evt evt;
+
+	err = downloader_init(&dl, &dl_cfg);
+	TEST_ASSERT_EQUAL(0, err);
+
+	zsock_getaddrinfo_fake.custom_fake = zsock_getaddrinfo_server_ok;
+	zsock_freeaddrinfo_fake.custom_fake = zsock_freeaddrinfo_server_ipv6;
+	z_impl_zsock_socket_fake.custom_fake = z_impl_zsock_socket_coap_ipv6_ok;
+	z_impl_zsock_connect_fake.custom_fake = z_impl_zsock_connect_ipv6_ok;
+	z_impl_zsock_setsockopt_fake.custom_fake = z_impl_zsock_setsockopt_coap_ok;
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_ok;
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_coap;
+
+	coap_get_transmission_parameters_fake.custom_fake = coap_get_transmission_parameters_ok;
+	coap_pending_cycle_fake.custom_fake = coap_pending_cycle_ok;
+	/* First received message is an empty ACK, the second is the separate
+	 * (confirmable) response carrying the content.
+	 */
+	coap_header_get_type_fake.custom_fake = coap_header_get_type_separate;
+	coap_header_get_code_fake.custom_fake = coap_header_get_code_empty_then_content;
+	/* The separate response carries a server-chosen message ID that differs
+	 * from the request's pending ID; the transport must match it by token and
+	 * acknowledge it using that ID.
+	 */
+	coap_header_get_id_fake.custom_fake = coap_header_get_id_separate;
+	coap_packet_get_payload_fake.custom_fake = coap_packet_get_payload_ok;
+
+	err = downloader_get(&dl, &dl_host_cfg, COAP_URL, 0);
+	TEST_ASSERT_EQUAL(0, err);
+
+	evt = dl_wait_for_event(DOWNLOADER_EVT_DONE, K_SECONDS(3));
+	TEST_ASSERT_EQUAL(DOWNLOADER_EVT_DONE, evt.id);
+
+	/* The separate response was confirmable, so the downloader must have
+	 * acknowledged it with an empty ACK, i.e. sent more than just the
+	 * initial GET request.
+	 */
+	TEST_ASSERT_GREATER_THAN(1, z_impl_zsock_sendto_fake.call_count);
+
+	/* The most recent coap_packet_init() call must be that empty ACK: an
+	 * ACK-type, empty-code message addressed with the separate response's
+	 * server-chosen message ID (arguments are ver, type, token_len, token,
+	 * code, id).
+	 */
+	TEST_ASSERT_EQUAL(COAP_TYPE_ACK, coap_packet_init_fake.arg4_val);
+	TEST_ASSERT_EQUAL(COAP_CODE_EMPTY, coap_packet_init_fake.arg7_val);
+	TEST_ASSERT_EQUAL(COAP_SEPARATE_RESPONSE_MSG_ID, coap_packet_init_fake.arg8_val);
+
+	downloader_deinit(&dl);
+	dl_wait_for_event(DOWNLOADER_EVT_DEINITIALIZED, K_SECONDS(1));
+}
+
 void test_downloader_get_einval(void)
 {
 	int err;
@@ -2915,6 +3015,7 @@ void setUp(void)
 	RESET_FAKE(coap_header_get_id);
 	RESET_FAKE(coap_header_get_type);
 	RESET_FAKE(coap_header_get_code);
+	RESET_FAKE(coap_header_get_token);
 	RESET_FAKE(coap_packet_get_payload);
 	RESET_FAKE(coap_packet_init);
 	RESET_FAKE(coap_next_token);
@@ -2923,6 +3024,13 @@ void setUp(void)
 	RESET_FAKE(coap_append_size2_option);
 	RESET_FAKE(coap_get_transmission_parameters);
 	RESET_FAKE(coap_pending_init);
+
+	/* Provide a stable request token and a matching response token by
+	 * default so that CoAP tests pass the transport's token validation
+	 * (RFC 7252 5.3.2).
+	 */
+	coap_next_token_fake.custom_fake = coap_next_token_ok;
+	coap_header_get_token_fake.custom_fake = coap_header_get_token_ok;
 
 	pipe_reset(&event_pipe);
 }


### PR DESCRIPTION
## Summary

Two RFC 7252 conformance gaps in the CoAP transport of the downloader library, both previously deferred to "the coap transport in the new downloader":

- **Token validation (NCSDK-25743)** — the request token was generated but never stored or checked, so a response carrying a different token was accepted (RFC 7252 §5.3.2). It was also regenerated on every retransmission rather than kept stable. Now the token is stored when a new request is built, reused across retransmissions, and verified in `coap_parse()`.

- **Separate responses (NCSDK-25747)** — a server may answer a confirmable request with an empty ACK and deliver the payload later in a separate CON/NON message (RFC 7252 §5.2.2). The transport rejected the empty ACK and any non-ACK response as malformed. Now an empty ACK is consumed and the separate response awaited within the existing retransmission window; a separate CON/NON response is accepted and matched by token (its message ID is server-chosen and, due to UDP reordering, may arrive before or after the empty ACK), and a confirmable separate response is acknowledged with an empty ACK. This also covers the NON-response-to-CON case.

The definitive-error handling (non-Content response code → `-ECONNREFUSED`) is preserved.

## Tests

- New `test_downloader_get_coap_separate_response` covers the empty-ACK-then-separate-CON flow.
- A matching response-token fake is wired so all existing CoAP tests now exercise the new token validation.
- `west twister -T tests/subsys/net/lib/downloader -p native_sim`: **56/56 test cases pass**.

## Related

- Resolves NCSDK-25743
- Resolves NCSDK-25747

🤖 Generated with [Claude Code](https://claude.com/claude-code)