### PR TITLE
doc: security manual backports for nRF54LS05, nRF54LV10, and nRF54LC10

### DIFF
--- a/doc/nrf/app_dev/device_guides/kmu_guides/kmu_cracen_overview.rst
+++ b/doc/nrf/app_dev/device_guides/kmu_guides/kmu_cracen_overview.rst
@@ -33,9 +33,13 @@ The following table shows which devices use KMU and CRACEN peripherals.
    * - | nRF54L05
        | nRF54L10
        | nRF54L15
-       | nRF54LM20
-       | nRF54LV10
-     - | nRF54LS05
+       | nRF54LC10A
+       | nRF54LM20A
+       | nRF54LM20B
+       | nRF54LV10A
+       | nRF54LV10B
+     - | nRF54LS05A
+       | nRF54LS05B
 
 .. _ug_cracen_hardware_peripheral:
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1055,6 +1055,7 @@
 .. _`AP-Protect for nRF54LV10A`: https://docs.nordicsemi.com/bundle/ps_nrf54LV10A/page/ctrl-ap.html
 .. _`AP-Protect for nRF54LM20A`: https://docs.nordicsemi.com/bundle/ps_nrf54LM20A/page/ctrl-ap.html
 .. _`AP-Protect for nRF54L15`: https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/ctrl-ap.html
+.. _`AP-Protect for nRF54LS05A`: https://docs.nordicsemi.com/bundle/ps_nrf54LS05A/page/ctrl-ap.html
 .. _`AP-Protect for nRF5340`: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/debugandtrace.html#ariaid-title9
 .. _`AP-Protect for nRF52840`:
 .. _`access port protection mechanism`: https://docs.nordicsemi.com/bundle/ps_nrf52840/page/dif.html#ariaid-title3

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -2597,6 +2597,7 @@ Trusted Firmware-M support
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LC10A
               - nRF54LM20A
               - nRF54LM20B
               - nRF54LV10A
@@ -2609,10 +2610,12 @@ Trusted Firmware-M support
               - Experimental
               - Experimental
               - Experimental
+              - Experimental
               - --
               - --
             * - :ref:`Minimal <ug_tfm_supported_services_profiles_minimal>`
               - --
+              - Experimental
               - Experimental
               - Experimental
               - Experimental
@@ -2772,6 +2775,7 @@ The lists are organized by device Series and implementation.
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LC10A
               - nRF54LM20A
               - nRF54LM20B
               - nRF54LV10A
@@ -2786,10 +2790,12 @@ The lists are organized by device Series and implementation.
               - --
               - --
               - --
+              - --
             * - :ref:`Oberon PSA Crypto - CRACEN <ug_crypto_architecture_implementation_standards_oberon>`
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - Supported
@@ -2799,6 +2805,7 @@ The lists are organized by device Series and implementation.
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - Supported
@@ -2811,9 +2818,11 @@ The lists are organized by device Series and implementation.
               - Experimental
               - Experimental
               - Experimental
+              - Experimental
               - --
               - --
             * - :ref:`IronSide Secure Enclave <ug_crypto_architecture_implementation_standards_ironside>`
+              - --
               - --
               - --
               - --
@@ -3021,6 +3030,7 @@ Hardware Unique Key
              - nRF54L05
              - nRF54L10
              - nRF54L15
+             - nRF54LC10A
              - nRF54LM20A
              - nRF54LM20B
              - nRF54LV10A
@@ -3030,9 +3040,10 @@ Hardware Unique Key
              - Supported
              - Supported
              - Supported
-             - Supported
-             - Supported
              - Experimental
+             - Supported
+             - Supported
+             - Supported
              - --
              - --
 
@@ -3117,6 +3128,7 @@ Trusted storage implements the PSA Certified Secure Storage APIs without TF-M.
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LC10A
               - nRF54LM20A
               - nRF54LM20B
               - nRF54LV10A
@@ -3126,6 +3138,7 @@ Trusted storage implements the PSA Certified Secure Storage APIs without TF-M.
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - Supported

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -2802,7 +2802,7 @@ The lists are organized by device Series and implementation.
               - Supported
               - Supported
               - Supported
-              - Experimental
+              - Supported
               - Supported
             * - :ref:`TF-M Crypto Service <ug_crypto_architecture_implementation_standards_tfm>`
               - --

--- a/doc/nrf/security.rst
+++ b/doc/nrf/security.rst
@@ -20,9 +20,9 @@ The |NCS| |release| allows you to develop applications with the following versio
        - IronSide Secure Enclave version
        - Mbed TLS version
      * - v3.4.0
-       - |tf-m_ver|
+       - v2.3.0
        - |ironside_se_ver|
-       - 4.1.0
+       - v4.1.0
      * - ``v3.4-branch`` of `sdk-nrf`_
        - |tf-m_ver|
        - |ironside_se_ver|
@@ -55,14 +55,14 @@ Expand the following section to see the table listing versions of different secu
        - |ironside_se_ver|
        - |mbed_tls_ver|
      * - v3.4.0
-       - |tf-m_ver|
+       - v2.3.0
        - |ironside_se_ver|
-       - 4.1.0
+       - v4.1.0
      * - v3.3.0
        - v2.2.2
        - |ironside_se_ver|
        - 3.6.6
-     * - v3.2.0 (up to v3.2.4)
+     * - v3.2.0 (incl. patch versions)
        - v2.2.0
        - |ironside_se_ver|
        - 3.6.5
@@ -70,11 +70,11 @@ Expand the following section to see the table listing versions of different secu
        - v2.1.2
        - n/a
        - 3.6.4
-     * - v3.0.0 (up to v3.0.2)
+     * - v3.0.0 (incl. patch versions)
        - v2.1.1
        - n/a
        - 3.6.3
-     * - v2.9.0 (up to v2.9.2)
+     * - v2.9.0 (incl. patch versions)
        - v2.1.1
        - n/a
        - 3.6.2
@@ -86,15 +86,15 @@ Expand the following section to see the table listing versions of different secu
        - v2.0.0
        - n/a
        - 3.5.2
-     * - v2.6.0 (up to v2.6.4)
+     * - v2.6.0 (incl. patch versions)
        - v2.0.0
        - n/a
        - 3.5.2
-     * - v2.5.0 (up to v2.5.3)
+     * - v2.5.0 (incl. patch versions)
        - v1.8.0
        - n/a
        - 3.3.0
-     * - v2.4.0 (up to v2.4.4)
+     * - v2.4.0 (incl. patch versions)
        - v1.7.0
        - n/a
        - 3.3.0
@@ -106,7 +106,7 @@ Expand the following section to see the table listing versions of different secu
        - v1.6.0
        - n/a
        - 3.1.0
-     * - v2.1.0 (up to v2.1.4)
+     * - v2.1.0 (incl. patch versions)
        - v1.6.0
        - n/a
        - 3.1.0

--- a/doc/nrf/security/ap_protect.rst
+++ b/doc/nrf/security/ap_protect.rst
@@ -675,7 +675,7 @@ nRF54L Series
 
       This command issues the ``ERASEALL`` command.
       Make sure to wait for the command to be completed.
-      On this device, this command also programs a piece of firmware that corresponds to setting :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE` and :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_DISABLE` to ``y``.
+      On this device, this command also programs a piece of firmware that corresponds to selecting :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE` and :kconfig:option:`CONFIG_NRF_SECURE_APPROTECT_DISABLE`.
 
       **Keeping AP-Protect disabled after hard reset:**
 
@@ -765,9 +765,9 @@ nRF54L Series
          :start-after: .. nrf54l15_approtect_tab_start
          :end-before: .. nrf54l15_approtect_tab_end
 
-   .. tab:: nRF54LM20
+   .. tab:: nRF54LM20A
 
-      .. list-table:: nRF54LM20 AP-Protect support
+      .. list-table:: nRF54LM20A AP-Protect support
          :header-rows: 1
          :align: center
          :widths: auto
@@ -780,6 +780,34 @@ nRF54L Series
            - ✔
            - ✔
            - `AP-Protect for nRF54LM20A`_
+
+      .. include:: ./ap_protect.rst
+         :start-after: .. nrf54l15_approtect_tab_kconfigs_standard_start
+         :end-before: .. nrf54l15_approtect_tab_kconfigs_standard_end
+
+      .. include:: ./ap_protect.rst
+         :start-after: .. nrf54l15_approtect_tab_kconfigs_secure_start
+         :end-before: .. nrf54l15_approtect_tab_kconfigs_secure_end
+
+      .. include:: ./ap_protect.rst
+         :start-after: .. nrf54l15_approtect_tab_start
+         :end-before: .. nrf54l15_approtect_tab_end
+
+   .. tab:: nRF54LM20B
+
+      .. list-table:: nRF54LM20B AP-Protect support
+         :header-rows: 1
+         :align: center
+         :widths: auto
+
+         * - AP-Protect (hardware only)
+           - AP-Protect (hardware and software)
+           - Secure AP-Protect
+           - Hardware documentation
+         * - ✗
+           - ✔
+           - ✔
+           - `AP-Protect for nRF54LM20B <AP-Protect for nRF54LM20A_>`_
 
       .. include:: ./ap_protect.rst
          :start-after: .. nrf54l15_approtect_tab_kconfigs_standard_start
@@ -821,9 +849,9 @@ nRF54L Series
          :start-after: .. nrf54l15_approtect_tab_start
          :end-before: .. nrf54l15_approtect_tab_end
 
-   .. tab:: nRF54LS05
+   .. tab:: nRF54LS05A
 
-      .. list-table:: nRF54LS05 AP-Protect support
+      .. list-table:: nRF54LS05A AP-Protect support
          :header-rows: 1
          :align: center
          :widths: auto
@@ -835,7 +863,7 @@ nRF54L Series
          * - ✗
            - ✔
            - ✗
-           - *Documentation not yet available*
+           - `AP-Protect for nRF54LS05A`_
 
       .. note::
          This device supports ``UICR.ERASEPROTECT``, which might prevent the ``ERASEALL`` command from executing when AP-Protect is enabled.
@@ -843,7 +871,7 @@ nRF54L Series
 
       **Configuring AP-Protect on the software side:**
 
-      The following Kconfig options configure AP-Protect on the software side on nRF54LS05 in the |NCS|:
+      The following Kconfig options configure AP-Protect on the software side on nRF54LS05A in the |NCS|:
 
       .. include:: ./ap_protect.rst
          :start-after: .. nrf54l15_approtect_tab_kconfigs_standard_start
@@ -871,7 +899,84 @@ nRF54L Series
 
       This command issues the ``ERASEALL`` command.
       Make sure to wait for the command to be completed.
-      On this device, this command also programs a piece of firmware that corresponds to setting :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE` to ``y``.
+      On this device, this command also programs a piece of firmware that corresponds to selecting :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE`.
+
+      **Keeping AP-Protect disabled after hard reset:**
+
+      If you want to keep the AP-Protect disabled after hard reset, you must flash firmware that opens the `debugger signals in Tamper Controller <nRF54L15 Debugger signals_>`_.
+      In the |NCS|, :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE` (enabled by default) handles the software unlock.
+
+      **Forcing AP-Protect to be disabled after hard reset:**
+
+      To force AP-Protect to be disabled after hard reset, issue an ``ERASEALL`` command using the following nRF Util command:
+
+      .. code-block:: console
+
+         nrfutil device recover
+
+      The device is automatically unlocked after erase.
+
+      **Production programming:**
+
+      For the devices that are in a production environment, it is highly recommended to lock the ``UICR.APPROTECT`` register to prevent unauthorized access to the device. If the access port protection is configured this way, it cannot be disabled without erasing the non-volatile memory.
+
+      Check also the following documentation pages for more information:
+
+      * `Disabling AP-Protect on nRF54L`_
+      * `Enabling device protection on nRF54L`_
+      * `Checking AP-Protect status on nRF54L`_
+
+   .. tab:: nRF54LS05B
+
+      .. list-table:: nRF54LS05B AP-Protect support
+         :header-rows: 1
+         :align: center
+         :widths: auto
+
+         * - AP-Protect (hardware only)
+           - AP-Protect (hardware and software)
+           - Secure AP-Protect
+           - Hardware documentation
+         * - ✗
+           - ✔
+           - ✗
+           - `AP-Protect for nRF54LS05B <AP-Protect for nRF54LS05A_>`_
+
+      .. note::
+         This device supports ``UICR.ERASEPROTECT``, which might prevent the ``ERASEALL`` command from executing when AP-Protect is enabled.
+         See hardware documentation for more information.
+
+      **Configuring AP-Protect on the software side:**
+
+      The following Kconfig options configure AP-Protect on the software side on nRF54LS05B in the |NCS|:
+
+      .. include:: ./ap_protect.rst
+         :start-after: .. nrf54l15_approtect_tab_kconfigs_standard_start
+         :end-before: .. nrf54l15_approtect_tab_kconfigs_standard_end
+
+      **Enabling AP-Protect on the hardware side:**
+
+      To enable AP-Protect on the hardware side, write ``Enabled`` to ``UICR.APPROTECT`` using the following nRF Util command:
+
+      .. code-block:: console
+
+         nrfutil device protection-set All
+
+      This set of commands enables AP-Protect on the hardware side and hard resets the device.
+
+      For more information about the ``nrfutil device protection-set`` command, see `Configuring readback protection`_ in the nRF Util documentation.
+
+      **Disabling AP-Protect:**
+
+      To disable AP-Protect, run the following nRF Util command:
+
+      .. code-block:: console
+
+         nrfutil device recover
+
+      This command issues the ``ERASEALL`` command.
+      Make sure to wait for the command to be completed.
+      On this device, this command also programs a piece of firmware that corresponds to selecting :kconfig:option:`CONFIG_NRF_APPROTECT_DISABLE`.
 
       **Keeping AP-Protect disabled after hard reset:**
 

--- a/doc/nrf/security/crypto/crypto_supported_features.rst
+++ b/doc/nrf/security/crypto/crypto_supported_features.rst
@@ -768,6 +768,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - nRF54L05
                 - nRF54L10
                 - nRF54L15
+                - nRF54LC10A
                 - nRF54LM20A
                 - nRF54LM20B
                 - nRF54LV10A
@@ -778,6 +779,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -788,6 +790,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -798,6 +801,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -808,6 +812,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -818,6 +823,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -828,6 +834,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -838,6 +845,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -848,6 +856,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -858,6 +867,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -868,6 +878,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -878,6 +889,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -888,6 +900,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -903,11 +916,13 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - HMAC
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HMAC`
                 - Supported
                 - Supported
                 - Supported
+                - Experimental
                 - Supported
                 - Supported
                 - Supported
@@ -915,6 +930,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
               * - HSS Public Key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                - --
                 - --
                 - --
                 - --
@@ -933,8 +949,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - XMSS Public Key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                - --
                 - --
                 - --
                 - --
@@ -953,8 +971,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-DSA-44
                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                - --
                 - --
                 - --
                 - --
@@ -973,8 +993,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-DSA-87
                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                - --
                 - --
                 - --
                 - --
@@ -993,8 +1015,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-DSA Key Pair Export
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                - --
                 - --
                 - --
                 - --
@@ -1013,8 +1037,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-DSA Key Pair Derive
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                - --
                 - --
                 - --
                 - --
@@ -1033,8 +1059,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM-512
                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                - --
                 - --
                 - --
                 - --
@@ -1053,8 +1081,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM-1024
                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                - --
                 - --
                 - --
                 - --
@@ -1073,8 +1103,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM Key Pair Export
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                - --
                 - --
                 - --
                 - --
@@ -1093,8 +1125,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM Key Pair Derive
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                - --
                 - --
                 - --
                 - --
@@ -1113,6 +1147,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - WPA3-SAE key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_WPA3_SAE`
                 - Experimental
@@ -1121,9 +1156,13 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Experimental
                 - Experimental
                 - Experimental
+                - Experimental
+                - --
                 - --
               * - ASCON
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ASCON`
+                - --
+                - --
                 - --
                 - --
                 - --
@@ -1143,6 +1182,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -1153,6 +1193,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1163,6 +1204,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1173,6 +1215,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1183,6 +1226,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1193,6 +1237,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1203,6 +1248,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1213,6 +1259,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1223,6 +1270,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1233,6 +1281,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1243,6 +1292,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1253,6 +1303,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1263,6 +1314,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1273,6 +1325,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1283,6 +1336,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -1290,6 +1344,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - HSS Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1308,8 +1363,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - XMSS Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1328,8 +1385,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA-44
                  - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1348,8 +1407,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA-87
                  - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1368,8 +1429,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA Key Pair Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1388,8 +1451,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA Key Pair Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1408,8 +1473,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-KEM-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1428,8 +1495,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-KEM-1024
                  - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1448,8 +1517,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-KEM Key Pair Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1468,8 +1539,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-KEM Key Pair Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1488,6 +1561,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - WPA3-SAE PT key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_WPA3_SAE`
                  - Experimental
@@ -1498,8 +1572,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ASCON
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ASCON`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -2486,6 +2562,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -2496,6 +2573,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -2506,6 +2584,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -2516,6 +2595,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -2526,6 +2606,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -2541,11 +2622,13 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - Stream cipher
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_STREAM_CIPHER`
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -2570,6 +2653,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -2580,6 +2664,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -2590,6 +2675,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -2600,6 +2686,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -2610,6 +2697,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -2620,6 +2708,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -2630,6 +2719,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3020,6 +3110,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -3030,6 +3121,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3047,6 +3139,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -3057,6 +3150,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3618,6 +3712,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -3628,6 +3723,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3638,6 +3734,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3648,6 +3745,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3658,6 +3756,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3668,6 +3767,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3678,6 +3778,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3688,6 +3789,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3698,6 +3800,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3708,6 +3811,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3718,6 +3822,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3725,6 +3830,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                * - WPA3-SAE hash-to-element
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_H2E`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -3745,6 +3851,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -3755,6 +3862,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3765,6 +3873,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3775,6 +3884,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3785,6 +3895,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3795,6 +3906,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3805,6 +3917,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3815,6 +3928,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3825,6 +3939,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3835,6 +3950,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3845,6 +3961,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -3852,6 +3969,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - WPA3-SAE hash-to-element
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_H2E`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -4156,6 +4274,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -4166,6 +4285,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                  - Experimental (with exceptions, see note)
                  - Experimental (with exceptions, see note)
                  - Experimental (with exceptions, see note)
@@ -4173,6 +4293,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                * - AES Key wrap with Padding (AES-KWP)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_AES_KWP`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -4200,6 +4321,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -4215,8 +4337,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - AES Key wrap with Padding (AES-KWP)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_AES_KWP`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -4413,6 +4537,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -4423,6 +4548,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported (with exceptions, see note)
                  - Supported (with exceptions, see note)
                  - Supported (with exceptions, see note)
@@ -4433,6 +4559,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -4457,6 +4584,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -4467,6 +4595,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -4477,6 +4606,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -4869,6 +4999,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -4879,6 +5010,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -4889,6 +5021,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported (with exceptions, see note)
                  - Supported (with exceptions, see note)
                  - Supported (with exceptions, see note)
@@ -4899,6 +5032,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -4914,8 +5048,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - ASCON AEAD128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_AEAD128`
+                 - --
                  - --
                  - --
                  - --
@@ -4944,6 +5080,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -4954,6 +5091,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -4964,6 +5102,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -4974,6 +5113,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -4989,8 +5129,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ASCON AEAD128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_AEAD128`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -5595,6 +5737,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -5605,6 +5748,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5615,6 +5759,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5625,6 +5770,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5635,6 +5781,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5645,6 +5792,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5655,6 +5803,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5665,6 +5814,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5675,6 +5825,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5682,6 +5833,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                * - HSS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                 - --
                  - --
                  - --
                  - --
@@ -5700,8 +5852,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - ML-DSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - --
                  - --
                  - --
                  - --
@@ -5720,6 +5874,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - XMSS-MT
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
                  - --
@@ -5730,6 +5885,44 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
+               * - Hash ML-DSA
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_HASH_ML_DSA`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - --
+                 - --
+                 - --
+               * - Deterministic ML-DSA
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ML_DSA`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - --
+                 - --
+                 - --
+               * - Deterministic Hash ML-DSA
+                 - :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_HASH_ML_DSA`
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - Experimental
+                 - --
+                 - --
+                 - --
+
+            .. note::
+
+               For ML-DSA algorithms, CRACEN only supports signature verification.
 
          .. tab:: nrf_oberon
 
@@ -5742,6 +5935,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -5752,6 +5946,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5762,6 +5957,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5772,6 +5968,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5782,6 +5979,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5789,6 +5987,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - HashEdDSA Edwards25519
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ED25519PH`
+                 - --
                  - --
                  - --
                  - --
@@ -5807,11 +6006,13 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - RSA PKCS#1 v1.5 sign
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN`
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5822,6 +6023,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -5829,6 +6031,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - HSS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -5847,8 +6050,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -5867,8 +6072,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - XMSS-MT
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -5887,6 +6094,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - Deterministic ML-DSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ML_DSA`
                  - Experimental
@@ -5897,8 +6105,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - Deterministic Hash ML-DSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_HASH_ML_DSA`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -6428,6 +6638,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -6438,6 +6649,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -6448,6 +6660,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -6465,6 +6678,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -6475,6 +6689,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -6485,6 +6700,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7029,6 +7245,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -7039,6 +7256,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7049,6 +7267,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7059,6 +7278,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7069,6 +7289,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7079,6 +7300,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7089,6 +7311,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7099,6 +7322,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7109,6 +7333,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7119,6 +7344,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7129,6 +7355,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7139,6 +7366,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7149,6 +7377,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7159,6 +7388,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7169,6 +7399,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7186,6 +7417,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -7193,6 +7425,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LS05B
                * - BrainpoolP224r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_224`
+                 - --
                  - --
                  - --
                  - --
@@ -7211,8 +7444,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - BrainpoolP320r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_320`
+                 - --
                  - --
                  - --
                  - --
@@ -7231,8 +7466,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - BrainpoolP512r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_512`
+                 - --
                  - --
                  - --
                  - --
@@ -7246,6 +7483,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7256,6 +7494,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7266,6 +7505,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7276,6 +7516,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7291,11 +7532,13 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - secp224r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_224`
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7306,6 +7549,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7316,6 +7560,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7323,6 +7568,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - secp521r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_521`
+                 - --
                  - --
                  - --
                  - --
@@ -7882,6 +8128,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -7892,6 +8139,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7902,6 +8150,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7909,6 +8158,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                * - HMAC-DRBG
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC_DRBG`
+                 - --
                  - --
                  - --
                  - --
@@ -7929,6 +8179,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -7939,6 +8190,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7949,6 +8201,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -7959,6 +8212,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8529,6 +8783,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -8539,6 +8794,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8549,6 +8805,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8559,6 +8816,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8569,6 +8827,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8579,6 +8838,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8589,6 +8849,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8599,6 +8860,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8609,6 +8871,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8619,6 +8882,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8626,6 +8890,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                * - SHA-256/192
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                 - --
                  - --
                  - --
                  - --
@@ -8644,8 +8909,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - SHAKE256 192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                 - --
                  - --
                  - --
                  - --
@@ -8664,11 +8931,13 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - SHAKE256 512 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8676,6 +8945,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                * - ASCON HASH256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_HASH256`
+                 - --
                  - --
                  - --
                  - --
@@ -8696,6 +8966,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -8706,6 +8977,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8716,6 +8988,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8726,6 +8999,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8736,6 +9010,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8746,6 +9021,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8753,6 +9029,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - SHA3-224
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_224`
+                 - --
                  - --
                  - --
                  - --
@@ -8771,8 +9048,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - SHA3-384
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_384`
+                 - --
                  - --
                  - --
                  - --
@@ -8791,8 +9070,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - SHA-256/192
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -8811,8 +9092,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - SHAKE256 192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -8831,11 +9114,13 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - SHAKE256 512 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -8843,6 +9128,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                * - ASCON HASH256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_HASH256`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -9667,6 +9953,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -9677,6 +9964,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -9687,6 +9975,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -9697,6 +9986,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -9707,6 +9997,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -9717,6 +10008,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                  - --
                  - --
                  - Experimental
@@ -9724,6 +10016,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                * - SRP password hashing
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_PASSWORD_HASH`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -9740,10 +10033,12 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                  - --
                  - --
                * - WPA3-SAE GDH
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_GDH`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -9764,6 +10059,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -9773,6 +10069,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -9782,6 +10079,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -9791,6 +10089,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -9800,12 +10099,14 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
                  - Supported
                * - SRP-6
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_6`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -9822,6 +10123,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - WPA3-SAE
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_FIXED`
                  - Experimental
@@ -9831,8 +10133,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - WPA3-SAE GDH
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_GDH`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -10159,6 +10463,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -10169,6 +10474,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10179,6 +10485,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10189,6 +10496,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10199,6 +10507,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10216,6 +10525,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -10226,6 +10536,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10236,6 +10547,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10251,11 +10563,13 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10435,6 +10749,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -10445,6 +10760,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - --
                  - --
                  - --
@@ -10455,9 +10771,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-                 - --
-                 - --
                  - Experimental
+                 - --
+                 - --
+                 - Supported
                  - --
                  - --
                * - Generate
@@ -10465,9 +10782,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-                 - --
-                 - --
                  - Experimental
+                 - --
+                 - --
+                 - Supported
                  - --
                  - --
                * - Derive
@@ -10475,9 +10793,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-                 - --
-                 - --
                  - Experimental
+                 - --
+                 - --
+                 - Supported
                  - --
                  - --
 
@@ -10492,6 +10811,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -10502,6 +10822,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10512,6 +10833,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10527,11 +10849,13 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_DERIVE`
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10709,6 +11033,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -10719,6 +11044,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10729,6 +11055,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10739,6 +11066,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10749,6 +11077,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10766,6 +11095,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -10776,6 +11106,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10786,6 +11117,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10796,6 +11128,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -10806,6 +11139,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11027,6 +11361,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -11037,6 +11372,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11047,6 +11383,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11057,6 +11394,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11067,6 +11405,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11084,6 +11423,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -11094,6 +11434,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11104,6 +11445,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11114,6 +11456,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11124,6 +11467,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11373,6 +11717,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -11383,6 +11728,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11393,6 +11739,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - --
                  - --
                  - --
@@ -11403,6 +11750,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11420,6 +11768,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -11430,6 +11779,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11440,6 +11790,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11450,6 +11801,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11705,6 +12057,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -11712,6 +12065,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LS05B
                * - 1024 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_1024`
+                 - --
                  - --
                  - --
                  - --
@@ -11730,14 +12084,16 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - 2048 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_2048`
                  - Supported
                  - Supported
                  - Supported
-                 - Supported
-                 - Supported
                  - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
                  - --
                  - --
                * - 3072 bits
@@ -11745,9 +12101,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-                 - Supported
-                 - Supported
                  - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
                  - --
                  - --
                * - 4096 bits
@@ -11755,9 +12112,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
-                 - Supported
-                 - Supported
                  - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
                  - --
                  - --
                * - 6144 bits
@@ -11770,8 +12128,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - 8192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_8192`
+                 - --
                  - --
                  - --
                  - --
@@ -11792,6 +12152,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54L05
                  - nRF54L10
                  - nRF54L15
+                 - nRF54LC10A
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
@@ -11802,6 +12163,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11812,6 +12174,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11822,6 +12185,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11832,6 +12196,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11842,6 +12207,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11852,6 +12218,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11862,6 +12229,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Experimental
                  - Supported
                  - Supported
                  - Supported
@@ -11997,84 +12365,6 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
 
 .. tabs::
 
-   .. tab:: nRF54L Series
-
-      The following table lists the supported side-channel countermeasures for nRF54L Series devices.
-
-      .. tabs::
-
-         .. tab:: CRACEN
-
-            .. note::
-               :kconfig:option:`CONFIG_CRACEN_LITE_ECC_COUNTERMEASURES_EXTENDED` does not support scalar blinding for Montgomery curve multiplication (X25519, X448).
-
-               nRF54L15, nRF54L10, and nRF54L05 do not support countermeasures for Montgomery curve multiplication (X25519, X448), EdDSA base point multiplication, and Edwards point multiplication.
-
-            .. list-table:: Side-channel countermeasures support (CRACEN driver) - nRF54L Series
-               :header-rows: 1
-               :widths: auto
-
-               * - Countermeasure
-                 - Configuration option
-                 - nRF54L15
-                 - nRF54L10
-                 - nRF54L05
-                 - nRF54LM20A
-                 - nRF54LM20B
-                 - nRF54LV10A
-                 - nRF54LS05A
-                 - nRF54LS05B
-               * - ECC scalar randomization
-                 - :kconfig:option:`CONFIG_CRACEN_ECC_COUNTERMEASURES`
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
-                 - --
-                 - --
-               * - ECC projective coordinate randomization
-                 - :kconfig:option:`CONFIG_CRACEN_ECC_COUNTERMEASURES`
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
-                 - --
-                 - --
-               * - ECC extended (Montgomery/Edwards)
-                 - :kconfig:option:`CONFIG_CRACEN_LITE_ECC_COUNTERMEASURES_EXTENDED` (see note above)
-                 - --
-                 - --
-                 - --
-                 - Supported
-                 - Supported
-                 - Supported
-                 - --
-                 - --
-               * - RSA exponent randomization
-                 - :kconfig:option:`CONFIG_CRACEN_RSA_COUNTERMEASURES`
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
-                 - --
-                 - --
-               * - RSA modulus randomization
-                 - :kconfig:option:`CONFIG_CRACEN_RSA_COUNTERMEASURES`
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
-                 - Supported
-                 - --
-                 - --
-
    .. tab:: nRF54H Series
 
       The following table lists the supported side-channel countermeasures for nRF54H Series devices.
@@ -12107,4 +12397,88 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - --
                * - RSA modulus randomization
                  - :kconfig:option:`CONFIG_CRACEN_RSA_COUNTERMEASURES`
+                 - --
+
+   .. tab:: nRF54L Series
+
+      The following table lists the supported side-channel countermeasures for nRF54L Series devices.
+
+      .. tabs::
+
+         .. tab:: CRACEN
+
+            .. note::
+               :kconfig:option:`CONFIG_CRACEN_LITE_ECC_COUNTERMEASURES_EXTENDED` does not support scalar blinding for Montgomery curve multiplication (X25519, X448).
+
+               nRF54L15, nRF54L10, and nRF54L05 do not support countermeasures for Montgomery curve multiplication (X25519, X448), EdDSA base point multiplication, and Edwards point multiplication.
+
+            .. list-table:: Side-channel countermeasures support (CRACEN driver) - nRF54L Series
+               :header-rows: 1
+               :widths: auto
+
+               * - Countermeasure
+                 - Configuration option
+                 - nRF54L15
+                 - nRF54L10
+                 - nRF54L05
+                 - nRF54LC10A
+                 - nRF54LM20A
+                 - nRF54LM20B
+                 - nRF54LV10A
+                 - nRF54LS05A
+                 - nRF54LS05B
+               * - ECC scalar randomization
+                 - :kconfig:option:`CONFIG_CRACEN_ECC_COUNTERMEASURES`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
+                 - --
+                 - --
+               * - ECC projective coordinate randomization
+                 - :kconfig:option:`CONFIG_CRACEN_ECC_COUNTERMEASURES`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
+                 - --
+                 - --
+               * - ECC extended (Montgomery/Edwards)
+                 - :kconfig:option:`CONFIG_CRACEN_LITE_ECC_COUNTERMEASURES_EXTENDED` (see note above)
+                 - --
+                 - --
+                 - --
+                 - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
+                 - --
+                 - --
+               * - RSA exponent randomization
+                 - :kconfig:option:`CONFIG_CRACEN_RSA_COUNTERMEASURES`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
+                 - --
+                 - --
+               * - RSA modulus randomization
+                 - :kconfig:option:`CONFIG_CRACEN_RSA_COUNTERMEASURES`
+                 - Supported
+                 - Supported
+                 - Supported
+                 - Experimental
+                 - Supported
+                 - Supported
+                 - Supported
+                 - --
                  - --

--- a/doc/nrf/security/crypto/crypto_supported_features.rst
+++ b/doc/nrf/security/crypto/crypto_supported_features.rst
@@ -771,7 +771,8 @@ The options are grouped by Series and drivers available for the device Series, a
                 - nRF54LM20A
                 - nRF54LM20B
                 - nRF54LV10A
-                - nRF54LS05
+                - nRF54LS05A
+                - nRF54LS05B
               * - AES
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_AES`
                 - Supported
@@ -780,6 +781,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - --
                 - --
               * - Chacha20
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_CHACHA20`
@@ -790,6 +792,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - --
+                - --
               * - ECC Key Pair Import
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
                 - Supported
@@ -798,6 +801,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - --
                 - --
               * - ECC Key Pair Export
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
@@ -808,6 +812,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - --
+                - --
               * - ECC Key Pair Generate
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
                 - Supported
@@ -816,6 +821,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - --
                 - --
               * - ECC Key Pair Derive
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
@@ -826,6 +832,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - --
+                - --
               * - ECC Public Key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
                 - Supported
@@ -834,6 +841,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - --
                 - --
               * - RSA Key Pair Import
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
@@ -844,6 +852,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - --
+                - --
               * - RSA Key Pair Export
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
                 - Supported
@@ -852,6 +861,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - --
                 - --
               * - RSA Key Pair Generate
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
@@ -862,6 +872,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - --
+                - --
               * - RSA Key Pair Derive
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                 - Supported
@@ -870,6 +881,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - Supported
+                - --
                 - --
               * - RSA Public Key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY`
@@ -880,8 +892,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - --
+                - --
               * - XChaCha20
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                - --
                 - --
                 - --
                 - --
@@ -898,8 +912,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - Supported
                 - Supported
                 - --
+                - --
               * - HSS Public Key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                - --
                 - --
                 - --
                 - --
@@ -916,8 +932,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - XMSS Public Key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                - --
                 - --
                 - --
                 - --
@@ -934,8 +952,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-DSA-44
                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                - --
                 - --
                 - --
                 - --
@@ -952,8 +972,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-DSA-87
                 - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                - --
                 - --
                 - --
                 - --
@@ -970,8 +992,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-DSA Key Pair Export
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                - --
                 - --
                 - --
                 - --
@@ -988,8 +1012,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-DSA Key Pair Derive
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                - --
                 - --
                 - --
                 - --
@@ -1006,8 +1032,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM-512
                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                - --
                 - --
                 - --
                 - --
@@ -1024,8 +1052,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM-1024
                 - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                - --
                 - --
                 - --
                 - --
@@ -1042,8 +1072,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM Key Pair Export
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                - --
                 - --
                 - --
                 - --
@@ -1060,6 +1092,7 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM Key Pair Derive
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
                 - --
@@ -1069,8 +1102,10 @@ The options are grouped by Series and drivers available for the device Series, a
                 - --
                 - --
                 - --
+                - --
               * - ML-KEM Public Key
                 - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_PUBLIC_KEY`
+                - --
                 - --
                 - --
                 - --
@@ -1111,9 +1146,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - AES
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_AES`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1130,8 +1167,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - ECC Key Pair Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1148,8 +1187,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - ECC Key Pair Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1166,8 +1207,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - ECC Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1184,8 +1227,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - RSA Key Pair Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1202,8 +1247,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - RSA Key Pair Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1220,8 +1267,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - XChaCha20
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XCHACHA20`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -1238,8 +1287,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - HSS Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_HSS_PUBLIC_KEY`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1256,8 +1307,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - XMSS Public Key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_XMSS_PUBLIC_KEY`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1274,8 +1327,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA-44
                  - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_44`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1292,8 +1347,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA-87
                  - :kconfig:option:`CONFIG_PSA_WANT_ML_DSA_KEY_SIZE_87`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1310,8 +1367,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA Key Pair Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_EXPORT`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1328,8 +1387,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA Key Pair Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_DSA_KEY_PAIR_DERIVE`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1346,8 +1407,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-KEM-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_512`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1364,8 +1427,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-KEM-1024
                  - :kconfig:option:`CONFIG_PSA_WANT_ML_KEM_KEY_SIZE_1024`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1382,8 +1447,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-KEM Key Pair Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_EXPORT`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1400,8 +1467,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-KEM Key Pair Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ML_KEM_KEY_PAIR_DERIVE`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -1418,6 +1487,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - WPA3-SAE PT key
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_WPA3_SAE`
                  - Experimental
@@ -1427,8 +1497,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ASCON
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ASCON`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -2417,7 +2489,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECB no padding
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECB_NO_PADDING`
                  - Supported
@@ -2426,6 +2499,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - CBC no padding
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CBC_NO_PADDING`
@@ -2436,6 +2510,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - CBC PKCS#7 padding
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CBC_PKCS7`
                  - Supported
@@ -2444,6 +2519,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - CTR
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CTR`
@@ -2454,8 +2530,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - CCM* no tag
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM_STAR_NO_TAG`
+                 - --
                  - --
                  - --
                  - --
@@ -2471,6 +2549,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
 
             .. note::
@@ -2494,9 +2573,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECB no padding
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECB_NO_PADDING`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -2513,8 +2594,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - CBC PKCS#7 padding
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CBC_PKCS7`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -2531,6 +2614,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - CCM* no tag
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM_STAR_NO_TAG`
                  - Supported
@@ -2540,8 +2624,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Stream cipher
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_STREAM_CIPHER`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -2937,7 +3023,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECDH
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDH`
                  - Supported
@@ -2946,6 +3033,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -2962,9 +3050,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECDH
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDH`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -3209,9 +3299,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ML-KEM
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_KEM`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -3529,7 +3621,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - HKDF
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF`
                  - Supported
@@ -3538,6 +3631,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - HKDF-Extract
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF_EXTRACT`
@@ -3548,6 +3642,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - HKDF-Expand
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF_EXPAND`
                  - Supported
@@ -3556,6 +3651,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - PBKDF2-HMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_PBKDF2_HMAC`
@@ -3566,6 +3662,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - PBKDF2-AES-CMAC-PRF-128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_PBKDF2_AES_CMAC_PRF_128`
                  - Supported
@@ -3574,6 +3671,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - TLS 1.2 PRF
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PRF`
@@ -3584,6 +3682,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - TLS 1.2 PSK to MS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PSK_TO_MS`
                  - Supported
@@ -3592,6 +3691,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - TLS 1.2 EC J-PAKE to PMS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS`
@@ -3602,6 +3702,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - SP 800-108r1 CMAC w/counter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC`
                  - Supported
@@ -3610,6 +3711,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - SP 800-108 HMAC counter mode
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_HMAC`
@@ -3620,6 +3722,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - WPA3-SAE hash-to-element
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_H2E`
                  - Experimental
@@ -3628,6 +3731,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -3644,9 +3748,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - HKDF
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -3663,8 +3769,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - HKDF-Expand
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HKDF_EXPAND`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -3681,8 +3789,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - PBKDF2-AES-CMAC-PRF-128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_PBKDF2_AES_CMAC_PRF_128`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -3699,8 +3809,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - TLS 1.2 PSK to MS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_TLS12_PSK_TO_MS`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -3717,8 +3829,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - SP 800-108r1 CMAC w/counter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SP800_108_COUNTER_CMAC`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -3735,8 +3849,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - WPA3-SAE hash-to-element
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_H2E`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -4043,7 +4159,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - AES Key wrap (AES-KW)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_AES_KW`
                  - Experimental
@@ -4053,6 +4170,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental (with exceptions, see note)
                  - Experimental (with exceptions, see note)
                  - --
+                 - --
                * - AES Key wrap with Padding (AES-KWP)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_AES_KWP`
                  - Experimental
@@ -4061,6 +4179,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental (with exceptions, see note)
                  - Experimental (with exceptions, see note)
                  - Experimental (with exceptions, see note)
+                 - --
                  - --
 
             .. note::
@@ -4084,7 +4203,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - AES Key wrap (AES-KW)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_AES_KW`
                  - Experimental
@@ -4094,8 +4214,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - AES Key wrap with Padding (AES-KWP)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_AES_KWP`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -4294,7 +4416,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - CMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CMAC`
                  - Supported
@@ -4304,6 +4427,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported (with exceptions, see note)
                  - Supported (with exceptions, see note)
                  - --
+                 - --
                * - HMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC`
                  - Supported
@@ -4312,6 +4436,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
 
             .. note::
@@ -4335,7 +4460,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - CMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CMAC`
                  - Supported
@@ -4345,8 +4471,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - HMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -4744,7 +4872,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - CCM
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`
                  - Supported
@@ -4753,6 +4882,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - GCM
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_GCM`
@@ -4763,6 +4893,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported (with exceptions, see note)
                  - Supported (with exceptions, see note)
                  - --
+                 - --
                * - ChaCha20-Poly1305
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305`
                  - Supported
@@ -4771,6 +4902,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - XChaCha20-Poly1305
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_XCHACHA20_POLY1305`
@@ -4781,8 +4913,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - ASCON AEAD128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_AEAD128`
+                 - --
                  - --
                  - --
                  - --
@@ -4813,9 +4947,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - CCM
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -4832,8 +4968,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - ChaCha20-Poly1305
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -4850,8 +4988,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ASCON AEAD128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_AEAD128`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -5458,7 +5598,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECDSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA`
                  - Supported
@@ -5467,6 +5608,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - ECDSA without hashing
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA_ANY`
@@ -5477,6 +5619,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - ECDSA (deterministic)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ECDSA`
                  - Supported
@@ -5485,6 +5628,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - PureEdDSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_PURE_EDDSA`
@@ -5495,6 +5639,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - HashEdDSA Edwards25519
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ED25519PH`
                  - Supported
@@ -5503,6 +5648,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - HashEdDSA Edwards448
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ED448PH`
@@ -5513,6 +5659,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - RSA PKCS#1 v1.5 sign
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN`
                  - Supported
@@ -5521,6 +5668,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - RSA PSS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`
@@ -5531,8 +5679,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - HSS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                 - --
                  - --
                  - --
                  - --
@@ -5549,8 +5699,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - ML-DSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - --
                  - --
                  - --
                  - --
@@ -5567,8 +5719,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - XMSS-MT
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
+                 - --
                  - --
                  - --
                  - --
@@ -5591,9 +5745,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECDSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -5610,8 +5766,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - ECDSA (deterministic)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ECDSA`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -5628,8 +5786,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - HashEdDSA Edwards25519
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ED25519PH`
+                 - --
                  - --
                  - --
                  - --
@@ -5646,8 +5806,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - RSA PKCS#1 v1.5 sign
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -5664,8 +5826,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - HSS
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HSS`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -5682,8 +5846,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ML-DSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ML_DSA`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -5700,8 +5866,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - XMSS-MT
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_XMSS_MT`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -5718,6 +5886,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - Deterministic ML-DSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ML_DSA`
                  - Experimental
@@ -5727,8 +5896,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - Deterministic Hash ML-DSA
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_HASH_ML_DSA`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -6260,7 +6431,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - RSA OAEP
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_OAEP`
                  - Supported
@@ -6270,6 +6442,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - RSA PKCS#1 v1.5 crypt
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_CRYPT`
                  - Supported
@@ -6278,6 +6451,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -6294,7 +6468,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - RSA OAEP
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_OAEP`
                  - Supported
@@ -6304,8 +6479,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - RSA PKCS#1 v1.5 crypt
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_CRYPT`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -6855,7 +7032,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - BrainpoolP224r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_224`
                  - Supported
@@ -6864,6 +7042,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - BrainpoolP256r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_256`
@@ -6874,6 +7053,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - BrainpoolP320r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_320`
                  - Supported
@@ -6882,6 +7062,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - BrainpoolP384r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_384`
@@ -6892,6 +7073,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - BrainpoolP512r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_512`
                  - Supported
@@ -6900,6 +7082,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - Curve25519 (X25519)
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_MONTGOMERY_255`
@@ -6910,6 +7093,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - Curve448 (X448)
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_MONTGOMERY_448`
                  - Supported
@@ -6918,6 +7102,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - Edwards25519 (Ed25519)
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_TWISTED_EDWARDS_255`
@@ -6928,6 +7113,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - Edwards448 (Ed448)
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_TWISTED_EDWARDS_448`
                  - Supported
@@ -6936,6 +7122,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - secp256k1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_K1_256`
@@ -6946,6 +7133,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - secp224r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_224`
                  - Supported
@@ -6954,6 +7142,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - secp256r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_256`
@@ -6964,6 +7153,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - secp384r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_384`
                  - Supported
@@ -6973,6 +7163,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - secp521r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_521`
                  - Supported
@@ -6981,6 +7172,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -6997,9 +7189,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - BrainpoolP224r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_224`
+                 - --
                  - --
                  - --
                  - --
@@ -7016,8 +7210,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - BrainpoolP320r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_320`
+                 - --
                  - --
                  - --
                  - --
@@ -7034,8 +7230,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - BrainpoolP512r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_512`
+                 - --
                  - --
                  - --
                  - --
@@ -7052,8 +7250,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Edwards25519 (Ed25519)
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_TWISTED_EDWARDS_255`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -7070,8 +7270,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Edwards448 (Ed448)
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_TWISTED_EDWARDS_448`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -7088,8 +7290,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - secp224r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_224`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -7106,6 +7310,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - secp384r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_384`
                  - Supported
@@ -7115,8 +7320,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - secp521r1
                  - :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_521`
+                 - --
                  - --
                  - --
                  - --
@@ -7678,7 +7885,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - RNG support
                  - :kconfig:option:`CONFIG_PSA_WANT_GENERATE_RANDOM`
                  - Supported
@@ -7687,6 +7895,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - CTR-DRBG
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_CTR_DRBG`
@@ -7697,8 +7906,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - HMAC-DRBG
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC_DRBG`
+                 - --
                  - --
                  - --
                  - --
@@ -7721,9 +7932,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - RNG support
                  - :kconfig:option:`CONFIG_PSA_WANT_GENERATE_RANDOM`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -7740,8 +7953,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - HMAC-DRBG
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC_DRBG`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -8317,7 +8532,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - SHA-1 (weak)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_1`
                  - Supported
@@ -8326,6 +8542,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - SHA-224
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_224`
@@ -8336,6 +8553,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - SHA-256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256`
                  - Supported
@@ -8344,6 +8562,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - SHA-384
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_384`
@@ -8354,6 +8573,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - SHA-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_512`
                  - Supported
@@ -8362,6 +8582,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - SHA3-224
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_224`
@@ -8372,6 +8593,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - SHA3-256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_256`
                  - Supported
@@ -8380,6 +8602,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - SHA3-384
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_384`
@@ -8390,6 +8613,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - SHA3-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_512`
                  - Supported
@@ -8399,8 +8623,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - SHA-256/192
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256_192`
+                 - --
                  - --
                  - --
                  - --
@@ -8417,8 +8643,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - SHAKE256 192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_192`
+                 - --
                  - --
                  - --
                  - --
@@ -8435,6 +8663,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - SHAKE256 512 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_512`
                  - Supported
@@ -8444,8 +8673,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - ASCON HASH256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_HASH256`
+                 - --
                  - --
                  - --
                  - --
@@ -8468,9 +8699,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - SHA-1 (weak)
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_1`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -8487,8 +8720,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - SHA-256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -8505,8 +8740,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - SHA-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_512`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -8523,8 +8760,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - SHA3-256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_256`
+                 - --
                  - --
                  - --
                  - --
@@ -8541,8 +8780,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - SHA3-512
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA3_512`
+                 - --
                  - --
                  - --
                  - --
@@ -8559,8 +8800,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - SHAKE128 256 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128_256`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -8577,8 +8820,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - SHAKE256 256 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE256_256`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -8595,8 +8840,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - ASCON HASH256
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_HASH256`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -9090,9 +9337,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - SHAKE128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SHAKE128`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -9109,6 +9358,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ASCON XOF128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_XOF128`
                  - Experimental
@@ -9118,8 +9368,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - Experimental
                * - ASCON CXOF128
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_ASCON_CXOF128`
+                 - Experimental
                  - Experimental
                  - Experimental
                  - Experimental
@@ -9418,7 +9670,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - EC J-PAKE
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_JPAKE`
                  - Supported
@@ -9427,6 +9680,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - SPAKE2+ with HMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SPAKE2P_HMAC`
@@ -9437,6 +9691,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - SPAKE2+ with CMAC
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SPAKE2P_CMAC`
                  - Supported
@@ -9445,6 +9700,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - SPAKE2+ for Matter
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SPAKE2P_MATTER`
@@ -9455,6 +9711,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - SRP-6
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_6`
                  - Experimental
@@ -9463,6 +9720,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - Experimental
+                 - --
                  - --
                * - SRP password hashing
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_SRP_PASSWORD_HASH`
@@ -9473,6 +9731,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - Experimental
                  - --
+                 - --
                * - WPA3-SAE fixed
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_FIXED`
                  - Experimental
@@ -9482,6 +9741,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - --
+                 - --
                * - WPA3-SAE GDH
                  - :kconfig:option:`CONFIG_PSA_WANT_ALG_WPA3_SAE_GDH`
                  - Experimental
@@ -9490,6 +9750,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Experimental
                  - Experimental
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -9901,7 +10162,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
                  - Supported
@@ -9910,6 +10172,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT`
@@ -9920,6 +10183,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
                  - Supported
@@ -9929,6 +10193,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
                  - Supported
@@ -9937,6 +10202,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -9953,9 +10219,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -9972,6 +10240,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE`
                  - --
@@ -9981,8 +10250,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10167,12 +10438,14 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_IMPORT`
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                  - --
                  - --
@@ -10186,6 +10459,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - Experimental
                  - --
+                 - --
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_GENERATE`
                  - Supported
@@ -10195,6 +10469,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - Experimental
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_DERIVE`
                  - Supported
@@ -10203,6 +10478,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - Experimental
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -10219,9 +10495,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_IMPORT`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10238,6 +10516,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_GENERATE`
                  - --
@@ -10247,8 +10526,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SRP_KEY_PAIR_DERIVE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10431,7 +10712,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_IMPORT`
                  - Supported
@@ -10440,6 +10722,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_EXPORT`
@@ -10450,6 +10733,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_GENERATE`
                  - Supported
@@ -10459,6 +10743,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_DERIVE`
                  - Supported
@@ -10467,6 +10752,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -10483,9 +10769,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_IMPORT`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10502,6 +10790,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_GENERATE`
                  - Supported
@@ -10511,8 +10800,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_DERIVE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10739,7 +11030,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
                  - Supported
@@ -10748,6 +11040,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - Import
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT`
@@ -10758,6 +11051,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
                  - Supported
@@ -10767,6 +11061,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
                  - Supported
@@ -10775,6 +11070,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -10791,9 +11087,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - Generate
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -10810,6 +11108,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Export
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT`
                  - Supported
@@ -10819,8 +11118,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - Derive
                  - :kconfig:option:`CONFIG_PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_DERIVE`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11075,7 +11376,8 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - 128 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_128`
                  - Supported
@@ -11085,11 +11387,13 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - --
+                 - --
                * - 192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_192`
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                  - --
                  - --
@@ -11102,6 +11406,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
 
          .. tab:: nrf_oberon
@@ -11118,9 +11423,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - 128 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_128`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11137,8 +11444,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - 256 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_AES_KEY_SIZE_256`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11399,9 +11708,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - 1024 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_1024`
+                 - --
                  - --
                  - --
                  - --
@@ -11418,6 +11729,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - 2048 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_2048`
                  - Supported
@@ -11426,6 +11738,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - 3072 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_3072`
@@ -11436,6 +11749,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Experimental
                  - --
+                 - --
                * - 4096 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_4096`
                  - Supported
@@ -11444,6 +11758,7 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Experimental
+                 - --
                  - --
                * - 6144 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_6144`
@@ -11454,8 +11769,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - --
                  - --
                  - --
+                 - --
                * - 8192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_8192`
+                 - --
                  - --
                  - --
                  - --
@@ -11478,9 +11795,11 @@ The options are grouped by Series and drivers available for the device Series, a
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - 1024 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_1024`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11497,8 +11816,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - 2048 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_2048`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11515,8 +11836,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - 4096 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_4096`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11533,8 +11856,10 @@ The options are grouped by Series and drivers available for the device Series, a
                  - Supported
                  - Supported
                  - Supported
+                 - Supported
                * - 8192 bits
                  - :kconfig:option:`CONFIG_PSA_WANT_RSA_KEY_SIZE_8192`
+                 - Supported
                  - Supported
                  - Supported
                  - Supported
@@ -11697,7 +12022,8 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - nRF54LM20A
                  - nRF54LM20B
                  - nRF54LV10A
-                 - nRF54LS05
+                 - nRF54LS05A
+                 - nRF54LS05B
                * - ECC scalar randomization
                  - :kconfig:option:`CONFIG_CRACEN_ECC_COUNTERMEASURES`
                  - Supported
@@ -11706,6 +12032,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - ECC projective coordinate randomization
                  - :kconfig:option:`CONFIG_CRACEN_ECC_COUNTERMEASURES`
@@ -11716,6 +12043,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - --
+                 - --
                * - ECC extended (Montgomery/Edwards)
                  - :kconfig:option:`CONFIG_CRACEN_LITE_ECC_COUNTERMEASURES_EXTENDED` (see note above)
                  - --
@@ -11724,6 +12052,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
                * - RSA exponent randomization
                  - :kconfig:option:`CONFIG_CRACEN_RSA_COUNTERMEASURES`
@@ -11734,6 +12063,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - --
+                 - --
                * - RSA modulus randomization
                  - :kconfig:option:`CONFIG_CRACEN_RSA_COUNTERMEASURES`
                  - Supported
@@ -11742,6 +12072,7 @@ The countermeasures are available only on the :ref:`CRACEN driver <crypto_driver
                  - Supported
                  - Supported
                  - Supported
+                 - --
                  - --
 
    .. tab:: nRF54H Series

--- a/doc/nrf/security/tfm/tfm_building.rst
+++ b/doc/nrf/security/tfm/tfm_building.rst
@@ -57,7 +57,8 @@ See :ref:`app_boards_names` for the complete list of boards and board targets su
    * - nRF54LM20 DK
      - PCA10184
      - :zephyr:board:`nrf54lm20dk <nrf54lm20dk>`
-     - ``nrf54lm20dk/nrf54lm20a/cpuapp/ns``
+     - | ``nrf54lm20dk/nrf54lm20a/cpuapp/ns``
+       | ``nrf54lm20dk/nrf54lm20b/cpuapp/ns``
    * - nRF54L15 DK
      - PCA10156
      - :zephyr:board:`nrf54l15dk <nrf54l15dk>`

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -12,7 +12,7 @@
 .. |54H_nrfutil_trace_ver| replace:: 4.4.0
 .. |ironside_se_ver| replace:: v23.7.0+30
 
-.. |mbed_tls_ver| replace:: 4.1.1
+.. |mbed_tls_ver| replace:: v4.1.1
 .. |tf-m_ver| replace:: v2.3.0
 
 .. ### Config shortcuts


### PR DESCRIPTION
**Commit 1**
doc: crypto: lm20b and ls05a update

Added entries for the nRF54LM20B and nRF54LS05A
to the security documentation where they were missing.
NCSDK-38891 and NCSDK-38892.

**Commit 2**
doc: crypto: feature support for LC10A and LV10A

Added nRF54LC10A to the crypto supported features tables
as Experimental. Updated nRF54LV10A to Supported.
Updated the v3.4.0 release entry in security.rst.
PR #29861 .