### PR TITLE
tests: bootloader: backward compatibility: header padding

### DIFF
--- a/tests/subsys/bootloader/backward_compatibility/v3.2/compressed_update/mcuboot_update/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/subsys/bootloader/backward_compatibility/v3.2/compressed_update/mcuboot_update/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -6,7 +6,9 @@
 
 /* Pin the flash map (via DTS, no Partition Manager) to the NCS v3.2 layout so
  * the overwrite-only update image is accepted by an NCS v3.2 MCUboot: primary
- * slot ends at 0xcf000, placing the secondary slot at 0xcf000.
+ * slot ends at 0xcf000, placing the secondary slot at 0xcf000. The mcuboot_pad
+ * is folded into the start of slot0 so the image trailer stays where the v3.2
+ * MCUboot on the device expects it.
  */
 /delete-node/ &boot_partition;
 /delete-node/ &slot0_partition;
@@ -31,6 +33,12 @@
 			reg = <0xb000 DT_SIZE_K(784)>;
 		};
 
+		slot0_app_partition: partition@b800 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-app";
+			reg = <0xb800 (DT_SIZE_K(784) - DT_SIZE_K(2))>;
+		};
+
 		slot1_partition: partition@cf000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
@@ -42,5 +50,11 @@
 			label = "storage";
 			reg = <0x155000 DT_SIZE_K(64)>;
 		};
+	};
+};
+
+/ {
+	chosen {
+		zephyr,code-partition = &slot0_app_partition;
 	};
 };

--- a/tests/subsys/bootloader/backward_compatibility/v3.2/compressed_update/mcuboot_update/prj.conf
+++ b/tests/subsys/bootloader/backward_compatibility/v3.2/compressed_update/mcuboot_update/prj.conf
@@ -13,6 +13,9 @@ CONFIG_MAIN_STACK_SIZE=2048
 # Ensure an MCUboot-compatible binary is generated.
 CONFIG_BOOTLOADER_MCUBOOT=y
 
+# Match NCS v3.2.0 imgtool signing (--align 16, --pad-header, header-size 0x800).
+CONFIG_MCUBOOT_EXTRA_IMGTOOL_ARGS="--align 16 --pad-header --header-size 0x800"
+
 # Backward compatibility with NCS v3.2: current NCS signs the update image with
 # imgtool --rom-fixed (sets ih_load_addr + IMAGE_F_ROM_FIXED), which an NCS v3.2
 # MCUboot rejects when validating the decompressed image. Sign without it so the

--- a/tests/subsys/bootloader/backward_compatibility/v3.2/compressed_update/mcuboot_update/prj.conf
+++ b/tests/subsys/bootloader/backward_compatibility/v3.2/compressed_update/mcuboot_update/prj.conf
@@ -13,6 +13,14 @@ CONFIG_MAIN_STACK_SIZE=2048
 # Ensure an MCUboot-compatible binary is generated.
 CONFIG_BOOTLOADER_MCUBOOT=y
 
+# Fill the gap between the 32-byte image header and the start of the application
+# with the flash erase value instead of zeros. When an NCS v3.2 MCUboot
+# decompresses an update into the primary slot it writes only the 32-byte header
+# and leaves the rest of the gap erased, so an image whose hash was computed over
+# a zero-filled gap installs but then fails the primary slot check on the next
+# boot.
+CONFIG_MCUBOOT_EXTRA_IMGTOOL_ARGS="--pad-value 0xff"
+
 # Backward compatibility with NCS v3.2: current NCS signs the update image with
 # imgtool --rom-fixed (sets ih_load_addr + IMAGE_F_ROM_FIXED), which an NCS v3.2
 # MCUboot rejects when validating the decompressed image. Sign without it so the

--- a/tests/subsys/bootloader/backward_compatibility/v3.2/compressed_update/mcuboot_update/testcase.yaml
+++ b/tests/subsys/bootloader/backward_compatibility/v3.2/compressed_update/mcuboot_update/testcase.yaml
@@ -7,8 +7,10 @@ common:
 
 tests:
   # BC-aware configuration for the compressed_update sample.
-  # Application name restored to "mcuboot_update" and the flash map pinned via
-  # DTS board overlays (no Partition Manager) to the NCS v3.2 layout.
+  # Application name restored to "mcuboot_update". The v3.2 flash map is pinned
+  # via DTS board overlays (no Partition Manager) and the image header gap is
+  # signed with the erase value (see prj.conf), so an NCS v3.2 MCUboot both
+  # accepts and boots the decompressed update.
   mcuboot.backward_compatibility.compressed_update:
     platform_allow:
       - nrf52840dk/nrf52840

--- a/tests/subsys/bootloader/backward_compatibility/v3.2/compressed_update/mcuboot_update/testcase.yaml
+++ b/tests/subsys/bootloader/backward_compatibility/v3.2/compressed_update/mcuboot_update/testcase.yaml
@@ -7,8 +7,9 @@ common:
 
 tests:
   # BC-aware configuration for the compressed_update sample.
-  # Application name restored to "mcuboot_update" and the flash map pinned via
-  # DTS board overlays (no Partition Manager) to the NCS v3.2 layout.
+  # Application name restored to "mcuboot_update". The v3.2 flash map is pinned
+  # via DTS (no Partition Manager); imgtool signs with v3.2-compatible trailer
+  # layout (see sysbuild.cmake) so NCS v3.2 MCUboot accepts the update.
   mcuboot.backward_compatibility.compressed_update:
     platform_allow:
       - nrf52840dk/nrf52840

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: cdc01217b2bd64a726a707a98b888fa07fa82d83
+      revision: 2516f19e1b88e5787338029aa1d37c35b729f7ae
       path: bootloader/mcuboot
     - name: qcbor
       repo-path: sdk-qcbor


### PR DESCRIPTION
adds custom signing to allow header filling of 0xff or 0x00