### PR TITLE
tests: drivers: i2c_latency: add dedicated overlay for nRF54LM20

### DIFF
--- a/tests/drivers/i2c/i2c_latency/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_latency/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,1 +1,68 @@
-#include "nrf54l15dk_nrf54l15_cpuapp.overlay"
+/* Test requires two loopbacks:
+ * - P1.13 - P1.14,
+ * - P1.23 - P1.24.
+ */
+
+/ {
+	aliases {
+		i2c-slave = &i2c22;
+		tst-timer = &timer20;
+	};
+};
+
+&pinctrl {
+	i2c21_default_alt: i2c21_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 13)>,
+				<NRF_PSEL(TWIM_SCL, 1, 23)>;
+		};
+	};
+
+	i2c21_sleep_alt: i2c21_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 13)>,
+				<NRF_PSEL(TWIM_SCL, 1, 23)>;
+			low-power-enable;
+		};
+	};
+
+	i2c22_default_alt: i2c22_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 14)>,
+				<NRF_PSEL(TWIS_SCL, 1, 24)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c22_sleep_alt: i2c22_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 14)>,
+				<NRF_PSEL(TWIS_SCL, 1, 24)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut_twim: &i2c21 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	pinctrl-0 = <&i2c21_default_alt>;
+	pinctrl-1 = <&i2c21_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+
+	sensor: sensor@54 {
+		reg = <0x54>;
+	};
+};
+
+dut_twis: &i2c22 {
+	compatible = "nordic,nrf-twis";
+	status = "okay";
+	pinctrl-0 = <&i2c22_default_alt>;
+	pinctrl-1 = <&i2c22_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+};
+
+&timer20 {
+	status = "okay";
+};

--- a/tests/drivers/i2c/i2c_latency/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_latency/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,1 +1,1 @@
-#include "nrf54l15dk_nrf54l15_cpuapp.overlay"
+#include "nrf54lm20dk_nrf54lm20a_cpuapp.overlay"


### PR DESCRIPTION
Add dedicated set of pins for nRF54LM20A/B, do not share overlay with nRF54L15.