### PR TITLE
scripts: nrf_profiler: Add multi-device synchronization support

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -887,6 +887,13 @@ This section provides detailed lists of changes by :ref:`script <scripts>`.
 
   * The SPDX output format from ``SPDX-2.2`` to ``SPDX-2.3``.
 
+* :ref:`nrf_profiler_script` script:
+
+  * Added multi-device synchronization support to the nRF Profiler host tools.
+    The :file:`data_collector.py` and :file:`real_time_plot.py` scripts accept the ``--sync`` argument (from ``1`` to ``10``, default: ``1``) to collect profiling data from multiple devices in lockstep.
+    When multiple devices are used, datasets are stored with an ``_<index>`` suffix.
+  * Updated the documentation with information about synchronized multi-device data collection.
+
 Integrations
 ============
 

--- a/scripts/nrf_profiler/README.rst
+++ b/scripts/nrf_profiler/README.rst
@@ -64,6 +64,18 @@ You can use the following scripts to collect the profiling data and visualize th
      python3 data_collector.py 5 test1
 
   In this command, ``5`` is the time value (in seconds) for collecting data and ``test1`` is the dataset name.
+
+  Use the ``--sync`` argument to collect profiling data from multiple devices in lockstep.
+  The argument accepts a value from ``1`` to ``10`` (default: ``1``).
+  For example:
+
+  .. code-block:: console
+
+     python3 data_collector.py 5 test1 --sync 2
+
+  In this command, profiling data is collected from two devices.
+  The script stores the data in the ``test1_0`` and ``test1_1`` datasets.
+  See :ref:`nrf_profiler_script_synchronized_collection` for details.
 * :file:`plot_from_files.py` - The script plots events from the dataset that is provided as the command-line argument.
   For example:
 
@@ -81,6 +93,16 @@ You can use the following scripts to collect the profiling data and visualize th
      python3 real_time_plot.py test1
 
   The script terminates when the window displaying the real-time plot is closed.
+
+  To plot (in separate windows) and collect data from multiple devices in lockstep, use the ``--sync`` argument.
+  For example:
+
+  .. code-block:: console
+
+     python3 real_time_plot.py test1 --sync 2
+
+  In this command, profiling data is ploted in two separate windows, collected from two devices and stored in the ``test1_0`` and ``test1_1`` datasets.
+  See :ref:`nrf_profiler_script_synchronized_collection` for details.
 
 .. _nrf_profiler_script_visualization_GUI:
 
@@ -123,6 +145,25 @@ Additionally, during a pause or when plotting data from files:
 * Click and drag with the left mouse button to pan the plot.
 * Click the left or right mouse button to place a vertical line at the cursor location.
   When two lines are present, the application measures the time between them and displays it.
+
+.. _nrf_profiler_script_synchronized_collection:
+
+Synchronized data collection from multiple devices
+==================================================
+
+The :file:`data_collector.py` and :file:`real_time_plot.py` scripts can collect profiling data from multiple embedded devices in lockstep.
+Use the ``--sync`` argument to specify the number of devices (from ``1`` to ``10``, default: ``1``).
+The scripts spawn a separate set of host processes for each device and synchronize the RTT connection and device reset before starting data collection.
+
+When collecting data from more than one device, each dataset name is extended with an ``_<index>`` suffix (for example, ``test1_0`` and ``test1_1`` for the ``test1`` dataset name and ``--sync 2``).
+Set the serial number of the device to connect to in the :file:`rtt_nordic_config.py` file (``device_snr`` field).
+The scripts connect to the devices one after another.
+When prompted in the console log, configure the next device and update the ``device_snr`` value before the script connects to it.
+
+After collecting the data, you can use the :file:`merge_data.py` script to combine datasets from multiple devices and compensate for clock drift.
+See :ref:`nrf_profiler_script_merging_data` for details.
+
+.. _nrf_profiler_script_merging_data:
 
 Merging profiling data from multiple devices
 ============================================

--- a/scripts/nrf_profiler/data_collector.py
+++ b/scripts/nrf_profiler/data_collector.py
@@ -13,29 +13,54 @@ from model_creator import ModelCreator
 from rtt2stream import Rtt2Stream
 from stream import Stream
 
+# timeout for processes synchronization
+SYNCHRONIZATION_TIMEOUT = 120
+SHUTDOWN_TIMEOUT = 2
+
 is_waiting = True
 def signal_handler(sig, frame):
     global is_waiting
     is_waiting = False
 
-def rtt2stream(stream, event, event_close, log_lvl_number):
+def rtt2stream(
+        stream,
+        event_model_creator, event_close,
+        log_lvl_number,
+        own_event, prev_event, last_event, time_event,
+        process_index
+    ):
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        rtt2s = Rtt2Stream(stream, event_close, log_lvl=log_lvl_number)
-        event.wait()
+        rtt2s = Rtt2Stream(
+            stream,
+            event_close,
+            own_event, prev_event, last_event,
+            process_index,
+            log_lvl = log_lvl_number
+        )
+        # synchronization with own ModelCreator
+        event_model_creator.wait()
+        # synchronization with main loop
+        time_event.set()
         rtt2s.read_and_transmit_data()
     except Exception as e:
         print(f"[ERROR] Unhandled exception in Profiler Rtt to stream module: {e}")
 
-def model_creator(stream, event, event_close, dataset_name, log_lvl_number):
+def model_creator(
+        stream,
+        event, event_close,
+        dataset_name,
+        log_lvl_number
+    ):
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        mc = ModelCreator(stream,
-                          event_close,
-                          sending_events=False,
-                          event_filename=dataset_name + ".csv",
-                          event_types_filename=dataset_name + ".json",
-                          log_lvl=log_lvl_number)
+        mc = ModelCreator(
+            stream,
+            event_close, sending_events = False,
+            event_filename = dataset_name + ".csv",
+            event_types_filename = dataset_name + ".json",
+            log_lvl = log_lvl_number
+        )
         event.set()
         mc.start()
     except Exception as e:
@@ -50,6 +75,8 @@ def main():
         allow_abbrev=False)
     parser.add_argument('time', type=int, help='Time of collecting data [s]')
     parser.add_argument('dataset_name', help='Name of dataset')
+    parser.add_argument('--sync', type=int, choices=range(1, 11), default=1,
+                        help='Enable synchronization mode with a specific number of connections (1 to 10).')
     parser.add_argument('--log', help='Log level')
     args = parser.parse_args()
 
@@ -58,48 +85,108 @@ def main():
     else:
         log_lvl_number = logging.INFO
 
-    # Event is made to ensure that ModelCreator class is initialized before Rtt2Stream starts sending data
-    event = Event()
-    # Setting these events results in closing corresponding modules.
-    event_close_rtt2stream = Event()
-    event_close_model_creator = Event()
+    dev_amount = args.sync
 
-    streams = Stream.create_stream(2)
+    sync_events = [Event() for _ in range(dev_amount)]
+    time_sync = [Event() for _ in range(dev_amount)]
 
     processes = []
-    processes.append((Process(target=rtt2stream,
-                                args=(streams[0], event, event_close_rtt2stream, log_lvl_number),
-                                daemon=True),
-                        event_close_rtt2stream))
-    processes.append((Process(target=model_creator,
-                                args=(streams[1], event, event_close_model_creator,
-                                    args.dataset_name, log_lvl_number),
-                                daemon=True),
-                        event_close_model_creator))
+    for item in range(0, dev_amount):
+        event_model_creator = Event()
+        # Setting these events results in closing corresponding modules.
+        event_close_rtt2stream = Event()
+        event_close_model_creator = Event()
+        streams = Stream.create_stream(2)
+        dataset_name = args.dataset_name
+        if dev_amount > 1:
+            dataset_name += '_' + str(item)
+        own_event = sync_events[item]
+        prev_event = sync_events[item - 1] if item > 0 else None
+        last_event = sync_events[dev_amount - 1] if item < dev_amount - 1 else None
+        time_event = time_sync[item]
+
+        processes.append(
+            (
+                Process(
+                    target = rtt2stream,
+                    args = (
+                        streams[0],
+                        event_model_creator, event_close_rtt2stream,
+                        log_lvl_number,
+                        own_event, prev_event, last_event, time_event,
+                        item
+                    ),
+                    daemon = True
+                ),
+                event_close_rtt2stream
+            )
+        )
+
+        processes.append(
+            (
+                Process(
+                    target = model_creator,
+                    args = (
+                        streams[1],
+                        event_model_creator, event_close_model_creator,
+                        dataset_name,
+                        log_lvl_number
+                    ),
+                    daemon = True
+                ),
+                event_close_model_creator
+            )
+        )
 
     for p, _ in processes:
         p.start()
 
-    start_time = time.time()
-    global is_waiting
-    while is_waiting:
-        for p, _ in processes:
-            p.join(timeout=0.5)
-            # Terminate other processes if one of the processes is not active.
-            if len(processes) > len(active_children()):
-                is_waiting = False
-                break
+    print("START measurements.")
 
-            # Terminate every process on timeout.
-            if (time.time() - start_time) >= args.time:
-                is_waiting = False
+    global is_waiting
+    start_time = time.time()
+    synchronization_done = False
+    while is_waiting and ((time.time() - start_time) < SYNCHRONIZATION_TIMEOUT):
+        if all(p.is_alive() for p, _ in processes):
+            if not all(i.is_set() for i in time_sync):
+                time.sleep(0.1)
+            else:
+                synchronization_done = True
                 break
+        else:
+            is_waiting = False
+            break
+
+    if (not synchronization_done) and is_waiting:
+        print("[ERROR] Synchronization timeout")
+    else:
+        start_time = time.time()
+        while is_waiting:
+            for p, _ in processes:
+                p.join(timeout = 0.5)
+                # Terminate other processes if one of the processes is not active.
+                if len(processes) > len(active_children()):
+                    is_waiting = False
+                    break
+
+                # Terminate every process on timeout.
+                if (time.time() - start_time) >= args.time:
+                    is_waiting = False
+                    break
+
+    print("STOP measurements.")
 
     for p, event_close in processes:
         if p.is_alive():
             event_close.set()
             # Ensure that we stop processes in order to prevent nrf_profiler data drop.
-            p.join()
+            p.join(timeout = SHUTDOWN_TIMEOUT)
+        if p.is_alive():
+            p.terminate()
+            p.join(timeout = SHUTDOWN_TIMEOUT)
+        if p.is_alive():
+            p.kill()
+            p.join(timeout = SHUTDOWN_TIMEOUT)
 
 if __name__ == "__main__":
     main()

--- a/scripts/nrf_profiler/model_creator.py
+++ b/scripts/nrf_profiler/model_creator.py
@@ -24,14 +24,14 @@ class Command(Enum):
 NRF_PROFILER_FATAL_ERROR_EVENT_NAME = "_nrf_profiler_fatal_error_event_"
 
 class ModelCreator:
-
-    def __init__(self, stream,
-                 event_close,
-                 sending_events=False,
-                 config=RttNordicConfig,
-                 event_filename=None,
-                 event_types_filename=None,
-                 log_lvl=logging.INFO):
+    def __init__(
+            self,
+            stream,
+            event_close, sending_events = False,
+            config = RttNordicConfig,
+            event_filename = None, event_types_filename = None,
+            log_lvl = logging.INFO
+        ):
 
         self.config = config
         self.event_filename = event_filename

--- a/scripts/nrf_profiler/real_time_plot.py
+++ b/scripts/nrf_profiler/real_time_plot.py
@@ -6,6 +6,7 @@
 import argparse
 import logging
 import signal
+import time
 from multiprocessing import Event, Process, active_children
 
 from model_creator import ModelCreator
@@ -13,42 +14,76 @@ from plot_nordic import PlotNordic
 from rtt2stream import Rtt2Stream
 from stream import Stream
 
+# timeout for processes synchronization
+SYNCHRONIZATION_TIMEOUT = 120
+SHUTDOWN_TIMEOUT = 2
+
 is_waiting = True
 def signal_handler(sig, frame):
     global is_waiting
     is_waiting = False
 
-def rtt2stream(stream, event_plot, event_model_creator, event_close, log_lvl_number):
+def rtt2stream(
+        stream,
+        event_plot, event_model_creator, event_close,
+        log_lvl_number,
+        own_event, prev_event, last_event, time_event,
+        process_index
+    ):
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        rtt2s = Rtt2Stream(stream, event_close, log_lvl=log_lvl_number)
+        rtt2s = Rtt2Stream(
+            stream,
+            event_close, own_event, prev_event, last_event,
+            process_index,
+            log_lvl = log_lvl_number
+        )
+        # synchronization with own PlotNordic
         event_plot.wait()
+        # synchronization with own ModelCreator
         event_model_creator.wait()
+        # synchronization with main loop
+        time_event.set()
         rtt2s.read_and_transmit_data()
     except Exception as e:
         print(f"[ERROR] Unhandled exception in Profiler Rtt to stream module: {e}")
 
-def model_creator(stream, event, event_close, dataset_name, log_lvl_number):
+def model_creator(
+        stream,
+        event, event_close,
+        dataset_name,
+        log_lvl_number
+    ):
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        mc = ModelCreator(stream, event_close, sending_events=True,
-                          event_filename=dataset_name + ".csv",
-                          event_types_filename=dataset_name + ".json",
-                          log_lvl=log_lvl_number)
+        mc = ModelCreator(
+            stream,
+            event_close, sending_events = True,
+            event_filename = dataset_name + ".csv",
+            event_types_filename = dataset_name + ".json",
+            log_lvl = log_lvl_number
+        )
         event.set()
         mc.start()
     except Exception as e:
         print(f"[ERROR] Unhandled exception in Profiler model creator module: {e}")
 
-def dynamic_plot(stream, event, event_close, log_lvl_number):
+def dynamic_plot(
+        stream,
+        event, event_close,
+        log_lvl_number
+    ):
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        pn = PlotNordic(stream=stream, event_close=event_close, log_lvl=log_lvl_number)
+        pn = PlotNordic(
+            stream = stream,
+            event_close = event_close,
+            log_lvl = log_lvl_number
+        )
         event.set()
         pn.plot_events_real_time()
     except Exception as e:
         print(f"[ERROR] Unhandled exception in Plot Nordic module: {e}")
-
 
 def main():
     signal.signal(signal.SIGINT, signal_handler)
@@ -57,6 +92,8 @@ def main():
         description='Collecting data from Nordic nrf_profiler for given time, plotting and saving to files.',
         allow_abbrev=False)
     parser.add_argument('dataset_name', help='Name of dataset')
+    parser.add_argument('--sync', type=int, choices=range(1, 11), default=1,
+                        help='Enable synchronization mode with a specific number of connections (1 to 10).')
     parser.add_argument('--log', help='Log level')
     args = parser.parse_args()
 
@@ -65,49 +102,115 @@ def main():
     else:
         log_lvl_number = logging.INFO
 
-    # Events are made to ensure that PlotNordic and ModelCreator classes are initialized before Rtt2Stream starts sending data.
-    event_plot = Event()
-    event_model_creator = Event()
-    # Setting these events results in closing corresponding modules.
-    event_close_rtt2stream = Event()
-    event_close_model_creator = Event()
-    event_close_plot = Event()
+    dev_amount = args.sync
 
-    streams = Stream.create_stream(3)
+    sync_events = [Event() for _ in range(dev_amount)]
+    time_sync = [Event() for _ in range(dev_amount)]
 
     processes = []
-    processes.append((Process(target=rtt2stream,
-                              args=(streams[0], event_plot, event_model_creator,
-                                    event_close_rtt2stream, log_lvl_number),
-                              daemon=True),
-                      event_close_rtt2stream))
-    processes.append((Process(target=model_creator,
-                              args=(streams[1], event_model_creator, event_close_model_creator,
-                                    args.dataset_name, log_lvl_number),
-                              daemon=True),
-                      event_close_model_creator))
-    processes.append((Process(target=dynamic_plot,
-                              args=(streams[2], event_plot, event_close_plot, log_lvl_number),
-                              daemon=True),
-                      event_close_plot))
+    for item in range(0, dev_amount):
+        event_plot = Event()
+        event_model_creator = Event()
+        # Setting these events results in closing corresponding modules.
+        event_close_rtt2stream = Event()
+        event_close_model_creator = Event()
+        event_close_plot = Event()
+        streams = Stream.create_stream(3)
+        dataset_name = args.dataset_name
+        if dev_amount > 1:
+            dataset_name += '_' + str(item)
+        own_event = sync_events[item]
+        prev_event = sync_events[item - 1] if item > 0 else None
+        last_event = sync_events[dev_amount - 1] if item < dev_amount - 1 else None
+        time_event = time_sync[item]
+
+        processes.append(
+            (
+                Process(
+                    target=rtt2stream,
+                    args=(
+                        streams[0],
+                        event_plot, event_model_creator, event_close_rtt2stream,
+                        log_lvl_number,
+                        own_event, prev_event, last_event, time_event,
+                        item
+                    ),
+                    daemon=True
+                ),
+                event_close_rtt2stream)
+        )
+        processes.append(
+            (
+                Process(
+                    target = model_creator,
+                    args = (
+                        streams[1],
+                        event_model_creator, event_close_model_creator,
+                        dataset_name,
+                        log_lvl_number
+                    ),
+                    daemon=True
+                ),
+                event_close_model_creator
+            )
+        )
+        processes.append(
+            (
+                Process(
+                    target = dynamic_plot,
+                    args = (
+                        streams[2],
+                        event_plot, event_close_plot,
+                        log_lvl_number
+                    ),
+                    daemon = True
+                ),
+                event_close_plot
+            )
+        )
 
     for p, _ in processes:
         p.start()
 
     global is_waiting
-    while is_waiting:
-        for p, _ in processes:
-            p.join(timeout=0.5)
-            # Terminate other processes if one of the processes is not active.
-            if len(processes) > len(active_children()):
-                is_waiting = False
+    start_time = time.time()
+    synchronization_done = False
+    while is_waiting and ((time.time() - start_time) < SYNCHRONIZATION_TIMEOUT):
+        if all(p.is_alive() for p, _ in processes):
+            if not all(i.is_set() for i in time_sync):
+                time.sleep(0.1)
+            else:
+                synchronization_done = True
                 break
+        else:
+            is_waiting = False
+            break
+
+    if (not synchronization_done) and is_waiting:
+        print("[ERROR] Synchronization timeout")
+    else:
+        while is_waiting:
+            if not all(i.is_set() for i in time_sync):
+                time.sleep(0.1)
+                continue
+            for p, _ in processes:
+                p.join(timeout = 0.5)
+                # Terminate other processes if one of the processes is not active.
+                if len(processes) > len(active_children()):
+                    is_waiting = False
+                    break
 
     for p, event_close in processes:
         if p.is_alive():
             event_close.set()
             # Ensure that we stop processes in order to prevent nrf_profiler data drop.
-            p.join()
+            p.join(timeout = SHUTDOWN_TIMEOUT)
+        if p.is_alive():
+            p.terminate()
+            p.join(timeout = SHUTDOWN_TIMEOUT)
+        if p.is_alive():
+            p.kill()
+            p.join(timeout = SHUTDOWN_TIMEOUT)
 
 if __name__ == "__main__":
     main()

--- a/scripts/nrf_profiler/rtt2stream.py
+++ b/scripts/nrf_profiler/rtt2stream.py
@@ -20,12 +20,22 @@ class Command(Enum):
     INFO = 3
 
 class Rtt2Stream:
-    def __init__(self, out_stream, event_close, config=RttNordicConfig, log_lvl=logging.INFO):
+    def __init__(
+            self,
+            out_stream,
+            event_close,
+            own_event, prev_event, last_event,
+            process_index,
+            config = RttNordicConfig,
+            log_lvl = logging.INFO
+        ):
         self.config = config
-
         self.out_stream = out_stream
-
         self.event_close = event_close
+        self.own_event = own_event
+        self.prev_event = prev_event
+        self.last_event = last_event
+        self.process_index = process_index
 
         self.logger = logging.getLogger('rtt2stream')
         self.logger_console = logging.StreamHandler()
@@ -56,6 +66,10 @@ class Rtt2Stream:
         return family
 
     def _connect_rtt(self):
+        # wait point 1
+        if self.prev_event:
+            self.prev_event.wait()
+        self.logger.info(f'Please configure device number {self.process_index + 1}')
         snr = self.config['device_snr']
         device_family = Rtt2Stream._rtt_get_device_family(snr)
         self.logger.info('Recognized device family: ' + device_family)
@@ -66,6 +80,11 @@ class Rtt2Stream:
             self.jlink.connect_to_emu_with_snr(self.config['device_snr'])
         else:
             self.jlink.connect_to_emu_without_snr()
+
+        # wait point 2
+        self.own_event.set()
+        if self.last_event:
+            self.last_event.wait()
 
         if self.config['reset_on_start']:
             self.jlink.sys_reset()


### PR DESCRIPTION
Add --sync argument to data_collector and real_time_plot to run profiler on 1–10 devices in lockstep. Spawn per-device processes, synchronize RTT connection and reset in Rtt2Stream, and wait for all devices before starting the measurement window.

Jira: NCSDK-39359