### PR TITLE
samples: esb: fix empty app core selection on nRF53 Series

### DIFF
--- a/samples/esb/esb_monitor/Kconfig.sysbuild
+++ b/samples/esb/esb_monitor/Kconfig.sysbuild
@@ -8,6 +8,6 @@ config PARTITION_MANAGER
 	default n
 
 config NRF_DEFAULT_EMPTY
-	default y if SOC_SERIES_NRF53X
+	default y if SOC_SERIES_NRF53
 
 source "share/sysbuild/Kconfig"

--- a/samples/esb/esb_prx/Kconfig.sysbuild
+++ b/samples/esb/esb_prx/Kconfig.sysbuild
@@ -8,6 +8,6 @@ config PARTITION_MANAGER
 	default n
 
 config NRF_DEFAULT_EMPTY
-	default y if SOC_SERIES_NRF53X
+	default y if SOC_SERIES_NRF53
 
 source "share/sysbuild/Kconfig"

--- a/samples/esb/esb_prx_ble/Kconfig.sysbuild
+++ b/samples/esb/esb_prx_ble/Kconfig.sysbuild
@@ -8,6 +8,6 @@ config PARTITION_MANAGER
 	default n
 
 config NRF_DEFAULT_EMPTY
-	default y if SOC_SERIES_NRF53X
+	default y if SOC_SERIES_NRF53
 
 source "share/sysbuild/Kconfig"

--- a/samples/esb/esb_ptx/Kconfig.sysbuild
+++ b/samples/esb/esb_ptx/Kconfig.sysbuild
@@ -8,6 +8,6 @@ config PARTITION_MANAGER
 	default n
 
 config NRF_DEFAULT_EMPTY
-	default y if SOC_SERIES_NRF53X
+	default y if SOC_SERIES_NRF53
 
 source "share/sysbuild/Kconfig"

--- a/samples/esb/esb_ptx_ble/Kconfig.sysbuild
+++ b/samples/esb/esb_ptx_ble/Kconfig.sysbuild
@@ -8,6 +8,6 @@ config PARTITION_MANAGER
 	default n
 
 config NRF_DEFAULT_EMPTY
-	default y if SOC_SERIES_NRF53X
+	default y if SOC_SERIES_NRF53
 
 source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Use SOC_SERIES_NRF53 instead of the deprecated SOC_SERIES_NRF53X in Kconfig.sysbuild.