### PR TITLE
[Backport v3.4-branch] Samples: Bluetooth: Mesh: Support for nRF54L15TAG in LPN sample

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -256,6 +256,10 @@ Bluetooth Mesh samples
 
 |no_changes_yet_note|
 
+* :ref:`bluetooth_mesh_light_switch` sample:
+
+  * Added support for the ``nrf54l15tag/nrf54l15/cpuapp`` board target in the LPN configuration.
+
 Bluetooth Fast Pair samples
 ---------------------------
 

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -21,6 +21,9 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. note::
+   Use the nRF54L15 Tag only in the Low Power Node (LPN) configuration.
+
 You need at least two development kits:
 
 * One development kit where you program this sample application (the client)
@@ -132,6 +135,12 @@ The mesh light switch sample can also be run as a Low Power node (LPN), giving t
       Instead, the user can manually enable the Node ID advertisement for a period of 30 seconds by pressing **Button 3** on the device.
       This will give the user a short period of time to connect directly to the LPN, and thus perform necessary configuration of the device.
 
+   .. group-tab:: nRF54 TAG
+
+      When you run the sample using the LPN configuration, Node ID advertisements are disabled.
+      You cannot manually enable the Node ID advertisements on the nRF54L15 Tag because it has only one button, which is used for the :ref:`bt_mesh_onoff_cli_readme`.
+      After friendship is established, all Bluetooth Mesh communication must go through the friendship.
+
 After the connection to the LPN is terminated, and the Node ID advertisement has stopped, the LPN will return to its previous state.
 
 Friendship establishment will happen automatically after provisioning the LPN light switch, given that a :ref:`bluetooth_mesh_light` sample is running and is provisioned into the same mesh network.
@@ -147,13 +156,14 @@ The following table shows a list of the supported boards for the LPN configurati
 .. table::
    :align: center
 
-   ===================  ========================  ====================
-   Board                Avg. consumption non-LPN  Avg. consumption LPN
-   ===================  ========================  ====================
-   nrf52dk/nrf52832     7.14 mA                    13.69 µA
-   nrf52840dk/nrf52840  6.71 mA                    14.63 µA
-   nrf52833dk/nrf52833  6.10 mA                    14.43 µA
-   ===================  ========================  ====================
+   ====================  ========================  ====================
+   Board                 Avg. consumption non-LPN  Avg. consumption LPN
+   ====================  ========================  ====================
+   nrf52dk/nrf52832      7.14 mA                   13.69 µA
+   nrf52840dk/nrf52840   6.71 mA                   14.63 µA
+   nrf52833dk/nrf52833   6.10 mA                   14.43 µA
+   nrf54l15tag/nrf54l15  -                         12.42 µA
+   ====================  ========================  ====================
 
 The following applies to the LPN measurements presented in this table:
 

--- a/samples/bluetooth/mesh/light_switch/boards/nrf54l15tag_nrf54l15_cpuapp.conf
+++ b/samples/bluetooth/mesh/light_switch/boards/nrf54l15tag_nrf54l15_cpuapp.conf
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+################################################################################
+# Application overlay - nrf54l15tag
+
+CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE=n
+CONFIG_NVS=n
+CONFIG_NVS_LOOKUP_CACHE=n
+CONFIG_SETTINGS_NVS_NAME_CACHE=n
+CONFIG_ZMS=y
+CONFIG_SETTINGS_ZMS_CUSTOM_SECTOR_COUNT=y
+CONFIG_SETTINGS_ZMS_SECTOR_COUNT=8
+CONFIG_ZMS_LOOKUP_CACHE=y
+CONFIG_ZMS_LOOKUP_CACHE_SIZE=512
+CONFIG_ZMS_LOOKUP_CACHE_FOR_SETTINGS=y
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+CONFIG_BT_RX_STACK_SIZE=5120
+
+# Shorten the Friend Offer listening window (scanner-on time) from the 1000 ms
+# default to save power; the LPN listens for offers for less time per request.
+CONFIG_BT_MESH_LPN_OFFER_WAIT_TIMEOUT=250
+
+# Increase interval between Friend Requests while establishing/re-establishing friendship.
+CONFIG_BT_MESH_LPN_RETRY_TIMEOUT=30

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -39,6 +39,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15tag/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
     extra_args: OVERLAY_CONFIG=overlay-lpn.conf
   sample.bluetooth.mesh.light_switch.settings_ext_flash:


### PR DESCRIPTION
Backport c9257ceaf985337b15216e4eddef8f25389fb123 from #31016.