### PR TITLE
drivers: wifi: nrf71: Fix 6 GHz support in scan path

### DIFF
--- a/drivers/wifi/nrf71/src/system/wifi_mgmt_scan.c
+++ b/drivers/wifi/nrf71/src/system/wifi_mgmt_scan.c
@@ -31,6 +31,8 @@ static enum nrf_wifi_band nrf_wifi_map_zep_band_to_rpu(enum wifi_frequency_bands
 		return NRF_WIFI_BAND_2GHZ;
 	case WIFI_FREQ_BAND_5_GHZ:
 		return NRF_WIFI_BAND_5GHZ;
+	case WIFI_FREQ_BAND_6_GHZ:
+		return NRF_WIFI_BAND_6GHZ;
 	default:
 		return NRF_WIFI_BAND_INVALID;
 	}
@@ -91,6 +93,7 @@ int nrf_wifi_disp_scan_zep(const struct device *dev,
 	if (params) {
 		band_flags &= (~(1 << WIFI_FREQ_BAND_2_4_GHZ));
 		band_flags &= (~(1 << WIFI_FREQ_BAND_5_GHZ));
+		band_flags &= (~(1 << WIFI_FREQ_BAND_6_GHZ));
 
 		if (params->bands & band_flags) {
 			LOG_ERR("%s: Unsupported band(s) (0x%X)", __func__, params->bands);

--- a/drivers/wifi/nrf71/utils/src/util.c
+++ b/drivers/wifi/nrf71/utils/src/util.c
@@ -117,6 +117,24 @@ int nrf_wifi_utils_chan_to_freq(enum nrf_wifi_band band,
 		}
 
 		break;
+	case NRF_WIFI_BAND_6GHZ:
+		/* IEEE 802.11ax 6 GHz channelization (global operating classes).
+		 * Channel 2 is a special case at 5935 MHz. The 20 MHz channels
+		 * are 1, 5, 9, ... 233 (i.e. chan % 4 == 1) and map to
+		 * 5950 + (chan * 5) MHz.
+		 */
+		if (chan == 2) {
+			freq = 5935;
+		} else if ((chan >= 1) && (chan <= 233) && ((chan % 4) == 1)) {
+			freq = 5950 + (chan * 5);
+		} else {
+			nrf_wifi_osal_log_err("%s: 6GHz: Invalid channel value %d",
+					      __func__,
+					      chan);
+			goto out;
+		}
+
+		break;
 	default:
 		nrf_wifi_osal_log_err("%s: Invalid band value %d",
 				      __func__,


### PR DESCRIPTION
Add the missing 6 GHz band handling so that 6 GHz SSIDs are detected in Wi-Fi scan results.

Fix WZN-10519.