### PR TITLE
tests: drivers: dmic_dump_buffer: add nRF54LM20 overlays

### DIFF
--- a/tests/drivers/audio/dmic_dump_buffer/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/audio/dmic_dump_buffer/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&pinctrl {
+	pdm20_default_alt: pdm20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 1, 23)>,
+				<NRF_PSEL(PDM_DIN, 1, 14)>;
+		};
+	};
+};
+
+dmic_dev: &pdm20 {
+	status = "okay";
+	pinctrl-0 = <&pdm20_default_alt>;
+	pinctrl-names = "default";
+	clock-source = "PCLK32M";
+};
+
+&uart20 {
+	current-speed = <921600>;
+};

--- a/tests/drivers/audio/dmic_dump_buffer/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/audio/dmic_dump_buffer/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf54lm20dk_nrf54lm20a_cpuapp.overlay"

--- a/tests/drivers/audio/dmic_dump_buffer/testcase.yaml
+++ b/tests/drivers/audio/dmic_dump_buffer/testcase.yaml
@@ -16,6 +16,8 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
   drivers.audio.dmic_dump_buffer.stereo:
@@ -27,6 +29,8 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
   drivers.audio.dmic_dump_buffer.dmm:


### PR DESCRIPTION
Added overlays for nRF54LM20 A/B.