### PR TITLE
samples/dfu/mcuboot_with_encryption: add nrf54ls05dk/nrf54ls05b/cpuapp

### DIFF
--- a/samples/dfu/mcuboot_with_encryption/boards/nrf54ls05dk_nrf54ls05b_cpuapp.conf
+++ b/samples/dfu/mcuboot_with_encryption/boards/nrf54ls05dk_nrf54ls05b_cpuapp.conf
@@ -1,0 +1,20 @@
+# Cutting down some of the features to fit onto the platform.
+CONFIG_STATS=n
+CONFIG_STATS_NAMES=n
+
+# Disable the LittleFS file system.
+CONFIG_FILE_SYSTEM=n
+CONFIG_FILE_SYSTEM_LITTLEFS=n
+
+# Disable file system commands
+CONFIG_MCUMGR_GRP_FS=n
+
+# Disable shell commands that are not needed
+CONFIG_CLOCK_CONTROL_NRF_SHELL=n
+CONFIG_DEVICE_SHELL=n
+CONFIG_DEVMEM_SHELL=n
+CONFIG_FLASH_SHELL=n
+
+CONFIG_MCUMGR_GRP_OS_TASKSTAT=n
+
+CONFIG_LOG_MODE_MINIMAL=y

--- a/samples/dfu/mcuboot_with_encryption/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
+++ b/samples/dfu/mcuboot_with_encryption/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+&cpuapp_rram {
+	partitions {
+		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(84)>;
+		};
+
+		slot0_partition: partition@15000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x15000 DT_SIZE_K(180)>;
+		};
+
+		slot1_partition: partition@42000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
+			reg = <0x42000 DT_SIZE_K(180)>;
+		};
+
+		storage_partition: partition@6f000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x6f000 DT_SIZE_K(64)>;
+		};
+	};
+};

--- a/samples/dfu/mcuboot_with_encryption/sysbuild/mcuboot/boards/nrf54ls05dk_nrf54ls05b_cpuapp.conf
+++ b/samples/dfu/mcuboot_with_encryption/sysbuild/mcuboot/boards/nrf54ls05dk_nrf54ls05b_cpuapp.conf
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SPI_NOR=n
+CONFIG_SPI=n
+CONFIG_FPROTECT=n
+CONFIG_FAULT_DUMP=0
+CONFIG_ARM_MPU=n
+
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+CONFIG_LTO=y

--- a/samples/dfu/mcuboot_with_encryption/sysbuild/mcuboot/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
+++ b/samples/dfu/mcuboot_with_encryption/sysbuild/mcuboot/boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "../../../boards/nrf54ls05dk_nrf54ls05b_cpuapp.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -145,10 +145,3 @@
   platforms:
     - nrf9151dk/nrf9151/ns
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-41027"
-
-- scenarios:
-    - sample.mcuboot_with_encryption.nrf54ls05a
-    - sample.mcuboot_with_encryption.nrf54ls05a.psa
-  platforms:
-    - nrf54ls05dk@0.2.0/nrf54ls05b/cpuapp
-  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-41028"


### PR DESCRIPTION
Add missing devicetree overlays and Kconfig fragments for the target.

ref.: NCSDK-41028