### PR TITLE
sysbuild: Add OTP write size config

### DIFF
--- a/cmake/sysbuild/provision_hex.cmake
+++ b/cmake/sysbuild/provision_hex.cmake
@@ -18,12 +18,6 @@ function(provision application prefix_name)
   set(PROVISION_HEX_NAME     ${prefix_name}provision.hex)
   set(PROVISION_HEX          ${CMAKE_BINARY_DIR}/${PROVISION_HEX_NAME})
 
-  if(CONFIG_SOC_SERIES_NRF54L)
-    set(otp_write_width 4) # OTP writes are in words (4 bytes)
-  else()
-    set(otp_write_width 2) # OTP writes are in half-words (2 bytes)
-  endif()
-
   if(CONFIG_SECURE_BOOT)
     if(SB_CONFIG_SECURE_BOOT_MONOTONIC_COUNTER)
       set(monotonic_counter_arg
@@ -154,7 +148,7 @@ function(provision application prefix_name)
       ${monotonic_counter_arg}
       ${no_verify_hashes_arg}
       ${mcuboot_counters_slots}
-      --otp-write-width ${otp_write_width}
+      --otp-write-width ${SB_CONFIG_SECURE_BOOT_OTP_WRITE_SIZE}
       ${psa_certificate_reference}
       DEPENDS
       ${PROVISION_KEY_DEPENDS}
@@ -178,7 +172,7 @@ function(provision application prefix_name)
       --max-size ${provision_size}
       ${mcuboot_counters_num}
       ${mcuboot_counters_slots}
-      --otp-write-width ${otp_write_width}
+      --otp-write-width ${SB_CONFIG_SECURE_BOOT_OTP_WRITE_SIZE}
       ${psa_certificate_reference}
       DEPENDS
       ${PROVISION_KEY_DEPENDS}

--- a/sysbuild/Kconfig.secureboot
+++ b/sysbuild/Kconfig.secureboot
@@ -10,6 +10,15 @@ config SECURE_BOOT
 	  This option will be set if the first stage bootloader which verifies the signature of the
 	  application is enabled for one or multiple cores.
 
+config SECURE_BOOT_OTP_WRITE_SIZE
+	int
+	depends on SECURE_BOOT || (MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION && !SOC_SERIES_NRF54H)
+	default 4 if SOC_SERIES_NRF54L
+	default 2
+	help
+	  The size of the write operation for the OTP area used to store
+	  downgrade prevention counters.
+
 menuconfig SECURE_BOOT_APPCORE
 	bool "Appcore"
 	select SECURE_BOOT


### PR DESCRIPTION
Make the OTP write size configurable through sysbuild Kconfig symbol.

Ref: NCSDK-40412