### PR TITLE
samples: vpr: add VPR VIO toggle sample

### DIFF
--- a/samples/vpr/vio_clocked_output/CMakeLists.txt
+++ b/samples/vpr/vio_clocked_output/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(vpr_vio_clocked_output)
+
+# NORDIC SDK APP START
+target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END

--- a/samples/vpr/vio_clocked_output/Kconfig
+++ b/samples/vpr/vio_clocked_output/Kconfig
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+menu "VPR VIO clocked output sample"
+
+config APP_VIO_PIN
+	int "VIO bit index used as UART TX"
+	range 0 15
+	default 0
+	help
+	  The VPR VIO pin number used for the emulated UART signal.
+	  This must match the physical pin routed to the VPR core.
+
+config APP_TX_GPIO_PORT
+	int "Physical GPIO port routed to the VPR (nRF54L only)"
+	default 2
+	help
+	  Physical GPIO port of the TX pin.
+	  It must correspond to the VIO index.
+
+config APP_TX_GPIO_PIN
+	int "Physical GPIO pin routed to the VPR (nRF54L only)"
+	default 9
+	help
+	  Physical GPIO pin of the TX pin.
+	  It must correspond to the VIO index.
+
+config APP_UART_BAUD_RATE
+	int "Baud rate of the emulated UART"
+	default 115200
+	help
+	  Baud rate of the bit-banged UART transmitter.
+	  The bit period is derived from the VPR core clock, so very low baud rates may exceed the 16-bit range of VTIM counter 0.
+
+endmenu
+
+source "Kconfig.zephyr"

--- a/samples/vpr/vio_clocked_output/README.rst
+++ b/samples/vpr/vio_clocked_output/README.rst
@@ -1,0 +1,84 @@
+.. _vpr_vio_clocked_output:
+
+VPR VIO clocked output
+######################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The sample emulates a UART transmitter by driving a single GPIO pin from a VPR coprocessor (FLPR or PPR).
+It uses counter-paced buffered VIO output.
+This sample is not intended to be a full UART implementation, it is a showcase of how to implement similar protocols.
+
+Application overview
+********************
+
+The sample combines two of the VPR CSR features:
+
+* **VTIM counter 0** runs as the bit-clock (baud-rate) generator.
+  It counts down to zero, when it hits zero it generates an event and reloads the bit period.
+
+* **VIO buffered output.** The next bit wil be set in the buffered out register.
+  On the event from the timer the bit wil be output on the pin.
+
+The loop sending the bits needs 6 clock ticks so baud-rates of up to 1/6 th of the VPR clock can be achieved.
+
+The application drives the VIO bit selected with :kconfig:option:`CONFIG_APP_VIO_PIN`.
+* On the **nRF9xx**, the pin is assigned to the VPR through the UICR, generated from the ``vpr_launcher`` devicetree overlay.
+* On the **nRF54L series**, the FLPR routes the pin to the VPR at runtime, using :kconfig:option:`CONFIG_APP_TX_GPIO_PORT` and :kconfig:option:`CONFIG_APP_TX_GPIO_PIN`.
+
+Requirements
+************
+
+The sample supports the following development kits and cores:
+
+.. table-from-sample-yaml::
+
+Pin mapping
+===========
+
+The TX pin depends on the target.
+The defaults, set in the board ``.conf`` files and/or routed in the matching ``vpr_launcher`` overlay, are:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Target
+     - VIO index
+     - GPIO pin
+   * - nRF9251 DK, ``cpuflpr``
+     - 8
+     - P2.05 (TXD1)
+   * - nRF9251 DK, ``cpuppr``
+     - 0
+     - P1.06 (TXD0)
+   * - nRF54L15 DK, ``cpuflpr``
+     - 9
+     - P2.09 (LED0)
+
+Configuration
+*************
+
+To use a different pin:
+* On the nRF9xx, update :kconfig:option:`CONFIG_APP_VIO_PIN` and (:file:`sysbuild/vpr_launcher/nrf9251_flpr.overlay` or :file:`_ppr.overlay`).
+* On the nRF54L series, update :kconfig:option:`CONFIG_APP_VIO_PIN`, :kconfig:option:`CONFIG_APP_TX_GPIO_PORT` and :kconfig:option:`CONFIG_APP_TX_GPIO_PIN`.
+
+Building and running
+********************
+
+.. |sample path| replace:: :file:`samples/vpr/vio_clocked_output`
+
+Build for a VPR core.
+Sysbuild automatically adds the VPR launcher image for the application core:
+
+.. code-block:: console
+
+   west build -b nrf9251dk/nrf9251/cpuflpr
+   west flash
+
+Testing
+*******
+
+* On the nRF9251dk the signals are routed to the debugger so you can test without external hardware.
+* On the nRF54L15dk you need to attach a logic analyzer or oscilloscope to the TX pin.

--- a/samples/vpr/vio_clocked_output/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
+++ b/samples/vpr/vio_clocked_output/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# VIO 9 corresponds to GPIO P2.9 / LED0.
+# On nRF54L the FLPR routes the pin to the VPR at runtime,
+# so the physical pin is specified here too.
+
+# GPIO -> VIO mapping:
+#    P2.1   -> 0
+#    P2.2   -> 1
+#    P2.4   -> 2
+#    P2.3   -> 3
+#    P2.0   -> 4
+#    P2.5   -> 5
+#    P2.6   -> 6
+#    P2.7   -> 7
+#    P2.8   -> 8
+#    P2.9   -> 9
+#    P2.10  -> 10
+
+CONFIG_APP_VIO_PIN=9
+CONFIG_APP_TX_GPIO_PORT=2
+CONFIG_APP_TX_GPIO_PIN=9

--- a/samples/vpr/vio_clocked_output/boards/nrf9251dk_nrf9251_cpuflpr.conf
+++ b/samples/vpr/vio_clocked_output/boards/nrf9251dk_nrf9251_cpuflpr.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# VIO 8 corresponds to GPIO P2.05 (routed in the vpr_launcher overlay).
+# This pin is wired to UART1 from the debugger.
+CONFIG_APP_VIO_PIN=8
+

--- a/samples/vpr/vio_clocked_output/boards/nrf9251dk_nrf9251_cpuppr.conf
+++ b/samples/vpr/vio_clocked_output/boards/nrf9251dk_nrf9251_cpuppr.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# VIO 0 corresponds to GPIO P1.06 (routed in the vpr_launcher overlay).
+# This pin is wired to UART0 from the debugger.
+CONFIG_APP_VIO_PIN=0

--- a/samples/vpr/vio_clocked_output/prj.conf
+++ b/samples/vpr/vio_clocked_output/prj.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause

--- a/samples/vpr/vio_clocked_output/sample.yaml
+++ b/samples/vpr/vio_clocked_output/sample.yaml
@@ -1,0 +1,15 @@
+sample:
+  name: VPR VIO clocked output
+  description: Drive a VIO pin from a VPR coprocessor emulating UART
+tests:
+  sample.vpr.vio_clocked_output.build:
+    build_only: true
+    sysbuild: true
+    integration_platforms:
+      - nrf9251dk/nrf9251/cpuflpr
+    platform_allow:
+      - nrf9251dk/nrf9251/cpuflpr
+      - nrf9251dk/nrf9251/cpuppr
+      - nrf54l15dk/nrf54l15/cpuflpr
+    tags:
+      - ci_build

--- a/samples/vpr/vio_clocked_output/src/main.c
+++ b/samples/vpr/vio_clocked_output/src/main.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdio.h>
+#include <zephyr/irq.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+#include <hal/nrf_vpr_csr.h>
+#include <hal/nrf_vpr_csr_vio.h>
+#include <hal/nrf_vpr_csr_vtim.h>
+#include <hal/nrf_gpio.h>
+
+#define TX_VIO_MASK BIT(CONFIG_APP_VIO_PIN)
+#define BAUD_RATE   CONFIG_APP_UART_BAUD_RATE
+
+/* 8N1 framing. */
+#define UART_DATA_BITS 8
+
+static void uart_send_byte(uint8_t byte)
+{
+	/* Prevent any interrupts to disturb the critical timing.*/
+	unsigned int key = irq_lock();
+
+	/* Configure counter 0 to load the top value once it hits 0. */
+	nrf_vpr_csr_vtim_count_mode_set(0, NRF_VPR_CSR_VTIM_COUNT_RELOAD);
+
+	/* Buffer the start bit and start counter 0 by setting it to a value larger than 0. */
+	nrf_vpr_csr_vio_out_buffered_set(0);
+	nrf_vpr_csr_vtim_simple_counter_set(0, 1);
+
+	/* Buffer data bits, LSB first.
+	 * Once counter 0 hits 0 the buffered bit is output.
+	 * The next buffered set call will only return once the previous bit is output.
+	 */
+	for (int i = 0; i < UART_DATA_BITS; i++) {
+		bool output_bit = (byte >> i) & 0x1;
+
+		nrf_vpr_csr_vio_out_buffered_set(output_bit ? TX_VIO_MASK : 0);
+	}
+
+	/* Schedule the stop bit and wait for it to output. */
+	nrf_vpr_csr_vio_out_buffered_set(TX_VIO_MASK);
+	nrf_vpr_csr_vtim_simple_wait_set(0, false, 0);
+
+	/* The stop bit is now output. Stop reloading the timer and wait for it to hit 0. */
+	nrf_vpr_csr_vtim_count_mode_set(0, NRF_VPR_CSR_VTIM_COUNT_STOP);
+	nrf_vpr_csr_vtim_simple_wait_set(0, false, 0);
+
+	/* Stop bit has been send, we are now ready to go to sleep or send the next byte. */
+	irq_unlock(key);
+}
+
+static void uart_send_string(const char *str)
+{
+	while (*str != '\0') {
+		uart_send_byte((uint8_t)*str++);
+	}
+}
+
+int main(void)
+{
+	static const char msg[] = "Hello world!\n";
+	uint32_t bit_period = (SystemCoreClock + BAUD_RATE / 2) / BAUD_RATE;
+
+	printf("VPR VIO clocked-output (UART TX) sample on %s\n", CONFIG_BOARD_TARGET);
+	printf("Core clock: %u Hz, baud: %d, bit period: %u cycles\n", SystemCoreClock, BAUD_RATE,
+	       bit_period);
+	printf("Emulated UART TX on VIO index %d\n", CONFIG_APP_VIO_PIN);
+
+#if NRF_GPIO_HAS_SEL
+	/* On the nRF54L series the FLPR routes the pin to the VPR at runtime.
+	 * On SoCs that route pins through the UICR periphconf this is done by the vpr_launcher
+	 * devicetree overlay.
+	 */
+	nrf_gpio_pin_control_select(
+		NRF_GPIO_PIN_MAP(CONFIG_APP_TX_GPIO_PORT, CONFIG_APP_TX_GPIO_PIN),
+		NRF_GPIO_PIN_SEL_VPR);
+#endif
+
+	/* Enable the VPR real-time peripherals (VIO + VTIM). */
+	nrf_vpr_csr_rtperiph_enable_set(true);
+
+	/* Configure counter 0 by setting the top register to the bit period. */
+	nrf_vpr_csr_vtim_simple_counter_top_set(0, bit_period - 1);
+
+	/* Configure the TX pin as a VIO output, idle high. */
+	nrf_vpr_csr_vio_out_set(TX_VIO_MASK);
+	nrf_vpr_csr_vio_dir_set(TX_VIO_MASK);
+
+	while (1) {
+		uart_send_string(msg);
+
+		k_msleep(1000);
+	}
+
+	return 0;
+}

--- a/samples/vpr/vio_clocked_output/sysbuild.cmake
+++ b/samples/vpr/vio_clocked_output/sysbuild.cmake
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# for the nRF9251 different overlay and configuration are needed depending on which VPR used.
+if("${BOARD}" MATCHES "nrf9251")
+  if("${BOARD_QUALIFIERS}" MATCHES "cpuflpr")
+    set(vpr_launcher_EXTRA_DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/sysbuild/vpr_launcher/nrf9251_flpr.overlay CACHE INTERNAL "")
+  elseif("${BOARD_QUALIFIERS}" MATCHES "cpuppr")
+    set(vpr_launcher_EXTRA_DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/sysbuild/vpr_launcher/nrf9251_ppr.overlay CACHE INTERNAL "")
+    set(vpr_launcher_EXTRA_CONF_FILE ${CMAKE_CURRENT_LIST_DIR}/sysbuild/vpr_launcher/nrf9251_ppr.conf CACHE INTERNAL "")
+  endif()
+endif()

--- a/samples/vpr/vio_clocked_output/sysbuild/vpr_launcher/nrf9251_flpr.overlay
+++ b/samples/vpr/vio_clocked_output/sysbuild/vpr_launcher/nrf9251_flpr.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Assign P2.05 (uart132 TX, wired to debugger UART1) to FLPR (VIO 8).
+ *
+ * GPIO -> VIO mapping:
+ *     P5.1         -> 0
+ *     P5.0         -> 1
+ *     P5.2         -> 2
+ *     P5.3         -> 3
+ *     P5.4 / P2.0  -> 4
+ *     P5.5 / P2.1  -> 5
+ *     P2.2         -> 6
+ *     P2.3         -> 7
+ *     (P2.4 not connected)
+ *     P2.5         -> 8
+ *     P2.6         -> 9
+ *     P2.7         -> 10
+ *     P2.8         -> 11
+ */
+&uart132 {
+	status = "disabled";
+};
+
+&pinctrl {
+	vpr_flpr_vio_default: vpr_flpr_vio_default {
+		group1 {
+			psels = <NRF_PSEL(VPR_VIO, 2, 5)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
+		};
+	};
+};
+
+&cpuflpr_vpr {
+	pinctrl-0 = <&vpr_flpr_vio_default>;
+	pinctrl-names = "default";
+};

--- a/samples/vpr/vio_clocked_output/sysbuild/vpr_launcher/nrf9251_ppr.conf
+++ b/samples/vpr/vio_clocked_output/sysbuild/vpr_launcher/nrf9251_ppr.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# uart133 is handed to the PPR VIO, so the vpr_launcher cannot use it.
+CONFIG_SERIAL=n
+CONFIG_CONSOLE=n
+CONFIG_UART_CONSOLE=n

--- a/samples/vpr/vio_clocked_output/sysbuild/vpr_launcher/nrf9251_ppr.overlay
+++ b/samples/vpr/vio_clocked_output/sysbuild/vpr_launcher/nrf9251_ppr.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Assign P1.06 (uart133 TX, wired to debugger UART0) to PPR (VIO 0).
+ *
+ * GPIO -> VIO mapping:
+ *     P0.0 / P1.6  -> 0
+ *     P0.1 / P1.7  -> 1
+ *     P1.10        -> 2
+ *     P1.11        -> 3
+ */
+&uart133 {
+	status = "disabled";
+};
+
+&pinctrl {
+	vpr_ppr_vio_default: vpr_ppr_vio_default {
+		group1 {
+			psels = <NRF_PSEL(VPR_VIO, 1, 6)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
+		};
+	};
+};
+
+&cpuppr_vpr {
+	pinctrl-0 = <&vpr_ppr_vio_default>;
+	pinctrl-names = "default";
+};

--- a/samples/vpr/vio_clocked_output/sysbuild/vpr_launcher/prj.conf
+++ b/samples/vpr/vio_clocked_output/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause

--- a/samples/vpr/vio_shift_output/CMakeLists.txt
+++ b/samples/vpr/vio_shift_output/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(vpr_vio_shift_output)
+
+# NORDIC SDK APP START
+target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END

--- a/samples/vpr/vio_shift_output/Kconfig
+++ b/samples/vpr/vio_shift_output/Kconfig
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+menu "VPR VIO shift output sample"
+
+config APP_VIO_PIN
+	int "VIO bit index used as UART TX"
+	range 0 15
+	default 0
+	help
+	  The VPR VIO pin number used for the emulated UART signal.
+	  This must match the physical pin routed to the VPR core.
+
+config APP_TX_GPIO_PORT
+	int "Physical GPIO port routed to the VPR (nRF54L only)"
+	default 2
+	help
+	  Physical GPIO port of the TX pin.
+	  It must correspond to the VIO index.
+
+config APP_TX_GPIO_PIN
+	int "Physical GPIO pin routed to the VPR (nRF54L only)"
+	default 9
+	help
+	  Physical GPIO pin of the TX pin.
+	  It must correspond to the VIO index.
+
+config APP_UART_BAUD_RATE
+	int "Baud rate of the emulated UART"
+	default 115200
+	help
+	  Baud rate of the bit-banged UART transmitter.
+	  The bit period is derived from the VPR core clock, so very low baud rates may exceed the 16-bit range of VTIM counter 0.
+
+endmenu
+
+source "Kconfig.zephyr"

--- a/samples/vpr/vio_shift_output/README.rst
+++ b/samples/vpr/vio_shift_output/README.rst
@@ -1,0 +1,89 @@
+.. _vpr_vio_shift_output:
+
+VPR VIO shift output
+####################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The sample emulates a UART transmitter by driving a single GPIO pin from a VPR coprocessor (FLPR or PPR).
+It uses output shifting to automatically output a whole (8N1) frame while the processor can prepare the next frame.
+This sample is not intended to be a full UART implementation, it is a showcase of how to implement similar protocols.
+
+Application overview
+********************
+
+The sample combines the VIO output shift register with a VTIM counter:
+
+* **VTIM counter 0** runs as the bit-clock (baud-rate) generator.
+  It counts down to zero, when it hits zero it generates an event and reloads the bit period.
+
+* **VIO output shift register** When shift mode is enabled, instead of copying the whole buffered output register (OUTB) to the output register (OUT) only a specific number of bit is copied.
+  The left over bit are moved to the right with the same number of bits.
+  In this sample we pack the byte with a start and stop bit into the buffered output register (OUTB).
+  When all bits are shifted out the next packed byte is put into OUTB.
+
+To get a consistent result, independent on the compiler configuration, the loop packing the bytes is provided as inline assembly.
+It takes a maximum of 10 clock cycles between writes to OUTB.
+As the packed bytes are 10 bits (start bit, 8 data bits and a stop bit), we can output at the full clock speed of the VPR core.
+
+The application drives the VIO bit selected with :kconfig:option:`CONFIG_APP_VIO_PIN`.
+* On the **nRF9xx**, the pin is assigned to the VPR through the UICR, generated from the ``vpr_launcher`` devicetree overlay.
+* On the **nRF54L series**, the FLPR routes the pin to the VPR at runtime, using :kconfig:option:`CONFIG_APP_TX_GPIO_PORT` and :kconfig:option:`CONFIG_APP_TX_GPIO_PIN`.
+
+
+Requirements
+************
+
+The sample supports the following development kits and cores:
+
+.. table-from-sample-yaml::
+
+Pin mapping
+===========
+
+The TX pin depends on the target.
+The defaults, set in the board ``.conf`` files and/or routed in the matching ``vpr_launcher`` overlay, are:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Target
+     - VIO index
+     - GPIO pin
+   * - nRF9251 DK, ``cpuflpr``
+     - 8
+     - P2.05 (TXD1)
+   * - nRF9251 DK, ``cpuppr``
+     - 0
+     - P1.06 (TXD0)
+   * - nRF54L15 DK, ``cpuflpr``
+     - 9
+     - P2.09 (LED0)
+
+Configuration
+*************
+
+To use a different pin:
+* On the nRF9xx, update :kconfig:option:`CONFIG_APP_VIO_PIN` and (:file:`sysbuild/vpr_launcher/nrf9251_flpr.overlay` or :file:`_ppr.overlay`).
+* On the nRF54L series, update :kconfig:option:`CONFIG_APP_VIO_PIN`, :kconfig:option:`CONFIG_APP_TX_GPIO_PORT` and :kconfig:option:`CONFIG_APP_TX_GPIO_PIN`.
+
+Building and running
+********************
+
+.. |sample path| replace:: :file:`samples/vpr/vio_shift_output`
+
+Build for a VPR core.
+Sysbuild automatically adds the VPR launcher image for the application core:
+
+.. code-block:: console
+
+   west build -b nrf9251dk/nrf9251/cpuflpr
+   west flash
+
+Testing
+*******
+
+* On the nRF9251dk the signals are routed to the debugger so you can test without external hardware.
+* On the nRF54L15dk you need to attach a logic analyzer or oscilloscope to the TX pin.

--- a/samples/vpr/vio_shift_output/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
+++ b/samples/vpr/vio_shift_output/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# The nRF54L VPR has no OUTMODE.SEL field, so the output shift register always
+# drives its serial stream out on VIO 0. VIO 0 maps to GPIO P2.1, so the emulated
+# UART TX must use VIO 0 and route P2.1 to the VPR.
+CONFIG_APP_VIO_PIN=0
+CONFIG_APP_TX_GPIO_PORT=2
+CONFIG_APP_TX_GPIO_PIN=1

--- a/samples/vpr/vio_shift_output/boards/nrf9251dk_nrf9251_cpuflpr.conf
+++ b/samples/vpr/vio_shift_output/boards/nrf9251dk_nrf9251_cpuflpr.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# VIO 8 corresponds to GPIO P2.05 (routed in the vpr_launcher overlay).
+# This pin is wired to UART1 from the debugger.
+CONFIG_APP_VIO_PIN=8

--- a/samples/vpr/vio_shift_output/boards/nrf9251dk_nrf9251_cpuppr.conf
+++ b/samples/vpr/vio_shift_output/boards/nrf9251dk_nrf9251_cpuppr.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# VIO 0 corresponds to GPIO P1.06 (routed in the vpr_launcher overlay).
+# This pin is wired to UART0 from the debugger.
+CONFIG_APP_VIO_PIN=0

--- a/samples/vpr/vio_shift_output/prj.conf
+++ b/samples/vpr/vio_shift_output/prj.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause

--- a/samples/vpr/vio_shift_output/sample.yaml
+++ b/samples/vpr/vio_shift_output/sample.yaml
@@ -1,0 +1,15 @@
+sample:
+  name: VPR VIO shift output
+  description: Drive a VIO pin from a VPR coprocessor emulating UART using output shifting.
+tests:
+  sample.vpr.vio_shift_output.build:
+    build_only: true
+    sysbuild: true
+    integration_platforms:
+      - nrf9251dk/nrf9251/cpuflpr
+    platform_allow:
+      - nrf9251dk/nrf9251/cpuflpr
+      - nrf9251dk/nrf9251/cpuppr
+      - nrf54l15dk/nrf54l15/cpuflpr
+    tags:
+      - ci_build

--- a/samples/vpr/vio_shift_output/src/main.c
+++ b/samples/vpr/vio_shift_output/src/main.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdio.h>
+#include <zephyr/irq.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+#include <hal/nrf_vpr_csr.h>
+#include <hal/nrf_vpr_csr_vio.h>
+#include <hal/nrf_vpr_csr_vtim.h>
+#include <hal/nrf_gpio.h>
+
+/* Rounded bit period in clock ticks. */
+#define BIT_PERIOD  (SystemCoreClock +  CONFIG_APP_UART_BAUD_RATE/ 2) / CONFIG_APP_UART_BAUD_RATE
+
+#define TX_VIO_PIN  CONFIG_APP_VIO_PIN
+#define TX_VIO_MASK BIT(TX_VIO_PIN)
+
+#if !NRF_VPR_HAS_OUTMODE_SEL && TX_VIO_PIN != 0
+#error "Only VIO 0 is supported for shift output on this SOC"
+#endif
+
+/* 8N1 framing: 1 start bit + 8 data bits + 1 stop bit. */
+#define UART_DATA_BITS  8
+#define UART_FRAME_BITS (1 + UART_DATA_BITS + 1)
+
+/*
+ * Copy byte into an 8N1 frame
+ *   bit 0      : start bit (0)
+ *   bits 1..8  : data bits (LSB first)
+ *   bit 9      : stop bit (1)
+ */
+static inline uint32_t uart_frame(uint8_t byte)
+{
+	return (uint32_t)byte << 1 | BIT(UART_FRAME_BITS - 1);
+}
+
+static void uart_send_string(const char *str)
+{
+	/* Prevent kernel tick from messing things up. */
+	unsigned int key = irq_lock();
+
+	/*
+	 * Set the configuration for the first byte.
+	 * Shift mode with a single pin.
+	 * This pin can only be chosen on some devices, for other devices it needs to be VIO 0.
+	 */
+	nrf_vpr_csr_vio_mode_out_t out_mode = {
+		.mode = NRF_VPR_CSR_VIO_SHIFT_OUTB,
+		.frame_width = 1,
+#if NRF_VPR_HAS_OUTMODE_SEL
+		.sel = TX_VIO_PIN,
+#endif
+	};
+
+	nrf_vpr_csr_vio_mode_out_set(&out_mode);
+	nrf_vpr_csr_vio_shift_cnt_out_set(UART_FRAME_BITS - 1);
+
+	/**
+	 * Set the configuration for all the other bytes.
+	 * These buffered values are loaded when shift_count == 0 on the CNT0 event.
+	 */
+	nrf_vpr_csr_vio_shift_ctrl_t shift_ctrl = {
+		.shift_count = UART_FRAME_BITS - 1,
+		.out_mode = NRF_VPR_CSR_VIO_SHIFT_OUTB,
+		.frame_width = 1,
+#if NRF_VPR_HAS_OUTMODE_SEL
+		.sel = TX_VIO_PIN,
+#endif
+	};
+
+	nrf_vpr_csr_vio_shift_ctrl_buffered_set(&shift_ctrl);
+
+	/**
+	 * Buffer the first byte.
+	 * Every CNT0 event (CNT0 hits 0):
+	 *   - The right most bit will be output.
+	 *   - The other bits are shifted right.
+	 *   - Shift_count will be decreased by one.
+	 */
+	nrf_vpr_csr_vio_out_buffered_set(uart_frame((uint8_t)str[0]));
+
+	/**
+	 * Set counter to (re)load the bit period every time Shift_count hits 0.
+	 * Start counter with value 1 so it hits 0 and outputs the first bit immediately.
+	 */
+	nrf_vpr_csr_vtim_simple_counter_top_set(0, BIT_PERIOD - 1);
+	nrf_vpr_csr_vtim_count_mode_set(0, NRF_VPR_CSR_VTIM_COUNT_RELOAD);
+	nrf_vpr_csr_vtim_simple_counter_set(0, 1);
+
+	/*
+	 * Timing critical output of the remaining bytes plus the termination.
+	 *
+	 * To allow for maximum baudrate (BIT_PERIOD == 1, for example 16 Mbit at 16 MHz clock)
+	 * we need to use manually optimized assembly code as we only have 10 clock ticks for each
+	 * byte and the termination.
+	 *
+	 * Equivalent C:
+	 *	for (const char *p = &str[1]; *p != '\0'; p++) {
+	 *		// Set next byte (blocks until Shift_count == 0)
+	 *		nrf_vpr_csr_vio_out_buffered_set(uart_frame((uint8_t)*p));
+	 *	}
+	 *
+	 *	// Stop shifting after the last bit.
+	 *	nrf_vpr_csr_vio_shift_ctrl_t shift_ctrl_end = {
+	 *		.out_mode = NRF_VPR_CSR_VIO_SHIFT_NONE,
+	 *		.frame_width = 1,
+	 *		.sel = TX_VIO_PIN,
+	 *	};
+	 *
+	 *	nrf_vpr_csr_vio_shift_ctrl_buffered_set(&shift_ctrl_end);
+	 *
+	 *	// Wait for shift_count to hit 0 and leave output high.
+	 *	nrf_vpr_csr_vio_out_buffered_set(1);
+	 */
+	__asm__ volatile(
+		"loop%=:\n"
+		"	addi	%[p], %[p], 1\n"		/* p++; */
+		"	lbu	t0, 0(%[p])\n"			/* frame = *p */
+		"	beqz	t0, exit%=\n"			/* if (frame == 0) goto: exit; */
+		"	slli	t0, t0, 1\n"			/* frame = frame << 1; */
+		"	ori	t0, t0, %[stopbit]\n"		/* frame |= 0x200; */
+		"	csrw	%[outb], t0\n"			/* OUTB = frame; (stalls) */
+		"	j	loop%=\n"			/* goto: loop; */
+		"exit%=:\n"
+		"	csrw	%[sctrl], %[shift_ctrl_end]\n"	/* SHIFTCTRLB.MODE = NoShifting; */
+		"	csrwi	%[outb], 1\n"			/* OUTB = 1; (stalls) */
+		: [p] "+r"(str)
+		: [outb] "i"(VPRCSR_NORDIC_OUTB),
+		  [sctrl] "i"(VPRCSR_NORDIC_SHIFTCTRLB),
+		  [stopbit] "i"(BIT(UART_FRAME_BITS - 1)),
+		  [shift_ctrl_end] "r"(
+	NRF_VPR_CSR_VIO_SHIFT_NONE << VPRCSR_NORDIC_SHIFTCTRLB_OUTMODEB_FRAMEWIDTH_Pos |
+	1 << VPRCSR_NORDIC_SHIFTCTRLB_OUTMODEB_FRAMEWIDTH_Pos
+#if NRF_VPR_HAS_OUTMODE_SEL
+	| TX_VIO_PIN << VPRCSR_NORDIC_SHIFTCTRLB_OUTMODEB_SEL_Pos
+#endif
+				      )
+		: "t0", "memory");
+
+	/* Stop the clock. */
+	nrf_vpr_csr_vtim_count_mode_set(0, NRF_VPR_CSR_VTIM_COUNT_STOP);
+
+	/* Resume kernel tick so we can use sleep. */
+	irq_unlock(key);
+}
+
+int main(void)
+{
+	static const char msg[] = "Hello world!\n";
+
+	printf("VPR VIO shift-output (UART TX) sample on %s\n",	CONFIG_BOARD_TARGET);
+	printf("Core clock: %u Hz, baud: %d, bit period: %u cycles\n",
+		SystemCoreClock, CONFIG_APP_UART_BAUD_RATE, BIT_PERIOD);
+	printf("Emulated UART TX on VIO index %d\n", TX_VIO_PIN);
+
+#if NRF_GPIO_HAS_SEL
+	/**
+	 * Assign the GPIO pin to the VPR core.
+	 * If this is not supported it needs to be done using UICR by configuring the pin in
+	 * the devicetree of the app core image.
+	 */
+	nrf_gpio_pin_control_select(
+		NRF_GPIO_PIN_MAP(CONFIG_APP_TX_GPIO_PORT, CONFIG_APP_TX_GPIO_PIN),
+		NRF_GPIO_PIN_SEL_VPR);
+#endif
+
+	/* Enable the VPR real-time peripherals (VIO + VTIM). */
+	nrf_vpr_csr_rtperiph_enable_set(true);
+
+	/* Configure the TX pin as a VIO output, start high. */
+	nrf_vpr_csr_vio_out_set(TX_VIO_MASK);
+	nrf_vpr_csr_vio_dir_set(TX_VIO_MASK);
+
+	while (1) {
+		uart_send_string(msg);
+
+		k_msleep(1000);
+	}
+
+	return 0;
+}

--- a/samples/vpr/vio_shift_output/sysbuild.cmake
+++ b/samples/vpr/vio_shift_output/sysbuild.cmake
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# for the nRF9251 different overlay and configuration are needed depending on which VPR used.
+if("${BOARD}" MATCHES "nrf9251")
+  if("${BOARD_QUALIFIERS}" MATCHES "cpuflpr")
+    set(vpr_launcher_EXTRA_DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/sysbuild/vpr_launcher/nrf9251_flpr.overlay CACHE INTERNAL "")
+  elseif("${BOARD_QUALIFIERS}" MATCHES "cpuppr")
+    set(vpr_launcher_EXTRA_DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/sysbuild/vpr_launcher/nrf9251_ppr.overlay CACHE INTERNAL "")
+    set(vpr_launcher_EXTRA_CONF_FILE ${CMAKE_CURRENT_LIST_DIR}/sysbuild/vpr_launcher/nrf9251_ppr.conf CACHE INTERNAL "")
+  endif()
+endif()

--- a/samples/vpr/vio_shift_output/sysbuild/vpr_launcher/nrf9251_flpr.overlay
+++ b/samples/vpr/vio_shift_output/sysbuild/vpr_launcher/nrf9251_flpr.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Assign P2.05 (uart132 TX, wired to debugger UART1) to FLPR (VIO 8).
+ *
+ * GPIO -> VIO mapping:
+ *     P5.1         -> 0
+ *     P5.0         -> 1
+ *     P5.2         -> 2
+ *     P5.3         -> 3
+ *     P5.4 / P2.0  -> 4
+ *     P5.5 / P2.1  -> 5
+ *     P2.2         -> 6
+ *     P2.3         -> 7
+ *     (P2.4 not connected)
+ *     P2.5         -> 8
+ *     P2.6         -> 9
+ *     P2.7         -> 10
+ *     P2.8         -> 11
+ */
+&uart132 {
+	status = "disabled";
+};
+
+&pinctrl {
+	vpr_flpr_vio_default: vpr_flpr_vio_default {
+		group1 {
+			psels = <NRF_PSEL(VPR_VIO, 2, 5)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
+		};
+	};
+};
+
+&cpuflpr_vpr {
+	pinctrl-0 = <&vpr_flpr_vio_default>;
+	pinctrl-names = "default";
+};

--- a/samples/vpr/vio_shift_output/sysbuild/vpr_launcher/nrf9251_ppr.conf
+++ b/samples/vpr/vio_shift_output/sysbuild/vpr_launcher/nrf9251_ppr.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# uart133 is handed to the PPR VIO, so the vpr_launcher cannot use it.
+CONFIG_SERIAL=n
+CONFIG_CONSOLE=n
+CONFIG_UART_CONSOLE=n

--- a/samples/vpr/vio_shift_output/sysbuild/vpr_launcher/nrf9251_ppr.overlay
+++ b/samples/vpr/vio_shift_output/sysbuild/vpr_launcher/nrf9251_ppr.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Assign P1.06 (uart133 TX, wired to debugger UART0) to PPR (VIO 0).
+ *
+ * GPIO -> VIO mapping:
+ *     P0.0 / P1.6  -> 0
+ *     P0.1 / P1.7  -> 1
+ *     P1.10        -> 2
+ *     P1.11        -> 3
+ */
+&uart133 {
+	status = "disabled";
+};
+
+&pinctrl {
+	vpr_ppr_vio_default: vpr_ppr_vio_default {
+		group1 {
+			psels = <NRF_PSEL(VPR_VIO, 1, 6)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
+		};
+	};
+};
+
+&cpuppr_vpr {
+	pinctrl-0 = <&vpr_ppr_vio_default>;
+	pinctrl-names = "default";
+};

--- a/samples/vpr/vio_shift_output/sysbuild/vpr_launcher/prj.conf
+++ b/samples/vpr/vio_shift_output/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause

--- a/samples/vpr/vio_toggle/CMakeLists.txt
+++ b/samples/vpr/vio_toggle/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(vpr_vio_toggle)
+
+# NORDIC SDK APP START
+target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END

--- a/samples/vpr/vio_toggle/Kconfig
+++ b/samples/vpr/vio_toggle/Kconfig
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+menu "VPR VIO sample"
+
+config APP_VIO_PIN
+	int "VIO bit index to drive"
+	range 0 15
+	default 0
+	help
+	  The VPR VIO pin number that the sample toggles. This must match the physical pin routed to
+	  this VPR core in the vpr_launcher devicetree overlay.
+
+config APP_PULSE_HIGH_CYCLES
+	int "Pulse HIGH width in core cycles"
+	default 4
+	help
+	  Total number of clock cycles the pin is held high.
+	  This can be as low as 1 cycle as that is how long a pin write takes.
+
+config APP_PULSE_LOW_CYCLES
+	int "Pulse LOW width in core cycles"
+	default 12
+	help
+	  Total number of clock cycles the pin is held low.
+	  This must be at least the 4 cycles needed for the loop and pin write.
+
+endmenu
+
+source "Kconfig.zephyr"

--- a/samples/vpr/vio_toggle/README.rst
+++ b/samples/vpr/vio_toggle/README.rst
@@ -1,0 +1,54 @@
+.. _vpr_vio_toggle_sample:
+
+VPR VIO toggle
+##############
+
+.. contents::
+   :local:
+   :depth: 2
+
+This sample runs on a VPR coprocessor and drives a single GPIO pin directly through the VPR VIO (VPR I/O) interface (not through GPIO).
+Each VIO write is a single-cycle CSR write, so the pin can be toggled with cycle-accurate, deterministic timing.
+The sample generates a continuous block wave whose HIGH and LOW widths are exact core-cycle counts.
+
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-sample-yaml::
+
+Overview
+********
+
+VIO (VPR IO) is a basic GPIO controller for the VPR cores, with support for up to 16 GPIO pins.
+The pins can be accessed in a single clock cycle making it possible to implement cycle-accurate IO operations.
+The pins are routed to the VPR-core by configuring them in devicetree overlay for the application running on the APP-core.
+When building for a VPR target, sysbuild will automatically build a vpr_launcher application for the APP-core.
+
+Configuration
+*************
+
+|config|
+
+The mapping of the GPIO pins to VIO pins is depends on the device and can not be changed.
+You can find which VIO pin of which VPR core corresponds to which GPIO pin in the GPIO port mapping of the device.
+To configure a specific GPIO pin you need to assign it to the VPR core inside `sysbuild/vpr_launcher/boards/<board>.overlay`.
+To allow for fast pin toggling, you can set the drive strength to `high`` or `extra high`, depending on the port.
+You need to set the corresponding VIO pin in :kconfig:option:`CONFIG_APP_VIO_PIN`.
+
+
+Building and running
+********************
+
+This sample is built for the VPR core and uses sysbuild:
+
+.. code-block:: console
+
+   west build -b nrf9251dk/nrf9251/cpuflpr
+   west flash
+
+Testing
+*******
+
+After programming, observe the selected pin on a logic analyzer or oscilloscope. The pin emits a continuous block wave, driven entirely by the VPR through VIO. The VPR console prints the board target and VIO index at startup.

--- a/samples/vpr/vio_toggle/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
+++ b/samples/vpr/vio_toggle/boards/nrf54l15dk_nrf54l15_cpuflpr.conf
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# VIO 9 corresponds to GPIO P2.9
+CONFIG_APP_VIO_PIN=9
+
+# @128 MHz clock this will create a 8 MHz block wave with 25% duty cycle.
+CONFIG_APP_PULSE_HIGH_CYCLES=4
+CONFIG_APP_PULSE_LOW_CYCLES=12

--- a/samples/vpr/vio_toggle/boards/nrf9251dk_nrf9251_cpuflpr.conf
+++ b/samples/vpr/vio_toggle/boards/nrf9251dk_nrf9251_cpuflpr.conf
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# VIO 0 corresponds to GPIO P5.0
+CONFIG_APP_VIO_PIN=1
+
+# @256 MHz clock this will create a 16 MHz block wave with 25% duty cycle.
+CONFIG_APP_PULSE_HIGH_CYCLES=4
+CONFIG_APP_PULSE_LOW_CYCLES=12

--- a/samples/vpr/vio_toggle/boards/nrf9251dk_nrf9251_cpuppr.conf
+++ b/samples/vpr/vio_toggle/boards/nrf9251dk_nrf9251_cpuppr.conf
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+# VIO 0 corresponds to GPIO P0.0 or P1.6
+CONFIG_APP_VIO_PIN=0
+
+# @16 MHz clock this will create a 1 MHz block wave with 25% duty cycle.
+CONFIG_APP_PULSE_HIGH_CYCLES=4
+CONFIG_APP_PULSE_LOW_CYCLES=12

--- a/samples/vpr/vio_toggle/prj.conf
+++ b/samples/vpr/vio_toggle/prj.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause

--- a/samples/vpr/vio_toggle/sample.yaml
+++ b/samples/vpr/vio_toggle/sample.yaml
@@ -1,0 +1,15 @@
+sample:
+  name: VPR VIO toggle
+  description: Toggle a GPIO pin directly from a VPR coprocessor using its VIO interface.
+tests:
+  sample.vpr.vio_toggle.build:
+    build_only: true
+    sysbuild: true
+    integration_platforms:
+      - nrf9251dk/nrf9251/cpuflpr
+    platform_allow:
+      - nrf9251dk/nrf9251/cpuflpr
+      - nrf9251dk/nrf9251/cpuppr
+      - nrf54l15dk/nrf54l15/cpuflpr
+    tags:
+      - ci_build

--- a/samples/vpr/vio_toggle/src/main.c
+++ b/samples/vpr/vio_toggle/src/main.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdio.h>
+#include <zephyr/sys/util.h>
+
+#include <hal/nrf_vpr_csr.h>
+#include <hal/nrf_vpr_csr_vio.h>
+
+#define VIO_MASK BIT(CONFIG_APP_VIO_PIN)
+
+/* Run exactly N nop instructions (N core cycles) inline. */
+#define MULTIPLE_NOPS(n) __asm__ volatile(".rept %c0\n\tnop\n.endr\n" : : "i"(n))
+
+/* Fixed in-loop overhead, in core cycles.*/
+#define VIO_WRITE_CYCLES     1
+#define LOOP_BRANCH_CYCLES   3
+#define HIGH_OVERHEAD_CYCLES (VIO_WRITE_CYCLES)
+#define LOW_OVERHEAD_CYCLES  (LOOP_BRANCH_CYCLES + VIO_WRITE_CYCLES)
+
+BUILD_ASSERT(CONFIG_APP_PULSE_HIGH_CYCLES >= HIGH_OVERHEAD_CYCLES,
+	     "APP_PULSE_HIGH_CYCLES must be >= the fixed HIGH overhead");
+BUILD_ASSERT(CONFIG_APP_PULSE_LOW_CYCLES >= LOW_OVERHEAD_CYCLES,
+	     "APP_PULSE_LOW_CYCLES must be >= the fixed LOW overhead");
+
+int main(void)
+{
+	printf("VPR VIO sample on %s: toggling VIO index %d\n", CONFIG_BOARD_TARGET,
+	       CONFIG_APP_VIO_PIN);
+
+	/* Configure the VIO bit as an output, starting low. */
+	nrf_vpr_csr_vio_dir_set(VIO_MASK);
+	nrf_vpr_csr_vio_out_set(0);
+
+	while (1) {
+		/* High. */
+		nrf_vpr_csr_vio_out_set(VIO_MASK);
+		MULTIPLE_NOPS(CONFIG_APP_PULSE_HIGH_CYCLES - HIGH_OVERHEAD_CYCLES);
+
+		/* Low. */
+		nrf_vpr_csr_vio_out_set(0);
+		MULTIPLE_NOPS(CONFIG_APP_PULSE_LOW_CYCLES - LOW_OVERHEAD_CYCLES);
+	}
+
+	return 0;
+}

--- a/samples/vpr/vio_toggle/src/main.c
+++ b/samples/vpr/vio_toggle/src/main.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdio.h>
+#include <zephyr/sys/util.h>
+
+#include <hal/nrf_vpr_csr.h>
+#include <hal/nrf_vpr_csr_vio.h>
+#include <hal/nrf_gpio.h>
+
+#define VIO_MASK BIT(CONFIG_APP_VIO_PIN)
+
+/* Run exactly N nop instructions (N core cycles) inline. */
+#define MULTIPLE_NOPS(n) __asm__ volatile(".rept %c0\n\tnop\n.endr\n" : : "i"(n))
+
+/* Fixed in-loop overhead, in core cycles.*/
+#define VIO_WRITE_CYCLES     1
+#define LOOP_BRANCH_CYCLES   3
+#define HIGH_OVERHEAD_CYCLES (VIO_WRITE_CYCLES)
+#define LOW_OVERHEAD_CYCLES  (LOOP_BRANCH_CYCLES + VIO_WRITE_CYCLES)
+
+BUILD_ASSERT(CONFIG_APP_PULSE_HIGH_CYCLES >= HIGH_OVERHEAD_CYCLES,
+	     "APP_PULSE_HIGH_CYCLES must be >= the fixed HIGH overhead");
+BUILD_ASSERT(CONFIG_APP_PULSE_LOW_CYCLES >= LOW_OVERHEAD_CYCLES,
+	     "APP_PULSE_LOW_CYCLES must be >= the fixed LOW overhead");
+
+int main(void)
+{
+	printf("VPR VIO sample on %s: toggling VIO index %d\n", CONFIG_BOARD_TARGET,
+	       CONFIG_APP_VIO_PIN);
+
+#if NRF_GPIO_HAS_SEL
+	/* On the nRF54L series the FLPR routes the pin to the VPR at runtime.
+	 * On SoCs that route pins through the UICR periphconf this is done by the vpr_launcher
+	 * devicetree overlay.
+	 */
+	nrf_gpio_pin_control_select(
+		NRF_GPIO_PIN_MAP(CONFIG_APP_TX_GPIO_PORT, CONFIG_APP_TX_GPIO_PIN),
+		NRF_GPIO_PIN_SEL_VPR);
+#endif
+
+	/* Configure the VIO bit as an output, starting low. */
+	nrf_vpr_csr_vio_dir_set(VIO_MASK);
+	nrf_vpr_csr_vio_out_set(0);
+
+	/* Prevent any interrupts to disturb the critical timing.*/
+	unsigned int key = irq_lock();
+
+	while (1) {
+		/* High. */
+		nrf_vpr_csr_vio_out_set(VIO_MASK);
+		MULTIPLE_NOPS(CONFIG_APP_PULSE_HIGH_CYCLES - HIGH_OVERHEAD_CYCLES);
+
+		/* Low. */
+		nrf_vpr_csr_vio_out_set(0);
+		MULTIPLE_NOPS(CONFIG_APP_PULSE_LOW_CYCLES - LOW_OVERHEAD_CYCLES);
+	}
+
+	return 0;
+}

--- a/samples/vpr/vio_toggle/sysbuild/vpr_launcher/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/vpr/vio_toggle/sysbuild/vpr_launcher/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Assign and configure the VIO pins for the VPR cores.
+ * The pin configuration will be applied on startup of the app core before enabling the VPR.
+ * FLPR (VPR, 128 MHz), port 2:
+ *     P2.1   -> 0
+ *     P2.2   -> 1
+ *     P2.4   -> 2
+ *     P2.3   -> 3
+ *     P2.0   -> 4
+ *     P2.5   -> 5
+ *     P2.6   -> 6
+ *     P2.7   -> 7
+ *     P2.8   -> 8
+ *     P2.9   -> 9
+ *     P2.10  -> 10
+ */
+&pinctrl {
+	vpr_flpr_vio_default: vpr_flpr_vio_default {
+		group1 {
+			psels = <NRF_PSEL(VPR_VIO, 2, 9)>; /* P2.9 -> VIO 9 */
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
+		};
+	};
+};
+
+&cpuflpr_vpr {
+	pinctrl-0 = <&vpr_flpr_vio_default>;
+	pinctrl-names = "default";
+};

--- a/samples/vpr/vio_toggle/sysbuild/vpr_launcher/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/samples/vpr/vio_toggle/sysbuild/vpr_launcher/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Assign and configure the VIO pins for the VPR cores.
+ * The pins will be assigned to the VPR core in the UICR registers.
+ * The pin configuration will be applied on startup of the app core before enabling the VPR.
+ *
+ * FLPR (VPR121, 256 MHz). Port 5 is the high-speed port and can set drive-mode extra high.
+ *     P5.1         -> 0
+ *     P5.0         -> 1
+ *     P5.2         -> 2
+ *     P5.3         -> 3
+ *     P5.4 / P2.0  -> 4
+ *     P5.5 / P2.1  -> 5
+ *     P2.2         -> 6
+ *     P2.3         -> 7
+ *     (P2.4 not connected)
+ *     P2.5         -> 8
+ *     P2.6         -> 9
+ *     P2.7         -> 10
+ *     P2.8         -> 11
+ *
+ * PPR (VPR130, 16 MHz):
+ *     P0.0 / P1.6  -> 0
+ *     P0.1 / P1.7  -> 1
+ *     P1.10        -> 2
+ *     P1.11        -> 3
+ */
+&pinctrl {
+	vpr_flpr_vio_default: vpr_flpr_vio_default {
+		group1 {
+			psels = <NRF_PSEL(VPR_VIO, 5, 0)>; /* P5.0 -> VIO 1 */
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
+		};
+	};
+
+	vpr_ppr_vio_default: vpr_ppr_vio_default {
+		group1 {
+			psels = <NRF_PSEL(VPR_VIO, 0, 0)>; /* P0.0 -> VIO 0 */
+		};
+	};
+};
+
+&cpuflpr_vpr {
+	pinctrl-0 = <&vpr_flpr_vio_default>;
+	pinctrl-names = "default";
+};
+
+&cpuppr_vpr {
+	pinctrl-0 = <&vpr_ppr_vio_default>;
+	pinctrl-names = "default";
+};

--- a/samples/vpr/vio_toggle/sysbuild/vpr_launcher/prj.conf
+++ b/samples/vpr/vio_toggle/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3d2d2b855fc3515284b47b87dfa74c821e34beef
+      revision: pull/4461/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -267,6 +267,17 @@ manifest:
       repo-path: sdk-hostap
       path: modules/lib/hostap
       revision: 09cf9bf998b9e70c2926203447f620c01d68a064
+
+    - name: hal_nordic
+      revision: nrfx-removed
+      url: https://github.com/zephyrproject-rtos/hal_nordic
+      path: modules/hal/nor
+
+    - name: nrfx
+      revision: v4.6.0
+      url: https://github.com/NordicSemiconductor/nrfx
+      path: modules/hal/nor/nrfx
+
   # West-related configuration for the nrf repository.
   self:
     # This repository should be cloned to ncs/nrf.


### PR DESCRIPTION
Add a sample that toggles a GPIO pin directly from a VPR coprocessor through its VIO interface, emitting a cycle-accurate block wave.

The pin is routed to the VPR from the application core through a vpr_launcher sysbuild image configured using devicetree.

There were no samples for the VPR IO. There are 2 applications but to get those to work on the nRF92 I needed somthing simpler first.