### PR TITLE
nfc: ndef: improve long record length validation

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -832,7 +832,10 @@ Libraries for networking
 Libraries for NFC
 -----------------
 
-|no_changes_yet_note|
+* :ref:`nfc_ndef_parser_readme`:
+
+  * Fixed an issue where parsing a malformed long-format NDEF record could produce an incorrect payload length.
+    The parser now validates type, ID, and payload lengths against the remaining input buffer.
 
 nRF RPC libraries
 -----------------

--- a/subsys/nfc/ndef/record_parser.c
+++ b/subsys/nfc/ndef/record_parser.c
@@ -75,6 +75,25 @@ int nfc_ndef_record_parse(struct nfc_ndef_bin_payload_desc *bin_pay_desc,
 		rec_desc->id = NULL;
 	}
 
+	/* Validate type, ID, and payload lengths for long-format records (SR flag is cleared). */
+	if (!(flags & NDEF_RECORD_SR_MASK)) {
+		uint32_t remaining = *nfc_data_len - expected_rec_size;
+
+		if (rec_desc->type_length > remaining) {
+			return -EINVAL;
+		}
+		remaining -= rec_desc->type_length;
+
+		if (rec_desc->id_length > remaining) {
+			return -EINVAL;
+		}
+		remaining -= rec_desc->id_length;
+
+		if (payload_length > remaining) {
+			return -EINVAL;
+		}
+	}
+
 	expected_rec_size += rec_desc->type_length + rec_desc->id_length + payload_length;
 
 	if (expected_rec_size > *nfc_data_len) {


### PR DESCRIPTION
Validate type, ID, and payload lengths individually for long-format NDEF records before computing the total record size. Long-format records use a 32-bit payload length field. Check each field against the remaining input size to reject malformed records that declare lengths exceeding the available data.
The existing total-size check is retained for short-format records.

KRKNWK-22420