### PR TITLE
lib: nrf_cloud: Fix build with the Memfault periodic upload disabled

### DIFF
--- a/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_codec_internal.c
+++ b/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_codec_internal.c
@@ -22,9 +22,9 @@
 #include <ncs_version.h>
 #include <ncs_commit.h>
 #include "cJSON_os.h"
-#if (CONFIG_MEMFAULT)
+#if defined(CONFIG_MEMFAULT_PERIODIC_UPLOAD)
 #include "memfault/ports/zephyr/periodic_upload.h"
-#endif /* CONFIG_MEMFAULT */
+#endif /* CONFIG_MEMFAULT_PERIODIC_UPLOAD */
 #if defined(CONFIG_MEMFAULT_FOTA_MODEM_UPDATE)
 #include "memfault/ports/zephyr/fota.h"
 #endif /* CONFIG_MEMFAULT_FOTA_MODEM_UPDATE */
@@ -3124,11 +3124,11 @@ void nrf_cloud_device_control_get(struct nrf_cloud_ctrl_data *const ctrl)
 		return;
 	}
 
-#if (CONFIG_MEMFAULT)
+#if defined(CONFIG_MEMFAULT_PERIODIC_UPLOAD)
 	ctrl->memfault_enabled = memfault_zephyr_port_periodic_upload_enabled();
 #else
 	ctrl->memfault_enabled = false;
-#endif /* CONFIG_MEMFAULT */
+#endif /* CONFIG_MEMFAULT_PERIODIC_UPLOAD */
 
 #if defined(CONFIG_MEMFAULT_FOTA_MODEM_UPDATE)
 	strncpy(ctrl->modem_project_key, applied_modem_project_key,
@@ -3401,11 +3401,11 @@ int nrf_cloud_shadow_control_process(struct nrf_cloud_obj_shadow_data *const inp
 	if (ctrl_status != NRF_CLOUD_CTRL_REJECT) {
 		if (device_ctrl.memfault_enabled != cloud_ctrl.memfault_enabled) {
 			ctrl_status = NRF_CLOUD_CTRL_REPLY;
-#if (CONFIG_MEMFAULT)
+#if defined(CONFIG_MEMFAULT_PERIODIC_UPLOAD)
 			LOG_INF("Changing Memfault enabled to: %s",
 				cloud_ctrl.memfault_enabled ? "true" : "false");
 			memfault_zephyr_port_periodic_upload_enable(cloud_ctrl.memfault_enabled);
-#endif /* CONFIG_MEMFAULT */
+#endif /* CONFIG_MEMFAULT_PERIODIC_UPLOAD */
 		}
 
 #if defined(CONFIG_MEMFAULT_FOTA_MODEM_UPDATE)


### PR DESCRIPTION
The shadow control code calls memfault_zephyr_port_periodic_upload_enabled() and memfault_zephyr_port_periodic_upload_enable() under CONFIG_MEMFAULT, but the Memfault Zephyr port only provides them when CONFIG_MEMFAULT_PERIODIC_UPLOAD is enabled. Building an application with CONFIG_MEMFAULT=y and CONFIG_MEMFAULT_PERIODIC_UPLOAD=n fails to link with undefined references to both functions.

Guard the include and the two call sites with CONFIG_MEMFAULT_PERIODIC_UPLOAD. Without the periodic upload the device reports memfault_enabled as false and leaves the shadow request unapplied, which is what it already does with CONFIG_MEMFAULT=n. The remaining CONFIG_MEMFAULT guards in the file only encode and decode the shadow field, so they are left as they are.

Jira: CLOUDMCU-361