### PR TITLE
scripts: ci: Add TF-M to allow list license check

### DIFF
--- a/scripts/ci/license_allow_list.yaml
+++ b/scripts/ci/license_allow_list.yaml
@@ -60,6 +60,7 @@ any: |
 # Allow different licenses from external sources
 LicenseRef-west-ncs-sbom-iperf-BSD-3-Clause: "^nrf/ext/"
 Apache-2.0: |
+  ^modules/tee/tf-m/trusted-firmware-m/
   ^nrf/ext/
   ^nrf/.clang-format
   ^nrf/.ruff.toml
@@ -94,6 +95,7 @@ MIT: |
   "^nrf/ext/"
   ^nrf/doc/_doxygen/doxygen-awesome.css
 BSD-3-CLAUSE: |
+  ^modules/tee/tf-m/trusted-firmware-m/
   ^nrf/ext/
   ^nrf/drivers/wifi/nrf71/
 BSD-2-CLAUSE-NETBSD: "^nrf/ext/"
@@ -101,4 +103,5 @@ GPL-2.0: |
   /matter_weather_station/.clang-format
   /matter_bridge/.clang-format
 Apache-2.0 OR GPL-2.0-or-later: |
+  ^modules/tee/tf-m/trusted-firmware-m/
   ^nrf/subsys/nrf_security/src/drivers/cracen/cracen_sw/ext/


### PR DESCRIPTION
Add allow listing for the TF-M module for the license to allow for BSD, APACHE 2.0 and APACHE-2.0 and GPL-2.0 Dual licenses which are the licenses allowed for files in TF-M.