### PR TITLE
bluetooth: hci_internal: PAwR sync, prepare for no special handling

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -38,7 +38,7 @@ static struct
 static uint8_t num_completed_packet_command_status;
 #endif /* CONFIG_BT_HCI_ACL_FLOW_CONTROL */
 
-#if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC)
+#if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC) && !defined(SDC_HCI_PAWR_SYNC_RETURN_IMMEDIATELY)
 static bool padv_response_data_cmd_pending;
 #endif
 
@@ -1959,7 +1959,7 @@ int hci_internal_cmd_put(uint8_t *cmd_in)
 #endif /* CONFIG_BT_HCI_ACL_FLOW_CONTROL */
 
 	if (cmd_complete_or_status.occurred
-#if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC)
+#if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC) && !defined(SDC_HCI_PAWR_SYNC_RETURN_IMMEDIATELY)
 		|| padv_response_data_cmd_pending
 #endif
 		) {
@@ -1979,7 +1979,7 @@ int hci_internal_cmd_put(uint8_t *cmd_in)
 
 	cmd_complete_or_status.occurred = true;
 
-#if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC)
+#if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC) && !defined(SDC_HCI_PAWR_SYNC_RETURN_IMMEDIATELY)
 	if (opcode == SDC_HCI_OPCODE_CMD_LE_SET_PERIODIC_ADV_RESPONSE_DATA
 		&&
 		cmd_complete_or_status.raw_event[0] == BT_HCI_EVT_CMD_COMPLETE) {
@@ -2027,7 +2027,7 @@ int hci_internal_msg_get(uint8_t *msg_out, sdc_hci_msg_type_t *msg_type_out)
 
 	const int retval = sdc_hci_get(msg_out, (uint8_t *)msg_type_out);
 
-#if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC)
+#if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC) && !defined(SDC_HCI_PAWR_SYNC_RETURN_IMMEDIATELY)
 	if (retval == 0 && *msg_type_out == SDC_HCI_MSG_TYPE_EVT
 		&& msg_out[0] == BT_HCI_EVT_CMD_COMPLETE) {
 		padv_response_data_cmd_pending = false;


### PR DESCRIPTION
This is in preparation for SDC returning immediately from the LE Set Periodic Advertising Response Data command, which makes sure nrfxlib can be updated independently of nrf.

Currently, SDC delays generating the command complete event for the command until the response is sent on air.
The code under the ifdefs handles this special case, and it can be removed once nrfxlib has been updated with the SDC changes.