### PR TITLE
net: hostap_crypto: Reset SAE state before hunting-and-pecking commit

### DIFF
--- a/subsys/net/lib/hostap_crypto/wpa3_psa.c
+++ b/subsys/net/lib/hostap_crypto/wpa3_psa.c
@@ -254,10 +254,7 @@ void sae_clear_data(struct sae_data *sae)
 
 	sae_clear_temp_data(sae);
 
-	if (sae->tmp) {
-		os_free(sae->tmp);
-		sae->tmp = NULL;
-	}
+	os_memset(sae, 0, sizeof(*sae));
 }
 
 /**
@@ -294,6 +291,9 @@ int sae_prepare_commit(const u8 *addr1, const u8 *addr2, const u8 *password, siz
 		wpa_printf(MSG_ERROR, "WPA3-PSA: sae_prepare_commit failed - init_psa_op failed");
 		return -1;
 	}
+
+	sae->h2e = 0;
+	sae->pk = 0;
 
 	op = get_psa_op(sae);
 	if (!op) {


### PR DESCRIPTION
sae_clear_data() only released sae->tmp and left the rest of struct sae_data untouched, so flags set by one authentication attempt survived into the next one. sae_prepare_commit_pt() sets sae->h2e = 1 so that the SME accepts WLAN_STATUS_SAE_HASH_TO_ELEMENT from the AP; that value stayed set when a later attempt fell back to the hunting-and-pecking sae_prepare_commit() path, leaving the SME expecting an H2E status code for a commit that is not H2E.

Clear the whole sae_data object once the temporary data has been released, and additionally reset sae->h2e and sae->pk in sae_prepare_commit() so the non-H2E path is correct even when the caller reuses a sae_data that was never cleared.

Dropping the os_free(sae->tmp) block does not leak: sae_clear_temp_data() already frees the operation and clears sae->tmp, so the block was dead code.

Fixes SHEL-4191.


Assisted-by: Copilot: Auto