### PR TITLE
applications: nrf_desktop: Add deprecation note

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -7,6 +7,11 @@
    Depending on the configuration, this application can work as a desktop mouse, gaming mouse, keyboard, or connection dongle.
    See `nRF Desktop reference design page`_ for an overview of supported features.
 
+   .. note::
+      Future development of the nRF Desktop HID application reference design will move to a dedicated `nRF Connect SDK Add-on <nRF Connect SDK Add-ons_>`_ (``HID Add-on``).
+      Existing feature set will be maintained in the |NCS| 3.4.x Long-term support (LTS) releases, but new features will be introduced only in the Add-on.
+      The Add-on will support nRF54L Series devices.
+
    .. tip::
       To get started with hardware programmed with pre-configured software, go to the :ref:`nrf_desktop_user_interface` section.
 

--- a/scripts/hid_configurator/README.rst
+++ b/scripts/hid_configurator/README.rst
@@ -20,6 +20,10 @@ It can be used for the following purposes:
 * `Getting identification information about the device`_
 * `Playing LED stream`_
 
+.. note::
+   Future development of the HID configurator for nRF Desktop will move to a dedicated `nRF Connect SDK Add-on <nRF Connect SDK Add-ons_>`_ (``HID Add-on``).
+   Existing feature set will be maintained in the |NCS| 3.4.x Long-term support (LTS) releases, but new features will be introduced only in the Add-on.
+
 Overview
 ********
 


### PR DESCRIPTION
nRF Desktop and HID configurator scripts are going to move to HID Add-on. Add documentation notes to inform about it.

Jira: NCSDK-40912