### PR TITLE
samples: wifi: nrf_cloud: Remove unused button functionality

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -598,6 +598,7 @@ Wi-Fi samples
   * Removed:
 
     * Networking shell support from nRF7002 DK and nRF54LM20 DK.
+    * Unused button functionality that only printed a log message.
 
 * Removed support from the following Zephyr samples:
 

--- a/samples/wifi/nrf_cloud/prj.conf
+++ b/samples/wifi/nrf_cloud/prj.conf
@@ -14,7 +14,6 @@ CONFIG_EVENTS=y
 CONFIG_PICOLIBC_IO_FLOAT=y
 CONFIG_RESET_ON_FATAL_ERROR=y
 CONFIG_NCS_SAMPLES_DEFAULTS=y
-CONFIG_DK_LIBRARY=y
 
 # Improved Logging
 # CONFIG_LOG_MODE_DEFERRED allows logging from multiple threads simultaneously without creating

--- a/samples/wifi/nrf_cloud/src/application.c
+++ b/samples/wifi/nrf_cloud/src/application.c
@@ -18,7 +18,6 @@
 #include <modem/location.h>
 #include "location_tracking.h"
 #endif
-#include <dk_buttons_and_leds.h>
 #include "application.h"
 #include "temperature.h"
 #include "cloud_connection.h"
@@ -141,17 +140,6 @@ static void test_counter_send(void)
 	}
 }
 
-#if defined(CONFIG_DK_LIBRARY)
-static void button_handler(uint32_t button_state, uint32_t has_changed)
-{
-	if (has_changed & DK_BTN1_MSK) {
-		if ((button_state & DK_BTN1_MSK) == DK_BTN1_MSK) {
-			LOG_INF("Button pressed");
-		}
-	}
-}
-#endif
-
 static void print_reset_reason(void)
 {
 	uint32_t reset_reason;
@@ -164,10 +152,6 @@ static void print_reset_reason(void)
 void main_application_thread_fn(void)
 {
 	print_reset_reason();
-
-#if defined(CONFIG_DK_LIBRARY)
-	dk_buttons_init(button_handler);
-#endif
 
 	/* Wait for first connection before starting the application. */
 	(void)await_cloud_ready(K_FOREVER);


### PR DESCRIPTION
Removes button functionality as the only functionality was printing a log message, no nRF Cloud posting.

This will also get the sample back on track now given now that we have this bug: https://nordicsemi.atlassian.net/browse/NCSIDB-1951

Ticket: https://nordicsemi.atlassian.net/browse/NCSDK-40959