### PR TITLE
doc: fast_pair: add nRF54LC10A support documentation

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -2017,6 +2017,7 @@ The following table indicates the software maturity levels of the support for Go
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LC10A
               - nRF54LM20A
               - nRF54LM20B
               - nRF54LV10A
@@ -2024,6 +2025,7 @@ The following table indicates the software maturity levels of the support for Go
               - nRF54LS05B
             * - **Input device**
               - :ref:`fast_pair_input_device`
+              - Experimental
               - Experimental
               - Experimental
               - Experimental
@@ -2037,6 +2039,7 @@ The following table indicates the software maturity levels of the support for Go
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Experimental
               - --
@@ -2148,6 +2151,7 @@ The following table indicates the software maturity levels of the support for ea
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LC10A
               - nRF54LM20A
               - nRF54LM20B
               - nRF54LV10A
@@ -2157,12 +2161,14 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Experimental
               - --
               - Experimental
               - Experimental
             * - **Subsequent pairing**
+              - Experimental
               - Experimental
               - Experimental
               - Experimental
@@ -2177,10 +2183,12 @@ The following table indicates the software maturity levels of the support for ea
               - Experimental
               - Experimental
               - Experimental
+              - Experimental
               - --
               - Experimental
               - Experimental
             * - **Personalized Name extension**
+              - Experimental
               - Experimental
               - Experimental
               - Experimental
@@ -2193,6 +2201,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Experimental
               - --
@@ -2272,6 +2281,7 @@ The following table indicates the software maturity levels of the support for th
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LC10A
               - nRF54LM20A
               - nRF54LM20B
               - nRF54LV10A
@@ -2283,10 +2293,12 @@ The following table indicates the software maturity levels of the support for th
               - Experimental
               - Experimental
               - Experimental
+              - Experimental
               - --
               - Experimental
               - Experimental
             * - **Precision Finding with Bluetooth LE Channel Sounding**
+              - Experimental
               - Experimental
               - Experimental
               - Experimental

--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -120,6 +120,7 @@ The following board targets support the ranging module:
 * ``nrf54l15dk/nrf54l10/cpuapp``
 * ``nrf54l15dk/nrf54l15/cpuapp``
 * ``nrf54l15tag/nrf54l15/cpuapp``
+* ``nrf54lc10dk/nrf54lc10a/cpuapp``
 * ``nrf54lm20dk/nrf54lm20a/cpuapp``
 * ``nrf54lm20dk/nrf54lm20b/cpuapp``
 
@@ -216,6 +217,7 @@ The configuration of the DFU solution varies depending on the board target:
 |              |                                | * ``nrf54l15dk/nrf54l10/cpuapp``                                     |
 |              |                                | * ``nrf54l15dk/nrf54l15/cpuapp``                                     |
 |              |                                | * ``nrf54l15tag/nrf54l15/cpuapp``                                    |
+|              |                                | * ``nrf54lc10dk/nrf54lc10a/cpuapp``                                  |
 |              |                                | * ``nrf54lm20dk/nrf54lm20a/cpuapp``                                  |
 |              |                                | * ``nrf54lm20dk/nrf54lm20b/cpuapp``                                  |
 |              |                                | * ``nrf54ls05dk/nrf54ls05a/cpuapp`` (only ``release`` configuration) |
@@ -243,6 +245,7 @@ The configuration of the signature algorithm and the public key storage solution
 |                                | * ``nrf54l15dk/nrf54l10/cpuapp``                                     |                           | Signature derived from    |
 |                                | * ``nrf54l15dk/nrf54l15/cpuapp``                                     |                           | image (pure)              |
 |                                | * ``nrf54l15tag/nrf54l15/cpuapp``                                    |                           |                           |
+|                                | * ``nrf54lc10dk/nrf54lc10a/cpuapp``                                  |                           |                           |
 |                                | * ``nrf54lm20dk/nrf54lm20a/cpuapp``                                  |                           |                           |
 |                                | * ``nrf54lm20dk/nrf54lm20b/cpuapp``                                  |                           |                           |
 +--------------------------------+----------------------------------------------------------------------+---------------------------+---------------------------+


### PR DESCRIPTION
Summary
- Add nRF54LC10 DK support to the Fast Pair locator tag sample documentation.
- Add nRF54LC10A to the Google Fast Pair software maturity tables.

Ref: NCSDK-40374