### PR TITLE
modules: tf-m: Refactor dummy UART implementation

### DIFF
--- a/modules/trusted-firmware-m/tfm_boards/CMakeLists.txt
+++ b/modules/trusted-firmware-m/tfm_boards/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(platform_s
   common/assert.c
   $<$<NOT:$<BOOL:${PLATFORM_DEFAULT_OTP}>>:${CMAKE_CURRENT_SOURCE_DIR}/common/dummy_otp.c>
   $<$<NOT:$<BOOL:${PLATFORM_DEFAULT_SYSTEM_RESET_HALT}>>:${CMAKE_CURRENT_SOURCE_DIR}/common/tfm_hal_reset_halt.c>
+  $<$<NOT:$<BOOL:${PLATFORM_DEFAULT_UART_STDOUT}>>:${CMAKE_CURRENT_SOURCE_DIR}/common/dummy_uart_stdout.c>
 )
 
 target_link_libraries(platform_s

--- a/modules/trusted-firmware-m/tfm_boards/common/dummy_uart_stdout.c
+++ b/modules/trusted-firmware-m/tfm_boards/common/dummy_uart_stdout.c
@@ -5,8 +5,14 @@
  */
 
 #include "uart_stdout.h"
+#include <stdbool.h>
 
-int stdio_output_string(const unsigned char *str, uint32_t len)
+bool stdio_is_initialized(void)
+{
+	return false;
+}
+
+int stdio_output_string(const char *str, uint32_t len)
 {
 	return 0;
 }


### PR DESCRIPTION
Extend dummy_uart_stdout.c to include
stdio_is_initialized.

This adds the dummy_uart_stdout.c always in
the build when PLATFORM_DEFAULT_UART_STDOUT is
not set. This is needed because when assertions
are enabled in TF-M many platform functions
use stdio_is_initialized to check if the print
log. So this function needs to be implemented.

Also updated the function stdio_output_string
parameter to match the new signature.

Ref: NCSDK-40680