### PR TITLE
tests: drivers: grtc_clk_output: Fix nrf54l15dk overlays

### DIFF
--- a/tests/drivers/grtc/grtc_clk_output/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/grtc/grtc_clk_output/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -18,7 +18,7 @@
 	status = "okay";
 };
 
-&gpiote20 {
+&gpiote30 {
 	status = "okay";
 };
 

--- a/tests/drivers/grtc/grtc_clk_output/boards/nrf54l15dk_nrf54l15_cpuapp_fast.overlay
+++ b/tests/drivers/grtc/grtc_clk_output/boards/nrf54l15dk_nrf54l15_cpuapp_fast.overlay
@@ -5,17 +5,13 @@
  */
 
 /* Required loopback between:
- * GPIO P0.0 and P1.8 (GRTC fast; defined @board; no other option)
+ * GPIO P1.9 and P1.8 (GRTC fast; defined @board; no other option)
  */
 
 / {
 	zephyr,user {
-		gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;  /* Connect to dedicated GRTC output */
+		gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;  /* Connect to dedicated GRTC output */
 	};
-};
-
-&gpio0 {
-	status = "okay";
 };
 
 &gpio1 {


### PR DESCRIPTION
Slow test variant uses loopback on GPIO port 0.
GPIOTE30 is the correct instance to use with GPIO P0.

Fast test variant uses invalid loopback.
CI setups have loopback between P1.08 - P1.09.

Fix both overlays.