### PR TITLE
boards: nordic: nrf9251dk: define ram region for nrf92 flpr

### DIFF
--- a/boards/nordic/nrf9251dk/nrf9251dk_nrf9251_cpuapp.dts
+++ b/boards/nordic/nrf9251dk/nrf9251dk_nrf9251_cpuapp.dts
@@ -85,7 +85,7 @@
 };
 
 &cpuflpr_vpr {
-	execution-memory = <&cpuflpr_tcm_sram>;
+	execution-memory = <&cpuflpr_code_data>;
 	source-memory = <&cpuflpr_code_partition>;
 };
 

--- a/boards/nordic/nrf9251dk/nrf9251dk_nrf9251_cpuflpr.dts
+++ b/boards/nordic/nrf9251dk/nrf9251dk_nrf9251_cpuflpr.dts
@@ -27,7 +27,7 @@
 		zephyr,console = &uart120;
 		zephyr,code-partition = &cpuflpr_code_partition;
 		zephyr,flash = &mram1x;
-		zephyr,sram = &cpuflpr_tcm_sram;
+		zephyr,sram = &cpuflpr_code_data;
 	};
 };
 

--- a/dts/common/nordic/nrf9251dk_nrf9251-memory_map.dtsi
+++ b/dts/common/nordic/nrf9251dk_nrf9251-memory_map.dtsi
@@ -47,6 +47,10 @@
 			reg = <0x2f88fd00 0x200>;
 		};
 
+		cpuflpr_code_data: memory@2f890000 {
+			reg = <0x2f890000 DT_SIZE_K(46)>;
+		};
+
 		cpuapp_cpuflpr_ipc_shm: memory@2f89b800 {
 			reg = <0x2f89b800 DT_SIZE_K(1)>;
 		};


### PR DESCRIPTION
Define flpr core memory used as ram (for code execution). Other section of RAM is used as buffers,
thus not usable for stacks etc.