### PR TITLE
Split clock alignment for MPSL

### DIFF
--- a/drivers/mpsl/clock_control/CMakeLists.txt
+++ b/drivers/mpsl/clock_control/CMakeLists.txt
@@ -7,5 +7,9 @@
 zephyr_library()
 zephyr_library_sources(nrfx_clock_mpsl.c)
 
+if(CONFIG_CLOCK_CONTROL_NRF_COMMON)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/clock_control)
+endif()
+
 target_include_directories(zephyr_interface BEFORE INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR})

--- a/drivers/mpsl/clock_control/nrfx_clock_mpsl.c
+++ b/drivers/mpsl/clock_control/nrfx_clock_mpsl.c
@@ -5,13 +5,41 @@
  */
 #include <nrfx_clock.h>
 
+#if !defined(CONFIG_CLOCK_CONTROL_NRF)
+#include <nrfx_clock_lfclk.h>
+#if NRF_CLOCK_HAS_HFCLK
+#include <nrfx_clock_hfclk.h>
+#endif
+#if NRF_CLOCK_HAS_XO
+#include <nrfx_clock_xo.h>
+#endif
+#if NRF_CLOCK_HAS_HFCLK24M
+#include <nrfx_clock_xo24m.h>
+#endif
+
+#include "clock_control_nrf_common.h"
+#endif /* !defined(CONFIG_CLOCK_CONTROL_NRF) */
+
 #include <mpsl.h>
 #include <mpsl_clock.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(nrfx_clock_mpsl, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 
-static nrfx_clock_event_handler_t event_handler;
+#if defined(CONFIG_CLOCK_CONTROL_NRF)
+static nrfx_clock_event_handler_t m_event_handler;
+#else
+static nrfx_clock_lfclk_event_handler_t m_lfclk_event_handler;
+#if NRF_CLOCK_HAS_HFCLK
+static nrfx_clock_hfclk_event_handler_t m_hfclk_event_handler;
+#endif
+#if NRF_CLOCK_HAS_XO
+static nrfx_clock_xo_event_handler_t m_xo_event_handler;
+#endif
+#if NRF_CLOCK_HAS_HFCLK24M
+static nrfx_clock_xo24m_event_handler_t m_xo24m_event_handler;
+#endif
+#endif /* CONFIG_CLOCK_CONTROL_NRF */
 
 static void mpsl_hfclk_src_callback(mpsl_clock_evt_type_t evt_type)
 {
@@ -21,95 +49,284 @@ static void mpsl_hfclk_src_callback(mpsl_clock_evt_type_t evt_type)
 	 * NRFX_CLOCK_EVT_XO_TUNE_FAILED events. There is no need to report them.
 	 */
 	case MPSL_CLOCK_EVT_XO_TUNED:
-		event_handler(NRFX_CLOCK_EVT_XO_TUNED);
+#if defined(CONFIG_CLOCK_CONTROL_NRF)
+		m_event_handler(NRFX_CLOCK_EVT_XO_TUNED);
+#else
+		if (m_xo_event_handler != NULL) {
+			m_xo_event_handler(NRFX_CLOCK_XO_EVT_XO_TUNED);
+		}
+#endif /* CONFIG_CLOCK_CONTROL_NRF */
 		break;
 #endif /* NRF_CLOCK_HAS_XO_TUNE */
 	case MPSL_CLOCK_EVT_HFCLK_STARTED:
-		event_handler(NRFX_CLOCK_EVT_HFCLK_STARTED);
+#if defined(CONFIG_CLOCK_CONTROL_NRF)
+		m_event_handler(NRFX_CLOCK_EVT_HFCLK_STARTED);
+#else
+#if NRF_CLOCK_HAS_XO
+		if (m_xo_event_handler != NULL) {
+			m_xo_event_handler(NRFX_CLOCK_XO_EVT_HFCLK_STARTED);
+		}
+#elif NRF_CLOCK_HAS_HFCLK
+		if (m_hfclk_event_handler != NULL) {
+			m_hfclk_event_handler();
+		}
+#endif /* NRF_CLOCK_HAS_XO */
+#endif /* CONFIG_CLOCK_CONTROL_NRF */
 		break;
 #if NRF_CLOCK_HAS_HFCLK24M
 	case MPSL_CLOCK_EVT_HFCLK24M_STARTED:
-		event_handler(NRFX_CLOCK_EVT_HFCLK24M_STARTED);
+#if defined(CONFIG_CLOCK_CONTROL_NRF)
+		m_event_handler(NRFX_CLOCK_EVT_HFCLK24M_STARTED);
+#else
+		if (m_xo24m_event_handler != NULL) {
+			m_xo24m_event_handler();
+		}
+#endif /* CONFIG_CLOCK_CONTROL_NRF */
 		break;
 #endif /* NRF_CLOCK_HAS_HFCLK24M */
 	default:
 		/* We do not send notification about any other clock event to higher level driver */
 		LOG_WRN("Unsupported HFCLK event: %d", evt_type);
+		break;
 	}
 }
 
+/*
+ * LFCLK initialization flow:
+ * 1. Zephyr lfclk driver init (PRE_KERNEL): nrfx_clock_lfclk_init() stores the event
+ *    handler; onoff manager is created with LF off. No HW access.
+ * 2. mpsl_init(): MPSL starts LFCLK in HW (clock_ctrl_init), optionally waits for
+ *    LFSTAT, and handles LFCLKSTARTED in MPSL_IRQ_CLOCK_Handler().
+ * 3. Later Zephyr LF request (onoff / z_nrf_clock_control_lf_on): lfclk_start() calls
+ *    nrfx_clock_lfclk_start() below.
+ *
+ * Short turnaround: nrfx_clock_lfclk_start() does not start HW, wait for an IRQ, or
+ * poll LFSTAT. LF is started by mpsl_init() (step 2). We only synchronously deliver
+ * LFCLK_STARTED so the Zephyr onoff manager can leave STARTING (common_clkstarted_handle).
+ *
+ * Do not block here waiting for LF: this path can run from another driver's init
+ * before mpsl_init(), while LF HW is still off. Blocking would stall that init (and
+ * can deadlock if mpsl_init depends on it). HW readiness is established by mpsl_init
+ * and, when needed, by lfclk_spinwait() in the caller (e.g. z_nrf_clock_control_lf_on).
+ * Ensure mpsl_init runs before LF consumers (MPSL uses PRE_KERNEL_1 for CLOCK_CONTROL_MPSL)
+ * or use CONFIG_SYSTEM_CLOCK_NO_WAIT to skip lfclk_spinwait().
+ *
+ * No Zephyr calibration handling: CLOCK_CONTROL_NRF_FORCE_ALT disables the Zephyr
+ * driver calibration module. LFCLKSTARTED and CAL_DONE from HW are consumed in
+ * MPSL_IRQ_CLOCK_Handler() (clock_ctrl_lfclk_calibration_init and ongoing RC cal).
+ * They are not forwarded to the lfclk event handler; nrfx_clock_lfclk_irq_handler()
+ * is intentionally empty.
+ */
 void nrfx_clock_lfclk_start(void)
 {
-	nrfx_clock_start(NRF_CLOCK_DOMAIN_LFCLK);
+#if defined(CONFIG_CLOCK_CONTROL_NRF)
+	m_event_handler(NRFX_CLOCK_EVT_LFCLK_STARTED);
+#else
+	if (m_lfclk_event_handler != NULL) {
+		m_lfclk_event_handler(NRFX_CLOCK_LFCLK_EVT_LFCLK_STARTED);
+	}
+#endif /* CONFIG_CLOCK_CONTROL_NRF */
 }
 
 void nrfx_clock_lfclk_stop(void)
 {
-	nrfx_clock_stop(NRF_CLOCK_DOMAIN_LFCLK);
+	/* HW stop is owned by MPSL; Zephyr onoff stop does not stop LFCLK. */
 }
 
+#if NRF_CLOCK_HAS_HFCLK
 void nrfx_clock_hfclk_start(void)
 {
-	nrfx_clock_start(NRF_CLOCK_DOMAIN_HFCLK);
+	int err = mpsl_clock_hfclk_src_request(MPSL_CLOCK_HF_SRC_XO, mpsl_hfclk_src_callback);
+
+	if (err < 0) {
+		__ASSERT(0, "Failed to request MPSL_CLOCK_HF_SRC_XO source: %d", err);
+	}
 }
 
 void nrfx_clock_hfclk_stop(void)
 {
-	nrfx_clock_stop(NRF_CLOCK_DOMAIN_HFCLK);
+	int err = mpsl_clock_hfclk_src_release(MPSL_CLOCK_HF_SRC_XO);
+
+	if (err < 0) {
+		__ASSERT(0, "Failed to release MPSL_CLOCK_HF_SRC_XO source: %d", err);
+	}
 }
+#endif /* NRF_CLOCK_HAS_HFCLK */
+
+#if NRF_CLOCK_HAS_XO
+void nrfx_clock_xo_start(void)
+{
+	int err = mpsl_clock_hfclk_src_request(MPSL_CLOCK_HF_SRC_XO, mpsl_hfclk_src_callback);
+
+	if (err < 0) {
+		__ASSERT(0, "Failed to request MPSL_CLOCK_HF_SRC_XO source: %d", err);
+	}
+}
+
+void nrfx_clock_xo_stop(void)
+{
+	int err = mpsl_clock_hfclk_src_release(MPSL_CLOCK_HF_SRC_XO);
+
+	if (err < 0) {
+		__ASSERT(0, "Failed to release MPSL_CLOCK_HF_SRC_XO source: %d", err);
+	}
+}
+#endif /* NRF_CLOCK_HAS_XO */
+
+#if NRF_CLOCK_HAS_HFCLK24M
+void nrfx_clock_xo24m_start(void)
+{
+	int err = mpsl_clock_hfclk_src_request(MPSL_CLOCK_HF_SRC_HFCLK24M, mpsl_hfclk_src_callback);
+
+	if (err < 0) {
+		__ASSERT(0, "Failed to request MPSL_CLOCK_HF_SRC_HFCLK24M source: %d", err);
+	}
+}
+
+void nrfx_clock_xo24m_stop(void)
+{
+	int err = mpsl_clock_hfclk_src_release(MPSL_CLOCK_HF_SRC_HFCLK24M);
+
+	if (err < 0) {
+		__ASSERT(0, "Failed to release MPSL_CLOCK_HF_SRC_HFCLK24M source: %d", err);
+	}
+}
+#endif /* NRF_CLOCK_HAS_HFCLK24M */
 
 void nrfx_clock_start(nrf_clock_domain_t domain)
 {
 	switch (domain) {
+#if NRF_CLOCK_HAS_LFCLK
+	case NRF_CLOCK_DOMAIN_LFCLK:
+		nrfx_clock_lfclk_start();
+		return;
+#endif /* NRF_CLOCK_HAS_LFCLK */
 	case NRF_CLOCK_DOMAIN_HFCLK:
-		mpsl_clock_hfclk_src_request(MPSL_CLOCK_HF_SRC_XO, mpsl_hfclk_src_callback);
-		break;
+#if NRF_CLOCK_HAS_XO
+		nrfx_clock_xo_start();
+#elif NRF_CLOCK_HAS_HFCLK
+		nrfx_clock_hfclk_start();
+#endif /* NRF_CLOCK_HAS_XO */
+		return;
 #if NRF_CLOCK_HAS_HFCLK24M
 	case NRF_CLOCK_DOMAIN_HFCLK24M:
-		mpsl_clock_hfclk_src_request(MPSL_CLOCK_HF_SRC_HFCLK24M, mpsl_hfclk_src_callback);
-		break;
+		nrfx_clock_xo24m_start();
+		return;
 #endif /* NRF_CLOCK_HAS_HFCLK24M */
-	case NRF_CLOCK_DOMAIN_LFCLK:
-		event_handler(NRFX_CLOCK_EVT_LFCLK_STARTED);
-		break;
 	default:
 		__ASSERT(0, "Not supported");
+		return;
 	}
 }
 
 void nrfx_clock_stop(nrf_clock_domain_t domain)
 {
 	switch (domain) {
+#if NRF_CLOCK_HAS_LFCLK
+	case NRF_CLOCK_DOMAIN_LFCLK:
+		nrfx_clock_lfclk_stop();
+		return;
+#endif /* NRF_CLOCK_HAS_LFCLK */
 	case NRF_CLOCK_DOMAIN_HFCLK:
-		mpsl_clock_hfclk_src_release(MPSL_CLOCK_HF_SRC_XO);
-		break;
+#if NRF_CLOCK_HAS_XO
+		nrfx_clock_xo_stop();
+#elif NRF_CLOCK_HAS_HFCLK
+		nrfx_clock_hfclk_stop();
+#endif /* NRF_CLOCK_HAS_XO */
+		return;
 #if NRF_CLOCK_HAS_HFCLK24M
 	case NRF_CLOCK_DOMAIN_HFCLK24M:
-		mpsl_clock_hfclk_src_release(MPSL_CLOCK_HF_SRC_HFCLK24M);
-		break;
+		nrfx_clock_xo24m_stop();
+		return;
 #endif /* NRF_CLOCK_HAS_HFCLK24M */
-	case NRF_CLOCK_DOMAIN_LFCLK:
-		/* empty */
-		break;
 	default:
 		__ASSERT(0, "Not supported");
+		return;
 	}
 }
 
 void nrfx_clock_enable(void)
 {
-
 }
 
+#if defined(CONFIG_CLOCK_CONTROL_NRF)
 int nrfx_clock_init(nrfx_clock_event_handler_t handler)
 {
-	event_handler = handler;
+	m_event_handler = handler;
 
 	return 0;
 }
+#endif /* CONFIG_CLOCK_CONTROL_NRF */
 
-
+/*
+ * Name and global linkage are required by nrfx_power.c: nrfx_power_clock_irq_handler()
+ * invokes this by the monolithic clock control driver (CONFIG_CLOCK_CONTROL_NRF).
+ *
+ * In the split clock control driver, there is no direct call site; the handler is invoked once
+ * per CLOCK IRQ via CLOCK_CONTROL_NRF_IRQ_HANDLERS_ITERABLE below.
+ */
 void nrfx_clock_irq_handler(void)
 {
 	MPSL_IRQ_CLOCK_Handler();
 }
+
+#if !defined(CONFIG_CLOCK_CONTROL_NRF)
+CLOCK_CONTROL_NRF_IRQ_HANDLERS_ITERABLE(clock_control_nrfx_mpsl, &nrfx_clock_irq_handler);
+
+int nrfx_clock_lfclk_init(nrfx_clock_lfclk_event_handler_t lfclk_event_handler)
+{
+	m_lfclk_event_handler = lfclk_event_handler;
+
+	return 0;
+}
+
+#if NRF_CLOCK_HAS_HFCLK
+int nrfx_clock_hfclk_init(nrfx_clock_hfclk_event_handler_t hfclk_event_handler)
+{
+	m_hfclk_event_handler = hfclk_event_handler;
+
+	return 0;
+}
+#endif /* NRF_CLOCK_HAS_HFCLK */
+
+#if NRF_CLOCK_HAS_XO
+int nrfx_clock_xo_init(nrfx_clock_xo_event_handler_t xo_event_handler)
+{
+	m_xo_event_handler = xo_event_handler;
+
+	return 0;
+}
+#endif /* NRF_CLOCK_HAS_XO */
+
+#if NRF_CLOCK_HAS_HFCLK24M
+int nrfx_clock_xo24m_init(nrfx_clock_xo24m_event_handler_t xo24m_event_handler)
+{
+	m_xo24m_event_handler = xo24m_event_handler;
+
+	return 0;
+}
+#endif /* NRF_CLOCK_HAS_HFCLK24M */
+
+void nrfx_clock_lfclk_irq_handler(void)
+{
+}
+
+#if NRF_CLOCK_HAS_HFCLK
+void nrfx_clock_hfclk_irq_handler(void)
+{
+}
+#endif /* NRF_CLOCK_HAS_HFCLK */
+
+#if NRF_CLOCK_HAS_XO
+void nrfx_clock_xo_irq_handler(void)
+{
+}
+#endif /* NRF_CLOCK_HAS_XO */
+
+#if NRF_CLOCK_HAS_HFCLK24M
+void nrfx_clock_xo24m_irq_handler(void)
+{
+}
+#endif /* NRF_CLOCK_HAS_HFCLK24M */
+
+#endif /* !defined(CONFIG_CLOCK_CONTROL_NRF) */

--- a/subsys/mpsl/clock_ctrl/mpsl_clock_ctrl.c
+++ b/subsys/mpsl/clock_ctrl/mpsl_clock_ctrl.c
@@ -9,9 +9,11 @@
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #include <zephyr/logging/log.h>
 
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
+#if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF) || (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_COMMON))) && \
+	!(IS_ENABLED(CONFIG_SOC_SERIES_NRF54H) || IS_ENABLED(CONFIG_SOC_SERIES_NRF92))
+
 #include <nrfx_clock.h>
-#endif /* CONFIG_CLOCK_CONTROL_NRF */
+#endif /* CONFIG_CLOCK_CONTROL_NRF || CONFIG_CLOCK_CONTROL_NRF_COMMON */
 
 #include <mpsl_clock.h>
 #include "mpsl_clock_ctrl.h"
@@ -179,7 +181,8 @@ static int32_t m_lfclk_wait(void)
 	return err;
 }
 
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
+#if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF) || IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_COMMON)) && \
+	 !(IS_ENABLED(CONFIG_SOC_SERIES_NRF54H) || IS_ENABLED(CONFIG_SOC_SERIES_NRF92))
 
 static void m_hfclk_request(void)
 {
@@ -513,7 +516,7 @@ int32_t mpsl_clock_ctrl_nvm_clock_wait(void)
 
 #else
 #error "Unsupported clock control"
-#endif /* CONFIG_CLOCK_CONTROL_NRF */
+#endif /* CONFIG_CLOCK_CONTROL_NRF || CONFIG_CLOCK_CONTROL_NRF_COMMON */
 
 static mpsl_clock_lfclk_ctrl_source_t m_nrf_lfclk_ctrl_data = {
 	.lfclk_wait = m_lfclk_wait,
@@ -574,15 +577,18 @@ int32_t mpsl_clock_ctrl_init(void)
 	}
 #endif /* CONFIG_MPSL_EXT_CLK_CTRL_NVM_CLOCK_REQUEST */
 
-#if !(defined(CONFIG_CLOCK_CONTROL_NRF_COMMON) || defined(CONFIG_CLOCK_CONTROL_NRF))
-#error "Unsupported HFCLK statup time get operation"
-#elif !defined(CONFIG_SOC_SERIES_NRF54H)
+#if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF) || IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_COMMON)) && \
+	 !(IS_ENABLED(CONFIG_SOC_SERIES_NRF54H) || IS_ENABLED(CONFIG_SOC_SERIES_NRF92))
+
 #if DT_NODE_EXISTS(DT_NODELABEL(hfxo))
 	m_nrf_hfclk_ctrl_data.startup_time_us = z_nrf_clock_bt_ctlr_hf_get_startup_time_us();
 #else
 	m_nrf_hfclk_ctrl_data.startup_time_us = CONFIG_MPSL_HFCLK_LATENCY;
 #endif /* DT_NODE_EXISTS(DT_NODELABEL(hfxo)) */
-#else
+
+#elif IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_COMMON) &&                                               \
+	(IS_ENABLED(CONFIG_SOC_SERIES_NRF54H) || IS_ENABLED(CONFIG_SOC_SERIES_NRF92))
+
 #if DT_NODE_HAS_STATUS(HFCLK_LABEL, okay) && DT_NODE_HAS_COMPAT(HFCLK_LABEL, nordic_nrf54h_hfxo)
 	uint32_t startup_time_us;
 
@@ -597,20 +603,23 @@ int32_t mpsl_clock_ctrl_init(void)
 		LOG_ERR("HFCLK startup time is too large: %d [us]", startup_time_us);
 		return -NRF_EFAULT;
 	}
-#if defined(CONFIG_SOC_SERIES_NRF54H) && defined(CONFIG_MPSL_USE_ZEPHYR_PM)
+#if defined(CONFIG_MPSL_USE_ZEPHYR_PM)
 	else if (startup_time_us < MPSL_PM_HFCLK_MINIMUM_ALLOWED_STARTUP_TIME_US) {
 		/* Override the startup time to the minimum allowed value. */
 		startup_time_us = MPSL_PM_HFCLK_MINIMUM_ALLOWED_STARTUP_TIME_US;
 	}
-#endif /* CONFIG_SOC_SERIES_NRF54H && CONFIG_MPSL_USE_ZEPHYR_PM */
+#endif /* CONFIG_MPSL_USE_ZEPHYR_PM */
 
 	m_nrf_hfclk_ctrl_data.startup_time_us = startup_time_us;
 #else
-#error "Unsupported HFCLK statup time get operation"
+#error "A HFXO DTS instance not found"
 #endif /* DT_NODE_HAS_STATUS(HFCLK_LABEL, okay) && \
 	* DT_NODE_HAS_COMPAT(HFCLK_LABEL, nordic_nrf54h_hfxo) \
 	*/
-#endif /* CONFIG_CLOCK_CONTROL_NRF */
+
+#else
+#error "Unsupported clock control configuration"
+#endif /* CONFIG_CLOCK_CONTROL_NRF || CONFIG_CLOCK_CONTROL_NRF_COMMON */
 
 #if defined(CONFIG_CLOCK_CONTROL_NRF_COMMON) &&                                                    \
 	(defined(CONFIG_SOC_SERIES_NRF54H) || defined(CONFIG_SOC_SERIES_NRF92))

--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -55,6 +55,10 @@
 #include "../clock_ctrl/mpsl_clock_ctrl.h"
 #endif /* CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL */
 
+#if !defined(CONFIG_CLOCK_CONTROL_NRF)
+#define CLOCK_NODE_LFCLK DT_COMPAT_GET_ANY_STATUS_OKAY(nordic_nrf_clock_lfclk)
+#endif /* !defined(CONFIG_CLOCK_CONTROL_NRF) */
+
 LOG_MODULE_REGISTER(mpsl_init, CONFIG_MPSL_LOG_LEVEL);
 
 #if defined(CONFIG_MPSL_CALIBRATION_PERIOD)
@@ -364,6 +368,7 @@ static void m_assert_handler(const char *const file, const uint32_t line)
 #endif /* IS_ENABLED(CONFIG_MPSL_ASSERT_HANDLER) */
 
 #if !defined(CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL)
+#if defined(CONFIG_CLOCK_CONTROL_NRF)
 static uint8_t m_config_clock_source_get(void)
 {
 #ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC
@@ -381,6 +386,25 @@ static uint8_t m_config_clock_source_get(void)
 	return 0;
 #endif
 }
+#else
+static uint8_t m_config_clock_source_get(void)
+{
+#if DT_ENUM_HAS_VALUE(CLOCK_NODE_LFCLK, k32src, rc)
+	return MPSL_CLOCK_LF_SRC_RC;
+#elif DT_ENUM_HAS_VALUE(CLOCK_NODE_LFCLK, k32src, xtal)
+	return MPSL_CLOCK_LF_SRC_XTAL;
+#elif DT_ENUM_HAS_VALUE(CLOCK_NODE_LFCLK, k32src, synth)
+	return MPSL_CLOCK_LF_SRC_SYNTH;
+#elif DT_ENUM_HAS_VALUE(CLOCK_NODE_LFCLK, k32src, ext_low_swing)
+	return MPSL_CLOCK_LF_SRC_EXT_LOW_SWING;
+#elif DT_ENUM_HAS_VALUE(CLOCK_NODE_LFCLK, k32src, ext_full_swing)
+	return MPSL_CLOCK_LF_SRC_EXT_FULL_SWING;
+#else
+	#error "Clock source is not supported or not defined"
+	return 0;
+#endif
+}
+#endif /* CONFIG_CLOCK_CONTROL_NRF */
 #endif /* !CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL */
 
 #if defined(CONFIG_MPSL_CALIBRATION_PERIOD)
@@ -419,7 +443,11 @@ static int32_t mpsl_lib_init_internal(void)
 	/* TODO: Clock config should be adapted in the future to new architecture. */
 #if !defined(CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL)
 	clock_cfg.source = m_config_clock_source_get();
+#if defined(CONFIG_CLOCK_CONTROL_NRF)
 	clock_cfg.accuracy_ppm = CONFIG_CLOCK_CONTROL_NRF_ACCURACY;
+#else
+	clock_cfg.accuracy_ppm = DT_PROP(CLOCK_NODE_LFCLK, k32src_accuracy_ppm);
+#endif /* CONFIG_CLOCK_CONTROL_NRF */
 	clock_cfg.skip_wait_lfclk_started =
 		IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT);
 

--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -451,21 +451,28 @@ static int32_t mpsl_lib_init_internal(void)
 	clock_cfg.skip_wait_lfclk_started =
 		IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT);
 
-#ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC
+#if defined(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC) || \
+	(!defined(CONFIG_CLOCK_CONTROL_NRF) && DT_ENUM_HAS_VALUE(CLOCK_NODE_LFCLK, k32src, rc))
+#if defined(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC)
 	BUILD_ASSERT(IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION),
 		    "MPSL requires clock calibration to be enabled when RC is used as LFCLK");
+#endif
 
 	/* clock_cfg.rc_ctiv is given in 1/4 seconds units.
 	 * CONFIG_MPSL_CALIBRATION_PERIOD is given in ms.
 	 */
 	clock_cfg.rc_ctiv = (CONFIG_MPSL_CALIBRATION_PERIOD * 4 / 1000);
+#if IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION)
 	clock_cfg.rc_temp_ctiv = CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP + 1;
 	BUILD_ASSERT(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_TEMP_DIFF == 2,
 		     "MPSL always uses a temperature diff threshold of 0.5 degrees");
 #else
+	clock_cfg.rc_temp_ctiv = MPSL_RECOMMENDED_RC_TEMP_CTIV;
+#endif
+#else
 	clock_cfg.rc_ctiv = 0;
 	clock_cfg.rc_temp_ctiv = 0;
-#endif /* CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC */
+#endif /* RC LFCLK source */
 #endif /* !CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL */
 
 #if defined(CONFIG_MPSL_USE_EXTERNAL_CLOCK_CONTROL)

--- a/west.yml
+++ b/west.yml
@@ -150,7 +150,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 87e4e027db1dcd56c57ace0be60d827697c3a40b
+      revision: 89151be8391ddc34d7cfb14dab8863ba4e47def0
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
@@ -169,7 +169,7 @@ manifest:
       # Only for internal Nordic development
       repo-path: dragoon.git
       remote: dragoon
-      revision: 60c85274f0688b88a9bd206e9853d20c82b5a242
+      revision: 26586a1e40f0282a25d50274bfa64d3b043794ae
       groups:
         - dragoon
     - name: cjson


### PR DESCRIPTION
The MPSL currently forces the legacy clock architecture when it is enabled.
This PR changes the MPSL to use the new split clock instead.