### PR TITLE
tests: drivers: gpio: Enable gpio_more_loops on nrf9251 FLPR

### DIFF
--- a/tests/drivers/gpio/gpio_more_loops/boards/nrf9251dk_nrf9251_cpuflpr.overlay
+++ b/tests/drivers/gpio/gpio_more_loops/boards/nrf9251dk_nrf9251_cpuflpr.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/* Test requirements:
+	 * out-gpios[0] wire connected with in-gpios[0],
+	 * out-gpios[1] wire connected with in-gpios[1],
+	 * etc.
+	 * Output-input GPIO pair must have identical active level flag.
+	 */
+	test_gpios {
+		compatible = "gpio-leds";
+
+		out_gpios: out_gpios {
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>, <&gpio1 0 GPIO_ACTIVE_HIGH>,
+				<&gpio1 2 GPIO_ACTIVE_HIGH>, <&gpio2 1 GPIO_ACTIVE_HIGH>,
+				<&gpio2 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		in_gpios: in_gpios {
+			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>, <&gpio1 1 GPIO_ACTIVE_HIGH>,
+				<&gpio1 4 GPIO_ACTIVE_HIGH>, <&gpio2 2 GPIO_ACTIVE_HIGH>,
+				<&gpio2 9 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpiote130 {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_more_loops/testcase.yaml
+++ b/tests/drivers/gpio/gpio_more_loops/testcase.yaml
@@ -32,6 +32,7 @@ tests:
       - nrf54lc10dk/nrf54lc10a/cpuflpr
       - nrf7120dk/nrf7120/cpuapp
       - nrf9251dk/nrf9251/cpuapp
+      - nrf9251dk/nrf9251/cpuflpr
       - nrf9251dk/nrf9251/cpuppr
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/drivers/gpio/gpio_nfct/boards/nrf9251dk_nrf9251_cpuflpr.overlay
+++ b/tests/drivers/gpio/gpio_nfct/boards/nrf9251dk_nrf9251_cpuflpr.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/* Test requirements:
+	 * NFC antenna connected to the DK.
+	 */
+	test_gpios {
+		compatible = "gpio-leds";
+
+		out_gpios: out_gpios {
+			gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		in_gpios: in_gpios {
+			gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&nfct {
+	status = "disabled";
+	nfct-pins-as-gpios;
+};
+
+&gpiote130 {
+	status = "okay";
+	owned-channels = <7>;
+};
+
+&gpio1 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_nfct/testcase.yaml
+++ b/tests/drivers/gpio/gpio_nfct/testcase.yaml
@@ -22,6 +22,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf7120dk/nrf7120/cpuapp
       - nrf9251dk/nrf9251/cpuapp
+      - nrf9251dk/nrf9251/cpuflpr
       - nrf9251dk/nrf9251/cpuppr
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/drivers/timer/grtc_multiple_access/boards/nrf9251dk_nrf9251_cpuflpr.overlay
+++ b/tests/drivers/timer/grtc_multiple_access/boards/nrf9251dk_nrf9251_cpuflpr.overlay
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: LicenseRef-Nordic-5-Clause */
+
+&grtc {
+	owned-channels = <5 6>;
+};

--- a/tests/drivers/timer/grtc_multiple_access/testcase.yaml
+++ b/tests/drivers/timer/grtc_multiple_access/testcase.yaml
@@ -18,6 +18,7 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf9251dk/nrf9251/cpuapp
+      - nrf9251dk/nrf9251/cpuflpr
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     harness_config:

--- a/tests/zephyr/drivers/timer/nrf_grtc_timer/boards/nrf9251dk_nrf9251_cpuflpr.overlay
+++ b/tests/zephyr/drivers/timer/nrf_grtc_timer/boards/nrf9251dk_nrf9251_cpuflpr.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&grtc {
+	owned-channels = <5 6>;
+};

--- a/tests/zephyr/drivers/timer/nrf_grtc_timer/testcase.yaml
+++ b/tests/zephyr/drivers/timer/nrf_grtc_timer/testcase.yaml
@@ -10,6 +10,7 @@ common:
     - nrf54lc10dk/nrf54lc10a/cpuapp
     - nrf54lc10dk/nrf54lc10a/cpuflpr
     - nrf9251dk/nrf9251/cpuapp
+    - nrf9251dk/nrf9251/cpuflpr
     - nrf9251dk/nrf9251/cpuppr
   integration_platforms:
     - nrf54ls05dk/nrf54ls05b/cpuapp

--- a/tests/zephyr/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/zephyr/kernel/timer/timer_behavior/testcase.yaml
@@ -12,6 +12,7 @@ tests:
       - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp/ns
       - nrf9251dk/nrf9251/cpuapp
+      - nrf9251dk/nrf9251/cpuflpr/xip
       - nrf9251dk/nrf9251/cpuppr/xip
     integration_platforms:
       - nrf54ls05dk/nrf54ls05b/cpuapp


### PR DESCRIPTION
Add overlay required to run the gpio_more_loops test on nrf9251dk/nrf9251/cpuflpr.