### PR TITLE
samples: dfu: usb_mcumgr: add optional LED thread

### DIFF
--- a/samples/dfu/fw_loader/usb_mcumgr/CMakeLists.txt
+++ b/samples/dfu/fw_loader/usb_mcumgr/CMakeLists.txt
@@ -9,3 +9,4 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(usb_mcumgr)
 
 target_sources(app PRIVATE ${ZEPHYR_BASE}/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c)
+target_sources_ifdef(CONFIG_SAMPLE_USB_MCUMGR_LED_THREAD app PRIVATE src/led_thread.c)

--- a/samples/dfu/fw_loader/usb_mcumgr/Kconfig
+++ b/samples/dfu/fw_loader/usb_mcumgr/Kconfig
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menu "USB MCUmgr firmware loader sample"
+
+config SAMPLE_USB_MCUMGR_LED_THREAD
+	bool "LED thread"
+	default y if BOARD_NRF54LM20DONGLE
+	depends on $(dt_alias_enabled,led0)
+	select GPIO
+	help
+	  Start a low-priority thread that blinks the LED selected with the
+	  devicetree alias "led0".
+
+endmenu
+
+source "Kconfig.zephyr"

--- a/samples/dfu/fw_loader/usb_mcumgr/src/led_thread.c
+++ b/samples/dfu/fw_loader/usb_mcumgr/src/led_thread.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+
+#define LED0_NODE DT_ALIAS(led0)
+
+#define LED_THREAD_STACK_SIZE 512
+#define LED_THREAD_BLINK_MS   500
+#define LED_THREAD_PRIORITY   K_LOWEST_APPLICATION_THREAD_PRIO
+
+static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+
+static void led_thread_fn(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	if (!gpio_is_ready_dt(&led)) {
+		return;
+	}
+
+	if (gpio_pin_configure_dt(&led, GPIO_OUTPUT_INACTIVE) != 0) {
+		return;
+	}
+
+	while (true) {
+		gpio_pin_toggle_dt(&led);
+		k_sleep(K_MSEC(LED_THREAD_BLINK_MS));
+	}
+}
+
+K_THREAD_DEFINE(usb_mcumgr_led_thread, LED_THREAD_STACK_SIZE,
+		led_thread_fn, NULL, NULL, NULL,
+		LED_THREAD_PRIORITY, 0, 0);


### PR DESCRIPTION
Add sample Kconfig and a low-priority thread that toggles the led0 alias for a simple loader heartbeat without affecting MCUmgr original source code.

This implements requirement for nRF54LM20dongle DFU mode: DFU mode indicated by RED LED (blinking pattern as on nRF52840 DONGLE)