### PR TITLE
samples: bme68x: Remove thingy53 board

### DIFF
--- a/samples/sensor/bme68x_iaq/sample.yaml
+++ b/samples/sensor/bme68x_iaq/sample.yaml
@@ -8,13 +8,9 @@ tests:
     integration_platforms:
       - thingy91/nrf9160
       - thingy91/nrf9160/ns
-      - thingy53/nrf5340/cpuapp
-      - thingy53/nrf5340/cpuapp/ns
     platform_allow:
       - thingy91/nrf9160
       - thingy91/nrf9160/ns
-      - thingy53/nrf5340/cpuapp
-      - thingy53/nrf5340/cpuapp/ns
     tags:
       - sensors
       - sysbuild
@@ -25,14 +21,10 @@ tests:
     integration_platforms:
       - thingy91/nrf9160
       - thingy91/nrf9160/ns
-      - thingy53/nrf5340/cpuapp
-      - thingy53/nrf5340/cpuapp/ns
     extra_args: CONFIG_APP_TRIGGER=n
     platform_allow:
       - thingy91/nrf9160
       - thingy91/nrf9160/ns
-      - thingy53/nrf5340/cpuapp
-      - thingy53/nrf5340/cpuapp/ns
     tags:
       - sensors
       - sysbuild


### PR DESCRIPTION
Removing Thingy53 support.