### PR TITLE
quarantine: script: Fix changed files propagation

### DIFF
--- a/.github/workflows/review-quarantine-generate.yml
+++ b/.github/workflows/review-quarantine-generate.yml
@@ -38,22 +38,31 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pyyaml west pathspec
 
-      # Compare base..head via GitHub API (works for fork PRs).
+      # Detect changed quarantine files via GitHub's REST API. This works for
+      # fork PRs and does not rely on local git history (the checkout is a
+      # shallow clone of the fork in the "nrf" subdirectory, so base_sha is not
+      # available for a local diff). The list is emitted as JSON and parsed with
+      # jq below to avoid separator/escaping pitfalls.
       - name: Detect changed quarantine YAML files (base vs PR)
         id: quarantine_changed_files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          base_sha: ${{ env.BASE_SHA }}
-          sha: ${{ env.HEAD_SHA }}
+          use_rest_api: true
+          token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             scripts/quarantine*.yaml
-          separator: "\n"
+          json: true
+          escape_json: false
 
       - name: Compare only affected quarantine YAMLs (base vs PR)
         shell: bash
         id: compare_quarantine
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass the JSON file list through the environment (never interpolate
+          # action outputs directly into the script: it is unsafe and, with
+          # newline separators, bash line-continuation glues the paths together).
+          CHANGED_FILES_JSON: ${{ steps.quarantine_changed_files.outputs.all_modified_files }}
         run: |
           set -euo pipefail
           west init -l ./nrf
@@ -62,10 +71,10 @@ jobs:
           OUTDIR="quarantine-diff-results"
           mkdir -p "$OUTDIR" quarantine-base-files quarantine-pr-files
 
-          echo "Changed quarantine files count: ${{ steps.quarantine_changed_files.outputs.all_modified_files_count }}"
-          files="${{ steps.quarantine_changed_files.outputs.all_modified_files }}"
+          mapfile -t CHANGED_FILES < <(printf '%s' "$CHANGED_FILES_JSON" | jq -r '.[]')
+          echo "Changed quarantine files count: ${#CHANGED_FILES[@]}"
 
-          while IFS= read -r rel; do
+          for rel in "${CHANGED_FILES[@]}"; do
             [[ -z "$rel" ]] && continue
             echo "== Comparing affected quarantine file: $rel =="
             fname="${rel##*/}"
@@ -91,7 +100,7 @@ jobs:
 
             python3 nrf/scripts/compare_quarantine.py "$pr_file" "$base_file" \
               --outdir "$OUTDIR" --repo-root ./nrf
-          done <<< "$files"
+          done
 
       - name: Prepare comment body
         working-directory: nrf

--- a/.github/workflows/review-quarantine-publish.yml
+++ b/.github/workflows/review-quarantine-publish.yml
@@ -34,10 +34,22 @@ jobs:
         id: prep
         run: |
           set -euo pipefail
+
+          # A missing/empty comment means the Generate run found no quarantine
+          # configuration changes worth reporting. That is a valid outcome, so
+          # skip publishing instead of failing the workflow.
           PR_FILE="$(find ./quarantine-artifacts -type f -name 'pr_number.txt' -print -quit)"
           if [[ -z "${PR_FILE}" || ! -s "${PR_FILE}" ]]; then
-            echo "ERROR: pr_number.txt not found or empty." >&2
-            exit 1
+            echo "No pr_number.txt found; nothing to publish. Skipping."
+            echo "has_comment=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          COMMENT_FILE="$(find ./quarantine-artifacts -type f -name 'quarantine_comment.md' -print -quit)"
+          if [[ -z "${COMMENT_FILE}" || ! -s "${COMMENT_FILE}" ]]; then
+            echo "No quarantine changes to report (comment absent or empty). Skipping."
+            echo "has_comment=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           PR_NUMBER="$(head -n1 -- "$PR_FILE" | tr -d '\r\n')"
@@ -46,16 +58,12 @@ jobs:
             exit 1
           fi
 
-          COMMENT_FILE="$(find ./quarantine-artifacts -type f -name 'quarantine_comment.md' -print -quit)"
-          if [[ -z "${COMMENT_FILE}" || ! -s "${COMMENT_FILE}" ]]; then
-            echo "ERROR: Quarantine comment not found or empty." >&2
-            exit 1
-          fi
-
           cp -- "$COMMENT_FILE" quarantine_comment_body.md
           printf 'pr_number=%s\n' "$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "has_comment=true" >> "$GITHUB_OUTPUT"
 
       - name: Find Comment
+        if: steps.prep.outputs.has_comment == 'true'
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: find_comment
         with:
@@ -64,6 +72,7 @@ jobs:
           body-includes: quarantine-notifier
 
       - name: Create or update comment
+        if: steps.prep.outputs.has_comment == 'true'
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}


### PR DESCRIPTION
Fixes observed issue where two file names where passed as a single (separator missed)