### PR TITLE
logging: rpc: panic mode potential race

### DIFF
--- a/subsys/logging/log_backend_rpc.c
+++ b/subsys/logging/log_backend_rpc.c
@@ -603,11 +603,13 @@ static void panic(struct log_backend const *const backend)
 {
 	ARG_UNUSED(backend);
 
+	/* Stop processing new backend messages before sealing history state. */
+	panic_mode = true;
+
 #ifdef CONFIG_LOG_BACKEND_RPC_HISTORY_STORAGE_RAM
 	/* Stores the buffer checksum for integrity verification. */
 	log_rpc_history_save_checksum();
 #endif
-	panic_mode = true;
 }
 
 static void init(struct log_backend const *const backend)


### PR DESCRIPTION
moved setting panic_mode earlier in the process to prevent potential logging during the checksum calc.