### PR TITLE
Manual backport v3.3: nrf_security: CRACEN: Fix the PKE data memory clear

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/baremetal_ba414e_with_ik/pk_baremetal.c
@@ -326,6 +326,14 @@ int sx_pk_clear_memory(sx_pk_req *req)
 	if (!IS_ENABLED(CONFIG_CRACEN_HW_VERSION_BASE)) {
 		sx_pk_set_cmd(req, SX_PK_CMD_CLEAR_MEMORY);
 
+		/* The clear operation has no operands, so it does not go through
+		 * the input slot setup that normally programs the command
+		 * register. Write it here, with an operand size of 1 and no
+		 * flags, so that neither the operand size nor the flags of the
+		 * previous operation are reused.
+		 */
+		sx_pk_write_command(req, 1, 0);
+
 		sx_pk_run(req);
 
 		return sx_pk_wait(req);

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/pkhardware_ba414e.c
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/pkhardware_ba414e.c
@@ -125,7 +125,7 @@ static int sx_pk_ik_mode(sx_pk_req *pk)
 	return pk->ik_mode;
 }
 
-static void write_command(sx_pk_req *req, int op_size, uint32_t flags)
+void sx_pk_write_command(sx_pk_req *req, int op_size, uint32_t flags)
 {
 	uint32_t command = sx_pk_get_cmd(req)->cmdcode | ((op_size - 1) << 8) | flags;
 
@@ -198,7 +198,7 @@ int sx_pk_list_ecc_inslots(sx_pk_req *req, const struct sx_pk_ecurve *curve, int
 	if (cmd->blind_flags) {
 		flags |= cmd->blind_flags;
 	}
-	write_command(req, curve->sz, curve->curveflags | flags);
+	sx_pk_write_command(req, curve->sz, curve->curveflags | flags);
 	if (cmd->cmdcode & SX_PK_OP_FLAGS_BIGENDIAN) {
 		/* In big endian mode, the operands should be put at the end
 		 * of the slot.
@@ -265,7 +265,7 @@ int sx_pk_list_gfp_inslots(sx_pk_req *req, const int *opsizes, struct sx_pk_slot
 	if (cmd->blind_flags) {
 		flags |= cmd->blind_flags;
 	}
-	write_command(req, req->op_size, flags);
+	sx_pk_write_command(req, req->op_size, flags);
 	if (cmd->cmdcode & SX_PK_OP_FLAGS_BIGENDIAN) {
 		/* In big endian mode, the operands should be put at the end
 		 * of the slot.

--- a/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/pkhardware_ba414e.h
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/target/hw/ba414/pkhardware_ba414e.h
@@ -19,6 +19,18 @@ struct sx_pk_cmd_def {
 	uint32_t blind_flags;
 };
 
+/** Program the command register of an acceleration request.
+ *
+ * Operations that list their input slots do this as part of the slot setup.
+ * Operations without operands must call this themselves, otherwise the
+ * hardware reruns whatever command is still latched in the register.
+ *
+ * @param[in,out] req The acceleration request.
+ * @param op_size Operand size in bytes. Use 1 for operations without operands.
+ * @param flags Command flags to write in addition to the command code.
+ */
+void sx_pk_write_command(sx_pk_req *req, int op_size, uint32_t flags);
+
 void sx_pk_write_curve(sx_pk_req *pk, const struct sx_pk_ecurve *curve);
 
 int sx_pk_count_curve_params(const struct sx_pk_ecurve *curve);


### PR DESCRIPTION
sx_pk_clear_memory() set the command pointer and started the PKE without programming PK_REG_COMMAND. That register is only written by write_command(), which runs as part of the input slot setup, so at release time it still held the operation that had just finished and the hardware re-executed that operation instead of clearing the memory. The PKE data memory was therefore never cleared, and the extra run doubled the runtime of the public key operations whose last command is the expensive one. On nRF54LM20A an Ed25519 psa_verify_message() took 24.7 ms instead of 12.5 ms.

Export write_command() as sx_pk_write_command() and call it from sx_pk_clear_memory() with an operand size of 1 and no flags, so that the clear is issued as its own command and does not inherit the operand size or the flags of the previous operation. The clear then costs around 100 us per public key operation.

The original commit also added CRACEN_CLEAR_PKE_MEMORY so that the clear can be disabled. That option is left out of this backport to avoid introducing a new Kconfig symbol on a release branch. The clear stays unconditional on devices that are not CRACEN_HW_VERSION_BASE, which is the behaviour this branch already had. Manual backport as automatic backport failed due to collisions

Ref: NCSDK-36624

(cherry picked from commit d7814cee5da76784e106ad53b49144e1dce21ad2)