### PR TITLE
lib: nrf_cloud_coap: disconnect on timeout

### DIFF
--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_coap
@@ -81,6 +81,16 @@ config NRF_CLOUD_COAP_DISCONNECT_ON_FAILED_REQUEST
 	  Enabling this option will ensure that the CoAP client is disconnected when a request
 	  fails to be sent. (Maximum retransmissions reached).
 
+config NRF_CLOUD_COAP_DISCONNECT_ON_TIMEOUT
+	bool "Disconnect when a confirmable request times out"
+	default y
+	help
+	  When a confirmable request receives no response after all retransmissions, the
+	  server-side session is most likely no longer valid; without this option the device
+	  keeps issuing requests that can never succeed. Enabling this option marks the
+	  connection as unauthenticated, closes the socket and propagates -ETIMEDOUT to the
+	  caller, so that the application reconnects and re-authenticates.
+
 # Increase the maximum path length to have enough room
 config COAP_CLIENT_MAX_PATH_LENGTH
 	default 128

--- a/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
+++ b/subsys/net/lib/nrf_cloud/coap/src/nrf_cloud_coap_transport.c
@@ -489,6 +489,11 @@ static void client_callback(const struct coap_client_response_data *data, void *
 	if (data->result_code == COAP_RESPONSE_CODE_UNAUTHORIZED) {
 		LOG_ERR("Device not authenticated; reconnection required.");
 		xfer->nrfc_cc->authenticated = false;
+	} else if (IS_ENABLED(CONFIG_NRF_CLOUD_COAP_DISCONNECT_ON_TIMEOUT) &&
+		   (data->result_code == -ETIMEDOUT)) {
+		/* No response after all retransmissions; the session is no longer usable. */
+		LOG_WRN("CoAP request timed out; reconnection required.");
+		xfer->nrfc_cc->authenticated = false;
 	} else if ((data->result_code >= COAP_RESPONSE_CODE_BAD_REQUEST) && data->payload_len) {
 		LOG_ERR("Unexpected response: %*s", data->payload_len, data->payload);
 	}
@@ -538,7 +543,8 @@ static int client_transfer(enum coap_method method,
 		.cb = client_callback,
 		.user_data = xfer
 	};
-	struct coap_client *const cc = &xfer->nrfc_cc->cc;
+	struct nrf_cloud_coap_client *const nrfc_cc = xfer->nrfc_cc;
+	struct coap_client *const cc = &nrfc_cc->cc;
 
 	size_t num_internal_options = 0;
 	if (response_expected) {
@@ -629,13 +635,21 @@ static int client_transfer(enum coap_method method,
 		 * so make sure a bad result is not ignored.
 		 */
 		err = xfer->result_code;
+	} else if (IS_ENABLED(CONFIG_NRF_CLOUD_COAP_DISCONNECT_ON_TIMEOUT) && !err &&
+		   (xfer->result_code == -ETIMEDOUT)) {
+		/* A timed out CON transfer completes the semaphore normally, so the
+		 * failure is only visible in the result code.
+		 */
+		err = xfer->result_code;
 	}
 
 transfer_end:
 	xfer_ctx_release(xfer);
 	coap_client_cancel_request(cc, &request);
-	if (err == -ETIMEDOUT && IS_ENABLED(CONFIG_NRF_CLOUD_COAP_DISCONNECT_ON_FAILED_REQUEST)) {
-		nrf_cloud_coap_disconnect();
+	if ((err == -ETIMEDOUT) &&
+	    (IS_ENABLED(CONFIG_NRF_CLOUD_COAP_DISCONNECT_ON_FAILED_REQUEST) ||
+	     IS_ENABLED(CONFIG_NRF_CLOUD_COAP_DISCONNECT_ON_TIMEOUT))) {
+		nrf_cloud_coap_transport_disconnect(nrfc_cc);
 	}
 	return err;
 }


### PR DESCRIPTION
Invalidate the session on timeouts to avoid zombie devices. The option can be disabled for advanced users who track errors.