### PR TITLE
b0_signing: Pick the header size from signed app

### DIFF
--- a/cmake/sysbuild/b0_mcuboot_signing.cmake
+++ b/cmake/sysbuild/b0_mcuboot_signing.cmake
@@ -30,7 +30,7 @@ function(ncs_secure_boot_mcuboot_sign application bin_files signed_targets prefi
   sysbuild_get(CONFIG_BUILD_OUTPUT_HEX IMAGE ${application} VAR CONFIG_BUILD_OUTPUT_HEX KCONFIG)
 
   set(slot_size)        # imgtool --slot-size
-  set(header_size)      # imgtool --header
+  set(header_size)      # imgtool --header-size
   if(SB_CONFIG_PARTITION_MANAGER)
     string(TOUPPER "${application}" application_uppercase)
     set(slot_size $<TARGET_PROPERTY:partition_manager,${prefix}PM_${application_uppercase}_SIZE>)
@@ -52,15 +52,34 @@ function(ncs_secure_boot_mcuboot_sign application bin_files signed_targets prefi
     else()
       dt_partition_addr(slot_address PATH "${code_partition_path}" TARGET ${application} REQUIRED ABSOLUTE)
     endif()
-    # Header size is picked from the image that is being signed.
-    sysbuild_get(header_size IMAGE ${DEFAULT_IMAGE} VAR CONFIG_ROM_START_OFFSET KCONFIG)
 
-    if(${header_size} EQUAL 0)
-      sysbuild_get(build_with_tfm IMAGE ${DEFAULT_IMAGE} VAR CONFIG_BUILD_WITH_TFM KCONFIG)
-      if(build_with_tfm)
-        sysbuild_get(header_size IMAGE ${DEFAULT_IMAGE} VAR CONFIG_TFM_MCUBOOT_HEADER_SIZE KCONFIG)
-      else()
-        message(FATAL_ERROR "imgtool header size picked from ${DEFAULT_IMAGE} is 0, check CONFIG_ROM_START_OFFSET value")
+    # Header size is picked from the image that is being signed, as an offset for where executables
+    # starts within generated binary, which is represented by CONFIG_ROM_START_OFFSET.
+    # It is assumed that all that space, from the start of a binary to the CONFIG_ROM_START_OFFSET
+    # is available for the header, but the header will take only several bytes from the beginning
+    # of the binary; most of other bytes will be wasted, but that may happen due to VTOR alignment
+    # requirements, that mandate alignment of CONFIG_ROM_START_OFFSET.
+    # Whatever will be built for nRF5340 NETCORE, CONFIG_SOC_NRF5340_CPUNET=y, will have
+    # CONFIG_ROM_START_OFFSET=0, as MCUboot is never run on CPUNET; b0n is and it does not need
+    # the MCUboot image header for anything, so when image is transferred to CPUNET, the
+    # MCUboot image header is stripped in process.
+    # This means that we will have to "glue" the header in front of firmware image, and we can
+    # choose any size for it as long as we are able to fit all information in it.
+    # CONFIG_ROM_START_OFFSET=0, for application, is not helping, getting size from default
+    # image makes no sense, so the --header-size=auto will be used.
+
+    # Do not bother picking header size from image that is for CPUNET
+    if("${prefix}" STREQUAL "CPUNET_")
+      set(header_size auto)
+    else()
+      sysbuild_get(header_size IMAGE ${application} VAR CONFIG_ROM_START_OFFSET KCONFIG)
+      if(${header_size} EQUAL 0)
+        sysbuild_get(build_with_tfm IMAGE ${DEFAULT_IMAGE} VAR CONFIG_BUILD_WITH_TFM KCONFIG)
+        if(build_with_tfm)
+          sysbuild_get(header_size IMAGE ${DEFAULT_IMAGE} VAR CONFIG_TFM_MCUBOOT_HEADER_SIZE KCONFIG)
+        else()
+          message(WARNING "imgtool header size picked from ${application} is 0, check CONFIG_ROM_START_OFFSET value")
+        endif()
       endif()
     endif()
   endif()

--- a/cmake/sysbuild/b0_mcuboot_signing.cmake
+++ b/cmake/sysbuild/b0_mcuboot_signing.cmake
@@ -30,7 +30,7 @@ function(ncs_secure_boot_mcuboot_sign application bin_files signed_targets prefi
   sysbuild_get(CONFIG_BUILD_OUTPUT_HEX IMAGE ${application} VAR CONFIG_BUILD_OUTPUT_HEX KCONFIG)
 
   set(slot_size)        # imgtool --slot-size
-  set(header_size)      # imgtool --header
+  set(header_size)      # imgtool --header-size
   if(SB_CONFIG_PARTITION_MANAGER)
     string(TOUPPER "${application}" application_uppercase)
     set(slot_size $<TARGET_PROPERTY:partition_manager,${prefix}PM_${application_uppercase}_SIZE>)
@@ -52,15 +52,35 @@ function(ncs_secure_boot_mcuboot_sign application bin_files signed_targets prefi
     else()
       dt_partition_addr(slot_address PATH "${code_partition_path}" TARGET ${application} REQUIRED ABSOLUTE)
     endif()
-    # Header size is picked from the image that is being signed.
-    sysbuild_get(header_size IMAGE ${DEFAULT_IMAGE} VAR CONFIG_ROM_START_OFFSET KCONFIG)
+    # Header size is picked from the image that is being signed, as an offset for where executables
+    # starts within generated binary, which is represented by CONFIG_ROM_START_OFFSET.
+    # It is assumed that all that space, from the start of a binary to the CONFIG_ROM_START_OFFSET
+    # is available for the header, but the header will take only several bytes from the beginning
+    # of the binary; most of other bytes will be wasted, but that may happen due to VTOR alignment
+    # requirements, that mandate alignment of CONFIG_ROM_START_OFFSET.
+    # Whatever will be built for nRF5340 NETCORE, CONFIG_SOC_NRF5340_CPUNET=y, will have
+    # CONFIG_ROM_START_OFFSET=0, as MCUboot is never run on CPUNET; b0n is and it does not need
+    # the MCUboot image header for anything, so when image is transferred to CPUNET, the
+    # MCUboot image header is stripped in process.
+    # This means that we will have to "glue" the header in front of firmware image, and we can
+    # choose any size for it as long as we are able to fit all information in it.
+    # CONFIG_ROM_START_OFFSET=0, for application, is not helping, getting size from default
+    # image makes no sense, so the --header-size=auto will be used.
 
-    if(${header_size} EQUAL 0)
+    # Do not bother picking header size from image that is for CPUNET
+    sysbuild_get(is_cpunet_target IMAGE ${application} VAR CONFIG_SOC_NRF5340_CPUNET KCONFIG)
+    if(is_cpunet_target)
+      set(header_size auto)
+    else()
+      sysbuild_get(header_size IMAGE ${application} VAR CONFIG_ROM_START_OFFSET KCONFIG)
+    endif()
+
+    if(NOT is_cpunet_target AND ${header_size} EQUAL 0)
       sysbuild_get(build_with_tfm IMAGE ${DEFAULT_IMAGE} VAR CONFIG_BUILD_WITH_TFM KCONFIG)
       if(build_with_tfm)
         sysbuild_get(header_size IMAGE ${DEFAULT_IMAGE} VAR CONFIG_TFM_MCUBOOT_HEADER_SIZE KCONFIG)
       else()
-        message(FATAL_ERROR "imgtool header size picked from ${DEFAULT_IMAGE} is 0, check CONFIG_ROM_START_OFFSET value")
+        message(FATAL_ERROR "imgtool header size picked from ${application} is 0, check CONFIG_ROM_START_OFFSET value")
       endif()
     endif()
   endif()

--- a/cmake/sysbuild/sign.cmake
+++ b/cmake/sysbuild/sign.cmake
@@ -14,12 +14,6 @@ function(b0_gen_keys)
   set(SIGNATURE_PUBLIC_KEY_FILE ${GENERATED_PATH}/public.pem)
   set(SIGNATURE_PUBLIC_KEY_FILE ${GENERATED_PATH}/public.pem PARENT_SCOPE)
 
-  if(CONFIG_PARTITION_MANAGER_ENABLED)
-    set(skip_size 0)
-  else()
-    set(skip_size ${CONFIG_SB_IMAGE_BOOT_OFFSET})
-  endif()
-
   if(SB_CONFIG_SECURE_BOOT_SIGNATURE_TYPE_ED25519)
     set(keygen_algorithm --algorithm ed25519)
   else()

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -882,6 +882,12 @@ The following list summarizes both the main changes inherited from upstream MCUb
   This enables a production or development signing custody model in which, for example, an updatable development bootloader can boot images signed with either key while a production bootloader embeds only the production verification key.
   MCUboot ``imgtool`` adds the ``keyinfo`` subcommand and ``--name-suffix`` for ``getpub`` and ``getpubhash``, which support the multiple keys embedded in the bootloader image.
 
+* Updated:
+
+  * The ``--header-size`` imgtool parameter to accept ``auto`` as a value and automatically calculate the smallest possible header.
+  * The sysbuild signing scripts for nRF5340 network core to automatically use the smallest needed MCUboot image header instead of the :kconfig:option:`CONFIG_ROM_START_OFFSET` Kconfig value, which has to account for proper VTOR alignment.
+    The size of network core firmware image signed for MCUboot is reduced by 480 bytes.
+
 Zephyr
 ======
 

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 97ed202eb2b2969be6f18189f0871014c4a6d135
+      revision: e994ef4e2828c751d1008dd34597ac8f471da633
       path: bootloader/mcuboot
     - name: qcbor
       repo-path: sdk-qcbor

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: cdc01217b2bd64a726a707a98b888fa07fa82d83
+      revision: pull/725/head
       path: bootloader/mcuboot
     - name: qcbor
       repo-path: sdk-qcbor


### PR DESCRIPTION
Pick the header size, for MCUboot signature, from signed app rather than default image.
Although all header sizes are decided by the CONFIG_ROM_START_OFFSET value, and, so far, should be the same for all images built for MCUboot for a selected platform, it is correct to pick the value from the image being signed, rather than default image.