### PR TITLE
tests: drivers: mspi: controller_periph: increase timeout for flash w…

### DIFF
--- a/tests/zephyr/drivers/mspi/controller_peripheral/src/main.c
+++ b/tests/zephyr/drivers/mspi/controller_peripheral/src/main.c
@@ -318,7 +318,7 @@ static void run_test(bool m_same_size, bool s_same_size, bool emu_spis_dev)
 		rv = k_sem_take(&tdata.sem, K_MSEC(100));
 		zassert_equal(rv, 0);
 	} else {
-		rv = k_sem_take(&tdata.sem, K_MSEC(100));
+		rv = k_sem_take(&tdata.sem, K_MSEC(300));
 		zassert_equal(rv, 0);
 
 		if (tdata.srx_set) {


### PR DESCRIPTION
…rite tests

Use timeout greater than the maximum specified sector erase time to fix instability.