### PR TITLE
samples: openthread: add suppport for nRF54LM20Dongle

### DIFF
--- a/samples/openthread/cli/boards/nrf54lm20dongle_nrf54lm20b_cpuapp.conf
+++ b/samples/openthread/cli/boards/nrf54lm20dongle_nrf54lm20b_cpuapp.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Increase Main and shell stack sizes to avoid stack overflow
+# while using CRACEN.
+CONFIG_MAIN_STACK_SIZE=6144
+CONFIG_SHELL_STACK_SIZE=5120

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -50,6 +50,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lm20dongle/nrf54lm20b/cpuapp
     extra_args:
       - cli_SNIPPET="ot-ci;ot-logging"
       - EXTRA_CONF_FILE="extra_conf/multiprotocol.conf;extra_conf/tcp.conf"
@@ -66,6 +67,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lm20dongle/nrf54lm20b/cpuapp
   sample.openthread.cli.singleprotocol:
     sysbuild: true
     build_only: true

--- a/samples/openthread/coprocessor/boards/nrf54lm20dongle_nrf54lm20b_cpuapp.conf
+++ b/samples/openthread/coprocessor/boards/nrf54lm20dongle_nrf54lm20b_cpuapp.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SPI_NOR=n
+
+# Increase Main stack size to avoid stack overflow while using CRACEN.
+CONFIG_MAIN_STACK_SIZE=2048
+
+CONFIG_UART_LINE_CTRL=y

--- a/samples/openthread/coprocessor/boards/nrf54lm20dongle_nrf54lm20b_cpuapp.overlay
+++ b/samples/openthread/coprocessor/boards/nrf54lm20dongle_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,ot-uart = &board_cdc_acm_uart;
+	};
+};

--- a/samples/openthread/coprocessor/sample.yaml
+++ b/samples/openthread/coprocessor/sample.yaml
@@ -22,6 +22,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lm20dongle/nrf54lm20b/cpuapp
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
@@ -34,6 +35,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lm20dongle/nrf54lm20b/cpuapp
   sample.openthread.coprocessor.vendor_hook:
     sysbuild: true
     build_only: true


### PR DESCRIPTION
nRF54LM20Dongle is now supported for thread cli and coprocessor