### PR TITLE
net: lib: nrf_cloud: omit JWT sub only for modem JWT UUID IDs

### DIFF
--- a/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_jwt.c
+++ b/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_jwt.c
@@ -229,9 +229,10 @@ int nrf_cloud_jwt_generate(uint32_t time_valid_s, char *const jwt_buf, size_t jw
 		exp_delta_s = NRF_CLOUD_JWT_VALID_TIME_S_DEF;
 	}
 
-	if (IS_ENABLED(CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID) ||
-	    IS_ENABLED(CONFIG_NRF_CLOUD_CLIENT_ID_SRC_MDM_DEVICE_UUID)) {
-		/* The UUID is present in the iss claim, so there is no need
+	if (!IS_ENABLED(CONFIG_NRF_CLOUD_JWT_SOURCE_CUSTOM) &&
+	    (IS_ENABLED(CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID) ||
+	     IS_ENABLED(CONFIG_NRF_CLOUD_CLIENT_ID_SRC_MDM_DEVICE_UUID))) {
+		/* The UUID is present in the modem JWT iss claim, so there is no need
 		 * to also include it in the sub claim.
 		 */
 		subject = NULL;


### PR DESCRIPTION
Only omit sub for UUID IDs when modem JWT is used and custom JWT is not. 084d67b skipped sub for all UUID client IDs, but iss is only set by modem JWT. With CONFIG_NRF_CLOUD_JWT_SOURCE_CUSTOM, app_jwt needs sub to identify the device, breaking dect_shell CoAP auth.