### PR TITLE
nrf_rpc: ipc: Defer processing of received data to a thread and use IPC TX buffer pool

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -842,7 +842,13 @@ Libraries for NFC
 nRF RPC libraries
 -----------------
 
-|no_changes_yet_note|
+* :ref:`nrf_rpc_ipc_readme` library:
+
+  * Added:
+
+    * Support for deferred processing of received IPC Service packets in a dedicated thread.
+      This is required for the IPC Service backends that invoke the receive callback from an interrupt context, like ICBMSG, because the nRF RPC core expects to be called from a thread context.
+      The :kconfig:option:`CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD` Kconfig option is used to enable this feature.
 
 Other libraries
 ---------------

--- a/include/nrf_rpc/nrf_rpc_ipc.h
+++ b/include/nrf_rpc/nrf_rpc_ipc.h
@@ -9,6 +9,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/ipc/ipc_service.h>
+#include <zephyr/kernel.h>
 
 #include <nrf_rpc.h>
 #include <nrf_rpc_tr.h>
@@ -59,9 +60,36 @@ struct nrf_rpc_ipc {
 	/** User context. */
 	void *context;
 
+#if defined(CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD)
+	/** Queue of the received packets waiting for processing by the Rx thread. */
+	struct k_msgq *rx_msgq;
+
+	/** Rx thread object. */
+	struct k_thread *rx_thread;
+
+	/** Rx thread stack. */
+	k_thread_stack_t *rx_stack;
+#endif
+
 	/** Current transport state. */
 	uint8_t state;
 };
+
+#if defined(CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD)
+
+/** @brief Descriptor of a received packet queued for processing by the Rx thread.
+ *
+ * For internal use only.
+ */
+struct nrf_rpc_ipc_rx_packet {
+	/** Packet data located in the held IPC Service Rx buffer. */
+	const void *data;
+
+	/** Packet length. */
+	size_t len;
+};
+
+#endif /* CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD */
 
 /** @brief Extern nRF RPC IPC Service transport declaration.
  *
@@ -108,15 +136,33 @@ struct nrf_rpc_ipc {
  *      NRF_RPC_GROUP_DEFINE(group_1, "Group_1", &nrf_rpc_1, NULL, NULL, NULL);
  *      NRF_RPC_GROUP_DEFINE(group_2, "Group_2", &nrf_rpc_2, NULL, NULL, NULL);
  *
+ * If @kconfig{CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD} is enabled, this macro also allocates
+ * the RX packet queue, and the RX thread object and stack for the transport instance.
+ * The thread is created when the transport is initialized.
+ *
  * @param[in] _name nRF RPC IPC Service transport instance name.
  * @param[in] _ipc The instance used for the IPC Service to transfer data between CPUs.
  * @param[in] _ept_name IPC Service endpoint name. The endpoint must have the same name on the
  *                      corresponding remote CPU.
  */
 #define NRF_RPC_IPC_TRANSPORT(_name, _ipc, _ept_name)                        \
+	IF_ENABLED(CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD, (                   \
+		K_MSGQ_DEFINE(_name##_rx_msgq,                               \
+			      sizeof(struct nrf_rpc_ipc_rx_packet),          \
+			      CONFIG_NRF_RPC_IPC_SERVICE_RX_QUEUE_SIZE,      \
+			      sizeof(void *));                               \
+		static K_THREAD_STACK_DEFINE(_name##_rx_stack,               \
+			CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD_STACK_SIZE);    \
+		static struct k_thread _name##_rx_thread;                    \
+	))                                                                   \
+									     \
 	static struct nrf_rpc_ipc _name##_instance = {                       \
 	       .ipc = _ipc,                                                  \
 	       .endpoint.ept_cfg.name = _ept_name,                           \
+	       IF_ENABLED(CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD,              \
+			  (.rx_msgq = &_name##_rx_msgq,                      \
+			   .rx_thread = &_name##_rx_thread,                  \
+			   .rx_stack = _name##_rx_stack,))                   \
 	};                                                                   \
 									     \
 	const struct nrf_rpc_tr _name = {                                    \

--- a/subsys/nrf_rpc/Kconfig
+++ b/subsys/nrf_rpc/Kconfig
@@ -61,6 +61,42 @@ config NRF_RPC_IPC_SERVICE_BIND_TIMEOUT_MS
 	  This timeout depends on the time to initialize all the remote devices
 	  the nRF RPC is going to communicate with.
 
+config NRF_RPC_IPC_SERVICE_RX_THREAD
+	bool "Process received packets in a dedicated thread"
+	default y if IPC_SERVICE_BACKEND_ICBMSG
+	help
+	  Defer processing of packets received on an IPC Service endpoint to a thread dedicated.
+	  This is required for the IPC Service backends that invoke the receive callback from
+	  an interrupt context, like ICBMSG, because the nRF RPC core expects to be called
+	  from a thread context. Received packets are not copied: the transport holds the
+	  RX buffer until the thread finishes processing the packet. Packets received
+	  on an endpoint of a backend that does not support holding the RX buffer are processed
+	  in the receive callback.
+
+if NRF_RPC_IPC_SERVICE_RX_THREAD
+
+config NRF_RPC_IPC_SERVICE_RX_THREAD_STACK_SIZE
+	int "RX thread stack size"
+	default 768
+	help
+	  Defines the stack size of the RX thread that is created for each nRF RPC IPC
+	  Service transport instance.
+
+config NRF_RPC_IPC_SERVICE_RX_THREAD_PRIORITY
+	int "RX thread priority"
+	default 0
+	help
+	  Defines the priority of the RX thread.
+
+config NRF_RPC_IPC_SERVICE_RX_QUEUE_SIZE
+	int "RX queue size"
+	default 8
+	help
+	  Defines the maximum number of the received packets that can be queued for
+	  processing by the RX thread.
+
+endif # NRF_RPC_IPC_SERVICE_RX_THREAD
+
 endif # NRF_RPC_IPC_SERVICE
 
 

--- a/subsys/nrf_rpc/nrf_rpc_ipc.c
+++ b/subsys/nrf_rpc/nrf_rpc_ipc.c
@@ -90,17 +90,108 @@ static void ept_bound(void *priv)
 	k_event_set(&ipc_config->endpoint.ept_bond, 0x01);
 }
 
+static void packet_handle(const struct nrf_rpc_tr *transport, const void *data, size_t len)
+{
+	struct nrf_rpc_ipc *ipc_config = transport->ctx;
+
+	__ASSERT_NO_MSG(ipc_config->receive_cb != NULL);
+
+	ipc_config->receive_cb(transport, data, len, ipc_config->context);
+}
+
+#if defined(CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD)
+/* Defer processing of the received packet to the transport Rx thread. The IPC Service Rx
+ * buffer holding feature is used, so the packet does not need to be copied. The thread
+ * releases the buffer once the packet is processed.
+ */
+static void packet_defer(const struct nrf_rpc_tr *transport, const void *data, size_t len)
+{
+	struct nrf_rpc_ipc *ipc_config = transport->ctx;
+	struct nrf_rpc_ipc_rx_packet packet = { .data = data, .len = len };
+	int err;
+
+	err = ipc_service_hold_rx_buffer(&ipc_config->endpoint.ept, (void *)data);
+	if (err < 0) {
+		__ASSERT_NO_MSG(!k_is_in_isr());
+		/* The backend does not support holding the Rx buffer, so the packet cannot
+		 * outlive this callback. Such backends invoke the callback from a thread
+		 * context, so the packet can be processed here.
+		 */
+		LOG_DBG("Failed to hold Rx buffer: %d, processing packet in place", err);
+		packet_handle(transport, data, len);
+		return;
+	}
+
+	err = k_msgq_put(ipc_config->rx_msgq, &packet, K_NO_WAIT);
+	if (err < 0) {
+		LOG_ERR("Rx queue full, dropping packet");
+
+		err = ipc_service_release_rx_buffer(&ipc_config->endpoint.ept, (void *)data);
+		if (err < 0) {
+			LOG_ERR("Failed to release Rx buffer: %d", err);
+		}
+	}
+}
+
+static void rx_thread_entry(void *p1, void *p2, void *p3)
+{
+	const struct nrf_rpc_tr *transport = p1;
+	struct nrf_rpc_ipc *ipc_config = transport->ctx;
+	struct nrf_rpc_ipc_rx_packet packet;
+	int err;
+
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	while (true) {
+		err = k_msgq_get(ipc_config->rx_msgq, &packet, K_FOREVER);
+		if (err < 0) {
+			LOG_ERR("Failed to get packet from Rx queue: %d", err);
+			continue;
+		}
+
+		packet_handle(transport, packet.data, packet.len);
+
+		err = ipc_service_release_rx_buffer(&ipc_config->endpoint.ept, (void *)packet.data);
+		if (err < 0) {
+			LOG_ERR("Failed to release Rx buffer: %d", err);
+		}
+	}
+}
+
+static void rx_thread_start(const struct nrf_rpc_tr *transport)
+{
+	struct nrf_rpc_ipc *ipc_config = transport->ctx;
+	k_tid_t tid;
+
+	tid = k_thread_create(ipc_config->rx_thread, ipc_config->rx_stack,
+			      CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD_STACK_SIZE, rx_thread_entry,
+			      (void *)transport, NULL, NULL,
+			      CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD_PRIORITY, 0, K_NO_WAIT);
+
+	k_thread_name_set(tid, ipc_config->endpoint.ept_cfg.name);
+}
+#else
+static void rx_thread_start(const struct nrf_rpc_tr *transport)
+{
+	ARG_UNUSED(transport);
+}
+#endif /* CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD */
+
 static void ept_received(const void *data, size_t len, void *priv)
 {
 	const struct nrf_rpc_tr *transport = priv;
-	struct nrf_rpc_ipc *ipc_config = transport->ctx;
 
 	__ASSERT_NO_MSG(data != NULL);
-	__ASSERT_NO_MSG(ipc_config->receive_cb != NULL);
 
 	DUMP_LIMITED_DBG(data, len, "Received");
 
-	ipc_config->receive_cb(transport, data, len, ipc_config->context);
+#if defined(CONFIG_NRF_RPC_IPC_SERVICE_RX_THREAD)
+	/* The endpoint receive callback may be called from an interrupt context. */
+	packet_defer(transport, data, len);
+#else
+	packet_handle(transport, data, len);
+#endif
 }
 
 static void ept_error(const char *message, void *priv)
@@ -142,6 +233,11 @@ static int init(const struct nrf_rpc_tr *transport, nrf_rpc_tr_receive_handler_t
 	cfg->priv = (void *)transport;
 
 	k_event_init(&endpoint->ept_bond);
+
+	/* Start the Rx thread before the endpoint is registered, so that it is ready
+	 * to process the packets as soon as they can be received.
+	 */
+	rx_thread_start(transport);
 
 	err = ipc_service_register_endpoint(ipc_config->ipc, &endpoint->ept, cfg);
 	if (err) {


### PR DESCRIPTION
PR with two changes in IPC transport for RPC:

### Process messages in the dedicated thread

ICBMSG backend is now calling receive callback from an interrupt context and RPC expects that callback is called from a thread context. Add option to use dedicated transport thread and processing is deferred to that thread. Option is enabled by default when ICBMSG is enabled.

Stack size set to 768 bytes. Typical usage was < 350 bytes.

### Use IPC TX buffer pool and zero copy API instead of a heap

If IPC backend supports it, TX buffers can be allocated from the IPC pool and not from heap. It is much faster and does not require heap.

