### PR TITLE
drivers: nrf71: Enable Wi-Fi keep-alive and KMU by default; Change default band to dual

### DIFF
--- a/doc/nrf/protocols/wifi/station_mode/powersave.rst
+++ b/doc/nrf/protocols/wifi/station_mode/powersave.rst
@@ -384,6 +384,27 @@ The following figure illustrates the two key parameters of TWT:
 
    TWT Wake Duration and Interval
 
+.. _ug_nrf70_developing_powersave_keepalive:
+
+Connection keep-alive
+*********************
+
+Certain access points disconnect a station device that has been idle for a period of time, without performing any explicit reachability check.
+When operating in Power Save mode, the nRF70 Series device can remain idle for extended periods, which may cause such access points to silently drop the connection.
+
+To interoperate with these access points, the nRF Wi-Fi driver periodically sends a Null data frame to the AP to keep the connection alive and to signal that the station is still reachable.
+The null data frame is an IEEE 802.11 MAC data frame with no payload that is generated and transmitted by the nRF70 Series firmware.
+This feature is enabled by default and slightly increases the average power consumption, because the device wakes up periodically to transmit the keep-alive frame.
+
+You can configure the feature using the following Kconfig options:
+
+* :kconfig:option:`CONFIG_NRF_WIFI_FEAT_KEEPALIVE` - Enables the keep-alive feature.
+  This option is enabled by default.
+  Disable it to avoid the additional power consumption when the connected AP does not disconnect idle clients.
+* :kconfig:option:`CONFIG_NRF_WIFI_KEEPALIVE_PERIOD_S` - Sets the interval, in seconds, between successive keep-alive frames.
+  The default value is 30 seconds and the valid range is 30 to 3600 seconds.
+  Use a longer period to reduce power consumption, provided the AP tolerates the longer idle interval.
+
 .. _ug_nrf70_developing_powersave_usage:
 
 Usage

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -582,12 +582,14 @@ Wi-Fi drivers
 -------------
 
 * Added the :ref:`nRF71 Series Wi-Fi driver <nrf71_wifi_fw_if>` page documenting its firmware interface.
-* Updated the :ref:`wifi_drivers` page by restructuring it into separate nRF70 Series and nRF71 Series sections.
-* Updated the default values of the following Kconfig options to reduce the default RAM footprint of the Wi-Fi drivers for the nRF70 and nRF71 Series:
 
-  * :kconfig:option:`CONFIG_NRF70_RX_NUM_BUFS` (or :kconfig:option:`CONFIG_NRF71_RX_NUM_BUFS`) from ``48`` to ``16``.
-  * :kconfig:option:`CONFIG_NRF70_MAX_TX_AGGREGATION` (or :kconfig:option:`CONFIG_NRF71_MAX_TX_AGGREGATION`) from ``12`` to ``4``.
-  * :kconfig:option:`CONFIG_NRF_WIFI_DATA_HEAP_SIZE` from ``130000`` to ``65536``.
+* Updated:
+
+  * The :ref:`wifi_drivers` page by restructuring it into separate nRF70 Series and nRF71 Series sections.
+  * The default values of the following Kconfig options to reduce the default RAM footprint of the Wi-Fi drivers for the nRF70 and nRF71 Series:
+    * :kconfig:option:`CONFIG_NRF70_RX_NUM_BUFS` (or :kconfig:option:`CONFIG_NRF71_RX_NUM_BUFS`) from ``48`` to ``16``.
+    * :kconfig:option:`CONFIG_NRF70_MAX_TX_AGGREGATION` (or :kconfig:option:`CONFIG_NRF71_MAX_TX_AGGREGATION`) from ``12`` to ``4``.
+    * :kconfig:option:`CONFIG_NRF_WIFI_DATA_HEAP_SIZE` from ``130000`` to ``65536``.
 
   See :ref:`migration_3.5` for more information.
 

--- a/drivers/wifi/nrf71/Kconfig
+++ b/drivers/wifi/nrf71/Kconfig
@@ -648,7 +648,7 @@ config WIFI_NRF71_SCAN_TIMEOUT_S
 
 choice NRF_WIFI_OP_BAND
 	prompt "nRF Wi-Fi operation bands"
-	default NRF_WIFI_ALL_BAND
+	default NRF_WIFI_DUAL_BAND
 
 config NRF_WIFI_ALL_BAND
 	bool "Set operation band to all supported bands"

--- a/drivers/wifi/nrf71/Kconfig
+++ b/drivers/wifi/nrf71/Kconfig
@@ -849,6 +849,7 @@ config NRF_WIFI_MGMT_BUFF_OFFLOAD
 config NRF_WIFI_FEAT_KEEPALIVE
 	bool "Wi-Fi keepalive feature for connection maintenance"
 	depends on NRF71_STA_MODE
+	default y
 	help
 	  Enable the Wi-Fi keepalive feature to keep the connection alive by sending
 	  keepalive packets to the AP. This feature is primarily intended to interoperate with APs

--- a/drivers/wifi/nrf71/Kconfig
+++ b/drivers/wifi/nrf71/Kconfig
@@ -991,6 +991,10 @@ config NRF_WIFI_TWT_SETUP_TIMEOUT_MS
 config NRF_WIFI_USE_KMU
 	bool "Use KMU for key installation"
 	depends on NRF_WIFI_KMU
+	default y
+	help
+	  Use KMU for key installation. This is the default KMU for the
+	  nRF71 Wi-Fi chip.
 
 config NRF_WIFI_CMD_EVENT_LOG
 	bool "Log HAL command/events (debug)"


### PR DESCRIPTION
Enable Wi-Fi keep-alive by default.
Enable KMU by default.
Change default band to dual (2.4GHz+5GHz)