### PR TITLE
nrf_security: CRACEN: Refactor names of internal functions

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/common/include/cracen/common.h
+++ b/subsys/nrf_security/src/drivers/cracen/common/include/cracen/common.h
@@ -44,10 +44,10 @@ typedef struct {
 __must_check psa_status_t silex_statuscodes_to_psa(int sx_status);
 
 __must_check psa_status_t
-hash_get_algo(psa_algorithm_t alg, const struct sxhashalg **sx_hash_algo);
+cracen_hash_get_algo(psa_algorithm_t alg, const struct sxhashalg **sx_hash_algo);
 
 __must_check psa_status_t
-xof_get_algo(psa_algorithm_t alg, const struct sxhashalg **sx_xof_algo);
+cracen_xof_get_algo(psa_algorithm_t alg, const struct sxhashalg **sx_xof_algo);
 
 /**
  * @brief Use cracen_get_random up to generate a random number in the range [1, upperlimit).

--- a/subsys/nrf_security/src/drivers/cracen/common/include/cracen/cracen_hmac.h
+++ b/subsys/nrf_security/src/drivers/cracen/common/include/cracen/cracen_hmac.h
@@ -20,11 +20,11 @@
 #include <psa/crypto.h>
 #include <stdint.h>
 
-int mac_create_hmac(const struct sxhashalg *hashalg, struct sxhash *hashopctx, const uint8_t *key,
-		    size_t keysz, uint8_t *workmem, size_t workmemsz);
+int cracen_hmac_create(const struct sxhashalg *hashalg, struct sxhash *hashopctx,
+		       const uint8_t *key, size_t keysz, uint8_t *workmem, size_t workmemsz);
 
-int hmac_produce(struct sxhash *hashctx, const struct sxhashalg *hashalg, uint8_t *out, size_t sz,
-		 uint8_t *workmem);
+int cracen_hmac_produce(struct sxhash *hashctx, const struct sxhashalg *hashalg, uint8_t *out,
+			size_t sz, uint8_t *workmem);
 
 /** @} */
 

--- a/subsys/nrf_security/src/drivers/cracen/common/include/cracen/ec_helpers.h
+++ b/subsys/nrf_security/src/drivers/cracen/common/include/cracen/ec_helpers.h
@@ -25,7 +25,7 @@
  *
  * @param[in,out] u Byte array containing a coordinate of size 32 bytes.
  */
-void decode_u_coordinate_25519(uint8_t *u);
+void cracen_decode_u_coordinate_25519(uint8_t *u);
 
 /**
  * @brief Decode a byte array containing a scalar in place.
@@ -34,7 +34,7 @@ void decode_u_coordinate_25519(uint8_t *u);
  *
  * @param[in,out] k Byte array containing a scalar of size 32.
  */
-void decode_scalar_25519(uint8_t *k);
+void cracen_decode_scalar_25519(uint8_t *k);
 
 /**
  * @brief Decode a byte array containing a scalar in place.
@@ -43,6 +43,6 @@ void decode_scalar_25519(uint8_t *k);
  *
  * @param[in,out] k Byte array containing a scalar of size 56.
  */
-void decode_scalar_448(uint8_t *k);
+void cracen_decode_scalar_448(uint8_t *k);
 
 /** @} */

--- a/subsys/nrf_security/src/drivers/cracen/common/src/cracen/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/common/src/cracen/common.c
@@ -88,7 +88,7 @@ psa_status_t silex_statuscodes_to_psa(int sx_status)
 	}
 }
 
-psa_status_t hash_get_algo(psa_algorithm_t alg, const struct sxhashalg **sx_hash_algo)
+psa_status_t cracen_hash_get_algo(psa_algorithm_t alg, const struct sxhashalg **sx_hash_algo)
 {
 	*sx_hash_algo = NOT_ENABLED_HASH_ALG;
 
@@ -130,7 +130,7 @@ psa_status_t hash_get_algo(psa_algorithm_t alg, const struct sxhashalg **sx_hash
 	return (*sx_hash_algo == NOT_ENABLED_HASH_ALG) ? PSA_ERROR_NOT_SUPPORTED : PSA_SUCCESS;
 }
 
-psa_status_t xof_get_algo(psa_algorithm_t alg, const struct sxhashalg **sx_xof_algo)
+psa_status_t cracen_xof_get_algo(psa_algorithm_t alg, const struct sxhashalg **sx_xof_algo)
 {
 	*sx_xof_algo = NOT_ENABLED_XOF_ALG;
 

--- a/subsys/nrf_security/src/drivers/cracen/common/src/cracen/cracen_hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/common/src/cracen/cracen_hmac.c
@@ -30,8 +30,8 @@ static void xorbuf(uint8_t *buf, uint8_t v, size_t sz)
 	}
 }
 
-int hmac_produce(struct sxhash *hashctx, const struct sxhashalg *hashalg, uint8_t *digest,
-		 size_t output_buffer_size, uint8_t *workmem)
+int cracen_hmac_produce(struct sxhash *hashctx, const struct sxhashalg *hashalg, uint8_t *digest,
+			size_t output_buffer_size, uint8_t *workmem)
 {
 	int status;
 	size_t blocksz;
@@ -85,8 +85,8 @@ static int internal_start_hmac_computation(struct sxhash *hashopctx,
 	return sx_hash_feed(hashopctx, workmem, blocksz);
 }
 
-int mac_create_hmac(const struct sxhashalg *hashalg, struct sxhash *hashopctx, const uint8_t *key,
-		    size_t keysz, uint8_t *workmem, size_t workmemsz)
+int cracen_hmac_create(const struct sxhashalg *hashalg, struct sxhash *hashopctx,
+		       const uint8_t *key, size_t keysz, uint8_t *workmem, size_t workmemsz)
 {
 	int status;
 	size_t digestsz;

--- a/subsys/nrf_security/src/drivers/cracen/common/src/cracen/ec_helpers.c
+++ b/subsys/nrf_security/src/drivers/cracen/common/src/cracen/ec_helpers.c
@@ -6,19 +6,19 @@
 
 #include <stdint.h>
 
-void decode_u_coordinate_25519(uint8_t *u)
+void cracen_decode_u_coordinate_25519(uint8_t *u)
 {
 	u[31] &= ~0x80; /* Clear the last bit. */
 }
 
-void decode_scalar_25519(uint8_t *k)
+void cracen_decode_scalar_25519(uint8_t *k)
 {
 	k[0] &= ~0x07; /* Clear bits 0, 1 and 2. */
 	k[31] &= ~0x80; /* Clear bit 255. */
 	k[31] |= 0x40; /* Set bit 254. */
 }
 
-void decode_scalar_448(uint8_t *k)
+void cracen_decode_scalar_448(uint8_t *k)
 {
 	k[0] &= ~0x03; /* Clear bits 0 and 1. */
 	k[56] = 0x00;  /* Clear the last byte */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_asymmetric.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_asymmetric.c
@@ -64,7 +64,7 @@ cracen_asymmetric_crypt_internal(const psa_key_attributes_t *attributes, const u
 
 	if (IS_ENABLED(PSA_NEED_CRACEN_RSA_OAEP)) {
 		if (PSA_ALG_IS_RSA_OAEP(alg)) {
-			status = hash_get_algo(PSA_ALG_RSA_OAEP_GET_HASH(alg), &hashalg);
+			status = cracen_hash_get_algo(PSA_ALG_RSA_OAEP_GET_HASH(alg), &hashalg);
 			if (status != PSA_SUCCESS) {
 				return status;
 			}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_hash.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_hash.c
@@ -29,7 +29,7 @@ psa_status_t cracen_hash_compute(psa_algorithm_t alg, const uint8_t *input, size
 {
 	const struct sxhashalg *sx_hash_algo = NULL;
 
-	psa_status_t psa_status = hash_get_algo(alg, &sx_hash_algo);
+	psa_status_t psa_status = cracen_hash_get_algo(alg, &sx_hash_algo);
 
 	if (psa_status != PSA_SUCCESS) {
 		return psa_status;
@@ -48,7 +48,7 @@ psa_status_t cracen_hash_setup(cracen_hash_operation_t *operation, psa_algorithm
 {
 	int status;
 
-	status = hash_get_algo(alg, &operation->sx_hash_algo);
+	status = cracen_hash_get_algo(alg, &operation->sx_hash_algo);
 	if (status != PSA_SUCCESS) {
 		return status;
 	}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_key_management.c
@@ -41,22 +41,24 @@ psa_status_t cracen_export_public_key(const psa_key_attributes_t *attributes,
 
 	if (IS_ENABLED(PSA_NEED_CRACEN_KEY_TYPE_ECC_KEY_PAIR_EXPORT) &&
 	    PSA_KEY_TYPE_IS_ECC_KEY_PAIR(key_type)) {
-		return export_ecc_public_key_from_keypair(attributes, key_buffer,
-							  key_buffer_size, data, data_size,
-							  data_length);
+		return cracen_export_ecc_public_key_from_keypair(attributes, key_buffer,
+								 key_buffer_size, data, data_size,
+								 data_length);
 	} else if (IS_ENABLED(PSA_NEED_CRACEN_KEY_TYPE_ECC_PUBLIC_KEY) &&
 		   PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type)) {
-		return ecc_export_key(key_buffer, key_buffer_size, data, data_size, data_length);
+		return cracen_export_ecc_key(key_buffer, key_buffer_size, data,
+					     data_size, data_length);
 	}
 
 	if (IS_ENABLED(PSA_NEED_CRACEN_KEY_TYPE_SPAKE2P_KEY_PAIR_EXPORT_SECP_R1_256)) {
 		if (PSA_KEY_TYPE_IS_SPAKE2P_KEY_PAIR(key_type)) {
-			return export_spake2p_public_key_from_keypair(attributes, key_buffer,
-								      key_buffer_size, data,
-								      data_size, data_length);
+			return cracen_export_spake2p_public_key_from_keypair(attributes, key_buffer,
+									     key_buffer_size, data,
+									     data_size,
+									     data_length);
 		} else if (PSA_KEY_TYPE_IS_SPAKE2P_PUBLIC_KEY(key_type)) {
-			return ecc_export_key(key_buffer, key_buffer_size, data,
-					      data_size, data_length);
+			return cracen_export_ecc_key(key_buffer, key_buffer_size, data,
+						     data_size, data_length);
 		} else {
 			/* For compliance */
 		}
@@ -64,12 +66,13 @@ psa_status_t cracen_export_public_key(const psa_key_attributes_t *attributes,
 
 	if (key_type == PSA_KEY_TYPE_RSA_KEY_PAIR &&
 	    IS_ENABLED(PSA_NEED_CRACEN_KEY_TYPE_RSA_KEY_PAIR_EXPORT)) {
-		return export_rsa_public_key_from_keypair(attributes, key_buffer, key_buffer_size,
-							  data, data_size, data_length);
+		return cracen_export_rsa_public_key_from_keypair(attributes,
+								 key_buffer, key_buffer_size,
+								 data, data_size, data_length);
 	} else if (key_type == PSA_KEY_TYPE_RSA_PUBLIC_KEY &&
 		   IS_ENABLED(PSA_NEED_CRACEN_KEY_TYPE_RSA_PUBLIC_KEY)) {
-		return rsa_export_public_key(attributes, key_buffer, key_buffer_size, data,
-					     data_size, data_length);
+		return cracen_rsa_export_public_key(attributes, key_buffer, key_buffer_size, data,
+						    data_size, data_length);
 	} else {
 		/* For compliance */
 	}
@@ -158,36 +161,39 @@ psa_status_t cracen_import_key(const psa_key_attributes_t *attributes, const uin
 
 	if (IS_ENABLED(PSA_NEED_CRACEN_KEY_TYPE_ECC_KEY_PAIR_IMPORT) &&
 	    PSA_KEY_TYPE_IS_ECC_KEY_PAIR(key_type)) {
-		return import_ecc_private_key(attributes, data, data_length, key_buffer,
+		return cracen_import_ecc_private_key(attributes, data, data_length, key_buffer,
 					      key_buffer_size, key_buffer_length, key_bits);
 
 	}
 
 	if (IS_ENABLED(PSA_NEED_CRACEN_KEY_TYPE_ECC_PUBLIC_KEY) &&
 	    PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type)) {
-		return import_ecc_public_key(attributes, data, data_length, key_buffer,
-					     key_buffer_size, key_buffer_length, key_bits);
+		return cracen_import_ecc_public_key(attributes, data, data_length, key_buffer,
+						    key_buffer_size, key_buffer_length, key_bits);
 	}
 
 	if (PSA_KEY_TYPE_IS_RSA(key_type) &&
 	    IS_ENABLED(PSA_NEED_CRACEN_KEY_TYPE_RSA_KEY_PAIR_IMPORT)) {
-		return import_rsa_key(attributes, data, data_length, key_buffer, key_buffer_size,
-				      key_buffer_length, key_bits);
+		return cracen_import_rsa_key(attributes, data, data_length,
+					     key_buffer, key_buffer_size,
+					     key_buffer_length, key_bits);
 	}
 
 	if (PSA_KEY_TYPE_IS_SPAKE2P(key_type) && IS_ENABLED(PSA_NEED_CRACEN_SPAKE2P)) {
-		return import_spake2p_key(attributes, data, data_length, key_buffer,
-					  key_buffer_size, key_buffer_length, key_bits);
+		return cracen_import_spake2p_key(attributes, data, data_length, key_buffer,
+						 key_buffer_size, key_buffer_length, key_bits);
 	}
 
 	if (PSA_KEY_TYPE_IS_SRP(key_type) && IS_ENABLED(PSA_NEED_CRACEN_SRP_6)) {
-		return import_srp_key(attributes, data, data_length, key_buffer, key_buffer_size,
-				      key_buffer_length, key_bits);
+		return cracen_import_srp_key(attributes, data, data_length,
+					     key_buffer, key_buffer_size,
+					     key_buffer_length, key_bits);
 	}
 
 	if (PSA_KEY_TYPE_IS_WPA3_SAE_ECC(key_type) && IS_ENABLED(PSA_NEED_CRACEN_WPA3_SAE)) {
-		return import_wpa3_sae_pt_key(attributes, data, data_length, key_buffer,
-					  key_buffer_size, key_buffer_length, key_bits);
+		return cracen_import_wpa3_sae_pt_key(attributes, data, data_length,
+						     key_buffer, key_buffer_size,
+						     key_buffer_length, key_bits);
 	}
 
 	return PSA_ERROR_NOT_SUPPORTED;
@@ -210,7 +216,8 @@ static psa_status_t generate_key_for_kmu(const psa_key_attributes_t *attributes,
 
 	if (PSA_KEY_TYPE_IS_ECC_KEY_PAIR(key_type) &&
 	    IS_ENABLED(PSA_NEED_CRACEN_KEY_TYPE_ECC_KEY_PAIR_GENERATE)) {
-		status = generate_ecc_private_key(attributes, key, key_size, key_buffer_length);
+		status = cracen_generate_ecc_private_key(attributes, key,
+							 key_size, key_buffer_length);
 		if (status != PSA_SUCCESS) {
 			return status;
 		}
@@ -257,14 +264,14 @@ psa_status_t cracen_generate_key(const psa_key_attributes_t *attributes, uint8_t
 
 	if (PSA_KEY_TYPE_IS_ECC_KEY_PAIR(key_type) &&
 	    IS_ENABLED(PSA_NEED_CRACEN_KEY_TYPE_ECC_KEY_PAIR_GENERATE)) {
-		return generate_ecc_private_key(attributes, key_buffer, key_buffer_size,
-						key_buffer_length);
+		return cracen_generate_ecc_private_key(attributes, key_buffer, key_buffer_size,
+						       key_buffer_length);
 	}
 
 	if (key_type == PSA_KEY_TYPE_RSA_KEY_PAIR &&
 	    IS_ENABLED(PSA_NEED_CRACEN_KEY_TYPE_RSA_KEY_PAIR_GENERATE)) {
-		return generate_rsa_private_key(attributes, key_buffer, key_buffer_size,
-						key_buffer_length);
+		return cracen_generate_rsa_private_key(attributes, key_buffer, key_buffer_size,
+						       key_buffer_length);
 	}
 
 	return PSA_ERROR_NOT_SUPPORTED;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_xof.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_xof.c
@@ -100,7 +100,7 @@ psa_status_t cracen_xof_setup(cracen_xof_operation_t *operation, psa_algorithm_t
 {
 	psa_status_t status;
 
-	status = xof_get_algo(alg, &operation->hash_op.sx_hash_algo);
+	status = cracen_xof_get_algo(alg, &operation->hash_op.sx_hash_algo);
 	if (status != PSA_SUCCESS) {
 		return status;
 	}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_helpers.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_helpers.c
@@ -248,7 +248,7 @@ static psa_status_t check_wstr_publ_key_for_ecdh(psa_ecc_family_t curve_family, 
 	return cracen_ecc_check_public_key(curve, &publ_key_pnt);
 }
 
-psa_status_t check_wstr_pub_key_data(psa_algorithm_t key_alg, psa_ecc_family_t curve,
+psa_status_t cracen_check_wstr_pub_key_data(psa_algorithm_t key_alg, psa_ecc_family_t curve,
 				     size_t key_bits, const uint8_t *data,
 				     size_t data_length)
 {

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_helpers.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_helpers.h
@@ -61,7 +61,7 @@ static inline size_t cracen_ecc_wstr_expected_pub_key_bytes(size_t priv_key_size
 	return (1 + (2 * priv_key_size));
 }
 
-psa_status_t check_wstr_pub_key_data(psa_algorithm_t key_alg, psa_ecc_family_t curve,
+psa_status_t cracen_check_wstr_pub_key_data(psa_algorithm_t key_alg, psa_ecc_family_t curve,
 					    size_t key_bits, const uint8_t *data,
 					    size_t data_length);
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_key_management.c
@@ -160,10 +160,10 @@ psa_status_t generate_ecc_private_key(const psa_key_attributes_t *attributes,
 			 */
 			if (key_size_bytes == 32) {
 				/* X25519 */
-				decode_scalar_25519(&workmem[0]);
+				cracen_decode_scalar_25519(&workmem[0]);
 			} else if (key_size_bytes == 56) {
 				/* X448 */
-				decode_scalar_448(&workmem[0]);
+				cracen_decode_scalar_448(&workmem[0]);
 			} else {
 				/* For compliance */
 			}
@@ -371,7 +371,7 @@ psa_status_t import_ecc_public_key(const psa_key_attributes_t *attributes,
 	switch (curve) {
 	case PSA_ECC_FAMILY_BRAINPOOL_P_R1:
 	case PSA_ECC_FAMILY_SECP_R1:
-		psa_status = check_wstr_pub_key_data(key_alg, curve, key_bits_attr,
+		psa_status = cracen_check_wstr_pub_key_data(key_alg, curve, key_bits_attr,
 						     local_key_buffer, data_length);
 		if (psa_status != PSA_SUCCESS) {
 			return psa_status;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_key_management.c
@@ -112,9 +112,9 @@ static psa_status_t check_ecc_key_attributes(const psa_key_attributes_t *attribu
 	return status;
 }
 
-psa_status_t generate_ecc_private_key(const psa_key_attributes_t *attributes,
-				      uint8_t *key_buffer, size_t key_buffer_size,
-				      size_t *key_buffer_length)
+psa_status_t cracen_generate_ecc_private_key(const psa_key_attributes_t *attributes,
+					     uint8_t *key_buffer, size_t key_buffer_size,
+					     size_t *key_buffer_length)
 {
 #if PSA_VENDOR_ECC_MAX_CURVE_BITS > 0
 	size_t key_bits_attr = psa_get_key_bits(attributes);
@@ -172,7 +172,7 @@ psa_status_t generate_ecc_private_key(const psa_key_attributes_t *attributes,
 		memcpy(key_buffer, workmem, key_size_bytes);
 	} else {
 
-		sx_status = ecc_genprivkey(sx_curve, key_buffer, key_buffer_size);
+		sx_status = cracen_ecc_genprivkey(sx_curve, key_buffer, key_buffer_size);
 		if (sx_status != SX_OK) {
 			return silex_statuscodes_to_psa(sx_status);
 		}
@@ -231,7 +231,7 @@ static psa_status_t handle_curve_family(psa_ecc_family_t psa_curve, size_t key_b
 		    IS_ENABLED(PSA_NEED_CRACEN_KEY_TYPE_ECC_BRAINPOOL_P_R1)) {
 			data[0] = CRACEN_ECC_PUBKEY_UNCOMPRESSED;
 			return silex_statuscodes_to_psa(
-				ecc_genpubkey(key_buffer, data + 1, sx_curve));
+				cracen_ecc_genpubkey(key_buffer, data + 1, sx_curve));
 		} else {
 			return PSA_ERROR_NOT_SUPPORTED;
 		}
@@ -271,10 +271,10 @@ static psa_status_t handle_curve_family(psa_ecc_family_t psa_curve, size_t key_b
 	return PSA_SUCCESS;
 }
 
-psa_status_t export_ecc_public_key_from_keypair(const psa_key_attributes_t *attributes,
-						const uint8_t *key_buffer,
-						size_t key_buffer_size, uint8_t *data,
-						size_t data_size, size_t *data_length)
+psa_status_t cracen_export_ecc_public_key_from_keypair(const psa_key_attributes_t *attributes,
+						       const uint8_t *key_buffer,
+						       size_t key_buffer_size, uint8_t *data,
+						       size_t data_size, size_t *data_length)
 {
 	psa_status_t status;
 
@@ -311,10 +311,10 @@ psa_status_t export_ecc_public_key_from_keypair(const psa_key_attributes_t *attr
 	return PSA_SUCCESS;
 }
 
-psa_status_t import_ecc_private_key(const psa_key_attributes_t *attributes,
-				    const uint8_t *data, size_t data_length,
-				    uint8_t *key_buffer, size_t key_buffer_size,
-				    size_t *key_buffer_length, size_t *key_bits)
+psa_status_t cracen_import_ecc_private_key(const psa_key_attributes_t *attributes,
+					   const uint8_t *data, size_t data_length,
+					   uint8_t *key_buffer, size_t key_buffer_size,
+					   size_t *key_buffer_length, size_t *key_bits)
 {
 	size_t key_bits_attr = psa_get_key_bits(attributes);
 	psa_status_t psa_status;
@@ -342,10 +342,10 @@ psa_status_t import_ecc_private_key(const psa_key_attributes_t *attributes,
 	}
 }
 
-psa_status_t import_ecc_public_key(const psa_key_attributes_t *attributes,
-				   const uint8_t *data, size_t data_length,
-				   uint8_t *key_buffer, size_t key_buffer_size,
-				   size_t *key_buffer_length, size_t *key_bits)
+psa_status_t cracen_import_ecc_public_key(const psa_key_attributes_t *attributes,
+					  const uint8_t *data, size_t data_length,
+					  uint8_t *key_buffer, size_t key_buffer_size,
+					  size_t *key_buffer_length, size_t *key_bits)
 {
 	size_t key_bits_attr = psa_get_key_bits(attributes);
 	psa_ecc_family_t curve = PSA_KEY_TYPE_ECC_GET_FAMILY(psa_get_key_type(attributes));
@@ -389,8 +389,8 @@ psa_status_t import_ecc_public_key(const psa_key_attributes_t *attributes,
 	return PSA_SUCCESS;
 }
 
-psa_status_t ecc_export_key(const uint8_t *key_buffer, size_t key_buffer_size, uint8_t *data,
-			    size_t data_size, size_t *data_length)
+psa_status_t cracen_export_ecc_key(const uint8_t *key_buffer, size_t key_buffer_size, uint8_t *data,
+				   size_t data_size, size_t *data_length)
 {
 	if (data_size < key_buffer_size) {
 		return PSA_ERROR_BUFFER_TOO_SMALL;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_key_management.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_key_management.h
@@ -9,26 +9,26 @@
 #include <psa/crypto.h>
 #include <stdint.h>
 
-psa_status_t generate_ecc_private_key(const psa_key_attributes_t *attributes,
+psa_status_t cracen_generate_ecc_private_key(const psa_key_attributes_t *attributes,
 					     uint8_t *key_buffer, size_t key_buffer_size,
 					     size_t *key_buffer_length);
 
-psa_status_t export_ecc_public_key_from_keypair(const psa_key_attributes_t *attributes,
-						const uint8_t *key_buffer,
-						size_t key_buffer_size, uint8_t *data,
-						size_t data_size, size_t *data_length);
+psa_status_t cracen_export_ecc_public_key_from_keypair(const psa_key_attributes_t *attributes,
+						       const uint8_t *key_buffer,
+						       size_t key_buffer_size, uint8_t *data,
+						       size_t data_size, size_t *data_length);
 
-psa_status_t import_ecc_private_key(const psa_key_attributes_t *attributes,
-				    const uint8_t *data, size_t data_length,
-				    uint8_t *key_buffer, size_t key_buffer_size,
-				    size_t *key_buffer_length, size_t *key_bits);
+psa_status_t cracen_import_ecc_private_key(const psa_key_attributes_t *attributes,
+					   const uint8_t *data, size_t data_length,
+					   uint8_t *key_buffer, size_t key_buffer_size,
+					   size_t *key_buffer_length, size_t *key_bits);
 
-psa_status_t import_ecc_public_key(const psa_key_attributes_t *attributes,
-				   const uint8_t *data, size_t data_length,
-				   uint8_t *key_buffer, size_t key_buffer_size,
-				   size_t *key_buffer_length, size_t *key_bits);
+psa_status_t cracen_import_ecc_public_key(const psa_key_attributes_t *attributes,
+					  const uint8_t *data, size_t data_length,
+					  uint8_t *key_buffer, size_t key_buffer_size,
+					  size_t *key_buffer_length, size_t *key_bits);
 
-psa_status_t ecc_export_key(const uint8_t *key_buffer, size_t key_buffer_size, uint8_t *data,
-			    size_t data_size, size_t *data_length);
+psa_status_t cracen_export_ecc_key(const uint8_t *key_buffer, size_t key_buffer_size, uint8_t *data,
+				   size_t data_size, size_t *data_length);
 
 #endif /* CRACEN_ECC_KEY_MANAGEMENT_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_keygen.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_keygen.c
@@ -19,7 +19,8 @@
 
 #define MAX_ECC_ATTEMPTS 10
 
-int ecc_genpubkey(const uint8_t *priv_key, uint8_t *pub_key, const struct sx_pk_ecurve *curve)
+int cracen_ecc_genpubkey(const uint8_t *priv_key, uint8_t *pub_key,
+			 const struct sx_pk_ecurve *curve)
 {
 	const uint8_t **outputs;
 	sx_pk_req req;
@@ -73,7 +74,7 @@ int ecc_genpubkey(const uint8_t *priv_key, uint8_t *pub_key, const struct sx_pk_
 	return status;
 }
 
-int ecc_genprivkey(const struct sx_pk_ecurve *curve, uint8_t *priv_key, size_t priv_key_size)
+int cracen_ecc_genprivkey(const struct sx_pk_ecurve *curve, uint8_t *priv_key, size_t priv_key_size)
 {
 	int status;
 	int opsz = sx_pk_curve_opsize(curve);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_keygen.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_keygen.h
@@ -9,8 +9,10 @@
 #include <psa/crypto.h>
 #include <stdint.h>
 
-int ecc_genpubkey(const uint8_t *priv_key, uint8_t *pub_key, const struct sx_pk_ecurve *curve);
+int cracen_ecc_genpubkey(const uint8_t *priv_key, uint8_t *pub_key,
+			 const struct sx_pk_ecurve *curve);
 
-int ecc_genprivkey(const struct sx_pk_ecurve *curve, uint8_t *priv_key, size_t priv_key_size);
+int cracen_ecc_genprivkey(const struct sx_pk_ecurve *curve, uint8_t *priv_key,
+			  size_t priv_key_size);
 
 #endif /* CRACEN_ECC_KEYGEN_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_signature.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_signature.c
@@ -328,7 +328,7 @@ cracen_signature_prepare_ec_pubkey(const uint8_t *key_buffer, size_t key_buffer_
 			return PSA_SUCCESS;
 
 		} else {
-			sx_status = ecc_genpubkey(key_buffer, pubkey_buffer, *sicurve);
+			sx_status = cracen_ecc_genpubkey(key_buffer, pubkey_buffer, *sicurve);
 		}
 	}
 	return silex_statuscodes_to_psa(sx_status);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_signature.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_signature.c
@@ -76,7 +76,7 @@ static psa_status_t handle_ikg_sign(bool is_message, const uint8_t *key_buffer,
 	struct sxhashalg hashalg = {0};
 	const struct sxhashalg *hashalgpointer = &hashalg;
 
-	status = hash_get_algo(alg, &hashalgpointer);
+	status = cracen_hash_get_algo(alg, &hashalgpointer);
 	if (status != PSA_SUCCESS) {
 		return status;
 	}
@@ -110,7 +110,7 @@ static psa_status_t handle_ecdsa_sign(bool is_message, const uint8_t *key_buffer
 
 	if (PSA_ALG_IS_DETERMINISTIC_ECDSA(alg) &&
 	    IS_ENABLED(PSA_NEED_CRACEN_DETERMINISTIC_ECDSA)) {
-		status = hash_get_algo(alg, &hashalgpointer);
+		status = cracen_hash_get_algo(alg, &hashalgpointer);
 		if (status != PSA_SUCCESS) {
 			return status;
 		}
@@ -124,7 +124,7 @@ static psa_status_t handle_ecdsa_sign(bool is_message, const uint8_t *key_buffer
 	} else if ((PSA_ALG_IS_ECDSA(alg) && IS_ENABLED(PSA_NEED_CRACEN_ECDSA)) &&
 		   !PSA_ALG_IS_DETERMINISTIC_ECDSA(alg)) {
 		if (is_message) {
-			status = hash_get_algo(alg, &hashalgpointer);
+			status = cracen_hash_get_algo(alg, &hashalgpointer);
 			if (status != PSA_SUCCESS) {
 				return status;
 			}
@@ -398,7 +398,7 @@ psa_status_t cracen_signature_ecc_verify(bool is_message,
 			return psa_status;
 		}
 		if (is_message) {
-			psa_status = hash_get_algo(alg, &hash_algorithm_ptr);
+			psa_status = cracen_hash_get_algo(alg, &hash_algorithm_ptr);
 			if (psa_status != PSA_SUCCESS) {
 				return psa_status;
 			}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecdsa.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecdsa.c
@@ -89,7 +89,7 @@ static void digest2op(const uint8_t *digest, size_t sz, uint8_t *dst, size_t ops
 /**
  * @brief Perform bits2int according to definition in RFC-6979.
  */
-void bits2int(const uint8_t *data, size_t data_len, uint8_t *out_data, size_t qlen)
+static void bits2int(const uint8_t *data, size_t data_len, uint8_t *out_data, size_t qlen)
 {
 	size_t data_bitlen = data_len * 8;
 	size_t qbytes = ROUND_UP(qlen, 8) / 8;
@@ -119,8 +119,8 @@ void bits2int(const uint8_t *data, size_t data_len, uint8_t *out_data, size_t ql
 /**
  * @brief Perform bits2octets according to definition in RFC-6979.
  */
-void bits2octets(const uint8_t *data, size_t data_len, uint8_t *out_data, const uint8_t *order,
-		 size_t order_len)
+static void bits2octets(const uint8_t *data, size_t data_len, uint8_t *out_data,
+			const uint8_t *order, size_t order_len)
 {
 	bits2int(data, data_len, out_data, order_len * 8 - clz_u8(order[0]));
 
@@ -291,7 +291,7 @@ static int deterministic_ecdsa_hmac(struct sxhash *hashctx, const struct sxhasha
 		sx_hash_get_alg_digestsz(hashalg) + sx_hash_get_alg_blocksz(hashalg);
 	uint8_t workmem[workmem_requirement];
 
-	status = mac_create_hmac(hashalg, hashctx, key, hash_len, workmem, workmem_requirement);
+	status = cracen_hmac_create(hashalg, hashctx, key, hash_len, workmem, workmem_requirement);
 	if (status != SX_OK) {
 		return status;
 	}
@@ -325,7 +325,7 @@ static int deterministic_ecdsa_hmac(struct sxhash *hashctx, const struct sxhasha
 		}
 	}
 
-	return hmac_produce(hashctx, hashalg, hmac, hash_len, workmem);
+	return cracen_hmac_produce(hashctx, hashalg, hmac, hash_len, workmem);
 }
 
 static int run_deterministic_ecdsa_hmac_step(struct sxhash *hashctx,

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_eddsa_ed25519.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_eddsa_ed25519.c
@@ -128,7 +128,7 @@ static int ed25519_sign_internal(const uint8_t *priv_key, uint8_t *signature,
 	/* The secret scalar s is computed in place from the first half of the
 	 * private key digest.
 	 */
-	decode_scalar_25519(area_1);
+	cracen_decode_scalar_25519(area_1);
 
 	/* Clear second half of private key digest: sx_ed25519_ptmult()
 	 * works on an input of SX_ED25519_DGST_SZ bytes.
@@ -275,7 +275,7 @@ int cracen_ed25519_create_pubkey(const uint8_t *priv_key, uint8_t *pub_key)
 	/* The secret scalar s is computed in place from the first half of the
 	 * private key digest.
 	 */
-	decode_scalar_25519(digest);
+	cracen_decode_scalar_25519(digest);
 
 	/* Clear second half of private key digest: ed25519_ptmult()
 	 * works on an input of SX_ED25519_DGST_SZ bytes.

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_eddsa_ed448.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_eddsa_ed448.c
@@ -110,7 +110,7 @@ static int ed448_sign_internal(const uint8_t *priv_key, uint8_t *signature,
 	/* The secret scalar s is computed in place from the first half of the
 	 * private key digest.
 	 */
-	decode_scalar_448(area_1);
+	cracen_decode_scalar_448(area_1);
 
 	/* Clear second half of private key digest: sx_ed448_ptmult()
 	 * works on an input of SX_ED448_DGST_SZ bytes.
@@ -258,7 +258,7 @@ int cracen_ed448_create_pubkey(const uint8_t *priv_key, uint8_t *pub_key)
 	/* The secret scalar s is computed in place from the first half of the
 	 * private key digest.
 	 */
-	decode_scalar_448(digest);
+	cracen_decode_scalar_448(digest);
 
 	/* Clear second half of private key digest: ed448_ptmult()
 	 * works on an input of SX_ED448_DGST_SZ bytes.

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecdh/cracen_ecdh_montgomery.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecdh/cracen_ecdh_montgomery.c
@@ -39,12 +39,12 @@ psa_status_t cracen_ecdh_montgmr_calc_secret(const struct sx_pk_ecurve *curve,
 		struct sx_x25519_op k;
 
 		memcpy(k.bytes, priv_key, CRACEN_X25519_KEY_SIZE_BYTES);
-		decode_scalar_25519(k.bytes);
+		cracen_decode_scalar_25519(k.bytes);
 
 		struct sx_x25519_op pt;
 
 		memcpy(pt.bytes, publ_key, CRACEN_X25519_KEY_SIZE_BYTES);
-		decode_u_coordinate_25519(pt.bytes);
+		cracen_decode_u_coordinate_25519(pt.bytes);
 
 		sx_status = sx_x25519_ptmult(&req, &k, &pt, (struct sx_x25519_op *)output);
 		if (sx_status != SX_OK) {
@@ -55,7 +55,7 @@ psa_status_t cracen_ecdh_montgmr_calc_secret(const struct sx_pk_ecurve *curve,
 		struct sx_x448_op k;
 
 		memcpy(k.bytes, priv_key, CRACEN_X448_KEY_SIZE_BYTES);
-		decode_scalar_448(k.bytes);
+		cracen_decode_scalar_448(k.bytes);
 
 		/* 448 % 8 = 0, so there is no need to decode pt coordinate. */
 		sx_status = sx_x448_ptmult(&req, &k, (struct sx_x448_op *)publ_key,

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_sp800_108_ctr_mac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_sp800_108_ctr_mac.c
@@ -94,7 +94,7 @@ static psa_status_t cracen_ctr_mac_generate_block(cracen_key_derivation_operatio
 	    PSA_ALG_IS_SP800_108_COUNTER_HMAC(operation->alg)) {
 		const struct sxhashalg *hash;
 
-		status = hash_get_algo(PSA_ALG_GET_HASH(operation->alg), &hash);
+		status = cracen_hash_get_algo(PSA_ALG_GET_HASH(operation->alg), &hash);
 		if (status != PSA_SUCCESS) {
 			return status;
 		}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_tls12.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_tls12.c
@@ -96,7 +96,7 @@ static psa_status_t tls12_prf_generate_block(cracen_key_derivation_operation_t *
 
 	const struct sxhashalg *hash;
 
-	status = silex_statuscodes_to_psa(hash_get_algo(PSA_ALG_GET_HASH(operation->alg), &hash));
+	status = cracen_hash_get_algo(PSA_ALG_GET_HASH(operation->alg), &hash);
 	if (status != PSA_SUCCESS) {
 		return status;
 	}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/mac/cracen_mac_hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/mac/cracen_mac_hmac.c
@@ -39,7 +39,7 @@ psa_status_t cracen_hmac_setup(cracen_mac_operation_t *operation,
 	}
 
 	/* HMAC operation creation and configuration. */
-	sx_status = mac_create_hmac(sx_hash_algo, &operation->hmac.hashctx, key_buffer,
+	sx_status = cracen_hmac_create(sx_hash_algo, &operation->hmac.hashctx, key_buffer,
 		key_buffer_size, operation->hmac.workmem, sizeof(operation->hmac.workmem));
 	if (sx_status != SX_OK) {
 		sx_hw_release(&operation->hmac.hashctx.dma);
@@ -191,8 +191,9 @@ psa_status_t cracen_hmac_finish(cracen_mac_operation_t *operation)
 	}
 
 	/* Generate the MAC */
-	sx_status = hmac_produce(&operation->hmac.hashctx, sx_hash_algo, operation->input_buffer,
-				 sizeof(operation->input_buffer), operation->hmac.workmem);
+	sx_status = cracen_hmac_produce(&operation->hmac.hashctx, sx_hash_algo,
+					operation->input_buffer, sizeof(operation->input_buffer),
+					operation->hmac.workmem);
 
 exit:
 	sx_hw_release(&operation->hmac.hashctx.dma);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/mac/cracen_mac_hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/mac/cracen_mac_hmac.c
@@ -26,7 +26,7 @@ psa_status_t cracen_hmac_setup(cracen_mac_operation_t *operation,
 	int sx_status;
 	const struct sxhashalg *sx_hash_algo = NULL;
 
-	psa_status_t psa_status = hash_get_algo(PSA_ALG_HMAC_GET_HASH(alg), &sx_hash_algo);
+	psa_status_t psa_status = cracen_hash_get_algo(PSA_ALG_HMAC_GET_HASH(alg), &sx_hash_algo);
 
 	if (psa_status != PSA_SUCCESS) {
 		return psa_status;
@@ -73,9 +73,10 @@ psa_status_t cracen_hmac_update(cracen_mac_operation_t *operation, const uint8_t
 	size_t input_chunk_length = 0;
 	size_t remaining_bytes = 0;
 	const struct sxhashalg *sx_hash_algo = NULL;
+	psa_status_t psa_status = PSA_ERROR_CORRUPTION_DETECTED;
 
 	/* As the block size is needed several times we compute it once here */
-	psa_status_t psa_status = hash_get_algo(PSA_ALG_GET_HASH(operation->alg), &sx_hash_algo);
+	psa_status = cracen_hash_get_algo(PSA_ALG_GET_HASH(operation->alg), &sx_hash_algo);
 
 	if (psa_status != PSA_SUCCESS) {
 		return psa_status;
@@ -159,12 +160,13 @@ exit:
 psa_status_t cracen_hmac_finish(cracen_mac_operation_t *operation)
 {
 	int sx_status;
+	psa_status_t psa_status = PSA_ERROR_CORRUPTION_DETECTED;
 	size_t block_size, digestsz;
 	const struct sxhashalg *sx_hash_algo = NULL;
 
-	sx_status = hash_get_algo(PSA_ALG_GET_HASH(operation->alg), &sx_hash_algo);
-	if (sx_status != SX_OK) {
-		return silex_statuscodes_to_psa(sx_status);
+	psa_status = cracen_hash_get_algo(PSA_ALG_GET_HASH(operation->alg), &sx_hash_algo);
+	if (psa_status != PSA_SUCCESS) {
+		return psa_status;
 	}
 
 	digestsz = sx_hash_get_alg_digestsz(sx_hash_algo);

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_spake2p_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_spake2p_key_management.c
@@ -71,7 +71,7 @@ psa_status_t import_spake2p_key(const psa_key_attributes_t *attributes, const ui
 		uint8_t L[CRACEN_P256_POINT_SIZE + 1];
 
 		memcpy(L, &data[CRACEN_P256_KEY_SIZE], sizeof(L));
-		if (check_wstr_pub_key_data(PSA_ALG_ECDH, PSA_ECC_FAMILY_SECP_R1, bits, L,
+		if (cracen_check_wstr_pub_key_data(PSA_ALG_ECDH, PSA_ECC_FAMILY_SECP_R1, bits, L,
 					    sizeof(L))) {
 			safe_memzero(L, sizeof(L));
 			return PSA_ERROR_INVALID_ARGUMENT;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_spake2p_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_spake2p_key_management.c
@@ -15,7 +15,7 @@
 #include <cracen_psa.h>
 #include <cracen/common.h>
 
-psa_status_t import_spake2p_key(const psa_key_attributes_t *attributes, const uint8_t *data,
+psa_status_t cracen_import_spake2p_key(const psa_key_attributes_t *attributes, const uint8_t *data,
 				size_t data_length, uint8_t *key_buffer,
 				size_t key_buffer_size, size_t *key_buffer_length,
 				size_t *key_bits)
@@ -138,7 +138,7 @@ psa_status_t cracen_derive_spake2p_key(const psa_key_attributes_t *attributes,
 	}
 }
 
-psa_status_t export_spake2p_public_key_from_keypair(const psa_key_attributes_t *attributes,
+psa_status_t cracen_export_spake2p_public_key_from_keypair(const psa_key_attributes_t *attributes,
 						    const uint8_t *priv_key,
 						    size_t priv_key_length, uint8_t *pub_key,
 						    size_t pub_key_size,
@@ -173,7 +173,7 @@ psa_status_t export_spake2p_public_key_from_keypair(const psa_key_attributes_t *
 		}
 		pub_key[CRACEN_P256_KEY_SIZE] = CRACEN_ECC_PUBKEY_UNCOMPRESSED;
 		status = silex_statuscodes_to_psa(
-			ecc_genpubkey(w1, &pub_key[CRACEN_P256_KEY_SIZE + 1], sx_curve));
+			cracen_ecc_genpubkey(w1, &pub_key[CRACEN_P256_KEY_SIZE + 1], sx_curve));
 		if (status != PSA_SUCCESS) {
 			return status;
 		}

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_spake2p_key_management.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_spake2p_key_management.h
@@ -9,19 +9,19 @@
 #include <psa/crypto.h>
 #include <stdint.h>
 
-psa_status_t import_spake2p_key(const psa_key_attributes_t *attributes, const uint8_t *data,
-				size_t data_length, uint8_t *key_buffer,
-				size_t key_buffer_size, size_t *key_buffer_length,
-				size_t *key_bits);
+psa_status_t cracen_import_spake2p_key(const psa_key_attributes_t *attributes, const uint8_t *data,
+				       size_t data_length, uint8_t *key_buffer,
+				       size_t key_buffer_size, size_t *key_buffer_length,
+				       size_t *key_bits);
 
 psa_status_t cracen_derive_spake2p_key(const psa_key_attributes_t *attributes,
 				       const uint8_t *input, size_t input_length,
 				       uint8_t *key, size_t *key_length);
 
-psa_status_t export_spake2p_public_key_from_keypair(const psa_key_attributes_t *attributes,
-						    const uint8_t *priv_key,
-						    size_t priv_key_length, uint8_t *pub_key,
-						    size_t pub_key_size,
-						    size_t *pub_key_length);
+psa_status_t cracen_export_spake2p_public_key_from_keypair(const psa_key_attributes_t *attributes,
+							   const uint8_t *priv_key,
+							   size_t priv_key_length, uint8_t *pub_key,
+							   size_t pub_key_size,
+							   size_t *pub_key_length);
 
 #endif /* CRACEN_SPAKE2P_KEY_MANAGEMENT_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_srp_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_srp_key_management.c
@@ -15,7 +15,7 @@
 
 extern const uint8_t cracen_N3072[384];
 
-psa_status_t import_srp_key(const psa_key_attributes_t *attributes, const uint8_t *data,
+psa_status_t cracen_import_srp_key(const psa_key_attributes_t *attributes, const uint8_t *data,
 			    size_t data_length, uint8_t *key_buffer, size_t key_buffer_size,
 			    size_t *key_buffer_length, size_t *key_bits)
 {

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_srp_key_management.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_srp_key_management.h
@@ -9,8 +9,8 @@
 #include <psa/crypto.h>
 #include <stdint.h>
 
-psa_status_t import_srp_key(const psa_key_attributes_t *attributes, const uint8_t *data,
-			    size_t data_length, uint8_t *key_buffer, size_t key_buffer_size,
-			    size_t *key_buffer_length, size_t *key_bits);
+psa_status_t cracen_import_srp_key(const psa_key_attributes_t *attributes, const uint8_t *data,
+				   size_t data_length, uint8_t *key_buffer, size_t key_buffer_size,
+				   size_t *key_buffer_length, size_t *key_bits);
 
 #endif /* CRACEN_SRP_KEY_MANAGEMENT_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_wpa3_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_wpa3_key_management.c
@@ -102,10 +102,10 @@ static psa_status_t cracen_wpa3_sae_reduce_p256(sx_pk_req *req,
 	return silex_statuscodes_to_psa(sx_status);
 }
 
-psa_status_t import_wpa3_sae_pt_key(const psa_key_attributes_t *attributes,
-				    const uint8_t *data, size_t data_length,
-				    uint8_t *key_buffer, size_t key_buffer_size,
-				    size_t *key_buffer_length, size_t *key_bits)
+psa_status_t cracen_import_wpa3_sae_pt_key(const psa_key_attributes_t *attributes,
+					   const uint8_t *data, size_t data_length,
+					   uint8_t *key_buffer, size_t key_buffer_size,
+					   size_t *key_buffer_length, size_t *key_bits)
 {
 	psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 	int sx_status;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_wpa3_key_management.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_wpa3_key_management.h
@@ -9,10 +9,10 @@
 #include <psa/crypto.h>
 #include <stdint.h>
 
-psa_status_t import_wpa3_sae_pt_key(const psa_key_attributes_t *attributes,
-				    const uint8_t *data, size_t data_length,
-				    uint8_t *key_buffer, size_t key_buffer_size,
-				    size_t *key_buffer_length, size_t *key_bits);
+psa_status_t cracen_import_wpa3_sae_pt_key(const psa_key_attributes_t *attributes,
+					   const uint8_t *data, size_t data_length,
+					   uint8_t *key_buffer, size_t key_buffer_size,
+					   size_t *key_buffer_length, size_t *key_bits);
 
 psa_status_t cracen_derive_wpa3_sae_pt_key(const psa_key_attributes_t *attributes,
 					   const uint8_t *input, size_t input_length,

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_coprime_check.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_coprime_check.c
@@ -114,8 +114,8 @@ static int modular_reduction_run(sx_pk_req *req, uint8_t *workmem,
 	return SX_OK;
 }
 
-int coprime_check_run(sx_pk_req *req, uint8_t *workmem, size_t workmemsz, const uint8_t *a,
-		      size_t asz, const uint8_t *b, size_t bsz)
+int cracen_coprime_check_run(sx_pk_req *req, uint8_t *workmem, size_t workmemsz, const uint8_t *a,
+			     size_t asz, const uint8_t *b, size_t bsz)
 {
 	int status;
 	int a_is_odd;
@@ -188,7 +188,7 @@ int cracen_coprime_check(uint8_t *workmem, size_t workmemsz, const uint8_t *a, s
 	sx_pk_acquire_hw(&req);
 	sx_pk_set_cmd(&req, SX_PK_CMD_ODD_MOD_INV);
 
-	status = coprime_check_run(&req, workmem, workmemsz, a, asz, b, bsz);
+	status = cracen_coprime_check_run(&req, workmem, workmemsz, a, asz, b, bsz);
 
 	sx_pk_release_req(&req);
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_coprime_check.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_coprime_check.h
@@ -38,7 +38,7 @@ int cracen_coprime_check(uint8_t *workmem, size_t workmemsz, const uint8_t *a, s
 /** Same as cracen_coprime_check, but uses an already-acquired request.
  * This allows chaining multiple CRACEN operations without releasing between them.
  */
-int coprime_check_run(sx_pk_req *req, uint8_t *workmem, size_t workmemsz, const uint8_t *a,
-		      size_t asz, const uint8_t *b, size_t bsz);
+int cracen_coprime_check_run(sx_pk_req *req, uint8_t *workmem, size_t workmemsz, const uint8_t *a,
+			     size_t asz, const uint8_t *b, size_t bsz);
 
 #endif /* CRACEN_RSA_COPRIME_CHECK_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_key_management.c
@@ -73,10 +73,10 @@ static void write_tag_and_length(struct sx_buf *buf, uint8_t tag)
 	memcpy(outbuf, ((uint8_t *)&length) + sizeof(length) - len_bytes, len_bytes);
 }
 
-psa_status_t export_rsa_public_key_from_keypair(const psa_key_attributes_t *attributes,
-						const uint8_t *key_buffer,
-						size_t key_buffer_size, uint8_t *data,
-						size_t data_size, size_t *data_length)
+psa_status_t cracen_export_rsa_public_key_from_keypair(const psa_key_attributes_t *attributes,
+						       const uint8_t *key_buffer,
+						       size_t key_buffer_size, uint8_t *data,
+						       size_t data_size, size_t *data_length)
 {
 	/*
 	 * RSAPublicKey ::= SEQUENCE {
@@ -145,8 +145,8 @@ psa_status_t export_rsa_public_key_from_keypair(const psa_key_attributes_t *attr
 	return PSA_SUCCESS;
 }
 
-psa_status_t generate_rsa_private_key(const psa_key_attributes_t *attributes, uint8_t *key,
-				      size_t key_size, size_t *key_length)
+psa_status_t cracen_generate_rsa_private_key(const psa_key_attributes_t *attributes, uint8_t *key,
+					     size_t key_size, size_t *key_length)
 {
 #if PSA_MAX_RSA_KEY_BITS > 0
 	size_t bits = psa_get_key_bits(attributes);
@@ -291,9 +291,9 @@ error_exit:
 #endif /* PSA_MAX_RSA_KEY_BITS > 0*/
 }
 
-psa_status_t import_rsa_key(const psa_key_attributes_t *attributes, const uint8_t *data,
-			    size_t data_length, uint8_t *key_buffer, size_t key_buffer_size,
-			    size_t *key_buffer_length, size_t *key_bits)
+psa_status_t cracen_import_rsa_key(const psa_key_attributes_t *attributes, const uint8_t *data,
+				   size_t data_length, uint8_t *key_buffer, size_t key_buffer_size,
+				   size_t *key_buffer_length, size_t *key_bits)
 {
 	size_t key_bits_attr = psa_get_key_bits(attributes);
 	psa_key_type_t key_type = psa_get_key_type(attributes);
@@ -343,9 +343,9 @@ cleanup:
 	return status;
 }
 
-psa_status_t rsa_export_public_key(const psa_key_attributes_t *attributes,
-				   const uint8_t *key_buffer, size_t key_buffer_size,
-				   uint8_t *data, size_t data_size, size_t *data_length)
+psa_status_t cracen_rsa_export_public_key(const psa_key_attributes_t *attributes,
+					  const uint8_t *key_buffer, size_t key_buffer_size,
+					  uint8_t *data, size_t data_size, size_t *data_length)
 {
 	if (data_size < key_buffer_size) {
 		return PSA_ERROR_BUFFER_TOO_SMALL;

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_key_management.h
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_key_management.h
@@ -9,20 +9,20 @@
 #include <psa/crypto.h>
 #include <stdint.h>
 
-psa_status_t export_rsa_public_key_from_keypair(const psa_key_attributes_t *attributes,
-						const uint8_t *key_buffer,
-						size_t key_buffer_size, uint8_t *data,
-						size_t data_size, size_t *data_length);
+psa_status_t cracen_export_rsa_public_key_from_keypair(const psa_key_attributes_t *attributes,
+						       const uint8_t *key_buffer,
+						       size_t key_buffer_size, uint8_t *data,
+						       size_t data_size, size_t *data_length);
 
-psa_status_t generate_rsa_private_key(const psa_key_attributes_t *attributes, uint8_t *key,
-				      size_t key_size, size_t *key_length);
+psa_status_t cracen_generate_rsa_private_key(const psa_key_attributes_t *attributes, uint8_t *key,
+					     size_t key_size, size_t *key_length);
 
-psa_status_t import_rsa_key(const psa_key_attributes_t *attributes, const uint8_t *data,
-			    size_t data_length, uint8_t *key_buffer, size_t key_buffer_size,
-			    size_t *key_buffer_length, size_t *key_bits);
+psa_status_t cracen_import_rsa_key(const psa_key_attributes_t *attributes, const uint8_t *data,
+				   size_t data_length, uint8_t *key_buffer, size_t key_buffer_size,
+				   size_t *key_buffer_length, size_t *key_bits);
 
-psa_status_t rsa_export_public_key(const psa_key_attributes_t *attributes,
-				   const uint8_t *key_buffer, size_t key_buffer_size,
-				   uint8_t *data, size_t data_size, size_t *data_length);
+psa_status_t cracen_rsa_export_public_key(const psa_key_attributes_t *attributes,
+					  const uint8_t *key_buffer, size_t key_buffer_size,
+					  uint8_t *data, size_t data_size, size_t *data_length);
 
 #endif /* CRACEN_RSA_KEY_MANAGEMENT_H */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_keygen.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_keygen.c
@@ -444,8 +444,8 @@ static int rsagenpq_get_random(sx_pk_req *req, uint8_t *workmem, struct cracen_r
 	 */
 	size_t candidatesz = rsacheckpq.candidatesz;
 
-	sx_status = coprime_check_run(req, workmem, WORKMEM_SIZE, candprime, candidatesz,
-				      product_small_primes, sizeof(product_small_primes));
+	sx_status = cracen_coprime_check_run(req, workmem, WORKMEM_SIZE, candprime, candidatesz,
+					     product_small_primes, sizeof(product_small_primes));
 	if (sx_status != SX_OK) {
 		return sx_status;
 	}
@@ -462,8 +462,8 @@ static int rsagenpq_get_random(sx_pk_req *req, uint8_t *workmem, struct cracen_r
 
 	/* step 4.5 (or 5.6): candprime - 1 and public exponent must be coprime
 	 */
-	sx_status = coprime_check_run(req, workmem, WORKMEM_SIZE, wmem, candidatesz,
-				      rsacheckpq.pubexp, rsacheckpq.pubexpsz);
+	sx_status = cracen_coprime_check_run(req, workmem, WORKMEM_SIZE, wmem, candidatesz,
+					     rsacheckpq.pubexp, rsacheckpq.pubexpsz);
 	/* the status code value here is SX_ERR_NOT_INVERTIBLE if
 	 * (candidate prime - 1) and the public exponent are not coprime
 	 */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_signature.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_signature.c
@@ -18,7 +18,7 @@
 #if PSA_MAX_RSA_KEY_BITS > 0
 static int cracen_signature_set_hashalgo(const struct sxhashalg **hashalg, psa_algorithm_t alg)
 {
-	return hash_get_algo(PSA_ALG_SIGN_GET_HASH(alg), hashalg);
+	return cracen_hash_get_algo(PSA_ALG_SIGN_GET_HASH(alg), hashalg);
 }
 
 static int cracen_signature_set_hashalgo_from_digestsz(const struct sxhashalg **hashalg,


### PR DESCRIPTION
After CRACEN refactoring some internal functions are still not aligned with general naming style.
This PR is aimed to fix it.