### PR TITLE
nrf_security: CRACEN: Fix point multiplication retries

### DIFF
--- a/subsys/nrf_security/src/drivers/cracen/silexpk/include/silexpk/sxops/eccweierstrass.h
+++ b/subsys/nrf_security/src/drivers/cracen/silexpk/include/silexpk/sxops/eccweierstrass.h
@@ -245,9 +245,12 @@ static inline int sx_ecp_ptmult(sx_pk_req *req,
 		sx_pk_run(req);
 
 		status = sx_pk_wait(req);
-		if (status != SX_OK) {
-			return status;
+		if (status != SX_ERR_NOT_INVERTIBLE) {
+			break;
 		}
+	}
+	if (status != SX_OK) {
+		return status;
 	}
 	const uint8_t **outputs = sx_pk_get_output_ops(req);
 	const int opsz = sx_pk_get_opsize(req);


### PR DESCRIPTION
The retry loop repeated successful point multiplications and returned on SX_ERR_NOT_INVERTIBLE. Retry that error instead and stop after success.