### PR TITLE
samples: crypto: remove include of <psa/crypto_extra.h>

### DIFF
--- a/samples/crypto/aes_cbc/src/main.c
+++ b/samples/crypto/aes_cbc/src/main.c
@@ -9,7 +9,6 @@
 #include <zephyr/logging/log.h>
 #include <stdio.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM
 #include <tfm_ns_interface.h>

--- a/samples/crypto/aes_ccm/src/main.c
+++ b/samples/crypto/aes_ccm/src/main.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM
 #include <tfm_ns_interface.h>

--- a/samples/crypto/aes_ctr/src/main.c
+++ b/samples/crypto/aes_ctr/src/main.c
@@ -9,7 +9,6 @@
 #include <zephyr/logging/log.h>
 #include <stdio.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM
 #include <tfm_ns_interface.h>

--- a/samples/crypto/aes_gcm/src/main.c
+++ b/samples/crypto/aes_gcm/src/main.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM
 #include <tfm_ns_interface.h>

--- a/samples/crypto/aes_kw/src/main.c
+++ b/samples/crypto/aes_kw/src/main.c
@@ -9,7 +9,6 @@
 #include <zephyr/logging/log.h>
 #include <stdio.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #include <cracen_psa_kmu.h>
 #include <cracen_psa_key_ids.h>

--- a/samples/crypto/chachapoly/src/main.c
+++ b/samples/crypto/chachapoly/src/main.c
@@ -9,7 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 #include <zephyr/logging/log.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM

--- a/samples/crypto/ecdh/src/main.c
+++ b/samples/crypto/ecdh/src/main.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM
 #include <tfm_ns_interface.h>

--- a/samples/crypto/ecdsa/src/main.c
+++ b/samples/crypto/ecdsa/src/main.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM
 #include <tfm_ns_interface.h>

--- a/samples/crypto/eddsa/src/main.c
+++ b/samples/crypto/eddsa/src/main.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM
 #include <tfm_ns_interface.h>

--- a/samples/crypto/hkdf/src/main.c
+++ b/samples/crypto/hkdf/src/main.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM
 #include <tfm_ns_interface.h>

--- a/samples/crypto/hmac/src/main.c
+++ b/samples/crypto/hmac/src/main.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM
 #include <tfm_ns_interface.h>

--- a/samples/crypto/kmu_cracen_usage/src/key_operations.h
+++ b/samples/crypto/kmu_cracen_usage/src/key_operations.h
@@ -5,7 +5,6 @@
  */
 
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifndef __KEY_OPERATIONS_H_
 #define __KEY_OPERATIONS_H_

--- a/samples/crypto/kmu_cracen_usage/src/main.c
+++ b/samples/crypto/kmu_cracen_usage/src/main.c
@@ -9,7 +9,6 @@
 #include <zephyr/logging/log.h>
 #include <stdio.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #include <cracen_psa_kmu.h>
 

--- a/samples/crypto/kmu_cracen_usage/src/main.h
+++ b/samples/crypto/kmu_cracen_usage/src/main.h
@@ -5,7 +5,6 @@
  */
 
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifndef __MAIN_H_
 #define __MAIN_H_

--- a/samples/crypto/ml_dsa/src/main.c
+++ b/samples/crypto/ml_dsa/src/main.c
@@ -7,7 +7,6 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/logging/log.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #include "ml_dsa_65_vectors.h"
 

--- a/samples/crypto/persistent_key_usage/src/main.c
+++ b/samples/crypto/persistent_key_usage/src/main.c
@@ -9,7 +9,6 @@
 #include <zephyr/logging/log.h>
 #include <stdio.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM
 #include <tfm_ns_interface.h>

--- a/samples/crypto/rng/src/main.c
+++ b/samples/crypto/rng/src/main.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM
 #include <tfm_ns_interface.h>

--- a/samples/crypto/rsa/src/main.c
+++ b/samples/crypto/rsa/src/main.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 
 #include "key.h"
 

--- a/samples/crypto/sha256/src/main.c
+++ b/samples/crypto/sha256/src/main.c
@@ -11,7 +11,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <psa/crypto.h>
-#include <psa/crypto_extra.h>
 #include <zephyr/logging/log.h>
 
 #ifdef CONFIG_BUILD_WITH_TFM


### PR DESCRIPTION
That manual include did not add anything extra as <psa/crypto.h> already includes it automatically, and not all PSA Crypto providers may actually provide <psa/crypto_extra.h>.