### PR TITLE
nrf_security: Add missing key_derivation function

### DIFF
--- a/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/subsys/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -2524,6 +2524,18 @@ psa_driver_wrapper_key_derivation_output_key(psa_key_derivation_operation_t *ope
 	return PSA_ERROR_NOT_SUPPORTED;
 }
 
+psa_status_t
+psa_driver_wrapper_key_derivation_verify_key(psa_key_derivation_operation_t *operation,
+					     const psa_key_attributes_t *key_attributes,
+					     const uint8_t *key, size_t key_length)
+{
+	(void)operation;
+	(void)key_attributes;
+	(void)key;
+	(void)key_length;
+	return PSA_ERROR_NOT_SUPPORTED;
+}
+
 psa_status_t psa_driver_wrapper_key_derivation_abort(psa_key_derivation_operation_t *operation)
 {
 	switch (operation->id) {


### PR DESCRIPTION
The new Oberon PSA 2.1.0 calls the function
psa_driver_wrapper_key_derivation_verify_key.

Define this function to avoid build errors.