### PR TITLE
sysbuild: Fix mcuboot build warnings on nRF54LS05A

### DIFF
--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -443,7 +443,9 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
 
         # MCUboot uses hash function to identify key internally when KMU is disabled.
         # Don't use Cracen hash driver on nrf54ls05 as this SoC uses Cracen only for TRNG.
-        if((SB_CONFIG_MCUBOOT_SIGNATURE_USING_KMU AND SB_CONFIG_BOOT_SIGNATURE_TYPE_PURE) OR SB_CONFIG_SOC_NRF54LS05B)
+        if((SB_CONFIG_MCUBOOT_SIGNATURE_USING_KMU AND SB_CONFIG_BOOT_SIGNATURE_TYPE_PURE)
+           OR SB_CONFIG_SOC_NRF54LS05A
+           OR SB_CONFIG_SOC_NRF54LS05B)
           set_config_bool(mcuboot CONFIG_PSA_USE_CRACEN_HASH_DRIVER n)
         else()
           set_config_bool(mcuboot CONFIG_PSA_USE_CRACEN_HASH_DRIVER y)


### PR DESCRIPTION
Change fixes CONFIG_PSA_USE_CRACEN_HASH_DRIVER build warning for mcuboot image.