### PR TITLE
tests: i2c: twim_instances: improve nRF54L15 test stability

### DIFF
--- a/tests/drivers/i2c/twim_instances/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/i2c/twim_instances/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -7,15 +7,16 @@
 &pinctrl {
 	i2c21_default_test: i2c21_default_test {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
-				<NRF_PSEL(TWIM_SCL, 1, 8)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 9)>;
+			bias-pull-up;
 		};
 	};
 
 	i2c21_sleep_test: i2c21_sleep_test {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
-				<NRF_PSEL(TWIM_SCL, 1, 8)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 9)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Changed pins to avoid using NFC antenna. Added missing pull-up to one of the instances.