### PR TITLE
tests: benchmarks: current_consumption: uart_console: longer active

### DIFF
--- a/tests/benchmarks/current_consumption/uart_console/src/main.c
+++ b/tests/benchmarks/current_consumption/uart_console/src/main.c
@@ -19,7 +19,7 @@ int main(void)
 #endif
 
 	while (1) {
-		printk("33 characters long string !!!!!!\n");
+		printk("83 characters long string !!!!!!#####!!!!!#####!!!!!#####!!!!!#####!!!!!#####!!!!!\n");
 		k_sleep(K_MSEC(SLEEP_TIME_MS));
 	}
 


### PR DESCRIPTION
Make active state longer, to easily detect from idle current.