### PR TITLE
samples: pmic: npm13xx: add nRF54LC10 support to the samples

### DIFF
--- a/samples/pmic/native/npm13xx_fuel_gauge/README.rst
+++ b/samples/pmic/native/npm13xx_fuel_gauge/README.rst
@@ -71,7 +71,7 @@ To connect your DK to the nPM1300 or nPM1304 EK, complete the following steps:
         - nRF52 DK pins
         - nRF52840 DK pins
         - nRF5340 DK pins
-        - nRF54L15/nRF54LM20 DK pins
+        - nRF54L Series DK pins
         - nRF54H20 DK pins
         - nRF9160 DK pins
       * - SDA

--- a/samples/pmic/native/npm13xx_fuel_gauge/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/pmic/native/npm13xx_fuel_gauge/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&pinctrl {
+	i2c21_default: i2c21_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+				<NRF_PSEL(TWIM_SCL, 1, 12)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c21_sleep: i2c21_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+				<NRF_PSEL(TWIM_SCL, 1, 12)>;
+			low-power-enable;
+		};
+	};
+};
+
+i2c_npm13xx: &i2c21 {
+	status = "okay";
+	pinctrl-0 = <&i2c21_default>;
+	pinctrl-1 = <&i2c21_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/samples/pmic/native/npm13xx_fuel_gauge/sample.yaml
+++ b/samples/pmic/native/npm13xx_fuel_gauge/sample.yaml
@@ -13,6 +13,7 @@ common:
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54lc10dk/nrf54lc10a/cpuapp
     - nrf54lm20dk/nrf54lm20a/cpuapp
     - nrf54lm20dk/nrf54lm20b/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp

--- a/samples/pmic/native/npm13xx_one_button/README.rst
+++ b/samples/pmic/native/npm13xx_one_button/README.rst
@@ -51,7 +51,7 @@ To connect your DK to the nPM1300 or nPM1304 EK, complete the following steps:
         - nRF52 DK pins
         - nRF52840 DK pins
         - nRF5340 DK pins
-        - nRF54L15/nRF54LM20 DK pins
+        - nRF54L Series DK pins
         - nRF54H20 DK pins
         - nRF9160 DK pins
       * - SDA

--- a/samples/pmic/native/npm13xx_one_button/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/samples/pmic/native/npm13xx_one_button/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&pinctrl {
+	i2c21_default: i2c21_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+				<NRF_PSEL(TWIM_SCL, 1, 12)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c21_sleep: i2c21_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+				<NRF_PSEL(TWIM_SCL, 1, 12)>;
+			low-power-enable;
+		};
+	};
+};
+
+i2c_npm13xx: &i2c21 {
+	status = "okay";
+	pinctrl-0 = <&i2c21_default>;
+	pinctrl-1 = <&i2c21_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/samples/pmic/native/npm13xx_one_button/sample.yaml
+++ b/samples/pmic/native/npm13xx_one_button/sample.yaml
@@ -13,6 +13,7 @@ common:
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54lc10dk/nrf54lc10a/cpuapp
     - nrf54lm20dk/nrf54lm20a/cpuapp
     - nrf54lm20dk/nrf54lm20b/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Fuel Gauge and One Button samples for nPM1300/nPM1304