### PR TITLE
[Backport v3.4-branch] samples: fast_pair: Add nRF54LC10 support for input_device

### DIFF
--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Align the advertised TX power with Fast Pair expectations.
+CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-11

--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuapp_rram {
+	/* Redefine the "partitions" DTS node. */
+	/delete-node/ partitions;
+
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x0 DT_SIZE_K(988)>;
+		};
+
+		bt_fast_pair_partition: partition@f7000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0xf7000 DT_SIZE_K(4)>;
+		};
+
+		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0xf8000 DT_SIZE_K(20)>;
+		};
+	};
+};

--- a/samples/bluetooth/fast_pair/input_device/sample.yaml
+++ b/samples/bluetooth/fast_pair/input_device/sample.yaml
@@ -14,6 +14,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
@@ -24,6 +25,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     tags:
       - bluetooth
       - ci_build


### PR DESCRIPTION
Backport https://github.com/nrfconnect/sdk-nrf/commit/67d8f9cbf97a2517566507094f7cb33a149308d8 from https://github.com/nrfconnect/sdk-nrf/pull/29869.