### PR TITLE
manifest: update hal_nordic nrfs gswdt changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -247,7 +247,7 @@ manifest:
     - name: hal_nordic
       repo-path: sdk-hal_nordic
       path: modules/hal/nordic
-      revision: 18da0cc9726f8759c627dba3180b3ba9294e433c
+      revision: 5fc6670d72d5004020fd6948ee3af9dc2572ab9f
 
     # Other third-party repositories.
     - name: cmock


### PR DESCRIPTION
Add changes in nrfs gswdt service so by default response is not sent, this is needed when gswdt is used when entering low power mode to avoid unnecessary wakeups. This implementation also maintains backward compatibility.