### PR TITLE
manifest: update sdk-zephyr and sdk-trusted-firmware-m for nRF71 Wi-Fi boot fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -154,7 +154,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 0287e435067334db021469da413ced0406c4cfb8
+      revision: 74c58c82a89cc739cd1b003c70a90e0f9d843039
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b9eeace2af2afddf58dc257b0239659d62ddad9a
+      revision: e274eb1c4bc2cf6f5111a07fce42e0d5e386330d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Manifest PR for the nRF71 Wi-Fi boot fix.

nrfx 4.5.0 restructured `NRF_WICR_Type`, moving the WICR field that holds the Wi-Fi LMAC boot address. `wifi_setup()` read it as `NRF_WICR->RESERVED[0]`, which used to resolve to WICR + `0x000` but now lands at `0x010` — an unprogrammed word. The LMAC VPR is started at a bogus PC, so the Wi-Fi core never boots and the IPC endpoint never binds:

```
<err> wifi_nrf: IPC endpoint not bound after 30000 ms
<err> wifi_nrf: nrf_wifi_fmac_dev_add_zep: dev_init failed
```

Both copies of `wifi_setup()` now read the named `FIRMWARE.LMACINITPC` field, which is the offset the WICR generation tooling actually programs for `firmware-lmacinitpc`.

### Depends on

| Project | PR |
| --- | --- |
| sdk-zephyr | https://github.com/nrfconnect/sdk-zephyr/pull/4327 |
| sdk-trusted-firmware-m | https://github.com/nrfconnect/sdk-trusted-firmware-m/pull/265 |

Both are `[nrf fromlist]`. Upstream:

- Zephyr: https://github.com/zephyrproject-rtos/zephyr/pull/114942
- TF-M: https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/53253

Revisions are pinned to `pull/<N>/head` for now and will be replaced with the merged SHAs once the project PRs land, per the manifest PR procedure.

### Verification

`nrf7120dk/nrf7120/cpuapp` and `nrf7120dk/nrf7120/cpuapp/ns` both build clean, with `nrf71_init.o` confirmed compiled in the `ns` build so the TF-M half is genuinely exercised. Wi-Fi boots on the nRF7120 DK.
