### PR TITLE
caf: ble_state: add frame space and PHY update events

### DIFF
--- a/doc/nrf/libraries/caf/ble_state.rst
+++ b/doc/nrf/libraries/caf/ble_state.rst
@@ -39,6 +39,10 @@ The following Kconfig options are also available for this module:
   The device disconnects if establishing the connection security level 2 fails.
 * :kconfig:option:`CONFIG_CAF_BLE_STATE_MAX_LOCAL_ID_BONDS` - This option allows to specify the maximum number of allowed bonds per Bluetooth local identity for a Bluetooth Peripheral (:kconfig:option:`CONFIG_BT_PERIPHERAL`).
   If a local identity is already bonded with the maximum number of allowed bonds, new peers are disconnected right after Bluetooth connection is established.
+* :kconfig:option:`CONFIG_CAF_BLE_FRAME_SPACE_EVENTS` - This option causes the module to emit the :c:struct:`ble_peer_frame_space_updated_event`.
+  This event is used to inform other application modules about frame space changes and failed frame space update requests.
+  It depends on :kconfig:option:`CONFIG_BT_FRAME_SPACE_UPDATE`.
+  This option is enabled by default.
 
 Implementation details
 **********************

--- a/doc/nrf/libraries/caf/ble_state.rst
+++ b/doc/nrf/libraries/caf/ble_state.rst
@@ -43,6 +43,10 @@ The following Kconfig options are also available for this module:
   This event is used to inform other application modules about frame space changes and failed frame space update requests.
   It depends on :kconfig:option:`CONFIG_BT_FRAME_SPACE_UPDATE`.
   This option is enabled by default.
+* :kconfig:option:`CONFIG_CAF_BLE_PHY_UPDATED_EVENTS` - This option causes the module to emit the :c:struct:`ble_peer_phy_updated_event`.
+  This event is used to inform other application modules about PHY changes.
+  It depends on :kconfig:option:`CONFIG_BT_USER_PHY_UPDATE`.
+  This option is enabled by default.
 
 Implementation details
 **********************

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -635,8 +635,11 @@ Common Application Framework
 
 * :ref:`caf_ble_state`:
 
-  * Added the :c:struct:`ble_peer_sci_conn_rate_event` event to report connection rate changes or failed connection rate change requests when shorter connection intervals are enabled.
-  * Added the :c:struct:`ble_peer_frame_space_updated_event` to report frame space changes or failed frame space update requests.
+* Added:
+
+  * The :c:struct:`ble_peer_sci_conn_rate_event` to report connection rate changes or failed connection rate change requests when shorter connection intervals are enabled.
+  * The :c:struct:`ble_peer_frame_space_updated_event` to report frame space changes or failed frame space update requests.
+  * The :c:struct:`ble_peer_phy_updated_event` to report PHY changes.
 
 Debug libraries
 ---------------

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -636,6 +636,7 @@ Common Application Framework
 * :ref:`caf_ble_state`:
 
   * Added the :c:struct:`ble_peer_sci_conn_rate_event` event to report connection rate changes or failed connection rate change requests when shorter connection intervals are enabled.
+  * Added the :c:struct:`ble_peer_frame_space_updated_event` to report frame space changes or failed frame space update requests.
 
 Debug libraries
 ---------------

--- a/include/caf/events/ble_common_event.h
+++ b/include/caf/events/ble_common_event.h
@@ -223,6 +223,22 @@ struct ble_peer_frame_space_updated_event {
 	struct bt_conn_le_frame_space_updated params;
 };
 
+/** @brief Bluetooth LE peer PHY updated event.
+ *
+ * The Bluetooth LE peer PHY updated event is submitted to inform that connection PHY
+ * parameters have changed.
+ */
+struct ble_peer_phy_updated_event {
+	/** Event header. */
+	struct app_event_header header;
+
+	/** ID used to identify Bluetooth connection - pointer to the bt_conn. */
+	void *id;
+
+	/** Connection PHY information. */
+	struct bt_conn_le_phy_info params;
+};
+
 /** @brief Bluetooth LE peer search event.
  *
  * The Bluetooth LE peer search event is submitted to inform if application is currently looking for
@@ -263,6 +279,7 @@ APP_EVENT_TYPE_DECLARE(ble_peer_operation_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_conn_params_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_sci_conn_rate_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_frame_space_updated_event);
+APP_EVENT_TYPE_DECLARE(ble_peer_phy_updated_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_search_event);
 APP_EVENT_TYPE_DECLARE(ble_adv_data_update_event);
 

--- a/include/caf/events/ble_common_event.h
+++ b/include/caf/events/ble_common_event.h
@@ -205,6 +205,24 @@ struct ble_peer_sci_conn_rate_event {
 	struct bt_conn_le_conn_rate_changed params;
 };
 
+/** @brief Bluetooth LE peer frame space updated event.
+ *
+ * The Bluetooth LE peer frame space updated event is submitted to inform that frame space
+ * parameters have changed or that a frame space update request failed.
+ * The params field members other than status are valid only if params.status is
+ * BT_HCI_ERR_SUCCESS and must be ignored otherwise.
+ */
+struct ble_peer_frame_space_updated_event {
+	/** Event header. */
+	struct app_event_header header;
+
+	/** ID used to identify Bluetooth connection - pointer to the bt_conn. */
+	void *id;
+
+	/** Frame space update parameters. */
+	struct bt_conn_le_frame_space_updated params;
+};
+
 /** @brief Bluetooth LE peer search event.
  *
  * The Bluetooth LE peer search event is submitted to inform if application is currently looking for
@@ -244,6 +262,7 @@ APP_EVENT_TYPE_DECLARE(ble_peer_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_operation_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_conn_params_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_sci_conn_rate_event);
+APP_EVENT_TYPE_DECLARE(ble_peer_frame_space_updated_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_search_event);
 APP_EVENT_TYPE_DECLARE(ble_adv_data_update_event);
 

--- a/subsys/caf/events/Kconfig
+++ b/subsys/caf/events/Kconfig
@@ -43,6 +43,14 @@ config CAF_BLE_SCI_CONN_RATE_EVENTS
 	help
 	  Enable support for BLE connection rate events.
 
+config CAF_BLE_FRAME_SPACE_EVENTS
+	bool "BLE frame space update events"
+	depends on CAF_BLE_COMMON_EVENTS
+	depends on BT_FRAME_SPACE_UPDATE
+	default y
+	help
+	  Enable support for BLE frame space update events.
+
 config CAF_INIT_LOG_BLE_PEER_EVENTS
 	bool "Log BLE peer events"
 	depends on CAF_BLE_COMMON_EVENTS
@@ -76,6 +84,12 @@ config CAF_INIT_LOG_BLE_PEER_CONN_PARAMS_EVENTS
 config CAF_INIT_LOG_BLE_SCI_CONN_RATE_EVENTS
 	bool "Log BLE peer connection rate events"
 	depends on CAF_BLE_SCI_CONN_RATE_EVENTS
+	depends on LOG
+	default y
+
+config CAF_INIT_LOG_BLE_FRAME_SPACE_EVENTS
+	bool "Log BLE peer frame space update events"
+	depends on CAF_BLE_FRAME_SPACE_EVENTS
 	depends on LOG
 	default y
 

--- a/subsys/caf/events/Kconfig
+++ b/subsys/caf/events/Kconfig
@@ -51,6 +51,14 @@ config CAF_BLE_FRAME_SPACE_EVENTS
 	help
 	  Enable support for BLE frame space update events.
 
+config CAF_BLE_PHY_UPDATED_EVENTS
+	bool "BLE PHY update events"
+	depends on CAF_BLE_COMMON_EVENTS
+	depends on BT_USER_PHY_UPDATE
+	default y
+	help
+	  Enable support for BLE PHY update events.
+
 config CAF_INIT_LOG_BLE_PEER_EVENTS
 	bool "Log BLE peer events"
 	depends on CAF_BLE_COMMON_EVENTS
@@ -90,6 +98,12 @@ config CAF_INIT_LOG_BLE_SCI_CONN_RATE_EVENTS
 config CAF_INIT_LOG_BLE_FRAME_SPACE_EVENTS
 	bool "Log BLE peer frame space update events"
 	depends on CAF_BLE_FRAME_SPACE_EVENTS
+	depends on LOG
+	default y
+
+config CAF_INIT_LOG_BLE_PHY_UPDATED_EVENTS
+	bool "Log BLE peer PHY update events"
+	depends on CAF_BLE_PHY_UPDATED_EVENTS
 	depends on LOG
 	default y
 

--- a/subsys/caf/events/ble_common_event.c
+++ b/subsys/caf/events/ble_common_event.c
@@ -219,3 +219,23 @@ APP_EVENT_TYPE_DEFINE(ble_peer_frame_space_updated_event,
 				(APP_EVENT_TYPE_FLAGS_INIT_LOG_ENABLE))));
 
 #endif /* CONFIG_CAF_BLE_FRAME_SPACE_EVENTS */
+
+#if CONFIG_CAF_BLE_PHY_UPDATED_EVENTS
+
+static void log_ble_peer_phy_updated_event(const struct app_event_header *aeh)
+{
+	const struct ble_peer_phy_updated_event *event =
+		cast_ble_peer_phy_updated_event(aeh);
+
+	APP_EVENT_MANAGER_LOG(aeh, "peer=%p tx_phy=0x%02" PRIx8 " rx_phy=0x%02" PRIx8,
+			      event->id, event->params.tx_phy, event->params.rx_phy);
+}
+
+APP_EVENT_TYPE_DEFINE(ble_peer_phy_updated_event,
+		  log_ble_peer_phy_updated_event,
+		  NULL,
+		  APP_EVENT_FLAGS_CREATE(
+			IF_ENABLED(CONFIG_CAF_INIT_LOG_BLE_PHY_UPDATED_EVENTS,
+				(APP_EVENT_TYPE_FLAGS_INIT_LOG_ENABLE))));
+
+#endif /* CONFIG_CAF_BLE_PHY_UPDATED_EVENTS */

--- a/subsys/caf/events/ble_common_event.c
+++ b/subsys/caf/events/ble_common_event.c
@@ -190,3 +190,32 @@ APP_EVENT_TYPE_DEFINE(ble_peer_sci_conn_rate_event,
 				(APP_EVENT_TYPE_FLAGS_INIT_LOG_ENABLE))));
 
 #endif /* CONFIG_CAF_BLE_SCI_CONN_RATE_EVENTS */
+
+#if CONFIG_CAF_BLE_FRAME_SPACE_EVENTS
+
+static void log_ble_peer_frame_space_updated_event(const struct app_event_header *aeh)
+{
+	const struct ble_peer_frame_space_updated_event *event =
+		cast_ble_peer_frame_space_updated_event(aeh);
+
+	if (event->params.status == BT_HCI_ERR_SUCCESS) {
+		APP_EVENT_MANAGER_LOG(aeh, "peer=%p frame_space=%" PRIu16
+				" phys=0x%02" PRIx8 " spacing_types=0x%04" PRIx16
+				" initiator=%" PRIu8,
+				event->id, event->params.frame_space,
+				event->params.phys, event->params.spacing_types,
+				event->params.initiator);
+	} else {
+		APP_EVENT_MANAGER_LOG(aeh, "peer=%p status=0x%02" PRIx8,
+				      event->id, event->params.status);
+	}
+}
+
+APP_EVENT_TYPE_DEFINE(ble_peer_frame_space_updated_event,
+		  log_ble_peer_frame_space_updated_event,
+		  NULL,
+		  APP_EVENT_FLAGS_CREATE(
+			IF_ENABLED(CONFIG_CAF_INIT_LOG_BLE_FRAME_SPACE_EVENTS,
+				(APP_EVENT_TYPE_FLAGS_INIT_LOG_ENABLE))));
+
+#endif /* CONFIG_CAF_BLE_FRAME_SPACE_EVENTS */

--- a/subsys/caf/modules/ble_state.c
+++ b/subsys/caf/modules/ble_state.c
@@ -289,6 +289,22 @@ static void conn_rate_changed(struct bt_conn *conn, uint8_t status,
 }
 #endif /* CONFIG_CAF_BLE_SCI_CONN_RATE_EVENTS */
 
+#if CONFIG_CAF_BLE_FRAME_SPACE_EVENTS
+static void frame_space_updated(struct bt_conn *conn,
+				const struct bt_conn_le_frame_space_updated *params)
+{
+	struct ble_peer_frame_space_updated_event *event =
+		new_ble_peer_frame_space_updated_event();
+
+	__ASSERT(params != NULL, "params pointer is NULL");
+
+	event->id = conn;
+	event->params = *params;
+
+	APP_EVENT_SUBMIT(event);
+}
+#endif /* CONFIG_CAF_BLE_FRAME_SPACE_EVENTS */
+
 static void bt_ready(int err)
 {
 	if (err) {
@@ -325,6 +341,9 @@ static int ble_state_init(void)
 #if CONFIG_CAF_BLE_SCI_CONN_RATE_EVENTS
 		.conn_rate_changed = conn_rate_changed,
 #endif /* CONFIG_CAF_BLE_SCI_CONN_RATE_EVENTS */
+#if CONFIG_CAF_BLE_FRAME_SPACE_EVENTS
+		.frame_space_updated = frame_space_updated,
+#endif /* CONFIG_CAF_BLE_FRAME_SPACE_EVENTS */
 	};
 	bt_conn_cb_register(&conn_callbacks);
 

--- a/subsys/caf/modules/ble_state.c
+++ b/subsys/caf/modules/ble_state.c
@@ -305,6 +305,20 @@ static void frame_space_updated(struct bt_conn *conn,
 }
 #endif /* CONFIG_CAF_BLE_FRAME_SPACE_EVENTS */
 
+#if CONFIG_CAF_BLE_PHY_UPDATED_EVENTS
+static void le_phy_updated(struct bt_conn *conn, struct bt_conn_le_phy_info *params)
+{
+	struct ble_peer_phy_updated_event *event = new_ble_peer_phy_updated_event();
+
+	__ASSERT(params != NULL, "params pointer is NULL");
+
+	event->id = conn;
+	event->params = *params;
+
+	APP_EVENT_SUBMIT(event);
+}
+#endif /* CONFIG_CAF_BLE_PHY_UPDATED_EVENTS */
+
 static void bt_ready(int err)
 {
 	if (err) {
@@ -344,6 +358,9 @@ static int ble_state_init(void)
 #if CONFIG_CAF_BLE_FRAME_SPACE_EVENTS
 		.frame_space_updated = frame_space_updated,
 #endif /* CONFIG_CAF_BLE_FRAME_SPACE_EVENTS */
+#if CONFIG_CAF_BLE_PHY_UPDATED_EVENTS
+		.le_phy_updated = le_phy_updated,
+#endif /* CONFIG_CAF_BLE_PHY_UPDATED_EVENTS */
 	};
 	bt_conn_cb_register(&conn_callbacks);
 


### PR DESCRIPTION
Extend CAF `ble_state` with two new Bluetooth connection callback events:

- **`ble_peer_frame_space_updated_event`** — submitted when the Host `frame_space_updated` callback is invoked. Reports updated frame space parameters, or the HCI status when a frame space update request fails.
- **`ble_peer_phy_updated_event`** — submitted when the Host `le_phy_updated` callback is invoked. Reports updated TX and RX PHY values.
