### PR TITLE
NRFX-NONE: Fix idle_flpr test for nrf54l15dk

### DIFF
--- a/tests/benchmarks/multicore/idle_flpr/flpr_test_app/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/tests/benchmarks/multicore/idle_flpr/flpr_test_app/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -4,6 +4,14 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+&led0 {
+	gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+};
+
+&button3 {
+	gpios = <&gpio2 9 GPIO_ACTIVE_HIGH>;
+};
+
 &uart30 {
 	zephyr,pm-device-runtime-auto;
 	disable-rx;


### PR DESCRIPTION
Signed-off-by: Bartosz Miller <bartosz.miller@nordicsemi.no>