### PR TITLE
[Backport v3.4-branch] samples: fast_pair: locator_tag: recalibrate TX power for nRF54LM20 DK

### DIFF
--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf52833dk_nrf52833.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf52833dk_nrf52833.conf
@@ -4,5 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Align the TX power encoded in the Fast Pair advertising set and
+# the Read Beacon Parameters response with Fast Pair expectations.
+CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
+CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-15
+
 # Enable code partitioning with DTS
 CONFIG_USE_DT_CODE_PARTITION=y

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf52840dk_nrf52840.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf52840dk_nrf52840.conf
@@ -4,5 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Align the TX power encoded in the Fast Pair advertising set and
+# the Read Beacon Parameters response with Fast Pair expectations.
+CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
+CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-15
+
 # Enable code partitioning with DTS
 CONFIG_USE_DT_CODE_PARTITION=y

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf52dk_nrf52832.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf52dk_nrf52832.conf
@@ -4,5 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Align the TX power encoded in the Fast Pair advertising set and
+# the Read Beacon Parameters response with Fast Pair expectations.
+CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
+CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-15
+
 # Enable code partitioning with DTS
 CONFIG_USE_DT_CODE_PARTITION=y

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -6,8 +6,5 @@
 
 # Align the TX power encoded in the Fast Pair advertising set and
 # the Read Beacon Parameters response with Fast Pair expectations.
-CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-2
-CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-2
-
-# Enable code partitioning with DTS
-CONFIG_USE_DT_CODE_PARTITION=y
+CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
+CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-15

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -4,6 +4,11 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Align the TX power encoded in the Fast Pair advertising set and
+# the Read Beacon Parameters response with Fast Pair expectations.
+CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
+CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-15
+
 # TF-M profile has to be properly configured to be able to run
 # the Bluetooth stack which uses PSA crypto API.
 # The following configuration is a minimal set of options required.

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf5340dk_nrf5340_cpuapp_ns_release.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf5340dk_nrf5340_cpuapp_ns_release.conf
@@ -4,6 +4,11 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Align the TX power encoded in the Fast Pair advertising set and
+# the Read Beacon Parameters response with Fast Pair expectations.
+CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
+CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-15
+
 # TF-M profile has to be properly configured to be able to run
 # the Bluetooth stack which uses PSA crypto API.
 # The following configuration is a minimal set of options required.

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
@@ -4,5 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Align the TX power encoded in the Fast Pair advertising set and
+# the Read Beacon Parameters response with Fast Pair expectations.
+CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-2
+CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-2
+
 # Enable code partitioning with DTS
 CONFIG_USE_DT_CODE_PARTITION=y

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/prj.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/prj.conf
@@ -98,15 +98,10 @@ CONFIG_BT_DIS_PNP=n
 
 # Align the TX power encoded in the Fast Pair advertising set and
 # the Read Beacon Parameters response with Fast Pair expectations.
-# The value has been tailored for following DKs:
-#   * nrf52dk/nrf52832
-#   * nrf52833dk/nrf52833
-#   * nrf52840dk/nrf52840
-#   * nrf5340dk/nrf5340/cpuapp(/ns)
-#   * nrf54lm20dk/nrf54lm20a/cpuapp
-#   * nrf54lm20dk/nrf54lm20b/cpuapp
-CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
-CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-15
+# The correction values are hardware-specific. Set the
+# CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL and
+# CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL Kconfig options in the
+# dedicated board configuration file in the configuration/boards directory.
 
 # Fast Pair use case configuration
 # Enable the FHN Kconfig options explicitly to avoid the deprecated FMDN Kconfig options.

--- a/samples/bluetooth/fast_pair/locator_tag/configuration/prj_release.conf
+++ b/samples/bluetooth/fast_pair/locator_tag/configuration/prj_release.conf
@@ -104,15 +104,10 @@ CONFIG_BT_DIS_PNP=n
 
 # Align the TX power encoded in the Fast Pair advertising set and
 # the Read Beacon Parameters response with Fast Pair expectations.
-# The value has been tailored for following DKs:
-#   * nrf52dk/nrf52832
-#   * nrf52833dk/nrf52833
-#   * nrf52840dk/nrf52840
-#   * nrf5340dk/nrf5340/cpuapp(/ns)
-#   * nrf54lm20dk/nrf54lm20a/cpuapp
-#   * nrf54lm20dk/nrf54lm20b/cpuapp
-CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL=-15
-CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL=-15
+# The correction values are hardware-specific. Set the
+# CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL and
+# CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL Kconfig options in the
+# dedicated board configuration file in the configuration/boards directory.
 
 # Fast Pair use case configuration
 # Enable the FHN Kconfig options explicitly to avoid the deprecated FMDN Kconfig options.


### PR DESCRIPTION
## Summary

Manual backport of #30985 (merged to `main` as 3d3c6b0858bfcff0c533581daf633dbd47666522) to the `v3.4-branch`. The issue was reported against `v3.4.0-rc1`.

Recalibrates the declared TX power for the nRF54LM20 DK board targets (`nrf54lm20dk/nrf54lm20a/cpuapp` and `nrf54lm20dk/nrf54lm20b/cpuapp`) in the Fast Pair Locator Tag sample.

- Changes `CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` and `CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL` from `-15` dBm to `-2` dBm.
- Relocates both Kconfig options out of the sample-wide `configuration/prj.conf` and `configuration/prj_release.conf` into the dedicated board configuration files under `configuration/boards`.

The previous value over-reported the signal strength, which caused the pairing notification appearance rate at 1.2 m to exceed the 20% limit defined by the [Fast Pair distance certification specification](https://developers.google.com/nearby/fast-pair/fast-pair-certification-guideline#24_certification_specification_for_distance).

Ref: NCSDK-39912

## Why this is a manual backport

The diff is wider than the 4-file change on `main` (10 files here). On `main`, the sample-wide `-15` dBm value was used only by the two nRF54LM20 DK board targets, so relocating it into their board configuration files was enough.

On this branch the same sample-wide value is also the effective calibration for the nRF52 and nRF53 board targets, which are no longer supported on `main`. Both Kconfig options default to `0`, so simply deleting the sample-wide values would have silently dropped those targets to an uncalibrated TX power. This backport therefore also moves `-15` dBm into their own board configuration files, leaving their effective value unchanged:

| Board target | Board configuration file | Value |
|---|---|---|
| `nrf52dk/nrf52832` | `nrf52dk_nrf52832.conf` | `-15` |
| `nrf52833dk/nrf52833` | `nrf52833dk_nrf52833.conf` | `-15` |
| `nrf52840dk/nrf52840` | `nrf52840dk_nrf52840.conf` | `-15` |
| `nrf5340dk/nrf5340/cpuapp` | `nrf5340dk_nrf5340_cpuapp.conf` (**new file**) | `-15` |
| `nrf5340dk/nrf5340/cpuapp/ns` | `nrf5340dk_nrf5340_cpuapp_ns.conf` + `nrf5340dk_nrf5340_cpuapp_ns_release.conf` | `-15` |
| `nrf54lm20dk/nrf54lm20a/cpuapp` | `nrf54lm20dk_nrf54lm20a_cpuapp.conf` | `-2` (recalibrated) |
| `nrf54lm20dk/nrf54lm20b/cpuapp` | `nrf54lm20dk_nrf54lm20b_cpuapp.conf` | `-2` (recalibrated) |

Two details are worth pointing out for review:

- `nrf5340dk/nrf5340/cpuapp` had no board configuration file at all in `configuration/boards`, only a devicetree overlay, so a new `.conf` file is added for it. A single file covers both the default and the release build, because Zephyr's file-suffix lookup falls back to `boards/<board_target>.conf` when no `_release` variant exists.
- `nrf5340dk/nrf5340/cpuapp/ns` needs the value in two files. `zephyr_file_suffix()` makes `nrf5340dk_nrf5340_cpuapp_ns_release.conf` *replace* `nrf5340dk_nrf5340_cpuapp_ns.conf` for release builds rather than supplement it, so setting it in only one of them would leave the other build type uncalibrated.

## Configuration reorganization

The TX power correction is hardware-specific, so it does not belong in the sample-wide configuration files. After this change every board target of the sample declares its own calibration in `configuration/boards`, and the sample-wide files keep only a comment pointing there. A newly added board target that forgets to set the options now produces an obviously uncalibrated result instead of silently inheriting a value tailored for a different DK.

## Known limitation

The `-2` dBm value was selected with the currently agreed calibration methodology, which sweeps all four edges of every reference phone. With this value, Pixel 8 in the top-edge orientation still shows the pairing notification at 1.2 m. Raising the value further is not an option under that methodology, because `-1` dBm and `0` dBm break the 0.3 m requirement for Pixel 10 (left-edge orientation) and Pixel 6a (bottom-edge orientation). A change to the calibration methodology is under discussion, and adopting it would move the value for this DK to roughly `+1` dBm.

## Test plan

- [x] Resolve the effective values of both Kconfig options for all 16 supported board targets in both the default and the release build (32 combinations), replicating Zephyr's `zephyr_build_string()` and `zephyr_file_suffix()` lookup, and diff the result against the pristine `v3.4-branch`. Outcome: 28 combinations unchanged, and exactly 4 changed (nRF54LM20A and nRF54LM20B, default and release, `-15` -> `-2`). No target falls back to the Kconfig default of `0`.
- [x] Confirm the resolution above against real sysbuild builds, checking the generated `zephyr/.config` of the application image (8 builds, all matching):
  - `nrf5340dk/nrf5340/cpuapp`, default and `FILE_SUFFIX=release` -> `-15` (exercises the new board configuration file in both build types)
  - `nrf5340dk/nrf5340/cpuapp/ns` with `FILE_SUFFIX=release` -> `-15` (exercises the `_ns_release.conf` replacement path)
  - `nrf52dk/nrf52832` with `FILE_SUFFIX=release` -> `-15` (exercises the fallback to `.conf` when no `_release.conf` exists)
  - `nrf52840dk/nrf52840`, default -> `-15`
  - `nrf54lm20dk/nrf54lm20a/cpuapp` with `FILE_SUFFIX=release` -> `-2`
  - `nrf54lm20dk/nrf54lm20b/cpuapp`, default -> `-2`
  - `nrf54l15dk/nrf54l15/cpuapp`, default -> `-11` (unaffected target, confirms removing the sample-wide values changes nothing for it)
- [x] Run the Fast Pair distance certification test at 0.3 m, 1.2 m and 2 m with the Pixel 6a, Pixel 8 and Pixel 10 reference phones, and verify that `-2` dBm is the best value available under the current calibration methodology (see the known limitation above).

## Notes for reviewers

- The changelog entry is intentionally omitted, matching #30985.
- The branch is based on e51358efc9d801e4f441ba9ad2f393045175476d rather than the current `v3.4-branch` tip. That tip is an sdk-nrfxlib manifest bump, and rebasing onto it would have desynced the local west workspace from the checked-out nrfxlib revision used for the verification builds. The base is an ancestor of the tip, so this merges cleanly.
- The equivalent recalibration for the Switchable Networks sample is in nrfconnect/sdk-find-my#462.