### PR TITLE
sysbuild: Allow building NSIB and MCUboot with support for dropping MCUboot image header on transfer to s0/s1 slot

### DIFF
--- a/cmake/sysbuild/b0_mcuboot_signing.cmake
+++ b/cmake/sysbuild/b0_mcuboot_signing.cmake
@@ -63,7 +63,7 @@ function(ncs_secure_boot_mcuboot_sign application bin_files signed_targets prefi
   # image makes no sense, so the --header-size=auto will be used.
 
   # Do not bother picking header size from image that is for CPUNET
-  if("${prefix}" STREQUAL "CPUNET_")
+  if("${prefix}" STREQUAL "CPUNET_" OR SB_CONFIG_SECURE_BOOT_MCUBOOT_DISCARDS_MCUBOOT_IMAGE_HEADER)
     set(header_size auto)
   else()
     sysbuild_get(header_size IMAGE ${application} VAR CONFIG_ROM_START_OFFSET KCONFIG)
@@ -83,7 +83,7 @@ function(ncs_secure_boot_mcuboot_sign application bin_files signed_targets prefi
   # CPUNET targets are special case and they require padding for either configuration,
   # as the header is not included neither in PM nor DTS builds and image starts exactly at
   # partition start address.
-  if("${prefix}" STREQUAL "CPUNET_")
+  if("${prefix}" STREQUAL "CPUNET_" OR SB_CONFIG_SECURE_BOOT_MCUBOOT_DISCARDS_MCUBOOT_IMAGE_HEADER)
     set(pad_header --pad-header)
   else()
     set(pad_header)

--- a/cmake/sysbuild/sign.cmake
+++ b/cmake/sysbuild/sign.cmake
@@ -88,7 +88,7 @@ function(b0_sign_image slot cpunet_target)
 
   if(NOT SB_CONFIG_BOOTLOADER_MCUBOOT)
     set(skip_size 0)
-  elseif(cpunet_target)
+  elseif(cpunet_target OR SB_CONFIG_SECURE_BOOT_MCUBOOT_DISCARDS_MCUBOOT_IMAGE_HEADER)
     set(skip_size 0)
   else()
     sysbuild_get(build_with_tfm IMAGE ${DEFAULT_IMAGE} VAR CONFIG_BUILD_WITH_TFM KCONFIG)

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -320,6 +320,16 @@ nRF Desktop
     Enable the feature with the :option:`CONFIG_DESKTOP_HIDS_SCI_ENABLE` Kconfig option.
   * The ``hid_sci`` and ``release_hid_sci`` build types for the ``nrf54l15dk/nrf54l15/cpuapp`` board target.
     The configurations act as a HID mouse peripheral with HID SCI support.
+  * The :kconfig:option:`CONFIG_NCS_MCUBOOT_DISCARDS_HEADER_IN_SECONDARY_MCUBOOT` Kconfig option that allows to drop the MCUboot image header in secondary MCUboot image update, when the update is installed to a designated slot by MCUboot.
+    If the option is off for compatibility, MCUboot cannot update itself with MCUboot that was built with the option enabled.
+    Same condition applies to NSIB that cannot boot MCUboot built with the option enabled, as it has been hardcoded to skip the header.
+    For NSIB to work with MCUboot built with the option enabled, you need to build NSIB with :kconfig:option:`CONFIG_SB_IMAGE_BOOT_OFFSET` set to ``0``, which would turn off the header skipping.
+    An NSIB + MCUboot setup discards the header.
+    You can build this setup using the sysbuild Kconfig option :kconfig:option:`SB_CONFIG_SECURE_BOOT_MCUBOOT_DISCARDS_MCUBOOT_IMAGE_HEADER`.
+
+    .. note::
+       The header is still added for DFU as MCUboot requires it for processing the image.
+       It is the minimum allowed header, which slightly reduces the DFU size of the MCUboot image, for example by 2016 bytes for nRF54L devices, and increases the partition size available for an MCUBoot executable.
 
 * Removed:
 

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -16,12 +16,15 @@ config SECURE_BOOT
 	  Set this option to enable the first stage bootloader which
 	  verifies the signature of the app.
 
+
 config SB_IMAGE_BOOT_OFFSET
-	hex
+	hex "Offset of executable code within firmware image"
 	default 0x800 if SOC_SERIES_NRF54L
 	default 0x200 if SOC_SERIES_NRF53 || SOC_SERIES_NRF91
 	default 0x200 if SOC_SERIES_NRF52
+	default 0
 	help
+	  Sysbuild, when used, will enforce the value by own logic in CMake files.
 	  Size of offset, from the beginning of storage partition, or __rom_start,
 	  where to application code begins. This is usually size of non-executable
 	  header that precedes the entry point and is not used by the applicaiton

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -615,6 +615,28 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
       set_config_bool(mcuboot CONFIG_SECURE_BOOT y)
       set_config_bool(mcuboot CONFIG_FW_INFO y)
 
+      # Discardable header is glued in front of image, not part of firmware image,
+      # so there is no offset to jump to, as executable image starts at the partition
+      # starting address.
+      if(SB_CONFIG_SECURE_BOOT_MCUBOOT_DISCARDS_MCUBOOT_IMAGE_HEADER)
+        set_config_int(b0 CONFIG_SB_IMAGE_BOOT_OFFSET 0)
+        set_config_bool(mcuboot CONFIG_NCS_MCUBOOT_DISCARDS_HEADER_IN_SECONDARY_MCUBOOT y)
+        # No nice way to do this without changes to Zephyr ROM_START_OFFSET definitions.
+        # This is special case, as we have MCUboot as bootloader and at the same time
+        # we do not want the shifter binary, as we usually do with Zephyr builds for
+        # MCUboot, with space left for MCUboot image header.
+        set_config_int(mcuboot CONFIG_ROM_START_OFFSET 0)
+      else()
+        if(SB_CONFIG_SOC_SERIES_NRF53 OR SB_CONFIG_SOC_SERIES_NRF91 OR SB_CONFIG_SOC_SERIES_NRF52)
+          set_config_int(b0 CONFIG_SB_IMAGE_BOOT_OFFSET 0x200)
+        elseif(SB_CONFIG_SOC_SERIES_NRF54L)
+          set_config_int(b0 CONFIG_SB_IMAGE_BOOT_OFFSET 0x800)
+        else()
+          message(WARNING "Missing CONFIG_SB_IMAGE_BOOT_OFFSET setting for selected SoC")
+        endif()
+        set_config_bool(mcuboot CONFIG_NCS_MCUBOOT_DISCARDS_HEADER_IN_SECONDARY_MCUBOOT n)
+      endif()
+
       if(SB_CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256)
         if(SB_CONFIG_BOOT_SHARED_CRYPTO_ECDSA_P256)
           add_overlay_config(

--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -192,6 +192,29 @@ config SECURE_BOOT_MCUBOOT_VERSION
 	help
 	  The version of the MCUboot S0/S1 upgrade package
 
+config SECURE_BOOT_MCUBOOT_DISCARDS_MCUBOOT_IMAGE_HEADER
+	bool "Use enough space in front of image to just fit header there"
+	depends on SECURE_BOOT
+	depends on BOOTLOADER_MCUBOOT
+	help
+	  INCOMPATIBILITY WARNING: MCUboot as secondary bootloader that have been
+	  built without the option enabled will not be able to update itself
+	  with a binary built with the option enabled. NSIB will not be able to
+	  boot such MCUboot either. The entire bootchain has to be built with the
+	  option enabled. This will happen because pre-existing MCUboot, built
+	  without the option, will try to skip non-existing header while trying
+	  to verify the image with NSIB, failing the process of verification.
+	  When this option is enabled, the MCUboot for secondary bootloader is
+	  built with ROM_START_OFFSET set to 0 and NSIB has nothing to skip over.
+	  Instead the header is glued in front of the image during signing, post
+	  build,  and is left out when MCUboot does update.
+	  NSIB will now have to verify, and boot MCUBOOT image, exactly at
+	  the beginning of S0/S1 partition, which means
+	  that SB_IMAGE_BOOT_OFFSET, for Secure Bootloader, has to be set to 0 too;
+	  RWX protections no longer need to skip the leftover MCUboot image header,
+	  because it no longer occupies the beginning of partition, so
+	  SB_DISABLE_SELF_RWX_SKIP_SIZE should also be set to 0.
+
 if BOOTLOADER_MCUBOOT
 
 choice BOOT_SIGNATURE_TYPE

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
           compare-by-default: true
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: bb1c08230a1871cd7481fceb654905a159391d22
+      revision: fcf47d0d3fb36ab6d7a1e05860e93b4bb3b0d001
       path: bootloader/mcuboot
     - name: qcbor
       repo-path: sdk-qcbor


### PR DESCRIPTION
Add sysbuild  Kconfig option SECURE_BOOT_MCUBOOT_DISCARDS_MCUBOOT_IMAGE_HEADER that allows to drop MCUboot image header while updating MCUboot image in s0/s1 slot.
Save some space in s0/s1 slots and DFU image size.
Incompatible with existing builds.

Depends on https://github.com/nrfconnect/sdk-nrf/pull/30545