### PR TITLE
Generate combined sitemap for all docsets.

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -120,6 +120,11 @@ jobs:
           cmake -GNinja -Bdoc/_build -Sdoc -DSPHINXOPTS_EXTRA="${SPHINXOPTS_EXTRA}" ${BUILD_CONF}
           ninja -C doc/_build
 
+      - name: Merge sitemaps
+        working-directory: ncs/nrf/doc/
+        run: |
+          python _scripts/merge_sitemaps.py
+
       - name: Check version
         run: |
           VERSION_REGEX="^v([0-9a-zA-Z\.\-]+)$"

--- a/doc/_scripts/merge_sitemaps.py
+++ b/doc/_scripts/merge_sitemaps.py
@@ -1,0 +1,87 @@
+"""
+Copyright (c) 2026 Nordic Semiconductor ASA
+
+SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+
+_BASE_URL = "https://nrfconnectdocs.nordicsemi.com/ncs/latest/{docset}/"
+
+
+def create_urlset(soup: BeautifulSoup) -> Tag:
+    return soup.new_tag(
+        "sitemapindex", attrs={"xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    )
+
+
+def create_loc(tag: Tag, url: str) -> Tag:
+    loc = tag.new_tag("loc")
+    loc.string = url
+    return loc
+
+
+def create_lastmod(tag: Tag) -> Tag:
+    lastmod = tag.new_tag("lastmod")
+
+    lastmod.string = datetime.now().strftime("%Y-%m-%d")
+    return lastmod
+
+
+def create_sitemap(tag: Tag, url: str) -> Tag:
+    sitemap = tag.new_tag("sitemap")
+    tag.append(sitemap)
+
+    sitemap.append(create_loc(sitemap, url))
+    sitemap.append(create_lastmod(sitemap))
+
+    return sitemap
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog=__file__,
+        description="Create sitemap_index.xml from sitemaps generated for each docset during build",
+        allow_abbrev=False,
+    )
+
+    parser.add_argument(
+        "--html-dir",
+        type=Path,
+        default=Path("_build/html"),
+        help="Path to the html output directory",
+    )
+
+    parser.add_argument("--base-url", type=str, default=_BASE_URL, help="Base url for sitemap")
+
+    parser.add_argument(
+        "sitemap",
+        type=Path,
+        nargs="?",
+        default=Path("_build/html/sitemap_index.xml"),
+        help="Output file path",
+    )
+
+    args = parser.parse_args()
+
+    soup = BeautifulSoup()
+    urlset = create_urlset(soup)
+    soup.append(urlset)
+
+    for path in args.html_dir.glob("**/sitemap.xml"):
+        docset = path.parent.name
+        urlset.append(create_sitemap(urlset, args.base_url.format(docset=docset)))
+
+    with open(args.sitemap, "w") as f:
+        f.write(soup.prettify())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/doc/_utils/utils.py
+++ b/doc/_utils/utils.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from sphinx.application import Sphinx
 from sphinx.cmd.build import get_parser
+from versions import Versions
 from west.manifest import Manifest
 
 _NRF_BASE = Path(__file__).parents[2]
@@ -16,6 +17,9 @@ _NRF_BASE = Path(__file__).parents[2]
 
 _MANIFEST = Manifest.from_file(_NRF_BASE / "west.yml")
 """Manifest instance"""
+
+_DOCS_BASEURL = "https://nrfconnectdocs.nordicsemi.com/ncs/{version}/{docset}/"
+"""Public URL of a docset, as served by docs.nordicsemi.com."""
 
 ALL_DOCSETS = {
     "nrf": ("nRF Connect SDK", "index", "manifest"),
@@ -98,6 +102,23 @@ def get_srcdir(docset: str) -> PathLike:
     """
 
     return get_builddir() / docset / "src"
+
+
+def get_baseurl(docset: str) -> str:
+    """
+    Returns the base url for given docset.
+
+    Args:
+        docset: Target docset.
+
+    Returns:
+        Public base URL of the given docset.
+    """
+
+    latest = Versions.from_topdir().latest()
+    version = "latest" if not latest or Versions.is_placeholder(latest) else latest
+
+    return _DOCS_BASEURL.format(version=version, docset=docset)
 
 
 def get_intersphinx_mapping(docset: str) -> tuple[str, str] | None:

--- a/doc/api/conf.py
+++ b/doc/api/conf.py
@@ -23,6 +23,7 @@ extensions = [
     "zephyr.external_content",
     "notfound.extension",
     "sphinx_copybutton",
+    "sphinx_sitemap",
 ]
 
 # Options for HTML output ------------------------------------------------------
@@ -32,6 +33,7 @@ html_static_path = [str(NRF_BASE / "doc" / "_static")]
 html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_show_sphinx = False
+html_baseurl = utils.get_baseurl("api")
 
 html_theme_options = {"docset": "api", "docsets": utils.ALL_DOCSETS}
 
@@ -40,6 +42,10 @@ html_theme_options = {"docset": "api", "docsets": utils.ALL_DOCSETS}
 external_content_contents = [
     (NRF_BASE / "doc" / "api", "*"),
 ]
+
+# Options for sphinx_sitemap ---------------------------------------------------
+
+sitemap_url_scheme = "{link}"
 
 
 def setup(app):

--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -30,7 +30,7 @@ version = "&nbsp;"
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))
 
-extensions = ["zephyr.kconfig", "zephyr.external_content", "kconfigdiff"]
+extensions = ["zephyr.kconfig", "zephyr.external_content", "kconfigdiff", "sphinx_sitemap"]
 
 # Options for HTML output ------------------------------------------------------
 
@@ -40,6 +40,7 @@ html_title = project
 html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_show_sphinx = False
+html_baseurl = utils.get_baseurl("kconfig")
 
 html_theme_options = {
     "docset": "kconfig", "docsets": utils.ALL_DOCSETS,
@@ -63,6 +64,10 @@ kconfig_ext_paths = [ZEPHYR_BASE, NRF_BASE]
 kconfigdiff_should_build = False
 kconfigdiff_is_release = False
 kconfigdiff_versions = None
+
+# Options for sphinx_sitemap ---------------------------------------------------
+
+sitemap_url_scheme = "{link}"
 
 # Adding NCS_ specific entries. Can be removed when the NCSDK-14227 improvement
 # task has been completed.

--- a/doc/mcuboot/conf.py
+++ b/doc/mcuboot/conf.py
@@ -35,7 +35,8 @@ extensions = [
     "recommonmark",
     "sphinx_markdown_tables",
     "sphinxcontrib.jquery",
-    "zephyr.external_content"
+    "zephyr.external_content",
+    "sphinx_sitemap",
 ]
 source_suffix = [".rst", ".md"]
 master_doc = "wrapper"
@@ -55,6 +56,7 @@ html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_show_sphinx = False
 html_title = "MCUBoot (nRF Connect SDK)"
+html_baseurl = utils.get_baseurl("mcuboot")
 
 html_theme_options = {
     "docset": "mcuboot",
@@ -93,6 +95,10 @@ external_content_contents = [
     (MCUBOOT_BASE / "docs", "compression_format.md"),
     (MCUBOOT_BASE / "docs", "images/decomp.png"),
 ]
+
+# Options for sphinx_sitemap ---------------------------------------------------
+
+sitemap_url_scheme = "{link}"
 
 
 def setup(app):

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -59,6 +59,7 @@ extensions = [
     "sphinxcontrib.programoutput",
     "sphinxcontrib.jquery",
     "samples",
+    "sphinx_sitemap",
 ]
 
 linkcheck_ignore = [
@@ -92,6 +93,7 @@ html_static_path = [str(NRF_BASE / "doc" / "_static")]
 html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_show_sphinx = False
+html_baseurl = utils.get_baseurl("nrf")
 
 html_theme_options = {"docset": "nrf", "docsets": utils.ALL_DOCSETS, "logo_url": "https://docs.nordicsemi.com/"}
 
@@ -218,6 +220,10 @@ manifest_revisions_table_manifest = NRF_BASE / "west.yml"
 notfound_urls_prefix = "/nRF_Connect_SDK/doc/{}/nrf/".format(
     "latest" if version.endswith("99") else version
 )
+
+# Options for sphinx_sitemap ---------------------------------------------------
+
+sitemap_url_scheme = "{link}"
 
 # -- Options for zephyr.gh_utils -----------------------------------------------
 

--- a/doc/nrf/installation/recommended_versions.rst
+++ b/doc/nrf/installation/recommended_versions.rst
@@ -276,6 +276,8 @@ They can all be installed using the ``doc/requirements.txt`` file using ``pip``.
      - :ncs-tool-version:`SPHINX_NCS_THEME_VERSION`
    * - sphinx-notfound-page
      - :ncs-tool-version:`SPHINX_NOTFOUND_PAGE_VERSION`
+   * - sphinx-sitemap
+     - :ncs-tool-version:`SPHINX_SITEMAP_VERSION`
    * - sphinx-tabs
      - :ncs-tool-version:`SPHINX_TABS_VERSION`
    * - sphinx-togglebutton

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "zephyr.doxybridge",
     "zephyr.domain",
     "zephyr.gh_utils",
+    "sphinx_sitemap",
 ]
 master_doc = "README"
 
@@ -59,6 +60,7 @@ html_static_path = [str(NRF_BASE / "doc" / "_static")]
 html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_show_sphinx = False
+html_baseurl = utils.get_baseurl("nrfxlib")
 
 html_theme_options = {"docset": "nrfxlib", "docsets": utils.ALL_DOCSETS, "logo_url": "https://docs.nordicsemi.com/"}
 
@@ -114,6 +116,10 @@ external_content_contents = [(NRFXLIB_BASE, "**/*.rst"), (NRFXLIB_BASE, "**/doc/
 
 gh_link_version = "main" if version.endswith("99") else f"v{version}"
 gh_link_base_url = "https://github.com/nrfconnect/sdk-nrfxlib"
+
+# -- Options for sphinx_sitemap ------------------------------------------------
+
+sitemap_url_scheme = "{link}"
 
 
 def setup(app):

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -22,6 +22,7 @@ sphinx-autobuild                # |  X  |    X    |   X     |    X    |   X   | 
 sphinx-copybutton               # |  X  |         |         |         |       |   X   |
 sphinx-ncs-theme<2.1            # |  X  |         |         |         |       |       |
 sphinx-notfound-page>=1.0.0     # |  X  |         |         |         |       |   X   |
+sphinx-sitemap                  # |  X  |    X    |   X     |    X    |   X   |   X   |
 sphinx_markdown_tables          # |     |         |   X     |         |       |   X   |
 sphinxcontrib-mermaid           # |     |         |         |         |       |   X   |
 sphinx-tabs>=3.4                # |  X  |         |         |         |       |   X   |

--- a/doc/tfm/conf.py
+++ b/doc/tfm/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinxcontrib.plantuml",
     "sphinx_tabs.tabs",
     "zephyr.external_content",
+    "sphinx_sitemap",
 ]
 source_suffix = [".rst", ".md"]
 master_doc = "wrapper"
@@ -63,6 +64,7 @@ html_show_sourcelink = True
 html_show_sphinx = False
 html_show_copyright = False
 html_title = "Trusted Firmware-M documentation (nRF Connect SDK)"
+html_baseurl = utils.get_baseurl("tfm")
 
 html_theme_options = {
     "docset": "tfm",
@@ -95,6 +97,10 @@ external_content_contents = [
     (NRF_BASE / "doc" / "tfm", "wrapper.rst"),
     (TFM_BASE / "docs", "**/*"),
 ]
+
+# Options for sphinx_sitemap ---------------------------------------------------
+
+sitemap_url_scheme = "{link}"
 
 
 def setup(app):

--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -35,7 +35,6 @@ locals().update(conf)
 
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))
 
-extensions.remove("sphinx_sitemap")
 extensions = ["sphinx.ext.intersphinx"] + extensions
 
 # Options for HTML output ------------------------------------------------------
@@ -49,6 +48,7 @@ html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_logo = None
 html_title = "Zephyr Project documentation (nRF Connect SDK)"
+html_baseurl = utils.get_baseurl("zephyr")
 
 html_context = {
     "show_license": True,
@@ -117,6 +117,10 @@ zephyr_hw_features_vendor_filter = ["nordic"]
 
 gh_link_version = Manifest.from_topdir().get_projects(["zephyr"])[0].revision
 gh_link_base_url = "https://github.com/nrfconnect/sdk-zephyr"
+
+# -- Options for sphinx_sitemap ------------------------------------------------
+
+sitemap_url_scheme = "{link}"
 
 # pylint: enable=undefined-variable,used-before-assignment
 


### PR DESCRIPTION
Use sphinx-sitemap extension to generate a sitemap for all docsets. In a CI docbuild add a step that generates a sitemap_index.xml which links to each docsets' individual sitemap. Thanks to that all separately generated docsets will be available to any bots/tools scanning the documentation.