### PR TITLE
sysbuild: netcore: Select RPC Bluetooth stack in the application image

### DIFF
--- a/snippets/nordic-bt-rpc/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/snippets/nordic-bt-rpc/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2024 Nordic Semiconductor
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-CONFIG_BT_RPC_STACK=y

--- a/snippets/nordic-bt-rpc/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/snippets/nordic-bt-rpc/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2024 Nordic Semiconductor
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-CONFIG_BT_RPC_STACK=y

--- a/snippets/nordic-bt-rpc/snippet.yml
+++ b/snippets/nordic-bt-rpc/snippet.yml
@@ -12,8 +12,4 @@ boards:
       EXTRA_DTC_OVERLAY_FILE: boards/nrf54h20dk_nrf54h20_cpurad.overlay
   nrf54h20dk/nrf54h20/cpuapp:
     append:
-      EXTRA_CONF_FILE: boards/nrf54h20dk_nrf54h20_cpuapp.conf
       EXTRA_DTC_OVERLAY_FILE: boards/nrf54h20dk_nrf54h20_cpuapp.overlay
-  nrf5340dk/nrf5340/cpuapp:
-    append:
-      EXTRA_CONF_FILE: boards/nrf5340dk_nrf5340_cpuapp.conf

--- a/sysbuild/netcore.cmake
+++ b/sysbuild/netcore.cmake
@@ -54,6 +54,11 @@ if(SB_CONFIG_SUPPORT_NETCORE AND NOT SB_CONFIG_NETCORE_NONE AND DEFINED SB_CONFI
     endif()
   endif()
 
+  # Not set by the nordic-bt-rpc snippet, as snippets apply to all images of the board target.
+  if(SB_CONFIG_NETCORE_IPC_RADIO_BT_RPC OR SB_CONFIG_NETCORE_RPC_HOST)
+    set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_RPC_STACK y)
+  endif()
+
   if(SB_CONFIG_BOARD_NRF5340BSIM_NRF5340_CPUAPP)
     native_simulator_set_child_images(${DEFAULT_IMAGE} ${SB_CONFIG_NETCORE_IMAGE_NAME})
     native_simulator_set_primary_mcu_index(${DEFAULT_IMAGE} ${SB_CONFIG_NETCORE_IMAGE_NAME})


### PR DESCRIPTION
CONFIG_BT_RPC_STACK was set by the nordic-bt-rpc snippet for every image built for the application core board target, including non-Bluetooth images such as the UICR generator. That triggered a Kconfig warning because BT_STACK_SELECTION is not available there.

Enable the option from sysbuild for the application image only.

Ref: NCSDK-40747