### PR TITLE
nrf_security: fix reference to CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/Kconfig
+++ b/subsys/nrf_security/src/drivers/cracen/Kconfig
@@ -89,7 +89,7 @@ config CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS
 	  This option indicates that the protected RAM invalidation slots are provisioned
 	  using nrfutil. When enabled, the manual provisioning options below are hidden because
 	  provisioning is expected to be handled through sysbuild/nrfutil instead.
-	  This option is controlled by the KMU_INVALIDATE_PROTECTED_RAM_SLOTS sysbuild
+	  This option is controlled by the CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS sysbuild
 	  configuration option, so enable it in your sysbuild
 	  configuration rather than setting this symbol manually.
 


### PR DESCRIPTION
Fixes reference to CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS sysbuild option in the description of the main CRACEN_KMU_INVALIDATE_PROTECTED_RAM_SLOTS Kconfig option.
https://github.com/nrfconnect/sdk-nrf/commit/a185ede15e135f42291cfafdb99344ca59463e10 added the main option and renamed the sysbuild option, but it did not use the new sysbuild option name in the description.