### PR TITLE
tests: drivers: i2c_pan: add support for nRF54H20 anomaly 244

### DIFF
--- a/tests/drivers/i2c/i2c_pan/src/main.c
+++ b/tests/drivers/i2c/i2c_pan/src/main.c
@@ -151,7 +151,8 @@ ZTEST(i2c_pan, test_clock_stretching_recovery)
 	 * anomaly 105.
 	 */
 	ret = i2c_read(fixture.dev, fixture.master_buffer, TEST_BUFFER_SIZE, fixture.addr);
-	if (NRF_ERRATA_DYNAMIC_CHECK(54L, 105) || NRF_ERRATA_DYNAMIC_CHECK(71, 105)) {
+	if (NRF_ERRATA_DYNAMIC_CHECK(54H, 244) || NRF_ERRATA_DYNAMIC_CHECK(54L, 105) ||
+	    NRF_ERRATA_DYNAMIC_CHECK(71, 105)) {
 		zassert_equal(ret, -ETIMEDOUT,
 			      "i2c_read failed with different error than expeced (ETIMEDOUT) %d\n",
 			      ret);


### PR DESCRIPTION
If nRF54H20 anomaly 244 is present, timeout error is expected.