### PR TITLE
tests: dummy change to validate CI-wifi-7120dk downstream trigger

### DIFF
--- a/drivers/wifi/nrf71/Kconfig
+++ b/drivers/wifi/nrf71/Kconfig
@@ -3,6 +3,8 @@
 # Copyright (c) 2024 Nordic Semiconductor
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# Dummy touch for CI-wifi-7120dk downstream validation. Remove after test.
 #
 
 menuconfig WIFI_NRF71


### PR DESCRIPTION
Touch an nRF71 WiFi path covered by CI-wifi-7120dk test-spec so the 7120 DK downstream pipeline can be verified on a test PR. Revert after CI validation.