### PR TITLE
tests: b0_lock_rw: Enable more platforms

### DIFF
--- a/tests/subsys/bootloader/b0_lock_rwx/testcase.yaml
+++ b/tests/subsys/bootloader/b0_lock_rwx/testcase.yaml
@@ -9,9 +9,11 @@ tests:
   b0.w:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
   b0.rwx:
     extra_args:


### PR DESCRIPTION
Enable the b0_lock_rwx on other platforms:
 - nrf54lc10dk/nrf54lc10a/cpuapp

Ref: NCSDK-40493