### PR TITLE
openthread: return OT_ERROR_BUSY from otPlatRadioSleep during TX

### DIFF
--- a/modules/openthread/platform/radio_nrf5.c
+++ b/modules/openthread/platform/radio_nrf5.c
@@ -1309,6 +1309,10 @@ otError otPlatRadioSleep(otInstance *aInstance)
 {
 	ARG_UNUSED(aInstance);
 
+	if (nrf5_data.state == OT_RADIO_STATE_TRANSMIT) {
+		return OT_ERROR_BUSY;
+	}
+
 	if (nrf5_data.state != OT_RADIO_STATE_SLEEP && nrf5_data.state != OT_RADIO_STATE_RECEIVE) {
 		return OT_ERROR_INVALID_STATE;
 	}


### PR DESCRIPTION
Align nrf5 radio platform sleep behavior with OpenThread API: reject sleep requests while a Mac-initiated transmission is in progress using OT_ERROR_BUSY instead of OT_ERROR_INVALID_STATE.