### PR TITLE
samples: matter: Fix nrf5340 Contact Sensor sample

### DIFF
--- a/applications/matter_bridge/Kconfig.sysbuild
+++ b/applications/matter_bridge/Kconfig.sysbuild
@@ -31,9 +31,6 @@ config DFU_MULTI_IMAGE_PACKAGE_BUILD
 config DFU_MULTI_IMAGE_PACKAGE_APP
 	default y
 
-config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	default y
-
 #### DFU network core configuration
 if SOC_SERIES_NRF53
 
@@ -55,14 +52,6 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 	default y
 
 endif # SOC_SERIES_NRF53
-
-if BOARD_NRF54LM20DK
-
-# Disable checking the external drivers for nRF54LM20 DK.
-config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-	default y
-
-endif # BOARD_NRF54LM20DK
 
 endif # BOOTLOADER_MCUBOOT
 

--- a/applications/matter_weather_station/Kconfig.sysbuild
+++ b/applications/matter_weather_station/Kconfig.sysbuild
@@ -28,9 +28,6 @@ config NETCORE_APP_UPDATE
 config DFU_MULTI_IMAGE_PACKAGE_NET
 	default y
 
-config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	default y
-
 endif
 
 #### DFU multi-image support
@@ -42,9 +39,6 @@ config DFU_MULTI_IMAGE_PACKAGE_APP
 
 # Internal flash only for nRF54L15 tag with compression
 if BOARD_NRF54L15TAG
-
-config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-	default y
 
 config MCUBOOT_COMPRESSED_IMAGE_SUPPORT
 	default y

--- a/samples/matter/closure/Kconfig.sysbuild
+++ b/samples/matter/closure/Kconfig.sysbuild
@@ -32,9 +32,6 @@ config DFU_MULTI_IMAGE_PACKAGE_BUILD
 config DFU_MULTI_IMAGE_PACKAGE_APP
 	default y
 
-config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	default y
-
 #### DFU network core configuration
 if SOC_SERIES_NRF53
 
@@ -56,14 +53,6 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 	default y
 
 endif # SOC_SERIES_NRF53
-
-if BOARD_NRF54L15DK || BOARD_NRF54LM20DK
-
-# Disable checking the external drivers for nRF54L15 and nRF54LM20 DKs.
-config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-	default y
-
-endif # BOARD_NRF54L15DK || BOARD_NRF54LM20DK
 
 endif # BOOTLOADER_MCUBOOT
 

--- a/samples/matter/contact_sensor/Kconfig.sysbuild
+++ b/samples/matter/contact_sensor/Kconfig.sysbuild
@@ -32,14 +32,8 @@ config DFU_MULTI_IMAGE_PACKAGE_BUILD
 config DFU_MULTI_IMAGE_PACKAGE_APP
 	default y
 
-config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	default y
-
 #### DFU network core configuration
 if SOC_SERIES_NRF53
-
-config MCUBOOT_UPDATEABLE_IMAGES
-	default 2
 
 choice MCUBOOT_MODE
 	default MCUBOOT_MODE_OVERWRITE_ONLY
@@ -59,14 +53,6 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 	default y
 
 endif # SOC_SERIES_NRF53
-
-if BOARD_NRF54L15DK || BOARD_NRF54LM20DK
-
-# Disable checking the external drivers for nRF54L15 and nRF54LM20 DKs.
-config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-	default y
-
-endif # BOARD_NRF54L15DK || BOARD_NRF54LM20DK
 
 endif # BOOTLOADER_MCUBOOT
 

--- a/samples/matter/light_bulb/Kconfig.sysbuild
+++ b/samples/matter/light_bulb/Kconfig.sysbuild
@@ -32,9 +32,6 @@ config DFU_MULTI_IMAGE_PACKAGE_BUILD
 config DFU_MULTI_IMAGE_PACKAGE_APP
 	default y
 
-config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	default y
-
 #### DFU network core configuration
 if SOC_SERIES_NRF53
 
@@ -54,14 +51,6 @@ config NETCORE_APP_UPDATE
 
 config DFU_MULTI_IMAGE_PACKAGE_NET
 	default y
-
-if BOARD_NRF54L15DK || BOARD_NRF54LM20DK
-
-# Disable checking the external drivers for nRF54L15 and nRF54LM20 DKs.
-config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-	default y
-
-endif # BOARD_NRF54L15DK || BOARD_NRF54LM20DK
 
 endif # BOOTLOADER_MCUBOOT
 

--- a/samples/matter/light_switch/Kconfig.sysbuild
+++ b/samples/matter/light_switch/Kconfig.sysbuild
@@ -32,9 +32,6 @@ config DFU_MULTI_IMAGE_PACKAGE_BUILD
 config DFU_MULTI_IMAGE_PACKAGE_APP
 	default y
 
-config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	default y
-
 #### DFU network core configuration
 if SOC_SERIES_NRF53
 
@@ -56,14 +53,6 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 	default y
 
 endif # SOC_SERIES_NRF53
-
-if BOARD_NRF54L15DK || BOARD_NRF54LM20DK
-
-# Disable checking the external drivers for nRF54L15 and nRF54LM20 DKs.
-config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-	default y
-
-endif # BOARD_NRF54L15DK || BOARD_NRF54LM20DK
 
 endif # BOOTLOADER_MCUBOOT
 

--- a/samples/matter/manufacturer_specific/Kconfig.sysbuild
+++ b/samples/matter/manufacturer_specific/Kconfig.sysbuild
@@ -32,9 +32,6 @@ config DFU_MULTI_IMAGE_PACKAGE_BUILD
 config DFU_MULTI_IMAGE_PACKAGE_APP
 	default y
 
-config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	default y
-
 #### DFU network core configuration
 if SOC_SERIES_NRF53
 
@@ -56,22 +53,6 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 	default y
 
 endif # SOC_SERIES_NRF53
-
-if BOARD_NRF54L15DK || BOARD_NRF54LM20DK
-
-# Disable checking the external drivers for nRF54L15 and nRF54LM20 DKs.
-config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-	default y
-
-endif # BOARD_NRF54L15DK || BOARD_NRF54LM20DK
-
-# Mcuboot padding size is modified to 0x1000 in pm_static file.
-if SOC_NRF54L10
-
-config PM_MCUBOOT_PAD
-	default 0x1000
-
-endif # SOC_NRF54L10
 
 endif # BOOTLOADER_MCUBOOT
 

--- a/samples/matter/smoke_co_alarm/Kconfig.sysbuild
+++ b/samples/matter/smoke_co_alarm/Kconfig.sysbuild
@@ -32,9 +32,6 @@ config DFU_MULTI_IMAGE_PACKAGE_BUILD
 config DFU_MULTI_IMAGE_PACKAGE_APP
 	default y
 
-config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	default y
-
 #### DFU network core configuration
 if SOC_SERIES_NRF53
 
@@ -56,22 +53,6 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 	default y
 
 endif # SOC_SERIES_NRF53
-
-if BOARD_NRF54L15DK || BOARD_NRF54LM20DK
-
-# Disable checking the external drivers for nRF54L15 and nRF54LM20 DKs.
-config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-	default y
-
-endif # BOARD_NRF54L15DK || BOARD_NRF54LM20DK
-
-# Mcuboot padding size is modified to 0x1000 in pm_static file.
-if SOC_NRF54L10
-
-config PM_MCUBOOT_PAD
-	default 0x1000
-
-endif # SOC_NRF54L10
 
 endif # BOOTLOADER_MCUBOOT
 

--- a/samples/matter/temperature_sensor/Kconfig.sysbuild
+++ b/samples/matter/temperature_sensor/Kconfig.sysbuild
@@ -38,14 +38,8 @@ config DFU_MULTI_IMAGE_PACKAGE_BUILD
 config DFU_MULTI_IMAGE_PACKAGE_APP
 	default y
 
-config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	default y
-
 #### DFU network core configuration
 if SOC_SERIES_NRF53
-
-config MCUBOOT_UPDATEABLE_IMAGES
-	default 2
 
 choice MCUBOOT_MODE
 	default MCUBOOT_MODE_OVERWRITE_ONLY
@@ -66,19 +60,8 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 
 endif # SOC_SERIES_NRF53
 
-if BOARD_NRF54L15DK || BOARD_NRF54LM20DK
-
-# Disable checking the external drivers for nRF54L15 and nRF54LM20 DKs.
-config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-	default y
-
-endif # BOARD_NRF54L15DK || BOARD_NRF54LM20DK
-
 # Internal flash only for nRF54L15 tag with compression
 if BOARD_NRF54L15TAG
-
-config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-	default y
 
 choice MCUBOOT_MODE
 	default MCUBOOT_MODE_OVERWRITE_ONLY

--- a/samples/matter/thermostat/Kconfig.sysbuild
+++ b/samples/matter/thermostat/Kconfig.sysbuild
@@ -32,9 +32,6 @@ config DFU_MULTI_IMAGE_PACKAGE_BUILD
 config DFU_MULTI_IMAGE_PACKAGE_APP
 	default y
 
-config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	default y
-
 #### DFU network core configuration
 if SOC_SERIES_NRF53
 
@@ -56,14 +53,6 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 	default y
 
 endif # SOC_SERIES_NRF53
-
-if BOARD_NRF54L15DK || BOARD_NRF54LM20DK
-
-# Disable checking the external drivers for nRF54L15 and nRF54LM20 DKs.
-config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-	default y
-
-endif # BOARD_NRF54L15DK || BOARD_NRF54LM20DK
 
 endif # BOOTLOADER_MCUBOOT
 

--- a/samples/matter/window_covering/Kconfig.sysbuild
+++ b/samples/matter/window_covering/Kconfig.sysbuild
@@ -32,9 +32,6 @@ config DFU_MULTI_IMAGE_PACKAGE_BUILD
 config DFU_MULTI_IMAGE_PACKAGE_APP
 	default y
 
-config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	default y
-
 #### DFU network core configuration
 if SOC_SERIES_NRF53
 
@@ -56,14 +53,6 @@ config DFU_MULTI_IMAGE_PACKAGE_NET
 	default y
 
 endif # SOC_SERIES_NRF53
-
-if BOARD_NRF54L15DK || BOARD_NRF54LM20DK
-
-# Disable checking the external drivers for nRF54L15 and nRF54LM20 DKs.
-config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
-	default y
-
-endif # BOARD_NRF54L15DK || BOARD_NRF54LM20DK
 
 endif # BOOTLOADER_MCUBOOT
 


### PR DESCRIPTION
The nRF5340 DK Matter Contact Sensor sample had incorrect Kconfig sysbuild configuration, which prevented the device from booting.