### PR TITLE
samples: pulse_meas: needs fixture

### DIFF
--- a/samples/pulse_meas/tests.yaml
+++ b/samples/pulse_meas/tests.yaml
@@ -11,6 +11,7 @@ common:
     - nrf54h20dk/nrf54h20/cpuapp
   harness: console
   harness_config:
+    fixture: gpio_loopback
     type: one_line
     regex:
       - "Measurement finished (.*)"


### PR DESCRIPTION
Loopback is needed.