### PR TITLE
scripts: ci: tags: extend deps for ci_samples_wifi

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -167,6 +167,7 @@ ci_samples_wifi:
     - nrf/subsys/net/openthread/
     - nrf/subsys/nrf_security/
     - nrfxlib/nrf_wifi/
+    - zephyr/boards/shields/nrf7002*
     - zephyr/drivers/wifi/
     - zephyr/modules/hostap/
     - zephyr/modules/nrf_wifi/


### PR DESCRIPTION
Depend on nrf7002 shield.