### PR TITLE
nrf_security: drivers: cracen: always read aligned words from PK memory

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/silexpk/include/silexpk/iomem.h
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/include/silexpk/iomem.h
@@ -67,14 +67,7 @@ void sx_wrpkmem_byte(void *dst, uint8_t input_byte);
  * @param[in] src Source of read operation
  * @param[in] sz The number of bytes to read from src to dst
  */
-#if !defined(CONFIG_PSA_NEED_CRACEN_MEMORY_ACCESS_WORKAROUND)
-static inline void sx_rdpkmem(void *dst, const void *src, size_t sz)
-{
-	memcpy(dst, src, sz);
-}
-#else
 void sx_rdpkmem(void *dst, const void *src, size_t sz);
-#endif
 
 /** Read a byte from device memory at src.
  *

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/src/iomem.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/src/iomem.c
@@ -164,6 +164,8 @@ void sx_wrpkmem_byte(void *dst, uint8_t input_byte)
 	*word_dst = word;
 }
 
+#endif /* !CONFIG_PSA_NEED_CRACEN_MEMORY_ACCESS_WORKAROUND */
+
 void sx_rdpkmem(void *dst, const void *src, size_t sz)
 {
 #ifdef SX_INSTRUMENT_MMIO_WITH_PRINTFS
@@ -175,17 +177,20 @@ void sx_rdpkmem(void *dst, const void *src, size_t sz)
 
 	/* Always read aligned words from CRACEN, write bytes to dst */
 	while (sz > 0) {
-		uint32_t word = *(const uint32_t *)(s & ~3);
+		uint32_t word = *(const volatile uint32_t *)(s & ~3);
 		size_t offset = s % 4;
 		size_t count = MIN(4 - offset, sz);
 
-		for (size_t i = 0; i < count; ++i) {
-			d[i] = ((const uint8_t *)&word)[offset + i];
+		if (count == sizeof(word)) {
+			/* A whole word is wanted, but d may be unaligned. */
+			UNALIGNED_PUT(word, (uint32_t *)d);
+		} else {
+			for (size_t i = 0; i < count; ++i) {
+				d[i] = ((const uint8_t *)&word)[offset + i];
+			}
 		}
 		d += count;
 		s += count;
 		sz -= count;
 	}
 }
-
-#endif


### PR DESCRIPTION
Make `sx_rdpkmem()` always be the version that used to be active only when `CONFIG_PSA_NEED_CRACEN_MEMORY_ACCESS_WORKAROUND`.

Faults were observed while trying to `memcpy()` out secp512r1 signatures on a 54L15 device because the address read from was not word-aligned.

In order to handle this and other potential unaligned reads, just always use the version of `sx_rdpkmem()` that handles unaligned addresses.

Plus some small improvements to it.