### PR TITLE
applications: nrf_desktop: Add deprecation build warning

### DIFF
--- a/applications/nrf_desktop/sysbuild/CMakeLists.txt
+++ b/applications/nrf_desktop/sysbuild/CMakeLists.txt
@@ -44,3 +44,15 @@ if(SB_CONFIG_MCUBOOT_SIGNATURE_USING_KMU)
           ------------------------------------------------------------------------------
           ")
 endif()
+
+if((NOT SB_CONFIG_SOC_SERIES_NRF52) AND
+   (NOT SB_CONFIG_SOC_SERIES_NRF53) AND
+   (NOT SB_CONFIG_SOC_SERIES_NRF54H))
+  message(DEPRECATION "
+          ------------------------------------------------------------------------------
+          --- Future development of the nRF Desktop HID application reference design ---
+          --- will move to HID Add-on. New features will be introduced only in the   ---
+          --- Add-on. See application documentation for details.                     ---
+          ------------------------------------------------------------------------------
+          ")
+endif()


### PR DESCRIPTION
nRF Desktop is going to move to HID Add-on. Add build warning to indicate that.

Jira: NCSDK-40912