### PR TITLE
scripts: sbom: Improve application package name and purpose

### DIFF
--- a/scripts/west_commands/sbom/data_structure.py
+++ b/scripts/west_commands/sbom/data_structure.py
@@ -144,6 +144,7 @@ class Data(DataBaseClass):
         application_roots Set of application source roots detected from build directories.
         module_roots     Set of module source roots detected from build directories.
         toolchain_paths  Mapping of detected toolchain root paths (resolved) to package IDs.
+        domain           Sysbuild domain name for this run. None for non-sysbuild builds.
     '''
     files: 'list[FileInfo]' = list()
     licenses: 'dict[License|LicenseExpr]' = dict()
@@ -156,3 +157,4 @@ class Data(DataBaseClass):
     application_roots: 'set[str]' = set()
     module_roots: 'set[str]' = set()
     toolchain_paths: 'dict[str,str]' = dict()
+    domain: 'str|None' = None

--- a/scripts/west_commands/sbom/git_info_detector.py
+++ b/scripts/west_commands/sbom/git_info_detector.py
@@ -15,7 +15,9 @@ from west import log
                                                     # FileInfo is used.
 
 _manifest_projects: 'dict[Path, object]' = {}
+_manifest_path_index: 'list[tuple[Path, object]]' = []
 _self_repo_path: 'Path|None' = None
+_self_repo_name: 'str|None' = None
 _self_repo_version: 'str|None' = None
 
 
@@ -186,9 +188,12 @@ def read_version(version_file: Path, include_dev: bool = False) -> 'str|None':
 
 def load_manifest():
     '''Populate the module-level manifest caches consulted by detect_dir.'''
-    global _manifest_projects, _self_repo_path, _self_repo_version
+    global _manifest_projects, _manifest_path_index
+    global _self_repo_path, _self_repo_name, _self_repo_version
     _manifest_projects = {}
+    _manifest_path_index = []
     _self_repo_path = None
+    _self_repo_name = None
     _self_repo_version = None
     try:
         from west.manifest import Manifest
@@ -203,13 +208,31 @@ def load_manifest():
             key = Path(abspath).resolve()
         except OSError:
             continue
+        _manifest_path_index.append((key, project))
         if getattr(project, 'url', None):
             _manifest_projects[key] = project
         elif _self_repo_path is None:
             # by west convention projects[0] is the manifest repo.
             _self_repo_path = key
+            _self_repo_name = getattr(project, 'name', None) or key.name
     if _self_repo_path is not None:
         _self_repo_version = read_version(_self_repo_path / 'VERSION')
+
+    _manifest_path_index.sort(key=lambda item: len(item[0].parts), reverse=True)
+
+
+def match_manifest_project(absolute_path: Path) -> 'tuple[Path, object]|None':
+    '''Return (project_root, project) for the manifest project whose directory is the
+    longest prefix of absolute_path, or None.'''
+    try:
+        target = absolute_path.resolve()
+    except OSError:
+        target = absolute_path
+    parents = set(target.parents)
+    for key, project in _manifest_path_index:
+        if target == key or key in parents:
+            return (key, project)
+    return None
 
 
 def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
@@ -238,8 +261,24 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
         git_sha = project.revision or git_sha
     elif _self_repo_version is not None and repo == _self_repo_path:
         git_sha = _self_repo_version
-    if (git_sha is not None) and (git_origin is not None):
-        package_id = f'git#{git_origin}#{git_sha}'.upper()
+    # Fall back to the west manifest when git provided no origin.
+    # This resolves package identity from the manifest without any git remote.
+    package_name = None
+    if git_origin is None:
+        match = match_manifest_project(absolute_path)
+        if match is not None:
+            project_root, mproject = match
+            git_origin = getattr(mproject, 'url', None) or None
+            git_sha = git_sha or getattr(mproject, 'revision', None)
+            if git_origin is None:
+                # The url-less self/manifest repo: resolve it by name only.
+                package_name = getattr(mproject, 'name', None) or project_root.name
+                if project_root == _self_repo_path and _self_repo_version is not None:
+                    git_sha = _self_repo_version
+            if project is None:
+                project = mproject
+
+    if repo is not None:
         output, error_code = command_execute(args.git, 'status', '--porcelain', '--ignored',
                                              '--untracked-files=all', '*', cwd=absolute_path,
                                              return_error_code=True, allow_stderr=True)
@@ -253,6 +292,11 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
                 untracked_files.add(Path(line[3:]).name.upper())
                 continue
             modified_files.add(Path(line[3:]).name.upper())
+    if (git_origin is not None) and (git_sha is not None):
+        package_id = f'git#{git_origin}#{git_sha}'.upper()
+    elif package_name is not None:
+        version_tag = git_sha if git_sha is not None else 'NONE'
+        package_id = f'pkg#{package_name}#{version_tag}'.upper()
     else:
         package_id = ''
     if package_id not in data.packages:
@@ -260,6 +304,8 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
         package.id = package_id
         package.url = git_origin
         package.version = git_sha
+        if git_origin is None and package_name is not None:
+            package.name = package_name
         if git_origin and git_sha:
             package.purl = git_url_to_purl(git_origin, git_sha)
             package.supplier = args.package_supplier or extract_supplier_from_url(git_origin)

--- a/scripts/west_commands/sbom/main.py
+++ b/scripts/west_commands/sbom/main.py
@@ -47,8 +47,9 @@ generators = {
 }
 
 
-def _run_pipeline():
+def _run_pipeline(domain: 'str|None' = None):
     data = Data()
+    data.domain = domain
 
     for input_name, input in inputs.items():
         t = dbg_time(f'INPUT: {input_name}')
@@ -193,7 +194,7 @@ def main():
                             base_outputs[key], domain_name, defaults[gen]
                         )
 
-                    _run_pipeline()
+                    _run_pipeline(domain_name)
                     processed_domains += 1
 
                 if processed_domains == 0:

--- a/scripts/west_commands/sbom/output_pre_process.py
+++ b/scripts/west_commands/sbom/output_pre_process.py
@@ -135,6 +135,10 @@ def pre_process(data: Data, built_date: 'str|None' = None):
         if (package.browser_url is None) and (package.url.startswith('http')):
             package.browser_url = package.url
     files_by_package = group_files_by_package(data)
+    # Drop the always-present empty catch-all package when nothing landed in it,
+    # so a fully resolved run does not emit a stray "unknown-package" entry.
+    if '' in data.packages and not files_by_package.get(''):
+        del data.packages['']
     assign_application_dependencies(data, files_by_package)
     add_dependency_placeholder_if_needed(data)
     assign_primary_package_purpose(data, files_by_package, built_date)
@@ -180,19 +184,35 @@ def packages_for_roots(roots: 'set[str]', files_by_package: dict) -> 'set[str]':
     return packages
 
 
+def application_packages(data: Data, files_by_package: dict) -> 'set[str]':
+    '''Treat the non-empty '' catch-all (this build's generated artifacts) as the
+    application package rather than leaving it unnamed as "unknown-package".'''
+    packages = packages_for_roots(data.application_roots, files_by_package)
+    if data.application_roots and files_by_package.get(''):
+        packages = packages | {''}
+    return packages
+
+
 def assign_primary_package_purpose(data: Data, files_by_package: dict,
                                    built_date: 'str|None' = None):
     '''Set Package.primary_package_purpose and (for APPLICATION) Package.built_date.
       DEPENDENCY_PLACEHOLDER_ID                                -> OTHER
       no-URL package with files under data.application_roots   -> APPLICATION
+      the unknown-package when an application is known         -> APPLICATION
       package.purl set (git-resolved)                          -> SOURCE
       otherwise                                                -> omit (left as None)
 
     Only no-URL packages can be APPLICATION: they hold the build-specific
-    generated artifacts that uniquely identify this build.
+    generated artifacts that uniquely identify this build. The empty-id ('')
+    catch-all collects those generated artifacts, so when an application is
+    known (build mode always sets application_roots) that catch-all is the
+    application rather than an "unknown-package".
     '''
-    application_pkgs = packages_for_roots(data.application_roots, files_by_package)
-    app_name = application_name(data.application_roots)
+    application_pkgs = application_packages(data, files_by_package)
+    # Prefer the sysbuild domain name (e.g. "mcuboot") over the application source
+    # directory basename, which can be misleading. e.g: MCUboot's application
+    # lives in boot/zephyr, so the basename would be the colliding name "zephyr".
+    app_name = data.domain or application_name(data.application_roots)
     for pkg_id, package in data.packages.items():
         if pkg_id == DEPENDENCY_PLACEHOLDER_ID:
             package.primary_package_purpose = 'OTHER'


### PR DESCRIPTION
When running sbom from a build dir (-d) the build's generated artifacts were collected into the empty package and emitted as "unknown-package".

Name that "unknown-package" after the sysbuild domain and set PrimaryPackagePurpose: APPLICATION. Omit it when it holds no files.

Resolve module package identity from the west manifest as well by path so package names no longer depend on a resolvable git remote.