### PR TITLE
bluetooth: controller: Remove delayed command complete not in use

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -38,10 +38,6 @@ static struct
 static uint8_t num_completed_packet_command_status;
 #endif /* CONFIG_BT_HCI_ACL_FLOW_CONTROL */
 
-#if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC) && !defined(SDC_HCI_PAWR_SYNC_RETURN_IMMEDIATELY)
-static bool padv_response_data_cmd_pending;
-#endif
-
 static hci_internal_user_cmd_handler_t user_cmd_handler;
 
 static bool command_generates_command_complete_event(uint16_t hci_opcode)
@@ -1982,11 +1978,7 @@ int hci_internal_cmd_put(uint8_t *cmd_in)
 	}
 #endif /* CONFIG_BT_HCI_ACL_FLOW_CONTROL */
 
-	if (cmd_complete_or_status.occurred
-#if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC) && !defined(SDC_HCI_PAWR_SYNC_RETURN_IMMEDIATELY)
-		|| padv_response_data_cmd_pending
-#endif
-		) {
+	if (cmd_complete_or_status.occurred) {
 		return -NRF_EPERM;
 	}
 
@@ -2002,19 +1994,6 @@ int hci_internal_cmd_put(uint8_t *cmd_in)
 	}
 
 	cmd_complete_or_status.occurred = true;
-
-#if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC) && !defined(SDC_HCI_PAWR_SYNC_RETURN_IMMEDIATELY)
-	if (opcode == SDC_HCI_OPCODE_CMD_LE_SET_PERIODIC_ADV_RESPONSE_DATA
-		&&
-		cmd_complete_or_status.raw_event[0] == BT_HCI_EVT_CMD_COMPLETE) {
-		/* SDC_HCI_OPCODE_CMD_LE_SET_PERIODIC_ADV_RESPONSE_DATA
-		 * will generate command complete at a later time (unless unsupported)
-		 */
-
-		cmd_complete_or_status.occurred = false;
-		padv_response_data_cmd_pending = true;
-	}
-#endif
 
 	return 0;
 }
@@ -2050,13 +2029,6 @@ int hci_internal_msg_get(uint8_t *msg_out, sdc_hci_msg_type_t *msg_type_out)
 	}
 
 	const int retval = sdc_hci_get(msg_out, (uint8_t *)msg_type_out);
-
-#if defined(CONFIG_BT_CTLR_SDC_PAWR_SYNC) && !defined(SDC_HCI_PAWR_SYNC_RETURN_IMMEDIATELY)
-	if (retval == 0 && *msg_type_out == SDC_HCI_MSG_TYPE_EVT
-		&& msg_out[0] == BT_HCI_EVT_CMD_COMPLETE) {
-		padv_response_data_cmd_pending = false;
-	}
-#endif
 
 	return retval;
 }


### PR DESCRIPTION
The SoftDevice Controller now returns immediately from the 7.8.126 LE Set Periodic Advertising Response Data command. This code is no longer necessary, so delete it.

The SoftDevice Controller changelog already mentions this change (DRGN-29455), so no need for duplicate changelog entries.