### PR TITLE
net: nrf_cloud: Disconnect CoAP connection before modem shutdown

### DIFF
--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
@@ -24,6 +24,7 @@
 #if defined(CONFIG_NRF_MODEM_LIB)
 #include <nrf_socket.h>
 #include <nrf_modem_at.h>
+#include <modem/nrf_modem_lib.h>
 #endif
 #include <date_time.h>
 #include <net/nrf_cloud.h>
@@ -1127,3 +1128,18 @@ int nrf_cloud_coap_transport_proxy_dl_uri_get(char *const uri, size_t uri_len,
 
 	return 0;
 }
+
+#if defined(CONFIG_NRF_MODEM_LIB)
+/* Close the CoAP socket before the modem is shut down so the shared
+ * coap_client recv thread is released from poll() rather than left wedged.
+ */
+static void on_modem_lib_shutdown(void *ctx)
+{
+	ARG_UNUSED(ctx);
+
+	if (internal_cc.initialized) {
+		nrf_cloud_coap_transport_disconnect(&internal_cc);
+	}
+}
+NRF_MODEM_LIB_ON_SHUTDOWN(nrf_cloud_coap_shutdown, on_modem_lib_shutdown, NULL);
+#endif


### PR DESCRIPTION
Register an NRF_MODEM_LIB_ON_SHUTDOWN callback that calls nrf_cloud_coap_transport_disconnect() before the modem is torn down.

The shared coap_client recv thread blocks in zsock_poll() on the CoAP DTLS socket. If the socket is still open when nrf_modem_shutdown() is called, the poll() never returns and the recv thread is permanently wedged. On the next connection attempt the JWT auth CON request gets no response callback, causing client_transfer() to block on k_sem_take(K_FOREVER) and stall any work queue the caller runs on.

Closing the socket while the modem is still up generates POLLNVAL, which releases the recv thread cleanly before the modem is torn down. nrf_cloud_coap_transport_disconnect() is idempotent (guarded by sock < 0), so concurrent or prior disconnects are harmless.