### PR TITLE
applications: nrf_desktop: Skip init conn params on HID SCI peripherals

### DIFF
--- a/applications/nrf_desktop/Kconfig.ble
+++ b/applications/nrf_desktop/Kconfig.ble
@@ -116,6 +116,13 @@ config BT_CONN_PARAM_UPDATE_TIMEOUT
 	  nRF Desktop peripherals update connection parameters earlier to lower
 	  HID data latency.
 
+configdefault BT_GAP_AUTO_UPDATE_CONN_PARAMS
+	default n if DESKTOP_HIDS_SCI_ENABLE
+	help
+	  nRF Desktop peripherals disable the automatic connection parameters
+	  update feature if HID SCI is supported to avoid conflicts with connections
+	  rate updates.
+
 config BT_BUF_ACL_TX_COUNT
 	default 4
 	help

--- a/applications/nrf_desktop/doc/ble_latency.rst
+++ b/applications/nrf_desktop/doc/ble_latency.rst
@@ -11,7 +11,7 @@ The Bluetooth® LE latency module manages Bluetooth LE connection parameters to 
 Use the Bluetooth LE latency module for the following purposes:
 
 * Lower the Bluetooth LE connection latency when the :ref:`nrf_desktop_config_channel` is in use or when a firmware update is received either by the :ref:`nrf_desktop_ble_smp` or :ref:`nrf_desktop_dfu_mcumgr` (low latency ensures quick data exchange).
-* Request setting the initial connection parameters for a new Bluetooth connection.
+* Request setting the initial connection parameters for a new Bluetooth connection (not applicable to HID SCI supporting peripherals).
 * Keep the connection latency low for the LLPM (Low Latency Packet Mode) connections to improve performance.
 * Handle mode change requests for HID Shorter Connection Intervals (SCI) and adjust the peripheral latency within the active SCI mode.
 * Disconnect the Bluetooth Central if the connection has not been secured in the predefined amount of time after the connection occurred.

--- a/applications/nrf_desktop/src/modules/ble_latency.c
+++ b/applications/nrf_desktop/src/modules/ble_latency.c
@@ -79,8 +79,6 @@ static void set_init_conn_params(void)
 		.timeout = DEFAULT_TIMEOUT
 	};
 
-	last_requested_latency_is_low = true;
-
 	int err = bt_conn_le_param_update(active_conn, &param);
 
 	if (!err || (err == -EALREADY)) {
@@ -657,7 +655,12 @@ static bool app_event_handler(const struct app_event_header *aeh)
 			if (IS_ENABLED(CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK)) {
 				latency_state |= CONN_LOW_LATENCY_LOCKED;
 			}
-			set_init_conn_params();
+
+			if (!IS_ENABLED(CONFIG_DESKTOP_BLE_LATENCY_HID_SCI_ENABLE)) {
+				set_init_conn_params();
+			}
+			last_requested_latency_is_low = true;
+
 			k_work_reschedule(&security_timeout,
 					      SECURITY_FAIL_TIMEOUT_MS);
 			break;


### PR DESCRIPTION
This PR adds skipping the call to set_init_conn_params() when
the peripheral suppports HID SCI
(i.e. CONFIG_DESKTOP_BLE_LATENCY_HID_SCI_ENABLE is set).

On connect, ble_latency calls set_init_conn_params, which in turn
calls  bt_conn_le_param_update() to request zero
peripheral latency. Zephyr does not send that request
immediately; it is deferred until BT_CONN_PARAM_UPDATE_TIMEOUT elapses
(1 s by default in nRF Desktop).

The host might switch the link to HID SCI before that timeout.
After the link is switched to HID SCI, only the connection
rate API should be used. The deferred connection parameter update
violates this rule and may an overlap with an in-flight
connection rate update. The Bluetooth Core Specification disallows
starting one of these procedures while the other is in progress.

Due to the change from this PR, security establishment may
take slightly longer on SCI builds connected to non-SCI hosts.
This is because the connect-time zero-latency request is
no longer sent. This has no effect when the link already starts with
zero peripheral latency.
