### PR TITLE
doc: matter: replace DMP platform CID table with matrix links

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -185,8 +185,12 @@
 .. _`Matter SDK tagged as v1.0.0`: https://github.com/project-chip/connectedhomeip/releases/tag/v1.0.0
 .. _`Testing with Apple Devices`: https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/darwin.md
 .. _`chip-tool`: https://docs.nordicsemi.com/bundle/ncs-latest/page/matter/chip_tool_guide.html
-.. _`Matter nRF Connect SDK Platform Certificate_1_4_2`: https://csa-iot.org/csa_product/nrf-connect-sdk/
-.. _`Matter nRF Connect SDK Platform Certificate_1_5_0`: https://csa-iot.org/csa_product/nrf-connect-sdk-with-nrf52-nrf53-and-nrf54l-series-socs/
+.. _`Matter CIDs for nRF54LM20B`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54lm20a/page/COMP/nrf54lm20a/nrf54lm20a_matter_cids.html
+.. _`Matter CIDs for nRF54LM20A`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54lm20a/page/COMP/nrf54lm20a/nrf54lm20a_matter_cids.html
+.. _`Matter CIDs for nRF54L15`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54l15/page/COMP/nrf54l15/nrf54l15_matter_cids.html
+.. _`Matter CIDs for nRF54L10`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54l10/page/COMP/nrf54l10/nrf54l10_matter_cids.html
+.. _`Matter CIDs for nRF5340`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf5340/page/COMP/nrf5340/nrf5340_matter_cids.html
+.. _`Matter CIDs for nRF52840`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf52840/page/COMP/nrf52840/nrf52840_matter_cids.html
 
 .. _`CoreMark GitHub`: https://github.com/eembc/coremark
 
@@ -929,6 +933,7 @@
 .. _`nRF54LM20A Datasheet`: https://docs.nordicsemi.com/bundle/ps_nrf54LM20A/page/keyfeatures_html5.html
 .. _`nRF54LM20 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf54lm20_dk/page/UG/nRF54LM20_DK/intro/intro.html
 .. _`nRF54LM20A Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54lm20a/page/COMP/nrf54lm20a/nrf54lm20a_comp_matrix.html
+.. _`nRF54LM20B Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54lm20a/page/COMP/nrf54lm20a/nrf54lm20a_comp_matrix.html
 
 .. _`nRF54LV10A Datasheet`: https://docs.nordicsemi.com/bundle/ps_nrf54LV10A/page/keyfeatures_html5.html
 .. _`nRF54LV10 DK User Guide`: https://docs.nordicsemi.com/bundle/ug_nrf54lv10_dk/page/UG/nRF54LV10_DK/intro/intro.html
@@ -2082,8 +2087,8 @@
 .. _`Personal Access Token (PAT)`: https://github.com/settings/tokens
 .. _`Homebrew`: https://brew.sh/
 .. _`nRF54L05 Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54l05/page/COMP/nrf54l05/nrf54l05_nrf_connect_sdk.html
-.. _`nRF54L10 Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54l10/page/COMP/nrf54l10/nrf54l10_nrf_connect_sdk.html
-.. _`nRF54L15 Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54l15/page/COMP/nrf54l15/nrf54l15_nrf_connect_sdk.html
+.. _`nRF54L10 Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54l10/page/COMP/nrf54l10/nrf54l10_comp_matrix.html
+.. _`nRF54L15 Compatibility Matrix`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54l15/page/COMP/nrf54l15/nrf54l15_comp_matrix.html
 
 .. _`10.23.3_ec 64-bit Windows, executable`: https://res.developer.nordicsemi.com/res/nrf-command-line-tools-10.23.3/nRF-Command-Line-Tools-10.23.3-x64.exe
 

--- a/doc/nrf/protocols/matter/end_product/certification.rst
+++ b/doc/nrf/protocols/matter/end_product/certification.rst
@@ -287,20 +287,25 @@ Nordic Semiconductor provides the following certification identifiers:
 * Bluetooth Qualified Design IDs (Bluetooth QDIDs) - Obtained in accordance with `Bluetooth SIG's Qualification Process`_.
 * Thread Certification IDs (Thread CIDs) - Obtained in accordance with `Thread Group's certification information`_.
 
-You can visit the following pages to check the Bluetooth QDIDs and Thread CIDs valid for SoCs that support Matter applications:
+Visit the following compatibility matrices to check the Bluetooth QDIDs and Thread CIDs valid for SoCs that support Matter applications:
 
-* `nRF52840 Compatibility Matrix <nRF52840 Compatibility Matrix_>`_
-* `nRF5340 Compatibility Matrix <nRF5340 Compatibility Matrix_>`_
-* `nRF54L15 Compatibility Matrix <nRF54L15 SoC Compatibility Matrix_>`_
+* `nRF52840 Compatibility Matrix`_
+* `nRF5340 Compatibility Matrix`_
+* `nRF54L10 Compatibility Matrix`_
+* `nRF54L15 Compatibility Matrix`_
+* `nRF54LM20A Compatibility Matrix`_
+* `nRF54LM20B Compatibility Matrix`_
+
+For Matter Compliant Platform Certification IDs and |NCS| release mappings, see :ref:`ug_matter_platform_and_dmp_matrix`.
 
 Matter certification process variants
 =====================================
 
 The standard Matter certification process has several variants, for example:
 
-* certification paths for different devices (including Derived Matter Product),
-* recertification for devices that are already certified,
-* variants for certifying several products of the same family.
+* Certification paths for different devices (including Derived Matter Product)
+* Recertification for devices that are already certified
+* Variants for certifying several products of the same family
 
 .. _ug_matter_device_certification_dmp:
 
@@ -341,11 +346,11 @@ The procedure for FastTrack recertification consists of the following steps:
 .. note::
    For critical and security fixes, you can deploy updates to devices after the Director of Certifications acknowledges the *receipt* of your certification request, without waiting for formal certification approval.
 
-To maintain qualified status, you must:
+To maintain qualified status, you must fulfill the following requirements:
 
-* be a registered Point of Contact (PoC),
-* participate in the relevant working-group subgroups (for example, Matter CSG),
-* undergo annual training for self-test individuals as required by the Alliance.
+* Be a registered Point of Contact (PoC).
+* Participate in the relevant working-group subgroups (for example, Matter CSG).
+* Undergo annual training for self-test individuals as required by the Alliance.
 
 .. figure:: images/matter_device_certification_process_ft.svg
    :alt: Matter's FastTrack Recertification program overview

--- a/doc/nrf/protocols/matter/end_product/platform_dmp_cert.rst
+++ b/doc/nrf/protocols/matter/end_product/platform_dmp_cert.rst
@@ -48,23 +48,20 @@ If you follow within the Matter Platform SOE and the platform's certified scope,
 
 .. _ug_matter_platform_and_dmp_matrix:
 
-Matter Compliant Platform certification matrix:
-===============================================
+Matter Compliant Platform certification information
+===================================================
 
-The following table presents the certification matrix for the Matter Compliant Platform delivered through the |NCS|.
-This matrix lists the |NCS| versions, Matter versions, product names, certification details, CSA certificate links, and supported hardware within the SDK (SOE).
-The table will be updated as new platform versions are certified.
+Use the following Matter CIDs compatibility matrices to find the current Matter Compliant Platform Certification IDs (CIDs), |NCS| release mappings, dependent certification references, and supported hardware within the SOE for each SoC that supports Matter in the |NCS|:
 
-+-------------------+-------------------+---------------------+---------------------+-----------------------+----------------------------------------------------------+-------------------------------------------+
-| |NCS| version     | Matter version    | Product name        | Certification ID    | Transport             | CSA Certificate link                                     | Supported hardware (SOE)                  |
-+===================+===================+=====================+=====================+=======================+==========================================================+===========================================+
-| 3.1.1             | 1.4.2             | |NCS|               | CSA25001MCPM0001-24 | Thread, Bluetooth LE  | `Matter nRF Connect SDK Platform Certificate_1_4_2`_     | nRF52 Series, nRF53 Series, nRF54L Series |
-+-------------------+-------------------+---------------------+---------------------+-----------------------+----------------------------------------------------------+-------------------------------------------+
-| 3.2.0             | 1.5.0             | |NCS|               | CSA26002MCPM0008-24 | Thread, Bluetooth LE  | `Matter nRF Connect SDK Platform Certificate_1_5_0`_     | nRF52 Series, nRF53 Series, nRF54L Series |
-+-------------------+-------------------+---------------------+---------------------+-----------------------+----------------------------------------------------------+-------------------------------------------+
+* `Matter CIDs for nRF52840`_
+* `Matter CIDs for nRF5340`_
+* `Matter CIDs for nRF54L10`_
+* `Matter CIDs for nRF54L15`_
+* `Matter CIDs for nRF54LM20A`_
+* `Matter CIDs for nRF54LM20B`_
 
-.. note::
-   The CSA Certificate link provides information about the platform certificate and the associated PICS baseline.
+The Matter CIDs compatibility matrices do not link directly to CSA platform certificates.
+Enter the platform Certification ID from the matrix for your SoC and |NCS| version in the **Certification ID #** filter on the `CSA Certified Products Database`_ to open the platform certificate entry and download the associated PICS baseline.
 
 Derived Matter Product
 ======================
@@ -244,10 +241,10 @@ What you can change safely (typical product work)
 
 You can safely make the following product-level changes:
 
-* Application code - Device type logic, endpoints, attributes, UI/UX, application cluster handlers, etc.
-* Application configuration - Kconfig/DTS overlays for product peripherals, partitions, etc.
+* Application code - Device type logic, endpoints, attributes, UI/UX, application cluster handlers.
+* Application configuration - Kconfig/DTS overlays for product peripherals, partitions.
 * Optional clusters/features within platform scope (enable/disable) with matching PICS updates.
-* Manufacturing data and branding - Stock keeping unit (SKU), product strings, documentation, etc.
+* Manufacturing data and branding - Stock keeping unit (SKU), product strings, documentation.
 * Changes to application clusters in :file:`modules/lib/matter` (not part of platform).
 
 .. rst-class:: numbered-step
@@ -263,13 +260,15 @@ Before testing, prepare the following inputs:
   Products may declare additional features beyond the platform's certified scope, but these additional features must be tested in the DMP certification process.
 * Request the platform's templated security attestation (pre-filled with platform details) through the `DevZone`_ (Nordic's developer portal for technical support and resources).
 * Leverage dependent certification identifiers from platform.
-  You can visit the following pages to check the Bluetooth QDIDs and Thread CIDs valid for SoCs that support Matter applications:
+  Use the compatibility matrix for your SoC to check the Bluetooth QDIDs and Thread CIDs valid for Matter applications:
 
   * `nRF52840 Compatibility Matrix`_
   * `nRF5340 Compatibility Matrix`_
+  * `nRF54L10 Compatibility Matrix`_
   * `nRF54L15 Compatibility Matrix`_
-
-* Retrieve the Platform PICS baseline from the CSA website ref :ref:`ug_matter_platform_and_dmp_matrix` to confirm compatibility.
+  * `nRF54LM20A Compatibility Matrix`_
+  * `nRF54LM20B Compatibility Matrix`_
+* Enter the platform Certification ID from the Matter CIDs compatibility matrix for your SoC in the **Certification ID #** filter on the `CSA Certified Products Database`_ and retrieve the Platform PICS baseline from the search result to confirm compatibility.
 
 .. rst-class:: numbered-step
 


### PR DESCRIPTION
Drop the manually maintained Matter Compliant Platform certification table and point to Matter CIDs compatibility matrices for all supported SoCs. Document CSA lookup by Certification ID for the PICS baseline, and expand Bluetooth and Thread dependent certification links across certification and DMP guidance.