### PR TITLE
doc: upgrade sphinx version

### DIFF
--- a/doc/_extensions/ncs_include/ncs_include.py
+++ b/doc/_extensions/ncs_include/ncs_include.py
@@ -12,7 +12,6 @@ import os.path
 
 from docutils import io, statemachine
 from docutils.parsers.rst import directives
-from docutils.utils.error_reporting import ErrorString, SafeString
 from sphinx.util.docutils import SphinxDirective
 
 
@@ -76,10 +75,12 @@ class NcsInclude(SphinxDirective):
                                         error_handler=e_handler)
         except UnicodeEncodeError:
             raise self.severe(f'Problems with "{self.name}" directive path:\n'
-                              f'Cannot encode input file path "{SafeString(path)}" '
+                              f'Cannot encode input file path "{str(path)}" '
                               '(wrong locale?).')
         except OSError as error:
-            raise self.severe(f'Problems with "{self.name}" directive path:\n{ErrorString(error)}.')
+            raise self.severe(
+                    f'Problems with "{self.name}" directive path:\n{io.error_string(error)}.'
+                )
 
         # Get to-be-included content
         startline = self.options.get('start-line', None)
@@ -91,7 +92,7 @@ class NcsInclude(SphinxDirective):
             else:
                 rawtext = include_file.read()
         except UnicodeError as error:
-            raise self.severe(f'Problem with "{self.name}" directive:\n{ErrorString(error)}')
+            raise self.severe(f'Problem with "{self.name}" directive:\n{io.error_string(error)}')
         # start-after/end-before: no restrictions on newlines in match-text,
         # and no restrictions on matching inside lines vs. line boundaries
         start_at_text = self.options.get('start-at', None)

--- a/doc/_extensions/table_from_rows.py
+++ b/doc/_extensions/table_from_rows.py
@@ -10,7 +10,6 @@ from itertools import chain
 import yaml
 from docutils import io, statemachine
 from docutils.parsers.rst import directives
-from docutils.utils.error_reporting import ErrorString
 from sphinx.util.docutils import SphinxDirective
 
 __version__ = '0.0.2'
@@ -97,7 +96,9 @@ class TableFromRows(SphinxDirective):
             self.state.document.settings.record_dependencies.add(source_path)
             include_file = io.FileInput(source_path=source_path)
         except OSError as error:
-            raise self.severe(f'Problems with "{self.name}" directive path:\n{ErrorString(error)}.')
+            raise self.severe(
+                    f'Problems with "{self.name}" directive path:\n{io.error_string(error)}.'
+                )
         lines = include_file.readlines()
         header_lines = self._load_section(lines, header_section)
         rows = [self._load_section(lines, section) for section in rows_sections]

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -196,7 +196,7 @@
    Also, different platforms have different methods of connecting, pairing, and streaming.
    For these reasons, providing a general guide on how to test with external devices is challenging.
    The suggested approach is to test with Nordic Semiconductor devices on both sides first to verify basic functionalities and get familiar with the solution before using custom devices.
-   Contact `Technical Support team <DevZone_>`_ if you need assistance.
+   Contact `Technical Support team <DevZone_>`__ if you need assistance.
 
 .. |usb_known_issues| replace:: Make sure to check the :ref:`nRF Audio application known issue OCT-2154 <known_issues_nrf_audio>` related to intermittent audio stream on the headset when using USB audio interface on macOS.
 
@@ -243,7 +243,7 @@
 .. |ATv2_maintenance_note| replace:: The Asset Tracker v2 application is in maintenance mode.
    For new projects, it is recommended to use one of the cellular nRF Cloud samples instead: :ref:`nrf_cloud_mqtt_device_message`, :ref:`nrf_cloud_mqtt_cell_location`, :ref:`nrf_cloud_mqtt_fota`, :ref:`nrf_cloud_coap_device_message`, :ref:`nrf_cloud_coap_cell_location`, or :ref:`nrf_cloud_coap_fota_sample`.
 
-.. |filter_samples_by_board| replace:: If you want to list samples available for one or more specific boards, `use the nRF Connect for Visual Studio Code extension to filter them <Browse samples_>`_.
+.. |filter_samples_by_board| replace:: If you want to list samples available for one or more specific boards, `use the nRF Connect for Visual Studio Code extension to filter them <Browse samples_>`__.
 
 .. |devicetree_bindings| replace:: The devicetree bindings provide the structure for the content of the devicetree nodes.
    The :ref:`compatible <zephyr:dt-bindings-compatible>` property defines the compatibility of a devicetree node with a devicetree binding.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -10,14 +10,14 @@ anytree                         # |     |         |         |         |      |  
 azure-storage-blob              # |  X  |         |         |         |      |        |
 beautifulsoup4                  # |     |         |         |         |      |        |
 doxmlparser                     # |     |         |         |         |      |    X   |
-myst-parser>=4,<5               # |     |         |         |         |  X   |        |
+myst-parser>=5,<6               # |     |         |         |         |  X   |        |
 natsort                         # |     |         |         |         |      |    x   |
 PyYAML                          # |  X  |         |         |         |      |    X   |
 pykwalify                       # |     |         |         |         |      |    X   |
 pytest                          # |     |         |         |         |      |    X   |
 recommonmark                    # |     |         |   X     |    X    |      |        |
 snowballstemmer<3.0.0           # https://github.com/snowballstem/snowball/issues/229
-sphinx>=8.1,<8.2                # |  X  |    X    |   X     |    X    |   X   |   X   |
+sphinx>=9.1,<9.2                # |  X  |    X    |   X     |    X    |   X   |   X   |
 sphinx-autobuild                # |  X  |    X    |   X     |    X    |   X   |   X   |
 sphinx-copybutton               # |  X  |         |         |         |       |   X   |
 sphinx-ncs-theme<2.1            # |  X  |         |         |         |       |       |

--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -30,7 +30,7 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 os.environ["ZEPHYR_BASE"] = str(ZEPHYR_BASE)
 os.environ["OUTPUT_DIR"] = str(utils.get_builddir() / "html" / "zephyr")
 
-conf = eval_config_file(str(ZEPHYR_BASE / "doc" / "conf.py"), tags)
+conf = eval_config_file(ZEPHYR_BASE / "doc" / "conf.py", tags)
 locals().update(conf)
 
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))


### PR DESCRIPTION
Update sphinx version used for docbuild. Fixes relevant issues regarding:
- changes in how docutils handle references in substitution
- removal/replacement of deprecated python api usage