### PR TITLE
samples: net: Add Twister targets for Wi-Fi with mutual TLS

### DIFF
--- a/samples/net/download/sample.yaml
+++ b/samples/net/download/sample.yaml
@@ -43,6 +43,25 @@ tests:
       - ci_samples_net
     extra_args:
       - download_EXTRA_CONF_FILE="wifi.conf;wifi-mutual-dtls.conf"
+  sample.net.downloader.wifi.tls_cert:
+    sysbuild: true
+    build_only: true
+    integration_platforms:
+      - nrf7002dk/nrf5340/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp/ns
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp/ns
+    extra_args:
+      - download_EXTRA_CONF_FILE=wifi.conf
+    # No real mutual-TLS-enabled HTTPS server is used; this reuses the sample's
+    # example Californium client certificate purely for Twister build coverage.
+    extra_configs:
+      - CONFIG_SAMPLE_PROVISION_CLIENT_CERT=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.downloader.nrf54lm20_nrf7002eb2.wifi:
     sysbuild: true
     tags:
@@ -77,3 +96,24 @@ tests:
       - download_SHIELD="nrf7002eb2"
       - download_SNIPPET=wifi-credentials
       - download_EXTRA_CONF_FILE="wifi.conf;wifi-mutual-dtls.conf"
+  sample.net.downloader.nrf54lm20_nrf7002eb2.wifi.tls_cert:
+    sysbuild: true
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
+    build_only: true
+    integration_platforms:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+    platform_allow:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+    extra_args:
+      - download_SHIELD="nrf7002eb2"
+      - download_SNIPPET=wifi-credentials
+      - download_EXTRA_CONF_FILE=wifi.conf
+    # No real mutual-TLS-enabled HTTPS server is used; this reuses the sample's
+    # example Californium client certificate purely for Twister build coverage.
+    extra_configs:
+      - CONFIG_SAMPLE_PROVISION_CLIENT_CERT=y

--- a/samples/net/http_server/sample.yaml
+++ b/samples/net/http_server/sample.yaml
@@ -30,6 +30,23 @@ tests:
       - ci_build
       - sysbuild
       - ci_samples_net
+  sample.net.http_server.wifi.tls.mtls:
+    sysbuild: true
+    build_only: true
+    integration_platforms:
+      - nrf7002dk/nrf5340/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp/ns
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp/ns
+      - nrf7120dk/nrf7120/cpuapp/ns
+    extra_args: http_server_EXTRA_CONF_FILE="wifi.conf;wifi-tls.conf"
+    # Enables peer verification (mutual TLS); see the README "Security" section.
+    extra_configs:
+      - CONFIG_HTTP_SERVER_SAMPLE_PEER_VERIFICATION_REQUIRE=y
+    tags:
+      - ci_build
+      - sysbuild
+      - ci_samples_net
   sample.net.http_server.lte:
     sysbuild: true
     build_only: true


### PR DESCRIPTION
  This PR enables mutual TLS for download and http_server samples. This is for code coverage. For download sample we don't use real client cert, the sample just builds with californium client cert which is for CoAP, not HTTP.

Jira: NCSDK-40635, NCSDK-40651