### PR TITLE
ci: add CI-wifi-7120dk test-spec for nRF7120 DK Wi-Fi validation

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -465,6 +465,13 @@
   - "subsys/net/lib/mqtt_helper/**/*"
   - "subsys/net/lib/hostap_crypto/**/*"
 
+"CI-wifi-7120dk":
+  - "drivers/wifi/nrf71/**/*"
+  - "include/drivers/wifi/nrf71/**/*"
+  - "tests/drivers/nrf71*/**/*"
+  - "samples/wifi/**/*7120*"
+  - "samples/wifi/wfa_qt_app/nrf7120*"
+
 "CI-cloud-test":
   - "include/caf/**/*"
   - "include/date_time.h"


### PR DESCRIPTION
Add a dedicated test-spec mapping to trigger the nRF7120 DK WiFi downstream pipeline only when nRF71 WiFi related paths change in sdk-nrf, without queuing all WiFi PRs on the 7120 DK test farm.