### PR TITLE
nrf_security: cracen: Consolidate mem handler and status codes

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/common/include/cracen/common.h
+++ b/subsys/nrf_security/src/drivers/cracen/common/include/cracen/common.h
@@ -1,4 +1,4 @@
-	/*
+/*
  * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
@@ -15,6 +15,10 @@
  */
 
 #pragma once
+
+/* These must stay above cracen_psa.h */
+#include <cracen/statuscodes.h>
+#include <nrf_security_mem_helpers.h>
 
 #include "cracen_psa.h"
 #include "sxsymcrypt/internal.h"
@@ -35,7 +39,6 @@
 #define cracen_abs(x) ((x) < 0 ? -(x) : (x))
 #endif
 
-
 typedef struct {
 	uint8_t slot_number;
 	uint8_t owner_id;
@@ -43,11 +46,11 @@ typedef struct {
 
 __must_check psa_status_t silex_statuscodes_to_psa(int sx_status);
 
-__must_check psa_status_t
-cracen_hash_get_algo(psa_algorithm_t alg, const struct sxhashalg **sx_hash_algo);
+__must_check psa_status_t cracen_hash_get_algo(psa_algorithm_t alg,
+					       const struct sxhashalg **sx_hash_algo);
 
-__must_check psa_status_t
-cracen_xof_get_algo(psa_algorithm_t alg, const struct sxhashalg **sx_xof_algo);
+__must_check psa_status_t cracen_xof_get_algo(psa_algorithm_t alg,
+					      const struct sxhashalg **sx_xof_algo);
 
 /**
  * @brief Use cracen_get_random up to generate a random number in the range [1, upperlimit).

--- a/subsys/nrf_security/src/drivers/cracen/common/src/cracen/common.c
+++ b/subsys/nrf_security/src/drivers/cracen/common/src/cracen/common.c
@@ -10,8 +10,6 @@
 #include <cracen_psa_ctr_drbg.h>
 #include <hal/nrf_cracen.h>
 #include <nrfx_kmu.h>
-#include <nrf_security_mem_helpers.h>
-#include <cracen/statuscodes.h>
 #include <silexpk/core.h>
 #include <silexpk/ec_curves.h>
 #include <silexpk/ik.h>

--- a/subsys/nrf_security/src/drivers/cracen/common/src/cracen/cracen_hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/common/src/cracen/cracen_hmac.c
@@ -15,8 +15,6 @@
 #include <string.h>
 #include <sxsymcrypt/hash.h>
 #include <sxsymcrypt/internal.h>
-#include <cracen/statuscodes.h>
-#include <nrf_security_mem_helpers.h>
 #include "cracen_psa_primitives.h"
 #include "cracen_psa.h"
 #include <cracen/common.h>

--- a/subsys/nrf_security/src/drivers/cracen/common/src/cracen/cracen_rndinrange.c
+++ b/subsys/nrf_security/src/drivers/cracen/common/src/cracen/cracen_rndinrange.c
@@ -7,8 +7,6 @@
  */
 
 #include <string.h>
-#include <cracen/statuscodes.h>
-#include <nrf_security_mem_helpers.h>
 #include <cracen_psa.h>
 #include <cracen_psa_ctr_drbg.h>
 #include <cracen/common.h>

--- a/subsys/nrf_security/src/drivers/cracen/common/src/cracen/hardware/hardware.c
+++ b/subsys/nrf_security/src/drivers/cracen/common/src/cracen/hardware/hardware.c
@@ -9,7 +9,6 @@
 
 #include <cracen/hardware.h>
 #include <cracen/interrupts.h>
-#include <cracen/statuscodes.h>
 #include <cracen/common.h>
 #include <cracen/cracen_kmu.h>
 #include "microcode_binary.h"

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aead.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aead.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <nrf_security_mem_helpers.h>
 #include <psa/crypto.h>
 #include <psa/crypto_values.h>
 #include <stdbool.h>
@@ -35,7 +34,6 @@
 #include <sxsymcrypt/chachapoly.h>
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
-#include <cracen/statuscodes.h>
 #endif
 
 psa_status_t cracen_aead_encrypt_setup(cracen_aead_operation_t *operation,

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aes_cbc.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aes_cbc.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <nrf_security_mem_helpers.h>
 #include <psa/crypto.h>
 #include <psa/crypto_values.h>
 #include <stdbool.h>
@@ -13,7 +12,6 @@
 #include <sxsymcrypt/blkcipher.h>
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
-#include <cracen/statuscodes.h>
 #include <zephyr/sys/util.h>
 
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aes_ccm.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aes_ccm.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <nrf_security_mem_helpers.h>
 #include <psa/crypto.h>
 #include <psa/crypto_values.h>
 #include <stdbool.h>
@@ -12,7 +11,6 @@
 #include <sxsymcrypt/aes.h>
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
-#include <cracen/statuscodes.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>
 

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aes_ctr.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aes_ctr.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <nrf_security_mem_helpers.h>
 #include <psa/crypto.h>
 #include <psa/crypto_values.h>
 #include <stdbool.h>
@@ -13,7 +12,6 @@
 #include <sxsymcrypt/blkcipher.h>
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
-#include <cracen/statuscodes.h>
 #include <zephyr/sys/util.h>
 
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aes_gcm.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_aes_gcm.c
@@ -12,7 +12,6 @@
  * [MGV] 4.1, pp. 12-13, to enhance speed without using too much memory.
  */
 
-#include <nrf_security_mem_helpers.h>
 #include <psa/crypto.h>
 #include <psa/crypto_values.h>
 #include <stdbool.h>
@@ -20,7 +19,6 @@
 #include <sxsymcrypt/aes.h>
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
-#include <cracen/statuscodes.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>
 

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_chacha20_poly1305.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_chacha20_poly1305.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <nrf_security_mem_helpers.h>
 #include <psa/crypto.h>
 #include <psa/crypto_values.h>
 #include <stdbool.h>
@@ -16,7 +15,6 @@
 #include <sxsymcrypt/aead.h>
 #include <sxsymcrypt/chachapoly.h>
 
-#include <cracen/statuscodes.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>
 

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_cipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_cipher.c
@@ -8,7 +8,6 @@
  */
 
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
 #include <psa/crypto.h>
 #include <psa/crypto_values.h>
 #include <zephyr/sys/util.h>
@@ -19,7 +18,6 @@
 #include <sxsymcrypt/chachapoly.h>
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
-#include <cracen/statuscodes.h>
 #include <zephyr/sys/__assert.h>
 #include <cracen_sw_aes_ctr.h>
 #include <cracen_sw_aes_cbc.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_common.c
@@ -8,7 +8,6 @@
 #include <sxsymcrypt/keyref.h>
 #include <sxsymcrypt/aes.h>
 #include <sxsymcrypt/internal.h>
-#include <cracen/statuscodes.h>
 #include <zephyr/logging/log.h>
 #include <cracen/common.h>
 #include <cracen_sw_common.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_mac_cmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracen_sw/src/cracen_sw_mac_cmac.c
@@ -6,7 +6,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <psa/crypto.h>
-#include <cracen/statuscodes.h>
 #include <sxsymcrypt/blkcipher.h>
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_aead.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_aead.c
@@ -16,8 +16,6 @@
 #include <sxsymcrypt/chachapoly.h>
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
-#include <nrf_security_mem_helpers.h>
-#include <cracen/statuscodes.h>
 #include <zephyr/sys/__assert.h>
 #include <cracen/common.h>
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_asymmetric.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_asymmetric.c
@@ -11,7 +11,6 @@
 
 #include <psa/crypto.h>
 #include <psa/crypto_values.h>
-#include <cracen/statuscodes.h>
 #include <silexpk/blinding.h>
 #include <internal/rsa/cracen_rsa_common.h>
 #include <internal/rsa/cracen_rsa_encryption.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_cipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_cipher.c
@@ -10,7 +10,6 @@
 #include <cracen_psa_cipher.h>
 
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
 #include <psa/crypto.h>
 #include <psa/crypto_values.h>
 #include <stdbool.h>
@@ -20,7 +19,6 @@
 #include <sxsymcrypt/chachapoly.h>
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
-#include <cracen/statuscodes.h>
 #include <zephyr/sys/__assert.h>
 
 #include "cracen_psa_primitives.h"

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_ctr_drbg.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_ctr_drbg.c
@@ -13,7 +13,6 @@
 #include "cracen_psa_ctr_drbg.h"
 #include "cracen_psa_primitives.h"
 #include <sxsymcrypt/blkcipher.h>
-#include <cracen/statuscodes.h>
 #include <cracen/hardware.h>
 #include <sxsymcrypt/trng.h>
 #include <sxsymcrypt/aes.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_hash.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_hash.c
@@ -14,10 +14,8 @@
 #include <sxsymcrypt/hash.h>
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/hashdefs.h>
-#include <cracen/statuscodes.h>
 #include <zephyr/sys/__assert.h>
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
 #include "cracen_psa_primitives.h"
 
 _Static_assert(SX_HASH_MAX_ENABLED_BLOCK_SIZE != 1,

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_ikg.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_ikg.c
@@ -8,7 +8,6 @@
 
 #include <stdint.h>
 #include <string.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa_primitives.h>
 #include <cracen_psa_builtin_key_policy.h>
 #include <cracen/common.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_jpake.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_jpake.c
@@ -10,9 +10,7 @@
 #include <psa/crypto.h>
 #include <cracen/common.h>
 #include <internal/ecc/cracen_ecc_helpers.h>
-#include <nrf_security_mem_helpers.h>
 #include "cracen_psa_primitives.h"
-#include <cracen/statuscodes.h>
 #include "psa/crypto_driver_contexts_key_derivation.h"
 #include "psa/crypto_sizes.h"
 #include "psa/crypto_types.h"

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_key_management.c
@@ -7,7 +7,6 @@
 #include <cracen_psa_key_management.h>
 
 #include <cracen/common.h>
-#include <cracen/statuscodes.h>
 #include <cracen/cracen_kmu.h>
 #include <cracen_psa.h>
 #include <cracen_psa_ctr_drbg.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_kmu.c
@@ -5,8 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <nrf_security_mem_helpers.h>
-#include <cracen/statuscodes.h>
 #include <nrf_security_mutexes.h>
 #include <psa/crypto.h>
 #include <stdint.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_mac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_mac.c
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <zephyr/sys/__assert.h>
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
 #include "cracen_psa_primitives.h"
 #include <internal/mac/cracen_mac_cmac.h>
 #include <internal/mac/cracen_mac_hmac.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_sign_verify.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_sign_verify.c
@@ -9,8 +9,6 @@
 #include <cracen_psa_sign_verify.h>
 
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
-#include <cracen/statuscodes.h>
 #include <psa/crypto.h>
 #include <psa/crypto_values.h>
 #include <silexpk/blinding.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_spake2p.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_spake2p.c
@@ -8,8 +8,6 @@
 
 #include <cracen/common.h>
 #include <internal/ecc/cracen_ecc_helpers.h>
-#include <nrf_security_mem_helpers.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen_psa_ctr_drbg.h>
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_srp.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_srp.c
@@ -10,8 +10,6 @@
 #include <cracen/common.h>
 #include <cracen_psa.h>
 #include <cracen_psa_ctr_drbg.h>
-#include <nrf_security_mem_helpers.h>
-#include <cracen/statuscodes.h>
 #include <psa/crypto.h>
 #include <string.h>
 #include <silexpk/sxbuf/sxbufop.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_wpa3_sae.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_wpa3_sae.c
@@ -8,8 +8,6 @@
 
 #include <cracen/common.h>
 #include <internal/ecc/cracen_ecc_helpers.h>
-#include <nrf_security_mem_helpers.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa_primitives.h>
 #include <psa/crypto.h>
 #include <psa/crypto_extra.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_xof.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_xof.c
@@ -13,11 +13,9 @@
 #include <sxsymcrypt/hash.h>
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/hashdefs.h>
-#include <cracen/statuscodes.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
 #include "cracen_psa_primitives.h"
 
 _Static_assert(SX_XOF_POOL_BUF_SZ != 1,

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/aes/cracen_aes_cbc.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/aes/cracen_aes_cbc.c
@@ -12,7 +12,6 @@
 #include <sxsymcrypt/aes.h>
 #include <sxsymcrypt/blkcipher.h>
 #include <sxsymcrypt/internal.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/aes/cracen_aes_ecb.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/aes/cracen_aes_ecb.c
@@ -9,7 +9,6 @@
 #include <stdbool.h>
 #include <sxsymcrypt/aes.h>
 #include <sxsymcrypt/blkcipher.h>
-#include <cracen/statuscodes.h>
 #include <cracen/common.h>
 
 /* The AES ECB does not support multipart operations in Cracen. This means that keeping

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_helpers.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_helpers.c
@@ -8,8 +8,6 @@
 
 #include <cracen/common.h>
 #include <hal/nrf_cracen.h>
-#include <nrf_security_mem_helpers.h>
-#include <cracen/statuscodes.h>
 #include <nrfx.h>
 #include <silexpk/core.h>
 #include <silexpk/ec_curves.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_key_management.c
@@ -14,7 +14,6 @@
 #include <string.h>
 #include <silexpk/core.h>
 #include <silexpk/ec_curves.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 #include <cracen/ec_helpers.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_keygen.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecc_keygen.c
@@ -12,7 +12,6 @@
 #include <silexpk/iomem.h>
 #include <silexpk/cmddefs/ecc.h>
 #include <silexpk/ec_curves.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include "cracen_ecc_keygen.h"
 #include <cracen/common.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecdsa.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_ecdsa.c
@@ -29,7 +29,6 @@
 #include <silexpk/iomem.h>
 #include <silexpk/cmddefs/ecc.h>
 #include <silexpk/ec_curves.h>
-#include <cracen/statuscodes.h>
 #include <sxsymcrypt/hash.h>
 #include <cracen_psa_primitives.h>
 #include <sxsymcrypt/hashdefs.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_eddsa_ed25519.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_eddsa_ed25519.c
@@ -36,8 +36,6 @@
 #include <silexpk/ed25519.h>
 #include <cracen/ec_helpers.h>
 #include <sxsymcrypt/hash.h>
-#include <nrf_security_mem_helpers.h>
-#include <cracen/statuscodes.h>
 #include <cracen/common.h>
 
 #define AREA2_MEM_OFFSET 32

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_eddsa_ed448.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecc/cracen_eddsa_ed448.c
@@ -14,8 +14,6 @@
 #include <silexpk/ed448.h>
 #include <cracen/ec_helpers.h>
 #include <sxsymcrypt/hash.h>
-#include <nrf_security_mem_helpers.h>
-#include <cracen/statuscodes.h>
 #include <cracen/common.h>
 
 /* Define SHAKE 256, 64 bit Digest size*/

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecdh/cracen_ecdh_montgomery.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecdh/cracen_ecdh_montgomery.c
@@ -8,7 +8,6 @@
 #include <internal/ecc/cracen_ecc_helpers.h>
 
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
 #include <cracen/ec_helpers.h>
 #include <silexpk/sxbuf/sxbufop.h>
 #include <silexpk/montgomery.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecdh/cracen_ecdh_weierstrass.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ecdh/cracen_ecdh_weierstrass.c
@@ -8,7 +8,6 @@
 #include <internal/ecc/cracen_ecc_helpers.h>
 
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
 #include <silexpk/sxbuf/sxbufop.h>
 #include <silexpk/sxops/eccweierstrass.h>
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ikg/cracen_ikg_operations.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ikg/cracen_ikg_operations.c
@@ -23,7 +23,6 @@
 #include <sxsymcrypt/hashdefs.h>
 #include <silexpk/ec_curves.h>
 #include <silexpk/ik.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa_primitives.h>
 #include <cracen/common.h>
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_hkdf.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_hkdf.c
@@ -10,7 +10,6 @@
 #include <string.h>
 #include <stdbool.h>
 #include <silexpk/core.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_kdf_common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_kdf_common.c
@@ -8,7 +8,6 @@
 
 #include <string.h>
 #include <stdbool.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_pbkdf2_hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_pbkdf2_hmac.c
@@ -10,7 +10,6 @@
 #include <string.h>
 #include <stdbool.h>
 #include <silexpk/core.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_sp800_108_ctr_mac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_sp800_108_ctr_mac.c
@@ -11,7 +11,6 @@
 #include <stdbool.h>
 #include <silexpk/core.h>
 #include <sxsymcrypt/hash.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_srp_password_hash.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_srp_password_hash.c
@@ -10,7 +10,6 @@
 #include <string.h>
 #include <stdbool.h>
 #include <silexpk/core.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_tls12.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_tls12.c
@@ -11,7 +11,6 @@
 #include <stdbool.h>
 #include <silexpk/core.h>
 #include <sxsymcrypt/hash.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_tls12_ecjpake_to_pms.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_tls12_ecjpake_to_pms.c
@@ -11,7 +11,6 @@
 #include <stdbool.h>
 #include <silexpk/core.h>
 #include <sxsymcrypt/hash.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_wpa3_sae_h2e.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_derivation/cracen_wpa3_sae_h2e.c
@@ -10,7 +10,6 @@
 #include <string.h>
 #include <stdbool.h>
 #include <silexpk/core.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_common.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_common.c
@@ -8,9 +8,7 @@
 #include <internal/aes/cracen_aes_ecb.h>
 
 #include <stddef.h>
-#include <cracen/statuscodes.h>
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
 #include <silexpk/core.h>
 #include <sxsymcrypt/internal.h>
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_kwp.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/key_wrap/cracen_key_wrap_kwp.c
@@ -9,9 +9,7 @@
 #include <internal/aes/cracen_aes_ecb.h>
 
 #include <stddef.h>
-#include <cracen/statuscodes.h>
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
 #include <silexpk/core.h>
 #include <sxsymcrypt/internal.h>
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/mac/cracen_mac_cmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/mac/cracen_mac_cmac.c
@@ -13,8 +13,6 @@
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
-#include <cracen/statuscodes.h>
 
 #define AES_BLOCK_SIZE (16)
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/mac/cracen_mac_hmac.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/mac/cracen_mac_hmac.c
@@ -14,8 +14,6 @@
 #include <sxsymcrypt/internal.h>
 #include <sxsymcrypt/keyref.h>
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa_primitives.h>
 #include <cracen/cracen_hmac.h>
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ml_dsa/cracen_ml_dsa.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/ml_dsa/cracen_ml_dsa.c
@@ -14,7 +14,6 @@
 #include <cracen_psa_xof.h>
 #include <cracen_psa_primitives.h>
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
 
 #include <string.h>
 #include <zephyr/sys/util.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_spake2p_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_spake2p_key_management.c
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <silexpk/core.h>
 #include <silexpk/ec_curves.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_srp_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_srp_key_management.c
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <silexpk/core.h>
 #include <silexpk/ec_curves.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_wpa3_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/pake/cracen_wpa3_key_management.c
@@ -13,7 +13,6 @@
 #include <silexpk/sxbuf/sxbufop.h>
 #include <silexpk/sxops/rsa.h>
 #include <silexpk/sxops/eccweierstrass.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_encryption_rsaes_oaep.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_encryption_rsaes_oaep.c
@@ -30,9 +30,7 @@
 #include <string.h>
 #include <silexpk/sxbuf/sxbufop.h>
 #include <sxsymcrypt/hash.h>
-#include <cracen/statuscodes.h>
 #include <cracen/common.h>
-#include <nrf_security_mem_helpers.h>
 #include <cracen_psa.h>
 #include <cracen_psa_ctr_drbg.h>
 #include <cracen_psa_primitives.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_key_management.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_key_management.c
@@ -10,7 +10,6 @@
 
 #include <string.h>
 #include <silexpk/core.h>
-#include <cracen/statuscodes.h>
 #include <cracen_psa.h>
 #include <cracen/common.h>
 #include <zephyr/sys/byteorder.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_keygen.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_keygen.c
@@ -15,7 +15,6 @@
 #include <silexpk/cmddefs/rsa.h>
 #include <silexpk/iomem.h>
 #include <sxsymcrypt/hash.h>
-#include <cracen/statuscodes.h>
 #include <cracen/common.h>
 #include <cracen_psa.h>
 #include <cracen_psa_ctr_drbg.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_mgf1xor.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_mgf1xor.c
@@ -14,7 +14,6 @@
 
 #include <sxsymcrypt/hash.h>
 #include <sxsymcrypt/hashdefs.h>
-#include <cracen/statuscodes.h>
 #include <cracen/common.h>
 
 /* number of bytes used for the MGF1 internal counter */

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_signature_rsapss.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_signature_rsapss.c
@@ -52,8 +52,6 @@
 #include <silexpk/iomem.h>
 #include <sxsymcrypt/hash.h>
 #include <psa/crypto.h>
-#include <cracen/statuscodes.h>
-#include <nrf_security_mem_helpers.h>
 #include <cracen/common.h>
 #include <cracen_psa.h>
 #include <cracen_psa_ctr_drbg.h>

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_signature_rsassa_pkcs1v15.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/internal/rsa/cracen_rsa_signature_rsassa_pkcs1v15.c
@@ -23,7 +23,6 @@
 #include <silexpk/core.h>
 #include <sxsymcrypt/hashdefs.h>
 #include <sxsymcrypt/hash.h>
-#include <cracen/statuscodes.h>
 #include <cracen/common.h>
 #include <cracen_psa_primitives.h>
 


### PR DESCRIPTION
This consolidates mem handling and status code into a single header cleaning up the includes. Ordering of the include is a bit important in this context as the other headers in `common.h` includes functions/defines from the above headers.