### PR TITLE
Nrfx 9881 lm20 power consumption with sensors

### DIFF
--- a/tests/benchmarks/current_consumption/twim_suspend/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/benchmarks/current_consumption/twim_suspend/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (C) 2026 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&i2c22 {
+	/delete-property/ zephyr,pm-device-runtime-auto;
+};

--- a/tests/benchmarks/current_consumption/twim_suspend/testcase.yaml
+++ b/tests/benchmarks/current_consumption/twim_suspend/testcase.yaml
@@ -33,6 +33,7 @@ tests:
       - ppk_power_measure
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp

--- a/tests/benchmarks/power_consumption/i2c/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/benchmarks/power_consumption/i2c/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		led = &led_custom0;
+	};
+};
+
+/ {
+	leds {
+		led_custom0: led_custom0 {
+			gpios = <&gpio3 0 GPIO_ACTIVE_HIGH>;
+			label = "Custom LED due to collision with PCA63565";
+		};
+	};
+};

--- a/tests/benchmarks/power_consumption/i2c/testcase.yaml
+++ b/tests/benchmarks/power_consumption/i2c/testcase.yaml
@@ -10,6 +10,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     extra_args:
       - SHIELD=pca63565
     harness_config:

--- a/tests/benchmarks/power_consumption/spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/benchmarks/power_consumption/spi/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		led = &led_custom0;
+	};
+};
+
+/ {
+	leds {
+		led_custom0: led_custom0 {
+			gpios = <&gpio3 0 GPIO_ACTIVE_HIGH>;
+			label = "Custom LED due to collision with PCA63565";
+		};
+	};
+};
+
+&spi21 {
+	zephyr,pm-device-runtime-auto;
+};
+
+/* Disable mx25r64. */
+&spi00 {
+	status = "disabled";
+};

--- a/tests/benchmarks/power_consumption/spi/testcase.yaml
+++ b/tests/benchmarks/power_consumption/spi/testcase.yaml
@@ -10,6 +10,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     extra_args:
       - SHIELD=pca63565
     harness_config:


### PR DESCRIPTION
Enable power consumption tests with PCA63565 sensors on nrf54lm20 DK.