### PR TITLE
net: lib: aws_fota: report the FOTA failure cause to the application and AWS IoT Jobs

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -718,6 +718,21 @@ Libraries for networking
       The :kconfig:option:`CONFIG_NRF_CLOUD_CREDENTIALS_KEYGEN_VERIFY` Kconfig option (enabled by default) exports the on-device public key so that host tooling can verify the key against the device certificate.
       See :ref:`lib_nrf_cloud_credentials_keygen` for more information.
 
+* :ref:`lib_aws_fota` library:
+
+  * Added:
+
+    * The :c:enum:`aws_fota_error_cause` enumeration and the ``cause`` field in the :c:struct:`aws_fota_event` structure.
+      The field is set when the :c:enumerator:`AWS_FOTA_EVT_ERROR` event is sent, and reports why the FOTA job failed.
+
+  * Updated the job execution update that marks a job as ``FAILED`` to report the failure in the AWS IoT Jobs ``statusDetails`` field, as ``{"reason":"<cause>","progress":"<percentage>"}``, instead of sending ``null``.
+    This makes it possible to diagnose a failed update from the AWS IoT Jobs console without a serial log from the device.
+
+* :ref:`lib_aws_iot` library:
+
+  * Updated the :c:enumerator:`AWS_IOT_EVT_FOTA_ERROR` event to report the cause of the FOTA failure in the ``data.err`` field, as a value of the :c:enum:`aws_fota_error_cause` enumeration.
+    Previously, the event carried no payload.
+
 * Added :ref:`TLS Credentials Subsystem <zephyr:sockets_tls_credentials_subsys>` support for TLS credential expiry retrieval when using the modem as TLS credentials storage.
 
 Libraries for NFC

--- a/include/net/aws_fota.h
+++ b/include/net/aws_fota.h
@@ -37,7 +37,9 @@ enum aws_fota_evt_id {
 	 *  needs to be reinitialized to apply the new modem image.
 	 */
 	AWS_FOTA_EVT_DONE,
-	/** AWS FOTA error */
+	/** AWS FOTA error.
+	 *  Payload of type @ref aws_fota_error_cause (cause).
+	 */
 	AWS_FOTA_EVT_ERROR,
 	/** AWS FOTA Erase pending*/
 	AWS_FOTA_EVT_ERASE_PENDING,
@@ -45,6 +47,53 @@ enum aws_fota_evt_id {
 	AWS_FOTA_EVT_ERASE_DONE,
 	/** AWS FOTA download progress */
 	AWS_FOTA_EVT_DL_PROGRESS,
+};
+
+/** @brief Cause of a failed FOTA job, reported with the @ref AWS_FOTA_EVT_ERROR event.
+ *
+ *  The same cause is reported to AWS IoT Jobs in the ``statusDetails`` field of the job
+ *  execution update that marks the job as ``FAILED``.
+ */
+enum aws_fota_error_cause {
+	/** No error. Used when the event ID is not @ref AWS_FOTA_EVT_ERROR. */
+	AWS_FOTA_ERROR_CAUSE_NO_ERROR = 0,
+	/** Connecting to the firmware server failed. A possible reason could be wrong
+	 *  TLS credentials. A retry with the same credentials is unlikely to help.
+	 */
+	AWS_FOTA_ERROR_CAUSE_CONNECT_FAILED,
+	/** Downloading the update failed. The download may be retried. */
+	AWS_FOTA_ERROR_CAUSE_DOWNLOAD_FAILED,
+	/** The update is invalid and was rejected. A retry will not help. */
+	AWS_FOTA_ERROR_CAUSE_INVALID_UPDATE,
+	/** The actual firmware type does not match the expected type. A retry will not help. */
+	AWS_FOTA_ERROR_CAUSE_TYPE_MISMATCH,
+	/** Generic error on the device side. */
+	AWS_FOTA_ERROR_CAUSE_INTERNAL,
+	/** Error reported by the DFU library. */
+	AWS_FOTA_ERROR_CAUSE_DFU,
+	/** The transfer protocol requested in the job document is not supported. */
+	AWS_FOTA_ERROR_CAUSE_PROTO_NOT_SUPPORTED,
+	/** Invalid URI or invalid download configuration. */
+	AWS_FOTA_ERROR_CAUSE_INVALID_CONFIGURATION,
+	/** The received job document could not be parsed. A retry will not help. */
+	AWS_FOTA_ERROR_CAUSE_INVALID_JOB_DOCUMENT,
+	/** The URL in the job document did not fit in the configured buffers.
+	 *  See :kconfig:option:`CONFIG_DOWNLOADER_MAX_HOSTNAME_SIZE` and
+	 *  :kconfig:option:`CONFIG_DOWNLOADER_MAX_FILENAME_SIZE`.
+	 */
+	AWS_FOTA_ERROR_CAUSE_URL_TOO_LONG,
+	/** The job document requested HTTPS, but no security tag is configured.
+	 *  See :kconfig:option:`CONFIG_AWS_FOTA_DOWNLOAD_SECURITY_TAG`.
+	 */
+	AWS_FOTA_ERROR_CAUSE_NO_SEC_TAG,
+	/** The firmware download could not be started. */
+	AWS_FOTA_ERROR_CAUSE_DOWNLOAD_START_FAILED,
+	/** The job execution update was rejected by AWS IoT Jobs. */
+	AWS_FOTA_ERROR_CAUSE_JOB_UPDATE_REJECTED,
+	/** The job execution could not be updated after a successful download. */
+	AWS_FOTA_ERROR_CAUSE_JOB_UPDATE_FAILED,
+	/** Unknown or unmapped error cause. */
+	AWS_FOTA_ERROR_CAUSE_UNKNOWN,
 };
 
 #define AWS_FOTA_EVT_DL_COMPLETE_VAL 100
@@ -57,6 +106,8 @@ struct aws_fota_event {
 	union {
 		struct aws_fota_event_dl dl;
 		enum dfu_target_image_type image;
+		/** Cause of the failure, set when the event ID is @ref AWS_FOTA_EVT_ERROR. */
+		enum aws_fota_error_cause cause;
 	};
 };
 

--- a/include/net/aws_iot.h
+++ b/include/net/aws_iot.h
@@ -163,7 +163,11 @@ enum aws_iot_evt_type {
 	 */
 	AWS_IOT_EVT_FOTA_DL_PROGRESS,
 
-	/** FOTA error. Something went wrong during the FOTA process, try again. */
+	/** FOTA error. Something went wrong during the FOTA process.
+	 *  Payload is of type int (.data.err), containing the cause of the failure as a
+	 *  value of type enum aws_fota_error_cause. The same cause is reported to
+	 *  AWS IoT Jobs in the statusDetails field of the failed job execution.
+	 */
 	AWS_IOT_EVT_FOTA_ERROR,
 
 	/** Irrecoverable error, if this event is received the device should perform a reboot.
@@ -234,6 +238,9 @@ struct aws_iot_evt {
 
 		/** Error code that indicates reason of failure when receiving
 		 *  the AWS_IOT_EVT_ERROR event.
+		 *
+		 *  When receiving the AWS_IOT_EVT_FOTA_ERROR event, this is the cause of the
+		 *  FOTA failure, as a value of type enum aws_fota_error_cause.
 		 */
 		int err;
 

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -19,6 +19,11 @@ LOG_MODULE_REGISTER(aws_fota, CONFIG_AWS_FOTA_LOG_LEVEL);
 
 #define AWS_JOB_ID_DEFAULT "INVALID-JOB-ID"
 
+/* Maximum length of the status details JSON object that is reported to AWS IoT Jobs when a job
+ * execution is marked as failed. Must fit {"reason":"<cause>","progress":"<0-100>"}.
+ */
+#define STATUS_DETAILS_MAX_LEN 64
+
 static enum internal_state {
 	STATE_UNINIT,
 	STATE_INIT,
@@ -50,6 +55,11 @@ static uint32_t execution_version_number;
 
 /* File download progress in percentage [0-100%]. */
 static size_t download_progress;
+
+/* Cause of the failure of the job execution currently being handled. Kept so that the reason can
+ * be reported to AWS IoT Jobs, also when the update is retried after a reconnect.
+ */
+static enum aws_fota_error_cause error_cause = AWS_FOTA_ERROR_CAUSE_NO_ERROR;
 
 /* Variable that keeps tracks of the MQTT connection state. */
 static bool connected;
@@ -88,6 +98,72 @@ static char *state2str(enum internal_state state)
 	}
 }
 
+/* Convert a fota_download error cause to the corresponding aws_fota error cause. */
+static enum aws_fota_error_cause error_cause_convert(enum fota_download_error_cause cause)
+{
+	switch (cause) {
+	case FOTA_DOWNLOAD_ERROR_CAUSE_NO_ERROR:
+		return AWS_FOTA_ERROR_CAUSE_NO_ERROR;
+	case FOTA_DOWNLOAD_ERROR_CAUSE_CONNECT_FAILED:
+		return AWS_FOTA_ERROR_CAUSE_CONNECT_FAILED;
+	case FOTA_DOWNLOAD_ERROR_CAUSE_DOWNLOAD_FAILED:
+		return AWS_FOTA_ERROR_CAUSE_DOWNLOAD_FAILED;
+	case FOTA_DOWNLOAD_ERROR_CAUSE_INVALID_UPDATE:
+		return AWS_FOTA_ERROR_CAUSE_INVALID_UPDATE;
+	case FOTA_DOWNLOAD_ERROR_CAUSE_TYPE_MISMATCH:
+		return AWS_FOTA_ERROR_CAUSE_TYPE_MISMATCH;
+	case FOTA_DOWNLOAD_ERROR_CAUSE_INTERNAL:
+		return AWS_FOTA_ERROR_CAUSE_INTERNAL;
+	case FOTA_DOWNLOAD_ERROR_CAUSE_DFU:
+		return AWS_FOTA_ERROR_CAUSE_DFU;
+	case FOTA_DOWNLOAD_ERROR_CAUSE_PROTO_NOT_SUPPORTED:
+		return AWS_FOTA_ERROR_CAUSE_PROTO_NOT_SUPPORTED;
+	case FOTA_DOWNLOAD_ERROR_CAUSE_INVALID_CONFIGURATION:
+		return AWS_FOTA_ERROR_CAUSE_INVALID_CONFIGURATION;
+	default:
+		return AWS_FOTA_ERROR_CAUSE_UNKNOWN;
+	}
+}
+
+/* Convert an error cause to the string that is reported in the job execution status details. */
+static const char *error_cause2str(enum aws_fota_error_cause cause)
+{
+	switch (cause) {
+	case AWS_FOTA_ERROR_CAUSE_NO_ERROR:
+		return "NO_ERROR";
+	case AWS_FOTA_ERROR_CAUSE_CONNECT_FAILED:
+		return "CONNECT_FAILED";
+	case AWS_FOTA_ERROR_CAUSE_DOWNLOAD_FAILED:
+		return "DOWNLOAD_FAILED";
+	case AWS_FOTA_ERROR_CAUSE_INVALID_UPDATE:
+		return "INVALID_UPDATE";
+	case AWS_FOTA_ERROR_CAUSE_TYPE_MISMATCH:
+		return "TYPE_MISMATCH";
+	case AWS_FOTA_ERROR_CAUSE_INTERNAL:
+		return "INTERNAL";
+	case AWS_FOTA_ERROR_CAUSE_DFU:
+		return "DFU";
+	case AWS_FOTA_ERROR_CAUSE_PROTO_NOT_SUPPORTED:
+		return "PROTO_NOT_SUPPORTED";
+	case AWS_FOTA_ERROR_CAUSE_INVALID_CONFIGURATION:
+		return "INVALID_CONFIGURATION";
+	case AWS_FOTA_ERROR_CAUSE_INVALID_JOB_DOCUMENT:
+		return "INVALID_JOB_DOCUMENT";
+	case AWS_FOTA_ERROR_CAUSE_URL_TOO_LONG:
+		return "URL_TOO_LONG";
+	case AWS_FOTA_ERROR_CAUSE_NO_SEC_TAG:
+		return "NO_SEC_TAG";
+	case AWS_FOTA_ERROR_CAUSE_DOWNLOAD_START_FAILED:
+		return "DOWNLOAD_START_FAILED";
+	case AWS_FOTA_ERROR_CAUSE_JOB_UPDATE_REJECTED:
+		return "JOB_UPDATE_REJECTED";
+	case AWS_FOTA_ERROR_CAUSE_JOB_UPDATE_FAILED:
+		return "JOB_UPDATE_FAILED";
+	default:
+		return "UNKNOWN";
+	}
+}
+
 static void internal_state_set(enum internal_state new_state)
 {
 	if (new_state == internal_state) {
@@ -111,6 +187,7 @@ static void reset_library(void)
 	internal_state_set(STATE_INIT);
 	execution_status = AWS_JOBS_QUEUED;
 	download_progress = 0;
+	error_cause = AWS_FOTA_ERROR_CAUSE_NO_ERROR;
 	set_current_job_id(AWS_JOB_ID_DEFAULT);
 	LOG_DBG("Library reset");
 }
@@ -193,6 +270,8 @@ static int update_job_execution(struct mqtt_client *const client,
 				const char *client_token)
 {
 	int err;
+	char status_details[STATUS_DETAILS_MAX_LEN];
+	const char *status_details_ptr = NULL;
 
 	/* Check if the library has obtained a job ID. */
 	if (strncmp(job_id, AWS_JOB_ID_DEFAULT, job_id_len) == 0) {
@@ -202,8 +281,25 @@ static int update_job_execution(struct mqtt_client *const client,
 	LOG_DBG("%s, status: %d, version_number: %d", __func__,
 		status, execution_version_number);
 
+	/* Report the cause of the failure and the download progress at the time of the failure
+	 * in the status details of the job execution. This makes it possible to diagnose a failed
+	 * update from the AWS IoT Jobs console, without access to a serial log from the device.
+	 */
+	if (status == AWS_JOBS_FAILED) {
+		int len = snprintf(status_details, sizeof(status_details),
+				   "{\"reason\":\"%s\",\"progress\":\"%u\"}",
+				   error_cause2str(error_cause),
+				   (unsigned int)download_progress);
+
+		if ((len > 0) && ((size_t)len < sizeof(status_details))) {
+			status_details_ptr = status_details;
+		} else {
+			LOG_WRN("Status details truncated, reporting failure without them");
+		}
+	}
+
 	err = aws_jobs_update_job_execution(client, job_id, status,
-					    NULL,
+					    status_details_ptr,
 					    execution_version_number,
 					    client_token, update_topic);
 
@@ -221,14 +317,26 @@ static int update_job_execution(struct mqtt_client *const client,
  * @brief Update the job document of the current job to AWS_JOBS_FAILED and move to ERROR state.
  *
  * @param client Connected MQTT client instance
+ * @param cause  Cause of the failure. Reported to the application in the
+ *		 AWS_FOTA_EVT_ERROR event and to AWS IoT Jobs in the job execution
+ *		 status details.
  *
  * @return 0 If successful otherwise a negative error code is returned.
  */
-static int set_current_job_failed(struct mqtt_client *const client)
+static int set_current_job_failed(struct mqtt_client *const client,
+				  enum aws_fota_error_cause cause)
 {
 	struct aws_fota_event aws_fota_evt = {
-		.id = AWS_FOTA_EVT_ERROR
+		.id = AWS_FOTA_EVT_ERROR,
+		.cause = cause
 	};
+
+	LOG_ERR("FOTA job failed, cause: %s", error_cause2str(cause));
+
+	/* Store the cause so that it is also reported if the job execution update has to be
+	 * retried after a reconnect.
+	 */
+	error_cause = cause;
 
 	callback(&aws_fota_evt);
 	internal_state_set(STATE_ERROR);
@@ -303,10 +411,11 @@ static int parse_job_execution(struct mqtt_client *const client, uint32_t payloa
 	/* Check if the update data is valid */
 	if (err == AWS_FOTA_JSON_RES_INVALID_DOCUMENT) {
 		LOG_ERR("Invalid FOTA update document: %d", err);
-		return set_current_job_failed(client);
+		return set_current_job_failed(client,
+					      AWS_FOTA_ERROR_CAUSE_INVALID_JOB_DOCUMENT);
 	} else if (err == AWS_FOTA_JSON_RES_URL_TOO_LONG) {
 		LOG_ERR("URL elements too long for buffer: %d", err);
-		return set_current_job_failed(client);
+		return set_current_job_failed(client, AWS_FOTA_ERROR_CAUSE_URL_TOO_LONG);
 	}
 
 	/* Valid update */
@@ -376,7 +485,8 @@ static int job_update_accepted(struct mqtt_client *const client, uint32_t payloa
 		if (strncmp(protocol, "https", 5) == 0) {
 			if (CONFIG_AWS_FOTA_DOWNLOAD_SECURITY_TAG == -1) {
 				LOG_ERR("Trying to use https without sec tag configured.");
-				return set_current_job_failed(client);
+				return set_current_job_failed(client,
+							      AWS_FOTA_ERROR_CAUSE_NO_SEC_TAG);
 			}
 
 			sec_tag = CONFIG_AWS_FOTA_DOWNLOAD_SECURITY_TAG;
@@ -387,7 +497,8 @@ static int job_update_accepted(struct mqtt_client *const client, uint32_t payloa
 		err = fota_download_start(hostname, file_path, sec_tag, 0, 0);
 		if (err) {
 			LOG_ERR("Error (%d) when trying to start firmware download", err);
-			return set_current_job_failed(client);
+			return set_current_job_failed(
+				client, AWS_FOTA_ERROR_CAUSE_DOWNLOAD_START_FAILED);
 		}
 
 		internal_state_set(STATE_DOWNLOADING);
@@ -435,7 +546,10 @@ static int job_update_accepted(struct mqtt_client *const client, uint32_t payloa
  */
 static int job_update_rejected(struct mqtt_client *const client, uint32_t payload_len)
 {
-	struct aws_fota_event aws_fota_evt = { .id = AWS_FOTA_EVT_ERROR };
+	struct aws_fota_event aws_fota_evt = {
+		.id = AWS_FOTA_EVT_ERROR,
+		.cause = AWS_FOTA_ERROR_CAUSE_JOB_UPDATE_REJECTED
+	};
 	LOG_ERR("Job document update was rejected");
 	execution_version_number--;
 	int err = get_published_payload(client, payload_buf, payload_len);
@@ -756,6 +870,7 @@ static void http_fota_handler(const struct fota_download_evt *evt)
 					   "");
 		if (err != 0 && connected) {
 			aws_fota_evt.id = AWS_FOTA_EVT_ERROR;
+			aws_fota_evt.cause = AWS_FOTA_ERROR_CAUSE_JOB_UPDATE_FAILED;
 			callback(&aws_fota_evt);
 			reset_library();
 			return;
@@ -782,9 +897,9 @@ static void http_fota_handler(const struct fota_download_evt *evt)
 		break;
 
 	case FOTA_DOWNLOAD_EVT_ERROR:
-		LOG_ERR("FOTA_DOWNLOAD_EVT_ERROR");
+		LOG_ERR("FOTA_DOWNLOAD_EVT_ERROR, cause: %d", evt->cause);
 
-		err = set_current_job_failed(client_internal);
+		err = set_current_job_failed(client_internal, error_cause_convert(evt->cause));
 		if (err < 0) {
 			reset_library();
 		}

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -209,8 +209,9 @@ static void aws_fota_cb_handler(struct aws_fota_event *fota_evt)
 		aws_iot_evt.type = AWS_IOT_EVT_FOTA_ERASE_DONE;
 		break;
 	case AWS_FOTA_EVT_ERROR:
-		LOG_ERR("AWS_FOTA_EVT_ERROR");
+		LOG_ERR("AWS_FOTA_EVT_ERROR, cause: %d", fota_evt->cause);
 		aws_iot_evt.type = AWS_IOT_EVT_FOTA_ERROR;
+		aws_iot_evt.data.err = (int)fota_evt->cause;
 		break;
 	case AWS_FOTA_EVT_DL_PROGRESS:
 		LOG_DBG("AWS_FOTA_EVT_DL_PROGRESS, (%d%%)", fota_evt->dl.progress);


### PR DESCRIPTION
## Problem

We use `aws_iot` + `aws_fota` on nRF91 for fleet firmware updates. When a job fails, both the device event and the AWS IoT job execution report the failure with no reason attached, which makes field debugging hard. The cause is already known inside `aws_fota` at the moment of failure. It is simply discarded.

On current `main`:

* `fota_download` produces a useful cause enum, `fota_download_error_cause`, but the `FOTA_DOWNLOAD_EVT_ERROR` handler in `aws_fota.c` never reads `evt->cause`.
* `set_current_job_failed()` emits `AWS_FOTA_EVT_ERROR` with no payload. `struct aws_fota_event` had no error member at all, only `dl` and `image`.
* `update_job_execution()` hardcoded `NULL` for `status_details`.
* `aws_iot` forwarded this as `AWS_IOT_EVT_FOTA_ERROR` with no `evt->data.err`.

The result is a job showing `status: FAILED` and `statusDetails: null`, and an application error event carrying no information. The only way to find out why an update failed is a serial log, which is not available on deployed devices.

`AWS_IOT_EVT_ERROR` is not a substitute, as it is documented as an irrecoverable library error and is not used for FOTA failures.

## Change

1. **`aws_fota`** gains an `aws_fota_error_cause` enumeration and a `cause` field in `struct aws_fota_event`. It covers the `fota_download` causes plus the `aws_fota`-level failures that previously all looked identical: invalid job document, URL too long, HTTPS requested without a security tag, download start failure, and a rejected or failed job execution update. The cause is set on every `AWS_FOTA_EVT_ERROR` emission, not just the download path.

2. **`aws_fota`** reports the cause to AWS IoT Jobs in the `statusDetails` field when marking a job `FAILED`:

   ```json
   {"reason":"CONNECT_FAILED","progress":"42"}
   ```

   `aws_jobs_update_job_execution()` already accepted `status_details`. The library just never filled it in. The cause is stored so that the reason survives a reconnect, where the library re-reports the status of a job it was already handling.

3. **`aws_iot`** forwards the cause to the application as `evt->data.err` on `AWS_IOT_EVT_FOTA_ERROR`.

This lets a failed update be diagnosed from the AWS IoT Jobs console without physical access to the device, and lets the application report a real cause instead of inferring one from whichever FOTA event happened to fire last.

## Compatibility

* Additive only. `enum aws_fota_error_cause` is a new type, and `cause` is a new member of the existing anonymous union in `struct aws_fota_event`, which already contained at least an `int`. No existing member changes type, position, or meaning.
* `AWS_IOT_EVT_FOTA_ERROR` previously left `data.err` unset. Applications that ignore it are unaffected.
* No Kconfig and no API function signatures changed.
* `statusDetails` fits the existing `CONFIG_UPDATE_JOB_PAYLOAD_LEN` budget (default 1350); the formatted object is bounded at 64 bytes and the library falls back to sending no details if formatting would truncate.

## Notes

* `progress` reports `download_progress`, which is only updated when `CONFIG_FOTA_DOWNLOAD_PROGRESS_EVT` is enabled. Without it the field reports `0`, and the `reason` field is still accurate.
* Related prior work: #11995 (`net: lib: aws_fota: Improve error handling for FOTA jobs`) improved job failure handling, but the job update still published `statusDetails: null`.

Happy to adjust the naming, split the enum differently, or drop the `progress` field if you would rather keep `statusDetails` to a single key.

## Testing

Written and reviewed against `main`, but **not yet built or run on hardware** by me. It needs a build and an on-device FOTA failure run before merging. I am glad to iterate on review feedback, and can test against our nRF9151 fleet if that is useful.

Environment this was written for: NCS 3.1.1, nRF91, `CONFIG_AWS_IOT` + `CONFIG_AWS_FOTA`.
