### PR TITLE
boards: shields: nrf2240eb: add nRF54LS05 DK overlay

### DIFF
--- a/boards/shields/nrf2240eb/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
+++ b/boards/shields/nrf2240eb/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
@@ -1,0 +1,111 @@
+/* Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* The nRF2240-EB shield is connected to the nRF54LS05 Development Kit Expansion Board Header.
+ *
+ * Important:
+ * On the nRF54LS05 Development Kit pins C0 (P1.04) and C1 (P1.05) are connected to the
+ * UART1 of the debugger chip to the nRF54LS05. The UART1 function (VCOM1) of
+ * the debugger chip must be disabled to allow the pins to be used as FEM control
+ * signals and FEM I2C interface. The "Board Configurator" tool
+ * (https://docs.nordicsemi.com/r/bundle/nrf-connect-for-desktop/page/board-configurator-app)
+ * being part of the "nRF Connect for Desktop" bundle can be used for this purpose.
+ */
+
+/ {
+	nrf_radio_fem: nrf2240_fem {
+		compatible = "nordic,nrf2240-fem";
+		cs-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		md-gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
+		pwrmd-gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+		twi-if = <&nrf_radio_fem_twi>;
+	};
+};
+
+&i2c21 {
+	status = "okay";
+
+	pinctrl-0 = <&i2c21_default>;
+	pinctrl-1 = <&i2c21_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	nrf_radio_fem_twi: nrf2240_fem_twi@30 {
+		compatible = "nordic,nrf2240-fem-twi";
+		status = "okay";
+		reg = <0x30>;
+	};
+
+	/* The nPM1300 on the nRF2240-EB is used to supply power to the nRF2240 device. */
+	nrf2240eb_pmic: pmic@6b {
+		compatible = "nordic,npm1300";
+		status = "okay";
+		reg = <0x6b>;
+
+		nrf2240eb_pmic_charger: charger {
+			compatible = "nordic,npm1300-charger";
+			status = "okay";
+			/* When objects are placed close to the PCB antenna of the nRF2240-EB shield
+			 * the supply voltage drops on the nRF2240 power supply pin VDDPALDO were
+			 * observed. As a workaround the current limit on VBUS of the PMIC
+			 * is increased.
+			 */
+			vbus-limit-microamp = <500000>;
+			/* This PMIC does not have a battery, but the settings below are required
+			 * by the driver
+			 */
+			term-microvolt = <4150000>;
+			current-microamp = <150000>;
+			dischg-limit-microamp = <1000000>;
+			thermistor-ohms = <10000>;
+			thermistor-beta = <3380>;
+		};
+	};
+};
+
+&pinctrl {
+	i2c21_default: i2c21_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
+				<NRF_PSEL(TWIM_SCL, 1, 4)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c21_sleep: i2c21_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
+				<NRF_PSEL(TWIM_SCL, 1, 4)>;
+			low-power-enable;
+		};
+	};
+};
+
+&ppib11 {
+	status = "okay";
+};
+
+&ppib21 {
+	status = "okay";
+};
+
+&ppib22 {
+	status = "okay";
+};
+
+&ppib30 {
+	status = "okay";
+};
+
+&dppic10 {
+	status = "okay";
+};
+
+&dppic20 {
+	status = "okay";
+};
+
+&dppic30 {
+	status = "okay";
+};

--- a/boards/shields/nrf2240eb/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
+++ b/boards/shields/nrf2240eb/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
@@ -3,21 +3,32 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/* The nRF2240-EB shield is connected to the nRF54LS05 Development Kit Expansion Board Header.
+ *
+ * Important:
+ * On the nRF54LS05 Development Kit pins C0 (P1.04) and C1 (P1.05) are connected to the
+ * UART1 of the debugger chip to the nRF54LS05. The UART1 function (VCOM1) of
+ * the debugger chip must be disabled to allow the pins to be used as FEM control
+ * signals and FEM I2C interface. The "Board Configurator" tool
+ * (https://docs.nordicsemi.com/r/bundle/nrf-connect-for-desktop/page/board-configurator-app)
+ * being part of the "nRF Connect for Desktop" bundle can be used for this purpose.
+ */
+
 / {
 	nrf_radio_fem: nrf2240_fem {
 		compatible = "nordic,nrf2240-fem";
-		cs-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
-		md-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
-		pwrmd-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		md-gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
+		pwrmd-gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
 		twi-if = <&nrf_radio_fem_twi>;
 	};
 };
 
-&i2c30 {
+&i2c21 {
 	status = "okay";
 
-	pinctrl-0 = <&i2c30_default>;
-	pinctrl-1 = <&i2c30_sleep>;
+	pinctrl-0 = <&i2c21_default>;
+	pinctrl-1 = <&i2c21_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	nrf_radio_fem_twi: nrf2240_fem_twi@30 {
@@ -54,18 +65,18 @@
 };
 
 &pinctrl {
-	i2c30_default: i2c30_default {
+	i2c21_default: i2c21_default {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 0, 4)>,
-				<NRF_PSEL(TWIM_SCL, 0, 3)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
+				<NRF_PSEL(TWIM_SCL, 1, 4)>;
 			bias-pull-up;
 		};
 	};
 
-	i2c30_sleep: i2c30_sleep {
+	i2c21_sleep: i2c21_sleep {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 0, 4)>,
-				<NRF_PSEL(TWIM_SCL, 0, 3)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 3)>,
+				<NRF_PSEL(TWIM_SCL, 1, 4)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Add a board-specific device tree overlay for connecting the nRF2240-EB shield to the nRF54LS05 Development Kit expansion board header. The nRF54LS05 DK uses different FEM control GPIOs and an I2C21 bus on port 1 (P1.03/P1.04) instead of the gpio0/i2c30 mapping shared by nRF54L15 and nRF54LC10, so this overlay is standalone and does not include nrf54l_common.overlay.

Related ticket:
- KRKNWK-22243