### PR TITLE
[Backport v3.4-branch] nrf_security: Simplify and fix Cracen PK memory alignments

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/common/include/cracen/membarriers.h
+++ b/subsys/nrf_security/src/drivers/cracen/common/include/cracen/membarriers.h
@@ -40,20 +40,10 @@ static inline void cmb(void)
  */
 static inline void wmb(void)
 {
-#ifdef __aarch64__
-	__asm__ volatile("dsb sy;" ::: "memory");
-#elif defined(__amd64__)
-	__asm__ volatile("sfence;" ::: "memory");
-#else
-	/* CUSTOMIZATION: implement CPU specific memory barrier if it has any.
-	 * Use at least a compiler memory barrier.
-	 */
-
 	/* Cortex-M33 does not support wmb, but cmb/DMB is more
 	 * restrictive and therefore safe to use.
 	 */
 	cmb();
-#endif
 }
 
 /** CPU read memory barrier.
@@ -66,20 +56,10 @@ static inline void wmb(void)
  */
 static inline void rmb(void)
 {
-#ifdef __aarch64__
-	__asm__ volatile("dsb sy;" ::: "memory");
-#elif defined(__amd64__)
-	__asm__ volatile("lfence;" ::: "memory");
-#else
-	/* CUSTOMIZATION: implement CPU specific memory barrier if it has any.
-	 * Use at least a compiler memory barrier.
-	 */
-
 	/* Cortex-M33 does not support rmb, but cmb/DMB is more
 	 * restrictive and therefore safe to use.
 	 */
 	cmb();
-#endif
 }
 
 /** @} */

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/include/silexpk/iomem.h
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/include/silexpk/iomem.h
@@ -67,14 +67,7 @@ void sx_wrpkmem_byte(void *dst, uint8_t input_byte);
  * @param[in] src Source of read operation
  * @param[in] sz The number of bytes to read from src to dst
  */
-#if !defined(CONFIG_PSA_NEED_CRACEN_MEMORY_ACCESS_WORKAROUND)
-static inline void sx_rdpkmem(void *dst, const void *src, size_t sz)
-{
-	memcpy(dst, src, sz);
-}
-#else
 void sx_rdpkmem(void *dst, const void *src, size_t sz);
-#endif
 
 /** Read a byte from device memory at src.
  *

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/src/iomem.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/src/iomem.c
@@ -13,52 +13,51 @@
 
 #define PTR_ALIGNMENT(ptr, type)	(((uintptr_t)ptr) & (sizeof(type) - 1))
 #define IS_NATURAL_ALIGNED(ptr, type)	!PTR_ALIGNMENT(ptr, type)
-#define IS_SAME_ALIGNMENT(p1, p2, type) (PTR_ALIGNMENT(p1, type) == PTR_ALIGNMENT(p2, type))
-#define MASK_TO_NATURAL_SIZE(sz, type)	((sz) & (~((sizeof(type) << 1) - 1)))
 
 void sx_clrpkmem(void *dst, size_t sz)
 {
-	typedef int64_t clrblk_t;
-	volatile uint8_t *dst_ptr = (volatile uint8_t *)dst;
+	uint8_t *dst_ptr = (uint8_t *)dst;
 
-	if (sz == 0) {
-		return;
-	}
-
-	while (sz && (!IS_NATURAL_ALIGNED(dst_ptr, clrblk_t))) {
-		*dst_ptr = 0;
+	/* Align start address since PK memory is device memory */
+	while (sz && !IS_NATURAL_ALIGNED(dst_ptr, uint32_t)) {
+		*(volatile uint8_t *)dst_ptr = 0;
 		dst_ptr++;
 		sz--;
 	}
 
-	memset((uint8_t *)dst_ptr, 0, MASK_TO_NATURAL_SIZE(sz, clrblk_t));
-	dst_ptr += MASK_TO_NATURAL_SIZE(sz, clrblk_t);
-	sz -= MASK_TO_NATURAL_SIZE(sz, clrblk_t);
-
-	while (sz) {
-		*dst_ptr = 0;
-		dst_ptr++;
-		sz--;
-	}
+	memset(dst_ptr, 0, sz);
 }
-
-struct uchunk {
-	int64_t a[2];
-};
-typedef struct uchunk tfrblk;
 
 void sx_wrpkmem(void *dst, const void *src, size_t sz)
 {
-	volatile uint8_t *dst_ptr = (volatile uint8_t *)dst;
-	volatile const uint8_t *src_ptr = (volatile const uint8_t *)src;
+	uint8_t *dst_ptr = (uint8_t *)dst;
+	const uint8_t *src_ptr = (const uint8_t *)src;
 
-	while (sz && !IS_NATURAL_ALIGNED(dst_ptr, tfrblk)) {
-		*dst_ptr = *src_ptr;
+	/* Align start address since PK memory is device memory */
+	while (sz && !IS_NATURAL_ALIGNED(dst_ptr, uint32_t)) {
+		*(volatile uint8_t *)dst_ptr = *src_ptr;
 		dst_ptr++;
 		src_ptr++;
 		sz--;
 	}
-	memcpy((uint8_t *)dst_ptr, (uint8_t *)src_ptr, sz);
+
+	memcpy(dst_ptr, src_ptr, sz);
+}
+
+void sx_rdpkmem(void *dst, const void *src, size_t sz)
+{
+	uint8_t *dst_ptr = (uint8_t *)dst;
+	const uint8_t *src_ptr = (const uint8_t *)src;
+
+	/* Align start address since PK memory is device memory */
+	while (sz && !IS_NATURAL_ALIGNED(src_ptr, uint32_t)) {
+		*dst_ptr = *(const volatile uint8_t *)src_ptr;
+		dst_ptr++;
+		src_ptr++;
+		sz--;
+	}
+
+	memcpy(dst_ptr, src_ptr, sz);
 }
 
 #else /* 54LM20A requires word-aligned, word-sized memory accesses */

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/src/iomem.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/src/iomem.c
@@ -15,11 +15,6 @@
 #define IS_NATURAL_ALIGNED(ptr, type)	!PTR_ALIGNMENT(ptr, type)
 #define IS_SAME_ALIGNMENT(p1, p2, type) (PTR_ALIGNMENT(p1, type) == PTR_ALIGNMENT(p2, type))
 #define MASK_TO_NATURAL_SIZE(sz, type)	((sz) & (~((sizeof(type) << 1) - 1)))
-#if defined(__aarch64__)
-#define IS_NATURAL_SIZE(sz, type) !((sz) & (sizeof(type) - 1))
-#else
-#define IS_NATURAL_SIZE(sz, type) 1
-#endif
 
 void sx_clrpkmem(void *dst, size_t sz)
 {
@@ -36,12 +31,10 @@ void sx_clrpkmem(void *dst, size_t sz)
 		sz--;
 	}
 
-#if !defined(__aarch64__)
 	memset((uint8_t *)dst_ptr, 0, MASK_TO_NATURAL_SIZE(sz, clrblk_t));
 	dst_ptr += MASK_TO_NATURAL_SIZE(sz, clrblk_t);
 	sz -= MASK_TO_NATURAL_SIZE(sz, clrblk_t);
 
-#endif
 	while (sz) {
 		*dst_ptr = 0;
 		dst_ptr++;
@@ -52,16 +45,14 @@ void sx_clrpkmem(void *dst, size_t sz)
 struct uchunk {
 	int64_t a[2];
 };
-
 typedef struct uchunk tfrblk;
-#define tfrblksz sizeof(tfrblk)
 
 void sx_wrpkmem(void *dst, const void *src, size_t sz)
 {
 	volatile uint8_t *dst_ptr = (volatile uint8_t *)dst;
 	volatile const uint8_t *src_ptr = (volatile const uint8_t *)src;
 
-	while (sz && (!IS_NATURAL_ALIGNED(dst_ptr, tfrblk) || !IS_NATURAL_SIZE(sz, tfrblk))) {
+	while (sz && !IS_NATURAL_ALIGNED(dst_ptr, tfrblk)) {
 		*dst_ptr = *src_ptr;
 		dst_ptr++;
 		src_ptr++;


### PR DESCRIPTION
Backport a21b98d4545891e762c9b696639f5584c20cedbf~2..a21b98d4545891e762c9b696639f5584c20cedbf from #30561.