### PR TITLE
samples|tests: Fix location of IPC shared memory regions on nRF54L15

### DIFF
--- a/samples/event_manager_proxy/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/event_manager_proxy/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -14,12 +14,12 @@
 		#size-cells = <1>;
 		ranges;
 
-		sram_rx: memory@20018000 {
-			reg = <0x20018000 0x8000>;
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 
-		sram_tx: memory@20020000 {
-			reg = <0x20020000 0x8000>;
+		sram_tx: memory@2001fc00 {
+			reg = <0x2001fc00 0x8000>;
 		};
 	};
 

--- a/samples/event_manager_proxy/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/samples/event_manager_proxy/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -10,12 +10,12 @@
 		#size-cells = <1>;
 		ranges;
 
-		sram_tx: memory@20018000 {
-			reg = <0x20018000 0x8000>;
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 
-		sram_rx: memory@20020000 {
-			reg = <0x20020000 0x8000>;
+		sram_rx: memory@2001fc00 {
+			reg = <0x2001fc00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/ipc/ipc_service/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -10,12 +10,12 @@
 		#size-cells = <1>;
 		ranges;
 
-		sram_rx: memory@20018000 {
-			reg = <0x20018000 0x8000>;
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 
-		sram_tx: memory@20020000 {
-			reg = <0x20020000 0x8000>;
+		sram_tx: memory@2001fc00 {
+			reg = <0x2001fc00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay
+++ b/samples/ipc/ipc_service/boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay
@@ -10,12 +10,12 @@
 		#size-cells = <1>;
 		ranges;
 
-		sram_rx: memory@20018000 {
-			reg = <0x20018000 0x8000>;
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 
-		sram_tx: memory@20020000 {
-			reg = <0x20020000 0x8000>;
+		sram_tx: memory@2001fc00 {
+			reg = <0x2001fc00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -10,12 +10,12 @@
 		#size-cells = <1>;
 		ranges;
 
-		sram_tx: memory@20018000 {
-			reg = <0x20018000 0x8000>;
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 
-		sram_rx: memory@20020000 {
-			reg = <0x20020000 0x8000>;
+		sram_rx: memory@2001fc00 {
+			reg = <0x2001fc00 0x8000>;
 		};
 	};
 

--- a/samples/ipc/ipc_service/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay
+++ b/samples/ipc/ipc_service/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay
@@ -10,12 +10,12 @@
 		#size-cells = <1>;
 		ranges;
 
-		sram_tx: memory@20018000 {
-			reg = <0x20018000 0x8000>;
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 
-		sram_rx: memory@20020000 {
-			reg = <0x20020000 0x8000>;
+		sram_rx: memory@2001fc00 {
+			reg = <0x2001fc00 0x8000>;
 		};
 	};
 

--- a/tests/subsys/event_manager_proxy/boards/nrf54l15dk_nrf54l15_cpuapp_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/boards/nrf54l15dk_nrf54l15_cpuapp_icmsg.overlay
@@ -14,12 +14,12 @@
 		#size-cells = <1>;
 		ranges;
 
-		sram_rx: memory@20018000 {
-			reg = <0x20018000 0x8000>;
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 
-		sram_tx: memory@20020000 {
-			reg = <0x20020000 0x8000>;
+		sram_tx: memory@2001fc00 {
+			reg = <0x2001fc00 0x8000>;
 		};
 	};
 

--- a/tests/subsys/event_manager_proxy/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icmsg.overlay
+++ b/tests/subsys/event_manager_proxy/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icmsg.overlay
@@ -10,12 +10,12 @@
 		#size-cells = <1>;
 		ranges;
 
-		sram_tx: memory@20018000 {
-			reg = <0x20018000 0x8000>;
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 
-		sram_rx: memory@20020000 {
-			reg = <0x20020000 0x8000>;
+		sram_rx: memory@2001fc00 {
+			reg = <0x2001fc00 0x8000>;
 		};
 	};
 

--- a/tests/subsys/ipc/ipc_reconnect/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/subsys/ipc/ipc_reconnect/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -10,12 +10,12 @@
 		#size-cells = <1>;
 		ranges;
 
-		sram_rx: memory@20018000 {
-			reg = <0x20018000 0x8000>;
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 
-		sram_tx: memory@20020000 {
-			reg = <0x20020000 0x8000>;
+		sram_tx: memory@2001fc00 {
+			reg = <0x2001fc00 0x8000>;
 		};
 	};
 

--- a/tests/subsys/ipc/ipc_reconnect/boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay
+++ b/tests/subsys/ipc/ipc_reconnect/boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay
@@ -10,12 +10,12 @@
 		#size-cells = <1>;
 		ranges;
 
-		sram_rx: memory@20018000 {
-			reg = <0x20018000 0x8000>;
+		sram_rx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 
-		sram_tx: memory@20020000 {
-			reg = <0x20020000 0x8000>;
+		sram_tx: memory@2001fc00 {
+			reg = <0x2001fc00 0x8000>;
 		};
 	};
 

--- a/tests/subsys/ipc/ipc_reconnect/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/tests/subsys/ipc/ipc_reconnect/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -10,12 +10,12 @@
 		#size-cells = <1>;
 		ranges;
 
-		sram_tx: memory@20018000 {
-			reg = <0x20018000 0x8000>;
+		sram_tx: memory@20017c00 {
+			reg = <0x20017c00 0x8000>;
 		};
 
-		sram_rx: memory@20020000 {
-			reg = <0x20020000 0x8000>;
+		sram_rx: memory@2001fc00 {
+			reg = <0x2001fc00 0x8000>;
 		};
 	};
 


### PR DESCRIPTION
Since the RAM region assigned to the FLPR core on nRF54L15 was moved 1 kB down (to provide space for hibernation data, see PR #111480 in Zephyr), also the IPC shared memory regions in samples and tests for that SoC need to be moved accordingly, otherwise the FLPR RAM might get overwritten with some random data.

Ref. NCSDK-40520