### PR TITLE
doc: Clarified information about supported Matter versions in NCS.

### DIFF
--- a/doc/nrf/protocols/matter/index.rst
+++ b/doc/nrf/protocols/matter/index.rst
@@ -10,4 +10,7 @@ It supports a wide range of existing technologies, including Wi-Fi®, Thread, an
 To learn more about the solution, see the `Matter Add-on`_ documentation.
 For source code, refer to the `ncs-matter add-on repository`_.
 
+In |NCS| v3.4.0 and earlier, Matter support is integrated in the SDK.
+In later |NCS| releases, Matter 1.6 support and Matter samples are available through the `Matter Add-on`_.
+
 See :ref:`migration_sdk_nrf_to_ncs_matter` for migration instructions.

--- a/doc/nrf/releases_and_maturity/migration/migration_ncs_matter.rst
+++ b/doc/nrf/releases_and_maturity/migration/migration_ncs_matter.rst
@@ -7,8 +7,8 @@ Migrating Matter projects from sdk-nrf to Matter add-on
    :local:
    :depth: 3
 
-Starting with |NCS| v3.5.0, all Matter samples, shared sample code, board partition devicetree files, and Matter-specific snippets are maintained in the separate `Matter add-on <ncs-matter add-on repository_>`_ repository (``ncs-matter``) instead of the ``sdk-nrf`` repository.
-The Matter reference applications and their supporting assets are moved to the add-on.
+The |NCS| v3.4.0 was the last major release with Matter samples, shared sample code, board partition devicetree files, and Matter-specific snippets integrated in the ``sdk-nrf`` repository.
+In later releases, the Matter reference applications and their supporting assets are maintained in the separate `Matter add-on <ncs-matter add-on repository_>`_ repository (``ncs-matter``).
 
 This guide describes the changes required when migrating a Matter project that was based on paths under ``sdk-nrf`` to the ``ncs-matter`` add-on structure.
 It covers workspace setup, repository layout, build system updates, Kconfig symbol renames, devicetree and snippet changes, and documentation references.


### PR DESCRIPTION
Added more precise information which versions are supported in Matter add-on and in NCS.