### PR TITLE
[Backport v3.4-branch] Update to Oberon PSA 2.1.0

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -116,6 +116,10 @@ Developing with custom boards
 Security
 ========
 
+* Updated:
+
+  * Oberon PSA Crypto from v2.0.0 to v2.1.0.
+    The new version has minor updates in internal APIs, restructures the directory hierarchy, and improves native support for built-in keys.
 
 Mbed TLS
 --------

--- a/lib/hw_unique_key/hw_unique_key_cracen_kmu.c
+++ b/lib/hw_unique_key/hw_unique_key_cracen_kmu.c
@@ -32,7 +32,7 @@ int hw_unique_key_derive_key(enum hw_unique_key_slot key_slot, const uint8_t *co
 
 	cracen_key_derivation_operation_t op = {};
 
-	status = cracen_key_derivation_setup(&op, PSA_ALG_SP800_108_COUNTER_CMAC);
+	status = cracen_key_derivation_setup(&op, NULL, PSA_ALG_SP800_108_COUNTER_CMAC);
 	if (status != PSA_SUCCESS) {
 		if (status == PSA_ERROR_DOES_NOT_EXIST) {
 			return -HW_UNIQUE_KEY_ERR_MISSING;

--- a/subsys/nrf_security/src/CMakeLists.txt
+++ b/subsys/nrf_security/src/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories(psa_crypto_library_config
     ${PSA_CRYPTO_CONFIG_LIBRARY_PATH}
     ${NRF_SECURITY_DIR}/include
     # This is needed for the oberon_check_unsupported.h
-    ${ZEPHYR_OBERON_PSA_CRYPTO_MODULE_DIR}/oberon/drivers
+    ${ZEPHYR_OBERON_PSA_CRYPTO_MODULE_DIR}/drivers/oberon
 )
 
 add_library(${mbedcrypto_target}

--- a/subsys/nrf_security/src/core/lite/psa_core_lite.c
+++ b/subsys/nrf_security/src/core/lite/psa_core_lite.c
@@ -556,7 +556,7 @@ psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key_id)
 		return status;
 	}
 
-	return psa_driver_wrapper_destroy_builtin_key(&attr);
+	return psa_driver_wrapper_destroy_key(&attr, NULL, 0);
 #endif /* PSA_NEED_CRACEN_KMU_DRIVER */
 
 	return PSA_ERROR_NOT_SUPPORTED;
@@ -602,6 +602,7 @@ psa_status_t psa_unwrap_key(const psa_key_attributes_t *attributes,
 	psa_core_lite_key_slot_t *key_slot;
 	size_t storage_size;
 	size_t required_key_size_bits;
+	size_t unwrapped_key_bits;
 
 	if (attributes == NULL || key == NULL || data == NULL || alg != PSA_ALG_KW ||
 	    data_length < PSA_CORE_LITE_KEY_WRAP_BLOCK_SIZE) {
@@ -628,12 +629,10 @@ psa_status_t psa_unwrap_key(const psa_key_attributes_t *attributes,
 		goto error;
 	}
 
-	status = psa_driver_wrapper_unwrap_key(attributes, &wrapping_key_slot.key_attributes,
-					       wrapping_key_slot.key,
-					       wrapping_key_slot.key_size, alg, data, data_length,
-					       key_slot->key,
-					       sizeof(key_slot->key),
-					       &key_slot->key_size);
+	status = psa_driver_wrapper_unwrap_key(
+		attributes, &wrapping_key_slot.key_attributes, wrapping_key_slot.key,
+		wrapping_key_slot.key_size, alg, data, data_length, key_slot->key,
+		sizeof(key_slot->key), &key_slot->key_size, &unwrapped_key_bits);
 
 	safe_memzero(&wrapping_key_slot, sizeof(wrapping_key_slot));
 	if (status != PSA_SUCCESS) {
@@ -643,9 +642,8 @@ psa_status_t psa_unwrap_key(const psa_key_attributes_t *attributes,
 	key_slot->key_attributes = *attributes;
 	required_key_size_bits = psa_get_key_bits(attributes);
 	if (required_key_size_bits == 0) {
-		psa_set_key_bits(&key_slot->key_attributes,
-				 PSA_BYTES_TO_BITS(key_slot->key_size));
-	} else if (required_key_size_bits != PSA_BYTES_TO_BITS(key_slot->key_size)) {
+		psa_set_key_bits(&key_slot->key_attributes, unwrapped_key_bits);
+	} else if (required_key_size_bits != unwrapped_key_bits) {
 		status = PSA_ERROR_INVALID_ARGUMENT;
 		goto error;
 	} else {
@@ -685,7 +683,7 @@ psa_status_t psa_key_derivation_setup(psa_key_derivation_operation_t *operation,
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 
-	status = psa_driver_wrapper_key_derivation_setup(operation, kdf_alg);
+	status = psa_driver_wrapper_key_derivation_setup(operation, NULL, kdf_alg);
 	if (status != PSA_SUCCESS) {
 		return status;
 	}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_key_derivation.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_key_derivation.h
@@ -43,13 +43,15 @@ psa_status_t cracen_key_agreement(const psa_key_attributes_t *attributes, const 
 
 /** @brief Set up a key derivation operation.
  *
- * @param[in,out] operation Key derivation operation context.
- * @param[in] alg           Key derivation algorithm.
+ * @param[in,out] operation      Key derivation operation context.
+ * @param[in]     key_attributes Attributes of the key used for the derivation.
+ * @param[in]     alg            Key derivation algorithm.
  *
  * @retval PSA_SUCCESS             The operation completed successfully.
  * @retval PSA_ERROR_NOT_SUPPORTED The algorithm is not supported.
  */
 psa_status_t cracen_key_derivation_setup(cracen_key_derivation_operation_t *operation,
+					 const psa_key_attributes_t *key_attributes,
 					 psa_algorithm_t alg);
 
 /** @brief Set the capacity for a key derivation operation.

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_key_wrap.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/include/cracen_psa_key_wrap.h
@@ -60,6 +60,8 @@ psa_status_t cracen_wrap_key(const psa_key_attributes_t *wrapping_key_attributes
  * @param[in] key_size                Size of the buffer containing the unwrapped key.
  * @param[out] key_length             On success, the number of bytes that make up
  *                                    the unwrapped key data
+ * @param[out] bits                   On success, the number of bits that make up
+ *                                    the unwrapped key data
  *
  * @retval PSA_SUCCESS                The operation completed successfully.
  * @retval PSA_ERROR_INVALID_ARGUMENT
@@ -70,9 +72,8 @@ psa_status_t cracen_wrap_key(const psa_key_attributes_t *wrapping_key_attributes
 psa_status_t cracen_unwrap_key(const psa_key_attributes_t *attributes,
 			       const psa_key_attributes_t *wrapping_key_attributes,
 			       const uint8_t *wrapping_key_data, size_t wrapping_key_size,
-			       psa_algorithm_t alg,
-			       const uint8_t *data, size_t data_length,
-			       uint8_t *key, size_t key_size, size_t *key_length);
+			       psa_algorithm_t alg, const uint8_t *data, size_t data_length,
+			       uint8_t *key, size_t key_size, size_t *key_length, size_t *bits);
 
 /** @} */
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_key_derivation.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_key_derivation.c
@@ -38,8 +38,10 @@ static psa_status_t ecc_key_agreement_check_alg(psa_algorithm_t alg)
 }
 
 psa_status_t cracen_key_derivation_setup(cracen_key_derivation_operation_t *operation,
+					 const psa_key_attributes_t *key_attributes,
 					 psa_algorithm_t alg)
 {
+	(void)key_attributes;
 	operation->alg = alg;
 
 #if defined(PSA_NEED_CRACEN_HKDF)

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_key_wrap.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_key_wrap.c
@@ -41,21 +41,20 @@ psa_status_t cracen_wrap_key(const psa_key_attributes_t *wrapping_key_attributes
 psa_status_t cracen_unwrap_key(const psa_key_attributes_t *attributes,
 			       const psa_key_attributes_t *wrapping_key_attributes,
 			       const uint8_t *wrapping_key_data, size_t wrapping_key_size,
-			       psa_algorithm_t alg,
-			       const uint8_t *data, size_t data_length,
-			       uint8_t *key, size_t key_size, size_t *key_length)
+			       psa_algorithm_t alg, const uint8_t *data, size_t data_length,
+			       uint8_t *key, size_t key_size, size_t *key_length, size_t *bits)
 {
 	psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
 	if (IS_ENABLED(PSA_NEED_CRACEN_AES_KW) && alg == PSA_ALG_KW) {
 		status = cracen_key_wrap_kw_unwrap(wrapping_key_attributes, wrapping_key_data,
 						   wrapping_key_size, data, data_length, key,
-						   key_size, key_length);
+						   key_size, key_length, bits);
 
 	} else if (IS_ENABLED(CONFIG_PSA_NEED_CRACEN_AES_KWP) && alg == PSA_ALG_KWP) {
 		status = cracen_key_wrap_kwp_unwrap(wrapping_key_attributes, wrapping_key_data,
 						    wrapping_key_size, data, data_length, key,
-						    key_size, key_length);
+						    key_size, key_length, bits);
 	} else {
 		status = PSA_ERROR_NOT_SUPPORTED;
 	}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_kmu.c
@@ -137,7 +137,7 @@ static psa_status_t get_encryption_key(const uint8_t *context, uint8_t *key)
 
 	cracen_key_derivation_operation_t op = {};
 
-	psa_status = cracen_key_derivation_setup(&op, PSA_ALG_SP800_108_COUNTER_CMAC);
+	psa_status = cracen_key_derivation_setup(&op, NULL, PSA_ALG_SP800_108_COUNTER_CMAC);
 	if (psa_status != PSA_SUCCESS) {
 		return psa_status;
 	}
@@ -555,7 +555,7 @@ psa_status_t cracen_kmu_destroy_key(const psa_key_attributes_t *attributes)
 		}
 
 		/* If the slot we attempt to destroy is blocked we will get a hardware failure, and
-		 * there is no way in hardware to distingush between an actual failure and the slot
+		 * there is no way in hardware to distinguish between an actual failure and the slot
 		 * being blocked. Therefore we attempt to push the key here to verify if the key is
 		 * blocked or not.
 		 */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_spake2p.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_spake2p.c
@@ -240,7 +240,7 @@ static psa_status_t cracen_get_confirmation_keys(cracen_spake2p_operation_t *ope
 		memcpy(operation->shared, V + operation->shared_len, operation->shared_len);
 	} else {
 		operation->shared_len = hash_len;
-		status = psa_driver_wrapper_key_derivation_setup(&kdf_op,
+		status = psa_driver_wrapper_key_derivation_setup(&kdf_op, NULL,
 								 PSA_ALG_HKDF(PSA_ALG_SHA_256));
 		if (status != SX_OK) {
 			goto exit;
@@ -267,7 +267,8 @@ static psa_status_t cracen_get_confirmation_keys(cracen_spake2p_operation_t *ope
 		(void)psa_driver_wrapper_key_derivation_abort(&kdf_op);
 	}
 
-	status = psa_driver_wrapper_key_derivation_setup(&kdf_op, PSA_ALG_HKDF(PSA_ALG_SHA_256));
+	status = psa_driver_wrapper_key_derivation_setup(&kdf_op, NULL,
+							 PSA_ALG_HKDF(PSA_ALG_SHA_256));
 	if (status != SX_OK) {
 		goto exit;
 	}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_kw.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_kw.c
@@ -68,9 +68,8 @@ exit:
 
 psa_status_t cracen_key_wrap_kw_unwrap(const psa_key_attributes_t *wrapping_key_attributes,
 				       const uint8_t *wrapping_key_data, size_t wrapping_key_size,
-				       const uint8_t *data, size_t data_size,
-				       uint8_t *key_data, size_t key_data_size,
-				       size_t *key_data_length)
+				       const uint8_t *data, size_t data_size, uint8_t *key_data,
+				       size_t key_data_size, size_t *key_data_length, size_t *bits)
 {
 	psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 	size_t blocks_count;
@@ -120,6 +119,7 @@ psa_status_t cracen_key_wrap_kw_unwrap(const psa_key_attributes_t *wrapping_key_
 	}
 
 	*key_data_length = data_size - CRACEN_KEY_WRAP_INTEGRITY_CHECK_REG_SIZE;
+	*bits = PSA_BYTES_TO_BITS(*key_data_length);
 	return status;
 exit:
 	safe_memzero(key_data, key_data_size);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_kw.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_kw.h
@@ -46,7 +46,9 @@ psa_status_t cracen_key_wrap_kw_wrap(const psa_key_attributes_t *wrapping_key_at
  * @param[out] key_data               Key material of the unwrapped key.
  * @param[in] key_data_size           Size of the buffer containing the unwrapped key.
  * @param[out] key_data_length        On success, the number of bytes that make up
- *                                    the unwrapped key data
+ *                                    the unwrapped key data.
+ * @param[out] bits                   On success, the number of bits that make up
+ *                                    the unwrapped key data.
  *
  * @retval PSA_SUCCESS                The operation completed successfully.
  * @retval PSA_ERROR_INVALID_ARGUMENT
@@ -56,8 +58,7 @@ psa_status_t cracen_key_wrap_kw_wrap(const psa_key_attributes_t *wrapping_key_at
  */
 psa_status_t cracen_key_wrap_kw_unwrap(const psa_key_attributes_t *wrapping_key_attributes,
 				       const uint8_t *wrapping_key_data, size_t wrapping_key_size,
-				       const uint8_t *data, size_t data_size,
-				       uint8_t *key_data, size_t key_data_size,
-				       size_t *key_data_length);
+				       const uint8_t *data, size_t data_size, uint8_t *key_data,
+				       size_t key_data_size, size_t *key_data_length, size_t *bits);
 
 #endif /* CRACEN_KEY_WRAP_KW_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_kwp.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_kwp.c
@@ -120,9 +120,8 @@ exit:
 
 psa_status_t cracen_key_wrap_kwp_unwrap(const psa_key_attributes_t *wrapping_key_attributes,
 					const uint8_t *wrapping_key_data, size_t wrapping_key_size,
-					const uint8_t *data, size_t data_size,
-					uint8_t *key_data, size_t key_data_size,
-					size_t *key_data_length)
+					const uint8_t *data, size_t data_size, uint8_t *key_data,
+					size_t key_data_size, size_t *key_data_length, size_t *bits)
 {
 	psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 	size_t blocks_count;
@@ -209,6 +208,7 @@ psa_status_t cracen_key_wrap_kwp_unwrap(const psa_key_attributes_t *wrapping_key
 	}
 
 	*key_data_length = length;
+	*bits = PSA_BYTES_TO_BITS(length);
 	return status;
 exit:
 	safe_memzero(key_data, key_data_size);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_kwp.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_kwp.h
@@ -46,7 +46,9 @@ psa_status_t cracen_key_wrap_kwp_wrap(const psa_key_attributes_t *wrapping_key_a
  * @param[out] key_data               Key material of the unwrapped key.
  * @param[in] key_data_size           Size of the buffer containing the unwrapped key.
  * @param[out] key_data_length        On success, the number of bytes that make up
- *                                    the unwrapped key data
+ *                                    the unwrapped key data.
+ * @param[out] bits                   On success, the number of bits that make up
+ *                                    the unwrapped key data.
  *
  * @retval PSA_SUCCESS                The operation completed successfully.
  * @retval PSA_ERROR_INVALID_ARGUMENT
@@ -56,8 +58,8 @@ psa_status_t cracen_key_wrap_kwp_wrap(const psa_key_attributes_t *wrapping_key_a
  */
 psa_status_t cracen_key_wrap_kwp_unwrap(const psa_key_attributes_t *wrapping_key_attributes,
 					const uint8_t *wrapping_key_data, size_t wrapping_key_size,
-					const uint8_t *data, size_t data_size,
-					uint8_t *key_data, size_t key_data_size,
-					size_t *key_data_length);
+					const uint8_t *data, size_t data_size, uint8_t *key_data,
+					size_t key_data_size, size_t *key_data_length,
+					size_t *bits);
 
 #endif /* CRACEN_KEY_WRAP_KWP_H */

--- a/subsys/nrf_security/src/drivers/nrf_oberon/CMakeLists.txt
+++ b/subsys/nrf_security/src/drivers/nrf_oberon/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 # Build Oberon PSA crypto driver
-set(drivers_path ${ZEPHYR_OBERON_PSA_CRYPTO_MODULE_DIR}/oberon/drivers)
+set(drivers_path ${ZEPHYR_OBERON_PSA_CRYPTO_MODULE_DIR}/drivers/oberon)
 
 target_include_directories(psa_crypto_library_config
   INTERFACE

--- a/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -2329,12 +2329,13 @@ psa_status_t psa_driver_wrapper_mac_abort(psa_mac_operation_t *operation)
  * Key derivation functions
  */
 psa_status_t psa_driver_wrapper_key_derivation_setup(psa_key_derivation_operation_t *operation,
+						     const psa_key_attributes_t *key_attributes,
 						     psa_algorithm_t alg)
 {
 	psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
 
 #if defined(PSA_NEED_CRACEN_KEY_DERIVATION_DRIVER)
-	status = cracen_key_derivation_setup(&operation->ctx.cracen_kdf_ctx, alg);
+	status = cracen_key_derivation_setup(&operation->ctx.cracen_kdf_ctx, NULL, alg);
 	if (status == PSA_SUCCESS) {
 		operation->id = PSA_CRYPTO_CRACEN_DRIVER_ID;
 	}
@@ -2344,7 +2345,7 @@ psa_status_t psa_driver_wrapper_key_derivation_setup(psa_key_derivation_operatio
 	}
 #endif /* PSA_NEED_CRACEN_KEY_DERIVATION_DRIVER */
 #if defined(PSA_NEED_OBERON_KEY_DERIVATION_DRIVER)
-	status = oberon_key_derivation_setup(&operation->ctx.oberon_kdf_ctx, alg);
+	status = oberon_key_derivation_setup(&operation->ctx.oberon_kdf_ctx, NULL, alg);
 	if (status == PSA_SUCCESS) {
 		operation->id = PSA_CRYPTO_OBERON_DRIVER_ID;
 	}
@@ -2353,6 +2354,7 @@ psa_status_t psa_driver_wrapper_key_derivation_setup(psa_key_derivation_operatio
 
 	(void)status;
 	(void)operation;
+	(void)key_attributes;
 	(void)alg;
 	return status;
 }
@@ -2404,25 +2406,25 @@ psa_driver_wrapper_key_derivation_input_bytes(psa_key_derivation_operation_t *op
 
 psa_status_t psa_driver_wrapper_key_derivation_input_key(psa_key_derivation_operation_t *operation,
 							 psa_key_derivation_step_t step,
-							 psa_key_attributes_t *attributes,
-							 const uint8_t *data, size_t data_length)
+							 const psa_key_attributes_t *attributes,
+							 const uint8_t *key, size_t key_length)
 {
 	switch (operation->id) {
 #if defined(PSA_NEED_CRACEN_KEY_DERIVATION_DRIVER)
 	case PSA_CRYPTO_CRACEN_DRIVER_ID:
 		return cracen_key_derivation_input_key(&operation->ctx.cracen_kdf_ctx, step,
-						       attributes, data, data_length);
+						       attributes, key, key_length);
 #endif /* PSA_NEED_CRACEN_KEY_DERIVATION_DRIVER */
 #if defined(PSA_NEED_OBERON_KEY_DERIVATION_DRIVER)
 	case PSA_CRYPTO_OBERON_DRIVER_ID:
-		return oberon_key_derivation_input_bytes(&operation->ctx.oberon_kdf_ctx, step, data,
-							 data_length);
+		return oberon_key_derivation_input_bytes(&operation->ctx.oberon_kdf_ctx, step, key,
+							 key_length);
 #endif /* PSA_NEED_OBERON_KEY_DERIVATION_DRIVER */
-
 	default:
 		(void)step;
-		(void)data;
-		(void)data_length;
+		(void)key;
+		(void)attributes;
+		(void)key_length;
 		return PSA_ERROR_BAD_STATE;
 	}
 }
@@ -2471,6 +2473,19 @@ psa_driver_wrapper_key_derivation_output_bytes(psa_key_derivation_operation_t *o
 		(void)output_length;
 		return PSA_ERROR_BAD_STATE;
 	}
+}
+
+psa_status_t
+psa_driver_wrapper_key_derivation_output_key(psa_key_derivation_operation_t *operation,
+					     const psa_key_attributes_t *key_attributes,
+					     uint8_t *key, size_t key_size, size_t *key_length)
+{
+	(void)operation;
+	(void)key_attributes;
+	(void)key;
+	(void)key_size;
+	(void)key_length;
+	return PSA_ERROR_NOT_SUPPORTED;
 }
 
 psa_status_t psa_driver_wrapper_key_derivation_abort(psa_key_derivation_operation_t *operation)
@@ -2557,6 +2572,20 @@ psa_status_t psa_driver_wrapper_key_agreement(const psa_key_attributes_t *attrib
 
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
+}
+
+psa_status_t psa_driver_wrapper_key_agreement_to_key(const psa_key_attributes_t *attributes,
+						     const uint8_t *key, size_t key_length,
+						     psa_algorithm_t alg, const uint8_t *peer_key,
+						     size_t peer_key_length,
+						     const psa_key_attributes_t *output_attributes,
+						     uint8_t *output, size_t output_size,
+						     size_t *output_length)
+{
+	(void)output_attributes;
+	return psa_driver_wrapper_key_agreement(attributes, key, key_length, alg, peer_key,
+						peer_key_length, output, output_size,
+						output_length);
 }
 
 #if defined(CONFIG_PSA_CORE_OBERON)
@@ -3124,7 +3153,7 @@ psa_status_t psa_driver_wrapper_unwrap_key(const psa_key_attributes_t *attribute
 					   const uint8_t *wrapping_key_data,
 					   size_t wrapping_key_size, psa_algorithm_t alg,
 					   const uint8_t *data, size_t data_length, uint8_t *key,
-					   size_t key_size, size_t *key_length)
+					   size_t key_size, size_t *key_length, size_t *bits)
 {
 
 	psa_key_location_t location =
@@ -3139,13 +3168,13 @@ psa_status_t psa_driver_wrapper_unwrap_key(const psa_key_attributes_t *attribute
 #ifdef PSA_NEED_CRACEN_KEY_WRAP_DRIVER
 		return cracen_unwrap_key(attributes, wrapping_key_attributes, wrapping_key_data,
 					 wrapping_key_size, alg, data, data_length, key, key_size,
-					 key_length);
+					 key_length, bits);
 #endif /* PSA_NEED_CRACEN_KEY_WRAP_DRIVER */
 
 #ifdef PSA_NEED_OBERON_KEY_WRAP_DRIVER
 		return oberon_unwrap_key(attributes, wrapping_key_attributes, wrapping_key_data,
 					 wrapping_key_size, alg, data, data_length, key, key_size,
-					 key_length);
+					 key_length, bits);
 #endif /* PSA_NEED_OBERON_KEY_WRAP_DRIVER */
 		return PSA_ERROR_NOT_SUPPORTED;
 
@@ -3163,6 +3192,7 @@ psa_status_t psa_driver_wrapper_unwrap_key(const psa_key_attributes_t *attribute
 		(void)key;
 		(void)key_size;
 		(void)key_length;
+		(void)bits;
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 }
@@ -3290,7 +3320,8 @@ psa_status_t psa_driver_wrapper_get_entropy(uint32_t flags, size_t *estimate_bit
 	return PSA_ERROR_INSUFFICIENT_ENTROPY;
 }
 
-psa_status_t psa_driver_wrapper_destroy_builtin_key(const psa_key_attributes_t *attributes)
+psa_status_t psa_driver_wrapper_destroy_key(const psa_key_attributes_t *attributes,
+					    const uint8_t *key_buffer, size_t key_buffer_size)
 {
 	psa_key_location_t location =
 		 PSA_KEY_LIFETIME_GET_LOCATION(psa_get_key_lifetime(attributes));
@@ -3304,7 +3335,14 @@ psa_status_t psa_driver_wrapper_destroy_builtin_key(const psa_key_attributes_t *
 	case PSA_KEY_LOCATION_CRACEN_KMU:
 		return cracen_destroy_key(attributes);
 #endif
+	default:
+		(void)location;
+		(void)attributes;
+		break;
 	}
+
+	(void)key_buffer;
+	(void)key_buffer_size;
 
 	return PSA_ERROR_NOT_SUPPORTED;
 }

--- a/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -2488,6 +2488,18 @@ psa_driver_wrapper_key_derivation_output_key(psa_key_derivation_operation_t *ope
 	return PSA_ERROR_NOT_SUPPORTED;
 }
 
+psa_status_t
+psa_driver_wrapper_key_derivation_verify_key(psa_key_derivation_operation_t *operation,
+					     const psa_key_attributes_t *key_attributes,
+					     const uint8_t *key, size_t key_length)
+{
+	(void)operation;
+	(void)key_attributes;
+	(void)key;
+	(void)key_length;
+	return PSA_ERROR_NOT_SUPPORTED;
+}
+
 psa_status_t psa_driver_wrapper_key_derivation_abort(psa_key_derivation_operation_t *operation)
 {
 	switch (operation->id) {

--- a/west.yml
+++ b/west.yml
@@ -146,7 +146,7 @@ manifest:
     - name: oberon-psa-crypto
       path: modules/crypto/oberon-psa-crypto
       repo-path: sdk-oberon-psa-crypto
-      revision: ncs-v3.4.0
+      revision: e8db62ed0fba5028e7ae0eba7b1fb63436ae6416
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib


### PR DESCRIPTION
Backport https://github.com/nrfconnect/sdk-nrf/pull/30169 to `v3.4-branch`.

Both the commits had conflicts and I did manual conflict resolution.
