### PR TITLE
drivers: wifi: nrf71: Add type-specific logging for error stats events

### DIFF
--- a/drivers/wifi/nrf71/fw_if/nrf71_wifi_common.h
+++ b/drivers/wifi/nrf71/fw_if/nrf71_wifi_common.h
@@ -957,6 +957,19 @@ struct nrf_wifi_umac_event_debug_stats {
 enum umac_fail_events {
 	UMAC_MEM_ALLOC_FAIL = 0,
 };
+
+enum lmac_fail_events {
+	RX_INT_MEM_UNDERRUN = 0,
+	DATA_PATH_STUCK,
+	WIFI_REQ_TO_PTA_FAIL,
+	HW_DATA_PATH_DEACTIVATE_FAIL,
+	HW_DATA_PATH_ACTIVATE_FAIL,
+	CAPTURE_DMA_NOT_FINISHING,
+	FEED_DMA_NOT_FINISHING,
+	RF_PLL_RECOVERY_FAILED,
+	DEVICE_IS_ACTIVE_FOR_TOO_LONG
+};
+
 /**
  * @brief This structure defines the event used to send error statistics to the Host.
  *
@@ -966,7 +979,7 @@ struct nrf_wifi_umac_event_error_stats {
 	struct nrf_wifi_sys_head sys_head;
 	/** Statistics type &enum rpu_stats_type */
 	signed int stats_type;
-	/** Error code, see &enum LMAC_ERROR_ID or &enum UMAC_ERROR_ID */
+	/** Error code, see &enum lmac_fail_events or &enum umac_fail_events */
 	unsigned int status_code;
 } __NRF_WIFI_PKD;
 

--- a/drivers/wifi/nrf71/fw_if/nrf71_wifi_debug_stats.h
+++ b/drivers/wifi/nrf71/fw_if/nrf71_wifi_debug_stats.h
@@ -1114,12 +1114,6 @@ struct rpu_lmac_stats {
 	unsigned int warmBootCnt;
 } __NRF_WIFI_PKD;
 
-/*! LMAC error event status */
-enum LMAC_ERROR_ID {
-	/*! LMAC internal memory full */
-	LMAC_FW_PEER_DATA_BASE_FULL = 0,
-};
-
 /**
  * @brief This structure defines the PHY (Physical Layer) debug statistics.
  *

--- a/drivers/wifi/nrf71/osal/fw_if/umac_if/src/system/fmac_event.c
+++ b/drivers/wifi/nrf71/osal/fw_if/umac_if/src/system/fmac_event.c
@@ -272,6 +272,49 @@ out:
 }
 #endif /* NRF71_UTIL */
 
+#if WIFI_NRF71_LOG_LEVEL >= NRF_WIFI_LOG_LEVEL_INF
+struct error_stats_log_entry {
+	unsigned int status_code;
+	const char *msg;
+};
+
+static const struct error_stats_log_entry umac_error_stats_log[] = {
+	{ UMAC_MEM_ALLOC_FAIL, "memory allocation failed" },
+};
+
+static const struct error_stats_log_entry lmac_error_stats_log[] = {
+	{ RX_INT_MEM_UNDERRUN, "RX internal memory underrun" },
+	{ DATA_PATH_STUCK, "data path stuck" },
+	{ WIFI_REQ_TO_PTA_FAIL, "Wi-Fi request to PTA failed" },
+	{ HW_DATA_PATH_DEACTIVATE_FAIL, "HW data path deactivation failed" },
+	{ HW_DATA_PATH_ACTIVATE_FAIL, "HW data path activation failed" },
+	{ CAPTURE_DMA_NOT_FINISHING, "capture DMA not finishing" },
+	{ FEED_DMA_NOT_FINISHING, "feed DMA not finishing" },
+	{ RF_PLL_RECOVERY_FAILED, "RF PLL recovery failed" },
+	{ DEVICE_IS_ACTIVE_FOR_TOO_LONG, "device active for too long" },
+};
+
+static void log_error_stats(const char *func,
+			    const char *type,
+			    unsigned int status_code,
+			    const struct error_stats_log_entry *table,
+			    size_t table_size)
+{
+	size_t i;
+
+	for (i = 0; i < table_size; i++) {
+		if (table[i].status_code == status_code) {
+			nrf_wifi_osal_log_info("%s: %s error: %s", func, type,
+					       table[i].msg);
+			return;
+		}
+	}
+
+	nrf_wifi_osal_log_info("%s: %s error stats: status_code=%u", func, type,
+			       status_code);
+}
+#endif /* WIFI_NRF71_LOG_LEVEL >= NRF_WIFI_LOG_LEVEL_INF */
+
 
 static enum nrf_wifi_status umac_event_sys_proc_events(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 						       struct host_rpu_msg *rpu_msg)
@@ -373,12 +416,29 @@ static enum nrf_wifi_status umac_event_sys_proc_events(struct nrf_wifi_fmac_dev_
 #if WIFI_NRF71_LOG_LEVEL >= NRF_WIFI_LOG_LEVEL_INF
 		struct nrf_wifi_umac_event_error_stats *err_ev =
 			(struct nrf_wifi_umac_event_error_stats *)sys_head;
-#endif
 
-		nrf_wifi_osal_log_info("%s: Error stats event: stats_type=%d status_code=%u",
-				       __func__,
-				       err_ev->stats_type,
-				       err_ev->status_code);
+		switch (err_ev->stats_type) {
+		case RPU_STATS_TYPE_UMAC:
+			log_error_stats(__func__, "UMAC", err_ev->status_code,
+					umac_error_stats_log,
+					sizeof(umac_error_stats_log) /
+					sizeof(umac_error_stats_log[0]));
+			break;
+		case RPU_STATS_TYPE_LMAC:
+			log_error_stats(__func__, "LMAC", err_ev->status_code,
+					lmac_error_stats_log,
+					sizeof(lmac_error_stats_log) /
+					sizeof(lmac_error_stats_log[0]));
+			break;
+		default:
+			nrf_wifi_osal_log_info("%s: Error stats event: "
+					       "stats_type=%d status_code=%u",
+					       __func__,
+					       err_ev->stats_type,
+					       err_ev->status_code);
+			break;
+		}
+#endif /* WIFI_NRF71_LOG_LEVEL >= NRF_WIFI_LOG_LEVEL_INF */
 		status = NRF_WIFI_STATUS_SUCCESS;
 		break;
 	}


### PR DESCRIPTION
Replace generic error stats logging with UMAC and LMAC specific messages. Align lmac_fail_events enum with firmware definitions.