### PR TITLE
samples: matter: Fix crash when printing unset clusterId

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -326,6 +326,8 @@ Matter samples
   DFU is not supported on this board target, as the nRF54LC10 DK is not equipped with external flash.
   See :ref:`ug_matter_hw_requirements_external_flash` for more information.
 
+* Fixed an issue where the binding table was not printed correctly when the cluster ID was not set.
+
 Networking samples
 ------------------
 

--- a/samples/matter/common/src/binding/binding_handler.cpp
+++ b/samples/matter/common/src/binding/binding_handler.cpp
@@ -27,7 +27,11 @@ namespace Nrf::Matter
 		VerifyOrReturn(bindingData->InvokeCommandFunc != nullptr,
 			       LOG_ERR("No valid InvokeCommandFunc assigned"););
 
+	CHIP_ERROR err =
 		DeviceLayer::PlatformMgr().ScheduleWork(DeviceWorkerHandler, reinterpret_cast<intptr_t>(bindingData));
+		if (CHIP_NO_ERROR != err) {
+			LOG_ERR("ScheduleWork failed due to: %" CHIP_ERROR_FORMAT, err.Format());
+		}
 	}
 
 	void BindingHandler::OnInvokeCommandSucces(BindingData *bindingData)
@@ -122,11 +126,14 @@ namespace Nrf::Matter
 				LOG_INF("[%d] UNICAST:", i++);
 				LOG_INF("\t\t+ Fabric: %d\n \
             \t+ LocalEndpoint %d \n \
-            \t+ ClusterId %d \n \
             \t+ RemoteEndpointId %d \n \
             \t+ NodeId %d",
-					(int)entry.fabricIndex, (int)entry.local, (int)entry.clusterId.value(),
-					(int)entry.remote, (int)entry.nodeId);
+				(int)entry.fabricIndex, (int)entry.local, (int)entry.remote, (int)entry.nodeId);
+				if (entry.clusterId.has_value()) {
+					LOG_INF("\t\t+ ClusterId %d", (int)*entry.clusterId);
+				} else {
+					LOG_INF("\t\t+ ClusterId: none");
+				}
 				break;
 			case Binding::MATTER_MULTICAST_BINDING:
 				LOG_INF("[%d] GROUP:", i++);


### PR DESCRIPTION
Check clusterId.has_value() in PrintBindingTable before logging unicast bindings, since clusterId is optional in
Binding::TableEntry.