### PR TITLE
[Backport v3.4-branch] samples: bluetooth: peripheral_nfc_pairing: revert LC10 and LV10 support

### DIFF
--- a/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
+++ b/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
@@ -21,10 +21,6 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp/ns
-      - nrf54lc10dk/nrf54lc10a/cpuapp
-      - nrf54lc10dk/nrf54lc10a/cpuapp/ns
     tags:
       - bluetooth
       - ci_build


### PR DESCRIPTION
Backport 5051094d4c786797eafefeb00ac0695661268649 from #29476.