### PR TITLE
dts: nordic: nrf9251dk: Add secondary boot partition

### DIFF
--- a/dts/common/nordic/nrf9251dk_nrf9251-memory_map.dtsi
+++ b/dts/common/nordic/nrf9251dk_nrf9251-memory_map.dtsi
@@ -143,5 +143,15 @@
 				reg = <0x1000 DT_SIZE_K(4)>;
 			};
 		};
+
+		secondary_partition: partition@40e000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x40e000 DT_SIZE_K(64)>;
+		};
+
+		secondary_periphconf_partition: partition@41e000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x41e000 DT_SIZE_K(8)>;
+		};
 	};
 };


### PR DESCRIPTION
Add secondary_partition and secondary_periphconf_partition to the nRF9251 DK memory map, matching the nRF54H20 DK layout.