### PR TITLE
doc: Added entry for nRF54LC10 in software maturity tables

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -338,6 +338,7 @@ The following table indicates the software maturity levels of the support for ea
            - nRF54L05
            - nRF54L10
            - nRF54L15
+           - nRF54LC10A
            - nRF54LM20A
            - nRF54LM20B
            - nRF54LV10A
@@ -347,6 +348,7 @@ The following table indicates the software maturity levels of the support for ea
            - Supported
            - Supported
            - Supported
+           - --
            - Supported
            - Supported
            - Experimental
@@ -356,6 +358,7 @@ The following table indicates the software maturity levels of the support for ea
            - Supported
            - Supported
            - Supported
+           - --
            - Supported
            - Supported
            - Experimental
@@ -370,16 +373,19 @@ The following table indicates the software maturity levels of the support for ea
            - --
            - --
            - --
+           - --
          * - **ESB**
            - Supported
            - Supported
            - Supported
+           - --
            - Supported
            - Supported
            - Experimental
            - --
            - Experimental
          * - **LTE**
+           - --
            - --
            - --
            - --
@@ -397,10 +403,12 @@ The following table indicates the software maturity levels of the support for ea
            - --\ :sup:`8`
            - --\ :sup:`8`
            - --\ :sup:`8`
+           - --\ :sup:`8`
          * - **NFC**
            - Supported
            - Supported
            - Supported
+           - --
            - Supported
            - Supported
            - --
@@ -413,12 +421,14 @@ The following table indicates the software maturity levels of the support for ea
            - --\ :sup:`4`
            - --\ :sup:`4`
            - --\ :sup:`4`
+           - --\ :sup:`4`
            - --
            - --\ :sup:`4`
          * - **Thread**
            - Supported
            - Supported
            - Supported
+           - Experimental
            - Supported
            - Supported
            - --
@@ -428,12 +438,14 @@ The following table indicates the software maturity levels of the support for ea
            - --
            - --
            - Supported\ :sup:`3`
+           - --
            - Supported\ :sup:`3`
            - Supported\ :sup:`3`
            - --
            - --
            - --
          * - **Zigbee**
+           - --\ :sup:`5`
            - --\ :sup:`5`
            - --\ :sup:`5`
            - --\ :sup:`5`
@@ -1281,6 +1293,7 @@ The following table indicates the software maturity levels of the support for ea
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LC10A
               - nRF54LM20A
               - nRF54LM20B
               - nRF54LV10A
@@ -1290,6 +1303,7 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - --
@@ -1299,6 +1313,7 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - --
@@ -1308,6 +1323,7 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - --
@@ -1317,6 +1333,7 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - --
@@ -1326,6 +1343,7 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - --
@@ -1335,6 +1353,7 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - --
@@ -1344,6 +1363,7 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - --
@@ -1353,6 +1373,7 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - --
@@ -1362,6 +1383,7 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - --
@@ -1371,6 +1393,7 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - --
@@ -1380,6 +1403,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - --
@@ -1389,6 +1413,7 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - --


### PR DESCRIPTION
Extended tables with entry for nRF54LC10. The data were itself updated only for the Thread protocol, the rest was left empty.