### PR TITLE
samples: net: Drop nRF54L15DK with nRF7002EB1 variant

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -409,6 +409,11 @@ Networking samples
   * :ref:`download_sample`
   * :ref:`aws_iot`
 
+* Removed the ``nrf54l15dk/nrf54l15/cpuapp`` with nRF7002 EB shield from the following samples, keeping only the nRF7002-EB II shield for the ``nrf54l15dk/nrf54l15/cpuapp`` board target:
+
+  * :ref:`https_client`
+  * :ref:`udp_sample`
+
 NFC samples
 -----------
 

--- a/samples/net/https_client/sample.yaml
+++ b/samples/net/https_client/sample.yaml
@@ -62,21 +62,6 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_net
-  sample.net.https_client.nrf54l15.wifi:
-    sysbuild: true
-    build_only: true
-    integration_platforms:
-      - nrf54l15dk/nrf54l15/cpuapp
-    platform_allow:
-      - nrf54l15dk/nrf54l15/cpuapp
-    tags:
-      - ci_build
-      - sysbuild
-      - ci_samples_net
-    extra_args:
-      - https_client_SHIELD="nrf7002eb_interposer_p1;nrf7002eb"
-      - https_client_SNIPPET="nrf70-wifi;wifi-credentials"
-      - https_client_EXTRA_CONF_FILE="wifi.conf"
   sample.net.https_client.nrf54l15_nrf7002eb2.wifi:
     sysbuild: true
     build_only: true

--- a/samples/net/udp/README.rst
+++ b/samples/net/udp/README.rst
@@ -8,7 +8,7 @@ UDP
 	:depth: 2
 
 The UDP sample demonstrates how to perform sequential transmissions of UDP packets to a server using an IP-connected device.
-The sample connects to an LTE network using an nRF91 Series DK or a Thingy:91, or to Wi-Fi® using an nRF7002 DK or an nRF54L15 DK connected with nRF7002 EB as a shield.
+The sample connects to an LTE network using an nRF91 Series DK or a Thingy:91, or to Wi-Fi® using an nRF7002 DK or an nRF54L15 DK connected with nRF7002-EB II as a shield.
 
 .. |wifi| replace:: Wi-Fi
 

--- a/samples/net/udp/sample.yaml
+++ b/samples/net/udp/sample.yaml
@@ -47,10 +47,8 @@ tests:
     build_only: true
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
     tags:
       - ci_build
       - sysbuild


### PR DESCRIPTION
This is a follow-up PR to #29900 to keep only 1 the most convenient variant for nRF54L15DK with nRF7002EB2.