### PR TITLE
[Backport v3.4-branch] doc: fast_pair: add nRF54LC10A support documentation

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -2224,6 +2224,7 @@ The following table indicates the software maturity levels of the support for Go
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LC10A
               - nRF54LM20A
               - nRF54LM20B
               - nRF54LV10A
@@ -2231,6 +2232,7 @@ The following table indicates the software maturity levels of the support for Go
               - nRF54LS05B
             * - **Input device**
               - :ref:`fast_pair_input_device`
+              - Experimental
               - Experimental
               - Experimental
               - Experimental
@@ -2244,6 +2246,7 @@ The following table indicates the software maturity levels of the support for Go
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Experimental
               - --
@@ -2355,6 +2358,7 @@ The following table indicates the software maturity levels of the support for ea
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LC10A
               - nRF54LM20A
               - nRF54LM20B
               - nRF54LV10A
@@ -2364,12 +2368,14 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Experimental
               - --
               - Experimental
               - Experimental
             * - **Subsequent pairing**
+              - Experimental
               - Experimental
               - Experimental
               - Experimental
@@ -2384,10 +2390,12 @@ The following table indicates the software maturity levels of the support for ea
               - Experimental
               - Experimental
               - Experimental
+              - Experimental
               - --
               - Experimental
               - Experimental
             * - **Personalized Name extension**
+              - Experimental
               - Experimental
               - Experimental
               - Experimental
@@ -2400,6 +2408,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Experimental
               - --
@@ -2479,6 +2488,7 @@ The following table indicates the software maturity levels of the support for th
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LC10A
               - nRF54LM20A
               - nRF54LM20B
               - nRF54LV10A
@@ -2490,10 +2500,12 @@ The following table indicates the software maturity levels of the support for th
               - Experimental
               - Experimental
               - Experimental
+              - Experimental
               - --
               - Experimental
               - Experimental
             * - **Precision Finding with Bluetooth LE Channel Sounding**
+              - Experimental
               - Experimental
               - Experimental
               - Experimental

--- a/samples/bluetooth/fast_pair/locator_tag/README.rst
+++ b/samples/bluetooth/fast_pair/locator_tag/README.rst
@@ -125,6 +125,7 @@ The following board targets support the ranging module:
 * ``nrf54l15dk/nrf54l10/cpuapp``
 * ``nrf54l15dk/nrf54l15/cpuapp``
 * ``nrf54l15tag/nrf54l15/cpuapp``
+* ``nrf54lc10dk/nrf54lc10a/cpuapp``
 * ``nrf54lm20dk/nrf54lm20a/cpuapp``
 * ``nrf54lm20dk/nrf54lm20b/cpuapp``
 
@@ -224,6 +225,7 @@ The configuration of the DFU solution varies depending on the board target:
 |              |                                | * ``nrf54l15dk/nrf54l10/cpuapp``                                     |
 |              |                                | * ``nrf54l15dk/nrf54l15/cpuapp``                                     |
 |              |                                | * ``nrf54l15tag/nrf54l15/cpuapp``                                    |
+|              |                                | * ``nrf54lc10dk/nrf54lc10a/cpuapp``                                  |
 |              |                                | * ``nrf54lm20dk/nrf54lm20a/cpuapp``                                  |
 |              |                                | * ``nrf54lm20dk/nrf54lm20b/cpuapp``                                  |
 |              |                                | * ``nrf54ls05dk/nrf54ls05a/cpuapp`` (only ``release`` configuration) |
@@ -268,6 +270,7 @@ The configuration of the signature algorithm and the public key storage solution
 |                                | * ``nrf54l15dk/nrf54l10/cpuapp``                                     |                           | Signature derived from    |
 |                                | * ``nrf54l15dk/nrf54l15/cpuapp``                                     |                           | image (pure)              |
 |                                | * ``nrf54l15tag/nrf54l15/cpuapp``                                    |                           |                           |
+|                                | * ``nrf54lc10dk/nrf54lc10a/cpuapp``                                  |                           |                           |
 |                                | * ``nrf54lm20dk/nrf54lm20a/cpuapp``                                  |                           |                           |
 |                                | * ``nrf54lm20dk/nrf54lm20b/cpuapp``                                  |                           |                           |
 +--------------------------------+----------------------------------------------------------------------+---------------------------+---------------------------+


### PR DESCRIPTION
Backport 3ca37d31142ce6cc45c736c3e050d8ebf8f1b17f~2..3ca37d31142ce6cc45c736c3e050d8ebf8f1b17f from #31117.