### PR TITLE
scripts: quarantine_zephyr: rename TF-M test scenarios

### DIFF
--- a/samples/zephyr/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/zephyr/tfm_integration/tfm_ipc/sample.yaml
@@ -9,7 +9,7 @@ common:
     - ci_samples_zephyr_tfm_integration
 
 tests:
-  nrf.extended.sample.tfm_ipc:
+  nrf.extended.sample.tfm.tfm_ipc:
     tags:
       - mcuboot
     platform_allow:
@@ -25,7 +25,7 @@ tests:
         - "The version of the PSA Framework API is"
         - "The PSA Crypto service minor version is"
         - "Generating 256 bytes of random data"
-  nrf.extended.sample.tfm_ipc.no_bl2:
+  nrf.extended.sample.tfm.tfm_ipc.no_bl2:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp/ns

--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -247,10 +247,9 @@
   comment: "Won't be fixed - https://nordicsemi.atlassian.net/browse/NCSDK-18853"
 
 - scenarios:
-    - tf-m.regression.ipc.lvl1
-    - tf-m.regression.ipc.lvl2
-    - tf-m.regression.sfn.profile.not_set
-    - tf-m.regression.sfn.profile.small
+    - tfm.regression.ipc.lvl1
+    - tfm.regression.ipc.lvl2
+    - tfm.regression.sfn
     - sample.tfm.psa_test_protected_storage
     - sample.tfm.psa_test_internal_trusted_storage
     - sample.tfm.psa_test_storage

--- a/scripts/quarantine_zephyr_integration.yaml
+++ b/scripts/quarantine_zephyr_integration.yaml
@@ -82,7 +82,7 @@
 
 - scenarios:
     - sample.tfm.protected_storage
-    - sample.tfm_ipc
+    - sample.tfm.tfm_ipc
   platforms:
     - nrf9160dk@0.14.0/nrf9160/ns
     - nrf5340dk/nrf5340/cpuapp/ns

--- a/tests/zephyr/modules/tf-m/regression/testcase.yaml
+++ b/tests/zephyr/modules/tf-m/regression/testcase.yaml
@@ -19,7 +19,7 @@ common:
       - "Test suite 'Platform Service Non-Secure interface tests.*' has.*PASSED"
 
 tests:
-  nrf.extended.tf-m.regression.ipc.lvl1:
+  nrf.extended.tfm.regression.ipc.lvl1:
     tags:
       - tfm_lvl1
     extra_args:
@@ -42,7 +42,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf7120dk/nrf7120/cpuapp/ns
       - nrf9151dk/nrf9151/ns
-  nrf.extended.tf-m.regression.ipc.lvl2.cc3xx:
+  nrf.extended.tfm.regression.ipc.lvl2.cc3xx:
     tags:
       - tfm_lvl2
     extra_args:
@@ -57,7 +57,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf9151dk/nrf9151/ns
-  nrf.extended.tf-m.regression.ipc.lvl2.oberon:
+  nrf.extended.tfm.regression.ipc.lvl2.oberon:
     tags:
       - tfm_lvl2
     extra_args:
@@ -72,7 +72,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf9151dk/nrf9151/ns
-  nrf.extended.tf-m.regression.ipc.lvl2.cc3xx.oberon:
+  nrf.extended.tfm.regression.ipc.lvl2.cc3xx.oberon:
     tags:
       - tfm_lvl2
     extra_args:
@@ -87,7 +87,7 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf9151dk/nrf9151/ns
-  nrf.extended.tf-m.regression.ipc.lvl2.cracen:
+  nrf.extended.tfm.regression.ipc.lvl2.cracen:
     tags:
       - tfm_lvl2
     extra_args:
@@ -104,7 +104,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf7120dk/nrf7120/cpuapp/ns
-  nrf.extended.tf-m.regression.sfn:
+  nrf.extended.tfm.regression.sfn:
     tags:
       - tfm_lvl1
     extra_args:
@@ -127,7 +127,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp/ns
       - nrf7120dk/nrf7120/cpuapp/ns
       - nrf9151dk/nrf9151/ns
-  nrf.extended.tf-m.regression.fp.hardabi:
+  nrf.extended.tfm.regression.fp.hardabi:
     tags:
       - tfm_fp
     extra_args:


### PR DESCRIPTION
To match upstream that renamed them.