### PR TITLE
tests: drivers: gpio: hpf_gpio_basic_api: remove flash filter

### DIFF
--- a/tests/drivers/gpio/hpf_gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/hpf_gpio_basic_api/testcase.yaml
@@ -22,16 +22,13 @@ common:
 
 tests:
   drivers.hpf.gpio.loopback.icmsg:
-    min_flash: 64
     timeout: 30
     extra_args: SB_CONFIG_HPF_GPIO_BACKEND_ICMSG=y
 
   drivers.hpf.gpio.loopback.icbmsg:
-    min_flash: 64
     timeout: 80
     extra_args: SB_CONFIG_HPF_GPIO_BACKEND_ICBMSG=y
 
   drivers.hpf.gpio.loopback.mbox:
-    min_flash: 64
     timeout: 30
     extra_args: SB_CONFIG_HPF_GPIO_BACKEND_MBOX=y


### PR DESCRIPTION
This was preventing from execution at all listed platforms.