### PR TITLE
manifest: points to tfm and zephyr nrf7120 soc update

### DIFF
--- a/modules/trusted-firmware-m/tfm_boards/nrf7120_cpuapp/CMakeLists.txt
+++ b/modules/trusted-firmware-m/tfm_boards/nrf7120_cpuapp/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(platform_s
 target_sources(platform_s
   PRIVATE
   ${ZEPHYR_BASE}/soc/nordic/nrf71/soc.c
+  ${ZEPHYR_BASE}/soc/nordic/nrf71/wicr_setup.c
   )
 
 target_include_directories(platform_s

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8b0093c951616fb6d91edf11d9b2aea850ca30b9
+      revision: 9884ab345f9bf0ebb6fc2900f23f99bf41959adc
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -154,7 +154,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: b2dc08d416bef316c7464356be96699e9a6f24c1
+      revision: eed3f3f1b616b262c0b57f05dac6796c5b493cff
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b312f8a8dcf8ba941a28c2ce457f9bbe83c25efd
+      revision: pull/4347/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -154,7 +154,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 74c58c82a89cc739cd1b003c70a90e0f9d843039
+      revision: pull/268/head
     - name: psa-arch-tests
       repo-path: sdk-psa-arch-tests
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
Update tfm to point to nrf71_init.c initialization changes. Update sdk-zephyr to point to soc.c initialization changes.

Corresponds to:
https://github.com/nrfconnect/sdk-zephyr/pull/4347
https://github.com/nrfconnect/sdk-trusted-firmware-m/pull/268