### PR TITLE
[Backport v3.4-branch] scripts: memory thresholds: add missing Find My locator tag targets

### DIFF
--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -35,6 +35,7 @@
     - nrf52dk/nrf52832
     - nrf52833dk/nrf52833
     - nrf54l15dk/nrf54l05/cpuapp
+    - nrf54ls05dk/nrf54ls05a/cpuapp
     - nrf54ls05dk/nrf54ls05b/cpuapp
   rom_increase: 512
   ram_increase: 512

--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -50,6 +50,7 @@
     - nrf5340dk/nrf5340/cpuapp/ns
     - nrf54l15dk/nrf54l10/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54lc10dk/nrf54lc10a/cpuapp
     - nrf54lm20dk/nrf54lm20a/cpuapp
   rom_increase: 1024
   ram_increase: 1024


### PR DESCRIPTION
Backport 2d5af655ef6e17e21a83e5aac9b056da6d9c1644~2..2d5af655ef6e17e21a83e5aac9b056da6d9c1644 from #30711.