### PR TITLE
nRF71 sample support

### DIFF
--- a/drivers/wifi/nrf71/src/common/rf_params.c
+++ b/drivers/wifi/nrf71/src/common/rf_params.c
@@ -43,7 +43,7 @@ enum nrf_wifi_status nrf_wifi_fmac_config_rf_params(void *dev_ctx, unsigned int 
 			continue;
 		}
 		str_len = strlen(rf_params[index].hex_str);
-		rf_params[index].bytes = k_malloc(str_len);
+		rf_params[index].bytes = nrf_wifi_osal_mem_alloc(str_len);
 		if (!rf_params[index].bytes) {
 			LOG_ERR("%s: Unable to allocate %zu bytes", __func__, str_len);
 			goto cleanup;
@@ -53,7 +53,7 @@ enum nrf_wifi_status nrf_wifi_fmac_config_rf_params(void *dev_ctx, unsigned int 
 						    (unsigned char *)rf_params[index].hex_str);
 		if (ret < 0) {
 			LOG_ERR("%s: hex_str_to_val failed", __func__);
-			k_free(rf_params[index].bytes);
+			nrf_wifi_osal_mem_free(rf_params[index].bytes);
 			rf_params[index].bytes = NULL;
 			goto cleanup;
 		}
@@ -66,7 +66,7 @@ enum nrf_wifi_status nrf_wifi_fmac_config_rf_params(void *dev_ctx, unsigned int 
 cleanup:
 	for (cleanup_idx = 0; cleanup_idx < index; cleanup_idx++) {
 		if (rf_params[cleanup_idx].bytes) {
-			k_free(rf_params[cleanup_idx].bytes);
+			nrf_wifi_osal_mem_free(rf_params[cleanup_idx].bytes);
 			rf_params[cleanup_idx].bytes = NULL;
 		}
 	}

--- a/drivers/wifi/nrf71/src/common/vtf.c
+++ b/drivers/wifi/nrf71/src/common/vtf.c
@@ -32,9 +32,9 @@ enum nrf_wifi_status nrf_wifi_fmac_config_vtf_params(struct nrf_wifi_fmac_dev_ct
 		return NRF_WIFI_STATUS_FAIL;
 	}
 
-	vtf_buf = k_malloc(sizeof(*vtf_buf));
+	vtf_buf = nrf_wifi_osal_mem_alloc(sizeof(*vtf_buf));
 	if (!vtf_buf) {
-		LOG_ERR("%s: k_malloc failed for VTF params", __func__);
+		LOG_ERR("%s: Unable to allocate memory for VTF params", __func__);
 		return NRF_WIFI_STATUS_FAIL;
 	}
 

--- a/drivers/wifi/nrf71/src/offload_raw_tx/api.c
+++ b/drivers/wifi/nrf71/src/offload_raw_tx/api.c
@@ -215,12 +215,12 @@ void nrf70_off_raw_tx_deinit(void)
 
 	for (i = 0; i < NUM_WIFI_PARAMS; i++) {
 		if (drv_ctx->phy_rf_params_addr[i]) {
-			k_free((void *)drv_ctx->phy_rf_params_addr[i]);
+			nrf_wifi_osal_mem_free((void *)drv_ctx->phy_rf_params_addr[i]);
 			drv_ctx->phy_rf_params_addr[i] = 0;
 		}
 	}
 	if (drv_ctx->vtf_buffer_start_address) {
-		k_free((void *)drv_ctx->vtf_buffer_start_address);
+		nrf_wifi_osal_mem_free((void *)drv_ctx->vtf_buffer_start_address);
 		drv_ctx->vtf_buffer_start_address = 0;
 	}
 

--- a/drivers/wifi/nrf71/src/radio_test/api.c
+++ b/drivers/wifi/nrf71/src/radio_test/api.c
@@ -24,11 +24,11 @@ enum nrf_wifi_status nrf_wifi_rt_fmac_dev_rem(struct nrf_wifi_rt_drv_priv *drv_p
 	nrf_wifi_fmac_dev_rem(drv_ctx->rpu_ctx);
 
 	for (int i = 0; i < NUM_RF_PARAM_ADDRS; i++) {
-		k_free((void *)drv_ctx->phy_rf_params_addr[i]);
+		nrf_wifi_osal_mem_free((void *)drv_ctx->phy_rf_params_addr[i]);
 		drv_ctx->phy_rf_params_addr[i] = 0;
 	}
 
-	k_free((void *)drv_ctx->vtf_buffer_start_address);
+	nrf_wifi_osal_mem_free((void *)drv_ctx->vtf_buffer_start_address);
 	drv_ctx->vtf_buffer_start_address = 0;
 
 	drv_ctx->rpu_ctx = NULL;

--- a/drivers/wifi/nrf71/src/system/main.c
+++ b/drivers/wifi/nrf71/src/system/main.c
@@ -602,10 +602,10 @@ enum nrf_wifi_status nrf_wifi_sys_fmac_dev_rem_zep(struct nrf_wifi_drv_priv_zep 
 	nrf_wifi_fmac_dev_rem(rpu_ctx_zep->rpu_ctx);
 
 	for (int i = 0; i < NUM_RF_PARAM_ADDRS; i++) {
-		k_free((void *)rpu_ctx_zep->phy_rf_params_addr[i]);
+		nrf_wifi_osal_mem_free((void *)rpu_ctx_zep->phy_rf_params_addr[i]);
 		rpu_ctx_zep->phy_rf_params_addr[i] = 0;
 	}
-	k_free((void *)rpu_ctx_zep->vtf_buffer_start_address);
+	nrf_wifi_osal_mem_free((void *)rpu_ctx_zep->vtf_buffer_start_address);
 	rpu_ctx_zep->vtf_buffer_start_address = 0;
 	nrf_wifi_osal_mem_free(rpu_ctx_zep->extended_capa);
 	rpu_ctx_zep->extended_capa = NULL;

--- a/samples/wifi/monitor/sample.yaml
+++ b/samples/wifi/monitor/sample.yaml
@@ -80,4 +80,4 @@ tests:
     tags:
       - ci_build
       - sysbuild
-      - ci_samples_wifi
+      - ci_samples_nrf71_wifi

--- a/samples/wifi/offloaded_raw_tx/boards/nrf7120dk_nrf7120_cpuapp.conf
+++ b/samples/wifi/offloaded_raw_tx/boards/nrf7120dk_nrf7120_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_WIFI_NRF71=y
+CONFIG_NRF71_OFFLOADED_RAW_TX=y

--- a/samples/wifi/offloaded_raw_tx/boards/nrf7120dk_nrf7120_cpuapp_ns.conf
+++ b/samples/wifi/offloaded_raw_tx/boards/nrf7120dk_nrf7120_cpuapp_ns.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_WIFI_NRF71=y
+CONFIG_NRF71_OFFLOADED_RAW_TX=y

--- a/samples/wifi/offloaded_raw_tx/sample.yaml
+++ b/samples/wifi/offloaded_raw_tx/sample.yaml
@@ -68,3 +68,19 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_wifi
+  sample.nrf7120.offloaded_raw_tx:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      # sysbuild by default is nRF70, to avoid Kconfig warns disable it
+      - SB_CONFIG_WIFI_NRF70=n
+    integration_platforms:
+      - nrf7120dk/nrf7120/cpuapp
+      - nrf7120dk/nrf7120/cpuapp/ns
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp
+      - nrf7120dk/nrf7120/cpuapp/ns
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_nrf71_wifi

--- a/samples/wifi/provisioning/ble/sample.yaml
+++ b/samples/wifi/provisioning/ble/sample.yaml
@@ -114,4 +114,4 @@ tests:
     tags:
       - ci_build
       - sysbuild
-      - ci_samples_wifi
+      - ci_samples_nrf71_wifi

--- a/samples/wifi/provisioning/softap/sample.yaml
+++ b/samples/wifi/provisioning/softap/sample.yaml
@@ -81,4 +81,4 @@ tests:
     tags:
       - ci_build
       - sysbuild
-      - ci_samples_wifi
+      - ci_samples_nrf71_wifi

--- a/samples/wifi/radio_test/single_domain/boards/nrf7120dk_nrf7120_cpuapp_ns.conf
+++ b/samples/wifi/radio_test/single_domain/boards/nrf7120dk_nrf7120_cpuapp_ns.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_WIFI_NRF71=y
+CONFIG_NRF71_RADIO_TEST=y
+
+# Enable the necessary drivers
+CONFIG_NRFX_TIMER=y
+CONFIG_NRFX_GPPI=y

--- a/samples/wifi/radio_test/single_domain/sample.yaml
+++ b/samples/wifi/radio_test/single_domain/sample.yaml
@@ -55,7 +55,10 @@ tests:
       - SB_CONFIG_WIFI_NRF70=n
     integration_platforms:
       - nrf7120dk/nrf7120/cpuapp
-    platform_allow: nrf7120dk/nrf7120/cpuapp
+      - nrf7120dk/nrf7120/cpuapp/ns
+    platform_allow:
+      - nrf7120dk/nrf7120/cpuapp
+      - nrf7120dk/nrf7120/cpuapp/ns
     tags:
       - ci_build
       - sysbuild

--- a/samples/wifi/raw_tx_packet/sample.yaml
+++ b/samples/wifi/raw_tx_packet/sample.yaml
@@ -93,4 +93,4 @@ tests:
     tags:
       - ci_build
       - sysbuild
-      - ci_samples_wifi
+      - ci_samples_nrf71_wifi

--- a/samples/wifi/scan/sample.yaml
+++ b/samples/wifi/scan/sample.yaml
@@ -132,4 +132,4 @@ tests:
     tags:
       - ci_build
       - sysbuild
-      - ci_samples_wifi
+      - ci_samples_nrf71_wifi

--- a/samples/wifi/softap/sample.yaml
+++ b/samples/wifi/softap/sample.yaml
@@ -116,4 +116,4 @@ tests:
     tags:
       - ci_build
       - sysbuild
-      - ci_samples_wifi
+      - ci_samples_nrf71_wifi

--- a/samples/wifi/sta/sample.yaml
+++ b/samples/wifi/sta/sample.yaml
@@ -136,4 +136,4 @@ tests:
     tags:
       - ci_build
       - sysbuild
-      - ci_samples_wifi
+      - ci_samples_nrf71_wifi

--- a/samples/wifi/twt/sample.yaml
+++ b/samples/wifi/twt/sample.yaml
@@ -81,4 +81,4 @@ tests:
     tags:
       - ci_build
       - sysbuild
-      - ci_samples_wifi
+      - ci_samples_nrf71_wifi


### PR DESCRIPTION
* Add nRF71 NS support to the radio test/single_domain sample.
* Add nRF71 support to the offload raw TX sample.
* Fix the CI tag name.
* Update memory allocation handling