### PR TITLE
[Backport v3.4-branch] samples: fast_pair: Add nRF54LS05 support for input_device

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -250,6 +250,10 @@ Bluetooth Fast Pair samples
 
 |no_changes_yet_note|
 
+* :ref:`fast_pair_input_device` sample:
+
+  * Added support for the ``nrf54ls05dk/nrf54ls05a/cpuapp`` and ``nrf54ls05dk/nrf54ls05b/cpuapp`` board targets.
+
 Cellular samples
 ----------------
 

--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54ls05dk_nrf54ls05a_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54ls05dk_nrf54ls05a_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Align the advertised TX power with Fast Pair expectations.
+CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-13

--- a/samples/bluetooth/fast_pair/input_device/boards/nrf54ls05dk_nrf54ls05a_cpuapp.overlay
+++ b/samples/bluetooth/fast_pair/input_device/boards/nrf54ls05dk_nrf54ls05a_cpuapp.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuapp_rram {
+	/* Redefine the "partitions" DTS node. */
+	/delete-node/ partitions;
+
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x0 DT_SIZE_K(484)>;
+		};
+
+		bt_fast_pair_partition: partition@79000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x79000 DT_SIZE_K(4)>;
+		};
+
+		storage_partition: partition@7a000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x7a000 DT_SIZE_K(20)>;
+		};
+	};
+};

--- a/samples/bluetooth/fast_pair/input_device/sample.yaml
+++ b/samples/bluetooth/fast_pair/input_device/sample.yaml
@@ -13,6 +13,7 @@ tests:
       - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
     platform_allow:
@@ -24,6 +25,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
     tags:


### PR DESCRIPTION
Add support for the nrf54ls05dk/nrf54ls05a/cpuapp and nrf54ls05dk/nrf54ls05b/cpuapp board targets in the input_device fast_pair sample.

Ref: NCSDK-40030