### PR TITLE
samples: fast_pair: locator_tag: recalibrate TX power for nRF54LM20 DK

### DIFF
--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
@@ -4,5 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Align the TX power encoded in the Fast Pair advertising set and
+# the Read Beacon Parameters response with Fast Pair expectations.
+CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-2
+CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-2
+
 # Enable code partitioning with DTS
 CONFIG_USE_DT_CODE_PARTITION=y

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
@@ -4,5 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Align the TX power encoded in the Fast Pair advertising set and
+# the Read Beacon Parameters response with Fast Pair expectations.
+CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-2
+CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-2
+
 # Enable code partitioning with DTS
 CONFIG_USE_DT_CODE_PARTITION=y

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/prj.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/prj.conf
@@ -98,11 +98,10 @@ CONFIG_BT_DIS_PNP=n
 
 # Align the TX power encoded in the Fast Pair advertising set and
 # the Read Beacon Parameters response with Fast Pair expectations.
-# The value has been tailored for following DKs:
-#   * nrf54lm20dk/nrf54lm20a/cpuapp
-#   * nrf54lm20dk/nrf54lm20b/cpuapp
-CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
-CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-15
+# The correction values are hardware-specific. Set the
+# CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL and
+# CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL Kconfig options in the
+# dedicated board configuration file in the configuration/boards directory.
 
 # Fast Pair use case configuration
 # Enable the FHN Kconfig options explicitly to avoid the deprecated FMDN Kconfig options.

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/prj_release.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/prj_release.conf
@@ -104,11 +104,10 @@ CONFIG_BT_DIS_PNP=n
 
 # Align the TX power encoded in the Fast Pair advertising set and
 # the Read Beacon Parameters response with Fast Pair expectations.
-# The value has been tailored for following DKs:
-#   * nrf54lm20dk/nrf54lm20a/cpuapp
-#   * nrf54lm20dk/nrf54lm20b/cpuapp
-CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
-CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-15
+# The correction values are hardware-specific. Set the
+# CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL and
+# CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL Kconfig options in the
+# dedicated board configuration file in the configuration/boards directory.
 
 # Fast Pair use case configuration
 # Enable the FHN Kconfig options explicitly to avoid the deprecated FMDN Kconfig options.


### PR DESCRIPTION
## Summary

Recalibrates the declared TX power for the nRF54LM20 DK board targets (`nrf54lm20dk/nrf54lm20a/cpuapp` and `nrf54lm20dk/nrf54lm20b/cpuapp`) in the Fast Pair Locator Tag sample.

- Changes `CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` and `CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL` from `-15` dBm to `-2` dBm.
- Relocates both Kconfig options out of the sample-wide `configuration/prj.conf` and `configuration/prj_release.conf` into the dedicated board configuration files `configuration/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf` and `configuration/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf`.

The previous value over-reported the signal strength, which caused the pairing notification appearance rate at 1.2 m to exceed the 20% limit defined by the [Fast Pair distance certification specification](https://developers.google.com/nearby/fast-pair/fast-pair-certification-guideline#24_certification_specification_for_distance).

### Configuration reorganization

The TX power correction is hardware-specific, so it does not belong in the sample-wide configuration files. Before this change, the nRF54LM20 DK was the only supported DK without its own entry in `configuration/boards` and relied on the sample-wide value instead, which every other board target already overrode.

After this change, every board target of the sample declares its own calibration in `configuration/boards`, and the sample-wide files keep only a comment pointing there. Both Kconfig options default to `0`, so a newly added board target that forgets to set them now produces an obviously uncalibrated result instead of silently inheriting a value tailored for a different DK.

A single board configuration file covers both the default and the release build, because Zephyr's file-suffix lookup falls back to `boards/<board_target>.conf` when no `_release` variant exists.

### Known limitation

The `-2` dBm value was selected with the currently agreed calibration methodology, which sweeps all four edges of every reference phone. With this value, Pixel 8 in the top-edge orientation still shows the pairing notification at 1.2 m. Raising the value further is not an option under that methodology, because `-1` dBm and `0` dBm break the 0.3 m requirement for Pixel 10 (left-edge orientation) and Pixel 6a (bottom-edge orientation). A change to the calibration methodology is under discussion, and adopting it would move the value for this DK to roughly `+1` dBm.

Ref: NCSDK-39912

## Test plan

- [x] Build the sample for `nrf54lm20dk/nrf54lm20a/cpuapp` and `nrf54lm20dk/nrf54lm20b/cpuapp`, in the default configuration and with `FILE_SUFFIX=release`, and confirm that both Kconfig options resolve to `-2` in the generated configuration (4 builds).
- [x] Build for `nrf54l15tag/nrf54l15/cpuapp` with `FILE_SUFFIX=release` and confirm it still resolves to `-11`, exercising the board `_release.conf` path that is unaffected by this change.
- [x] Confirm that all nine supported board targets set both Kconfig options explicitly, in both the default and the release build, so that no target falls back to the Kconfig default of `0` now that the sample-wide values are gone.
- [x] Run the Fast Pair distance certification test at 0.3 m, 1.2 m and 2 m with the Pixel 6a, Pixel 8 and Pixel 10 reference phones, and verify that `-2` dBm is the best value available under the current calibration methodology (see the known limitation above).

## Notes for reviewers

- The changelog entry is intentionally omitted here and will be added in a dedicated pull request.
- The issue was reported against `v3.4.0-rc1`, so a backport to the `v3.4-branch` may be wanted.
- The equivalent recalibration for the Switchable Networks sample is in nrfconnect/sdk-find-my#462.