### PR TITLE
samples: wifi: Add raw TX aggregation support

### DIFF
--- a/samples/wifi/raw_tx_packet/Kconfig
+++ b/samples/wifi/raw_tx_packet/Kconfig
@@ -85,6 +85,24 @@ config RAW_TX_PKT_SAMPLE_QUEUE_NUM
 	  3 - Voice
 	  4 - Beacon.
 
+config RAW_TX_PKT_SAMPLE_AGGREGATION_ENABLE
+	bool "Raw packets TX aggregation"
+	default n
+	depends on NRF70_RAW_DATA_TX
+	help
+	  When enabled, sets the raw TX header aggregation field so the nRF70
+	  driver may coalesce multiple MPDUs per RAW_TX command (up to
+	  num_frames).
+
+config RAW_TX_PKT_SAMPLE_NUM_FRAMES
+	int "Number of frames to aggregate"
+	default 4
+	range 1 16
+	depends on RAW_TX_PKT_SAMPLE_AGGREGATION_ENABLE
+	help
+	  Maximum number of MPDUs to aggregate per TX command when aggregation
+	  is enabled. Must not exceed CONFIG_NRF70_MAX_TX_AGGREGATION.
+
 choice
 	prompt "Select transmission mode"
 	default RAW_TX_PKT_SAMPLE_TX_MODE_CONTINUOUS

--- a/samples/wifi/raw_tx_packet/README.rst
+++ b/samples/wifi/raw_tx_packet/README.rst
@@ -69,6 +69,8 @@ The following configuration options are available for the raw TX packet header:
 * :kconfig:option:`CONFIG_RAW_TX_PKT_SAMPLE_RATE_VALUE`: Specifies the data transmission PHY rate.
 * :kconfig:option:`CONFIG_RAW_TX_PKT_SAMPLE_RATE_FLAGS`: Specifies the data transmission mode.
 * :kconfig:option:`CONFIG_RAW_TX_PKT_SAMPLE_QUEUE_NUM`: Specifies the transmission queue to which raw TX packets are assigned for sending.
+* :kconfig:option:`CONFIG_RAW_TX_PKT_SAMPLE_AGGREGATION_ENABLE`: Enables TX aggregation in the raw TX packet header.
+* :kconfig:option:`CONFIG_RAW_TX_PKT_SAMPLE_NUM_FRAMES`: Specifies the maximum number of MPDUs to aggregate per TX command when aggregation is enabled.
 
 Additionally, you must configure the :kconfig:option:`CONFIG_RAW_TX_PKT_SAMPLE_INTER_FRAME_DELAY_MS` Kconfig option in the :file:`prj.conf` file to define the time delay between raw TX packets.
 

--- a/samples/wifi/raw_tx_packet/src/main.c
+++ b/samples/wifi/raw_tx_packet/src/main.c
@@ -35,6 +35,8 @@ LOG_MODULE_REGISTER(raw_tx_packet, CONFIG_LOG_DEFAULT_LEVEL);
 #define IEEE80211_SEQ_CTRL_SEQ_NUM_MASK 0xFFF0
 #define IEEE80211_SEQ_NUMBER_INC BIT(4) /* 0-3 is fragment number */
 #define NRF_WIFI_MAGIC_NUM_RAWTX 0x12345678
+#define AGGR_DISABLE 0
+#define AGGR_ENABLE  1
 
 static struct net_mgmt_event_callback net_iface_mgmt_cb;
 K_SEM_DEFINE(wait_for_oper_up, 0, 1);
@@ -91,7 +93,9 @@ struct raw_tx_pkt_header {
 	unsigned short packet_length;
 	unsigned char tx_mode;
 	unsigned char queue;
-	unsigned char reserved[3];
+	unsigned char aggregation;
+	unsigned char num_frames;
+	unsigned char reserved;
 } __packed;
 
 #ifdef CONFIG_RAW_TX_PKT_SAMPLE_NON_CONNECTED_MODE
@@ -312,8 +316,15 @@ static void fill_raw_tx_pkt_hdr(struct raw_tx_pkt_header *raw_tx_pkt)
 	raw_tx_pkt->packet_length = calculate_beacon_frame_length(&test_beacon_frame);
 	raw_tx_pkt->tx_mode = CONFIG_RAW_TX_PKT_SAMPLE_RATE_FLAGS;
 	raw_tx_pkt->queue = CONFIG_RAW_TX_PKT_SAMPLE_QUEUE_NUM;
-	/* The byte is reserved and used by the driver */
-	memset(raw_tx_pkt->reserved, 0, sizeof(raw_tx_pkt->reserved));
+#if defined(CONFIG_RAW_TX_PKT_SAMPLE_AGGREGATION_ENABLE)
+	raw_tx_pkt->aggregation = AGGR_ENABLE;
+	raw_tx_pkt->num_frames = CONFIG_RAW_TX_PKT_SAMPLE_NUM_FRAMES;
+#else
+	/* nRF71 ignores bytes 9-11 (driver reserved[]); keep disabled. */
+	raw_tx_pkt->aggregation = AGGR_DISABLE;
+	raw_tx_pkt->num_frames = 1;
+#endif
+	raw_tx_pkt->reserved = 0;
 }
 
 int wifi_send_raw_tx_pkt(int sockfd, char *test_frame,
@@ -370,6 +381,10 @@ static void wifi_send_raw_tx_packets(void)
 	}
 
 	fill_raw_tx_pkt_hdr(&packet);
+
+	LOG_INF("Raw TX header: aggregation=%u num_frames=%u inter_frame_delay=%d ms",
+		packet.aggregation, packet.num_frames,
+		CONFIG_RAW_TX_PKT_SAMPLE_INTER_FRAME_DELAY_MS);
 
 	ret = get_pkt_transmit_count(&transmission_mode, &num_pkts);
 	if (ret < 0) {

--- a/samples/wifi/shell/src/wifi_raw_tx_pkt_shell.c
+++ b/samples/wifi/shell/src/wifi_raw_tx_pkt_shell.c
@@ -22,6 +22,9 @@ LOG_MODULE_REGISTER(raw_tx_pkt, CONFIG_LOG_DEFAULT_LEVEL);
 #define IEEE80211_SEQ_CTRL_SEQ_NUM_MASK 0xFFF0
 #define IEEE80211_SEQ_NUMBER_INC BIT(4) /* 0-3 is fragment number */
 #define NRF_WIFI_MAGIC_NUM_RAWTX 0x12345678
+#define AGGR_DISABLE 0
+#define AGGR_ENABLE  1
+#define RAW_TX_MAX_AGG_FRAMES 16
 
 /* TODO: Copied from nRF70 Wi-Fi driver, need to be moved to a common place */
 
@@ -52,7 +55,9 @@ struct raw_tx_pkt_header {
 	unsigned short packet_length;
 	unsigned char tx_mode;
 	unsigned char queue;
-	unsigned char reserved[3];
+	unsigned char aggregation;
+	unsigned char num_frames;
+	unsigned char reserved;
 } __packed;
 
 struct raw_tx_pkt_header raw_tx_pkt;
@@ -101,14 +106,17 @@ static struct beacon test_beacon_frame = {
 	}
 };
 
-void fill_raw_tx_pkt_hdr(int rate_flags, int data_rate, int queue_num)
+void fill_raw_tx_pkt_hdr(int rate_flags, int data_rate, int queue_num,
+			 int aggregation, int num_frames)
 {
 	raw_tx_pkt.magic_num = NRF_WIFI_MAGIC_NUM_RAWTX;
 	raw_tx_pkt.data_rate = data_rate;
 	raw_tx_pkt.packet_length = sizeof(test_beacon_frame);
 	raw_tx_pkt.tx_mode = rate_flags;
 	raw_tx_pkt.queue = queue_num;
-	memset(raw_tx_pkt.reserved, 0, sizeof(raw_tx_pkt.reserved));
+	raw_tx_pkt.aggregation = (unsigned char)aggregation;
+	raw_tx_pkt.num_frames = (unsigned char)num_frames;
+	raw_tx_pkt.reserved = 0;
 }
 
 int validate(int value, int min, int max, const char *param)
@@ -235,7 +243,8 @@ static void send_packet(const char *transmission_mode,
 static int parse_raw_tx_configure_args(const struct shell *sh,
 				       size_t argc,
 				       char *argv[],
-				       int *flags, int *rate, int *queue)
+				       int *flags, int *rate, int *queue,
+				       int *aggregation, int *num_frames)
 {
 	struct sys_getopt_state *state;
 	int opt;
@@ -243,12 +252,22 @@ static int parse_raw_tx_configure_args(const struct shell *sh,
 		{"rate-flags", sys_getopt_required_argument, 0, 'f'},
 		{"data-rate", sys_getopt_required_argument, 0, 'd'},
 		{"queue-number", sys_getopt_required_argument, 0, 'q'},
+#ifdef CONFIG_NRF70_RAW_DATA_TX
+		{"aggregation", sys_getopt_required_argument, 0, 'g'},
+		{"num-frames", sys_getopt_required_argument, 0, 'F'},
+#endif
 		{"help", sys_getopt_no_argument, 0, 'h'},
 		{0, 0, 0, 0}};
 	int opt_index = 0;
 	int opt_num = 0;
 
-	while ((opt = sys_getopt_long(argc, argv, "f:d:q:h", long_options, &opt_index)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv,
+#ifdef CONFIG_NRF70_RAW_DATA_TX
+				     "f:d:q:g:F:h",
+#else
+				     "f:d:q:h",
+#endif
+				     long_options, &opt_index)) != -1) {
 		state = sys_getopt_state_get();
 		switch (opt) {
 		case 'f':
@@ -273,6 +292,22 @@ static int parse_raw_tx_configure_args(const struct shell *sh,
 			}
 			opt_num++;
 			break;
+#ifdef CONFIG_NRF70_RAW_DATA_TX
+		case 'g':
+			*aggregation = atoi(state->optarg);
+			if (!validate(*aggregation, AGGR_DISABLE, AGGR_ENABLE, "Aggregation")) {
+				return -ENOEXEC;
+			}
+			opt_num++;
+			break;
+		case 'F':
+			*num_frames = atoi(state->optarg);
+			if (!validate(*num_frames, 1, RAW_TX_MAX_AGG_FRAMES, "Num Frames")) {
+				return -ENOEXEC;
+			}
+			opt_num++;
+			break;
+#endif
 		case'h':
 			shell_help(sh);
 			opt_num++;
@@ -293,11 +328,17 @@ static int cmd_configure_raw_tx_pkt(
 		size_t argc,
 		char *argv[])
 {
-	int opt_num, rate_flags = -1, data_rate = -1, queue_num = -1;
+	int opt_num;
+	int rate_flags = raw_tx_pkt.tx_mode;
+	int data_rate = raw_tx_pkt.data_rate;
+	int queue_num = raw_tx_pkt.queue;
+	int aggregation = raw_tx_pkt.aggregation;
+	int num_frames = raw_tx_pkt.num_frames;
 
-	if (argc == 7) {
+	if (argc > 1) {
 		opt_num = parse_raw_tx_configure_args(sh, argc, argv, &rate_flags,
-						      &data_rate, &queue_num);
+						      &data_rate, &queue_num,
+						      &aggregation, &num_frames);
 		if (opt_num < 0) {
 			shell_help(sh);
 			return -ENOEXEC;
@@ -307,10 +348,26 @@ static int cmd_configure_raw_tx_pkt(
 		}
 	}
 
+#ifndef CONFIG_NRF70_RAW_DATA_TX
+	aggregation = AGGR_DISABLE;
+	num_frames = 1;
+#else
+	if (aggregation == AGGR_DISABLE) {
+		num_frames = 1;
+	} else if (num_frames < 1) {
+		num_frames = 4;
+	}
+#endif
+
+#ifdef CONFIG_NRF70_RAW_DATA_TX
+	LOG_INF("Rate-flags: %d Data-rate:%d queue-num:%d aggregation:%d num-frames:%d",
+		rate_flags, data_rate, queue_num, aggregation, num_frames);
+#else
 	LOG_INF("Rate-flags: %d Data-rate:%d queue-num:%d",
 		rate_flags, data_rate, queue_num);
+#endif
 
-	fill_raw_tx_pkt_hdr(rate_flags, data_rate, queue_num);
+	fill_raw_tx_pkt_hdr(rate_flags, data_rate, queue_num, aggregation, num_frames);
 
 	return 0;
 }
@@ -462,10 +519,18 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "[-f, --rate-flags] : Rate flag value.\n"
 		      "[-d, --data-rate] : Data rate value.\n"
 		      "[-q, --queue-number] : Queue number.\n"
+#ifdef CONFIG_NRF70_RAW_DATA_TX
+		      "[-g, --aggregation] : Aggregation (0=disable, 1=enable, nRF70 only).\n"
+		      "[-F, --num-frames] : MPDUs to aggregate when enabled (1-16, nRF70 only).\n"
+#endif
 		      "[-h, --help] : Print out the help for the configure command\n"
-		      "Usage: raw_tx configure -f 0 -d 9 -q 1\n",
+		      "Usage: raw_tx configure -f 1 -d 7 -q 1"
+#ifdef CONFIG_NRF70_RAW_DATA_TX
+		      " -g 1 -F 4"
+#endif
+		      "\n",
 		      cmd_configure_raw_tx_pkt,
-		      7, 0),
+		      1, 10),
 	SHELL_CMD_ARG(send, NULL,
 		      "Send raw TX packet\n"
 		      "This command may be used to send raw TX packets\n"


### PR DESCRIPTION
Extend the raw_tx_pkt_header in the raw_tx_packet sample and Wi-Fi shell with aggregation and num_frames fields so they match the nRF70 driver layout and per-packet batching support. Add Kconfig options to enable aggregation and set the frame count.