### PR TITLE
tests: drivers: dect: zero-init invalid_if_dev in integration test

### DIFF
--- a/scripts/quarantine_no_optimization.yaml
+++ b/scripts/quarantine_no_optimization.yaml
@@ -16,9 +16,3 @@
   platforms:
     - native_sim/native
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-39378"
-
-- scenarios:
-    - unity.dect_integration_test
-  platforms:
-    - native_sim/native
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-40858"

--- a/tests/drivers/dect/dect_mdm/integration/src/test_dect_integration.c
+++ b/tests/drivers/dect/dect_mdm/integration/src/test_dect_integration.c
@@ -623,7 +623,7 @@ void tearDown(void)
  */
 void test_dect_net_mgmt_invalid_iface_errors(void)
 {
-	struct net_if_dev invalid_if_dev;
+	struct net_if_dev invalid_if_dev = {0};
 	struct net_if invalid_iface = {
 		.if_dev = &invalid_if_dev,
 	};


### PR DESCRIPTION
Complete the Zephyr upmerge adaptation started in 0e054e3183; uninitialized dev could segfault on native_sim.
Jira: NCSDK-40858