### PR TITLE
doc: nrf: add link to SPI RTIO sample

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -2140,6 +2140,7 @@
 .. _`Zephyr's sensor driver API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers/sensor.h
 .. _`Zephyr's nRF clock control API extensions`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/drivers/clock_control/nrf_clock_control.h
 .. _`Zephyr's SPI driver twister test`: https://github.com/nrfconnect/sdk-zephyr/tree/main/tests/drivers/spi/spi_loopback
+.. _`Zephyr's SPI RTIO loopback sample`: https://github.com/nrfconnect/sdk-zephyr/tree/main/samples/drivers/spi/rtio_loopback
 .. _`Zephyr's pressure sensor sample`: https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/sensor/pressure_interrupt
 .. _`clocks devicetree macro API`: https://github.com/nrfconnect/sdk-zephyr/blob/main/include/zephyr/devicetree/clocks.h
 

--- a/doc/nrf/peripherals_drivers/spim.rst
+++ b/doc/nrf/peripherals_drivers/spim.rst
@@ -55,16 +55,12 @@ The following samples and tests use the SPIM peripheral and can serve as a usage
    :header-rows: 1
 
    * - Application
-     - Link
      - Comment
-   * - Zephyr ``spi`` driver twister loopback test
-     - `Zephyr's SPI driver twister test`_
+   * - `Zephyr's SPI driver twister test`_
      - Test utilizing `Zephyr's SPI driver API`_ to send data between MOSI and MISO pins connected using a jumper wire
-   * - Zephyr ``spi_rtio`` loopback sample
-     - `Zephyr's SPI RTIO loopback sample`_
+   * - `Zephyr's SPI RTIO loopback sample`_
      - Sample utilizing the RTIO-based SPI API to perform transfers between two SPI controllers, one acting as controller and the other as peripheral
-   * - Zephyr ``sensor`` driver sample for pressure sensor
-     - `Zephyr's pressure sensor sample`_
+   * - `Zephyr's pressure sensor sample`_
      - Sample utilizing `Zephyr's sensor driver API`_ to communicate with external pressure sensor over SPI bus.
 
 Usage guides

--- a/doc/nrf/peripherals_drivers/spim.rst
+++ b/doc/nrf/peripherals_drivers/spim.rst
@@ -60,6 +60,9 @@ The following samples and tests use the SPIM peripheral and can serve as a usage
    * - Zephyr ``spi`` driver twister loopback test
      - `Zephyr's SPI driver twister test`_
      - Test utilizing `Zephyr's SPI driver API`_ to send data between MOSI and MISO pins connected using a jumper wire
+   * - Zephyr ``spi_rtio`` loopback sample
+     - `Zephyr's SPI RTIO loopback sample`_
+     - Sample utilizing the RTIO-based SPI API to perform transfers between two SPI controllers, one acting as controller and the other as peripheral
    * - Zephyr ``sensor`` driver sample for pressure sensor
      - `Zephyr's pressure sensor sample`_
      - Sample utilizing `Zephyr's sensor driver API`_ to communicate with external pressure sensor over SPI bus.


### PR DESCRIPTION
Improve the SPIM-related doc page with reference to sample showcasing SPI RTIO usage.