### PR TITLE
lib: sms: Fix too long data length for 8bit

### DIFF
--- a/lib/sms/sms_deliver.c
+++ b/lib/sms/sms_deliver.c
@@ -613,8 +613,8 @@ static int decode_pdu_ud_7bit(struct parser *parser, uint8_t *buf)
 	int length_udh_skipped;
 
 	if (pdata->udl > SMS_MAX_PAYLOAD_LEN_CHARS) {
-		LOG_ERR("User Data Length exceeds maximum number of characters (%d) in SMS spec",
-			SMS_MAX_PAYLOAD_LEN_CHARS);
+		LOG_ERR("User Data Length (%d) exceeds maximum length (%d) in SMS spec",
+			pdata->udl, SMS_MAX_PAYLOAD_LEN_CHARS);
 		return -EMSGSIZE;
 	}
 
@@ -674,6 +674,13 @@ static int decode_pdu_ud_7bit(struct parser *parser, uint8_t *buf)
 static int decode_pdu_ud_8bit(struct parser *parser, uint8_t *buf)
 {
 	struct pdu_deliver_data * const pdata = parser->data;
+
+	if (pdata->udl > SMS_MAX_PAYLOAD_LEN_CHARS) {
+		LOG_ERR("User Data Length (%d) exceeds maximum length (%d) in SMS spec",
+			pdata->udl, SMS_MAX_PAYLOAD_LEN_CHARS);
+		return -EMSGSIZE;
+	}
+
 	/* Data length to be used is the minimum from the remaining bytes in the input buffer and
 	 * length indicated by User-Data-Length taking into account User-Data-Header-Length.
 	 */

--- a/tests/lib/sms/src/sms_test.c
+++ b/tests/lib/sms/src/sms_test.c
@@ -2091,6 +2091,20 @@ void test_recv_invalid_udl_shorter_than_ud_8bit(void)
 	sms_unreg_helper();
 }
 
+/** Receive too long message with 161 bytes in 8bit encoding. */
+void test_recv_fail_len161_8bit(void)
+{
+	sms_reg_helper();
+
+	__cmock_nrf_modem_at_cmd_async_ExpectAndReturn(sms_ack_resp_handler, "AT+CNMA=1", 0);
+	sms_callback_called_expected = false;
+	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
+		"00040091000412201232054480A10102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A0102030405060708090A01\r\n");
+	k_sleep(K_MSEC(1));
+
+	sms_unreg_helper();
+}
+
 /** Tests User-Data-Header Length that is longer than User-Data-Length. */
 void test_recv_fail_udhl_longer_than_udh(void)
 {


### PR DESCRIPTION
When 8bit encoding is defined, user data length (TP-UDL) is not checked against 160 (maximum SMS length).
Due to implementation details, the length cannot be very high but 166 characters was accepted as length.