### PR TITLE
net: nrf_provisioning: Add configurable heap allocator

### DIFF
--- a/doc/nrf/libraries/networking/nrf_provisioning.rst
+++ b/doc/nrf/libraries/networking/nrf_provisioning.rst
@@ -42,6 +42,9 @@ To enable the library, set the :kconfig:option:`CONFIG_NRF_CLOUD` and :kconfig:o
 * :kconfig:option:`CONFIG_NRF_PROVISIONING_STACK_SIZE` - Stack size for the nRF Provisioning thread.
 * :kconfig:option:`CONFIG_NRF_PROVISIONING_SHELL` - Enables shell module, which allows you to control the client over UART.
 * :kconfig:option:`CONFIG_NRF_PROVISIONING_SETTINGS_STORAGE_PATH` - Sets the path for provisioning settings storage.
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_HEAP_KERNEL` - Uses the Zephyr kernel heap (:c:func:`k_malloc` and :c:func:`k_free`) for the library's dynamic allocations.
+  This is the default allocator.
+* :kconfig:option:`CONFIG_NRF_PROVISIONING_HEAP_SYSTEM` - Uses the system heap (:c:func:`malloc` and :c:func:`free`) for the library's dynamic allocations.
 
 Configuration options for HTTP
 ==============================

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -754,6 +754,10 @@ Libraries for networking
 
 * Added :ref:`TLS Credentials Subsystem <zephyr:sockets_tls_credentials_subsys>` support for TLS credential expiry retrieval when using the modem as TLS credentials storage.
 
+* :ref:`lib_nrf_provisioning` library:
+
+  * Added a configurable heap allocator for the library's dynamic allocations, selected with the :kconfig:option:`CONFIG_NRF_PROVISIONING_HEAP_KERNEL` (default) and :kconfig:option:`CONFIG_NRF_PROVISIONING_HEAP_SYSTEM` Kconfig options.
+
 Libraries for NFC
 -----------------
 

--- a/subsys/net/lib/nrf_provisioning/Kconfig
+++ b/subsys/net/lib/nrf_provisioning/Kconfig
@@ -117,6 +117,21 @@ config NRF_PROVISIONING_INITIAL_BACKOFF
 	  after each failed (busy or timeout) attempt to connect to the server.
 	  The maximum time is 86400 seconds (24 hours).
 
+choice NRF_PROVISIONING_HEAP
+	prompt "Memory allocator"
+	default NRF_PROVISIONING_HEAP_KERNEL
+	help
+	  Select the heap allocator used for dynamic allocations inside the
+	  nRF Provisioning library.
+
+config NRF_PROVISIONING_HEAP_KERNEL
+	bool "Zephyr kernel heap (k_malloc/k_free)"
+
+config NRF_PROVISIONING_HEAP_SYSTEM
+	bool "System heap (malloc/free)"
+
+endchoice
+
 rsource "Kconfig.nrf_provisioning_http"
 
 rsource "Kconfig.nrf_provisioning_coap"

--- a/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_mem.h
+++ b/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_mem.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef NRF_PROVISIONING_MEM_H__
+#define NRF_PROVISIONING_MEM_H__
+
+#if defined(CONFIG_NRF_PROVISIONING_HEAP_SYSTEM)
+#include <stdlib.h>
+#define nrf_provisioning_malloc malloc
+#define nrf_provisioning_free   free
+#else
+#include <zephyr/kernel.h>
+#define nrf_provisioning_malloc k_malloc
+#define nrf_provisioning_free   k_free
+#endif
+
+#endif /* NRF_PROVISIONING_MEM_H__ */

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_coap.c
@@ -26,6 +26,7 @@
 #include "nrf_provisioning_codec.h"
 #include "nrf_provisioning_coap.h"
 #include "nrf_provisioning_jwt.h"
+#include "nrf_provisioning_mem.h"
 
 LOG_MODULE_REGISTER(nrf_provisioning_coap, CONFIG_NRF_PROVISIONING_LOG_LEVEL);
 
@@ -396,7 +397,7 @@ static int generate_auth_token(char **auth_token)
 		return -EINVAL;
 	}
 
-	*auth_token = k_malloc(tok_len);
+	*auth_token = nrf_provisioning_malloc(tok_len);
 	if (!*auth_token) {
 		return -ENOMEM;
 	}
@@ -414,7 +415,7 @@ static int generate_auth_token(char **auth_token)
 	return 0;
 
 fail:
-	k_free(*auth_token);
+	nrf_provisioning_free(*auth_token);
 	*auth_token = NULL;
 
 	return ret;
@@ -710,7 +711,7 @@ retry_response:
 	nrf_provisioning_codec_teardown();
 
 	if (auth_token) {
-		k_free(auth_token);
+		nrf_provisioning_free(auth_token);
 	}
 
 	socket_close(&coap_ctx->connect_socket);

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_codec.c
@@ -15,6 +15,7 @@
 
 #include "nrf_provisioning_at.h"
 #include "nrf_provisioning_codec.h"
+#include "nrf_provisioning_mem.h"
 #include <nrf_provisioning_cbor_decode.h>
 #include <nrf_provisioning_cbor_encode.h>
 #include "nrf_provisioning_cbor_decode_types.h"
@@ -96,7 +97,7 @@ int nrf_provisioning_codec_setup(struct cdc_context *const cdc_ctx,
 int nrf_provisioning_codec_teardown(void)
 {
 	for (int i = 0; i < CONFIG_NRF_PROVISIONING_CBOR_RECORDS; i++) {
-		k_free(o_fmt_data.msgs[i]);
+		nrf_provisioning_free(o_fmt_data.msgs[i]);
 		o_fmt_data.msgs[i] = NULL;
 	}
 
@@ -296,7 +297,7 @@ static int exec_at_cmd(struct command *cmd_req, struct cdc_out_fmt_data *out)
 	resp_sz = check_at_cmd(out->at_buff, &clear_tag, &sec_tag, &type);
 
 	while (true) {
-		resp = k_malloc(resp_sz);
+		resp = nrf_provisioning_malloc(resp_sz);
 		if (!resp) {
 			LOG_ERR("Unable to write response msg field");
 			LOG_ERR("Not enough memory for AT response, size %d", resp_sz);
@@ -309,7 +310,7 @@ static int exec_at_cmd(struct command *cmd_req, struct cdc_out_fmt_data *out)
 
 		if (ret == -E2BIG) {
 			LOG_DBG("Buffer too small for AT response, retrying");
-			k_free(resp);
+			nrf_provisioning_free(resp);
 			resp = NULL;
 
 			if (clear_tag) {
@@ -381,13 +382,13 @@ static int write_config(struct command *cmd_req, struct cdc_out_fmt_data *out)
 		max_key_sz = MAX(max_key_sz, pair->config_properties_tstrtstr_key.len + 1);
 	}
 
-	key = k_malloc(max_key_sz);
+	key = nrf_provisioning_malloc(max_key_sz);
 	if (!key) {
 		ret = -ENOMEM;
 		goto exit;
 	}
 
-	resp = k_malloc(resp_sz);
+	resp = nrf_provisioning_malloc(resp_sz);
 	if (!resp) {
 		ret = -ENOMEM;
 		goto exit;
@@ -420,12 +421,12 @@ static int write_config(struct command *cmd_req, struct cdc_out_fmt_data *out)
 	}
 
 	/* No error to report */
-	k_free(resp);
+	nrf_provisioning_free(resp);
 	resp = NULL;
 
 exit:
 	if (key) {
-		k_free(key);
+		nrf_provisioning_free(key);
 	}
 
 	/* Keeps track of response messages to be freed once the whole responses request is send */

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
@@ -38,6 +38,7 @@
 #include "nrf_provisioning_cbor_encode_types.h"
 #include "nrf_provisioning_http.h"
 #include "nrf_provisioning_jwt.h"
+#include "nrf_provisioning_mem.h"
 
 LOG_MODULE_REGISTER(nrf_provisioning_http, CONFIG_NRF_PROVISIONING_LOG_LEVEL);
 
@@ -169,7 +170,7 @@ static int generate_auth_header(char **auth_hdr_out)
 	prefix_len = max_auth_prefix_len();
 
 	hdr_size = prefix_len + tok_len + postfix_len + 1;
-	*auth_hdr_out = k_malloc(hdr_size);
+	*auth_hdr_out = nrf_provisioning_malloc(hdr_size);
 	if (!*auth_hdr_out) {
 		return -ENOMEM;
 	}
@@ -197,7 +198,7 @@ static int generate_auth_header(char **auth_hdr_out)
 	return 0;
 
 fail:
-	k_free(*auth_hdr_out);
+	nrf_provisioning_free(*auth_hdr_out);
 	*auth_hdr_out = NULL;
 
 	return ret;
@@ -237,7 +238,7 @@ static int gen_result_url(struct rest_client_req_context *const req)
 	int ret;
 
 	buff_sz = sizeof(API_POST_RSLT);
-	url = k_malloc(buff_sz);
+	url = nrf_provisioning_malloc(buff_sz);
 	if (!url) {
 		ret = -ENOMEM;
 		return ret;
@@ -279,7 +280,7 @@ static int gen_provisioning_url(struct rest_client_req_context *const req)
 	buff_sz = sizeof(API_CMDS_TEMPLATE) +
 		strlen(after) + strlen(rx_buf_sz) + strlen(tx_buf_sz) +
 		strlen(mver) + strlen(cver) + strlen(limit);
-	url = k_malloc(buff_sz);
+	url = nrf_provisioning_malloc(buff_sz);
 	if (!url) {
 		ret = -ENOMEM;
 		return ret;
@@ -382,11 +383,11 @@ static int nrf_provisioning_responses_req(struct nrf_provisioning_http_context *
 
 clean_up:
 	if (req->url) {
-		k_free((char *)req->url);
+		nrf_provisioning_free((char *)req->url);
 		req->url = NULL;
 	}
 	if (auth_hdr) {
-		k_free(auth_hdr);
+		nrf_provisioning_free(auth_hdr);
 	}
 
 	return ret;
@@ -442,9 +443,9 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 
 		LOG_INF("Requesting commands");
 		ret = rest_client_request(&req, &resp);
-		k_free(auth_hdr);
+		nrf_provisioning_free(auth_hdr);
 		auth_hdr = NULL;
-		k_free((char *)req.url);
+		nrf_provisioning_free((char *)req.url);
 		req.url = NULL;
 
 		if (ret < 0) {
@@ -510,10 +511,10 @@ int nrf_provisioning_http_req(struct nrf_provisioning_http_context *const rest_c
 	nrf_provisioning_codec_teardown();
 
 	if (req.url) {
-		k_free((char *)req.url);
+		nrf_provisioning_free((char *)req.url);
 	}
 	if (auth_hdr) {
-		k_free(auth_hdr);
+		nrf_provisioning_free(auth_hdr);
 	}
 
 	return ret;


### PR DESCRIPTION
Introduce a Kconfig choice NRF_PROVISIONING_HEAP that selects between the Zephyr kernel heap (k_malloc/k_free, default) and the system C heap (malloc/free). A thin internal header nrf_provisioning_mem.h resolves the choice to nrf_provisioning_malloc/nrf_provisioning_free macros used throughout the library (coap, codec, http).

No functional change when building with the default configuration.