### PR TITLE
lib: modem_info: missing stddef

### DIFF
--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -12,6 +12,7 @@
 #endif
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The `modem_info` library is using the `size_t` type but does not include `stddef.h` where `size_t` is defined.
This makes the build fails if `modem_info` is included before everything without using `CONFIG_CJSON_LIB`.