### PR TITLE
tests: Fix syntax in Kconfig.sysbuild files

### DIFF
--- a/samples/event_manager_proxy/Kconfig.sysbuild
+++ b/samples/event_manager_proxy/Kconfig.sysbuild
@@ -18,7 +18,7 @@ config PPRCORE_IMAGE_NAME
 	default "remote" if PPRCORE_REMOTE
 
 config PPRCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if PPRCORE_REMOTE
+	default "$(APP_DIR)/remote" if PPRCORE_REMOTE
 
 endif # SUPPORT_PPRCORE
 
@@ -36,7 +36,7 @@ config FLPRCORE_IMAGE_NAME
 	default "remote" if FLPRCORE_REMOTE
 
 config FLPRCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if FLPRCORE_REMOTE
+	default "$(APP_DIR)/remote" if FLPRCORE_REMOTE
 
 endif # SUPPORT_FLPRCORE && !SUPPORT_PPRCORE
 
@@ -54,7 +54,7 @@ config NETCORE_IMAGE_NAME
 	default "remote" if NETCORE_REMOTE
 
 config NETCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if NETCORE_REMOTE
+	default "$(APP_DIR)/remote" if NETCORE_REMOTE
 
 endif # SUPPORT_NETCORE && !SUPPORT_FLPRCORE && !SUPPORT_PPRCORE
 

--- a/samples/ipc/ipc_service/Kconfig.sysbuild
+++ b/samples/ipc/ipc_service/Kconfig.sysbuild
@@ -19,7 +19,7 @@ config PPRCORE_IMAGE_NAME
 	default "remote" if PPRCORE_REMOTE
 
 config PPRCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if PPRCORE_REMOTE
+	default "$(APP_DIR)/remote" if PPRCORE_REMOTE
 
 endif # SUPPORT_PPRCORE
 
@@ -37,7 +37,7 @@ config NETCORE_IMAGE_NAME
 	default "remote" if NETCORE_REMOTE
 
 config NETCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if NETCORE_REMOTE
+	default "$(APP_DIR)/remote" if NETCORE_REMOTE
 
 endif # SUPPORT_NETCORE
 
@@ -55,7 +55,7 @@ config FLPRCORE_IMAGE_NAME
 	default "remote" if FLPRCORE_REMOTE
 
 config FLPRCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if FLPRCORE_REMOTE
+	default "$(APP_DIR)/remote" if FLPRCORE_REMOTE
 
 endif # SUPPORT_FLPRCORE && !SOC_SERIES_NRF92 && !SUPPORT_PPRCORE
 

--- a/samples/zephyr/sysbuild/hello_world/Kconfig.sysbuild
+++ b/samples/zephyr/sysbuild/hello_world/Kconfig.sysbuild
@@ -13,6 +13,6 @@ config FLPRCORE_IMAGE_NAME
 	default "hello_world_cpuflpr" if FLPRCORE_HELLO_WORLD_CPUFLPR
 
 config FLPRCORE_IMAGE_PATH
-	default "${ZEPHYR_BASE}/samples/sysbuild/hello_world" if FLPRCORE_HELLO_WORLD_CPUFLPR
+	default "$(ZEPHYR_BASE)/samples/sysbuild/hello_world" if FLPRCORE_HELLO_WORLD_CPUFLPR
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/bootup_time/Kconfig.sysbuild
+++ b/tests/benchmarks/bootup_time/Kconfig.sysbuild
@@ -21,7 +21,7 @@ config NETCORE_IMAGE_NAME
 	default "testapp_cpunet" if NETCORE_TESTAPP
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/bootup_time/testapp" if NETCORE_TESTAPP
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/bootup_time/testapp" if NETCORE_TESTAPP
 
 endif # !NETCORE_NONE
 
@@ -42,7 +42,7 @@ config PPRCORE_IMAGE_NAME
 	default "testapp_cpuppr" if PPRCORE_TESTAPP
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/bootup_time/testapp" if PPRCORE_TESTAPP
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/bootup_time/testapp" if PPRCORE_TESTAPP
 
 endif # !PPRCORE_NONE
 
@@ -63,7 +63,7 @@ config FLPRCORE_IMAGE_NAME
 	default "testapp_cpuflpr" if FLPRCORE_TESTAPP
 
 config FLPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/bootup_time/testapp" if FLPRCORE_TESTAPP
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/bootup_time/testapp" if FLPRCORE_TESTAPP
 
 endif # !FLPRCORE_NONE
 

--- a/tests/benchmarks/can_performance/Kconfig.sysbuild
+++ b/tests/benchmarks/can_performance/Kconfig.sysbuild
@@ -20,6 +20,6 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/current_consumption/can_idle/Kconfig.sysbuild
+++ b/tests/benchmarks/current_consumption/can_idle/Kconfig.sysbuild
@@ -20,6 +20,6 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/current_consumption/fll16_mode/Kconfig.sysbuild
+++ b/tests/benchmarks/current_consumption/fll16_mode/Kconfig.sysbuild
@@ -22,7 +22,7 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 endif # !NETCORE_NONE
 

--- a/tests/benchmarks/current_consumption/multicore_system_off/Kconfig.sysbuild
+++ b/tests/benchmarks/current_consumption/multicore_system_off/Kconfig.sysbuild
@@ -18,7 +18,7 @@ config FLPRCORE_IMAGE_NAME
 	default "remote" if FLPRCORE_REMOTE
 
 config FLPRCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if FLPRCORE_REMOTE
+	default "$(APP_DIR)/remote" if FLPRCORE_REMOTE
 
 endif # SUPPORT_FLPRCORE
 

--- a/tests/benchmarks/multicore/idle/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle/Kconfig.sysbuild
@@ -24,7 +24,7 @@ config PPRCORE_IMAGE_NAME
 	default "remote" if PPRCORE_REMOTE
 
 config PPRCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if PPRCORE_REMOTE
+	default "$(APP_DIR)/remote" if PPRCORE_REMOTE
 
 endif # SUPPORT_PPRCORE
 
@@ -42,7 +42,7 @@ config NETCORE_IMAGE_NAME
 	default "remote" if NETCORE_REMOTE
 
 config NETCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if NETCORE_REMOTE
+	default "$(APP_DIR)/remote" if NETCORE_REMOTE
 
 endif # SUPPORT_NETCORE
 

--- a/tests/benchmarks/multicore/idle_comp/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_comp/Kconfig.sysbuild
@@ -16,6 +16,6 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/multicore/idle_exmif/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_exmif/Kconfig.sysbuild
@@ -16,6 +16,6 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/multicore/idle_flpr/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_flpr/Kconfig.sysbuild
@@ -21,7 +21,7 @@ config FLPRCORE_IMAGE_NAME
 	default "flpr_test_app" if FLPRCORE_TESTAPP
 
 config FLPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_flpr/flpr_test_app" if FLPRCORE_TESTAPP
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_flpr/flpr_test_app" if FLPRCORE_TESTAPP
 
 endif # !FLPRCORE_NONE
 

--- a/tests/benchmarks/multicore/idle_gpio/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_gpio/Kconfig.sysbuild
@@ -24,9 +24,9 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_gpio/remote" if NETCORE_REMOTE
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_gpio/wakeup_trigger" if NETCORE_WAKEUP_TRIGGER
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_gpio/remote" if NETCORE_REMOTE
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_gpio/wakeup_trigger" if NETCORE_WAKEUP_TRIGGER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 choice PPRCORE
 	default PPRCORE_NONE
@@ -40,6 +40,6 @@ config PPRCORE_IMAGE_NAME
 	default "remote" if PPRCORE_REMOTE
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_gpio/remote" if PPRCORE_REMOTE
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_gpio/remote" if PPRCORE_REMOTE
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/multicore/idle_hpu_temp_meas/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_hpu_temp_meas/Kconfig.sysbuild
@@ -37,7 +37,7 @@ config PPRCORE_IMAGE_NAME
 	default "remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
 
 endif # SUPPORT_PPRCORE
 

--- a/tests/benchmarks/multicore/idle_ipc/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_ipc/Kconfig.sysbuild
@@ -16,7 +16,7 @@ config NETCORE_IMAGE_NAME
 	default "remote" if NETCORE_REMOTE
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_ipc/remote" if NETCORE_REMOTE
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_ipc/remote" if NETCORE_REMOTE
 
 choice PPRCORE
 	default PPRCORE_REMOTE if SOC_NRF9251_CPUAPP
@@ -31,6 +31,6 @@ config PPRCORE_IMAGE_NAME
 	default "remote_ppr" if PPRCORE_REMOTE
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_ipc/remote" if PPRCORE_REMOTE
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_ipc/remote" if PPRCORE_REMOTE
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/multicore/idle_outside_of_main/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_outside_of_main/Kconfig.sysbuild
@@ -16,7 +16,7 @@ config NETCORE_IMAGE_NAME
 	default "remote" if NETCORE_REMOTE
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_outside_of_main/remote" if NETCORE_REMOTE
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_outside_of_main/remote" if NETCORE_REMOTE
 
 choice PPRCORE
 	default PPRCORE_REMOTE
@@ -30,6 +30,6 @@ config PPRCORE_IMAGE_NAME
 	default "remote_ppr" if PPRCORE_REMOTE
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_outside_of_main/remote" if PPRCORE_REMOTE
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_outside_of_main/remote" if PPRCORE_REMOTE
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/multicore/idle_ppr/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_ppr/Kconfig.sysbuild
@@ -16,7 +16,7 @@ config NETCORE_IMAGE_NAME
 	default "remote" if NETCORE_REMOTE
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_ppr/remote" if NETCORE_REMOTE
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_ppr/remote" if NETCORE_REMOTE
 
 choice PPRCORE
 	default PPRCORE_REMOTE
@@ -30,6 +30,6 @@ config PPRCORE_IMAGE_NAME
 	default "remote_ppr" if PPRCORE_REMOTE
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_ppr/remote" if PPRCORE_REMOTE
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_ppr/remote" if PPRCORE_REMOTE
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/multicore/idle_pwm_led/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_pwm_led/Kconfig.sysbuild
@@ -16,7 +16,7 @@ config NETCORE_IMAGE_NAME
 	default "remote" if NETCORE_REMOTE
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_pwm_led/remote" if NETCORE_REMOTE
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_pwm_led/remote" if NETCORE_REMOTE
 
 choice PPRCORE
 	default PPRCORE_REMOTE_SLEEP_FOREVER if SOC_NRF9251_CPUAPP
@@ -31,6 +31,6 @@ config PPRCORE_IMAGE_NAME
 	default "remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/multicore/idle_pwm_loopback/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_pwm_loopback/Kconfig.sysbuild
@@ -16,7 +16,7 @@ config NETCORE_IMAGE_NAME
 	default "remote" if NETCORE_REMOTE
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_pwm_loopback/remote" if NETCORE_REMOTE
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_pwm_loopback/remote" if NETCORE_REMOTE
 
 choice PPRCORE
 	default PPRCORE_REMOTE_SLEEP_FOREVER if SOC_NRF9251_CPUAPP
@@ -31,6 +31,6 @@ config PPRCORE_IMAGE_NAME
 	default "remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/multicore/idle_spim/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_spim/Kconfig.sysbuild
@@ -16,7 +16,7 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config SUPPORT_NETCORE
 	default y if (SOC_NRF54H20_CPUPPR || SOC_NRF54H20_CPUAPP)

--- a/tests/benchmarks/multicore/idle_spim_loopback/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_spim_loopback/Kconfig.sysbuild
@@ -18,7 +18,7 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 endif # SUPPORT_NETCORE
 
@@ -37,7 +37,7 @@ config PPRCORE_IMAGE_NAME
 	default "remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
 
 endif # SUPPORT_PPRCORE
 

--- a/tests/benchmarks/multicore/idle_spim_loopback/test_on_ppr/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_spim_loopback/test_on_ppr/Kconfig.sysbuild
@@ -18,7 +18,7 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 endif # SUPPORT_NETCORE
 

--- a/tests/benchmarks/multicore/idle_twim/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_twim/Kconfig.sysbuild
@@ -16,7 +16,7 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config SUPPORT_NETCORE
 	default y if (SOC_NRF54H20_CPUPPR || SOC_NRF54H20_CPUAPP)

--- a/tests/benchmarks/multicore/idle_uarte/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_uarte/Kconfig.sysbuild
@@ -16,7 +16,7 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 choice PPRCORE
 	default PPRCORE_REMOTE_SLEEP_FOREVER if SOC_NRF9251_CPUAPP
@@ -31,6 +31,6 @@ config PPRCORE_IMAGE_NAME
 	default "remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/multicore/idle_wdt/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/idle_wdt/Kconfig.sysbuild
@@ -20,8 +20,8 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/idle_wdt/remote" if NETCORE_REMOTE
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/idle_wdt/remote" if NETCORE_REMOTE
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 choice APPCORE
 	default APPCORE_REMOTE_SLEEP_FOREVER
@@ -35,7 +35,7 @@ config APPCORE_IMAGE_NAME
 	default "remote_sleep_forever" if APPCORE_REMOTE_SLEEP_FOREVER
 
 config APPCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if APPCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if APPCORE_REMOTE_SLEEP_FOREVER
 
 choice PPRCORE
 	default PPRCORE_REMOTE_SLEEP_FOREVER if SOC_NRF9251_CPUAPP
@@ -50,7 +50,7 @@ config PPRCORE_IMAGE_NAME
 	default "remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if PPRCORE_REMOTE_SLEEP_FOREVER
 
 config TEST_SYNCHRONIZE_CORES
 	bool "Synchronize both cores"

--- a/tests/benchmarks/multicore/stm_stress/Kconfig.sysbuild
+++ b/tests/benchmarks/multicore/stm_stress/Kconfig.sysbuild
@@ -17,7 +17,7 @@ config NETCORE_IMAGE_NAME
 	default "testapp_cpunet" if NETCORE_TESTAPP
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/stm_stress/testapp" if NETCORE_TESTAPP
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/stm_stress/testapp" if NETCORE_TESTAPP
 
 endif # !NETCORE_NONE
 
@@ -38,7 +38,7 @@ config PPRCORE_IMAGE_NAME
 	default "testapp_cpuppr" if PPRCORE_TESTAPP
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/stm_stress/testapp" if PPRCORE_TESTAPP
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/stm_stress/testapp" if PPRCORE_TESTAPP
 
 endif # !PPRCORE_NONE
 
@@ -55,7 +55,7 @@ config FLPRCORE_IMAGE_NAME
 	default "testapp_cpuflpr" if FLPRCORE_TESTAPP
 
 config FLPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/multicore/stm_stress/testapp" if FLPRCORE_TESTAPP
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/multicore/stm_stress/testapp" if FLPRCORE_TESTAPP
 
 endif # !FLPRCORE_NONE
 

--- a/tests/benchmarks/power_consumption/adc/Kconfig.sysbuild
+++ b/tests/benchmarks/power_consumption/adc/Kconfig.sysbuild
@@ -16,7 +16,7 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config SUPPORT_NETCORE
 	default y if (SOC_NRF54H20_CPUPPR || SOC_NRF54H20_CPUAPP)

--- a/tests/benchmarks/power_load/Kconfig.sysbuild
+++ b/tests/benchmarks/power_load/Kconfig.sysbuild
@@ -17,7 +17,7 @@ config FLPRCORE_IMAGE_NAME
 	default "flpr_vpr_test_app" if FLPR_VPR_TEST_APP
 
 config FLPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_load/vpr_test_app" if FLPR_VPR_TEST_APP
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_load/vpr_test_app" if FLPR_VPR_TEST_APP
 
 endif # !FLPRCORE_NONE
 
@@ -34,7 +34,7 @@ config PPRCORE_IMAGE_NAME
 	default "ppr_vpr_test_app" if PPR_VPR_TEST_APP
 
 config PPRCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_load/vpr_test_app" if PPR_VPR_TEST_APP
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_load/vpr_test_app" if PPR_VPR_TEST_APP
 
 endif # !PPRCORE_NONE
 

--- a/tests/benchmarks/sdmmc_performance/Kconfig.sysbuild
+++ b/tests/benchmarks/sdmmc_performance/Kconfig.sysbuild
@@ -20,6 +20,6 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 source "share/sysbuild/Kconfig"

--- a/tests/benchmarks/xspi_performance/Kconfig.sysbuild
+++ b/tests/benchmarks/xspi_performance/Kconfig.sysbuild
@@ -20,7 +20,7 @@ config NETCORE_IMAGE_NAME
 	default "remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_IMAGE_PATH
-	default "${ZEPHYR_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
+	default "$(ZEPHYR_NRF_MODULE_DIR)/tests/benchmarks/power_consumption/common/remote_sleep_forever" if NETCORE_REMOTE_SLEEP_FOREVER
 
 config NETCORE_REMOTE_BOARD_TARGET_CPUCLUSTER
 	default "cpurad" if SOC_NRF54H20

--- a/tests/subsys/event_manager_proxy/Kconfig.sysbuild
+++ b/tests/subsys/event_manager_proxy/Kconfig.sysbuild
@@ -18,7 +18,7 @@ config PPRCORE_IMAGE_NAME
 	default "remote" if PPRCORE_REMOTE
 
 config PPRCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if PPRCORE_REMOTE
+	default "$(APP_DIR)/remote" if PPRCORE_REMOTE
 
 endif # SUPPORT_PPRCORE
 
@@ -36,7 +36,7 @@ config FLPRCORE_IMAGE_NAME
 	default "remote" if FLPRCORE_REMOTE
 
 config FLPRCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if FLPRCORE_REMOTE
+	default "$(APP_DIR)/remote" if FLPRCORE_REMOTE
 
 endif # SUPPORT_FLPRCORE && !SUPPORT_PPRCORE
 
@@ -54,7 +54,7 @@ config NETCORE_IMAGE_NAME
 	default "remote" if NETCORE_REMOTE
 
 config NETCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if NETCORE_REMOTE
+	default "$(APP_DIR)/remote" if NETCORE_REMOTE
 
 endif # SUPPORT_NETCORE && !SUPPORT_FLPRCORE && !SUPPORT_PPRCORE
 

--- a/tests/subsys/ipc/ipc_latency/Kconfig.sysbuild
+++ b/tests/subsys/ipc/ipc_latency/Kconfig.sysbuild
@@ -16,7 +16,7 @@ config NETCORE_IMAGE_NAME
 	default "remote" if NETCORE_REMOTE
 
 config NETCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if NETCORE_REMOTE
+	default "$(APP_DIR)/remote" if NETCORE_REMOTE
 
 endif # SUPPORT_NETCORE
 

--- a/tests/subsys/ipc/ipc_reconnect/Kconfig.sysbuild
+++ b/tests/subsys/ipc/ipc_reconnect/Kconfig.sysbuild
@@ -16,7 +16,7 @@ config NETCORE_IMAGE_NAME
 	default "remote" if NETCORE_REMOTE
 
 config NETCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if NETCORE_REMOTE
+	default "$(APP_DIR)/remote" if NETCORE_REMOTE
 
 endif # SUPPORT_NETCORE
 
@@ -34,7 +34,7 @@ config FLPRCORE_IMAGE_NAME
 	default "remote" if FLPRCORE_REMOTE
 
 config FLPRCORE_IMAGE_PATH
-	default "${APP_DIR}/remote" if FLPRCORE_REMOTE
+	default "$(APP_DIR)/remote" if FLPRCORE_REMOTE
 
 endif # SUPPORT_FLPRCORE && !SUPPORT_NETCORE
 


### PR DESCRIPTION
Instead of `default "${VARIABLE}"`,
`default "$(VARIABLE)"` shall be used.