### PR TITLE
applications: nrf_desktop: Go to SCI LOW_POWER on power down

### DIFF
--- a/applications/nrf_desktop/doc/ble_latency.rst
+++ b/applications/nrf_desktop/doc/ble_latency.rst
@@ -43,7 +43,9 @@ This speeds up sending the first HID report after not sending a report for some 
 Enabling this option increases the power consumption - the connection latency is kept low unless the device is in the low power mode.
 
 You can use the :option:`CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS` Kconfig option to enable or disable handling of the power management events, such as :c:struct:`power_down_event` and :c:struct:`wake_up_event`.
-The option is enabled by default and depends on the :kconfig:option:`CONFIG_CAF_PM_EVENTS` Kconfig option.
+The option depends on the :kconfig:option:`CONFIG_CAF_PM_EVENTS` Kconfig option.
+It is enabled by default when either :option:`CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK` or :option:`CONFIG_DESKTOP_BLE_LATENCY_HID_SCI_ENABLE` is selected.
+Without one of these options, there is no power-management behavior for the module to apply to these events.
 
 When the :option:`CONFIG_DESKTOP_HIDS_SCI_ENABLE` Kconfig option is enabled in the :ref:`nrf_desktop_hids`, the |ble_latency| sets the promptless :option:`CONFIG_DESKTOP_BLE_LATENCY_HID_SCI_ENABLE` Kconfig option.
 With this option set, the module handles HID SCI mode change requests and adjusts connection latency using the connection rate API.
@@ -111,6 +113,18 @@ The module listens for the following SCI-related events:
 When an SCI mode other than NONE is active, the module adjusts the peripheral latency within the limits of the active mode in response to the same data transfer events as in the non-SCI case (:c:struct:`config_event` and :c:struct:`ble_smp_transfer_event`).
 The module skips the latency update request if the maximum latency configured for the active SCI mode is zero, because such a request would have no effect.
 
+Power down and wake up
+----------------------
+
+When the :option:`CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS` Kconfig option is enabled, the module reacts to the power management events.
+
+On a :c:struct:`power_down_event`, the module requests the LOW_POWER mode.
+On a :c:struct:`wake_up_event`, the module restores the last SCI mode requested by the host through the HID Control Point characteristic.
+If the connection is in the out-of-spec state described in :ref:`nrf_desktop_ble_latency_sci_host_updates`, the module does not change SCI mode in response to power management events.
+
+If the host requests a mode other than LOW_POWER while the device is suspended, the module will save the requested mode but will remain in the LOW_POWER SCI mode.
+On wake up, the module will restore the saved mode.
+
 Pending SCI mode and latency updates
 ------------------------------------
 
@@ -162,4 +176,9 @@ In order to return to the normal operation, the host must:
 
 1. Update the connection rate parameters to a range allowing to support all the HID SCI modes.
 2. Request an HID SCI mode change through the HID Control Point characteristic.
-   As a result, the Bluetooth LE latency module requests a matching connection rate update and clears the out-of-spec host-initiated transport parameter update state.
+   As a result, the Bluetooth LE latency module requests a matching connection rate update and clears the out-of-spec host-initiated transport parameter update state if the request succeeds.
+   If the current connection parameters are already valid for the requested mode, the module clears the out-of-spec state but no connection rate update is requested.
+
+   .. note::
+      If the peripheral is in suspended/power-down state, the module will save the requested mode and attempt to request LOW_POWER mode parameters.
+      Only if this succeeds, the peripheral will exit the out-of-spec state.

--- a/applications/nrf_desktop/src/modules/Kconfig.ble_latency
+++ b/applications/nrf_desktop/src/modules/Kconfig.ble_latency
@@ -45,7 +45,8 @@ config DESKTOP_BLE_LOW_LATENCY_LOCK
 config DESKTOP_BLE_LATENCY_PM_EVENTS
 	bool "Power management events support"
 	depends on CAF_PM_EVENTS
-	default y
+	default y if DESKTOP_BLE_LOW_LATENCY_LOCK
+	default y if DESKTOP_BLE_LATENCY_HID_SCI_ENABLE
 	help
 	  React on power management events in BLE latency module.
 

--- a/applications/nrf_desktop/src/modules/ble_latency.c
+++ b/applications/nrf_desktop/src/modules/ble_latency.c
@@ -43,12 +43,14 @@ enum {
 	CONN_IS_SECURED			= BIT(5),
 	CONN_IS_SCI_PARAM_UPDATE_PENDING = BIT(6),
 	CONN_IS_SCI_OUT_OF_SPEC	= BIT(7),
+	CONN_IS_POWER_DOWN		= BIT(8),
 };
 
-static uint8_t latency_state;
+static uint16_t latency_state;
 
 static enum bt_hids_sci_mode_value processed_sci_mode = BT_HIDS_SCI_MODE_NONE;
 static enum bt_hids_sci_mode_value last_requested_sci_mode = BT_HIDS_SCI_MODE_NONE;
+static enum bt_hids_sci_mode_value host_requested_sci_mode = BT_HIDS_SCI_MODE_NONE;
 static bool last_requested_latency_is_low;
 
 static void security_timeout_fn(struct k_work *w)
@@ -355,6 +357,21 @@ static void hid_sci_mode_request(enum bt_hids_sci_mode_value mode)
 
 	__ASSERT_NO_MSG(mode != BT_HIDS_SCI_MODE_NONE);
 
+	if (latency_state & CONN_IS_POWER_DOWN) {
+		/* Force the SCI mode to LOW_POWER if the peripheral is in power down/suspended
+		 * state, regardless of the HID SCI mode requested by the host.
+		 * Usually in this case the peripheral will already be in the LOW_POWER SCI mode,
+		 * so the code below will result in no connection rate update and no SCI mode change
+		 * notification to the host.
+		 * The notable exception is if the peripheral is operating in an out-of-spec state,
+		 * due to a previous direct connection rate update from the host.
+		 * In this case, the current mode might be different - an attempt will be made to
+		 * switch to the LOW_POWER mode, and only if it succeeds, the peripheral will exit
+		 * the out-of-spec state.
+		 */
+		mode = BT_HIDS_SCI_MODE_LOW_POWER;
+	}
+
 	last_requested_sci_mode = mode;
 	/* Once the host issues a HID SCI mode request or uses the connection
 	 * rate API to set the connection parameters, the peripheral switches
@@ -612,6 +629,27 @@ static void conn_rate_updated(const struct ble_peer_sci_conn_rate_event *event)
 	}
 }
 
+static void sci_power_event_handle(void)
+{
+	if (!active_conn) {
+		return;
+	}
+
+	if (latency_state & CONN_IS_SCI_OUT_OF_SPEC) {
+		return;
+	}
+
+	__ASSERT_NO_MSG(latency_state & CONN_IS_SCI);
+
+	if (latency_state & CONN_IS_POWER_DOWN) {
+		hid_sci_mode_request(BT_HIDS_SCI_MODE_LOW_POWER);
+	} else if (host_requested_sci_mode != BT_HIDS_SCI_MODE_NONE) {
+		hid_sci_mode_request(host_requested_sci_mode);
+	} else {
+		/* Do nothing. */
+	}
+}
+
 static void init(void)
 {
 	k_work_init_delayable(&security_timeout, security_timeout_fn);
@@ -673,6 +711,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 			if (IS_ENABLED(CONFIG_DESKTOP_BLE_LATENCY_HID_SCI_ENABLE)) {
 				processed_sci_mode = BT_HIDS_SCI_MODE_NONE;
 				last_requested_sci_mode = BT_HIDS_SCI_MODE_NONE;
+				host_requested_sci_mode = BT_HIDS_SCI_MODE_NONE;
 			}
 
 			/* Cancel cannot fail if executed from another work's context. */
@@ -724,6 +763,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 			return true;
 		}
 
+		host_requested_sci_mode = event->mode;
 		hid_sci_mode_request(event->mode);
 
 		return false;
@@ -736,25 +776,46 @@ static bool app_event_handler(const struct app_event_header *aeh)
 		return false;
 	}
 
-	if (IS_ENABLED(CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK) &&
-	    IS_ENABLED(CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS) &&
+	if (IS_ENABLED(CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS) &&
 	    is_power_down_event(aeh)) {
 		const struct power_down_event *event =
 			cast_power_down_event(aeh);
 
-		if (!event->error) {
+		if (event->error) {
+			return false;
+		}
+
+		latency_state |= CONN_IS_POWER_DOWN;
+
+		if (IS_ENABLED(CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK) &&
+		    !(latency_state & CONN_IS_SCI)) {
 			latency_state &= ~CONN_LOW_LATENCY_LOCKED;
 			update_llpm_conn_latency_lock();
+		} else if (IS_ENABLED(CONFIG_DESKTOP_BLE_LATENCY_HID_SCI_ENABLE) &&
+			   (latency_state & CONN_IS_SCI)) {
+			sci_power_event_handle();
+		} else {
+			/* No handling of the power down event is needed. */
 		}
 
 		return false;
 	}
 
-	if (IS_ENABLED(CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK) &&
-	    IS_ENABLED(CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS) &&
+	if (IS_ENABLED(CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS) &&
 	    is_wake_up_event(aeh)) {
-		latency_state |= CONN_LOW_LATENCY_LOCKED;
-		update_llpm_conn_latency_lock();
+
+		latency_state &= ~CONN_IS_POWER_DOWN;
+
+		if (IS_ENABLED(CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK) &&
+		    !(latency_state & CONN_IS_SCI)) {
+			latency_state |= CONN_LOW_LATENCY_LOCKED;
+			update_llpm_conn_latency_lock();
+		} else if (IS_ENABLED(CONFIG_DESKTOP_BLE_LATENCY_HID_SCI_ENABLE) &&
+			   (latency_state & CONN_IS_SCI)) {
+			sci_power_event_handle();
+		} else {
+			/* No handling of the wake up event is needed. */
+		}
 
 		return false;
 	}
@@ -779,7 +840,7 @@ APP_EVENT_SUBSCRIBE(MODULE, ble_smp_transfer_event);
 #if CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE
 APP_EVENT_SUBSCRIBE_EARLY(MODULE, config_event);
 #endif
-#if CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK && CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS
+#ifdef CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS
 APP_EVENT_SUBSCRIBE(MODULE, power_down_event);
 APP_EVENT_SUBSCRIBE(MODULE, wake_up_event);
 #endif


### PR DESCRIPTION
Add power-down handling for nrf_desktop HID SCI peripherals. On power_down_event, request LOW_POWER SCI mode; on wake_up_event, restore the last host-requested mode.