### PR TITLE
doc: Fix broken links in the nRF70 Driver doc

### DIFF
--- a/doc/nrf/drivers/wifi/nrf70_native.rst
+++ b/doc/nrf/drivers/wifi/nrf70_native.rst
@@ -148,8 +148,8 @@ You can calculate the TX power by using the following formula:
 where the following parameters are used:
 
 * :math:`P_\text{reg}` is the applicable regulatory power limit, as described in :ref:`ug_nrf70_developing_regulatory_support`.
-* ``AntGain`` is the compensation for the antenna gain in the TX direction, as described in `Antenna gain compensation`_.
-* ``EdgeBackoff`` is the backoff applied to band edge channels, as described in `Band edge compensation`_.
+* ``AntGain`` is the compensation for the antenna gain in the TX direction, as described in :ref:`ug_wifi_antenna_gain_compensation`.
+* ``EdgeBackoff`` is the backoff applied to band edge channels, as described in :ref:`ug_wifi_band_edge_compensation`.
 * :math:`P_\text{max} = min (P_\text{ps} , P_\text{max-tx-pwr})`
 * :math:`P_\text{ps}`  is the maximum power level for the package type, modulation, and band as described in `Electrical specification for nRF7002`_.
 * :math:`P_\text{max-tx-pwr}` is the sub-band power limit, dependent on the PCB design.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -695,8 +695,6 @@
 .. _`Using nRF7002 EB with the Nordic Thingy:53`: https://docs.nordicsemi.com/bundle/ug_nrf7002_eb/page/UG/nrf7002_EB/use_thingy53.html
 .. _`nRF7002 EB castellated edge holes`: https://docs.nordicsemi.com/bundle/ug_nrf7002_eb/page/UG/nrf7002_EB/castellated_mounting_holes.html
 .. _`nRF7002 companion IC`: https://docs.nordicsemi.com/bundle/ug_nrf7002_ek/page/UG/nrf7002_EK/hw_wifi_companion_ic.html
-.. _`Antenna gain compensation`: https://docs.nordicsemi.com/bundle/nan_046/page/APP/nan_046/antenna_compensation.html
-.. _`Band edge compensation`: https://docs.nordicsemi.com/bundle/nan_046/page/APP/nan_046/band_compensation.html
 .. _`overlay-iot-devices.conf`: https://github.com/nrfconnect/sdk-nrf/blob/main/samples/wifi/throughput/overlay-iot-devices.conf
 .. _`overlay-memory-optimized.conf`: https://github.com/nrfconnect/sdk-nrf/blob/main/samples/wifi/throughput/overlay-memory-optimized.conf
 .. _`overlay-high-performance.conf`: https://github.com/nrfconnect/sdk-nrf/blob/main/samples/wifi/throughput/overlay-high-performance.conf


### PR DESCRIPTION
Fixed the broken links in the nRF70 Driver documentation. TECHDOC-4799