### PR TITLE
samples: net: wifi: Change TF-M Profile Type to Configurable

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -478,27 +478,29 @@ Networking samples
 * Updated the TF-M configuration in nRF7002 DK networking samples by removing :kconfig:option:`CONFIG_TFM_PROFILE_TYPE_SMALL` (as it is not supported by the |NCS|).
   Instead, use the configurable profile (:kconfig:option:`CONFIG_TFM_PROFILE_TYPE_NOT_SET`), select the SFN backend (:kconfig:option:`CONFIG_TFM_SFN`) to save RAM and select memory-mapped iovecs (:kconfig:option:`CONFIG_TFM_PSA_FRAMEWORK_HAS_MM_IOVEC`) to reduce copying of client vectors during TLS handshakes.
 
-* Removed support for the ``nrf5340dk/nrf5340/cpuapp/ns`` board target from the following samples:
+* Removed:
 
-  * :ref:`mqtt_sample`
-  * :ref:`udp_sample`
-  * :ref:`net_coap_client_sample`
-  * :ref:`https_client`
-  * :ref:`http_server`
-  * :ref:`download_sample`
+  * Support for the ``nrf5340dk/nrf5340/cpuapp/ns`` board target from the following samples:
 
-* Removed support for the ``nrf54l15dk/nrf54l15/cpuapp`` board target from the following samples:
+    * :ref:`mqtt_sample`
+    * :ref:`udp_sample`
+    * :ref:`net_coap_client_sample`
+    * :ref:`https_client`
+    * :ref:`http_server`
+    * :ref:`download_sample`
 
-  * :ref:`mqtt_sample`
-  * :ref:`net_coap_client_sample`
-  * :ref:`http_server`
-  * :ref:`download_sample`
-  * :ref:`aws_iot`
+  * Support for the ``nrf54l15dk/nrf54l15/cpuapp`` board target from the following samples:
 
-* Removed the ``nrf54l15dk/nrf54l15/cpuapp`` with nRF7002 EB shield from the following samples, keeping only the nRF7002-EB II shield for the ``nrf54l15dk/nrf54l15/cpuapp`` board target:
+    * :ref:`mqtt_sample`
+    * :ref:`net_coap_client_sample`
+    * :ref:`http_server`
+    * :ref:`download_sample`
+    * :ref:`aws_iot`
 
-  * :ref:`https_client`
-  * :ref:`udp_sample`
+  * The ``nrf54l15dk/nrf54l15/cpuapp`` with nRF7002 EB shield from the following samples, keeping only the nRF7002-EB II shield for the ``nrf54l15dk/nrf54l15/cpuapp`` board target:
+
+    * :ref:`https_client`
+    * :ref:`udp_sample`
 
 * :ref:`download_sample` sample:
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -475,6 +475,9 @@ Matter samples
 Networking samples
 ------------------
 
+* Updated the TF-M configuration in nRF7002 DK networking samples by removing :kconfig:option:`CONFIG_TFM_PROFILE_TYPE_SMALL` (as it is not supported by the |NCS|).
+  Instead, use the configurable profile (:kconfig:option:`CONFIG_TFM_PROFILE_TYPE_NOT_SET`), select the SFN backend (:kconfig:option:`CONFIG_TFM_SFN`) to save RAM and select memory-mapped iovecs (:kconfig:option:`CONFIG_TFM_PSA_FRAMEWORK_HAS_MM_IOVEC`) to reduce copying of client vectors during TLS handshakes.
+
 * Removed support for the ``nrf5340dk/nrf5340/cpuapp/ns`` board target from the following samples:
 
   * :ref:`mqtt_sample`

--- a/samples/net/aws_iot/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
+++ b/samples/net/aws_iot/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
@@ -40,8 +40,12 @@ CONFIG_DFU_TARGET=y
 CONFIG_DOWNLOADER=y
 CONFIG_DOWNLOADER_STACK_SIZE=4096
 
-# Optimize TF-M
-CONFIG_TFM_PROFILE_TYPE_SMALL=y
+# TF-M: configurable profile + SFN backend (isolation level 1) to reduce RAM usage
+CONFIG_TFM_SFN=y
+# MM-IOVEC maps TLS buffers directly instead of copying through the crypto
+# partition's small internal scratch buffer, which is too small for the TLS
+# handshake
+CONFIG_TFM_PSA_FRAMEWORK_HAS_MM_IOVEC=y
 
 # Enable LTO to save flash memory
 CONFIG_LTO=y

--- a/samples/net/azure_iot_hub/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
+++ b/samples/net/azure_iot_hub/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
@@ -7,5 +7,9 @@
 # FOTA config is in wifi-fota.conf; this board can give MCUboot all available RAM.
 CONFIG_MCUBOOT_USE_ALL_AVAILABLE_RAM=y
 
-# Optimize TF-M
-CONFIG_TFM_PROFILE_TYPE_SMALL=y
+# TF-M: configurable profile + SFN backend (isolation level 1) to reduce RAM usage
+CONFIG_TFM_SFN=y
+# MM-IOVEC maps TLS buffers directly instead of copying through the crypto
+# partition's small internal scratch buffer, which is too small for the TLS
+# handshake
+CONFIG_TFM_PSA_FRAMEWORK_HAS_MM_IOVEC=y

--- a/samples/net/coap_client/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
+++ b/samples/net/coap_client/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
@@ -4,5 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Optimize TF-M
-CONFIG_TFM_PROFILE_TYPE_SMALL=y
+# TF-M: configurable profile + SFN backend (isolation level 1) to reduce RAM usage
+CONFIG_TFM_SFN=y
+# MM-IOVEC maps TLS buffers directly instead of copying through the crypto
+# partition's small internal scratch buffer, which is too small for the TLS
+# handshake
+CONFIG_TFM_PSA_FRAMEWORK_HAS_MM_IOVEC=y

--- a/samples/net/download/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
+++ b/samples/net/download/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
@@ -4,5 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Optimize TF-M
-CONFIG_TFM_PROFILE_TYPE_SMALL=y
+# TF-M: configurable profile + SFN backend (isolation level 1) to reduce RAM usage
+CONFIG_TFM_SFN=y
+# MM-IOVEC maps TLS buffers directly instead of copying through the crypto
+# partition's small internal scratch buffer, which is too small for the TLS
+# handshake
+CONFIG_TFM_PSA_FRAMEWORK_HAS_MM_IOVEC=y

--- a/samples/net/http_server/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
+++ b/samples/net/http_server/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
@@ -4,5 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Optimize TF-M
-CONFIG_TFM_PROFILE_TYPE_SMALL=y
+# TF-M: configurable profile + SFN backend (isolation level 1) to reduce RAM usage
+CONFIG_TFM_SFN=y
+# MM-IOVEC maps TLS buffers directly instead of copying through the crypto
+# partition's small internal scratch buffer, which is too small for the TLS
+# handshake
+CONFIG_TFM_PSA_FRAMEWORK_HAS_MM_IOVEC=y

--- a/samples/net/https_client/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
+++ b/samples/net/https_client/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
@@ -4,5 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Optimize TF-M
-CONFIG_TFM_PROFILE_TYPE_SMALL=y
+# TF-M: configurable profile + SFN backend (isolation level 1) to reduce RAM usage
+CONFIG_TFM_SFN=y
+# MM-IOVEC maps TLS buffers directly instead of copying through the crypto
+# partition's small internal scratch buffer, which is too small for the TLS
+# handshake
+CONFIG_TFM_PSA_FRAMEWORK_HAS_MM_IOVEC=y

--- a/samples/net/mqtt/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
+++ b/samples/net/mqtt/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
@@ -4,5 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Optimize TF-M
-CONFIG_TFM_PROFILE_TYPE_SMALL=y
+# TF-M: configurable profile + SFN backend (isolation level 1) to reduce RAM usage
+CONFIG_TFM_SFN=y
+# MM-IOVEC maps TLS buffers directly instead of copying through the crypto
+# partition's small internal scratch buffer, which is too small for the TLS
+# handshake
+CONFIG_TFM_PSA_FRAMEWORK_HAS_MM_IOVEC=y

--- a/samples/net/udp/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
+++ b/samples/net/udp/boards/nrf7002dk_nrf5340_cpuapp_ns.conf
@@ -1,8 +1,0 @@
-#
-# Copyright (c) 2023 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-# Optimize TF-M
-CONFIG_TFM_PROFILE_TYPE_SMALL=y


### PR DESCRIPTION
TF-M Profile Type Small is not supported by nRF5340.
Switching to Configurable (CONFIG_TFM_PROFILE_TYPE_NOT_SET).

Selecting SFN backend explicitly as IPC backend doesn't fit in RAM.
No functional downgrade as SFN backend is used in Small Profile Type.
There is no requirement to support PSA isolation level 2 enabled by IPC
backend in these samples.

The MM-IOVEC is enabled to voids TLS handshakes overflowing the crypto
partition's small IPC scratch buffer (5120 bytes).

Jira: NCSDK-38693