### PR TITLE
[Backport v3.4-branch] dult: adv: Gate payload fill on the associated user +  dult: Zero-initialize the user slot foreach snapshot + dult: Add deprecated struct dult_firmware_version alias

### DIFF
--- a/include/dult.h
+++ b/include/dult.h
@@ -11,4 +11,7 @@
 
 #include <dult/dult.h>
 
+/* Deprecated type aliases. */
+#define dult_firmware_version dult_version
+
 #endif /* _DULT_H_ */

--- a/include/dult/bt.h
+++ b/include/dult/bt.h
@@ -118,8 +118,8 @@ struct dult_bt_adv_data {
 
 /** @brief Encode the DULT location-enabled Bluetooth advertising payload.
  *
- *  This function can only be called if the DULT user was previously registered with the
- *  @ref dult_user_register API.
+ *  This function can only be called by the currently associated DULT user, that is the
+ *  user that has enabled DULT with the @ref dult_enable API and has not yet been reset.
  *
  *  Serializes the DULT data (UUID, network ID, near-owner byte, and optional
  *  proprietary data from @p adv_data) into @p buf and populates @p bt_adv_data to

--- a/subsys/dult/bt/adv.c
+++ b/subsys/dult/bt/adv.c
@@ -47,7 +47,7 @@ int dult_bt_adv_data_fill(const struct dult_user *user, struct bt_data *bt_adv_d
 		return -EINVAL;
 	}
 
-	if (!dult_user_is_registered(user)) {
+	if (!dult_user_is_associated(user)) {
 		return -EACCES;
 	}
 

--- a/subsys/dult/user_slot.c
+++ b/subsys/dult/user_slot.c
@@ -118,7 +118,7 @@ void dult_user_slot_foreach(void (*cb)(const struct dult_user *user, const void 
 	 */
 	static bool in_foreach;
 
-	const struct dult_user *snapshot[CONFIG_DULT_USER_MAX];
+	const struct dult_user *snapshot[CONFIG_DULT_USER_MAX] = {0};
 	size_t count = 0;
 
 	__ASSERT_NO_MSG(cb);


### PR DESCRIPTION
Backport 99ad6086eeb2bb60805b5426c62372d604cf1c43~3..99ad6086eeb2bb60805b5426c62372d604cf1c43 from #31082.