### PR TITLE
net: lib: nrf_cloud: Fix build error for IPv4/IPv6-only configs

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -138,10 +138,3 @@
     - nrf54h20dk@0.9.0/nrf54h20/cpuapp
     - nrf9251dk@0.1.0/nrf9251/cpuapp
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-40944"
-
-- scenarios:
-    - sample.dect.dect_shell.nrf_cloud_coap
-    - sample.dect.dect_shell.nrf_cloud_mqtt
-  platforms:
-    - nrf9151dk/nrf9151/ns
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-41027"

--- a/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_dns.c
+++ b/subsys/net/lib/nrf_cloud/common/src/nrf_cloud_dns.c
@@ -181,40 +181,40 @@ int nrf_cloud_connect_host(const char *hostname, uint16_t port, struct zsock_add
 	 * IPv6 address, even if both IPv4 and IPv6 are available.
 	 */
 
-#if defined(CONFIG_NET_IPV6)
-	if (!ipv6_ready()) {
-		LOG_DBG("Skipping IPv6 for %s; no local IPv6 address", hostname);
-	} else {
-		LOG_DBG("Trying IPv6 addresses for %s", hostname);
-
-		hints->ai_family = AF_INET6;
-		sock = nrf_cloud_try_addresses(hostname, port, hints, connect_cb);
-
-		if (sock >= 0) {
-			goto out;
+	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+		if (!ipv6_ready()) {
+			LOG_DBG("Skipping IPv6 for %s; no local IPv6 address", hostname);
 		} else {
-			LOG_DBG("Could not connect over IPv6 to %s, falling back to IPv4",
-				hostname);
+			LOG_DBG("Trying IPv6 addresses for %s", hostname);
+
+			hints->ai_family = AF_INET6;
+			sock = nrf_cloud_try_addresses(hostname, port, hints, connect_cb);
+
+			if (sock >= 0) {
+				goto out;
+			} else {
+				LOG_DBG("Could not connect over IPv6 to %s, falling back to IPv4",
+					hostname);
+			}
 		}
 	}
-#endif /* defined (CONFIG_NET_IPV6) */
 
-#if defined(CONFIG_NET_IPV4) && !defined(CONFIG_NRF_CLOUD_IPV6)
-	if (!ipv4_ready()) {
-		LOG_DBG("Skipping IPv4 for %s; no local IPv4 address", hostname);
-	} else {
-		LOG_DBG("Trying IPv4 addresses for %s", hostname);
-
-		hints->ai_family = AF_INET;
-		sock = nrf_cloud_try_addresses(hostname, port, hints, connect_cb);
-
-		if (sock >= 0) {
-			goto out;
+	if (IS_ENABLED(CONFIG_NET_IPV4) && !IS_ENABLED(CONFIG_NRF_CLOUD_IPV6)) {
+		if (!ipv4_ready()) {
+			LOG_DBG("Skipping IPv4 for %s; no local IPv4 address", hostname);
 		} else {
-			LOG_DBG("Could not connect over IPv4 to %s", hostname);
+			LOG_DBG("Trying IPv4 addresses for %s", hostname);
+
+			hints->ai_family = AF_INET;
+			sock = nrf_cloud_try_addresses(hostname, port, hints, connect_cb);
+
+			if (sock >= 0) {
+				goto out;
+			} else {
+				LOG_DBG("Could not connect over IPv4 to %s", hostname);
+			}
 		}
 	}
-#endif /* defined (CONFIG_NET_IPV4) */
 
 out:
 	if (sock < 0) {


### PR DESCRIPTION
Fixes a build regression introduced by `c3ed58fb882b`.

Replace ipv6_ready() and ipv4_ready() with one single function family_ready() in such a way that IPv4- and IPv6-only builds do not end up with an unused function.

Ticket: [NCSDK-41027](https://nordicsemi.atlassian.net/browse/NCSDK-41027)

[NCSDK-41027]: https://nordicsemi.atlassian.net/browse/NCSDK-41027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ