### PR TITLE
samples: wifi: shell: Create superset tag for nRF7120

### DIFF
--- a/samples/wifi/shell/overlay-superset.conf
+++ b/samples/wifi/shell/overlay-superset.conf
@@ -1,0 +1,81 @@
+# Consolidated nrf7120 superset overlay
+# Covers throughput, monitor/promiscuous, raw-tx, enterprise options,
+# WEP, fragmentation, and GARP.
+
+# Throughput / zperf
+CONFIG_NET_ZPERF=y
+CONFIG_NET_ZPERF_SERVER=y
+# Zperf TCP=6, UDP=2, Others=1
+CONFIG_ZVFS_POLL_MAX=20
+# Sockets: select + poll take up more stack
+CONFIG_MAIN_STACK_SIZE=5200
+CONFIG_SHELL_STACK_SIZE=5200
+CONFIG_NET_MGMT_EVENT_STACK_SIZE=4600
+
+# Optimized networking settings for performance
+CONFIG_NET_PKT_RX_COUNT=28
+CONFIG_NET_PKT_TX_COUNT=27
+CONFIG_NET_BUF_RX_COUNT=28
+CONFIG_NET_BUF_TX_COUNT=54
+CONFIG_HEAP_MEM_POOL_SIZE=40144
+CONFIG_NRF_WIFI_CTRL_HEAP_SIZE=20000
+CONFIG_NRF_WIFI_DATA_HEAP_SIZE=199856
+CONFIG_NRF70_QSPI_LOW_POWER=n
+# To enable optimization configuration options
+CONFIG_PICOLIBC_USE_MODULE=y
+CONFIG_SPEED_OPTIMIZATIONS=y
+CONFIG_CACHE_MANAGEMENT=y
+
+# Necessary for zperf_tcp_receiver.c
+CONFIG_NET_CONFIG_SETTINGS=y
+CONFIG_NET_CONFIG_INIT_TIMEOUT=0
+
+# Zephyr NET Connection Manager Connectivity layer.
+CONFIG_NET_CONNECTION_MANAGER=y
+
+# Consumes more memory
+CONFIG_WIFI_CREDENTIALS=y
+CONFIG_FLASH=y
+CONFIG_NVS=y
+CONFIG_SETTINGS=y
+CONFIG_NRF71_UTIL=y
+
+# Disable rate limiting to avoid log flooding (default is drop)
+CONFIG_LOG_RATELIMIT=n
+
+# Required by nrf71 util heap command (sys_heap_runtime_stats_get)
+CONFIG_SYS_HEAP_RUNTIME_STATS=y
+
+# Disabled to avoid pulling in CONFIG_THREAD_RUNTIME_STATS, whose
+# per-context-switch overhead reduces throughput.
+CONFIG_POSIX_MULTI_PROCESS=n
+
+# Promiscuous / monitor related
+CONFIG_NRF71_PROMISC_DATA_RX=y
+CONFIG_NET_PROMISCUOUS_MODE=y
+CONFIG_NET_CAPTURE=y
+
+CONFIG_NET_IF_MAX_IPV6_COUNT=3
+CONFIG_NET_IF_MAX_IPV4_COUNT=3
+CONFIG_NET_IF_UNICAST_IPV4_ADDR_COUNT=2
+CONFIG_NET_CONFIG_AUTO_INIT=y
+CONFIG_NET_CONFIG_NEED_IPV6=y
+CONFIG_NET_CONFIG_NEED_IPV4=y
+
+# Net capture support without USB net backend (nrf7120 has no usable USB device
+# controller path for these netusb options in this sample).
+CONFIG_POSIX_THREAD_THREADS_MAX=5
+
+# Raw TX packet mode
+CONFIG_NRF71_RAW_DATA_TX=y
+CONFIG_LOG_MODE_IMMEDIATE=y
+
+# Enterprise / WEP / fragmentation / GARP options
+CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE=y
+CONFIG_WPA_CLI=y
+CONFIG_NET_IPV4_FRAGMENT=y
+CONFIG_NET_IPV4_FRAGMENT_MAX_COUNT=10
+CONFIG_NET_IPV4_FRAGMENT_MAX_PKT=24
+CONFIG_WIFI_NM_WPA_SUPPLICANT_WEP=y
+CONFIG_NET_ARP_GRATUITOUS_TRANSMISSION=y
+CONFIG_NET_ARP_GRATUITOUS_INTERVAL=30

--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -560,6 +560,24 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_nrf71_wifi
+  # Used by QA and also acts as a memory stress test
+  sample.nrf7120.superset:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - SB_CONFIG_WIFI_NRF70=n
+      - SNIPPET=nordic-wifi-enterprise
+      - EXTRA_CONF_FILE=overlay-superset.conf
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp
+      - nrf7120dk/nrf7120/cpuapp/ns
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp
+      - nrf7120dk/nrf7120/cpuapp/ns
+    tags:
+      - ci_build_superset
+      - sysbuild
+      - ci_samples_nrf71_wifi
   sample.nrf7002.shell.wpa3_psa:
     build_only: true
     extra_args:


### PR DESCRIPTION
Create a tag to enable maximum Wi-Fi snd network features in shell sample for nRF7120 device.

Fixes WZN-10448.