### PR TITLE
[Backport v3.4-branch] nrf_security: drivers: cracen: fix size parameters

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecdsa.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecdsa.c
@@ -81,6 +81,7 @@ static void digest2op(const uint8_t *digest, size_t sz, uint8_t *dst, size_t ops
 	if (opsz > sz) {
 		sx_clrpkmem(dst, opsz - sz);
 		dst += opsz - sz;
+		opsz = sz;
 	}
 	sx_wrpkmem(dst, digest, opsz);
 }
@@ -498,6 +499,13 @@ int cracen_ecdsa_sign_digest_deterministic(const struct cracen_ecc_priv_key *pri
 {
 	struct sxhash hashctx;
 	int status;
+
+	/* The workmem layout and the HMAC_DRBG steps are sized from the digest length of hashalg,
+	 * so a caller-provided digest of a different length cannot be used here.
+	 */
+	if (digestsz != sx_hash_get_alg_digestsz(hashalg)) {
+		return SX_ERR_INVALID_PARAM;
+	}
 
 	status = sx_hw_reserve(&hashctx.dma, SX_HW_RESERVE_DEFAULT);
 	if (status != SX_OK) {

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ikg/cracen_ikg_operations.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ikg/cracen_ikg_operations.c
@@ -46,6 +46,7 @@ static void digest2op(const uint8_t *digest, size_t sz, uint8_t *dst, size_t ops
 	if (opsz > sz) {
 		sx_clrpkmem(dst, opsz - sz);
 		dst += opsz - sz;
+		opsz = sz;
 	}
 	sx_wrpkmem(dst, digest, opsz);
 }
@@ -102,6 +103,9 @@ int cracen_ikg_sign_digest(int identity_key_index, const struct sxhashalg *hasha
 	uint8_t workmem[digestsz];
 	struct cracen_signature internal_signature = {0};
 
+	if (digest_length > digestsz) {
+		return SX_ERR_TOO_BIG;
+	}
 	memcpy(workmem, digest, digest_length);
 
 	internal_signature.r = signature;
@@ -122,7 +126,7 @@ int cracen_ikg_sign_digest(int identity_key_index, const struct sxhashalg *hasha
 			return status;
 		}
 
-		digest2op(workmem, digestsz, inputs.h.addr, opsz);
+		digest2op(workmem, digest_length, inputs.h.addr, opsz);
 		sx_pk_run(&req);
 		status = sx_pk_wait(&req);
 


### PR DESCRIPTION
Backport 97c6958bb67481e91fe8dff220b32dd21ba6d8f9 from #30376.