### PR TITLE
lib: hw_unique_key: Minor refactor

### DIFF
--- a/lib/hw_unique_key/Kconfig
+++ b/lib/hw_unique_key/Kconfig
@@ -45,12 +45,12 @@ config HW_UNIQUE_KEY
 	depends on NRF_SECURITY
 	depends on MPU_ALLOW_FLASH_WRITE || BUILD_WITH_TFM || HAS_HW_NRF_CRACEN
 	depends on !BUILD_WITH_TFM || (TFM_CRYPTO_BUILTIN_KEYS || HAS_HW_NRF_CRACEN)
+	select PSA_NEED_CRACEN_KMU_DRIVER if CRACEN_KMU
 	select PSA_WANT_ALG_SP800_108_COUNTER_CMAC if HAS_HW_NRF_CRACEN
 	select PSA_WANT_ALG_CMAC if HAS_HW_NRF_CRACEN
 	select PSA_WANT_KEY_TYPE_AES if HAS_HW_NRF_CRACEN
 	select PSA_WANT_ALG_ECB_NO_PADDING if HAS_HW_NRF_CRACEN
 	select PSA_WANT_ALG_GCM if HAS_HW_NRF_CRACEN
-	select PSA_NEED_CRACEN_KMU_DRIVER if HAS_HW_NRF_CRACEN
 	select CRACEN_IKG if HAS_HW_NRF_CRACEN
 	select FPROTECT if HAS_HW_NRF_ACL
 	imply NRFX_NVMC if !HAS_HW_NRF_CRACEN
@@ -58,7 +58,7 @@ config HW_UNIQUE_KEY
 	help
 	  This option will load the Hardware Unique Key (HUK) in the KDR
 	  registers of the CryptoCell peripheral and sets the LCS. It will also
-	  lock its flash page so that it's not accesible by the CPU until the
+	  lock its flash page so that it's not accessible by the CPU until the
 	  next reboot.
 
 if HW_UNIQUE_KEY


### PR DESCRIPTION
Update the if statement when selecting the
PSA_NEED_CRACEN_KMU_DRIVER. Instead of relying
on HAS_HW_NRF_CRACEN, rely on CRACEN_KMU.

This is done because in some cases, especially during the development of new targets, KMU support doesn't come at the same time as other Cracen features.

This has no functional change.