### PR TITLE
scripts: ci: Add PSA-Arch-Test to allow list license check

### DIFF
--- a/scripts/ci/license_allow_list.yaml
+++ b/scripts/ci/license_allow_list.yaml
@@ -60,6 +60,7 @@ any: |
 # Allow different licenses from external sources
 LicenseRef-west-ncs-sbom-iperf-BSD-3-Clause: "^nrf/ext/"
 Apache-2.0: |
+  ^modules/tee/tf-m/psa-arch-tests/
   ^modules/tee/tf-m/trusted-firmware-m/
   ^nrf/ext/
   ^nrf/.clang-format
@@ -95,6 +96,7 @@ MIT: |
   "^nrf/ext/"
   ^nrf/doc/_doxygen/doxygen-awesome.css
 BSD-3-CLAUSE: |
+  ^modules/tee/tf-m/psa-arch-tests/
   ^modules/tee/tf-m/trusted-firmware-m/
   ^nrf/ext/
   ^nrf/drivers/wifi/nrf71/


### PR DESCRIPTION
Add allow listing for the PSA-Arch-Test module for the license to allow for BSD, APACHE 2.0 and APACHE-2.0 and GPL-2.0 Dual licenses.