### PR TITLE
scripts: memory thresholds: add missing Find My locator tag targets

### DIFF
--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -38,6 +38,7 @@
   platforms: # configuration for large memory devices
     - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54lc10dk/nrf54lc10a/cpuapp
     - nrf54lm20dk/nrf54lm20a/cpuapp
   rom_increase: 1024
   ram_increase: 1024

--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -26,6 +26,7 @@
     - sample.find_my.locator_tag.release
   platforms: # configuration for small memory devices
     - nrf54l15dk/nrf54l05/cpuapp
+    - nrf54ls05dk/nrf54ls05a/cpuapp
     - nrf54ls05dk/nrf54ls05b/cpuapp
   rom_increase: 512
   ram_increase: 512


### PR DESCRIPTION
## Summary

- Add nRF54LS05A to the small-memory threshold group for the Find My Locator Tag release build.
- Add nRF54LC10A to the corresponding large-memory threshold group.

Ref: NCSDK-40732
Ref: NCSDK-40268

## Test plan

- [x] Verified the memory threshold YAML diff and formatting with `git diff --check`.
