### PR TITLE
samples: net: Replace preprocessor guards with IS_ENABLED

### DIFF
--- a/samples/net/aws_iot/src/main.c
+++ b/samples/net/aws_iot/src/main.c
@@ -196,9 +196,9 @@ static void on_aws_iot_evt_connected(const struct aws_iot_evt *const evt)
 	}
 
 	/* Mark image as working to avoid reverting to the former image after a reboot. */
-#if defined(CONFIG_BOOTLOADER_MCUBOOT)
-	boot_write_img_confirmed();
-#endif
+	if (IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT)) {
+		boot_write_img_confirmed();
+	}
 
 	/* Start sequential updates to AWS IoT. */
 	(void)k_work_reschedule(&shadow_update_work, K_NO_WAIT);
@@ -387,17 +387,17 @@ int main(void)
 		return err;
 	}
 
-#if defined(CONFIG_AWS_IOT_SAMPLE_DEVICE_ID_USE_HW_ID)
-	/* Get unique hardware ID, can be used as AWS IoT MQTT broker device/client ID. */
-	err = hw_id_get(hw_id, ARRAY_SIZE(hw_id));
-	if (err) {
-		LOG_ERR("Failed to retrieve hardware ID, error: %d", err);
-		FATAL_ERROR();
-		return err;
-	}
+	if (IS_ENABLED(CONFIG_AWS_IOT_SAMPLE_DEVICE_ID_USE_HW_ID)) {
+		/* Get unique hardware ID, can be used as AWS IoT MQTT broker device/client ID. */
+		err = hw_id_get(hw_id, ARRAY_SIZE(hw_id));
+		if (err) {
+			LOG_ERR("Failed to retrieve hardware ID, error: %d", err);
+			FATAL_ERROR();
+			return err;
+		}
 
-	LOG_INF("Hardware ID: %s", hw_id);
-#endif /* CONFIG_AWS_IOT_SAMPLE_DEVICE_ID_USE_HW_ID */
+		LOG_INF("Hardware ID: %s", hw_id);
+	}
 
 	err = aws_iot_client_init();
 	if (err) {

--- a/samples/net/azure_iot_hub/src/main.c
+++ b/samples/net/azure_iot_hub/src/main.c
@@ -20,8 +20,10 @@
 #include <cJSON.h>
 #include <cJSON_os.h>
 
-#if IS_ENABLED(CONFIG_AZURE_IOT_HUB_SAMPLE_DEVICE_ID_USE_HW_ID)
 #include <hw_id.h>
+
+#ifndef CONFIG_AZURE_IOT_HUB_DPS_TIMEOUT_SEC
+#define CONFIG_AZURE_IOT_HUB_DPS_TIMEOUT_SEC 0
 #endif
 
 LOG_MODULE_REGISTER(azure_iot_hub_sample, CONFIG_AZURE_IOT_HUB_SAMPLE_LOG_LEVEL);
@@ -58,9 +60,7 @@ static K_SEM_DEFINE(network_connected_sem, 0, 1);
 static K_SEM_DEFINE(recv_buf_sem, 1, 1);
 static atomic_t event_interval = EVENT_INTERVAL;
 
-#ifdef CONFIG_AZURE_IOT_HUB_DPS
 static bool dps_was_successful;
-#endif
 
 /* A work queue is created to execute potentially blocking calls from.
  * This is done to avoid blocking for example the system work queue for extended
@@ -198,9 +198,9 @@ static void azure_event_handler(struct azure_iot_hub_evt *const evt)
 		/* All initializations and cloud connection were successful, now mark
 		 * image as working so that we will not revert upon reboot.
 		 */
-#if defined(CONFIG_BOOTLOADER_MCUBOOT)
-		boot_write_img_confirmed();
-#endif
+		if (IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT)) {
+			boot_write_img_confirmed();
+		}
 
 		/* The AZURE_IOT_HUB_EVT_READY event indicates that the
 		 * IoT hub connection is established and interaction with the
@@ -332,15 +332,15 @@ static void direct_method_handler(struct k_work *work)
 		return;
 	}
 
-#if defined(CONFIG_DK_LIBRARY)
-	err = dk_set_led(DK_LED1, led_state);
-	if (err) {
-		LOG_ERR("Failed to set LED, error: %d", err);
-		return;
+	if (IS_ENABLED(CONFIG_DK_LIBRARY)) {
+		err = dk_set_led(DK_LED1, led_state);
+		if (err) {
+			LOG_ERR("Failed to set LED, error: %d", err);
+			return;
+		}
+	} else {
+		LOG_INF("No hardware interface to set LED state to %d", led_state);
 	}
-#else
-	LOG_INF("No hardware interface to set LED state to %d", led_state);
-#endif
 
 	err = azure_iot_hub_method_respond(&result);
 	if (err) {
@@ -447,7 +447,6 @@ static void work_init(void)
 		       K_HIGHEST_APPLICATION_THREAD_PRIO, &cfg);
 }
 
-#if IS_ENABLED(CONFIG_AZURE_IOT_HUB_DPS)
 static K_SEM_DEFINE(dps_done_sem, 0, 1);
 
 static void dps_handler(enum azure_iot_hub_dps_reg_status status)
@@ -544,7 +543,6 @@ static int dps_run(struct azure_iot_hub_buf *hostname, struct azure_iot_hub_buf 
 
 	return 0;
 }
-#endif /* CONFIG_AZURE_IOT_HUB_DPS */
 
 int main(void)
 {
@@ -592,14 +590,14 @@ int main(void)
 		return err;
 	}
 
-#if IS_ENABLED(CONFIG_AZURE_IOT_HUB_SAMPLE_DEVICE_ID_USE_HW_ID)
-	err = hw_id_get(device_id, ARRAY_SIZE(device_id));
-	if (err) {
-		LOG_ERR("Failed to retrieve device ID");
-		return 0;
+	if (IS_ENABLED(CONFIG_AZURE_IOT_HUB_SAMPLE_DEVICE_ID_USE_HW_ID)) {
+		err = hw_id_get(device_id, ARRAY_SIZE(device_id));
+		if (err) {
+			LOG_ERR("Failed to retrieve device ID");
+			return 0;
+		}
+		cfg.device_id.size = strlen(device_id);
 	}
-	cfg.device_id.size = strlen(device_id);
-#endif
 
 	LOG_INF("Device ID: %s", device_id);
 
@@ -607,9 +605,9 @@ int main(void)
 		LOG_INF("Host name: %s", hostname);
 	}
 
-#if IS_ENABLED(CONFIG_DK_LIBRARY)
-	dk_leds_init();
-#endif
+	if (IS_ENABLED(CONFIG_DK_LIBRARY)) {
+		dk_leds_init();
+	}
 
 	work_init();
 	cJSON_Init();
@@ -628,14 +626,15 @@ int main(void)
 
 	LOG_INF("Connected to network");
 
-#if IS_ENABLED(CONFIG_AZURE_IOT_HUB_DPS)
-	/* Using the device ID as DPS registration ID. */
-	err = dps_run(&cfg.hostname, &cfg.device_id);
-	if (err) {
-		LOG_ERR("Failed to run DPS, error: %d, terminating connection attempt", err);
-		return 0;
+	if (IS_ENABLED(CONFIG_AZURE_IOT_HUB_DPS)) {
+		/* Using the device ID as DPS registration ID. */
+		err = dps_run(&cfg.hostname, &cfg.device_id);
+		if (err) {
+			LOG_ERR("Failed to run DPS, error: %d, terminating connection attempt",
+				err);
+			return 0;
+		}
 	}
-#endif
 
 	err = azure_iot_hub_init(azure_event_handler);
 	if (err) {

--- a/samples/net/coap_client/src/main.c
+++ b/samples/net/coap_client/src/main.c
@@ -26,8 +26,19 @@
 #include <zephyr/net/coap_client.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_ctrl.h>
-#if defined(CONFIG_COAP_SAMPLE_DTLS)
 #include <zephyr/net/tls_credentials.h>
+
+/* CONFIG_COAP_SAMPLE_DTLS_SEC_TAG and CONFIG_COAP_SAMPLE_DTLS_HANDSHAKE_TIMEOUT_MAX_MS
+ * are defined in Kconfig under "if COAP_SAMPLE_DTLS", so they don't exist at all when
+ * CONFIG_COAP_SAMPLE_DTLS is disabled. Provide fallback values so the code referencing
+ * them below compiles unconditionally; the IS_ENABLED(CONFIG_COAP_SAMPLE_DTLS) runtime
+ * check ensures they are never actually used in that case.
+ */
+#ifndef CONFIG_COAP_SAMPLE_DTLS_SEC_TAG
+#define CONFIG_COAP_SAMPLE_DTLS_SEC_TAG 0
+#endif
+#ifndef CONFIG_COAP_SAMPLE_DTLS_HANDSHAKE_TIMEOUT_MAX_MS
+#define CONFIG_COAP_SAMPLE_DTLS_HANDSHAKE_TIMEOUT_MAX_MS 0
 #endif
 
 LOG_MODULE_REGISTER(coap_client_sample, CONFIG_COAP_CLIENT_SAMPLE_LOG_LEVEL);
@@ -68,7 +79,6 @@ static void server_addr_set_ipv4(struct sockaddr_storage *server, struct addrinf
 	LOG_INF("IPv4 Address found %s", addr_str);
 }
 
-#if defined(CONFIG_NET_IPV6)
 static void server_addr_set_ipv6(struct sockaddr_storage *server, struct addrinfo *result)
 {
 	struct sockaddr_in6 *server6 = (struct sockaddr_in6 *)server;
@@ -83,7 +93,6 @@ static void server_addr_set_ipv6(struct sockaddr_storage *server, struct addrinf
 	inet_ntop(AF_INET6, &server6->sin6_addr, addr_str, sizeof(addr_str));
 	LOG_INF("IPv6 Address found %s", addr_str);
 }
-#endif /* CONFIG_NET_IPV6 */
 
 static int server_resolve(struct sockaddr_storage *server)
 {
@@ -110,11 +119,12 @@ static int server_resolve(struct sockaddr_storage *server)
 	case AF_INET:
 		server_addr_set_ipv4(server, result);
 		break;
-#if defined(CONFIG_NET_IPV6)
 	case AF_INET6:
-		server_addr_set_ipv6(server, result);
-		break;
-#endif /* CONFIG_NET_IPV6 */
+		if (IS_ENABLED(CONFIG_NET_IPV6)) {
+			server_addr_set_ipv6(server, result);
+			break;
+		}
+		__fallthrough;
 	default:
 		LOG_ERR("Unexpected address family: %d", result->ai_family);
 		freeaddrinfo(result);
@@ -171,113 +181,120 @@ static int periodic_coap_request_loop(void)
 		return err;
 	}
 
+	if (IS_ENABLED(CONFIG_COAP_SAMPLE_DTLS)) {
+		static const char ca_cert[] = {
 #if defined(CONFIG_COAP_SAMPLE_DTLS)
-	static const char ca_cert[] = {
-		#include "coap_sample_ca_cert.inc"
-		'\0'
-	};
-	static const char client_cert[] = {
-		#include "coap_sample_client_cert.inc"
-		'\0'
-	};
-	static const char client_key[] = {
-		#include "coap_sample_client_key.inc"
-		'\0'
-	};
-
-	err = tls_credential_add(CONFIG_COAP_SAMPLE_DTLS_SEC_TAG,
-				 TLS_CREDENTIAL_CA_CERTIFICATE,
-				 ca_cert, sizeof(ca_cert));
-	if ((err < 0) && (err != -EEXIST)) {
-		LOG_ERR("Failed to register CA certificate: %d", err);
-		return err;
-	}
-
-	err = tls_credential_add(CONFIG_COAP_SAMPLE_DTLS_SEC_TAG,
-				 TLS_CREDENTIAL_PUBLIC_CERTIFICATE,
-				 client_cert, sizeof(client_cert));
-	if ((err < 0) && (err != -EEXIST)) {
-		LOG_ERR("Failed to register client certificate: %d", err);
-		return err;
-	}
-
-	err = tls_credential_add(CONFIG_COAP_SAMPLE_DTLS_SEC_TAG,
-				 TLS_CREDENTIAL_PRIVATE_KEY,
-				 client_key, sizeof(client_key));
-	if ((err < 0) && (err != -EEXIST)) {
-		LOG_ERR("Failed to register private key: %d", err);
-		return err;
-	}
-
-	sock = socket(server.ss_family, SOCK_DGRAM, IPPROTO_DTLS_1_2);
-#else
-	sock = socket(server.ss_family, SOCK_DGRAM, IPPROTO_UDP);
+			#include "coap_sample_ca_cert.inc"
+			'\0'
 #endif
+		};
+		static const char client_cert[] = {
+#if defined(CONFIG_COAP_SAMPLE_DTLS)
+			#include "coap_sample_client_cert.inc"
+			'\0'
+#endif
+		};
+		static const char client_key[] = {
+#if defined(CONFIG_COAP_SAMPLE_DTLS)
+			#include "coap_sample_client_key.inc"
+			'\0'
+#endif
+		};
+
+		err = tls_credential_add(CONFIG_COAP_SAMPLE_DTLS_SEC_TAG,
+					 TLS_CREDENTIAL_CA_CERTIFICATE,
+					 ca_cert, sizeof(ca_cert));
+		if ((err < 0) && (err != -EEXIST)) {
+			LOG_ERR("Failed to register CA certificate: %d", err);
+			return err;
+		}
+
+		err = tls_credential_add(CONFIG_COAP_SAMPLE_DTLS_SEC_TAG,
+					 TLS_CREDENTIAL_PUBLIC_CERTIFICATE,
+					 client_cert, sizeof(client_cert));
+		if ((err < 0) && (err != -EEXIST)) {
+			LOG_ERR("Failed to register client certificate: %d", err);
+			return err;
+		}
+
+		err = tls_credential_add(CONFIG_COAP_SAMPLE_DTLS_SEC_TAG,
+					 TLS_CREDENTIAL_PRIVATE_KEY,
+					 client_key, sizeof(client_key));
+		if ((err < 0) && (err != -EEXIST)) {
+			LOG_ERR("Failed to register private key: %d", err);
+			return err;
+		}
+	}
+
+	sock = socket(server.ss_family, SOCK_DGRAM,
+		      IS_ENABLED(CONFIG_COAP_SAMPLE_DTLS) ? IPPROTO_DTLS_1_2 : IPPROTO_UDP);
 	if (sock < 0) {
 		LOG_ERR("Failed to create CoAP socket: %d.", -errno);
 		return -errno;
 	}
 
-#if defined(CONFIG_COAP_SAMPLE_DTLS)
-	sec_tag_t sec_tag_list[] = { CONFIG_COAP_SAMPLE_DTLS_SEC_TAG };
+	if (IS_ENABLED(CONFIG_COAP_SAMPLE_DTLS)) {
+		sec_tag_t sec_tag_list[] = { CONFIG_COAP_SAMPLE_DTLS_SEC_TAG };
 
-	err = setsockopt(sock, SOL_TLS, TLS_SEC_TAG_LIST,
-			 sec_tag_list, sizeof(sec_tag_list));
-	if (err < 0) {
-		LOG_ERR("Failed to set TLS_SEC_TAG_LIST: %d", -errno);
-		(void)zsock_close(sock);
-		return -errno;
+		err = setsockopt(sock, SOL_TLS, TLS_SEC_TAG_LIST,
+				 sec_tag_list, sizeof(sec_tag_list));
+		if (err < 0) {
+			LOG_ERR("Failed to set TLS_SEC_TAG_LIST: %d", -errno);
+			(void)zsock_close(sock);
+			return -errno;
+		}
+
+		uint32_t handshake_timeout_ms = CONFIG_COAP_SAMPLE_DTLS_HANDSHAKE_TIMEOUT_MAX_MS;
+
+		err = setsockopt(sock, SOL_TLS, TLS_DTLS_HANDSHAKE_TIMEOUT_MAX,
+				 &handshake_timeout_ms, sizeof(handshake_timeout_ms));
+		if (err < 0) {
+			LOG_ERR("Failed to set TLS_DTLS_HANDSHAKE_TIMEOUT_MAX: %d", -errno);
+			(void)zsock_close(sock);
+			return -errno;
+		}
+
+		/* Set the expected server hostname for SNI and server certificate
+		 * CN/SAN verification.
+		 */
+		err = setsockopt(sock, SOL_TLS, TLS_HOSTNAME,
+				 CONFIG_COAP_SAMPLE_SERVER_HOSTNAME,
+				 sizeof(CONFIG_COAP_SAMPLE_SERVER_HOSTNAME) - 1);
+		if (err < 0) {
+			LOG_ERR("Failed to set TLS_HOSTNAME: %d", -errno);
+			(void)zsock_close(sock);
+			return -errno;
+		}
+
+		/* Explicitly connect to trigger the DTLS handshake now so we can log
+		 * the outcome and negotiated ciphersuite before handing the socket to
+		 * the CoAP client.
+		 */
+		LOG_INF("Performing DTLS handshake with %s:%d (mutual TLS)...",
+			CONFIG_COAP_SAMPLE_SERVER_HOSTNAME,
+			CONFIG_COAP_SAMPLE_SERVER_PORT);
+
+		err = zsock_connect(sock, (struct sockaddr *)&server,
+				    server.ss_family == AF_INET6 ?
+					    sizeof(struct sockaddr_in6) :
+					    sizeof(struct sockaddr_in));
+		if (err < 0) {
+			LOG_ERR("DTLS handshake failed: %d", -errno);
+			(void)zsock_close(sock);
+			return -errno;
+		}
+
+		int cipher_id;
+		socklen_t cipher_id_len = sizeof(cipher_id);
+
+		err = getsockopt(sock, SOL_TLS, TLS_CIPHERSUITE_USED, &cipher_id, &cipher_id_len);
+		if (err == 0) {
+			LOG_INF("DTLS handshake complete, ciphersuite: 0x%04x", cipher_id);
+		} else {
+			LOG_INF("DTLS handshake complete (ciphersuite unknown, getsockopt err %d)",
+				err);
+		}
 	}
-
-	uint32_t handshake_timeout_ms = CONFIG_COAP_SAMPLE_DTLS_HANDSHAKE_TIMEOUT_MAX_MS;
-
-	err = setsockopt(sock, SOL_TLS, TLS_DTLS_HANDSHAKE_TIMEOUT_MAX,
-			 &handshake_timeout_ms, sizeof(handshake_timeout_ms));
-	if (err < 0) {
-		LOG_ERR("Failed to set TLS_DTLS_HANDSHAKE_TIMEOUT_MAX: %d", -errno);
-		(void)zsock_close(sock);
-		return -errno;
-	}
-
-	/* Set the expected server hostname for SNI and server certificate
-	 * CN/SAN verification.
-	 */
-	err = setsockopt(sock, SOL_TLS, TLS_HOSTNAME,
-			 CONFIG_COAP_SAMPLE_SERVER_HOSTNAME,
-			 sizeof(CONFIG_COAP_SAMPLE_SERVER_HOSTNAME) - 1);
-	if (err < 0) {
-		LOG_ERR("Failed to set TLS_HOSTNAME: %d", -errno);
-		(void)zsock_close(sock);
-		return -errno;
-	}
-
-	/* Explicitly connect to trigger the DTLS handshake now so we can log
-	 * the outcome and negotiated ciphersuite before handing the socket to
-	 * the CoAP client.
-	 */
-	LOG_INF("Performing DTLS handshake with %s:%d (mutual TLS)...",
-		CONFIG_COAP_SAMPLE_SERVER_HOSTNAME,
-		CONFIG_COAP_SAMPLE_SERVER_PORT);
-
-	err = zsock_connect(sock, (struct sockaddr *)&server,
-			    server.ss_family == AF_INET6 ?
-				    sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in));
-	if (err < 0) {
-		LOG_ERR("DTLS handshake failed: %d", -errno);
-		(void)zsock_close(sock);
-		return -errno;
-	}
-
-	int cipher_id;
-	socklen_t cipher_id_len = sizeof(cipher_id);
-
-	err = getsockopt(sock, SOL_TLS, TLS_CIPHERSUITE_USED, &cipher_id, &cipher_id_len);
-	if (err == 0) {
-		LOG_INF("DTLS handshake complete, ciphersuite: 0x%04x", cipher_id);
-	} else {
-		LOG_INF("DTLS handshake complete (ciphersuite unknown, getsockopt err %d)", err);
-	}
-#endif
 
 	err = coap_client_init(&coap_client, NULL);
 	if (err) {

--- a/samples/net/download/src/main.c
+++ b/samples/net/download/src/main.c
@@ -24,7 +24,11 @@ LOG_MODULE_REGISTER(download, LOG_LEVEL_INF);
 #endif
 
 #define URL CONFIG_SAMPLE_FILE_URL
+#if defined(CONFIG_SAMPLE_SEC_TAG)
 #define SEC_TAG CONFIG_SAMPLE_SEC_TAG
+#else
+#define SEC_TAG 0
+#endif
 
 /* Macros used to subscribe to specific Zephyr NET management events. */
 #define L4_EVENT_MASK (NET_EVENT_L4_CONNECTED | NET_EVENT_L4_DISCONNECTED)
@@ -40,34 +44,41 @@ static struct net_if *net_if;
 
 static K_SEM_DEFINE(network_connected_sem, 0, 1);
 
-#if CONFIG_SAMPLE_SECURE_SOCKET
 static int sec_tag_list[] = { SEC_TAG };
-#if CONFIG_SAMPLE_PROVISION_CERT
 static const char cert[] = {
+#if defined(CONFIG_SAMPLE_PROVISION_CERT)
 	#include "sample_cert.inc"
 
 	/* Null terminate certificate if running Mbed TLS on the application core.
 	 * Required by TLS credentials API.
 	 */
 	IF_ENABLED(CONFIG_TLS_CREDENTIALS, (0x00))
+#else
+	0x00
+#endif
 };
 BUILD_ASSERT(sizeof(cert) < KB(4), "Certificate too large");
 
-#if CONFIG_SAMPLE_PROVISION_CLIENT_CERT
 static const char client_cert[] = {
+#if defined(CONFIG_SAMPLE_PROVISION_CLIENT_CERT)
 	#include "sample_client_cert.inc"
 	IF_ENABLED(CONFIG_TLS_CREDENTIALS, (0x00))
+#else
+	0x00
+#endif
 };
-BUILD_ASSERT(sizeof(client_cert) < KB(4), "Client certificate too large");
+BUILD_ASSERT(!IS_ENABLED(CONFIG_SAMPLE_PROVISION_CLIENT_CERT) || sizeof(client_cert) < KB(4),
+	     "Client certificate too large");
 static const char client_key[] = {
+#if defined(CONFIG_SAMPLE_PROVISION_CLIENT_CERT)
 	#include "sample_client_key.inc"
 	IF_ENABLED(CONFIG_TLS_CREDENTIALS, (0x00))
+#else
+	0x00
+#endif
 };
-BUILD_ASSERT(sizeof(client_key) < KB(4), "Client private key too large");
-#endif /* CONFIG_SAMPLE_PROVISION_CLIENT_CERT */
-#endif /* CONFIG_SAMPLE_PROVISION_CERT */
-
-#endif /* CONFIG_SAMPLE_SECURE_SOCKET */
+BUILD_ASSERT(!IS_ENABLED(CONFIG_SAMPLE_PROVISION_CLIENT_CERT) || sizeof(client_key) < KB(4),
+	     "Client private key too large");
 
 static char dl_buf[2048];
 
@@ -80,10 +91,8 @@ static struct downloader_cfg dl_cfg = {
 	.buf_size = sizeof(dl_buf),
 };
 static struct downloader_host_cfg host_dl_cfg = {
-#if CONFIG_SAMPLE_SECURE_SOCKET
-	.sec_tag_list = sec_tag_list,
-	.sec_tag_count = ARRAY_SIZE(sec_tag_list),
-#endif
+	.sec_tag_list = IS_ENABLED(CONFIG_SAMPLE_SECURE_SOCKET) ? sec_tag_list : 0,
+	.sec_tag_count = IS_ENABLED(CONFIG_SAMPLE_SECURE_SOCKET) ? ARRAY_SIZE(sec_tag_list) : 0,
 	.range_override = 0,
 };
 
@@ -91,15 +100,16 @@ static struct downloader_host_cfg host_dl_cfg = {
 #include <psa/crypto.h>
 static psa_hash_operation_t hash_ctx;
 
-#if CONFIG_SAMPLE_COMPARE_HASH
+#if defined(CONFIG_SAMPLE_COMPARE_HASH)
 BUILD_ASSERT(sizeof(CONFIG_SAMPLE_SHA256_HASH) == 65,
 	     "CONFIG_SAMPLE_SHA256_HASH is not set or wrong length");
-#endif
+#else
+#define CONFIG_SAMPLE_SHA256_HASH 0
+#endif /* CONFIG_SAMPLE_COMPARE_HASH */
 #endif
 
 static int64_t ref_time;
 
-#if CONFIG_SAMPLE_PROVISION_CERT
 static int cert_provision(void)
 {
 	int err;
@@ -155,34 +165,33 @@ static int cert_provision(void)
 		return err;
 	}
 
-#if CONFIG_SAMPLE_PROVISION_CLIENT_CERT
-	err = tls_credential_add(SEC_TAG,
-				 TLS_CREDENTIAL_PUBLIC_CERTIFICATE,
-				 client_cert,
-				 sizeof(client_cert));
-	if (err == -EEXIST) {
-		printk("Client certificate already exists, sec tag: %d\n", SEC_TAG);
-	} else if (err < 0) {
-		printk("Failed to register client certificate: %d\n", err);
-		return err;
-	}
+	if (IS_ENABLED(CONFIG_SAMPLE_PROVISION_CLIENT_CERT)) {
+		err = tls_credential_add(SEC_TAG,
+					 TLS_CREDENTIAL_PUBLIC_CERTIFICATE,
+					 client_cert,
+					 sizeof(client_cert));
+		if (err == -EEXIST) {
+			printk("Client certificate already exists, sec tag: %d\n", SEC_TAG);
+		} else if (err < 0) {
+			printk("Failed to register client certificate: %d\n", err);
+			return err;
+		}
 
-	err = tls_credential_add(SEC_TAG,
-				 TLS_CREDENTIAL_PRIVATE_KEY,
-				 client_key,
-				 sizeof(client_key));
-	if (err == -EEXIST) {
-		printk("Client private key already exists, sec tag: %d\n", SEC_TAG);
-	} else if (err < 0) {
-		printk("Failed to register client private key: %d\n", err);
-		return err;
+		err = tls_credential_add(SEC_TAG,
+					 TLS_CREDENTIAL_PRIVATE_KEY,
+					 client_key,
+					 sizeof(client_key));
+		if (err == -EEXIST) {
+			printk("Client private key already exists, sec tag: %d\n", SEC_TAG);
+		} else if (err < 0) {
+			printk("Failed to register client private key: %d\n", err);
+			return err;
+		}
 	}
-#endif /* CONFIG_SAMPLE_PROVISION_CLIENT_CERT */
 #endif /* !CONFIG_MODEM_KEY_MGMT */
 
 	return 0;
 }
-#endif
 
 static void on_net_event_l4_disconnected(void)
 {
@@ -309,12 +318,11 @@ static int callback(const struct downloader_evt *event)
 
 		printk("SHA256: %s\n", hash_str);
 
-#if CONFIG_SAMPLE_COMPARE_HASH
-		if (strcmp(hash_str, CONFIG_SAMPLE_SHA256_HASH)) {
+		if (IS_ENABLED(CONFIG_SAMPLE_COMPARE_HASH) &&
+		    strcmp(hash_str, CONFIG_SAMPLE_SHA256_HASH)) {
 			printk("Expect: %s\n", CONFIG_SAMPLE_SHA256_HASH);
 			printk("SHA256 mismatch!\n");
 		}
-#endif /* CONFIG_SAMPLE_COMPARE_HASH */
 #endif /* CONFIG_SAMPLE_COMPUTE_HASH */
 
 		(void)conn_mgr_if_disconnect(net_if);
@@ -362,13 +370,14 @@ int main(void)
 		return err;
 	}
 
-#if CONFIG_SAMPLE_PROVISION_CERT
-	/* Provision certificates before connecting to the network */
-	err = cert_provision();
-	if (err) {
-		return 0;
+	if (IS_ENABLED(CONFIG_SAMPLE_PROVISION_CERT)) {
+		/* Provision certificates before connecting to the network */
+		err = cert_provision();
+		if (err) {
+			return 0;
+		}
 	}
-#endif
+
 #if CONFIG_SAMPLE_COMPUTE_HASH
 	psa_status_t status = psa_hash_setup(&hash_ctx, PSA_ALG_SHA_256);
 

--- a/samples/net/http_server/src/main.c
+++ b/samples/net/http_server/src/main.c
@@ -25,9 +25,7 @@
 #include <zephyr/net/http/client.h>
 #include <zephyr/net/http/parser.h>
 
-#if defined(CONFIG_DK_LIBRARY)
 #include <dk_buttons_and_leds.h>
-#endif /* defined(CONFIG_DK_LIBRARY) */
 
 #if defined(CONFIG_POSIX_API)
 #include <zephyr/posix/arpa/inet.h>
@@ -159,16 +157,16 @@ static int led_update(uint8_t index, uint8_t state)
 		return -EBADMSG;
 	}
 
-#if defined(CONFIG_DK_LIBRARY)
-	int ret;
+	if (IS_ENABLED(CONFIG_DK_LIBRARY)) {
+		int ret;
 
-	ret = dk_set_led(index, led_states[index]);
-	if (ret) {
-		LOG_ERR("Failed to update LED %d state to %d", index, led_states[index]);
-		FATAL_ERROR();
-		return -EIO;
+		ret = dk_set_led(index, led_states[index]);
+		if (ret) {
+			LOG_ERR("Failed to update LED %d state to %d", index, led_states[index]);
+			FATAL_ERROR();
+			return -EIO;
+		}
 	}
-#endif /* defined(CONFIG_DK_LIBRARY) */
 
 	LOG_INF("LED %d state updated to %d", index, led_states[index]);
 
@@ -674,14 +672,14 @@ int main(void)
 
 	parser_init();
 
-#if defined(CONFIG_DK_LIBRARY)
-	ret = dk_leds_init();
-	if (ret) {
-		LOG_ERR("dk_leds_init, error: %d", ret);
-		FATAL_ERROR();
-		return ret;
+	if (IS_ENABLED(CONFIG_DK_LIBRARY)) {
+		ret = dk_leds_init();
+		if (ret) {
+			LOG_ERR("dk_leds_init, error: %d", ret);
+			FATAL_ERROR();
+			return ret;
+		}
 	}
-#endif /* defined(CONFIG_DK_LIBRARY) */
 
 	/* Setup handler for Zephyr NET Connection Manager events. */
 	net_mgmt_init_event_callback(&l4_cb, l4_event_handler, L4_EVENT_MASK);

--- a/samples/net/mqtt/src/modules/trigger/trigger.c
+++ b/samples/net/mqtt/src/modules/trigger/trigger.c
@@ -7,9 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/zbus/zbus.h>
-#if CONFIG_DK_LIBRARY
 #include <dk_buttons_and_leds.h>
-#endif /* CONFIG_DK_LIBRARY */
 
 #include "message_channel.h"
 
@@ -28,26 +26,24 @@ static void message_send(void)
 	}
 }
 
-#if CONFIG_DK_LIBRARY
 static void button_handler(uint32_t button_states, uint32_t has_changed)
 {
 	if (has_changed & button_states) {
 		message_send();
 	}
 }
-#endif /* CONFIG_DK_LIBRARY */
 
 static void trigger_task(void)
 {
-#if CONFIG_DK_LIBRARY
-	int err = dk_buttons_init(button_handler);
+	if (IS_ENABLED(CONFIG_DK_LIBRARY)) {
+		int err = dk_buttons_init(button_handler);
 
-	if (err) {
-		LOG_ERR("dk_buttons_init, error: %d", err);
-		SEND_FATAL_ERROR();
-		return;
+		if (err) {
+			LOG_ERR("dk_buttons_init, error: %d", err);
+			SEND_FATAL_ERROR();
+			return;
+		}
 	}
-#endif /* CONFIG_DK_LIBRARY */
 
 	while (true) {
 		message_send();


### PR DESCRIPTION
This PR replaces `#if defined(CONFIG_X)` preprocessor guards with runtime `if (IS_ENABLED(CONFIG_X))` checks in networking samples where possible.

The guarded code compiles fine regardless of the Kconfig state, so this lets the compiler dead-code-eliminate the disabled paths instead of needing separate preprocessor-gated build variants.

Jira: NCSDK-40640