### PR TITLE
scripts: sbom: Use UTF-8 encoding and fix DocumentNamespace

### DIFF
--- a/scripts/west_commands/sbom/data_structure.py
+++ b/scripts/west_commands/sbom/data_structure.py
@@ -153,8 +153,12 @@ class Data(DataBaseClass):
     packages_sorted: 'list[str]' = list()
     inputs: 'list[str]' = list()
     detectors: 'set[str]' = set()
-    report_uuid: 'str' = uuid4()
+    report_uuid: str = ''
     application_roots: 'set[str]' = set()
     module_roots: 'set[str]' = set()
     toolchain_paths: 'dict[str,str]' = dict()
     domain: 'str|None' = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.report_uuid = str(uuid4())

--- a/scripts/west_commands/sbom/output_template.py
+++ b/scripts/west_commands/sbom/output_template.py
@@ -135,11 +135,11 @@ def generate(data: Data, output_file: 'Path|str', template_file: Path):
     '''Generate output_file from data using template_file.'''
     output_file = Path(output_file)
     log.dbg(f'Writing output to "{output_file}" using template "{template_file}"')
-    with open(template_file) as fd:
+    with open(template_file, encoding='utf-8') as fd:
         template_source = fd.read()
     t = Template(template_source)
     out = t.render(**data_to_dict(data, output_file.parent.resolve()))
-    with open(output_file, 'w') as fd:
+    with open(output_file, 'w', encoding='utf-8') as fd:
         fd.write(out)
     escaped_path = quote(str(output_file.resolve()).replace(os.sep, '/').strip("/"))
     log.inf(f'Output written to file:///{escaped_path}')


### PR DESCRIPTION
Read templates and write generated reports using UTF-8.

Generate a new report UUID for every SBOM data instance. This gives each sysbuild domain a unique SPDX DocumentNamespace.