### PR TITLE
samples: esb: fix console harness stability for CI

### DIFF
--- a/samples/esb/esb_monitor/sample.yaml
+++ b/samples/esb/esb_monitor/sample.yaml
@@ -8,7 +8,6 @@ common:
     regex:
       - "Enhanced ShockBurst monitor sample"
       - "Initialization complete"
-      - "Start receiving packets"
   timeout: 15
 
 tests:

--- a/samples/esb/esb_prx/sample.yaml
+++ b/samples/esb/esb_prx/sample.yaml
@@ -8,7 +8,6 @@ common:
     regex:
       - "Enhanced ShockBurst prx sample"
       - "Initialization complete"
-      - "Setting up for packet reception"
   timeout: 15
 
 tests:

--- a/samples/esb/esb_prx_ble/sample.yaml
+++ b/samples/esb/esb_prx_ble/sample.yaml
@@ -10,8 +10,6 @@ common:
       - "Bluetooth initialized"
       - "Advertising successfully started"
       - "ESB initialized"
-      - "Setting up for packet reception"
-      - "Initialization complete"
   timeout: 15
 
 tests:

--- a/samples/esb/esb_ptx/sample.yaml
+++ b/samples/esb/esb_ptx/sample.yaml
@@ -8,7 +8,6 @@ common:
     regex:
       - "Enhanced ShockBurst ptx sample"
       - "Initialization complete"
-      - "Sending test packet"
   timeout: 15
 
 tests:

--- a/samples/esb/esb_ptx_ble/sample.yaml
+++ b/samples/esb/esb_ptx_ble/sample.yaml
@@ -10,7 +10,6 @@ common:
       - "Bluetooth initialized"
       - "Advertising successfully started"
       - "Initialization complete"
-      - "Sending test packet"
   timeout: 15
 
 tests:


### PR DESCRIPTION
Remove regex patterns that match log lines printed after the rx/tx path is initialized. When another board is connected, additional logs appear on the console and those lines are sometimes lost, causing intermittent test failures.

Keep only the early, deterministic log lines in the Twister console harness regex list.