### PR TITLE
applications: nrf_desktop: Protect against sci init conn params race

### DIFF
--- a/applications/nrf_desktop/Kconfig.ble
+++ b/applications/nrf_desktop/Kconfig.ble
@@ -116,6 +116,14 @@ config BT_CONN_PARAM_UPDATE_TIMEOUT
 	  nRF Desktop peripherals update connection parameters earlier to lower
 	  HID data latency.
 
+configdefault BT_GAP_AUTO_UPDATE_CONN_PARAMS
+	default n
+	help
+	  nRF Desktop peripherals disable the automatic connection parameters
+	  update to avoid conflicts with connection initial parameters update
+	  initiated by the peripheral as well as connection rate updates initiated
+	  by the central.
+
 config BT_BUF_ACL_TX_COUNT
 	default 4
 	help

--- a/applications/nrf_desktop/doc/ble_latency.rst
+++ b/applications/nrf_desktop/doc/ble_latency.rst
@@ -98,6 +98,25 @@ By default, the module uses the standard connection parameter update API (:c:fun
 Once a :c:struct:`hid_sci_mode_request_event` or a :c:struct:`ble_peer_sci_conn_rate_event` is received, the module marks the peer as SCI capable.
 All the subsequent connection parameter adjustments for the peer rely on :c:func:`bt_conn_le_conn_rate_request` and :c:func:`bt_conn_le_param_update` is no longer used.
 
+Initial connection parameters on HID SCI peripherals
+----------------------------------------------------
+
+The module uses :c:func:`bt_conn_le_param_update` to request zero peripheral latency as the initial connection parameters.
+After a new connection is established, the Zephyr Bluetooth LE Host does not send this request immediately.
+If the API is called during that post-connect window, the stack stores the parameters and sends the Connection Parameter Update Request only after the time (in milliseconds) set in the :kconfig:option:`CONFIG_BT_CONN_PARAM_UPDATE_TIMEOUT` Kconfig option from connect.
+
+nRF Desktop peripherals instead use an application-level delay before calling :c:func:`bt_conn_le_param_update`.
+The module schedules a delayed work item that invokes the API after the same time as set in the :kconfig:option:`CONFIG_BT_CONN_PARAM_UPDATE_TIMEOUT` Kconfig option.
+This keeps the update out of the Bluetooth stack until that timeout elapses, so you can cancel it if the HID host switches to HID SCI first.
+Without this delay, the stack already holds a pending connection parameter update that would still be sent after the timeout even if the host had moved the link to HID SCI.
+The peer might switch the link to HID SCI during this window.
+After the link uses HID SCI, only the connection rate API might be used to adjust transport parameters.
+
+If a HID SCI mode request through the HID Control Point characteristic or Connection Rate Update Request is received before the delayed work runs, the module cancels the scheduled initial connection parameter request and switches to the connection rate API instead.
+If a HID SCI mode request arrives while the initial connection parameter update is already in progress, the requested SCI mode is made pending and applied after that update completes or fails.
+As of |NCS| 3.4.0 (which the current code must be compatible with), no connection parameter update rejection callback was available.
+As a workaround, a timeout is scheduled that treats the update as failed if a completion callback is not received within 5 seconds after the update is requested.
+
 Module events
 -------------
 
@@ -134,9 +153,10 @@ When a connection rate change is already in progress, further SCI-related action
 A pending state is set when:
 
 * A HID SCI mode is requested while a connection rate update is already in progress.
+* A HID SCI mode is requested while the initial connection parameter update is still in progress.
 * A low-latency or high-latency adjustment requested while a connection rate update is already in progress.
 
-In both cases, the module stores the most recently requested SCI mode and latency preference and sets the pending flag.
+In these cases, the module stores the most recently requested SCI mode and latency preference and sets the pending flag.
 If a pending state was already set, the module overrides the previous HID SCI mode and latency preference with the new one.
 
 When the in-flight connection rate update completes, the module checks whether a deferred mode change or latency change is still needed.

--- a/applications/nrf_desktop/src/modules/ble_latency.c
+++ b/applications/nrf_desktop/src/modules/ble_latency.c
@@ -21,6 +21,9 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_DESKTOP_BLE_LATENCY_LOG_LEVEL);
 
 #define SECURITY_FAIL_TIMEOUT_MS \
 	K_SECONDS(CONFIG_DESKTOP_BLE_SECURITY_FAIL_TIMEOUT_S)
+#define INIT_CONN_PARAMS_UPDATE_DELAY \
+	K_MSEC(CONFIG_BT_CONN_PARAM_UPDATE_TIMEOUT)
+#define INIT_CONN_PARAMS_UPDATE_TIMEOUT_MS K_SECONDS(5)
 #define LOW_LATENCY_CHECK_PERIOD_MS	K_SECONDS(5)
 #define DEFAULT_LATENCY			CONFIG_BT_PERIPHERAL_PREF_LATENCY
 #define DEFAULT_TIMEOUT			CONFIG_BT_PERIPHERAL_PREF_TIMEOUT
@@ -30,9 +33,15 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_DESKTOP_BLE_LATENCY_LOG_LEVEL);
 #define REG_CONN_INTERVAL_LLPM_MASK	0x0d00
 #define REG_CONN_INTERVAL_BLE_DEFAULT	0x0006
 
+BUILD_ASSERT(!IS_ENABLED(CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS),
+	     "CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS must be disabled for "
+	     "nRF Desktop peripherals");
+
 static struct bt_conn *active_conn;
 static struct k_work_delayable security_timeout;
 static struct k_work_delayable low_latency_check;
+static struct k_work_delayable init_conn_params;
+static struct k_work_delayable init_conn_params_update_timeout;
 
 enum {
 	CONN_LOW_LATENCY_ENABLED	= BIT(0),
@@ -45,6 +54,7 @@ enum {
 	CONN_IS_SCI_OUT_OF_SPEC	= BIT(7),
 	CONN_IS_POWER_DOWN		= BIT(8),
 	CONN_IS_SCI_LOW_POWER_HIGH_INTERVAL_FORBIDDEN = BIT(9),
+	CONN_IS_INIT_PARAMS_UPDATE_IN_PROGRESS = BIT(10),
 };
 
 static uint16_t latency_state;
@@ -82,15 +92,38 @@ static void set_init_conn_params(void)
 		.timeout = DEFAULT_TIMEOUT
 	};
 
+	int err = bt_conn_le_param_update(active_conn, &param);
 	last_requested_latency_is_low = true;
 
-	int err = bt_conn_le_param_update(active_conn, &param);
+	if (!err) {
+		latency_state |= CONN_IS_INIT_PARAMS_UPDATE_IN_PROGRESS;
+		/* The conn_params_update_rejected callback was not
+		 * available on NCS 3.4.0 which this code needs to be compatible with.
+		 * To avoid the CONN_IS_INIT_PARAMS_UPDATE_IN_PROGRESS being set
+		 * permanently locking connection rate updates, treat the update
+		 * as rejected/failed after the INIT_CONN_PARAMS_UPDATE_TIMEOUT_MS
+		 * timeout expires.
+		 * This workaround should be removed when the callback is integrated
+		 * to nRF Desktop.
+		 */
+		(void)k_work_schedule(&init_conn_params_update_timeout,
+				      INIT_CONN_PARAMS_UPDATE_TIMEOUT_MS);
+	}
 
 	if (!err || (err == -EALREADY)) {
 		LOG_INF("Init connection parameters are set");
 	} else {
 		LOG_WRN("Failed to update conn parameters (err %d)", err);
 	}
+}
+
+static void init_conn_params_fn(struct k_work *w)
+{
+	ARG_UNUSED(w);
+
+	__ASSERT_NO_MSG(active_conn);
+
+	set_init_conn_params();
 }
 
 static void set_conn_latency_non_sci(bool low_latency)
@@ -310,6 +343,45 @@ static void latency_updated(bool low_latency)
 	}
 }
 
+static void pending_sci_conn_rate_update_handle(void);
+
+static void conn_params_update_finished_sci_conn(void)
+{
+	__ASSERT_NO_MSG(latency_state & CONN_IS_SCI);
+
+	if (latency_state & CONN_IS_INIT_PARAMS_UPDATE_IN_PROGRESS) {
+		if (latency_state & CONN_IS_SCI_PARAM_UPDATE_PENDING) {
+			pending_sci_conn_rate_update_handle();
+		}
+	} else {
+		LOG_WRN("Unexpected non-SCI connection parameters update while SCI is active");
+
+		latency_state &= ~CONN_IS_SCI_PARAM_UPDATE_PENDING;
+		latency_state |= CONN_IS_SCI_OUT_OF_SPEC;
+		(void)k_work_cancel_delayable(&low_latency_check);
+	}
+
+	latency_state &= ~CONN_IS_INIT_PARAMS_UPDATE_IN_PROGRESS;
+}
+
+static void init_conn_params_update_timeout_fn(struct k_work *w)
+{
+	ARG_UNUSED(w);
+
+	__ASSERT_NO_MSG(active_conn);
+	__ASSERT_NO_MSG(latency_state & CONN_IS_INIT_PARAMS_UPDATE_IN_PROGRESS);
+
+	LOG_WRN("Connection parameter update timed out");
+
+	if (IS_ENABLED(CONFIG_DESKTOP_BLE_LATENCY_HID_SCI_ENABLE) &&
+	    (latency_state & CONN_IS_SCI)) {
+		conn_params_update_finished_sci_conn();
+		return;
+	}
+
+	latency_state &= ~CONN_IS_INIT_PARAMS_UPDATE_IN_PROGRESS;
+}
+
 static void conn_params_updated(const struct ble_peer_conn_params_event *event)
 {
 	if (!event->updated) {
@@ -317,16 +389,14 @@ static void conn_params_updated(const struct ble_peer_conn_params_event *event)
 		return;
 	}
 
+	(void)k_work_cancel_delayable(&init_conn_params_update_timeout);
+
 	if (IS_ENABLED(CONFIG_DESKTOP_BLE_LATENCY_HID_SCI_ENABLE) &&
 	    (latency_state & CONN_IS_SCI)) {
-		LOG_WRN("Unexpected non-SCI connection parameters update while SCI is active");
-
-		latency_state &= ~CONN_IS_SCI_PARAM_UPDATE_PENDING;
-		latency_state |= CONN_IS_SCI_OUT_OF_SPEC;
-		(void)k_work_cancel_delayable(&low_latency_check);
-
+		conn_params_update_finished_sci_conn();
 		return;
 	}
+	latency_state &= ~CONN_IS_INIT_PARAMS_UPDATE_IN_PROGRESS;
 
 	__ASSERT_NO_MSG(event->interval_min == event->interval_max);
 
@@ -399,9 +469,11 @@ static void hid_sci_mode_request(enum bt_hids_sci_mode_value mode)
 	 */
 	latency_state |= CONN_IS_SCI;
 	latency_state &= ~CONN_IS_LLPM;
+	(void)k_work_cancel_delayable(&init_conn_params);
 
-	if (processed_sci_mode != BT_HIDS_SCI_MODE_NONE) {
-		/* A connection rate update is already in progress */
+	if ((processed_sci_mode != BT_HIDS_SCI_MODE_NONE) ||
+	    (latency_state & CONN_IS_INIT_PARAMS_UPDATE_IN_PROGRESS)) {
+		/* A connection rate/params update is already in progress */
 		latency_state |= CONN_IS_SCI_PARAM_UPDATE_PENDING;
 		return;
 	}
@@ -511,11 +583,23 @@ get_new_sci_mode(const struct bt_conn_le_conn_rate_changed *params,
 	return mode;
 }
 
-static void pending_sci_conn_rate_update_handle(bool is_low_latency)
+static void pending_sci_conn_rate_update_handle(void)
 {
+	struct bt_conn_info info;
+	int err = bt_conn_get_info(active_conn, &info);
+	bool is_low_latency;
+
+	if (err) {
+		LOG_ERR("Failed to get connection info: %d", err);
+		return;
+	}
+
+	is_low_latency = (info.le.latency == 0);
+
 	bool latency_request_pending = (last_requested_latency_is_low != is_low_latency);
 	enum bt_hids_sci_mode_value current_mode = BT_HIDS_SCI_MODE_NONE;
-	int err = bt_hids_sci_mode_get(active_conn, &current_mode);
+
+	err = bt_hids_sci_mode_get(active_conn, &current_mode);
 
 	if (err) {
 		LOG_ERR("Failed to get current SCI mode: %d", err);
@@ -631,6 +715,7 @@ static void conn_rate_updated(const struct ble_peer_sci_conn_rate_event *event)
 		LOG_WRN("Peripheral will start using SCI and attempt to find a valid SCI mode");
 		latency_state |= CONN_IS_SCI;
 		latency_state &= ~CONN_IS_LLPM;
+		(void)k_work_cancel_delayable(&init_conn_params);
 	}
 
 	if (event->status == BT_HCI_ERR_SUCCESS) {
@@ -674,7 +759,7 @@ static void conn_rate_updated(const struct ble_peer_sci_conn_rate_event *event)
 		latency_updated(is_low_latency);
 
 		if (latency_state & CONN_IS_SCI_PARAM_UPDATE_PENDING) {
-			pending_sci_conn_rate_update_handle(is_low_latency);
+			pending_sci_conn_rate_update_handle();
 		}
 	} else {
 		LOG_ERR("Failed to get connection info: %d", err);
@@ -706,6 +791,9 @@ static void init(void)
 {
 	k_work_init_delayable(&security_timeout, security_timeout_fn);
 	k_work_init_delayable(&low_latency_check, low_latency_check_fn);
+	k_work_init_delayable(&init_conn_params, init_conn_params_fn);
+	k_work_init_delayable(&init_conn_params_update_timeout,
+			      init_conn_params_update_timeout_fn);
 }
 
 static void use_low_latency(void)
@@ -744,7 +832,15 @@ static bool app_event_handler(const struct app_event_header *aeh)
 		switch (event->state) {
 		case PEER_STATE_CONNECTED:
 			active_conn = event->id;
-			set_init_conn_params();
+
+			(void)k_work_schedule(&init_conn_params, INIT_CONN_PARAMS_UPDATE_DELAY);
+			/* This is needed so that low latency is used if the remote
+			 * requests a HID SCI mode before the init conn params work
+			 * is executed.
+			 * Low latency speeds up security establishment and GATT discovery.
+			 */
+			last_requested_latency_is_low = true;
+
 			k_work_reschedule(&security_timeout,
 					      SECURITY_FAIL_TIMEOUT_MS);
 			break;
@@ -764,6 +860,8 @@ static bool app_event_handler(const struct app_event_header *aeh)
 			}
 
 			/* Cancel cannot fail if executed from another work's context. */
+			(void)k_work_cancel_delayable(&init_conn_params);
+			(void)k_work_cancel_delayable(&init_conn_params_update_timeout);
 			(void)k_work_cancel_delayable(&low_latency_check);
 			(void)k_work_cancel_delayable(&security_timeout);
 			break;


### PR DESCRIPTION
This commit adds protection against the initial conn params request racing with a conn rate request which could result from a HID SCI control point request from the host.

On connect, ble_latency calls set_init_conn_params, which in turn calls  bt_conn_le_param_update() to request zero
peripheral latency. Zephyr does not send that request immediately; it is deferred until BT_CONN_PARAM_UPDATE_TIMEOUT elapses (1 s by default in nRF Desktop).

The host might switch the link to HID SCI before that timeout. After the link is switched to HID SCI, only the connection rate API should be used. The deferred connection parameter update violates this rule and may cause an overlap with an in-flight connection rate update. The Bluetooth Core Specification disallows starting one of these procedures while the other is in progress.

This is solved by adding a "manual" delay in ble_latency equal to CONFIG_BT_CONN_PARAM_UPDATE_TIMEOUT before requesting the initial parameters. The request is cancelled if any HID SCI control point request arrives.
If a HID control point arrives while the parameter update is already in progress, the requested HID SCI mode is made pending and requested after the parameter update procedure finishes.

Also, disabled CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS, as it would cause triggering of a parameter update request without the control of the ble_latency module.