### PR TITLE
manifest: sdk-zephyr: Update nrf-mramc secure mem read

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 56ce996672b5acd5c8f76d14dc568cf53a075bdc
+      revision: pull/4307/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr to point to secure memory read update in soc_flash_nrf_mramc driver.