### PR TITLE
samples: nrf93m1dk: Configure LED output on PPP sample

### DIFF
--- a/samples/nrf93m1dk/ppp_shell/src/main.c
+++ b/samples/nrf93m1dk/ppp_shell/src/main.c
@@ -6,10 +6,10 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/device.h>
 
-static const struct gpio_dt_spec led_blue = GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios);
+static const struct gpio_dt_spec led_green = GPIO_DT_SPEC_GET(DT_ALIAS(led2), gpios);
 
 int main(void)
 {
-	/* LED4 blue */
-	gpio_pin_set_dt(&led_blue, 1);	return 0;
+	gpio_pin_configure_dt(&led_green, GPIO_OUTPUT_ACTIVE);
+	return 0;
 }


### PR DESCRIPTION
Use gpio_pin_configure_dt() for the LED so it is properly initialized on boot.

Also, change the color to green, so it is different from the modem_bypass sample.
