### PR TITLE
tests: boot_chains: Enable nRF54L SoCs

### DIFF
--- a/tests/subsys/bootloader/boot_chains/testcase.yaml
+++ b/tests/subsys/bootloader/boot_chains/testcase.yaml
@@ -5,6 +5,10 @@ common:
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54lm20dk/nrf54lm20a/cpuapp
+    - nrf54lm20dk/nrf54lm20b/cpuapp
+    - nrf54lv10dk/nrf54lv10a/cpuapp
+    - nrf54lc10dk/nrf54lc10a/cpuapp
   tags:
     - ci_tests_subsys_bootloader
   harness: console
@@ -26,10 +30,6 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9161dk/nrf9161/ns
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
-      - nrf54lv10dk/nrf54lv10a/cpuapp
-      - nrf54lc10dk/nrf54lc10a/cpuapp
   boot_chains.secure_boot_and_bootloader_mcuboot:
     extra_args:
       - FILE_SUFFIX=b0_mcuboot


### PR DESCRIPTION
Enable boot_chains tests on nRF54L SoCs.

Ref: NCSDK-40883