### PR TITLE
LTE / Modem: Guard against unsolicited secondary PDP context events

### DIFF
--- a/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
+++ b/lib/nrf_modem_lib/lte_net_if/lte_net_if.c
@@ -332,6 +332,12 @@ static void lte_evt_handler(const struct lte_lc_evt *const evt)
 
 		break;
 	case LTE_LC_EVT_PDN:
+		/* We only handle default PDN (CID 0), ignore others */
+		if (evt->pdn.cid != 0) {
+			LOG_DBG("Filtered PDN CID %d event: %d", evt->pdn.cid, evt->pdn.type);
+			break;
+		}
+
 		switch (evt->pdn.type) {
 		case LTE_LC_EVT_PDN_ACTIVATED:
 			LOG_DBG("PDN connection activated");


### PR DESCRIPTION
This PR fixes bugs in handling of unsolicited PDN context events.

When using a SGP.02 compatible SIM, it may activate a secondary PDN context on its own as part of SCP81 over HTTPS/CAT_TP using BIP (Bearer Independent Protocol). When this secondary context was later deactivated, LTE link control was reporting it and modem lib net_if integration triggered a IP addresses cleanup and L4 disconnect event.

Added guards to prevent unsolicited PDN event propagation

- LTE link control now only report PDN events for the CIDs it manages
- Modem lib net_if integration ignores events not from default PDN (CID != 0)