### PR TITLE
bluetooth: dtm: Constant Carrier support in DTM 2-wire HCI library

### DIFF
--- a/doc/nrf/libraries/bluetooth/dtm_twowire_to_hci.rst
+++ b/doc/nrf/libraries/bluetooth/dtm_twowire_to_hci.rst
@@ -52,6 +52,9 @@ Check and adjust the following Kconfig options:
 Also configure the chosen Bluetooth LE Controller to support DTM HCI commands.
 For the SoftDevice Controller and Zephyr Bluetooth LE Controller, use the :kconfig:option:`CONFIG_BT_CTLR_DTM_HCI` Kconfig option.
 
+To enable support for vendor-specific commands using the SoftDevice Controller, use the :kconfig:option:`CONFIG_DTM_TWOWIRE_TO_HCI_SDC_VS_COMMANDS` Kconfig option.
+See the `Vendor-specific packet payload`_ section for more information.
+
 Usage
 *****
 
@@ -71,6 +74,25 @@ The flow of the application could look like this:
      #. Call the :c:func:`dtm_tw_to_hci_process_hci_event` function to process the resulting HCI event.
      #. Send the generated 2-wire UART event to the tester.
      #. Return to **Step 1**.
+
+Vendor-specific packet payload
+******************************
+
+For non-coded PHYs, the Bluetooth Low Energy 2-wire UART DTM interface standard reserves the Packet Type with binary value ``11`` for vendor-specific commands.
+
+The DTM command is interpreted as vendor-specific when all of the following conditions are met:
+
+* Its **CMD** field is set to Transmitter Test, binary ``10``.
+* Its **PKT** field is set to vendor-specific, binary ``11``.
+* The test has not been set up to use coded PHY.
+
+When the :kconfig:option:`CONFIG_DTM_TWOWIRE_TO_HCI_SDC_VS_COMMANDS` Kconfig option is enabled, the library implements vendor-specific DTM 2-wire commands using the SoftDevice Controller vendor-specific HCI commands.
+The **Length** field of the DTM command is used as a vendor-specific subcommand code and the **Frequency** field as the command's parameter.
+
+The following vendor-specific subcommands are supported:
+
+* If the **Length** field is set to ``0``, an unmodulated carrier is turned on at the channel indicated by the **Frequency** field.
+  It remains turned on until a ``TEST_END`` command is issued.
 
 Limitations
 ***********

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -406,7 +406,13 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
-|no_changes_yet_note|
+* :ref:`dtm_twowire_to_hci_readme` library:
+
+  * Added:
+
+    * The :kconfig:option:`CONFIG_DTM_TWOWIRE_TO_HCI_SDC_VS_COMMANDS` Kconfig option to support vendor-specific DTM 2-wire commands.
+      The option is enabled by default if :kconfig:option:`CONFIG_BT_HCI_VS` is enabled.
+    * A vendor-specific DTM 2-wire command for constant carrier transmission.
 
 Common Application Framework
 ----------------------------

--- a/lib/dtm_twowire/Kconfig
+++ b/lib/dtm_twowire/Kconfig
@@ -15,8 +15,8 @@ config DTM_TWOWIRE_TO_HCI_RECEIVER_TEST_VERSION
 	default 3 if BT_CTLR_DTM_HCI_RX_V3
 	default 2
 	help
-		Selects the version of the HCI_LE_Receiver_Test command to generate,
-		as specified in the Bluetooth Core Specification 6.2 Vol 4, Part E, 7.8.28.
+	  Selects the version of the HCI_LE_Receiver_Test command to generate,
+	  as specified in the Bluetooth Core Specification 6.2 Vol 4, Part E, 7.8.28.
 
 config DTM_TWOWIRE_TO_HCI_TRANSMITTER_TEST_VERSION
 	int "HCI_LE_Transmitter_Test command version"
@@ -25,8 +25,17 @@ config DTM_TWOWIRE_TO_HCI_TRANSMITTER_TEST_VERSION
 	default 3 if BT_CTLR_DTM_HCI_TX_V3
 	default 2
 	help
-		Selects the version of the HCI_LE_Transmitter_Test command to generate,
-		as specified in the Bluetooth Core Specification 6.2 Vol 4, Part E, 7.8.29.
+	  Selects the version of the HCI_LE_Transmitter_Test command to generate,
+	  as specified in the Bluetooth Core Specification 6.2 Vol 4, Part E, 7.8.29.
+
+config DTM_TWOWIRE_TO_HCI_SDC_VS_COMMANDS
+	bool "SDC vendor-specific commands"
+	depends on BT_HCI_VS
+	default y
+	help
+	  Enable support for the vendor-specific commands listed in the DTM 2-wire to HCI
+	  conversion library documentation, utilizing vendor-specific HCI commands from
+	  the SoftDevice Controller (SDC).
 
 module=DTM_TWOWIRE_TO_HCI
 module-dep=LOG

--- a/lib/dtm_twowire/dtm_twowire_to_hci.c
+++ b/lib/dtm_twowire/dtm_twowire_to_hci.c
@@ -10,6 +10,10 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/hci_types.h>
 
+#if defined(CONFIG_DTM_TWOWIRE_TO_HCI_SDC_VS_COMMANDS)
+#include <sdc_hci_vs.h>
+#endif /* CONFIG_DTM_TWOWIRE_TO_HCI_SDC_VS_COMMANDS */
+
 #include <bluetooth/dtm_twowire/dtm_twowire_types.h>
 #include <bluetooth/dtm_twowire/dtm_twowire_to_hci.h>
 
@@ -58,6 +62,17 @@ struct {
 	uint8_t modulation_index;   /**< Modulation index for Receiver Test HCI command */
 	int8_t transmit_power;      /**< Transmit power for Transmitter Test HCI command */
 } dtm_hci_parameters;
+
+#if defined(CONFIG_DTM_TWOWIRE_TO_HCI_SDC_VS_COMMANDS)
+/* Vendor Specific DTM subcommand for the 2-wire Transmitter Test command.
+ * It replaces Length field and must be combined with DTM_TW_PKT_0XFF_OR_VS
+ * packet type.
+ */
+enum dtm_vs_subcmd {
+	/* Length=0 indicates a constant, unmodulated carrier until an LE Test End command. */
+	CARRIER_TEST = 0,
+};
+#endif /* CONFIG_DTM_TWOWIRE_TO_HCI_SDC_VS_COMMANDS */
 
 static uint16_t reset_dtm(uint8_t parameter)
 {
@@ -276,15 +291,8 @@ static int get_hci_param_pkt_payload(enum dtm_tw_pkt_type pkt_type_tw, uint8_t *
 		break;
 
 	case DTM_TW_PKT_0XFF_OR_VS:
-		if (dtm_hci_parameters.tx_phy == BT_HCI_LE_TX_PHY_CODED_S8 ||
-		    dtm_hci_parameters.tx_phy == BT_HCI_LE_TX_PHY_CODED_S2) {
-			*pkt_payload_hci = BT_HCI_TEST_PKT_PAYLOAD_11111111;
-		} else {
-			/* For non-Coded PHY, the 0xFF packet type is vendor specific.
-			 * We do not support vendor specific packet types in this implementation.
-			 */
-			return -EINVAL;
-		}
+		/* Assume the caller has verified that the packet is not vendor-specific */
+		*pkt_payload_hci = BT_HCI_TEST_PKT_PAYLOAD_11111111;
 		break;
 
 	default:
@@ -292,6 +300,42 @@ static int get_hci_param_pkt_payload(enum dtm_tw_pkt_type pkt_type_tw, uint8_t *
 	}
 
 	return 0;
+}
+
+static uint16_t on_vendor_specific_cmd(uint8_t channel, uint8_t length, struct net_buf *hci_cmd)
+{
+#if defined(CONFIG_DTM_TWOWIRE_TO_HCI_SDC_VS_COMMANDS)
+	/* In this VS command implementation, we use the length parameter as a VS subcommand code,
+	 * and the channel parameter as a subcommand parameter.
+	 */
+	switch (length) {
+	case CARRIER_TEST:
+		/* Generate HCI command to send constant, unmodulated carrier */
+		uint8_t hci_param_channel;
+
+		if (get_hci_param_channel(channel, &hci_param_channel)) {
+			return DTM_TW_EVENT_TEST_STATUS_ERROR;
+		}
+
+		struct bt_hci_cmd_hdr *cmd_hdr = net_buf_add(hci_cmd, BT_HCI_CMD_HDR_SIZE);
+
+		cmd_hdr->opcode = SDC_HCI_OPCODE_CMD_VS_TRANSMITTER_CARRIER_TEST;
+		cmd_hdr->param_len = sizeof(sdc_hci_cmd_vs_transmitter_carrier_test_t);
+		sdc_hci_cmd_vs_transmitter_carrier_test_t *cp = net_buf_add(
+			hci_cmd, sizeof(sdc_hci_cmd_vs_transmitter_carrier_test_t));
+		cp->tx_channel = hci_param_channel;
+		cp->tx_power_level = dtm_hci_parameters.transmit_power;
+
+		return HCI_GENERATED;
+
+	default:
+		return DTM_TW_EVENT_TEST_STATUS_ERROR;
+	}
+#else
+	ARG_UNUSED(channel);
+	ARG_UNUSED(length);
+	return DTM_TW_EVENT_TEST_STATUS_ERROR;
+#endif /* CONFIG_DTM_TWOWIRE_TO_HCI_SDC_VS_COMMANDS */
 }
 
 static uint16_t on_test_rx_cmd(uint8_t channel, struct net_buf *hci_cmd)
@@ -346,6 +390,14 @@ static uint16_t on_test_rx_cmd(uint8_t channel, struct net_buf *hci_cmd)
 static uint16_t on_test_tx_cmd(uint8_t channel, uint8_t length, enum dtm_tw_pkt_type type,
 			       struct net_buf *hci_cmd)
 {
+
+	if (type == DTM_TW_PKT_0XFF_OR_VS &&
+	    !(dtm_hci_parameters.tx_phy == BT_HCI_LE_TX_PHY_CODED_S8 ||
+	      dtm_hci_parameters.tx_phy == BT_HCI_LE_TX_PHY_CODED_S2)) {
+		/* For non-coded PHY, this payload type is vendor-specific. */
+		return on_vendor_specific_cmd(channel, length, hci_cmd);
+	}
+
 	uint8_t hci_param_channel, hci_param_pkt_payload;
 
 	if (get_hci_param_channel(channel, &hci_param_channel) ||
@@ -686,6 +738,9 @@ dtm_tw_to_hci_status_t dtm_tw_to_hci_process_hci_event(const uint16_t tw_cmd,
 	case BT_HCI_OP_LE_ENH_TX_TEST:
 	case BT_HCI_OP_LE_TX_TEST_V3:
 	case BT_HCI_OP_LE_TX_TEST_V4:
+#if defined(CONFIG_DTM_TWOWIRE_TO_HCI_SDC_VS_COMMANDS)
+	case SDC_HCI_OPCODE_CMD_VS_TRANSMITTER_CARRIER_TEST:
+#endif /* CONFIG_DTM_TWOWIRE_TO_HCI_SDC_VS_COMMANDS */
 		__ASSERT_NO_MSG(param_len == sizeof(struct bt_hci_evt_cc_status));
 		const struct bt_hci_evt_cc_status *status_rp = cc_event_return_params;
 


### PR DESCRIPTION
Support for the Vendor Specific DTM 2-wire Constant Carrier command was removed when the DTM sample was updated to use a BLE controller backend.
This commit re-introduces support for it, such that the Constant Carrier option in the Direct Test Mode app in nRF Connect for Desktop can be used again.

Modifications from cherry picked commit:
* The grouped HCI command for vendor-specific DTM commands was not available in v3.4, so this was changed to use the now-deprecated standalone version of the Transmitter Carrier Test command.


(cherry picked from commit dedd04e86407816232b796f17ab93202db5b3131)