### PR TITLE
modules: memfault: upgrade to 1.44.0

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -841,7 +841,7 @@ Memfault integration
 
 * Added support for setting the Memfault project key at runtime using the :kconfig:option:`CONFIG_MEMFAULT_PROJECT_KEY_SETTINGS` Kconfig option.
 
-* Updated Memfault to version 1.42.1.
+* Updated Memfault to version 1.44.0.
   See the `Memfault firmware SDK changelog`_ for details.
 
 * Removed the ``CONFIG_MEMFAULT_NCS_PROVISION_CERTIFICATES`` Kconfig option from nRF91x targets.

--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
       remote: throwtheswitch
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 1.43.0
+      revision: 1.44.0
       remote: memfault
     - name: bsim
       repo-path: bsim_west


### PR DESCRIPTION
Upgrade the memfault module to pick up Zephyr library rename and MRAM coredump support fix.