### PR TITLE
samples: wifi: nrf_cloud: Fix small doc findings

### DIFF
--- a/samples/wifi/nrf_cloud/README.rst
+++ b/samples/wifi/nrf_cloud/README.rst
@@ -360,9 +360,9 @@ If you are certain you understand the inherent security risks, you can use this 
 
 1. Follow the instructions under :ref:`wifi_nrf_cloud_onboard_hardcoded`.
 
-#. Create a :file:`certs` folder directly in the :file:`wifi_nrf_cloud` folder, and copy :file:`client-cert.pem`, :file:`private-key.pem`, and :file:`ca-cert.pem` files into it.
+#. Create a :file:`certs` folder directly in the :file:`samples/wifi/nrf_cloud` folder, and copy :file:`client-cert.pem`, :file:`private-key.pem`, and :file:`ca-cert.pem` files into it.
 
-   Make sure not to place the new folder in the :file:`wifi_nrf_cloud/src` folder by accident.
+   Make sure not to place the new folder in the :file:`samples/wifi/nrf_cloud/src` folder by accident.
 
    Now, these certificates are automatically used if the :kconfig:option:`CONFIG_NRF_CLOUD_PROVISION_CERTIFICATES` Kconfig option is enabled.
 

--- a/samples/wifi/nrf_cloud/README.rst
+++ b/samples/wifi/nrf_cloud/README.rst
@@ -427,7 +427,8 @@ You must select either MQTT or CoAP by adding one of the following parameters to
 * For MQTT, add ``-DEXTRA_CONF_FILE=mqtt.conf``.
 * For CoAP, add ``-DEXTRA_CONF_FILE=coap.conf``.
 
-On board targets that can enable :kconfig:option:`CONFIG_SAMPLE_MEMFAULT_FOTA` (currently only ``nrf7120dk/nrf7120/cpuapp``, see :ref:`wifi_nrf_cloud_fota`), also merge in the :file:`coap-fota.conf` file:
+If you also want to enable :kconfig:option:`CONFIG_SAMPLE_MEMFAULT_FOTA` on a board target that supports it (see :ref:`wifi_nrf_cloud_fota` for the list of supported targets), merge in the :file:`coap-fota.conf` file in addition to the :file:`coap.conf` file.
+The :file:`coap-fota.conf` file only extends the CoAP transport and cannot be used on its own:
 
 ``-DEXTRA_CONF_FILE="coap.conf;coap-fota.conf"``
 

--- a/samples/wifi/nrf_cloud/README.rst
+++ b/samples/wifi/nrf_cloud/README.rst
@@ -366,6 +366,12 @@ If you are certain you understand the inherent security risks, you can use this 
 
    Now, these certificates are automatically used if the :kconfig:option:`CONFIG_NRF_CLOUD_PROVISION_CERTIFICATES` Kconfig option is enabled.
 
+   .. note::
+      This works through the :kconfig:option:`CONFIG_NRF_CLOUD_CERTIFICATES_FILE` Kconfig option, which defaults to the :file:`nrf_cloud-certs.h` file found in the :file:`subsys/net/lib/nrf_cloud/common/include` folder.
+      That header pulls in :file:`ca-cert.pem`, :file:`client-cert.pem`, and :file:`private-key.pem` files using unqualified, quoted ``#include`` directives, so the preprocessor looks in its own directory first before falling back to the sample's :file:`certs` folder.
+      Because of this, if you ever place :file:`.pem` files directly in :file:`subsys/net/lib/nrf_cloud/common/include` (for example, while experimenting), they will silently take precedence over the ones in the sample's :file:`certs` folder.
+      Keep your :file:`.pem` files only in the sample's :file:`certs` folder, or point the :kconfig:option:`CONFIG_NRF_CLOUD_CERTIFICATES_FILE` Kconfig option at a header file of your own instead.
+
 #. Build the sample with the :kconfig:option:`CONFIG_NRF_CLOUD_PROVISION_CERTIFICATES` Kconfig option enabled and the device ID you created configured.
 
    This is required for onboarding to succeed.


### PR DESCRIPTION
This PR:
- fixes folder path in the README
- corrects sentence in the transport selection section
- adds a note about certificates location issue