### PR TITLE
samples: nrf5340: extxip_smp_svr: Fix TF-M ext XIP build failures

### DIFF
--- a/cmake/sysbuild/image_signing_split.cmake
+++ b/cmake/sysbuild/image_signing_split.cmake
@@ -103,8 +103,8 @@ function(zephyr_mcuboot_tasks)
     # The MCUboot header is placed at slot0 start by --pad-header, so ih_load_addr
     # must match slot0 and not the NS-only code partition.
     if(CONFIG_BUILD_WITH_TFM)
-      dt_partition_size(slot_size PATH "${slot0_flash}" REQUIRED)
-      dt_partition_addr(slot_address PATH "${slot0_flash}" REQUIRED ABSOLUTE)
+      dt_partition_size(slot_size PATH "${slot0_partition_path}" REQUIRED)
+      dt_partition_addr(slot_address PATH "${slot0_partition_path}" REQUIRED ABSOLUTE)
     else()
       dt_partition_size(slot_size PATH "${code_partition_path}" REQUIRED)
       dt_partition_addr(slot_address PATH "${code_partition_path}" REQUIRED ABSOLUTE)

--- a/samples/nrf5340/extxip_smp_svr/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/nrf5340/extxip_smp_svr/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -89,3 +89,22 @@
 		};
 	};
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/nrf5340/extxip_smp_svr/boards/nrf5340dk_nrf5340_cpuapp_ns_no_network_core.overlay
+++ b/samples/nrf5340/extxip_smp_svr/boards/nrf5340dk_nrf5340_cpuapp_ns_no_network_core.overlay
@@ -90,3 +90,22 @@
 		};
 	};
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};


### PR DESCRIPTION
The sample was moved out of quarantine just after the upmerge PR was merged. Because during the upmerge testing those were in quarantine, they were not aligned accordingly and is not causing the twister on main to fail.

Also fix a bug in `image_signing_split.cmake` that caused yet another build failure.