### PR TITLE
scripts: sbom: Make FileName relative to the package root

### DIFF
--- a/scripts/west_commands/sbom/data_structure.py
+++ b/scripts/west_commands/sbom/data_structure.py
@@ -88,6 +88,8 @@ class Package(DataBaseClass):
         dependencies            List of package IDs this package depends on
         primary_package_purpose Estimate of the most likely package usage; None to omit
         built_date              Actual date the package was built; None to omit
+        root_path               Absolute path of the package root directory. SPDX file names are
+                                relative to it. None if the root is unknown.
     '''
     id: str = ''
     name: 'str|None' = None
@@ -100,6 +102,7 @@ class Package(DataBaseClass):
     dependencies: 'list[str]' = list()
     primary_package_purpose: 'str|None' = None
     built_date: 'str|None' = None
+    root_path: 'Path|None' = None
 
 
 class LicenseExpr(DataBaseClass):

--- a/scripts/west_commands/sbom/git_info_detector.py
+++ b/scripts/west_commands/sbom/git_info_detector.py
@@ -264,10 +264,12 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
     # Fall back to the west manifest when git provided no origin.
     # This resolves package identity from the manifest without any git remote.
     package_name = None
+    manifest_root = None
     if git_origin is None:
         match = match_manifest_project(absolute_path)
         if match is not None:
             project_root, mproject = match
+            manifest_root = project_root
             git_origin = getattr(mproject, 'url', None) or None
             git_sha = git_sha or getattr(mproject, 'revision', None)
             if git_origin is None:
@@ -304,6 +306,7 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
         package.id = package_id
         package.url = git_origin
         package.version = git_sha
+        package.root_path = repo or manifest_root
         if git_origin is None and package_name is not None:
             package.name = package_name
         if git_origin and git_sha:

--- a/scripts/west_commands/sbom/input_build.py
+++ b/scripts/west_commands/sbom/input_build.py
@@ -268,6 +268,7 @@ def register_toolchain_for_build(data: Data, build_dir: Path):
     package.id = f'TOOLCHAIN#{pkg_name.upper()}#{pkg_version.upper()}'
     package.name = pkg_name
     package.version = pkg_version
+    package.root_path = resolved
     if args.package_supplier:
         package.supplier = args.package_supplier
     data.toolchain_paths[resolved_str] = package.id

--- a/scripts/west_commands/sbom/output_template.py
+++ b/scripts/west_commands/sbom/output_template.py
@@ -66,8 +66,38 @@ def counter() -> int:
     return counter_value
 
 
-def relative_path(file: 'str|Path', output_directory: Path) -> str:
-    return './' + os.path.relpath(Path(file).resolve(), output_directory)
+def package_roots(data: Data) -> 'dict[str,Path]':
+    '''Resolved root directory of each package that provides one.'''
+    roots = {}
+    for package_id, package in data.packages.items():
+        if package.root_path is None:
+            continue
+        try:
+            roots[package_id] = Path(package.root_path).resolve()
+        except OSError:
+            continue
+    return roots
+
+
+def strip_anchor(path: Path) -> str:
+    '''POSIX form of an absolute path.'''
+    return path.relative_to(path.anchor).as_posix() if path.anchor else path.as_posix()
+
+
+def spdx_file_name(file: FileInfo, roots: 'dict[str,Path]') -> str:
+    '''SPDX FileName of a file: a POSIX path relative to the root of its package.
+    See SPDX 2.3 clause 8.1: the name is relative to the package root and starts with "./".
+    '''
+    root = roots.get(file.package)
+    if root is not None:
+        try:
+            return './' + Path(file.file_path).resolve().relative_to(root).as_posix()
+        except (ValueError, OSError):
+            pass
+    workspace_path = Path(file.file_rel_path)
+    if not workspace_path.is_absolute() and '..' not in workspace_path.parts:
+        return './' + workspace_path.as_posix()
+    return './' + strip_anchor(Path(file.file_path).resolve())
 
 
 def timestamp() -> str:
@@ -112,17 +142,18 @@ def get_ncs_version() -> 'str|None':
     return None
 
 
-def data_to_dict(data: Data, output_directory: Path) -> dict:
+def data_to_dict(data: Data) -> dict:
     '''Convert object to dict by copying public attributes to a new dictionary.'''
     result = dict()
     for name in dir(data):
         if name.startswith('_'):
             continue
         result[name] = getattr(data, name)
+    roots = package_roots(data)
     result['func'] = {
         'group_by': group_by,
         'counter': counter,
-        'relative_path': lambda file: relative_path(file, output_directory),
+        'spdx_file_name': lambda file: spdx_file_name(file, roots),
         'timestamp': timestamp,
         'download_location': download_location,
     }
@@ -138,7 +169,7 @@ def generate(data: Data, output_file: 'Path|str', template_file: Path):
     with open(template_file, encoding='utf-8') as fd:
         template_source = fd.read()
     t = Template(template_source)
-    out = t.render(**data_to_dict(data, output_file.parent.resolve()))
+    out = t.render(**data_to_dict(data))
     with open(output_file, 'w', encoding='utf-8') as fd:
         fd.write(out)
     escaped_path = quote(str(output_file.resolve()).replace(os.sep, '/').strip("/"))

--- a/scripts/west_commands/sbom/templates/raport.spdx.jinja
+++ b/scripts/west_commands/sbom/templates/raport.spdx.jinja
@@ -71,7 +71,7 @@ PackageCopyrightText: NOASSERTION
 
 # File
 
-FileName: {{func.relative_path(file.file_path)}}
+FileName: {{func.spdx_file_name(file)}}
 SPDXID: {{file_refs[file.file_path]}}
 FileChecksum: SHA1: {{file.sha1}}
 {% if file.local_modifications -%}


### PR DESCRIPTION
Record each package's root directory and emit FileName as a POSIX path relative to it.