### PR TITLE
lib: nrf_modem_lib: release socket context if close fails with EBADF

### DIFF
--- a/lib/nrf_modem_lib/nrf9x_sockets.c
+++ b/lib/nrf_modem_lib/nrf9x_sockets.c
@@ -1104,7 +1104,9 @@ static int nrf9x_socket_offload_close(void *obj)
 	int retval;
 
 	retval = nrf_close(ctx->nrf_fd);
-	if (retval == 0) {
+
+	/* Do not keep the context if the library is no longer aware of the fd. */
+	if ((retval == 0) || (errno == EBADF)) {
 		release_ctx(ctx);
 	}
 


### PR DESCRIPTION
Do not keep the socket context if close() fails due to the nRF Modem Library not recognizing the descriptor, otherwise the offloaded context will never get cleaned up. This could happen for example if the modem was shut down and close() was not invoked beforehand.