### PR TITLE
scripts: sbom: Report the upstream CPE and purl of each module

### DIFF
--- a/scripts/west_commands/sbom/README.rst
+++ b/scripts/west_commands/sbom/README.rst
@@ -22,15 +22,15 @@ The process of using the ``ncs-sbom`` command involves the following steps:
 
 #. Create a list of input files based on provided command-line arguments,
    for example, all source files used for building a specific application.
-   For details, see :ref:`west_sbom Specifying input`.
+   For details, see :ref:`west_sbom_specifying_input`.
 
 #. Detect the license applied to each file,
    for example, read `SPDX identifier`_ from ``SPDX-License-Identifier`` tag.
-   For details, see :ref:`west_sbom Detectors`.
+   For details, see :ref:`west_sbom_detectors`.
 
 #. Create an output report containing all the files and license information related to them.
    Depending on the selected output format, the command can also group files into packages and include package metadata in the report, for example, write a report file in HTML format.
-   For details, see :ref:`west_sbom Specifying output`.
+   For details, see :ref:`west_sbom_specifying_output`.
 
 When the input is a build directory, the command starts from the linked target, walks the Ninja dependency graph to collect build inputs, validates the result against the :file:`.map` file, and checks archive contents with the GNU ar tool.
 
@@ -124,7 +124,7 @@ The input options and output options can be combined as needed.
 
      west ncs-sbom --input-files *file1* *file2* --output-spdx *file-name.spdx*
 
-.. _west_sbom Specifying input:
+.. _west_sbom_specifying_input:
 
 Specifying input
 ================
@@ -144,7 +144,7 @@ You can also mix them, for example, to generate a report for the application and
 
   You can skip this option if you are in the application directory and you have a default :file:`build` directory there - the same way as in ``west build`` command.
 
-  The :ref:`west_sbom Extracting from build` section describes in detail how to extract a list of files from a build directory.
+  The :ref:`west_sbom_extracting_from_build` section describes in detail how to extract a list of files from a build directory.
 
   You can use the ``-d`` option multiple times.
   For example, to include both the ``mcuboot`` child image and the main application, use the following command:
@@ -234,7 +234,7 @@ You can also mix them, for example, to generate a report for the application and
   Comments starting with a ``#`` character are allowed.
 
 
-.. _west_sbom Specifying output:
+.. _west_sbom_specifying_output:
 
 Specifying output
 =================
@@ -248,7 +248,7 @@ You can specify the format of the report output using the ``output`` argument.
 
      --output-html *file-name.html*
 
-  The :ref:`west_sbom HTML report overview` section provides more details about the report.
+  The :ref:`west_sbom_HTML_report_overview` section provides more details about the report.
 
   If you use the ``-d`` option, you do not need to specify any output argument.
   The :file:`sbom_report.html` file is generated in your build directory
@@ -267,7 +267,9 @@ You can specify the format of the report output using the ``output`` argument.
   * Component name, version, and ``PackageDownloadLocation`` (``git+<url>@<sha>`` for git-resolved packages; use ``--package-download-format github-archive`` to emit a GitHub archive zip URL instead)
   * ``PackageHomePage`` for browsable project links
   * Package URLs (PURLs) for unique package identification
-  * Common Platform Enumeration (CPE) identifiers when specified via ``--package-cpe``
+  * Upstream ``ExternalRef`` entries taken from each Zephyr module's :file:`zephyr/module.yml`
+    (see :ref:`upstream_external_references`)
+  * A Common Platform Enumeration (CPE) identifier for the application package when specified using ``--package-cpe``
   * Dependency relationships showing supply chain connections
   * File checksums and license information
   * ``PrimaryPackagePurpose`` (``APPLICATION``, ``SOURCE``, or ``OTHER``) auto-detected for each package
@@ -290,7 +292,7 @@ You can specify the format of the report output using the ``output`` argument.
 
   For details, see ``cache-database`` detector.
 
-.. _west_sbom Detectors:
+.. _west_sbom_detectors:
 
 Detectors
 =========
@@ -401,17 +403,53 @@ The following options enhance SBOM compliance with CRA, EO 14028, and FDA requir
 
   If not specified, the supplier is auto-detected from git repository owner/organization names.
 
-* ``--package-cpe`` - Set the Common Platform Enumeration (CPE) identifier:
+* ``--package-cpe`` - Set the Common Platform Enumeration (CPE) identifier of the application:
 
   .. code-block:: bash
 
      --package-cpe "cpe:2.3:a:nordicsemi:nrf_connect_sdk:2.0.0:*:*:*:*:*:*:*"
 
   CPE identifiers follow the CPE 2.3 specification and help identify software packages in vulnerability databases.
+  A CPE names one product so this option applies to the application package only.
+
+  The identifiers of the components you build on come from their Zephyr modules instead as described in :ref:`upstream_external_references`.
 
 These options ensure that generated SBOMs include all required fields for regulatory compliance.
 
-.. _west_sbom HTML report overview:
+.. _upstream_external_references:
+
+Upstream external references
+============================
+
+Most |NCS| components are redistributed rather than taken from the project that develops them.
+Some are Nordic forks under ``nrfconnect`` some are hosted under ``zephyrproject-rtos`` and a few come straight from their original project.
+A package is reported under the name and revision that was actually built, for example ``nrfconnect/sdk-mbedtls`` or ``zephyrproject-rtos/cmsis``.
+Vulnerability databases carry entries for the originating project.
+
+Zephyr modules declare the upstream project they are derived from in :file:`zephyr/module.yml`:
+
+.. code-block:: yaml
+
+   security:
+     external-references:
+       - cpe:2.3:a:arm:mbed_tls:3.6.3:*:*:*:*:*:*:*
+       - pkg:github/Mbed-TLS/mbedtls@v3.6.3
+
+When a repository declares that block the entries are emitted as additional ``ExternalRef`` records on its package next to the fork's own package URL::
+
+   PackageName: nrfconnect/sdk-mbedtls
+   PackageVersion: v3.6.3-ncs1
+   ExternalRef: PACKAGE-MANAGER purl pkg:github/nrfconnect/sdk-mbedtls@<commit>
+   ExternalRef: SECURITY cpe23Type cpe:2.3:a:arm:mbed_tls:3.6.3:*:*:*:*:*:*:*
+   ExternalRef: PACKAGE-MANAGER purl pkg:github/Mbed-TLS/mbedtls@v3.6.3
+
+The fork keeps describing what was built and the upstream references say which product the code came from.
+Only the module at the root of a repository is read and a reference that is neither a CPE 2.3 name nor a package URL is skipped with a warning.
+
+An upstream reference describes the product a fork is derived from.
+Where a fix has been backported the upstream version does not change so a scanner can still report an issue that is already fixed.
+
+.. _west_sbom_HTML_report_overview:
 
 HTML report overview
 ********************
@@ -456,12 +494,12 @@ The HTML report has following structure:
 
 * License texts added to this report.
 
-.. _west_sbom Extracting from build:
+.. _west_sbom_extracting_from_build:
 
 Extracting a list of files from a build directory
 *************************************************
 
-The ``ncs-sbom`` extracts a list of files from a build directory.
+The ``ncs-sbom`` command extracts a list of files from a build directory.
 It queries ninja for the targets and dependencies.
 
 The entry point is the :file:`zephyr/zephyr.elf` target file.
@@ -484,7 +522,7 @@ There are two additional methods for improving the correctness of the above algo
   If the list of files returned by the GNU ar tool is covered by the list returned from the ninja, the list is assumed to be valid.
   Otherwise, the library is assumed to be a leaf, so it is shown in the report and its inputs are not analyzed further.
 
-* The ``ncs-sbom`` parses the :file:`.map` file created during the :file:`zephyr/zephyr.elf` linking.
+* The ``ncs-sbom`` command parses the :file:`.map` file created during the :file:`zephyr/zephyr.elf` linking.
 
   It provides a list of all object files and libraries linked to the :file:`zephyr/zephyr.elf` file.
   The script ends with a fatal error if any file in the :file:`.map` file is not visible by ninja.

--- a/scripts/west_commands/sbom/data_structure.py
+++ b/scripts/west_commands/sbom/data_structure.py
@@ -85,6 +85,8 @@ class Package(DataBaseClass):
         supplier                Supplier name
         purl                    Package URL (PURL) identifier
         cpe                     Common Platform Enumeration (CPE) identifier
+        external_refs           Additional SPDX external references as
+                                (category, type, locator) tuples.
         dependencies            List of package IDs this package depends on
         primary_package_purpose Estimate of the most likely package usage; None to omit
         built_date              Actual date the package was built; None to omit
@@ -97,6 +99,7 @@ class Package(DataBaseClass):
     supplier: 'str|None' = None
     purl: 'str|None' = None
     cpe: 'str|None' = None
+    external_refs: 'list[tuple[str,str,str]]' = list()
     dependencies: 'list[str]' = list()
     primary_package_purpose: 'str|None' = None
     built_date: 'str|None' = None

--- a/scripts/west_commands/sbom/git_info_detector.py
+++ b/scripts/west_commands/sbom/git_info_detector.py
@@ -7,6 +7,7 @@ import sys
 import re
 from pathlib import Path
 
+import zephyr_module
 from args import args
 from common import SbomException, command_execute, concurrent_pool_iter
 from data_structure import Data, FileInfo, Package
@@ -14,11 +15,13 @@ from west import log
 
                                                     # FileInfo is used.
 
+
 _manifest_projects: 'dict[Path, object]' = {}
 _manifest_path_index: 'list[tuple[Path, object]]' = []
 _self_repo_path: 'Path|None' = None
 _self_repo_name: 'str|None' = None
 _self_repo_version: 'str|None' = None
+_module_refs_cache: 'dict[Path, list]' = {}
 
 
 def split_lines(text: str) -> 'tuple[str]':
@@ -161,6 +164,56 @@ def upstream_url(project) -> 'str|None':
     return url.strip() if isinstance(url, str) and url.strip() else None
 
 
+def classify_external_ref(locator: str) -> 'tuple[str,str,str]|None':
+    '''Return the SPDX (category, type, locator) triple for a supported locator.'''
+    locator = locator.strip()
+    if locator.startswith('cpe:2.3:'):
+        return ('SECURITY', 'cpe23Type', locator)
+    if locator.startswith('pkg:'):
+        return ('PACKAGE-MANAGER', 'purl', locator)
+    return None
+
+
+def read_module_external_refs(module_root: 'Path|None') -> 'list[tuple[str,str,str]]':
+    '''Returns the external references the Zephyr module declares.
+
+    Uses Zephyr's module metadata API to read "security: external-references:". A Nordic fork
+    keeps its own name and revision which no vulnerability database knows. That block names
+    the upstream project the fork is derived from which is the identity a scanner can match.
+
+    Only the module at the root of the repository is read.
+    '''
+    if module_root is None:
+        return []
+    if module_root in _module_refs_cache:
+        return _module_refs_cache[module_root]
+    module_file = module_root / Path(zephyr_module.MODULE_YML_PATH)
+    yaml_module_file = module_file.with_suffix('.yaml')
+    if not module_file.is_file() and yaml_module_file.is_file():
+        module_file = yaml_module_file
+    try:
+        meta = zephyr_module.process_module(module_root, require_yaml_validation=False)
+    except SystemExit as ex:
+        log.wrn(f'Cannot parse "{module_file}": {ex}')
+        meta = None
+    except Exception as ex:
+        log.wrn(f'Cannot parse "{module_file}": {ex}')
+        meta = None
+    security = meta.get('security') if isinstance(meta, dict) else None
+    locators = security.get('external-references') if isinstance(security, dict) else None
+    refs = []
+    for locator in locators or tuple():
+        if not isinstance(locator, str):
+            continue
+        ref = classify_external_ref(locator)
+        if ref is None:
+            log.wrn(f'Ignoring unknown external reference "{locator}" in "{module_file}".')
+        elif ref not in refs:
+            refs.append(ref)
+    _module_refs_cache[module_root] = refs
+    return refs
+
+
 def read_version(version_file: Path, include_dev: bool = False) -> 'str|None':
     '''Returns the NCS version from `version_file` when PATCHLEVEL != 99.
 
@@ -195,6 +248,7 @@ def load_manifest():
     _self_repo_path = None
     _self_repo_name = None
     _self_repo_version = None
+    _module_refs_cache.clear()
     try:
         from west.manifest import Manifest
         manifest = Manifest.from_topdir()
@@ -247,6 +301,7 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
     absolute_path = Path(files_to_assign[0].file_path).parent
     relative_path = Path(files_to_assign[0].file_rel_path).parent
     repo = get_toplevel(absolute_path)
+    module_root = repo
     if repo is None:
         log.wrn(f'Directory "{relative_path}" is not a git repository. '
                 'Files will be included without git-info detector information.')
@@ -268,6 +323,7 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
         match = match_manifest_project(absolute_path)
         if match is not None:
             project_root, mproject = match
+            module_root = module_root or project_root
             git_origin = getattr(mproject, 'url', None) or None
             git_sha = git_sha or getattr(mproject, 'revision', None)
             if git_origin is None:
@@ -311,8 +367,7 @@ def detect_dir(func_args: 'tuple[list[FileInfo],Data]') -> None:
             package.supplier = args.package_supplier or extract_supplier_from_url(git_origin)
         if project is not None:
             package.browser_url = upstream_url(project)
-        if args.package_cpe:
-            package.cpe = args.package_cpe
+        package.external_refs = read_module_external_refs(module_root)
         data.packages[package_id] = package
     for file in files_to_assign:
         file.package = package_id

--- a/scripts/west_commands/sbom/ncs_sbom_command.py
+++ b/scripts/west_commands/sbom/ncs_sbom_command.py
@@ -7,9 +7,11 @@ The "ncs-sbom" extension command.
 '''
 
 import argparse
+import os
+import sys
+from pathlib import Path
 
 import args
-import main
 from west.commands import WestCommand
 
 
@@ -28,5 +30,13 @@ class NcsSbom(WestCommand):
         return parser
 
     def do_run(self, arguments, unknown_arguments):
+        zephyr_scripts = str(Path(os.environ['ZEPHYR_BASE']) / 'scripts')
+        if zephyr_scripts not in sys.path:
+            sys.path.insert(0, zephyr_scripts)
+
+        # zephyr_module is available only after Zephyr's scripts directory is on sys.path.
+        # Delay importing the SBOM pipeline until zephyr_scripts is available.
+        import main
+
         args.copy_arguments(arguments)
         main.main()

--- a/scripts/west_commands/sbom/output_pre_process.py
+++ b/scripts/west_commands/sbom/output_pre_process.py
@@ -7,6 +7,7 @@
 Pre-processing of data before it goes to the output.
 '''
 
+from args import args
 from data_structure import Data, License, LicenseExpr, Package
 from license_utils import get_license, get_spdx_license_expr_info, is_spdx_license
 
@@ -222,6 +223,10 @@ def assign_primary_package_purpose(data: Data, files_by_package: dict,
                 package.built_date = built_date
             if package.name is None and app_name:
                 package.name = app_name
+            # The CPE names one product so it can only describe the application itself.
+            # Every other package is a dependency with an identity of its own.
+            if getattr(args, 'package_cpe', None):
+                package.cpe = args.package_cpe
         elif package.purl:
             package.primary_package_purpose = 'SOURCE'
 

--- a/scripts/west_commands/sbom/templates/raport.spdx.jinja
+++ b/scripts/west_commands/sbom/templates/raport.spdx.jinja
@@ -53,6 +53,9 @@ ExternalRef: PACKAGE-MANAGER purl {{package.purl}}
 {% if package.cpe -%}
 ExternalRef: SECURITY cpe23Type {{package.cpe}}
 {% endif -%}
+{% for category, ref_type, locator in package.external_refs -%}
+ExternalRef: {{category}} {{ref_type}} {{locator}}
+{% endfor -%}
 {% if package.primary_package_purpose -%}
 PrimaryPackagePurpose: {{package.primary_package_purpose}}
 {% endif -%}


### PR DESCRIPTION
A package is reported in SBOM under the repository it was built from. For example nrfconnect/sdk-mbedtls at a commit. Vulnerability databases know the project that develops the code not the one that redistributes it so a scanner finds nothing to match.

Zephyr modules name that project in zephyr/module.yml under security: external-references. Emit every entry as an SPDX ExternalRef next to the existing purl so the report says both what was built and where the code came from. Only the module at the root of a repository is read since tests and samples carry modules of their own.

--package-cpe set the CPE to the application only.