### PR TITLE
[Backport v3.4-branch] nrf_cloud: fix memory leak in nrf_cloud_fota_poll

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -520,7 +520,9 @@ AVSystem integration
 nRF Cloud integration
 ---------------------
 
-|no_changes_yet_note|
+* Added the :kconfig:option:`CONFIG_NRF_CLOUD_FOTA_POLL_JOB_CHECK_PROGRESS_THRESHOLD` Kconfig option to the :ref:`lib_nrf_cloud` FOTA polling helpers, allowing the progress-based FOTA job re-check to be configured or disabled.
+
+* Fixed a memory leak in the :ref:`lib_nrf_cloud` FOTA polling helpers where the temporary job info returned by each FOTA job check was not released on all code paths.
 
 CoreMark integration
 --------------------

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
@@ -85,6 +85,18 @@ config FOTA_DL_TIMEOUT_MIN
 	  the download will be cancelled and the job status will be
 	  set as failed.
 
+config NRF_CLOUD_FOTA_POLL_JOB_CHECK_PROGRESS_THRESHOLD
+	int "Progress percentage interval at which the FOTA job is re-checked"
+	range 0 100
+	default 0 if MEMFAULT_USE_NRF_CLOUD_COAP
+	default 10
+	help
+	  During a FOTA download, the current FOTA job is re-checked with
+	  nRF Cloud at every multiple of this progress percentage, to allow
+	  the download to be canceled if the job is no longer valid.
+	  0 disables these checks, for backends that do not provide
+	  cancellation information.
+
 module = NRF_CLOUD_FOTA_POLL
 module-str = nRF Cloud FOTA Poll
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_fota_poll.c
+++ b/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_fota_poll.c
@@ -122,6 +122,7 @@ static void on_download_evt_finished(struct nrf_cloud_fota_poll_ctx *ctx,
 			nrf_cloud_download_cancel();
 		}
 
+		nrf_cloud_coap_fota_job_free(&job);
 		return;
 	}
 
@@ -134,7 +135,14 @@ static void cancel_if_job_is_not_valid(struct nrf_cloud_fota_poll_ctx *ctx, uint
 	int err;
 	struct nrf_cloud_fota_job_info job_current = {0};
 	static uint32_t last_progress_threshold;
-	uint32_t current_progress_threshold = ROUND_DOWN(progress, threshold);
+	uint32_t current_progress_threshold;
+
+	if (threshold == 0) {
+		/* Progress checks are disabled */
+		return;
+	}
+
+	current_progress_threshold = ROUND_DOWN(progress, threshold);
 
 	if ((current_progress_threshold != last_progress_threshold) &&
 	    (current_progress_threshold != 0)) {
@@ -145,9 +153,10 @@ static void cancel_if_job_is_not_valid(struct nrf_cloud_fota_poll_ctx *ctx, uint
 		if (err == 1) {
 			LOG_ERR("No job available, canceling...");
 
-			nrf_cloud_coap_fota_job_free(&job_current);
 			k_work_schedule(&ctx->cancel_work, K_SECONDS(1));
 		}
+
+		nrf_cloud_coap_fota_job_free(&job_current);
 	}
 }
 
@@ -200,6 +209,7 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 			ctx_ptr->status_fn(fota_status, fota_status_details);
 
 			(void)update_job_status(ctx_ptr);
+			nrf_cloud_coap_fota_job_free(&job);
 		} else {
 			k_sem_give(&fota_download_sem);
 		}
@@ -221,12 +231,14 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 			ctx_ptr->status_fn(fota_status, fota_status_details);
 
 			(void)update_job_status(ctx_ptr);
+			nrf_cloud_coap_fota_job_free(&job);
 		}
 		break;
 	case FOTA_DOWNLOAD_EVT_PROGRESS:
 		LOG_DBG("FOTA download percent: %d%%", evt->progress);
 
-		cancel_if_job_is_not_valid(ctx_ptr, evt->progress, 10);
+		cancel_if_job_is_not_valid(ctx_ptr, evt->progress,
+					   CONFIG_NRF_CLOUD_FOTA_POLL_JOB_CHECK_PROGRESS_THRESHOLD);
 		break;
 	default:
 		break;
@@ -605,6 +617,8 @@ int nrf_cloud_fota_poll_update_apply(struct nrf_cloud_fota_poll_ctx *ctx)
 {
 	int err = handle_downloaded_image(ctx, false);
 
+	nrf_cloud_coap_fota_job_free(&job);
+
 	if (err) {
 		LOG_ERR("handle_downloaded_image, error: %d", err);
 		return err;
@@ -642,6 +656,7 @@ int nrf_cloud_fota_poll_process(struct nrf_cloud_fota_poll_ctx *ctx)
 		return err;
 	} else if (err < 0) {
 		LOG_ERR("Failed to check for FOTA job, error: %d", err);
+		nrf_cloud_coap_fota_job_free(&job);
 		return IS_RECOVERABLE_NETWORK_ERR(err) ? err : -ENOTRECOVERABLE;
 	} else if (err > 0) {
 		/* No job. */
@@ -655,6 +670,7 @@ int nrf_cloud_fota_poll_process(struct nrf_cloud_fota_poll_ctx *ctx)
 	err = start_download();
 	if (err) {
 		LOG_ERR("Failed to start FOTA download");
+		nrf_cloud_coap_fota_job_free(&job);
 		return -ENOTRECOVERABLE;
 	}
 
@@ -680,6 +696,7 @@ int nrf_cloud_fota_poll_process(struct nrf_cloud_fota_poll_ctx *ctx)
 	 */
 	if (fota_status == NRF_CLOUD_FOTA_SUCCEEDED) {
 		handle_downloaded_image(ctx, true);
+		nrf_cloud_coap_fota_job_free(&job);
 		/* Application was expected to reboot... */
 		return -EBUSY;
 	}


### PR DESCRIPTION
Backport dcfc289f9597c9c32a7ce7ec85c2e147817fd2b8 from #30740.