### PR TITLE
samples: wifi: monitor: Allow setting channel at runtime

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -553,6 +553,10 @@ Wi-Fi samples
   * :zephyr:code-sample:`mqtt-sn-publisher`
   * :zephyr:code-sample:`coap-server`
 
+* :ref:`wifi_monitor_sample` sample:
+
+  * Added the Wi-Fi shell, so that the monitored channel can be changed at runtime using the ``wifi channel`` command.
+
 Other samples
 -------------
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -553,6 +553,10 @@ Wi-Fi samples
   * :zephyr:code-sample:`mqtt-sn-publisher`
   * :zephyr:code-sample:`coap-server`
 
+* :ref:`wifi_monitor_sample` sample:
+
+  * Added the Wi-Fi shell, so that you can change the monitored channel at runtime using the ``wifi channel`` command.
+
 Other samples
 -------------
 

--- a/samples/wifi/monitor/README.rst
+++ b/samples/wifi/monitor/README.rst
@@ -119,6 +119,17 @@ Testing
       [00:00:05.492,980] <inf> monitor:       Null Count: 0
       [00:00:05.493,011] <inf> monitor:       QoS Null Count: 0
 
+Changing the channel at runtime
+*******************************
+
+The sample enables the Wi-Fi shell, so you can change the monitored channel at runtime without rebuilding, using the ``wifi channel`` command:
+
+.. code-block:: console
+
+   uart:~$ wifi channel -i 1 -b 2 -c 6
+
+The ``-b`` option selects the band (``2`` for 2.4 GHz, ``5`` for 5 GHz, and ``6`` for 6 GHz) and is required for channels that exist in multiple bands.
+
 Offline net capture
 *******************
 

--- a/samples/wifi/monitor/README.rst
+++ b/samples/wifi/monitor/README.rst
@@ -119,6 +119,17 @@ Testing
       [00:00:05.492,980] <inf> monitor:       Null Count: 0
       [00:00:05.493,011] <inf> monitor:       QoS Null Count: 0
 
+Changing the channel at runtime
+*******************************
+
+The sample enables the Wi-Fi shell, so the monitored channel can be changed at runtime without rebuilding, using the ``wifi channel`` command:
+
+.. code-block:: console
+
+   uart:~$ wifi channel -i 1 -b 2 -c 6
+
+The ``-b`` option selects the band (``2`` for 2.4 GHz, ``5`` for 5 GHz, and ``6`` for 6 GHz) and is required for channels that exist in multiple bands.
+
 Offline net capture
 *******************
 

--- a/samples/wifi/monitor/prj.conf
+++ b/samples/wifi/monitor/prj.conf
@@ -56,3 +56,7 @@ CONFIG_NET_MGMT=y
 CONFIG_NET_MGMT_EVENT=y
 CONFIG_NRF70_STA_MODE=n
 CONFIG_NET_SOCKETS_PACKET=y
+
+# Shell, used to change the monitor mode channel at runtime via "wifi channel"
+CONFIG_SHELL=y
+CONFIG_NET_L2_WIFI_SHELL=y


### PR DESCRIPTION
Add Wi-Fi shell to the monitor, making it possible to switch channel without having to rebuild:
```
uart:~$ wifi channel -i 1 -b 2 -c 1                                                                                                                       
Wi-Fi channel set to 1 
```