### PR TITLE
scripts: sbom: Use release tags as the package version

### DIFF
--- a/scripts/west_commands/sbom/data_structure.py
+++ b/scripts/west_commands/sbom/data_structure.py
@@ -81,6 +81,8 @@ class Package(DataBaseClass):
         name                    User friendly name
         url                     URL pointing to the source of this package
         version                 Version string of this package
+        revision                Commit SHA this package was taken from. "version" may hold
+                                a release tag. This keeps the exact source revision
         browser_url             URL that can be opened in a web browser
         supplier                Supplier name
         purl                    Package URL (PURL) identifier
@@ -93,6 +95,7 @@ class Package(DataBaseClass):
     name: 'str|None' = None
     url: 'str|None' = None
     version: 'str|None' = None
+    revision: 'str|None' = None
     browser_url: 'str|None' = None
     supplier: 'str|None' = None
     purl: 'str|None' = None

--- a/scripts/west_commands/sbom/git_info_detector.py
+++ b/scripts/west_commands/sbom/git_info_detector.py
@@ -8,17 +8,22 @@ import re
 from pathlib import Path
 
 from args import args
-from common import SbomException, command_execute, concurrent_pool_iter
+from common import SbomException, command_execute, concurrent_pool_iter, is_sha
 from data_structure import Data, FileInfo, Package
 from west import log
 
                                                     # FileInfo is used.
+
+NCS_TAG_RE = re.compile(r'^ncs-v\d+\.\d+\.\d+')  # ncs-v3.4.0, the NCS release
+VERSION_TAG_RE = re.compile(r'^v?\d+\.\d+')      # v3.4.0, v1.3.4-ncs1, 1.42.0
+PRERELEASE_RE = re.compile(r'-(rc|snapshot|alpha|beta|dev)', re.IGNORECASE)  # ncs-v3.4.0-rc2
 
 _manifest_projects: 'dict[Path, object]' = {}
 _manifest_path_index: 'list[tuple[Path, object]]' = []
 _self_repo_path: 'Path|None' = None
 _self_repo_name: 'str|None' = None
 _self_repo_version: 'str|None' = None
+_version_cache: 'dict[tuple[Path, str], str]' = {}
 
 
 def split_lines(text: str) -> 'tuple[str]':
@@ -149,6 +154,51 @@ def get_toplevel(absolute_path: Path) -> 'Path|None':
         return None
 
 
+def tags_at(repo: Path, revision: str) -> 'tuple[str]':
+    '''Returns all git tags pointing exactly at `revision` in the `repo` directory.
+
+    Returns an empty tuple when the revision is unknown locally.
+    '''
+    output, error_code = command_execute(args.git, 'tag', '--points-at', revision, cwd=repo,
+                                         return_error_code=True, allow_stderr=True,
+                                         log_stderr=False)
+    if error_code != 0:
+        return tuple()
+    return split_lines(output)
+
+
+def tag_priority(tag: str) -> 'tuple[int,int,str]':
+    '''Returns the sort key of `tag`. The greatest key identifies a release best.
+
+    An NCS release tag wins over the repository's own version tag, a final release wins over
+    a pre-release and the highest tag name wins the rest.
+    '''
+    if NCS_TAG_RE.match(tag):
+        group = 2
+    elif VERSION_TAG_RE.match(tag):
+        group = 1
+    else:
+        group = 0
+    return (group, 0 if PRERELEASE_RE.search(tag) else 1, tag)
+
+
+def select_tag(tags: 'tuple[str]') -> 'str|None':
+    '''Returns the tag from `tags` that identifies a release best, or None if there is none.'''
+    return max(tags, key=tag_priority) if tags else None
+
+
+def resolve_version(repo: 'Path|None', revision: 'str|None') -> 'str|None':
+    '''Returns a release tag pointing at `revision` or `revision` if there is no such tag.'''
+
+    if (revision is None) or (repo is None) or (not is_sha(revision)):
+        return revision
+    key = (repo, revision)
+    if key not in _version_cache:
+        # detect_dir runs once per directory. Cache the tags of each repository.
+        _version_cache[key] = select_tag(tags_at(repo, revision)) or revision
+    return _version_cache[key]
+
+
 def upstream_url(project) -> 'str|None':
     '''Returns userdata.ncs.upstream-url for a manifest project.'''
     userdata = getattr(project, 'userdata', None)
@@ -195,6 +245,7 @@ def load_manifest():
     _self_repo_path = None
     _self_repo_name = None
     _self_repo_version = None
+    _version_cache.clear()
     try:
         from west.manifest import Manifest
         manifest = Manifest.from_topdir()
@@ -278,6 +329,9 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
             if project is None:
                 project = mproject
 
+    # report the tag when there is one.
+    git_version = resolve_version(repo, git_sha)
+
     if repo is not None:
         output, error_code = command_execute(args.git, 'status', '--porcelain', '--ignored',
                                              '--untracked-files=all', '*', cwd=absolute_path,
@@ -303,7 +357,8 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
         package = Package()
         package.id = package_id
         package.url = git_origin
-        package.version = git_sha
+        package.version = git_version
+        package.revision = git_sha
         if git_origin is None and package_name is not None:
             package.name = package_name
         if git_origin and git_sha:

--- a/scripts/west_commands/sbom/output_template.py
+++ b/scripts/west_commands/sbom/output_template.py
@@ -93,11 +93,12 @@ def github_archive_url(git_url: str, version: str) -> 'str|None':
 def download_location(package: Package) -> str:
     '''Format the SPDX PackageDownloadLocation field for a package.'''
     if package.purl:
+        revision = package.revision or package.version
         if args.package_download_format == 'github-archive':
-            archive_url = github_archive_url(package.url, package.version)
+            archive_url = github_archive_url(package.url, revision)
             if archive_url is not None:
                 return archive_url
-        return f'git+{package.url}@{package.version}'
+        return f'git+{package.url}@{revision}'
     return package.url or 'NONE'
 
 


### PR DESCRIPTION
PackageVersion was the manifest revision, which west.yml pins as a full commit SHA sometime. A SHA cannot be mapped to a release, so customers could not tell which version a package is when a new vulnerability comes out.

Report the release tag pointing at that revision instead. Tags already exist at those commits. An NCS release tag wins over the repository own version tag and a final release wins over a pre-release. Revisions that are already a tag are kept as they are and the SHA is still used when the commit carries no tag.

Keep the commit SHA in the new Package.revision field so the purl external reference and PackageDownloadLocation remain commit.