### PR TITLE
bluetooth: hci: Add KConfig option to support deprecated HCI commands

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -167,7 +167,8 @@ See `Samples`_ for lists of changes for the protocol-related samples.
 Bluetooth® LE
 -------------
 
-|no_changes_yet_note|
+* Added the :kconfig:option:`CONFIG_BT_HCI_SUPPORT_DEPRECATED_COMMANDS` Kconfig option to support deprecated HCI commands.
+  The option is disabled by default, and enabling it may cause deprecation warnings or errors during compilation.
 
 Bluetooth Mesh
 --------------

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -790,5 +790,11 @@ config BT_LL_SOFTDEVICE_INIT_PRIORITY
 	  This option configures the LL_SOFTDEVICE initialization priority level. The priority
 	  must be lower than the CONFIG_MPSL_INIT_PRIORITY due to dependency on the MPSL library.
 
+config BT_HCI_SUPPORT_DEPRECATED_COMMANDS
+	bool "Support deprecated HCI commands"
+	help
+	  Enable support for deprecated HCI commands in the SoftDevice Controller, if any.
+	  These may cause deprecation warnings or errors during compilation.
+
 endmenu
 endif  # BT_LL_SOFTDEVICE

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -1838,12 +1838,14 @@ static uint8_t vs_cmd_put(uint8_t const *const cmd, uint8_t *const raw_event_out
 		(sdc_hci_cmd_vs_enable_periodic_adv_event_counter_reports_t const *)cmd_params);
 #endif
 #if defined(CONFIG_BT_CTLR_DTM_HCI)
+#if defined(CONFIG_BT_HCI_SUPPORT_DEPRECATED_COMMANDS)
 	case SDC_HCI_OPCODE_CMD_VS_TRANSMITTER_CARRIER_TEST:
 		/* This command is deprecated and will be removed in the future.
 		 * Use the Transmitter Carrier Test subcommand of the VS DTM command instead.
 		 */
 		return sdc_hci_cmd_vs_transmitter_carrier_test(
 			(sdc_hci_cmd_vs_transmitter_carrier_test_t const *)cmd_params);
+#endif /* CONFIG_BT_HCI_SUPPORT_DEPRECATED_COMMANDS */
 	case SDC_HCI_OPCODE_CMD_VS_DTM_COMMAND:
 		return sdc_hci_cmd_vs_dtm_command(
 			(sdc_hci_cmd_vs_dtm_command_t const *)cmd_params,


### PR DESCRIPTION
Added a new KConfig option to support deprecated HCI commands in hci_internal.c.
This is useful because the calling of the deprecated SDC functions will trigger compiler warnings/errors, which is unnecessary if the customer is not using the deprecated API anyway. With the new option disabled (default), handling of deprecated HCI commands is not included in the build.