### PR TITLE
mcuboot: Kconfig: CC310 image encryption fix PSA

### DIFF
--- a/doc/nrf/releases_and_maturity/known_issues.rst
+++ b/doc/nrf/releases_and_maturity/known_issues.rst
@@ -4978,10 +4978,10 @@ NCSDK-33207: MCUboot has its NVM protection disabled
 
   **Workaround:** Enable protection manually using the :kconfig:option:`CONFIG_FPROTECT` and  :kconfig:option:`CONFIG_FPROTECT_ALLOW_COMBINED_REGIONS` Kconfig options of MCUboot.
 
-.. rst-class:: wontfix v3-4-0 v3-3-4 v3-3-3 v3-3-2 v3-3-1 v3-3-0 v3-2-5 v3-2-4 v3-2-3 v3-2-2 v3-2-1 v3-2-0 v3-1-1 v3-1-0 v3-0-2 v3-0-1 v3-0-0
+.. rst-class:: v3-4-0 v3-3-4 v3-3-3 v3-3-2 v3-3-1 v3-3-0 v3-2-5 v3-2-4 v3-2-3 v3-2-2 v3-2-1 v3-2-0 v3-1-1 v3-1-0 v3-0-2 v3-0-1 v3-0-0
 
 NCSDK-29460: Encryption: Build error for default configuration on the ``nrf52840dk/nrf52840`` board target (ECDSA_P256)
-  This happens because of inconsistency in the configuration of the signature check and the encryption key extraction: both must use the same base encryption algorithm.
+  ECDSA P-256 signature verification, in MCUboot, defaults to cc310 crypto backend driver that lacks support for key exchange, key derivation and AES, required by firmware image encryption.
 
   **Affected platforms:** nRF52840
 

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -58,6 +58,9 @@ Bootloaders and DFU
 
 * Added the :ref:`ug_bootloader_nrf54l_memory_protection` documentation page to explaining the memory protection features of the bootloader on the nRF54L Series.
 
+* Fixed  MCUboot build failure with image encryption when the ECDSA P-256 signature was enabled on devices based on SoCs with the CryptoCell 310 peripheral, such as nRF52840 and nRF9160 SoCs.
+  These configurations will now use PSA Crypto instead of the cc310 backend that supports signature verification only.
+
 Developing with nRF91 Series
 ============================
 

--- a/modules/mcuboot/boot/zephyr/Kconfig
+++ b/modules/mcuboot/boot/zephyr/Kconfig
@@ -150,8 +150,16 @@ choice BOOT_SIGNATURE_TYPE
 
 endchoice
 
+# cc310 (nrf_cc310_bl) backend driver provides ECDSA verification only, so image
+# encryption, which additionally needs ECDH, HKDF/HMAC and AES, has to be
+# provided with use of PSA crypto.
+configdefault PSA_CRYPTO
+	default y if BOOT_SIGNATURE_TYPE_ECDSA_P256 && BOOT_ENCRYPT_IMAGE && \
+		HAS_HW_NRF_CC310 && !SECURE_BOOT
+
 choice BOOT_ECDSA_IMPLEMENTATION
 	default BOOT_NRF_EXTERNAL_CRYPTO if SECURE_BOOT
+	default BOOT_ECDSA_PSA if PSA_CRYPTO
 	default BOOT_ECDSA_CC310 if HAS_HW_NRF_CC310
 
 config BOOT_NRF_EXTERNAL_CRYPTO

--- a/samples/dfu/smp_svr/sample.yaml
+++ b/samples/dfu/smp_svr/sample.yaml
@@ -98,6 +98,7 @@ tests:
 
   sample.dfu.smp_svr.encryption.ecdsa_p256:
     platform_allow:
+      - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
@@ -273,6 +274,7 @@ tests:
 
   sample.dfu.smp_svr.nrf_compress.encryption_ecdsa_p256:
     platform_allow:
+      - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
fix ambiguous encryption crypto backend when CC310 is present