### PR TITLE
tests: benchmarks: Update SPI performance test

### DIFF
--- a/tests/benchmarks/xspi_performance/Kconfig
+++ b/tests/benchmarks/xspi_performance/Kconfig
@@ -12,3 +12,6 @@ config TEST_FIXED_OPERATION_SIZE
 config TEST_FLASH_OPERATION_SIZE
 	int "Flash operation size for fixed size mode"
 	default 65536
+
+config TEST_DISABLE_CPU_LOAD_MONITOR
+	bool "Disable the background CPU load monitor"

--- a/tests/benchmarks/xspi_performance/src/main.c
+++ b/tests/benchmarks/xspi_performance/src/main.c
@@ -242,7 +242,9 @@ static void test_flash_operation(size_t flash_operation_size, flash_operation_fn
 	printk("Flash %s test [size: %u bytes]\n", operation_name, flash_operation_size);
 	memset(test_buffer, 0xAB, MAX_TEST_BUFFER_SIZE);
 
+#if !defined(CONFIG_TEST_DISABLE_CPU_LOAD_MONITOR)
 	k_sem_give(&cpu_load_start_sem);
+#endif
 	dk_set_led_on(DK_LED1);
 	counter_reset(tst_timer_dev);
 	counter_start(tst_timer_dev);
@@ -259,7 +261,9 @@ static void test_flash_operation(size_t flash_operation_size, flash_operation_fn
 	counter_get_value(tst_timer_dev, &tst_timer_value);
 	counter_stop(tst_timer_dev);
 	dk_set_led_off(DK_LED1);
+#if !defined(CONFIG_TEST_DISABLE_CPU_LOAD_MONITOR)
 	k_sem_give(&cpu_load_stop_sem);
+#endif
 
 	if (err != 0) {
 		printk("!!!! Flash operation error: %d !!!!\n", err);


### PR DESCRIPTION
Add option to disable the CPU load monitor (for current measurement).