### PR TITLE
[Backport v3.4-branch] tests: align nRF54LC10 with nRF54LV10 in mcuboot CI scope

### DIFF
--- a/tests/drivers/fprotect/storage/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/tests/drivers/fprotect/storage/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,34 @@
+/ {
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
+};
+
+/delete-node/ &cpuapp_rram;
+
+&rram_controller {
+	cpuapp_rram: rram@0 {
+		compatible = "soc-nv-flash";
+		erase-block-size = <DT_SIZE_K(4)>;
+		write-block-size = <0x10>;
+		reg = <0 DT_SIZE_K(1012)>;
+
+		partitions {
+			ranges;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_partition: partition@0 {
+				compatible = "zephyr,mapped-partition";
+				label = "image-0";
+				reg = <0 DT_SIZE_K(54)>;
+			};
+
+			storage_partition: partition@f4000 {
+				compatible = "zephyr,mapped-partition";
+				label = "storage";
+				reg = <0xf4000 DT_SIZE_K(36)>;
+			};
+		};
+	};
+};

--- a/tests/drivers/fprotect/storage/testcase.yaml
+++ b/tests/drivers/fprotect/storage/testcase.yaml
@@ -7,6 +7,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
@@ -14,6 +15,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     tags:
       - b0
       - fprotect

--- a/tests/subsys/bootloader/upgrade/b0_hello_world/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/tests/subsys/bootloader/upgrade/b0_hello_world/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+&cpuapp_rram {
+	partitions {
+		b0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "b0";
+			reg = <0x0 0x7800>;
+		};
+
+		s0_partition: partition@7800 {
+			compatible = "zephyr,mapped-partition";
+			label = "b0-image-0";
+			reg = <0x7800 0x72800>;
+		};
+
+		s1_partition: partition@7a000 {
+			compatible = "zephyr,mapped-partition";
+			label = "b0-image-1";
+			reg = <0x7a000 0x72800>;
+		};
+	};
+};
+
+/ {
+	chosen {
+		zephyr,code-partition = &s0_partition;
+	};
+};
+
+&uicr {
+	ranges = <0x0 0xffd000 0x1000>;
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	bl_storage: uicr@500 {
+		reg = <0x500 0x460>;
+	};
+};

--- a/tests/subsys/bootloader/upgrade/b0_hello_world/sysbuild/b0/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
+++ b/tests/subsys/bootloader/upgrade/b0_hello_world/sysbuild/b0/boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf54lc10dk_nrf54lc10a_cpuapp.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &b0_partition;
+	};
+};

--- a/tests/subsys/bootloader/upgrade/b0_hello_world/testcase.yaml
+++ b/tests/subsys/bootloader/upgrade/b0_hello_world/testcase.yaml
@@ -25,6 +25,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp


### PR DESCRIPTION
Add nRF54LC10 platforms to lib.fprotect.storage_fprotect and nsib.security.tampered_app configurations.

Add board overlays for nRF54LC10 b0_hello_world secure boot tests and fprotect storage tests.

backport #f1ce44b from #30896
 