### PR TITLE
tests: gatt_dm: add four intentional Doxygen violations

### DIFF
--- a/include/bluetooth/gatt_dm.h
+++ b/include/bluetooth/gatt_dm.h
@@ -9,6 +9,9 @@
 
 /**
  * @file
+ */
+
+/**
  * @defgroup bt_gatt_dm GATT Discovery Manager API
  * @{
  * @brief Module for GATT Discovery Manager.
@@ -145,29 +148,30 @@ size_t bt_gatt_dm_attr_cnt(const struct bt_gatt_dm *dm);
 
 /** @brief Get service value
  *
- * Function returns the value that contains UUID and attribute
- * end handler of the service found
+ * The function returns the value containing the service UUID and the end
+ * handle of the discovered service.
  *
- * @param[in] dm Discovery Manager instance
+ * @param[in] dm Discovery Manager instance.
  *
- * @returns The pointer service value structure
+ * @return Pointer to the service value structure.
  */
 const struct bt_gatt_dm_attr *bt_gatt_dm_service_get(
 	const struct bt_gatt_dm *dm);
 
-/** @brief Get next characteristic
+/** @brief Getting the next characteristic
  *
  * @note Search starts from the previous attribute when provided
+ * @note NULL means search from the first characteristic in the service
  *
- * @param[in] dm Discovery Manager instance
- * @param[in] prev An attribute where start to search
+ * @param dm Discovery Manager instance
+ * @param prev An attribute where start to search
  *            If NULL - the first characteristic in the service would be found
  *            Note: It can be the previous characteristic attribute or the
  *            last descriptor inside the previous attribute
  *            Function would start searching for the next characteristic
  *            from that point
  *
- * @return The pointer for an attribute that describes the characteristic
+ * @returns The pointer for an attribute that describes the characteristic
  *         or NULL if no more characteristic is present
  */
 const struct bt_gatt_dm_attr *bt_gatt_dm_char_next(

--- a/include/bluetooth/gatt_dm.h
+++ b/include/bluetooth/gatt_dm.h
@@ -124,49 +124,51 @@ struct bt_gatt_chrc *bt_gatt_dm_attr_chrc_val(
 /** @brief Get the connection object
  *
  * Function returns connection object that is used by given
- * discovery manager instance.
+ * discovery manager instance
  *
  * @param[in] dm Discovery Manager instance
  *
- * @return Connection object.
+ * @return Connection object
  */
 struct bt_conn *bt_gatt_dm_conn_get(struct bt_gatt_dm *dm);
 
 /** @brief Get total number of attributes decoded
  *
- * The number of attributes including the service attribute.
- * It means that service without any attribute would return 1 here.
+ * The number of attributes including the service attribute
+ * It means that service without any attribute would return 1 here
  *
- * @param[in] dm Discovery Manager instance.
+ * @param dm Discovery Manager instance
  *
- * @return Total number of attributes parsed.
+ * @return Total number of attributes parsed
  */
 size_t bt_gatt_dm_attr_cnt(const struct bt_gatt_dm *dm);
 
 /** @brief Get service value
  *
  * Function returns the value that contains UUID and attribute
- * end handler of the service found.
+ * end handler of the service found
  *
- * @param[in] dm Discovery Manager instance.
+ * @param[in] dm Discovery Manager instance
  *
- * @return The pointer service value structure.
+ * @returns The pointer service value structure
  */
 const struct bt_gatt_dm_attr *bt_gatt_dm_service_get(
 	const struct bt_gatt_dm *dm);
 
 /** @brief Get next characteristic
  *
- * @param[in] dm Discovery Manager instance.
- * @param[in] prev An attribute where start to search.
- *            If NULL - the first characteristic in the service would be found.
+ * @note Search starts from the previous attribute when provided
+ *
+ * @param[in] dm Discovery Manager instance
+ * @param[in] prev An attribute where start to search
+ *            If NULL - the first characteristic in the service would be found
  *            Note: It can be the previous characteristic attribute or the
- *            last descriptor inside the previous attribute.
+ *            last descriptor inside the previous attribute
  *            Function would start searching for the next characteristic
- *            from that point.
+ *            from that point
  *
  * @return The pointer for an attribute that describes the characteristic
- *         or NULL if no more characteristic is present.
+ *         or NULL if no more characteristic is present
  */
 const struct bt_gatt_dm_attr *bt_gatt_dm_char_next(
 	const struct bt_gatt_dm *dm,


### PR DESCRIPTION
Introduce missing periods, bare @param, @returns, and misplaced @note for doxygen-pr-reviewer flow testing.