### PR TITLE
tests: subsys: ipc: Enable ipc_reconnect on nrf9251dk

### DIFF
--- a/tests/subsys/ipc/ipc_reconnect/Kconfig.sysbuild
+++ b/tests/subsys/ipc/ipc_reconnect/Kconfig.sysbuild
@@ -15,5 +15,6 @@ config REMOTE_BOARD
 	default "$(BOARD)/nrf54lv10a/cpuflpr" if SOC_NRF54LV10A_CPUAPP
 	default "$(BOARD)/nrf54lc10a/cpuflpr" if SOC_NRF54LC10A_CPUAPP
 	default "$(BOARD)/nrf7120/cpuflpr" if SOC_NRF7120_ENGA_CPUAPP
+	default "$(BOARD)/nrf9251/cpuflpr" if SOC_NRF9251_CPUAPP
 
 source "share/sysbuild/Kconfig"

--- a/tests/subsys/ipc/ipc_reconnect/boards/nrf9251dk_nrf9251_cpuapp.overlay
+++ b/tests/subsys/ipc/ipc_reconnect/boards/nrf9251dk_nrf9251_cpuapp.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+ipc0: &cpuapp_cpuflpr_ipc {
+	status = "okay";
+	unbound = "enable";
+};
+
+&cpuflpr_vevif {
+	status = "okay";
+};

--- a/tests/subsys/ipc/ipc_reconnect/boards/nrf9251dk_nrf9251_cpuapp_icbmsg.overlay
+++ b/tests/subsys/ipc/ipc_reconnect/boards/nrf9251dk_nrf9251_cpuapp_icbmsg.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+ipc0: &cpuapp_cpuflpr_ipc {
+	compatible = "zephyr,ipc-icbmsg";
+	tx-blocks = <16>;
+	rx-blocks = <18>;
+	status = "okay";
+	unbound = "enable";
+};
+
+&cpuflpr_vevif {
+	status = "okay";
+};

--- a/tests/subsys/ipc/ipc_reconnect/remote/boards/nrf9251dk_nrf9251_cpuflpr.overlay
+++ b/tests/subsys/ipc/ipc_reconnect/remote/boards/nrf9251dk_nrf9251_cpuflpr.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+ipc0: &cpuapp_cpuflpr_ipc {
+	status = "okay";
+	unbound = "enable";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};
+
+&cpuflpr_vevif {
+	status = "okay";
+};
+
+&uart120 {
+	/delete-property/ hw-flow-control;
+};

--- a/tests/subsys/ipc/ipc_reconnect/remote/boards/nrf9251dk_nrf9251_cpuflpr_icbmsg.overlay
+++ b/tests/subsys/ipc/ipc_reconnect/remote/boards/nrf9251dk_nrf9251_cpuflpr_icbmsg.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+ipc0: &cpuapp_cpuflpr_ipc {
+	compatible = "zephyr,ipc-icbmsg";
+	tx-blocks = <18>;
+	rx-blocks = <16>;
+	status = "okay";
+	unbound = "enable";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};
+
+&cpuflpr_vevif {
+	status = "okay";
+};
+
+&uart120 {
+	/delete-property/ hw-flow-control;
+};

--- a/tests/subsys/ipc/ipc_reconnect/testcase.yaml
+++ b/tests/subsys/ipc/ipc_reconnect/testcase.yaml
@@ -52,6 +52,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
@@ -65,6 +66,7 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf7120dk/nrf7120/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:


### PR DESCRIPTION
Add overlays required to run the ipc_reconnect test on nrf9251dk/nrf9251/cpuapp platform.