### PR TITLE
applications: nrf_audio: Move conn unref to after zbus publish

### DIFF
--- a/applications/nrf_audio/include/zbus_common.h
+++ b/applications/nrf_audio/include/zbus_common.h
@@ -87,6 +87,14 @@ enum bt_mgmt_evt_type {
 
 struct bt_mgmt_msg {
 	enum bt_mgmt_evt_type event;
+	/**
+	 * Valid only in a ZBUS_OBSERVER_LISTENER_TYPE callback. ZBUS_OBSERVER_SUBSCRIBER_TYPE,
+	 * ZBUS_OBSERVER_MSG_SUBSCRIBER_TYPE and ZBUS_OBSERVER_ASYNC_LISTENER_TYPE must NOT use this
+	 * pointer, as bt_mgmt may release its reference before the observer processes the message.
+	 *
+	 * A ZBUS_OBSERVER_LISTENER_TYPE that needs to keep this pointer beyond its callback must
+	 * call bt_conn_ref() before returning, and bt_conn_unref() when done.
+	 */
 	struct bt_conn *conn;
 	uint8_t index;
 	struct bt_le_ext_adv *ext_adv;

--- a/applications/nrf_audio/src/bluetooth/bt_management/bt_mgmt.c
+++ b/applications/nrf_audio/src/bluetooth/bt_management/bt_mgmt.c
@@ -134,16 +134,16 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 	/* NOTE: The string below is used by the Nordic CI system */
 	LOG_INF("Disconnected: %s, reason 0x%02x %s", addr, reason, bt_hci_err_to_str(reason));
 
-	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
-		bt_conn_unref(conn);
-	}
-
 	/* Publish disconnected */
 	msg.event = BT_MGMT_DISCONNECTED;
 	msg.conn = conn;
 
 	ret = zbus_chan_pub(&bt_mgmt_chan, &msg, K_NO_WAIT);
 	ERR_CHK(ret);
+
+	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+		bt_conn_unref(conn);
+	}
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
 		ret = bt_mgmt_adv_start(0, NULL, 0, NULL, 0, true);

--- a/applications/nrf_audio/unicast_client/main.c
+++ b/applications/nrf_audio/unicast_client/main.c
@@ -487,6 +487,11 @@ static void bt_mgmt_evt_handler(const struct zbus_channel *chan)
 		/* NOTE: The string below is used by the Nordic CI system */
 		LOG_INF("Disconnection event. Num connections: %u", num_conn);
 
+		if (msg->conn == NULL) {
+			LOG_ERR("Disconnected event with NULL conn");
+			return;
+		}
+
 		unicast_client_conn_disconnected(msg->conn);
 
 		/* Update the locations / number of encoder channels */

--- a/applications/nrf_audio/unicast_server/main.c
+++ b/applications/nrf_audio/unicast_server/main.c
@@ -362,6 +362,11 @@ static void bt_mgmt_evt_handler(const struct zbus_channel *chan)
 		/* NOTE: The string below is used by the Nordic CI system */
 		LOG_INF("Disconnection event. Num connections: %u", num_conn);
 
+		if (msg->conn == NULL) {
+			LOG_ERR("Disconnected event with NULL conn");
+			return;
+		}
+
 		ret = bt_content_ctrl_conn_disconnected(msg->conn);
 		if (ret) {
 			LOG_ERR("Failed to handle disconnection in content control: %d", ret);


### PR DESCRIPTION

 - Move the unref of a conn pointer to after it has been published
   - Increases chance of the conn pointer being valid
 - Document that the conn pointer might be unvalid
 - Add checks to make sure conn pointer is valid where it is used
 - OCT-3490