### PR TITLE
[Backport v3.4-branch] samples: esb: Add nRF54LC10 non-secure target to remaining samples

### DIFF
--- a/samples/esb/esb_monitor/sample.yaml
+++ b/samples/esb/esb_monitor/sample.yaml
@@ -37,6 +37,7 @@ tests:
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp/ns
     tags:
       - esb
       - samples
@@ -70,6 +71,7 @@ tests:
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp/ns
     tags:
       - esb
       - ci_build

--- a/samples/esb/esb_prx_ble/sample.yaml
+++ b/samples/esb/esb_prx_ble/sample.yaml
@@ -42,6 +42,7 @@ tests:
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
     tags:
       - esb

--- a/samples/esb/esb_ptx_ble/sample.yaml
+++ b/samples/esb/esb_ptx_ble/sample.yaml
@@ -41,6 +41,7 @@ tests:
       - nrf54ls05dk/nrf54ls05a/cpuapp
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp/ns
       - nrf54lv10dk/nrf54lv10a/cpuapp
     tags:
       - esb


### PR DESCRIPTION
Backport https://github.com/nrfconnect/sdk-nrf/commit/7bb9eb19aeb7979d5aa0a291c402bc2a16499b0c from https://github.com/nrfconnect/sdk-nrf/pull/30893.