### PR TITLE
samples: bluetooth: fix GPPI group setup in time sync samples

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -304,6 +304,10 @@ This section provides detailed lists of changes by :ref:`sample <samples>`.
 Bluetooth samples
 -----------------
 
+* :ref:`bluetooth_conn_time_synchronization` and :ref:`bluetooth_isochronous_time_synchronization` samples:
+
+  * Fixed an issue on nRF52 and nRF53 Series devices where timed LED toggling did not work due to incorrect GPPI group setup after the nrfx 4.0 API migration.
+
 * :ref:`bluetooth_central_hids`, :ref:`peripheral_hids_keyboard`, and :ref:`peripheral_hids_mouse` samples:
 
   * Added support for the ``nrf54lc10dk/nrf54lc10a/cpuapp`` board target.

--- a/samples/bluetooth/conn_time_sync/src/controller_time_nrf52.c
+++ b/samples/bluetooth/conn_time_sync/src/controller_time_nrf52.c
@@ -167,12 +167,6 @@ int config_egu_trigger_on_rtc_and_timer_match(void)
 		return ret;
 	}
 
-	ret = nrfx_gppi_group_ep_add(group, eep0);
-	if (ret < 0) {
-		printk("Failed attaching an event to the group\n");
-		return ret;
-	}
-
 	ret = nrfx_gppi_conn_alloc(eep0, nrfx_gppi_group_task_en_addr(group), &ppi_on_rtc_match);
 	if (ret < 0) {
 		printk("Failed allocating for RTC match\n");
@@ -185,6 +179,18 @@ int config_egu_trigger_on_rtc_and_timer_match(void)
 		return ret;
 	}
 	(void)nrfx_gppi_ep_attach(nrfx_gppi_group_task_dis_addr(group), ppi_on_timer_match);
+
+	ret = nrfx_gppi_group_ep_add(group, eep0);
+	if (ret < 0) {
+		printk("Failed attaching an event to the group\n");
+		return ret;
+	}
+
+	ret = nrfx_gppi_group_ep_add(group, eep1);
+	if (ret < 0) {
+		printk("Failed attaching an event to the group\n");
+		return ret;
+	}
 
 	return 0;
 }

--- a/samples/bluetooth/conn_time_sync/src/controller_time_nrf53_app.c
+++ b/samples/bluetooth/conn_time_sync/src/controller_time_nrf53_app.c
@@ -138,12 +138,6 @@ int config_egu_trigger_on_rtc_and_timer_match(void)
 		return ret;
 	}
 
-	ret = nrfx_gppi_group_ep_add(group, eep0);
-	if (ret < 0) {
-		printk("Failed attaching an event to the group\n");
-		return ret;
-	}
-
 	ret = nrfx_gppi_conn_alloc(eep0, nrfx_gppi_group_task_en_addr(group), &ppi_on_rtc_match);
 	if (ret < 0) {
 		printk("Failed allocating for RTC match\n");
@@ -156,6 +150,18 @@ int config_egu_trigger_on_rtc_and_timer_match(void)
 		return ret;
 	}
 	(void)nrfx_gppi_ep_attach(nrfx_gppi_group_task_dis_addr(group), ppi_on_timer_match);
+
+	ret = nrfx_gppi_group_ep_add(group, eep0);
+	if (ret < 0) {
+		printk("Failed attaching an event to the group\n");
+		return ret;
+	}
+
+	ret = nrfx_gppi_group_ep_add(group, eep1);
+	if (ret < 0) {
+		printk("Failed attaching an event to the group\n");
+		return ret;
+	}
 
 	return 0;
 }

--- a/samples/bluetooth/iso_time_sync/src/controller_time_nrf52.c
+++ b/samples/bluetooth/iso_time_sync/src/controller_time_nrf52.c
@@ -166,12 +166,6 @@ int config_egu_trigger_on_rtc_and_timer_match(void)
 		return ret;
 	}
 
-	ret = nrfx_gppi_group_ep_add(group, eep0);
-	if (ret < 0) {
-		printk("Failed attaching an event to the group\n");
-		return ret;
-	}
-
 	ret = nrfx_gppi_conn_alloc(eep0, nrfx_gppi_group_task_en_addr(group), &ppi_on_rtc_match);
 	if (ret < 0) {
 		printk("Failed allocating for RTC match\n");
@@ -184,6 +178,18 @@ int config_egu_trigger_on_rtc_and_timer_match(void)
 		return ret;
 	}
 	(void)nrfx_gppi_ep_attach(nrfx_gppi_group_task_dis_addr(group), ppi_on_timer_match);
+
+	ret = nrfx_gppi_group_ep_add(group, eep0);
+	if (ret < 0) {
+		printk("Failed attaching an event to the group\n");
+		return ret;
+	}
+
+	ret = nrfx_gppi_group_ep_add(group, eep1);
+	if (ret < 0) {
+		printk("Failed attaching an event to the group\n");
+		return ret;
+	}
 
 	return 0;
 }

--- a/samples/bluetooth/iso_time_sync/src/controller_time_nrf53_app.c
+++ b/samples/bluetooth/iso_time_sync/src/controller_time_nrf53_app.c
@@ -139,12 +139,6 @@ int config_egu_trigger_on_rtc_and_timer_match(void)
 		return ret;
 	}
 
-	ret = nrfx_gppi_group_ep_add(group, eep0);
-	if (ret < 0) {
-		printk("Failed attaching an event to the group\n");
-		return ret;
-	}
-
 	ret = nrfx_gppi_conn_alloc(eep0, nrfx_gppi_group_task_en_addr(group), &ppi_on_rtc_match);
 	if (ret < 0) {
 		printk("Failed allocating for RTC match\n");
@@ -157,6 +151,18 @@ int config_egu_trigger_on_rtc_and_timer_match(void)
 		return ret;
 	}
 	(void)nrfx_gppi_ep_attach(nrfx_gppi_group_task_dis_addr(group), ppi_on_timer_match);
+
+	ret = nrfx_gppi_group_ep_add(group, eep0);
+	if (ret < 0) {
+		printk("Failed attaching an event to the group\n");
+		return ret;
+	}
+
+	ret = nrfx_gppi_group_ep_add(group, eep1);
+	if (ret < 0) {
+		printk("Failed attaching an event to the group\n");
+		return ret;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Move nrfx_gppi_group_ep_add after conn_alloc in the nRF52/nRF53 controller time setup. The endpoints must be configured before they can be added to a PPI group; the previous order broke the EGU trigger and timed LED toggling after the nrfx 4.0 GPPI API migration.

Also add the timer compare event to the group, which was omitted in the migration.

Affected samples: conn_time_sync, iso_time_sync.