### PR TITLE
[backport to v3.4-branch] mcuboot: Kconfig: CC310 image encryption fix PSA

### DIFF
--- a/modules/mcuboot/boot/zephyr/Kconfig
+++ b/modules/mcuboot/boot/zephyr/Kconfig
@@ -150,8 +150,16 @@ choice BOOT_SIGNATURE_TYPE
 
 endchoice
 
+# cc310 (nrf_cc310_bl) backend driver provides ECDSA verification only, so image
+# encryption, which additionally needs ECDH, HKDF/HMAC and AES, has to be
+# provided with use of PSA crypto.
+configdefault PSA_CRYPTO
+	default y if BOOT_SIGNATURE_TYPE_ECDSA_P256 && BOOT_ENCRYPT_IMAGE && \
+		HAS_HW_NRF_CC310 && !SECURE_BOOT
+
 choice BOOT_ECDSA_IMPLEMENTATION
 	default BOOT_NRF_EXTERNAL_CRYPTO if SECURE_BOOT
+	default BOOT_ECDSA_PSA if PSA_CRYPTO
 	default BOOT_ECDSA_CC310 if HAS_HW_NRF_CC310
 
 config BOOT_NRF_EXTERNAL_CRYPTO

--- a/samples/dfu/smp_svr/sample.yaml
+++ b/samples/dfu/smp_svr/sample.yaml
@@ -93,6 +93,7 @@ tests:
 
   sample.dfu.smp_svr.encryption.ecdsa_p256:
     platform_allow:
+      - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
@@ -274,6 +275,7 @@ tests:
 
   sample.dfu.smp_svr.nrf_compress.encryption_ecdsa_p256:
     platform_allow:
+      - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
fix ambiguous encryption crypto backend when CC310 is present

backport of https://github.com/nrfconnect/sdk-nrf/pull/30927

ref.: NCSDK-29460