### PR TITLE
tests: benchmarks: current_consumption: Fix nfc_idle on nrf9251dk

### DIFF
--- a/tests/benchmarks/current_consumption/nfc_idle/boards/nrf9251dk_nrf9251_cpuapp.conf
+++ b/tests/benchmarks/current_consumption/nfc_idle/boards/nrf9251dk_nrf9251_cpuapp.conf
@@ -1,0 +1,3 @@
+# Disable NFC low latency IRQ
+CONFIG_NFC_LOW_LATENCY_IRQ=n
+CONFIG_PM=y


### PR DESCRIPTION
On nrf9251dk NFC low latency IRQ has to be disabled.