### PR TITLE
doc: release notes: add nRF54LS05A Fast Pair support changelog

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -304,6 +304,8 @@ Bluetooth Mesh samples
 Bluetooth Fast Pair samples
 ---------------------------
 
+* Added experimental support for the ``nrf54ls05dk/nrf54ls05a/cpuapp`` board target in all Bluetooth Fast Pair samples.
+
 * Removed support for the nRF52 and nRF53 Series devices from the :ref:`fast_pair_locator_tag` and :ref:`fast_pair_input_device` samples.
   The following board targets have been removed from both samples:
 
@@ -328,7 +330,7 @@ Bluetooth Fast Pair samples
 
 * :ref:`fast_pair_input_device` sample:
 
-    * Added support for the ``nrf54ls05dk/nrf54ls05a/cpuapp``, ``nrf54ls05dk/nrf54ls05b/cpuapp``, and ``nrf54lc10dk/nrf54lc10a/cpuapp`` board targets.
+  * Added support for the ``nrf54lc10dk/nrf54lc10a/cpuapp`` board target.
 
 Cellular samples
 ----------------


### PR DESCRIPTION
## Summary

- Document experimental nRF54LS05A support across all Bluetooth Fast Pair samples.
- Remove redundant nRF54LS05A and nRF54LS05B entries from the input device-specific changelog item while retaining the nRF54LC10 entry.

Ref: NCSDK-38387

## Test plan

- `git diff --check`
