### PR TITLE
[Backport v3.4-branch] nfc: ndef: improve long record length validation

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -473,7 +473,10 @@ Libraries for networking
 Libraries for NFC
 -----------------
 
-|no_changes_yet_note|
+* :ref:`nfc_ndef_parser_readme`:
+
+  * Fixed an issue where parsing a malformed long-format NDEF record could produce an incorrect payload length.
+    The parser now validates type, ID, and payload lengths against the remaining input buffer.
 
 nRF RPC libraries
 -----------------

--- a/subsys/nfc/ndef/record_parser.c
+++ b/subsys/nfc/ndef/record_parser.c
@@ -75,6 +75,25 @@ int nfc_ndef_record_parse(struct nfc_ndef_bin_payload_desc *bin_pay_desc,
 		rec_desc->id = NULL;
 	}
 
+	/* Validate type, ID, and payload lengths for long-format records (SR flag is cleared). */
+	if (!(flags & NDEF_RECORD_SR_MASK)) {
+		uint32_t remaining = *nfc_data_len - expected_rec_size;
+
+		if (rec_desc->type_length > remaining) {
+			return -EINVAL;
+		}
+		remaining -= rec_desc->type_length;
+
+		if (rec_desc->id_length > remaining) {
+			return -EINVAL;
+		}
+		remaining -= rec_desc->id_length;
+
+		if (payload_length > remaining) {
+			return -EINVAL;
+		}
+	}
+
 	expected_rec_size += rec_desc->type_length + rec_desc->id_length + payload_length;
 
 	if (expected_rec_size > *nfc_data_len) {


### PR DESCRIPTION
Backport 459faab041ab83cc90e1ffd9f04838b394167a1b from #31065.