### PR TITLE
tests: Increase ref_smp_svr test timeout to 900 seconds

### DIFF
--- a/tests/subsys/bootloader/upgrade/ref_smp_svr/testcase.yaml
+++ b/tests/subsys/bootloader/upgrade/ref_smp_svr/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   sysbuild: true
-  timeout: 700
+  timeout: 900
   slow: true
   harness: pytest
   tags:


### PR DESCRIPTION
Increased timeout to avoid failing tests.