### PR TITLE
[Backport v3.4-branch] net: lwm2m_client_utils: Fix char pointer arrays used as string buffers

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
@@ -43,9 +43,9 @@ static struct k_work modem_data_work;
 static struct k_work modem_signal_work;
 static int16_t modem_rsrp;
 
-static char *ip_addr[IP_ADDR_LENGTH];
-static char *apn[APN_LENGTH];
-static char *fw_version[FW_VERSION_LENGTH];
+static char ip_addr[IP_ADDR_LENGTH];
+static char apn[APN_LENGTH];
+static char fw_version[FW_VERSION_LENGTH];
 
 /* LTE-FDD bearer & NB-IoT bearer */
 #define LTE_FDD_BEARER 6U


### PR DESCRIPTION
Backport bec77e698510419a7db8b015702c7ea9bdfa1f4f from #30523.