### PR TITLE
samples: Recreate nordic-tz descriptors to match overlay partitions

### DIFF
--- a/samples/bluetooth/central_and_peripheral_hrs/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/central_and_peripheral_hrs/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/central_bas/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/central_bas/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/central_uart/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/central_uart/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/multiple_adv_sets/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/multiple_adv_sets/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/peripheral_ams_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_ams_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/peripheral_ancs_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_ancs_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/peripheral_cgms/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_cgms/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/peripheral_cts_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_cts_client/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/peripheral_gatt_dm/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_gatt_dm/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/peripheral_mds/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_mds/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/peripheral_nfc_pairing/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_nfc_pairing/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/peripheral_power_profiling/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_power_profiling/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/peripheral_rscs/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_rscs/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/peripheral_status/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/peripheral_status/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/shell_bt_nus/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/shell_bt_nus/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/bluetooth/throughput/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/throughput/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -82,3 +82,22 @@
 &sram0_ns_app {
 	reg = <0x0 0x64000>;
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/samples/wifi/shell/boards/nrf7002dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/wifi/shell/boards/nrf7002dk_nrf5340_cpuapp_ns.overlay
@@ -102,3 +102,22 @@
 		};
 	};
 };
+
+/ {
+	/delete-node/ nordic-tz-secure;
+	/delete-node/ nordic-tz-nonsecure;
+
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -101,30 +101,6 @@
   comment: "RAM Overflow"
 
 - scenarios:
-    - sample.bluetooth.central_and_peripheral_hrs
-    - sample.bluetooth.central_bas
-    - sample.bluetooth.central_uart
-    - sample.bluetooth.multiple_adv_sets
-    - sample.bluetooth.peripheral_ams_client.build
-    - sample.bluetooth.peripheral_ancs_client.build
-    - sample.bluetooth.peripheral_cgm
-    - sample.bluetooth.peripheral_cts_client
-    - sample.bluetooth.peripheral_gatt_dm
-    - sample.bluetooth.peripheral_mds
-    - sample.bluetooth.peripheral_nfc_pairing
-    - sample.bluetooth.peripheral_nsms
-    - sample.bluetooth.peripheral_nsms_no_security
-    - sample.bluetooth.peripheral_power_profiling
-    - sample.bluetooth.peripheral_rscs
-    - sample.bluetooth.shell_bt_nus
-    - sample.bluetooth.throughput
-    - sample.nrf7002_ns.shell
-  platforms:
-    - nrf5340dk/nrf5340/cpuapp/ns
-    - nrf7002dk/nrf5340/cpuapp/ns
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-40844"
-
-- scenarios:
     - benchmarks.current_consumption.nfc_idle
   platforms:
     - nrf9251dk/nrf9251/cpuapp


### PR DESCRIPTION
Fix leftover partition configurations not caught in the upmerge PR.

These non-secure overlays redefine the partition map with a single code slot, leaving the inherited nordic-tz descriptors pointing at the now-undefined slot1_s/ns partitions and failing the devicetree build. Recreate the descriptors to match the partitions each overlay defines, covering the samples missed by the earlier treewide fix.

Ref: NCSDK-40844
