### PR TITLE
[manual v3.4 backport] doc: update links to nRF Util

### DIFF
--- a/doc/nrf/app_dev/device_guides/kmu_guides/kmu_provisioning_overview.rst
+++ b/doc/nrf/app_dev/device_guides/kmu_guides/kmu_provisioning_overview.rst
@@ -148,7 +148,7 @@ Provisioning keys to the board
 
 Before uploading keys, ensure that the SoC is unprovisioned.
 If the SoC has been previously provisioned and you need to use a different set of keys, you must first erase the SoC.
-You can use nRF Util's `device command <Erasing the device_>`_ for this purpose:
+You can use `nrfutil device erase`_ command for this purpose:
 
 .. code-block::
 

--- a/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_logging.rst
+++ b/doc/nrf/app_dev/device_guides/nrf54h/ug_nrf54h20_logging.rst
@@ -37,7 +37,7 @@ For more information on STM, see :ref:`zephyr:logging_cs_stm`.
 
 .. note::
    The STM logging feature for the nRF54H20 SoC underwent testing with the J-Trace PRO V2 Cortex-M, using firmware compiled on ``Mar 28 2024 15:14:04``.
-   Using this feature also requires ``nrfutil-trace`` version 2.10.0 or later.
+   Using this feature also requires `nrfutil trace command`_ version 2.10.0 or later.
 
 Embedded Trace Router (ETR)
 ===========================
@@ -185,7 +185,7 @@ The following are the prefixes used to indicate the cores:
    Fast Lightweight Processor (FLPR), ``flpr``, 0x2d
    Peripheral Processor (PPR), ``ppr``, 0x2e
 
-For more information, see `Capturing STM trace data`_ in the nRF Util documentation.
+For more information, see `nrfutil trace stm`_ command page.
 
 Additional considerations
 -------------------------

--- a/doc/nrf/app_dev/device_guides/thingy91x/thingy91x_recover_to_factory_firmware.rst
+++ b/doc/nrf/app_dev/device_guides/thingy91x/thingy91x_recover_to_factory_firmware.rst
@@ -7,7 +7,7 @@ Recovering the Thingy:91 X to factory firmware
    :local:
    :depth: 2
 
-You can recover the Thingy:91 X to factory firmware using the ``nrfutil device`` command in the `nRF Util commands <Device command overview_>`_.
+You can recover the Thingy:91 X to factory firmware using `nRF Util's device command <Device command overview_>`_.
 
 If your Thingy:91 X is powered on and connected using a USB cable, it shows up as a USB device.
 Else, something is preventing the :ref:`connectivity_bridge` application on the nRF5340 from running.

--- a/doc/nrf/app_dev/programming.rst
+++ b/doc/nrf/app_dev/programming.rst
@@ -149,4 +149,4 @@ Programming with ``--recover``
 
      * ``nrfjprog --recover`` for devices from nRF52, nRF53, and nRF91 Series.
      * ``nrfutil device recover`` for devices from nRF54H and nRF54L Series.
-       For more information about how ``nrfutil device recover`` works, see the `nRF Util documentation <Recovering the device_>`_.
+       For more information, see `nrfutil device recover`_ command page.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1094,28 +1094,24 @@
 .. _`Upgrading nRF Util core module`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html#upgrading-nrf-util
 .. _`Installing and upgrading nRF Util commands`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing_commands.html
 .. _`Installing specific versions of nRF Util commands`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing_commands.html#installing-specific-versions-of-commands
-.. _`nrf5sdk-tools command overview`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-nrf5sdk-tools/guides/intro.html
-.. _`Generating DFU packages`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides-nrf5sdk/dfu_generating_packages.html
-.. _`DFU over a serial USB connection`: https://docs.nordicsemi.com/bundle/nrfutil/page/guides-nrf5sdk/dfu_performing.html#dfu-over-a-serial-usb-connection
-.. _`Toolchain Manager command`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-toolchain-manager/nrfutil-toolchain-manager.html
+.. _`nrfutil nrf5sdk-tools`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-nrf5sdk-tools/nrfutil-nrf5sdk-tools.html
 .. _`sdk-manager command`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-sdk-manager/nrfutil-sdk-manager.html
 .. _`sdk-manager Configuration settings`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-sdk-manager/guides/sdk_manager_config_settings.html
 .. _`sdk-manager Starting and inspecting the toolchain environment`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-sdk-manager/guides/sdk_manager_env_launch.html
-.. _`nrfutil-trace`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-trace/CHANGELOG.html
-.. _`Capturing LTE modem trace data`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-trace/guides/tracing_lte.html
-.. _`Capturing STM trace data`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-trace/guides/tracing_stm.html
+.. _`nrfutil trace command`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-trace/CHANGELOG.html
+.. _`nrfutil trace stm`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-trace/guides/tracing_stm.html
 .. _`nRF Sniffer for Bluetooth LE`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-ble-sniffer/guides/overview.html
-.. _`Logging HCI packets`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-ble-sniffer/guides/hci_logger.html
-.. _`Device command overview`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming.html
-.. _`Programming application firmware using MCUboot serial recovery`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming_firmware_thingy91.html
-.. _`Programming modem firmware using MCUboot serial recovery`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming_firmware_thingy91.html
-.. _`Programming application firmware on the nRF54L SoCs`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming_nrf54L15.html
-.. _`Upgrading modem firmware using J-Link`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming_modem_9160.html
-.. _`Provisioning cryptographic keys`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/provisioning_keys.html
-.. _`Erasing the device`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming_erasing.html
-.. _`Recovering the device`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming_recovery.html
+.. _`nRF Logger for Bluetooth HCI`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-ble-sniffer/guides/hci_logger_wireshark.html
+.. _`Device command overview`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/nrfutil-device.html
+.. _`Programming application firmware using MCUboot serial recovery`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming.html#programming-application-firmware-using-mcuboot-serial-recovery
+.. _`Programming modem firmware using MCUboot serial recovery`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming.html#upgrading-modem-firmware-using-mcuboot-serial-recovery
+.. _`Programming application firmware on the nRF54L SoCs`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming.html#programming-application-firmware-on-nrf54l-series
+.. _`Upgrading modem firmware using J-Link`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming.html#upgrading-modem-firmware-using-j-link
+.. _`nrfutil device x-provision-keys`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/provisioning_keys.html
+.. _`nrfutil device erase`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming_erasing.html
+.. _`nrfutil device recover`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming_recovery.html
 .. _`Configuring readback protection`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming_readback_protection.html
-.. _`nRF Util mcu-manager serial`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-mcu-manager/nrfutil-mcu-manager.html
+.. _`nrfutil mcu-manager serial`: https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-mcu-manager/nrfutil-mcu-manager.html
 
 .. _`anomaly 19`: https://docs.nordicsemi.com/bundle/errata_nRF5340_EngA/page/ERR/nRF5340/EngineeringA/latest/anomaly_340_19.html
 

--- a/doc/nrf/protocols/thread/tools.rst
+++ b/doc/nrf/protocols/thread/tools.rst
@@ -112,7 +112,7 @@ To program the nRF device with the RCP application, complete the following steps
 
                nrfutil install nrf5sdk-tools
 
-            See `nrf5sdk-tools command overview`_ for more information.
+            See `nrfutil nrf5sdk-tools`_ command page for more information.
          #. Generate the RCP firmware package:
 
             .. code-block:: console

--- a/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_guide_2.8.rst
@@ -192,12 +192,12 @@ nrfutil device
 
     For more information, consult the `nRF Util`_ documentation.
 
-nrfutil-trace
+nrfutil trace
 +++++++++++++
 
 .. toggle::
 
-  * ``nrfutil-trace`` has been updated to version 2.11.0.
+  * ``nrfutil trace`` has been updated to version 2.11.0.
 
     Install the nRF Util ``trace`` command version 2.11.0 as follows::
 
@@ -242,7 +242,7 @@ SEGGER J-Link
       #. Add the J-Link executable to the system path on Linux and MacOS, or to the environment variables on Windows, to run it from anywhere on the system.
 
   * The STM logging feature for the nRF54H20 SoC was tested using the J-Trace PRO V2 Cortex-M, with firmware compiled on ``Mar 28 2024 15:14:04``.
-    Using this feature also requires ``nrfutil-trace`` version 2.10.0 or later.
+    Using this feature also requires `nrfutil trace command`_ version 2.10.0 or later.
 
 nRF Connect Device Manager
 ++++++++++++++++++++++++++

--- a/doc/nrf/security/ap_protect.rst
+++ b/doc/nrf/security/ap_protect.rst
@@ -291,7 +291,7 @@ nRF91 Series
 
       On the nRF9160, AP-Protect and Secure AP-Protect are *hardware-only*; there are no |NCS| Kconfig options for this device.
       Both mechanisms are controlled solely by writing to the UICR using nRF Util.
-      For more information about the ``nrfutil device protection-set`` command, see `Configuring readback protection`_ in the nRF Util documentation.
+      For more information, see `device protection-set <Configuring readback protection_>`_ command page in the nRF Util documentation.
 
       **Enabling AP-Protect on the hardware side:**
 
@@ -443,7 +443,7 @@ nRF91 Series
 
       This command enables Secure AP-Protect on the hardware side and hard resets the device.
 
-      For more information about the ``nrfutil device protection-set`` command, see `Configuring readback protection`_ in the nRF Util documentation.
+      For more information, see `device protection-set <Configuring readback protection_>`_ command page in the nRF Util documentation.
 
       .. note::
          With devices that use AP-Protect controlled by software, nRF Util cannot enable Secure AP-Protect on the hardware side if the Secure AP-Protect on the software side is already enabled.
@@ -659,7 +659,7 @@ nRF54L Series
 
       This command enables Secure AP-Protect on the hardware side and hard resets the device.
 
-      For more information about the ``nrfutil device protection-set`` command, see `Configuring readback protection`_ in the nRF Util documentation.
+      For more information, see `device protection-set <Configuring readback protection_>`_ command page in the nRF Util documentation.
 
       .. note::
          With devices that use software AP-Protect, nRF Util cannot enable hardware Secure AP-Protect if the software Secure AP-Protect is already enabled.
@@ -859,7 +859,7 @@ nRF54L Series
 
       This set of commands enables AP-Protect on the hardware side and hard resets the device.
 
-      For more information about the ``nrfutil device protection-set`` command, see `Configuring readback protection`_ in the nRF Util documentation.
+      For more information, see `device protection-set <Configuring readback protection_>`_ command page in the nRF Util documentation.
 
       **Disabling AP-Protect:**
 
@@ -1058,7 +1058,7 @@ nRF53 Series
       nRF5340 only supports Secure AP-Protect for the application core.
       You can check the serial number of your device by running the ``nrfutil device list`` command.
 
-      For more information about the ``nrfutil device protection-set`` command, see `Configuring readback protection`_ in the nRF Util documentation.
+      For more information, see `device protection-set <Configuring readback protection_>`_ command page in the nRF Util documentation.
 
       .. note::
          With devices that use software AP-Protect, nRF Util cannot enable hardware Secure AP-Protect if the software Secure AP-Protect is already enabled.
@@ -1170,7 +1170,7 @@ nRF52 Series
          nrfutil device protection-set All
 
       This command enables AP-Protect on the hardware side and hard resets the device.
-      For more information about this command, see `Configuring readback protection`_ in the nRF Util documentation.
+      For more information, see `device protection-set <Configuring readback protection_>`_ command page in the nRF Util documentation.
 
       **Keeping AP-Protect disabled after hard reset:**
 

--- a/doc/nrf/security/key_storage.rst
+++ b/doc/nrf/security/key_storage.rst
@@ -171,7 +171,7 @@ Configuring the KMU varies depending on the device.
 See the device-specific documentation for more information.
 
 For the nRF54L Series devices, you can use nRF Util for provisioning keys to KMU.
-See `Provisioning cryptographic keys`_ in the nRF Util documentation for more information.
+See `nrfutil device x-provision-keys`_ command page for more information.
 
 .. _key_storage_otp:
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -100,9 +100,6 @@
 .. |file_suffix_related_deprecation_note| replace:: This feature is deprecated and is being replaced by :ref:`suffix-based configurations <app_build_file_suffixes>`.
     You can continue to use it until the transition is complete in the |NCS| and the feature is removed in one of the upcoming |NCS| releases.
 
-.. |nrfjprog_deprecation_note| replace:: Starting with the |NCS| v2.8.0, nrfjprog is in the process of being archived.
-   It will remain available for download, but `nRF Util (device command) <Device command overview_>`_ will gradually replace it.
-
 .. |nrf_CLT_deprecation_note| replace:: The `nRF Command Line Tools`_ have been archived and replaced by `nRF Util`_.
    No further updates will be made to the nRF Command Line Tools.
    Last supported operating systems are Windows 10, Linux Ubuntu 22.04, and macOS 13.

--- a/doc/nrf/test_and_optimize/debugging.rst
+++ b/doc/nrf/test_and_optimize/debugging.rst
@@ -92,7 +92,7 @@ To ensure that the logger module is enabled and you can see the logs, set the :k
 
 For more advanced debug purposes, see the following:
 
-* `Logging HCI packets`_ for logs with a detailed view of what happens both inside and between Bluetooth devices.
+* `nRF Logger for Bluetooth HCI`_ for logs with a detailed view of what happens both inside and between Bluetooth devices.
 * The :kconfig:option:`CONFIG_MPSL_PIN_DEBUG` Kconfig option to figure out when the radio is used.
   On multi-core SoCs, set this option on the core that runs the radio firmware.
 

--- a/samples/crypto/kmu_cracen_usage/README.rst
+++ b/samples/crypto/kmu_cracen_usage/README.rst
@@ -208,7 +208,7 @@ Before you program the sample to your development kit, complete the following st
 1. |connect_kit|
 #. |connect_terminal|
 #. Perform a full erase of the device.
-   You can use nRF Util's `device command <Erasing the device_>`_ for this purpose:
+   You can use `nrfutil device erase`_ command for this purpose:
 
    .. code-block:: console
 

--- a/samples/dfu/single_slot/README.rst
+++ b/samples/dfu/single_slot/README.rst
@@ -68,10 +68,9 @@ After programming the sample to your development kit, perform the following step
 
    b. USB CDC ACM serial firmware loader:
 
-      Use `nRF Util mcu-manager serial` to perform DFU over serial port.
+      Use `nrfutil mcu-manager serial`_ command to perform DFU over serial port.
 
       * Send the generated update package for the second version of the sample.
-        See `nRF Util mcu-manager serial`_ for details on how to use the command to perform the DFU.
 
 #. Verify that the printed build time corresponds to the new version once the update is complete and the device reboots into the main application.
 

--- a/scripts/generate_psa_key_attributes/generate_psa_key_attributes.rst
+++ b/scripts/generate_psa_key_attributes/generate_psa_key_attributes.rst
@@ -111,7 +111,7 @@ To provision keys onto the KMU, use the following nRF Util command, with the ``<
 
 You can call this command multiple times also to provision multiple keys, as long as each key has a different ID that is part of the ``metadata`` string.
 
-For more information about this command, see the `Provisioning cryptographic keys`_ page in the nRF Util documentation.
+For more information about this command, see the `nrfutil device x-provision-keys`_ command page.
 
 .. nrfutil_provision_keys_command_end
 


### PR DESCRIPTION
Updated links pointing to nRF Util pages.
Removed some, renamed some others.
NRFU-1440.

----

Manual backport of #30556 