### PR TITLE
samples: wifi: thread_coex: fix stack overflow during Thread joiner

### DIFF
--- a/samples/wifi/thread_coex/prj.conf
+++ b/samples/wifi/thread_coex/prj.conf
@@ -128,3 +128,7 @@ CONFIG_OT_ROLE_CLIENT=y
 CONFIG_OPENTHREAD_L2_LOG_LEVEL_OFF=y
 CONFIG_IEEE802154_DRIVER_LOG_LEVEL_OFF=y
 CONFIG_NET_PKT_LOG_LEVEL_OFF=y
+
+# Joiner + PSA crypto on the OpenThread workqueue overflows the default
+# stack size when Wi-Fi and Thread coexistence (MPSL_CX) are active.
+CONFIG_OPENTHREAD_THREAD_STACK_SIZE=10240


### PR DESCRIPTION
[SHEL-4357] Set CONFIG_OPENTHREAD_THREAD_STACK_SIZE to 10240. The OpenThread workqueue overflows during joiner + PSA crypto when Wi-Fi and Thread coexistence (MPSL_CX) are active.

[SHEL-4357]: https://nordicsemi.atlassian.net/browse/SHEL-4357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ