### PR TITLE
drivers: wifi: nrf71: Fix IPC transport across interface down/up

### DIFF
--- a/drivers/wifi/nrf71/bus/ipc_if.c
+++ b/drivers/wifi/nrf71/bus/ipc_if.c
@@ -167,14 +167,22 @@ void wifi_ipc_host_rx_free_event(const wifi_ipc_buf_desc_t *event_info)
 
 int ipc_init(void)
 {
+	static bool slots_initialized;
 	int i;
 
 	wifi_ipc_host_tx_init(&wifi_host_tx, 0);
 	wifi_ipc_host_rx_init(&wifi_host_rx, 0);
 
-	for (i = 0; i < IPC_TX_ACK_SLOTS; i++) {
-		host_tx_ack_slots[i] = 0U;
-		host_tx_pending_bufs[i] = NULL;
+	/* The ack slots track buffers the UMAC may still be reading. Clearing
+	 * them on a re-init would leak every in-flight buffer, so initialize
+	 * them only once.
+	 */
+	if (!slots_initialized) {
+		for (i = 0; i < IPC_TX_ACK_SLOTS; i++) {
+			host_tx_ack_slots[i] = 0U;
+			host_tx_pending_bufs[i] = NULL;
+		}
+		slots_initialized = true;
 	}
 
 	LOG_DBG("IPC host single endpoint (ipc0) TX+RX initialized");
@@ -183,6 +191,17 @@ int ipc_init(void)
 
 int ipc_deinit(void)
 {
+	/* Reclaim whatever the UMAC has already acknowledged. Buffers still in
+	 * flight stay owned by the ack slots and are reclaimed on a later send.
+	 */
+	host_tx_reclaim_completed();
+
+	/* TODO(WZN-10457): this runs on interface teardown, where the core stays
+	 * powered and the IPC endpoint stays bound. When power management gains a
+	 * real core power-down, tear the endpoint down here (clear the bind latch
+	 * so the next power-up re-runs the handshake) rather than leaving it armed
+	 * against a core that has rebooted.
+	 */
 	return 0;
 }
 

--- a/drivers/wifi/nrf71/bus/ipc_if.c
+++ b/drivers/wifi/nrf71/bus/ipc_if.c
@@ -126,11 +126,25 @@ static void host_tx_ack_slot_free(uint32_t *ack_addr)
 static void host_rx_recv(void *data, size_t len, void *priv)
 {
 	struct nrf_wifi_bus_qspi_dev_ctx *dev_ctx = (struct nrf_wifi_bus_qspi_dev_ctx *)priv;
-	struct nrf_wifi_bal_dev_ctx *bal_dev_ctx = dev_ctx->bal_dev_ctx;
-	struct nrf_wifi_hal_dev_ctx *hal_dev_ctx = bal_dev_ctx->hal_dev_ctx;
+	struct nrf_wifi_bal_dev_ctx *bal_dev_ctx;
+	struct nrf_wifi_hal_dev_ctx *hal_dev_ctx;
 	wifi_ipc_buf_desc_t msg_info = *(wifi_ipc_buf_desc_t *)data;
 
 	LOG_DBG("Host RX IPC received");
+
+	/* The endpoint stays bound across device teardown, so events can arrive
+	 * with no consumer attached. Drop them, but always release the ring slot
+	 * or the UMAC event ring fills up and wedges the next bring-up.
+	 */
+	if ((callback_func == NULL) || (dev_ctx == NULL)) {
+		LOG_DBG("Host RX IPC event dropped, no consumer");
+		wifi_ipc_host_rx_free_event(&msg_info);
+		return;
+	}
+
+	bal_dev_ctx = dev_ctx->bal_dev_ctx;
+	hal_dev_ctx = bal_dev_ctx->hal_dev_ctx;
+
 	hal_dev_ctx->ipc_msg = (void *)msg_info.addr;
 	callback_func(priv);
 	wifi_ipc_host_rx_free_event(&msg_info);
@@ -254,8 +268,18 @@ int ipc_register_rx_cb(int (*rx_handler)(void *priv), void *data)
 					     host_rx_recv, data);
 	if (ret != WIFI_IPC_STATUS_OK) {
 		LOG_ERR("Failed to bind IPC host TX+RX (ipc0): %d", ret);
+		callback_func = NULL;
 		return -1;
 	}
 
 	return 0;
+}
+
+void ipc_unregister_rx_cb(void)
+{
+	/* Detach the consumer only. The endpoint stays bound for the lifetime of
+	 * the Wi-Fi core; events arriving from now on are dropped in
+	 * host_rx_recv() with their ring slot released.
+	 */
+	callback_func = NULL;
 }

--- a/drivers/wifi/nrf71/bus/ipc_if.h
+++ b/drivers/wifi/nrf71/bus/ipc_if.h
@@ -44,5 +44,7 @@ int ipc_send(ipc_ctx_t ctx, const void *data, int len);
 int ipc_recv(ipc_ctx_t ctx, void *data, int len);
 /* Non-blocking Receive (global, not per instance) */
 int ipc_register_rx_cb(int (*rx_handler)(void *priv), void *data);
+/* Detach the receive consumer, leaving the endpoint bound */
+void ipc_unregister_rx_cb(void);
 
 #endif /* __IPC_IF_H__ */

--- a/drivers/wifi/nrf71/bus/ipc_service.c
+++ b/drivers/wifi/nrf71/bus/ipc_service.c
@@ -85,7 +85,14 @@ static void wifi_ipc_busyq_init(wifi_ipc_busyq_t *busyq, const ipc_device_wrappe
 	busyq->ipc_inst = ipc_inst;
 	busyq->ipc_ep_cfg.cb.bound = wifi_ipc_ep_bound;
 	busyq->recv_cb = rx_cb;
-	busyq->ipc_ready = false;
+	/* Never clear a bind that already completed: the ICMsg endpoint stays
+	 * bound for the lifetime of the Wi-Fi core, and its bound callback only
+	 * fires once. Clearing this on a re-bind would latch the endpoint as
+	 * not-ready forever and wedge every subsequent send.
+	 */
+	if (!busyq->ipc_bound) {
+		busyq->ipc_ready = false;
+	}
 	busyq->priv = priv;
 	busyq->ipc_ep_cfg.cb.received = wifi_ipc_recv_callback;
 }
@@ -94,6 +101,19 @@ static wifi_ipc_status_t wifi_ipc_busyq_register(wifi_ipc_t *context)
 {
 	int ret;
 	const struct device *ipc_instance = GET_IPC_INSTANCE(context->busy_q.ipc_inst);
+
+	if (context->busy_q.ipc_bound) {
+		/* Already bound, only the RX consumer was re-armed. This holds while the
+		 * Wi-Fi core stays powered; interface down/up never crosses it.
+		 *
+		 * TODO(WZN-10457): a power cycle reboots the core and resets the peer
+		 * ICMsg state, so the bind goes stale. Once power management can power
+		 * the core down, clear ipc_bound (and ipc_ready) on that leg so the next
+		 * bring-up re-opens the instance and re-runs the handshake here.
+		 */
+		LOG_DBG("IPC busy queue already registered");
+		return WIFI_IPC_STATUS_OK;
+	}
 
 	k_sem_reset(&wifi_ipc_bind_sem);
 
@@ -114,6 +134,8 @@ static wifi_ipc_status_t wifi_ipc_busyq_register(wifi_ipc_t *context)
 	if (wifi_ipc_wait_bound(context) != 0) {
 		return WIFI_IPC_STATUS_INIT_ERR;
 	}
+
+	context->busy_q.ipc_bound = true;
 
 	LOG_INF("IPC busy queue registered");
 
@@ -145,6 +167,13 @@ wifi_ipc_status_t wifi_ipc_bind_ipc_service_tx_rx(wifi_ipc_t *tx_context,
 
 	ret = wifi_ipc_busyq_register(tx_context);
 	wifi_ipc_rx_ctx_shared = NULL;
+
+	if (ret == WIFI_IPC_STATUS_OK) {
+		/* Only the TX context owns the endpoint registration, but both
+		 * share its bound state.
+		 */
+		rx_context->busy_q.ipc_bound = true;
+	}
 
 	return ret;
 }

--- a/drivers/wifi/nrf71/bus/ipc_service.h
+++ b/drivers/wifi/nrf71/bus/ipc_service.h
@@ -64,6 +64,11 @@ typedef struct {
 	void (*recv_cb)(void *data, size_t len, void *priv);
 	void *priv;
 	volatile bool ipc_ready;
+	/* Endpoint registration has completed at least once. The ICMsg endpoint
+	 * is bound for the lifetime of the Wi-Fi core, so a re-bind must not
+	 * re-run the handshake nor clear @ref ipc_ready.
+	 */
+	bool ipc_bound;
 } wifi_ipc_busyq_t;
 
 typedef struct {

--- a/drivers/wifi/nrf71/os/shim.c
+++ b/drivers/wifi/nrf71/os/shim.c
@@ -1014,8 +1014,13 @@ out:
 
 static void zep_shim_bus_qspi_intr_unreg(void *os_qspi_dev_ctx)
 {
-
 	ARG_UNUSED(os_qspi_dev_ctx);
+
+	/* Detach the event consumer before the HAL context is torn down. The IPC
+	 * endpoint itself stays bound: it is the control plane and its lifetime
+	 * follows the Wi-Fi core, not the interface.
+	 */
+	ipc_unregister_rx_cb();
 }
 
 #ifdef CONFIG_NRF_WIFI_LOW_POWER

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/system/fmac_api.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/system/fmac_api.c
@@ -2203,7 +2203,15 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_del_vif(void *dev_ctx,
 
 	sys_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
-	switch (sys_dev_ctx->vif_ctx[if_idx]->if_type) {
+	vif_ctx = sys_dev_ctx->vif_ctx[if_idx];
+
+	if (!vif_ctx) {
+		nrf_wifi_osal_log_err("%s: VIF ctx does not exist",
+				      __func__);
+		goto out;
+	}
+
+	switch (vif_ctx->if_type) {
 	case NRF_WIFI_IFTYPE_STATION:
 	case NRF_WIFI_IFTYPE_P2P_CLIENT:
 	case NRF_WIFI_IFTYPE_AP:
@@ -2211,14 +2219,6 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_del_vif(void *dev_ctx,
 		break;
 	default:
 		nrf_wifi_osal_log_err("%s: VIF type not supported",
-				      __func__);
-		goto out;
-	}
-
-	vif_ctx = sys_dev_ctx->vif_ctx[if_idx];
-
-	if (!vif_ctx) {
-		nrf_wifi_osal_log_err("%s: VIF ctx does not exist",
 				      __func__);
 		goto out;
 	}
@@ -2261,6 +2261,11 @@ out:
 	}
 
 	if (vif_ctx) {
+		/* Release the slot along with the context. Leaving it set would
+		 * both dangle and make nrf_wifi_fmac_vif_idx_get() hand out the
+		 * next index instead of reusing this one.
+		 */
+		sys_dev_ctx->vif_ctx[if_idx] = NULL;
 		nrf_wifi_osal_mem_free(vif_ctx);
 	}
 

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/system/fmac_api.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/system/fmac_api.c
@@ -460,8 +460,11 @@ void nrf_wifi_sys_fmac_dev_deinit(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 		return;
 	}
 
-	nrf_wifi_hal_dev_deinit(fmac_dev_ctx->hal_dev_ctx);
+	/* Tell the firmware to stand down first: the de-init command travels over
+	 * the same transport that the HAL de-init tears down.
+	 */
 	nrf_wifi_sys_fmac_fw_deinit(fmac_dev_ctx);
+	nrf_wifi_hal_dev_deinit(fmac_dev_ctx->hal_dev_ctx);
 	nrf_wifi_osal_mem_free(fmac_dev_ctx->tx_pwr_ceil_params);
 }
 

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/system/fmac_api.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/system/fmac_api.c
@@ -2201,6 +2201,12 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_del_vif(void *dev_ctx,
 		goto out;
 	}
 
+	if (if_idx >= MAX_NUM_VIFS) {
+		nrf_wifi_osal_log_err("%s: Invalid VIF index %d",
+				      __func__, if_idx);
+		goto out;
+	}
+
 	sys_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	vif_ctx = sys_dev_ctx->vif_ctx[if_idx];
@@ -2718,7 +2724,7 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_get_interface(void *dev_ctx,
 	struct nrf_wifi_cmd_get_interface *cmd = NULL;
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = NULL;
 
-	if (!dev_ctx || if_idx > MAX_NUM_VIFS) {
+	if (!dev_ctx || if_idx >= MAX_NUM_VIFS) {
 		goto out;
 	}
 	fmac_dev_ctx = dev_ctx;

--- a/drivers/wifi/nrf71/src/fmac_main.c
+++ b/drivers/wifi/nrf71/src/fmac_main.c
@@ -836,6 +836,7 @@ static int nrf_wifi_drv_main_zep(const struct device *dev)
 
 	/* Setup the linkage between the FMAC and the VIF contexts */
 	vif_ctx_zep->rpu_ctx_zep = &rpu_drv_priv_zep.rpu_ctx_zep;
+	k_mutex_init(&vif_ctx_zep->vif_lock);
 #ifndef CONFIG_NRF71_RADIO_TEST
 	k_work_init_delayable(&vif_ctx_zep->scan_timeout_work,
 			      nrf_wifi_scan_timeout_work);

--- a/drivers/wifi/nrf71/src/net_if.c
+++ b/drivers/wifi/nrf71/src/net_if.c
@@ -774,6 +774,7 @@ int nrf_wifi_if_start_zep(const struct device *dev)
 	unsigned int mac_addr_len = 0;
 	int ret = -1;
 	bool fmac_dev_added = false;
+	bool locked = false;
 
 	if (!dev) {
 		LOG_ERR("%s: Invalid parameters",
@@ -816,6 +817,7 @@ int nrf_wifi_if_start_zep(const struct device *dev)
 		LOG_ERR("%s: Failed to lock vif_lock", __func__);
 		goto out;
 	}
+	locked = true;
 
 	if (!rpu_ctx_zep->rpu_ctx) {
 		status = nrf_wifi_fmac_dev_add_zep(&rpu_drv_priv_zep);
@@ -944,7 +946,9 @@ dev_rem:
 		nrf_wifi_fmac_dev_rem_zep(&rpu_drv_priv_zep);
 	}
 out:
-	k_mutex_unlock(&vif_ctx_zep->vif_lock);
+	if (locked) {
+		k_mutex_unlock(&vif_ctx_zep->vif_lock);
+	}
 	return ret;
 }
 
@@ -974,7 +978,7 @@ int nrf_wifi_if_stop_zep(const struct device *dev)
 	ret = k_mutex_lock(&vif_ctx_zep->vif_lock, K_FOREVER);
 	if (ret != 0) {
 		LOG_ERR("%s: Failed to lock vif_lock", __func__);
-		goto unlock;
+		goto out;
 	}
 
 	rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;

--- a/drivers/wifi/nrf71/src/net_if.c
+++ b/drivers/wifi/nrf71/src/net_if.c
@@ -762,6 +762,46 @@ __weak int nrf_wifi_if_zep_stop_board(const struct device *dev)
 	return 0;
 }
 
+/* Clear the per-VIF operational state that must not survive an interface down.
+ * vif_ctx_zep lives in the device data, so anything left set here is inherited
+ * by the next bring-up: a stale scan_in_progress, for instance, makes every
+ * later scan fail with "Scan already in progress". Scan work and any cached
+ * scan results have to go too, otherwise a display scan can run against torn
+ * down state and the connect scan database leaks or returns stale results.
+ */
+static void nrf_wifi_if_reset_vif_state(struct nrf_wifi_vif_ctx_zep *vif_ctx_zep)
+{
+	k_work_cancel_delayable(&vif_ctx_zep->scan_timeout_work);
+	k_work_cancel(&vif_ctx_zep->disp_scan_res_work);
+
+	vif_ctx_zep->scan_in_progress = false;
+	vif_ctx_zep->scan_type = 0;
+	vif_ctx_zep->scan_res_cnt = 0;
+	vif_ctx_zep->disp_scan_cb = NULL;
+	vif_ctx_zep->set_if_event_received = false;
+	vif_ctx_zep->set_if_status = 0;
+	vif_ctx_zep->if_op_state = NRF_WIFI_FMAC_IF_OP_STATE_DOWN;
+
+#if defined(CONFIG_NRF71_STA_MODE) || defined(CONFIG_NRF71_RAW_DATA_TX)
+	vif_ctx_zep->authorized = false;
+#endif
+#ifdef CONFIG_NRF71_STA_MODE
+	vif_ctx_zep->assoc_freq = 0;
+	vif_ctx_zep->if_carr_state = NRF_WIFI_FMAC_IF_CARR_STATE_OFF;
+	vif_ctx_zep->twt_flows_map = 0;
+	vif_ctx_zep->twt_flow_in_progress_map = 0;
+	vif_ctx_zep->ps_config_info_evnt = false;
+	vif_ctx_zep->cookie_resp_received = false;
+#ifdef CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM
+	if (vif_ctx_zep->connect_scan_db_addr) {
+		nrf_wifi_osal_mem_free((void *)(uintptr_t)vif_ctx_zep->connect_scan_db_addr);
+		vif_ctx_zep->connect_scan_db_addr = 0;
+	}
+	vif_ctx_zep->connect_scan_res_cnt = 0;
+#endif /* CONFIG_NRF_WIFI_CONNECT_SCAN_RESULTS_GDRAM */
+#endif /* CONFIG_NRF71_STA_MODE */
+}
+
 int nrf_wifi_if_start_zep(const struct device *dev)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -980,6 +1020,12 @@ int nrf_wifi_if_stop_zep(const struct device *dev)
 		LOG_ERR("%s: Failed to lock vif_lock", __func__);
 		goto out;
 	}
+
+	/* Drop any operation still outstanding on this VIF before the FMAC state
+	 * goes away. vif_ctx_zep is device data and survives the down/up cycle,
+	 * so state left behind here is state the next bring-up inherits.
+	 */
+	nrf_wifi_if_reset_vif_state(vif_ctx_zep);
 
 	rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;
 	if (!rpu_ctx_zep || !rpu_ctx_zep->rpu_ctx) {

--- a/drivers/wifi/nrf71/src/net_if.c
+++ b/drivers/wifi/nrf71/src/net_if.c
@@ -853,7 +853,6 @@ int nrf_wifi_if_start_zep(const struct device *dev)
 		goto dev_rem;
 	}
 
-	k_mutex_init(&vif_ctx_zep->vif_lock);
 	vif_ctx_zep->if_type = add_vif_info.iftype;
 
 	/* Check if user has provided a valid MAC address, if not


### PR DESCRIPTION
## Summary

Bringing a nRF71 Wi-Fi interface down and back up wedged the IPC control
plane: the re-bind hit -EALREADY, the bound callback never re-fired, and
every later send timed out. The FMAC device is torn down on the last
interface down (as on main) and rebuilt on the next up, so this hardens
that teardown/rebuild path rather than changing when it runs.

The endpoint is the control plane, so its bind now follows the lifetime of
the Wi-Fi core, not the interface. Per-VIF state, the VIF slot table, the
TX ack slots and the de-init ordering are all corrected so a second
bring-up starts clean.

Fixes WZN-10299.

## Changes

- Initialise `vif_lock` at driver init and fix its unlock paths.
- Latch the IPC endpoint bind; do not re-run the handshake or clear
  `ipc_ready` on a re-bind.
- Detach the IPC event consumer on teardown so stale events cannot
  dereference freed HAL context.
- Keep in-flight TX ack slots across an IPC re-init.
- Send the firmware de-init before the HAL de-init tears the transport down.
- Reset per-VIF state (and the scan timeout) on interface down.
- Release the VIF slot on delete; bounds check the VIF index.

A power cycle that reboots the core (power management, WZN-10457) is out of
scope and left as TODOs at the bind latch and de-init paths.

## Test plan

Board: nrf7120dk/nrf7120/cpuapp, wifi/shell, SB_CONFIG_WIFI_NRF70=n.

- [x] `net iface down` / `up`, `wifi scan`, `wifi connect` cycled 5 times, no wedge.
- [x] Builds pristine.

Made with [Cursor](https://cursor.com)