### PR TITLE
ci: remove extra gate from docbuild

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -134,7 +134,6 @@ jobs:
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - name: Prepare legacy upload
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'external') || contains(github.event.pull_request.labels.*.name, 'CI-trusted-author') }}
         working-directory: ncs/nrf
         run: |
           MONITOR="monitor_${{ github.run_id }}.txt"
@@ -184,7 +183,6 @@ jobs:
           fi
 
       - name: Store
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'external') || contains(github.event.pull_request.labels.*.name, 'CI-trusted-author') }}
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: docs


### PR DESCRIPTION
We have a gate on repo level so that workflows from externals won't run so that is main gate. Having extra "label gates" here are not needed. 