### PR TITLE
bluetooth: controller: Add SDC config for enabling MPSL coex

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -304,6 +304,18 @@ config BT_CTLR_DF_CONN_CTE_RSP
 	  Enable support for Bluetooth v5.1 Connection CTE Response feature
 	  in controller.
 
+config BT_CTLR_SDC_MPSL_COEX_SUPPORT
+	bool
+	depends on !(BT_CTLR_PHY_CODED && MPSL_FEM && SOC_SERIES_NRF53)
+
+config BT_CTLR_SDC_MPSL_COEX
+	bool "SoftDevice Controller support for MPSL Coex"
+	default y if MPSL_CX
+	select BT_CTLR_SDC_MPSL_COEX_SUPPORT
+	help
+	  Enable support for MPSL Coex in the SoftDevice Controller.
+	  This is not supported with Coded Phy and FEM on the nRF5340 SoC.
+
 # As CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY is defined for the Zephyr LL
 # only, and BT_CLTR_DF_ADV_CTE_TX expects it existence, we define it as an empty
 # configuration here.
@@ -318,7 +330,7 @@ choice BT_LL_SOFTDEVICE_VARIANT
 						     BT_CTLR_PHY_CODED || \
 						     BT_CTLR_ADV_PERIODIC || \
 						     BT_CTLR_DF_CTE_TX || \
-						     MPSL_CX || \
+						     BT_CTLR_SDC_MPSL_COEX || \
 						     BT_CTLR_SYNC_PERIODIC || \
 						     BT_CTLR_SCA_UPDATE || \
 						     BT_CTLR_SUBRATING || \

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -1008,7 +1008,7 @@ static void configure_supported_features(void)
 		sdc_support_mpsl_fem();
 	}
 
-	if (IS_ENABLED(CONFIG_MPSL_CX)) {
+	if (IS_ENABLED(CONFIG_BT_CTLR_SDC_MPSL_COEX)) {
 		sdc_support_mpsl_coex();
 	}
 }

--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -28,15 +28,12 @@ config MPSL_CX_SOFTWARE_SUPPORT
 config MPSL_CX
 	bool "Radio Coexistence interface support"
 	depends on MPSL_CX_ANY_SUPPORT
-	depends on !(BT_CTLR_PHY_CODED && MPSL_FEM && SOC_SERIES_NRF53)
 	help
 	  Controls if Radio Coexistence interface is to be configured and enabled
 	  when MPSL is initialized.
 
 	  Radio Coexistence interface connects nRF5 radio protocols with external
 	  Packet Traffic Arbiter (PTA) which denies or grants access to RF.
-
-	  This is not supported with Coded Phy and FEM on the nRF5340 SoC.
 
 config MPSL_CX_PIN_FORWARDER
 	bool


### PR DESCRIPTION
This lets us enable coex support simply in sdc without relying on the MPSL_CX handling in NCS.

Also, we can move the bluetooth specific dependency out of mpsl.