### PR TITLE
doc: release notes: add nRF54LC10A Fast Pair support changelog

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -383,6 +383,8 @@ Bluetooth Fast Pair samples
 
 * :ref:`fast_pair_locator_tag` sample:
 
+  * Added experimental support for the ``nrf54lc10dk/nrf54lc10a/cpuapp`` board target.
+
   * Updated:
 
     * The references to the deleted ``CONFIG_CRACEN_LIB_KMU`` Kconfig option to use the :kconfig:option:`CONFIG_CRACEN_KMU` replacement.


### PR DESCRIPTION
Summary
- Document experimental nRF54LC10A support for the Fast Pair locator tag sample.

Ref: NCSDK-40374