### PR TITLE
Revert "manifest: update sdk-zephyr for missing redesigned clocks ali…

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 203fe7cac470f6fa5bdbb876656b8233c88ed2d3
+      revision: 2f1d55e1625cb3a3d1711e0d65ea9609cfd569ff
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
…gnments"

This reverts commit 624d51ae47eea1786157303c9b36cbdb7148c2f3.

That commit moved the sdk-zephyr pointer backwards, presumably due to incorrect resolution of the conflict in west.yml when its PR was rebased.