### PR TITLE
scripts: quarantine: Add Wi-Fi KMU TF-M test.

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -94,3 +94,9 @@
   platforms:
     - native_sim/native
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-40216"
+
+- scenarios:
+    - tests.wifi_kmu.tfm
+  platforms:
+    - nrf7120dk/nrf7120/cpuapp
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-40622"


### PR DESCRIPTION
TF-M support has not been implemented yet.

ref: NCSDK-40622, CAL-6362, CAL-7434