### PR TITLE
Backport lc10 fix

### DIFF
--- a/samples/crypto/psa_tls/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns.overlay
+++ b/samples/crypto/psa_tls/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns.overlay
@@ -1,1 +1,83 @@
-#include "nrf54lc10dk_nrf54lc10a_cpuapp.overlay"
+/*
+ * Copyright (c) 2026 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &slot0_partition;
+/delete-node/ &slot0_ns_partition;
+/delete-node/ &storage_partition;
+
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+
+/delete-node/ &sram0_s;
+/delete-node/ &sram0_ns;
+
+/* Rebalance the secure/non-secure SRAM split to 64 kB / 127 kB so the
+ * non-secure image (psa_tls needs ~115 kB of RAM) fits. nRF54LV10A has
+ * 192 kB total SRAM; 1 kB at the top is left unused to match the upstream
+ * TF-M layout.
+ */
+&cpuapp_sram {
+	sram0_s: image_s@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		/* Secure image memory */
+		reg = <0x0 DT_SIZE_K(64)>;
+		ranges = <0x0 0x0 DT_SIZE_K(64)>;
+	};
+
+	sram0_ns: image_ns@10000 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		/* Non-Secure image memory */
+		reg = <0x10000 DT_SIZE_K(127)>;
+		ranges = <0x0 0x10000 DT_SIZE_K(127)>;
+	};
+};
+
+&cpuapp_rram {
+	partitions {
+		slot0_s_partition: partition@0 {
+			label = "image-0-secure";
+			reg = <0x0 0x40000>;
+		};
+
+		tfm_storage_partition: partition@40000 {
+			compatible = "fixed-subpartitions";
+			label = "tfm-storage";
+			reg = <0x40000 DT_SIZE_K(40)>;
+			ranges = <0x0 0x40000 DT_SIZE_K(40)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(16)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@6000 {
+				label = "tfm-ps";
+				reg = <0x6000 DT_SIZE_K(16)>;
+			};
+		};
+
+		slot0_ns_partition: partition@4a000 {
+			label = "image-0-nonsecure";
+			reg = <0x4a000 0xb3000>;
+		};
+	};
+};
+
+/ {
+	eth-rtt {
+		compatible = "segger,eth-rtt";
+	};
+};

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -112,6 +112,14 @@
   comment: "Unsupported TFM_PLATFORM"
 
 - scenarios:
+    - drivers.timer.delay_accuracy
+    - drivers.timer.delay_accuracy.hfxo
+  platforms:
+    - nrf9251dk@0.1.0/nrf9251/cpuflpr
+    - nrf9251dk@0.1.0/nrf9251/cpuppr
+  comment: "https://nordicsemi.atlassian.net/browse/NRFX-9630"
+
+- scenarios:
     - nrf.extended.drivers.counter.basic_api
   platforms:
     - nrf9251dk@0.1.0/nrf9251/cpuflpr/xip

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -106,26 +106,10 @@
   comment: "no HPF for nrf54lc10 at the moment"
 
 - scenarios:
-    - nrf.extended.drivers.spi.direct_xfer
-    - nrf.extended.drivers.spi.direct_xfer.no_prealloc
-    - nrf.extended.drivers.clock.clock_control_onoff
-    - nrf.extended.drivers.clock.nrf5_clock_calibration
-    - nrf.extended.drivers.clock.nrf_lf_clock_start_rc_available
-    - nrf.extended.drivers.clock.nrf_lf_clock_start_rc_no_wait
-    - nrf.extended.drivers.clock.nrf_lf_clock_start_rc_stable
-    - nrf.extended.drivers.clock.nrf_lf_clock_start_synth_available
-    - nrf.extended.drivers.clock.nrf_lf_clock_start_synth_no_wait
-    - nrf.extended.drivers.clock.nrf_lf_clock_start_synth_stable
-    - nrf.extended.drivers.clock.nrf_lf_clock_start_xtal_available
-    - nrf.extended.drivers.clock.nrf_lf_clock_start_xtal_no_wait
-    - nrf.extended.drivers.clock.nrf_lf_clock_start_xtal_stable
-    - nrf.extended.drivers.comparator.gpio_loopback.nrf_comp
-    - nrf.extended.drivers.comparator.gpio_loopback.nrf_lpcomp
-    - sample.bluetooth.peripheral_lbs
-    - sample.bluetooth.peripheral_uart
+    - all
   platforms:
     - nrf54lc10dk@0.8.0/nrf54lc10a/cpuapp/ns
-  comment: "no TFM for nrf54lc10 at the moment"
+  comment: "Unsupported TFM_PLATFORM"
 
 - scenarios:
     - nrf.extended.drivers.counter.basic_api

--- a/tests/drivers/adc/adc_scan/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/tests/drivers/adc/adc_scan/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,1 +1,0 @@
-#include "nrf54lc10dk_nrf54lc10a_cpuapp.overlay"


### PR DESCRIPTION
Backport of https://github.com/nrfconnect/sdk-nrf/pull/30468 + additional quarantine updates