### PR TITLE
boards: shields: common overlay and nRF54L DK support for nrf2240eb

### DIFF
--- a/boards/shields/nrf2240eb/Kconfig.defconfig
+++ b/boards/shields/nrf2240eb/Kconfig.defconfig
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if SHIELD_NRF2240EB
+
+if $(dt_nodelabel_enabled,nrf2240eb_pmic)
+
+# Options related to the nPM13XX regulator and the workaround
+# against voltage drops on the nRF2240 power supply pin VDDPALDO.
+config NPM13XX_CHARGER
+	default y if $(dt_nodelabel_enabled,nrf2240eb_pmic_charger)
+
+config SENSOR
+	default y
+
+config SENSOR_INIT_PRIORITY
+	default 90
+
+# Ensure that FEM is initialized after the nPM13XX current limit on the nRF2240-EB is set.
+config MPSL_FEM_INIT_PRIORITY
+	default 91
+
+endif # $(dt_nodelabel_enabled,nrf2240eb_pmic)
+
+endif # SHIELD_NRF2240EB

--- a/boards/shields/nrf2240eb/boards/nrf52833dk_nrf52833.conf
+++ b/boards/shields/nrf2240eb/boards/nrf52833dk_nrf52833.conf
@@ -1,7 +1,0 @@
-# Options related to the nPM13XX regulator and the workaround
-# against voltage drops on the nRF2240 power supply pin VDDPALDO.
-CONFIG_SENSOR=y
-CONFIG_NPM13XX_CHARGER=y
-# Ensure that FEM is initialized after the nPM13XX current limit on the nRF2240EB is set.
-CONFIG_SENSOR_INIT_PRIORITY=90
-CONFIG_MPSL_FEM_INIT_PRIORITY=91

--- a/boards/shields/nrf2240eb/boards/nrf52840dk_nrf52840.conf
+++ b/boards/shields/nrf2240eb/boards/nrf52840dk_nrf52840.conf
@@ -1,7 +1,0 @@
-# Options related to the nPM13XX regulator and the workaround
-# against voltage drops on the nRF2240 power supply pin VDDPALDO.
-CONFIG_SENSOR=y
-CONFIG_NPM13XX_CHARGER=y
-# Ensure that FEM is initialized after the nPM13XX current limit on the nRF2240EB is set.
-CONFIG_SENSOR_INIT_PRIORITY=90
-CONFIG_MPSL_FEM_INIT_PRIORITY=91

--- a/boards/shields/nrf2240eb/boards/nrf5340dk_nrf5340_cpunet.conf
+++ b/boards/shields/nrf2240eb/boards/nrf5340dk_nrf5340_cpunet.conf
@@ -1,7 +1,0 @@
-# Options related to the nPM13XX regulator and the workaround
-# against voltage drops on the nRF2240 power supply pin VDDPALDO.
-CONFIG_SENSOR=y
-CONFIG_NPM13XX_CHARGER=y
-# Ensure that FEM is initialized after the nPM13XX current limit on the nRF2240EB is set.
-CONFIG_SENSOR_INIT_PRIORITY=90
-CONFIG_MPSL_FEM_INIT_PRIORITY=91

--- a/boards/shields/nrf2240eb/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/boards/shields/nrf2240eb/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024 Nordic Semiconductor ASA
+/* Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */

--- a/boards/shields/nrf2240eb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/boards/shields/nrf2240eb/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,7 +1,0 @@
-# Options related to the nPM13XX regulator and the workaround
-# against voltage drops on the nRF2240 power supply pin VDDPALDO.
-CONFIG_SENSOR=y
-CONFIG_NPM13XX_CHARGER=y
-# Ensure that FEM is initialized after the nPM13XX current limit on the nRF2240EB is set.
-CONFIG_SENSOR_INIT_PRIORITY=90
-CONFIG_MPSL_FEM_INIT_PRIORITY=91

--- a/boards/shields/nrf2240eb/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/boards/shields/nrf2240eb/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,37 @@
+/* Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Important:
+ * On the nRF54LC10 Development Kit pins P0.00...P0.03 are
+ * connected to the debugger chip and by default connect UART0 of the
+ * debugger chip to the nRF54LC10. The UART0 function (VCOM0) of the debugger
+ * chip must be disabled to allow the pins to be used as FEM control signals
+ * and FEM I2C interface. The "Board Configurator" tool (v0.3.7) being part of
+ * "nRF Connect for Desktop" bundle can be used for this purpose.
+ *
+ * On the nRF54LC10 Development Kit pin P0.04 is connected also to "Button 3".
+ * Please do not press this button while firmware that uses this shield
+ * is running.
+ */
+
+#include "../common/nrf54l_common.overlay"
+
+/ {
+	chosen {
+		zephyr,uart-mcumgr = &uart20;
+		zephyr,console = &uart20;
+		zephyr,shell-uart = &uart20;
+		zephyr,bt-mon-uart = &uart20;
+		zephyr,bt-c2h-uart = &uart20;
+	};
+};
+
+&uart20 {
+	status = "okay";
+};
+
+&uart30 {
+	status = "disabled";
+};

--- a/boards/shields/nrf2240eb/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/boards/shields/nrf2240eb/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,6 @@
+/* Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../common/nrf54l_common.overlay"

--- a/boards/shields/nrf2240eb/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/boards/shields/nrf2240eb/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,6 @@
+/* Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../common/nrf54l_common.overlay"

--- a/boards/shields/nrf2240eb/common/arduino_compatible.overlay
+++ b/boards/shields/nrf2240eb/common/arduino_compatible.overlay
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/* Pin mapping suitable for use nRF2240EB PCA63564 with
+/* Pin mapping suitable for use nRF2240-EB PCA63564 with
  * Nordic Interposer Board A PCA64172 v0.2.0.
- * The nRF2240EB in SLOT 2 of PCA64172.
+ * The nRF2240-EB in SLOT 2 of PCA64172.
  */
 
 / {
@@ -28,7 +28,7 @@
 		reg = <0x30>;
 	};
 
-	/* The nPM1300 on the nRF2240EB is used to supply power to the nRF2240 device. */
+	/* The nPM1300 on the nRF2240-EB is used to supply power to the nRF2240 device. */
 	nrf2240eb_pmic: pmic@6b {
 		compatible = "nordic,npm1300";
 		status = "okay";
@@ -37,7 +37,7 @@
 		nrf2240eb_pmic_charger: charger {
 			compatible = "nordic,npm1300-charger";
 			status = "okay";
-			/* When objects are placed close to the PCB antenna of the nRF2240EB
+			/* When objects are placed close to the PCB antenna of the nRF2240-EB
 			 * shield the supply voltage drops on the nRF2240 power supply pin
 			 * VDDPALDO were observed. As a workaround the current limit on VBUS
 			 * of the PMIC is increased.

--- a/boards/shields/nrf2240eb/common/nrf54l_common.overlay
+++ b/boards/shields/nrf2240eb/common/nrf54l_common.overlay
@@ -1,0 +1,100 @@
+/* Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	nrf_radio_fem: nrf2240_fem {
+		compatible = "nordic,nrf2240-fem";
+		cs-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+		md-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+		pwrmd-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		twi-if = <&nrf_radio_fem_twi>;
+	};
+};
+
+&i2c30 {
+	status = "okay";
+
+	pinctrl-0 = <&i2c30_default>;
+	pinctrl-1 = <&i2c30_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	nrf_radio_fem_twi: nrf2240_fem_twi@30 {
+		compatible = "nordic,nrf2240-fem-twi";
+		status = "okay";
+		reg = <0x30>;
+	};
+
+	/* The nPM1300 on the nRF2240-EB is used to supply power to the nRF2240 device. */
+	nrf2240eb_pmic: pmic@6b {
+		compatible = "nordic,npm1300";
+		status = "okay";
+		reg = <0x6b>;
+
+		nrf2240eb_pmic_charger: charger {
+			compatible = "nordic,npm1300-charger";
+			status = "okay";
+			/* When objects are placed close to the PCB antenna of the nRF2240-EB shield
+			 * the supply voltage drops on the nRF2240 power supply pin VDDPALDO were
+			 * observed. As a workaround the current limit on VBUS of the PMIC
+			 * is increased.
+			 */
+			vbus-limit-microamp = <500000>;
+			/* This PMIC does not have a battery, but the settings below are required
+			 * by the driver
+			 */
+			term-microvolt = <4150000>;
+			current-microamp = <150000>;
+			dischg-limit-microamp = <1000000>;
+			thermistor-ohms = <10000>;
+			thermistor-beta = <3380>;
+		};
+	};
+};
+
+&pinctrl {
+	i2c30_default: i2c30_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 4)>,
+				<NRF_PSEL(TWIM_SCL, 0, 3)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c30_sleep: i2c30_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 4)>,
+				<NRF_PSEL(TWIM_SCL, 0, 3)>;
+			low-power-enable;
+		};
+	};
+};
+
+&ppib11 {
+	status = "okay";
+};
+
+&ppib21 {
+	status = "okay";
+};
+
+&ppib22 {
+	status = "okay";
+};
+
+&ppib30 {
+	status = "okay";
+};
+
+&dppic10 {
+	status = "okay";
+};
+
+&dppic20 {
+	status = "okay";
+};
+
+&dppic30 {
+	status = "okay";
+};


### PR DESCRIPTION
Extend nRF2240-EB shield support for additional nRF54L-series development kits and reduce duplication in board-specific devicetree and Kconfig. Extract the shared FEM, I2C, PMIC, and interconnect configuration into common/nrf54l_common.overlay. Board overlays now include this file instead of repeating the same nodes.
Add board overlays for:
- nrf54l15dk/nrf54l10/cpuapp
- nrf54lc10dk/nrf54lc10a/cpuapp
- nrf54lm20dk/nrf54lm20a/cpuapp
- nrf54lm20dk/nrf54lm20b/cpuapp On nRF54LC10 DK, move console and shell UART from UART30 to UART20 and disable UART30, because UART30 uses P0.00–P0.03 which conflict with FEM control and I2C signals.
Replace duplicated per-board .conf fragments with Kconfig.defconfig to enable the nPM13XX charger workaround and ensure FEM initialization runs after the PMIC current limit is configured.

Related tickets:
- KRKNWK-22244
- KRKNWK-22245