### PR TITLE
doc: release notes: add Fast Pair Locator Tag nRF54LM20 DK entries

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -377,6 +377,11 @@ Bluetooth Fast Pair samples
     * The references to the deleted ``CONFIG_CRACEN_LIB_KMU`` Kconfig option to use the :kconfig:option:`CONFIG_CRACEN_KMU` replacement.
     * The TX power calibration for the ``nrf54l15tag/nrf54l15/cpuapp`` board target.
       The :kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` and :kconfig:option:`CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL` Kconfig options were changed from ``-13`` dBm to ``-11`` dBm to meet the Fast Pair distance certification requirements.
+    * The TX power calibration for the ``nrf54lm20dk/nrf54lm20a/cpuapp`` and ``nrf54lm20dk/nrf54lm20b/cpuapp`` board targets.
+      The :kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` and :kconfig:option:`CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL` Kconfig options were changed from ``-15`` dBm to ``-2`` dBm to meet the Fast Pair distance certification requirements.
+    * The location of the :kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` and :kconfig:option:`CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL` Kconfig options.
+      The options were moved from the sample-wide configuration files to the board configuration files in the :file:`configuration/boards` directory, as the TX power correction is hardware-specific.
+      Every supported board target now declares its own calibration.
 
 * :ref:`fast_pair_input_device` sample:
 


### PR DESCRIPTION
## Summary

Adds the changelog entries for the nRF54LM20 DK TX power recalibration of the Fast Pair Locator Tag sample. The entries were intentionally omitted from #30985 and deferred to this dedicated pull request.

The change documents both parts of #30985:

- The recalibration of `CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` and `CONFIG_BT_FAST_PAIR_FHN_TX_POWER_CORRECTION_VAL` from `-15` dBm to `-2` dBm for the `nrf54lm20dk/nrf54lm20a/cpuapp` and `nrf54lm20dk/nrf54lm20b/cpuapp` board targets.
- The relocation of both Kconfig options out of the sample-wide `configuration/prj.conf` and `configuration/prj_release.conf` into the board configuration files in `configuration/boards`.

The relocation is listed as a separate bullet on purpose. It is the part of the change that is visible to users maintaining an out-of-tree board configuration or adding a new board target to the sample, because such a target now has to set both Kconfig options itself instead of inheriting a sample-wide value.

The entries slot into the existing `Updated:` list of the sample, directly after the earlier nRF54L15 TAG recalibration entry, and follow its wording and formatting.

Ref: NCSDK-39912

## Test plan

- [x] Confirm the added bullets use the same indentation as their sibling bullets (4 spaces for list items, 6 for continuation lines) and the same `:kconfig:option:` roles as the existing entries.
- [x] Confirm no nRF54LM20 DK entry for this sample already exists in the changelog.
- [ ] Documentation build in CI passes.

## Notes for reviewers

- The code change was backported to the `v3.4-branch` in #30992, which is already merged. A changelog backport may be wanted as well, so I have deliberately not applied a backport label yet.
- The equivalent changelog entry for the Switchable Networks sample recalibration (nrfconnect/sdk-find-my#462) is tracked separately in the `sdk-find-my` repository.