### PR TITLE
tests: drivers: uart: added test pin state samples configurable

### DIFF
--- a/tests/drivers/uart/uart_baudrate_test/Kconfig
+++ b/tests/drivers/uart/uart_baudrate_test/Kconfig
@@ -6,6 +6,16 @@
 
 source "Kconfig.zephyr"
 
+config TEST_PIN_STATE_SAMPLES
+	int "Number of GPIO samples captured per transmitted symbol"
+	default 32768
+	range 1024 262144
+	help
+	  Size of the buffer holding the sampled state of the loopback pin. The buffer
+	  must be large enough to hold one full UART symbol, otherwise the low baudrate
+	  tests are skipped. The needed size depends on how fast the CPU can sample the
+	  GPIO port, so it scales with the CPU frequency and inversely with the baudrate.
+
 config TEST_ALLOWED_DEVIATION
 	int "Allowed deviation (%) for UART timing checks"
 	default 5

--- a/tests/drivers/uart/uart_baudrate_test/src/main.c
+++ b/tests/drivers/uart/uart_baudrate_test/src/main.c
@@ -23,7 +23,7 @@ static const struct device *const uart_dev = DEVICE_DT_GET(DT_NODELABEL(dut));
 
 static const uint8_t tx_buf[] = {0x00, 0x00, 0x00, 0x00};
 
-#define PIN_STATE_SIZE 32768
+#define PIN_STATE_SIZE CONFIG_TEST_PIN_STATE_SAMPLES
 static uint8_t pin_state[PIN_STATE_SIZE] = {};
 
 #define REPEAT_NUMBER 3
@@ -167,6 +167,17 @@ static void check_timing(uint32_t baudrate)
 			}
 		}
 		TC_PRINT("Start index: %d, stop index: %d\n", start_index, stop_index);
+
+		if ((start_index == -1) || (stop_index == -1)) {
+			TC_PRINT("[%d] Sampling window of %.2f us is too short "
+				 "to capture a full symbol.\n",
+				 baudrate, PIN_STATE_SIZE * gpio_read_time_us_mean);
+			TC_PRINT("Increase CONFIG_TEST_PIN_STATE_SAMPLES to at least %d.\n",
+				 PIN_STATE_SIZE * 2);
+			ztest_test_fail();
+			return;
+		}
+
 		double measured_period_us = (stop_index - start_index) * gpio_read_time_us_mean;
 		double measured_bit_us = measured_period_us / (double)number_of_bits;
 


### PR DESCRIPTION
For some SOCs there is need to configure number of GPIO samples to be captured. 

For example if SOC if fast enought baud rate test for 4800 baud will fail with neagtive mesurement.
This situation now will be reported.