### PR TITLE
samples: net: Name previously unnamed threads

### DIFF
--- a/samples/net/azure_iot_hub/src/main.c
+++ b/samples/net/azure_iot_hub/src/main.c
@@ -433,13 +433,18 @@ static void connectivity_event_handler(struct net_mgmt_event_callback *cb,
 
 static void work_init(void)
 {
+	const struct k_work_queue_config cfg = {
+		.name = "application_work_q",
+	};
+
 	k_work_init(&method_data.work, direct_method_handler);
 	k_work_init(&twin_report_work, twin_report_work_fn);
 	k_work_init_delayable(&send_event_work, send_event);
 	k_work_init_delayable(&reboot_work, reboot_work_fn);
+
 	k_work_queue_start(&application_work_q, application_stack_area,
 		       K_THREAD_STACK_SIZEOF(application_stack_area),
-		       K_HIGHEST_APPLICATION_THREAD_PRIO, NULL);
+		       K_HIGHEST_APPLICATION_THREAD_PRIO, &cfg);
 }
 
 #if IS_ENABLED(CONFIG_AZURE_IOT_HUB_DPS)

--- a/samples/net/http_server/src/main.c
+++ b/samples/net/http_server/src/main.c
@@ -559,6 +559,7 @@ static void process_tcp(sa_family_t family, int *sock, int *accepted)
 			&tcp6_handler_tid[slot],
 			THREAD_PRIORITY,
 			0, K_NO_WAIT);
+		k_thread_name_set(tcp6_handler_tid[slot], "tcp6_handler");
 	} else if (family == AF_INET) {
 		tcp4_handler_tid[slot] = k_thread_create(
 			&tcp4_handler_thread[slot],
@@ -570,6 +571,7 @@ static void process_tcp(sa_family_t family, int *sock, int *accepted)
 			&tcp4_handler_tid[slot],
 			THREAD_PRIORITY,
 			0, K_NO_WAIT);
+		k_thread_name_set(tcp4_handler_tid[slot], "tcp4_handler");
 	}
 
 	net_addr_ntop(client_addr.sin6_family, &client_addr.sin6_addr, addr_str, sizeof(addr_str));

--- a/samples/net/mqtt/src/modules/transport/transport.c
+++ b/samples/net/mqtt/src/modules/transport/transport.c
@@ -368,11 +368,15 @@ static void transport_task(void)
 	 * This workqueue can be used to offload tasks and/or as a timer when wanting to
 	 * schedule functionality using the 'k_work' API.
 	 */
+	const struct k_work_queue_config queue_cfg = {
+		.name = "transport_work_q",
+	};
+
 	k_work_queue_init(&transport_queue);
 	k_work_queue_start(&transport_queue, stack_area,
 			   K_THREAD_STACK_SIZEOF(stack_area),
 			   K_HIGHEST_APPLICATION_THREAD_PRIO,
-			   NULL);
+			   &queue_cfg);
 
 	err = mqtt_helper_init(&cfg);
 	if (err) {


### PR DESCRIPTION
Name threads in samples azure_iot_hub, http_server and mqtt, for clearer inspection and fault logging.