### PR TITLE
[Backport v3.4-branch] lib: nrf_modem_lib: release socket context if close fails with EBADF

### DIFF
--- a/lib/nrf_modem_lib/nrf9x_sockets.c
+++ b/lib/nrf_modem_lib/nrf9x_sockets.c
@@ -1104,7 +1104,9 @@ static int nrf9x_socket_offload_close(void *obj)
 	int retval;
 
 	retval = nrf_close(ctx->nrf_fd);
-	if (retval == 0) {
+
+	/* Do not keep the context if the library is no longer aware of the fd. */
+	if ((retval == 0) || (errno == EBADF)) {
 		release_ctx(ctx);
 	}
 


### PR DESCRIPTION
Backport 94a000a1588b57537962c93c8be4c8b735264e43 from #30968.