### PR TITLE
modules: tf-m: Reduce crypto operations

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -104,7 +104,7 @@ config TFM_CRYPTO_CONC_OPER_NUM
 	int
 	prompt "TF-M Crypto - Number of concurrent operations" if !TFM_PROFILE_TYPE_MINIMAL
 	default 1 if TFM_PROFILE_TYPE_MINIMAL
-	default 8
+	default 6
 	help
 	  This parameter defines the maximum number of possible
 	  concurrent operation contexts (cipher, MAC, hash and key derivation)


### PR DESCRIPTION
Reduce the concurrent crypto operations
from 8 to 6 to reduce the RAM usage of TF-M.
Each concurrent crypto operation takes ~1K
per operation. 8 seems unreasonable high
number so reduce to 6.