### PR TITLE
nrf_security: cracen: Forbid DMA to peripheral ranges

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/Kconfig
+++ b/subsys/nrf_security/src/drivers/cracen/Kconfig
@@ -36,6 +36,14 @@ module = CRACEN
 module-str = CRACEN
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
+config CRACEN_DMA_REJECT_PERIPHERAL_ACCESS
+	bool "Reject peripheral addresses in CRACEN DMA descriptors"
+	default y if BUILD_WITH_TFM
+	help
+	  Reject DMA input and output buffers that overlap device peripheral or
+	  system control register regions. This prevents caller-controlled CRACEN
+	  DMA descriptors from accessing peripheral registers.
+
 config PSA_NEED_CRACEN_ECC_KEY_GEN_PKE
 	bool
 	default y if PSA_NEED_CRACEN_KEY_TYPE_ECC_KEY_PAIR_GENERATE_SECP_R1 || \

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/aead.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/aead.c
@@ -322,8 +322,14 @@ int sx_aead_crypt(struct sxaead *aead_ctx, const uint8_t *datain, size_t datains
 
 static int sx_aead_run(struct sxaead *aead_ctx)
 {
-	sx_cmdma_start(&aead_ctx->dma, sizeof(aead_ctx->descs) + sizeof(aead_ctx->extramem),
-		       aead_ctx->descs);
+	int status;
+
+	status = sx_cmdma_start(&aead_ctx->dma,
+				 sizeof(aead_ctx->descs) + sizeof(aead_ctx->extramem),
+				 aead_ctx->descs);
+	if (status != SX_OK) {
+		return sx_handle_nested_error(sx_aead_free(aead_ctx), status);
+	}
 
 	return SX_OK;
 }
@@ -431,6 +437,8 @@ int sx_aead_resume_state(struct sxaead *aead_ctx)
 
 int sx_aead_save_state(struct sxaead *aead_ctx)
 {
+	int status;
+
 	if (!aead_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
@@ -449,8 +457,12 @@ int sx_aead_save_state(struct sxaead *aead_ctx)
 
 	aead_ctx->dma.dmamem.cfg |= aead_ctx->cfg->ctxsave;
 
-	sx_cmdma_start(&aead_ctx->dma, sizeof(aead_ctx->descs) + sizeof(aead_ctx->extramem),
-		       aead_ctx->descs);
+	status = sx_cmdma_start(&aead_ctx->dma,
+				 sizeof(aead_ctx->descs) + sizeof(aead_ctx->extramem),
+				 aead_ctx->descs);
+	if (status != SX_OK) {
+		return sx_handle_nested_error(sx_aead_free(aead_ctx), status);
+	}
 
 	return SX_OK;
 }

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/blkcipher.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/blkcipher.c
@@ -265,6 +265,8 @@ int sx_blkcipher_crypt(struct sxblkcipher *cipher_ctx, const uint8_t *datain, si
 
 int sx_blkcipher_run(struct sxblkcipher *cipher_ctx)
 {
+	int status;
+
 	if (!cipher_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
@@ -282,8 +284,12 @@ int sx_blkcipher_run(struct sxblkcipher *cipher_ctx)
 		cipher_ctx->dma.dmamem.cfg &= ~cipher_ctx->cfg->ctxsave;
 	}
 
-	sx_cmdma_start(&cipher_ctx->dma, sizeof(cipher_ctx->descs) + sizeof(cipher_ctx->extramem),
-		       cipher_ctx->descs);
+	status = sx_cmdma_start(&cipher_ctx->dma,
+				 sizeof(cipher_ctx->descs) + sizeof(cipher_ctx->extramem),
+				 cipher_ctx->descs);
+	if (status != SX_OK) {
+		return sx_handle_nested_error(sx_blkcipher_free(cipher_ctx), status);
+	}
 
 	return SX_OK;
 }
@@ -328,6 +334,8 @@ int sx_blkcipher_resume_state(struct sxblkcipher *cipher_ctx)
 
 int sx_blkcipher_save_state(struct sxblkcipher *cipher_ctx)
 {
+	int status;
+
 	if (!cipher_ctx->dma.hw_acquired) {
 		return SX_ERR_UNINITIALIZED_OBJ;
 	}
@@ -350,8 +358,12 @@ int sx_blkcipher_save_state(struct sxblkcipher *cipher_ctx)
 
 	ADD_OUTDESC_PRIV(cipher_ctx->dma, OFFSET_EXTRAMEM(cipher_ctx), 16, 0x0F);
 
-	sx_cmdma_start(&cipher_ctx->dma, sizeof(cipher_ctx->descs) + sizeof(cipher_ctx->extramem),
-		       cipher_ctx->descs);
+	status = sx_cmdma_start(&cipher_ctx->dma,
+				 sizeof(cipher_ctx->descs) + sizeof(cipher_ctx->extramem),
+				 cipher_ctx->descs);
+	if (status != SX_OK) {
+		return sx_handle_nested_error(sx_blkcipher_free(cipher_ctx), status);
+	}
 
 	return SX_OK;
 }

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmdma.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmdma.c
@@ -13,6 +13,72 @@
 #include <cracen/hardware.h>
 #include <nrf_security_core.h>
 
+#if defined(CONFIG_CRACEN_DMA_REJECT_PERIPHERAL_ACCESS)
+
+static bool sx_cmdma_range_overlaps(uintptr_t address, size_t size, uintptr_t range_start,
+				    size_t range_size)
+{
+	uintptr_t end = address + size;
+	uintptr_t range_end = range_start + range_size;
+
+	if (size > UINTPTR_MAX - address || range_size > UINTPTR_MAX - range_start) {
+		return true;
+	}
+
+	return (address < range_end) && (end > range_start);
+}
+
+static bool sx_cmdma_range_is_forbidden(uintptr_t address, size_t size)
+{
+#if defined(NRF_MEMORY_PERIPHERALSAPBNS_BASE) && defined(NRF_MEMORY_PERIPHERALSAPBNS_SIZE)
+	if (sx_cmdma_range_overlaps(address, size, NRF_MEMORY_PERIPHERALSAPBNS_BASE,
+				    NRF_MEMORY_PERIPHERALSAPBNS_SIZE)) {
+		return true;
+	}
+#endif
+#if defined(NRF_MEMORY_PERIPHERALSAPBS_BASE) && defined(NRF_MEMORY_PERIPHERALSAPBS_SIZE)
+	if (sx_cmdma_range_overlaps(address, size, NRF_MEMORY_PERIPHERALSAPBS_BASE,
+				    NRF_MEMORY_PERIPHERALSAPBS_SIZE)) {
+		return true;
+	}
+#endif
+#if defined(NRF_MEMORY_PERIPHERALSAHB_BASE) && defined(NRF_MEMORY_PERIPHERALSAHB_SIZE)
+	if (sx_cmdma_range_overlaps(address, size, NRF_MEMORY_PERIPHERALSAHB_BASE,
+				    NRF_MEMORY_PERIPHERALSAHB_SIZE)) {
+		return true;
+	}
+#endif
+#if defined(NRF_MEMORY_SYSTEMSFR_BASE) && defined(NRF_MEMORY_SYSTEMSFR_SIZE)
+	if (sx_cmdma_range_overlaps(address, size, NRF_MEMORY_SYSTEMSFR_BASE,
+				    NRF_MEMORY_SYSTEMSFR_SIZE)) {
+		return true;
+	}
+#endif
+
+	return false;
+}
+
+static int sx_cmdma_validate_descs(const struct sxdesc *start, const struct sxdesc *end)
+{
+	const struct sxdesc *desc;
+
+	for (desc = start; desc < end; desc++) {
+		uintptr_t address = (uintptr_t)desc->addr;
+		size_t size = desc->sz & DMA_SZ_MASK;
+
+		if (address == 0 || size == 0) {
+			continue;
+		}
+
+		if (sx_cmdma_range_is_forbidden(address, size)) {
+			return SX_ERR_INVALID_PARAM;
+		}
+	}
+
+	return SX_OK;
+}
+#endif
+
 void sx_cmdma_newcmd(struct sx_dmactl *dma, struct sxdesc *desc_ptr, uint32_t cmd, uint32_t tag)
 {
 	dma->d = desc_ptr;
@@ -45,9 +111,16 @@ static void sx_cmdma_finalize_descs(struct sxdesc *start, struct sxdesc *end)
 #endif
 }
 
-void sx_cmdma_start(struct sx_dmactl *dma, size_t privsz, struct sxdesc *indescs)
+int sx_cmdma_start(struct sx_dmactl *dma, size_t privsz, struct sxdesc *indescs)
 {
 	struct sxdesc *desc;
+
+#if defined(CONFIG_CRACEN_DMA_REJECT_PERIPHERAL_ACCESS)
+	if (sx_cmdma_validate_descs(indescs, dma->d) != SX_OK ||
+	    sx_cmdma_validate_descs(dma->dmamem.outdescs, dma->out) != SX_OK) {
+		return SX_ERR_INVALID_PARAM;
+	}
+#endif
 
 	sx_cmdma_finalize_descs(indescs, dma->d - 1);
 	sx_cmdma_finalize_descs(dma->dmamem.outdescs, dma->out - 1);
@@ -71,6 +144,8 @@ void sx_cmdma_start(struct sx_dmactl *dma, size_t privsz, struct sxdesc *indescs
 	sx_wrreg_addr(REG_PUSH_ADDR, desc);
 	sx_wrreg(REG_CONFIG, REG_CONFIG_SG);
 	sx_wrreg(REG_START, REG_START_ALL);
+
+	return SX_OK;
 }
 
 #ifdef CONFIG_DCACHE

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmdma.h
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmdma.h
@@ -160,8 +160,13 @@ struct sx_dmactl;
 /** Prepare for a new command/operation over DMA */
 void sx_cmdma_newcmd(struct sx_dmactl *dma, struct sxdesc *d, uint32_t cmd, uint32_t tag);
 
-/** Start input/fetcher DMA at indescs and output/pusher DMA at outdescs */
-void sx_cmdma_start(struct sx_dmactl *dma, size_t privsz, struct sxdesc *indescs);
+/**
+ * Start input/fetcher DMA at indescs and output/pusher DMA at outdescs.
+ *
+ * @retval SX_ERR_INVALID_PARAM when a descriptor buffer overlaps a forbidden
+ * peripheral or system-register address range.
+ */
+int sx_cmdma_start(struct sx_dmactl *dma, size_t privsz, struct sxdesc *indescs);
 
 #ifdef CONFIG_DCACHE
 /** Invalidate the D-cache lines backing the output descriptor buffers.

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmmask.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/cmmask.c
@@ -24,13 +24,17 @@ int sx_cm_load_mask(uint32_t csprng_value)
 
 	ADD_OUTDESCA(channel.dma, NULL, 0, 0xf);
 
-	sx_cmdma_start(&channel.dma, sizeof(channel.descs), channel.descs);
+	status = sx_cmdma_start(&channel.dma, sizeof(channel.descs), channel.descs);
+	if (status != SX_OK) {
+		goto exit;
+	}
 
 	status = SX_ERR_HW_PROCESSING;
 	while (status == SX_ERR_HW_PROCESSING) {
 		status = sx_cmdma_check();
 	}
 
+exit:
 	safe_memzero(&channel, sizeof(channel));
 	return status;
 }

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hash.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/hash.c
@@ -189,10 +189,8 @@ int sx_hash_feed(struct sxhash *hash_ctx, const uint8_t *msg, size_t sz)
 
 static int start_hash_hw(struct sxhash *hash_ctx)
 {
-	sx_cmdma_start(&hash_ctx->dma, sizeof(hash_ctx->descs) + sizeof(hash_ctx->extramem),
-		       hash_ctx->descs);
-
-	return 0;
+	return sx_cmdma_start(&hash_ctx->dma, sizeof(hash_ctx->descs) + sizeof(hash_ctx->extramem),
+			      hash_ctx->descs);
 }
 
 int sx_hash_save_state(struct sxhash *hash_ctx)

--- a/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/mac.c
+++ b/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/mac.c
@@ -61,10 +61,16 @@ int sx_mac_feed(struct sxmac *mac_ctx, const uint8_t *datain, size_t sz)
 
 static int sx_mac_run(struct sxmac *mac_ctx)
 {
+	int status;
+
 	if ((mac_ctx->feedsz == 0) && (mac_ctx->dma.dmamem.cfg & mac_ctx->cfg->loadstate)) {
 		return sx_handle_nested_error(sx_mac_free(mac_ctx), SX_ERR_INPUT_BUFFER_TOO_SMALL);
 	}
-	sx_cmdma_start(&mac_ctx->dma, sizeof(mac_ctx->descs), mac_ctx->descs);
+
+	status = sx_cmdma_start(&mac_ctx->dma, sizeof(mac_ctx->descs), mac_ctx->descs);
+	if (status != SX_OK) {
+		return sx_handle_nested_error(sx_mac_free(mac_ctx), status);
+	}
 
 	return SX_OK;
 }


### PR DESCRIPTION
Forbid accepting addresses for DMA operations in the peripheral ranges.