### PR TITLE
[Backport v3.4-branch] net: hostap_crypto: Reset SAE state before hunting-and-pecking commit

### DIFF
--- a/subsys/net/lib/hostap_crypto/wpa3_psa.c
+++ b/subsys/net/lib/hostap_crypto/wpa3_psa.c
@@ -254,10 +254,7 @@ void sae_clear_data(struct sae_data *sae)
 
 	sae_clear_temp_data(sae);
 
-	if (sae->tmp) {
-		os_free(sae->tmp);
-		sae->tmp = NULL;
-	}
+	os_memset(sae, 0, sizeof(*sae));
 }
 
 /**
@@ -294,6 +291,9 @@ int sae_prepare_commit(const u8 *addr1, const u8 *addr2, const u8 *password, siz
 		wpa_printf(MSG_ERROR, "WPA3-PSA: sae_prepare_commit failed - init_psa_op failed");
 		return -1;
 	}
+
+	sae->h2e = 0;
+	sae->pk = 0;
 
 	op = get_psa_op(sae);
 	if (!op) {


### PR DESCRIPTION
Backport 297a39450299cbab5a1abe67b064062b9b74013e from #31018.