### PR TITLE
tests: subsys: west_flash: adapt for nrf7120dk.

### DIFF
--- a/tests/subsys/west_flash/pytest/test_west_flash.py
+++ b/tests/subsys/west_flash/pytest/test_west_flash.py
@@ -105,6 +105,8 @@ def test_west_flash(dut: DeviceAdapter):
     expected = r"Flash download: Bank \d @ 0x\d+: Skipped. Contents already match"
     if "nrf54h20dk" in dut.device_config.platform:
         expected = r"O\.K\."
+    if "nrf7120dk" in dut.device_config.platform:
+        expected = r"O\.K\."
     if "nrf9251dk" in dut.device_config.platform:
         expected = r"O\.K\."
     run_communicate_check(


### PR DESCRIPTION
Fill missing expected string for nrf7120dk.