### PR TITLE
[Backport v3.4-branch] samples: even nRF54LV10/LC10 DK out in bluetooth and coremark samples

### DIFF
--- a/samples/benchmarks/coremark/Kconfig.sysbuild
+++ b/samples/benchmarks/coremark/Kconfig.sysbuild
@@ -9,7 +9,7 @@ config PARTITION_MANAGER
 
 config APP_CPUFLPR_RUN
 	bool "Run the CoreMark benchmark on the FLPR core"
-	depends on SUPPORT_FLPRCORE && !SOC_NRF54LV10A
+	depends on SUPPORT_FLPRCORE && !SOC_NRF54LV10A && !SOC_NRF54LC10A
 	default y
 
 config APP_CPUNET_RUN

--- a/samples/benchmarks/coremark/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
+++ b/samples/benchmarks/coremark/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+CONFIG_COREMARK_ITERATIONS=4000
+
+CONFIG_LOG_MODE_IMMEDIATE=y

--- a/samples/benchmarks/coremark/sample.yaml
+++ b/samples/benchmarks/coremark/sample.yaml
@@ -29,6 +29,7 @@ tests:
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf7120dk/nrf7120/cpuapp
     integration_platforms: *coremark_platforms
 

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -62,6 +62,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns

--- a/samples/bluetooth/peripheral_ams_client/sample.yaml
+++ b/samples/bluetooth/peripheral_ams_client/sample.yaml
@@ -19,6 +19,10 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
+      - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp/ns
     tags:
       - bluetooth
       - ci_build

--- a/samples/bluetooth/peripheral_ancs_client/sample.yaml
+++ b/samples/bluetooth/peripheral_ancs_client/sample.yaml
@@ -19,6 +19,10 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
+      - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp/ns
     tags:
       - bluetooth
       - ci_build

--- a/samples/bluetooth/peripheral_lbs/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_lbs/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns.overlay
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &slot0_partition;
+/delete-node/ &storage_partition;
+/delete-node/ &slot0_ns_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+
+&cpuapp_rram {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x40000>;
+		};
+
+		tfm_storage_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0x40000 DT_SIZE_K(40)>;
+			ranges = <0x0 0x40000 DT_SIZE_K(40)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(16)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@6000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x6000 DT_SIZE_K(16)>;
+			};
+		};
+
+		slot0_ns_partition: partition@4a000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x4a000 0xb1000>;
+		};
+
+		nonsecure_storage: partition@fb000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xfb000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xfb000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+	};
+};

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -128,6 +128,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
     tags:

--- a/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
+++ b/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
@@ -21,6 +21,10 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
+      - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp/ns
     tags:
       - bluetooth
       - ci_build

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp.conf
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NFC_T2T_NRFXLIB=n
+
+CONFIG_NFC_NDEF=n
+CONFIG_NFC_NDEF_MSG=n
+CONFIG_NFC_NDEF_RECORD=n
+CONFIG_NFC_NDEF_LE_OOB_REC=n
+CONFIG_NFC_NDEF_CH_MSG=n
+
+CONFIG_PM_DEVICE=y
+CONFIG_PM_DEVICE_RUNTIME=y

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		/delete-property/ sw2;
+		/delete-property/ sw3;
+	};
+};
+
+/delete-node/ &button2;
+/delete-node/ &button3;
+
+&uart30 {
+	zephyr,pm-device-runtime-auto;
+};

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp_auto_conn_advert.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp_auto_conn_advert.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include "nrf54lv10dk_nrf54lv10a_cpuapp.overlay"
+#include "nrf54lc10dk_nrf54lc10a_cpuapp.overlay"
 
 / {
 	/*

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp_auto_non_conn_advert.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp_auto_non_conn_advert.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include "nrf54lv10dk_nrf54lv10a_cpuapp.overlay"
+#include "nrf54lc10dk_nrf54lc10a_cpuapp.overlay"
 
 / {
 	/*

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns.conf
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns.conf
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NFC_T2T_NRFXLIB=n
+
+CONFIG_NFC_NDEF=n
+CONFIG_NFC_NDEF_MSG=n
+CONFIG_NFC_NDEF_RECORD=n
+CONFIG_NFC_NDEF_LE_OOB_REC=n
+CONFIG_NFC_NDEF_CH_MSG=n
+
+CONFIG_PM_DEVICE=y
+CONFIG_PM_DEVICE_RUNTIME=y
+
+# RRAM always on, not needed for basic bluetooth features.
+CONFIG_MPSL_FORCE_RRAM_ON_ALL_THE_TIME=n
+
+CONFIG_TFM_SFN=y
+CONFIG_TFM_NRF_SYSTEM_OFF_SERVICE=y

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	aliases {
+		/delete-property/ sw2;
+		/delete-property/ sw3;
+	};
+};
+
+/delete-node/ &button2;
+/delete-node/ &button3;
+
+&uart30 {
+	zephyr,pm-device-runtime-auto;
+};

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns_auto_conn_advert.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns_auto_conn_advert.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include "nrf54lv10dk_nrf54lv10a_cpuapp_ns.overlay"
+#include "nrf54lc10dk_nrf54lc10a_cpuapp_ns.overlay"
 
 / {
 	/*

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns_auto_non_conn_advert.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns_auto_non_conn_advert.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include "nrf54lv10dk_nrf54lv10a_cpuapp_ns.overlay"
+#include "nrf54lc10dk_nrf54lc10a_cpuapp_ns.overlay"
 
 / {
 	/*

--- a/samples/bluetooth/peripheral_power_profiling/sample.yaml
+++ b/samples/bluetooth/peripheral_power_profiling/sample.yaml
@@ -285,6 +285,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     platform_allow:

--- a/samples/bluetooth/peripheral_uart/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_uart/boards/nrf54lc10dk_nrf54lc10a_cpuapp_ns.overlay
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &slot0_partition;
+/delete-node/ &storage_partition;
+/delete-node/ &slot0_ns_partition;
+/delete-node/ &tfm_its_partition;
+/delete-node/ &tfm_otp_partition;
+/delete-node/ &tfm_ps_partition;
+
+&cpuapp_rram {
+	partitions {
+		slot0_s_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-secure";
+			reg = <0x0 0x40000>;
+		};
+
+		tfm_storage_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
+			label = "tfm-storage";
+			reg = <0x40000 DT_SIZE_K(40)>;
+			ranges = <0x0 0x40000 DT_SIZE_K(40)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tfm_its_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-its";
+				reg = <0x0 DT_SIZE_K(16)>;
+			};
+
+			tfm_otp_partition: partition@4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-otp";
+				reg = <0x4000 DT_SIZE_K(8)>;
+			};
+
+			tfm_ps_partition: partition@6000 {
+				compatible = "zephyr,mapped-partition";
+				label = "tfm-ps";
+				reg = <0x6000 DT_SIZE_K(16)>;
+			};
+		};
+
+		slot0_ns_partition: partition@4a000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0-nonsecure";
+			reg = <0x4a000 0xb1000>;
+		};
+
+		nonsecure_storage: partition@fb000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nonsecure-storage";
+			reg = <0xfb000 DT_SIZE_K(8)>;
+			ranges = <0x0 0xfb000 DT_SIZE_K(8)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0x0 DT_SIZE_K(8)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Backport bf0b0cfb285b238b51190547f692825b032e5ddd from #29388.