### PR TITLE
samples: net: mqtt: Various documentation fixes

### DIFF
--- a/samples/net/mqtt/doc/architecture.rst
+++ b/samples/net/mqtt/doc/architecture.rst
@@ -55,23 +55,10 @@ Subscribers use its thread primarily to monitor and process incoming messages fr
 When a channel that a module subscribes to, is invoked, the subscriber will handle the incoming message depending on its content.
 The following code snippet shows how a module thread polls for incoming messages on a subscribed channel:
 
-.. code-block:: c
-
-    static void sampler_task(void)
-    {
-    	const struct zbus_channel *chan;
-
-    	while (!zbus_sub_wait(&sampler, &chan, K_FOREVER)) {
-
-    		if (&TRIGGER_CHAN == chan) {
-    			sample();
-    		}
-    	}
-    }
-
-    K_THREAD_DEFINE(sampler_task_id,
-		    CONFIG_MQTT_SAMPLE_SAMPLER_THREAD_STACK_SIZE,
-		    sampler_task, NULL, NULL, NULL, 3, 0, 0);
+.. literalinclude:: ../src/modules/sampler/sampler.c
+   :language: c
+   :start-after: include_startingpoint_architecture_rst_3
+   :end-before: include_endpoint_architecture_rst_3
 
 .. note::
    Zbus implements internal message queues for subscribers.
@@ -84,52 +71,18 @@ The difference between a listener and a subscriber is that listeners do not requ
 The callbacks are called in the context of the thread that published the message.
 The following code snippet shows how a listener is set up in order to listen to changes to the ``NETWORK`` channel:
 
-.. code-block:: c
-
-    void led_callback(const struct zbus_channel *chan)
-    {
-    	int err = 0;
-    	const enum network_status *status;
-
-    	if (&NETWORK_CHAN == chan) {
-
-    		/* Get network status from channel. */
-    		status = zbus_chan_const_msg(chan);
-
-    		switch (*status) {
-    		case NETWORK_CONNECTED:
-    			err = led_on(led_device, LED_1_GREEN);
-    			if (err) {
-    				LOG_ERR("led_on, error: %d", err);
-    			}
-    			break;
-    		case NETWORK_DISCONNECTED:
-    			err = led_off(led_device, LED_1_GREEN);
-    			if (err) {
-    				LOG_ERR("led_off, error: %d", err);
-    			}
-    			break;
-    		default:
-    			LOG_ERR("Unknown event: %d", *status);
-    			break;
-    		}
-    	}
-    }
-
-    ZBUS_LISTENER_DEFINE(led, led_callback);
+.. literalinclude:: ../src/modules/led/led.c
+   :language: c
+   :start-after: include_startingpoint_architecture_rst_1
+   :end-before: include_endpoint_architecture_rst_1
 
 A module publishes a message to a channel by calling the :c:func:`zbus_chan_pub` function.
 The following code snippet shows how this is typically carried out throughout the sample:
 
-.. code-block:: c
-
-    int err;
-    struct payload payload = "Some payload";
-
-    err = zbus_chan_pub(&PAYLOAD_CHAN, &payload, K_SECONDS(1));
-    if (err) {
-    	LOG_ERR("zbus_chan_pub, error: %d", err);
-    }
+.. literalinclude:: ../src/modules/sampler/sampler.c
+   :language: c
+   :start-after: include_startingpoint_architecture_rst_2
+   :end-before: include_endpoint_architecture_rst_2
 
 
 .. _mqtt_sample_module_list:

--- a/samples/net/mqtt/doc/description.rst
+++ b/samples/net/mqtt/doc/description.rst
@@ -7,7 +7,7 @@ Sample description
    :local:
    :depth: 2
 
-The MQTT sample communicates with an MQTT broker either over LTE using an nRF91 Series device, or over Wi-Fi® using an nRF70 Series device or an nRF54LM20 DK connected with nRF7002 EB2 as a shield.
+The MQTT sample communicates with an MQTT broker either over LTE using an nRF91 Series device, or over Wi-Fi® using an nRF71 Series device, or an nRF70 Series device combined with a compatible host platform (for example, an nRF54LM20 DK connected with an nRF7002-EB II as a shield).
 
 .. |wifi| replace:: Wi-Fi
 

--- a/samples/net/mqtt/doc/description.rst
+++ b/samples/net/mqtt/doc/description.rst
@@ -310,3 +310,4 @@ This sample uses the following |NCS| and Zephyr libraries:
 * :ref:`mqtt_socket_interface`
 * :ref:`net_mgmt_interface`
 * :ref:`lib_hw_id`
+* :ref:`conn_mgr_overview`

--- a/samples/net/mqtt/doc/description.rst
+++ b/samples/net/mqtt/doc/description.rst
@@ -107,25 +107,23 @@ The sample provides predefined configuration files for the following development
 * :file:`boards/nrf9161dk_nrf9161_ns.conf` - Configuration file for the nRF9161 DK.
 * :file:`boards/nrf9160dk_nrf9160_ns.conf` - Configuration file for the nRF9160 DK.
 * :file:`boards/thingy91_nrf9160_ns.conf` - Configuration file for the Thingy:91.
-* :file:`thingy91x_nrf9151_ns.conf` - Configuration file for the Thingy:91 X.
-* :file:`boards/nrf7002dk_nrf5340_cpuapp.conf` - Configuration file for the nRF7002 DK.
-* :file:`nrf54lm20dk_nrf54lm20a_cpuapp.conf` - Configuration file for the nRF54LM20 DK.
-* :file:`boards/native_sim.conf` - Configuration file for the native simulator board.
+* :file:`boards/thingy91x_nrf9151_ns.conf` - Configuration file for the Thingy:91 X.
+* :file:`boards/nrf7002dk_nrf5340_cpuapp_ns.conf` - Configuration file for the nRF7002 DK.
 * :file:`boards/nrf7120dk_nrf7120_cpuapp_ns.conf` - Configuration file for the nRF7120 DK.
+* :file:`boards/native_sim.conf` - Configuration file for the native simulator board.
 
-Files that are located under the :file:`/boards` folder is automatically merged with the :file:`prj.conf` file when you build for corresponding target.
+Files that are located under the :file:`/boards` folder are automatically merged with the :file:`prj.conf` file when you build for the corresponding target.
 
-In addition, the sample provides the following overlay configuration files, which are used to enable additional features in the sample:
+In addition, the sample provides the following configuration overlay files, which are used to enable additional features in the sample:
 
-* :file:`overlay-tls-nrf91.conf` - TLS overlay configuration file for nRF91 Series devices.
-* :file:`tls-nrf7002.conf` - TLS overlay configuration file for nRF70 Series devices.
-* :file:`tls-nrf54l-nrf70.conf` - TLS overlay configuration file for nRF54L Series devices.
-* :file:`overlay-tls-native_sim.conf` - TLS overlay configuration file for the native simulator board.
-* :file:`tls-nrf7120.conf` - TLS overlay configuration file for nRF71 Series devices.
+* :file:`overlay-tls-nrf91.conf` - TLS configuration overlay file for nRF91 Series devices.
+* :file:`overlay-tls-native_sim.conf` - TLS configuration overlay file for the native simulator board.
+* :file:`wifi.conf` - Configuration overlay file for Wi-Fi devices.
+* :file:`wifi-tls.conf` - TLS configuration overlay file for Wi-Fi devices.
 
 They are located in :file:`samples/net/mqtt` folder.
 
-To add a specific overlay configuration file to the build, add the ``-- -DEXTRA_CONF_FILE=<overlay_config_file>`` flag to your build.
+To add a specific configuration overlay file to the build, add the ``-- -DEXTRA_CONF_FILE=<overlay_config_file>`` flag to your build.
 
 See :ref:`cmake_options` for instructions on how to add this option to your build.
 For example, when building with the command line, the following commands can be used for the nRF9160 DK:
@@ -169,7 +167,7 @@ Testing
 Sample output
 =============
 
-The following serial UART output is displayed in the terminal emulator using a Wi-Fi connection, with the TLS overlay:
+The following serial UART output is displayed in the terminal emulator on a Wi-Fi device, with the TLS configuration overlay file:
 
 .. code-block:: console
 
@@ -189,7 +187,7 @@ The following serial UART output is displayed in the terminal emulator using a W
 
 .. _mqtt_sample_output_IPv6:
 
-The sample output showing IPv6, but for a different build configuration using LTE on the Thingy:91 with the TLS overlay, and debug logging enabled for the :ref:`lib_mqtt_helper` library:
+The sample output showing IPv6, but for a different build configuration using LTE on the Thingy:91 with the TLS configuration overlay file, and debug logging enabled for the :ref:`lib_mqtt_helper` library:
 
 .. code-block:: console
 

--- a/samples/net/mqtt/doc/description.rst
+++ b/samples/net/mqtt/doc/description.rst
@@ -149,6 +149,17 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
+Wi-Fi with TLS
+==============
+
+For |wifi| builds with TLS enabled, set the ``mqtt_EXTRA_CONF_FILE`` sysbuild variable to include both :file:`wifi.conf` and :file:`wifi-tls.conf`.
+
+For example, use the following command for the nRF7120 DK:
+
+.. code-block:: console
+
+   west build -b nrf7120dk/nrf5340/cpuapp/ns samples/net/mqtt --sysbuild -- -Dmqtt_EXTRA_CONF_FILE="wifi.conf;wifi-tls.conf"
+
 Testing
 =======
 

--- a/samples/net/mqtt/doc/provisioning.rst
+++ b/samples/net/mqtt/doc/provisioning.rst
@@ -31,7 +31,7 @@ Intermediate certificates (located further down the chain) might change over tim
 
 To turn off runtime credential provisioning, disable either of the following Kconfig options:
 
-* :kconfig:option:`CONFIG_MQTT_HELPER_PROVISION_CERTIFICATES` - For native simulator and nRF70 Series builds.
+* :kconfig:option:`CONFIG_MQTT_HELPER_PROVISION_CERTIFICATES` - For the nRF71 Series, nRF70 Series, and native simulator builds.
 * :kconfig:option:`CONFIG_MODEM_KEY_MGMT` - For nRF91 Series builds.
 
 The CA is provisioned to the security tag set by the :kconfig:option:`CONFIG_MQTT_HELPER_SEC_TAG` Kconfig option.

--- a/samples/net/mqtt/src/modules/led/led.c
+++ b/samples/net/mqtt/src/modules/led/led.c
@@ -19,6 +19,7 @@ const static struct device *led_device = DEVICE_DT_GET_ANY(gpio_leds);
 /* LED 1, green on Thingy:91 boards. */
 #define LED_1_GREEN 1
 
+/* include_startingpoint_architecture_rst_1 (used by docs; keep this marker) */
 void led_callback(const struct zbus_channel *chan)
 {
 	int err = 0;
@@ -58,3 +59,4 @@ void led_callback(const struct zbus_channel *chan)
  * receives a new message.
  */
 ZBUS_LISTENER_DEFINE(led, led_callback);
+/* include_endpoint_architecture_rst_1 (used by docs; keep this marker) */

--- a/samples/net/mqtt/src/modules/sampler/sampler.c
+++ b/samples/net/mqtt/src/modules/sampler/sampler.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(sampler, CONFIG_MQTT_SAMPLE_SAMPLER_LOG_LEVEL);
 /* Register subscriber */
 ZBUS_SUBSCRIBER_DEFINE(sampler, CONFIG_MQTT_SAMPLE_SAMPLER_MESSAGE_QUEUE_SIZE);
 
+/* include_startingpoint_architecture_rst_2 (used by docs; keep this marker) */
 static void sample(void)
 {
 	struct payload payload = { 0 };
@@ -41,7 +42,9 @@ static void sample(void)
 		SEND_FATAL_ERROR();
 	}
 }
+/* include_endpoint_architecture_rst_2 (used by docs; keep this marker) */
 
+/* include_startingpoint_architecture_rst_3 (used by docs; keep this marker) */
 static void sampler_task(void)
 {
 	const struct zbus_channel *chan;
@@ -56,3 +59,4 @@ static void sampler_task(void)
 K_THREAD_DEFINE(sampler_task_id,
 		CONFIG_MQTT_SAMPLE_SAMPLER_THREAD_STACK_SIZE,
 		sampler_task, NULL, NULL, NULL, 3, 0, 0);
+/* include_endpoint_architecture_rst_3 (used by docs; keep this marker) */


### PR DESCRIPTION
This PR implements small fixes to mqtt sample readme:
- Removes not existing `.conf` files from readme
- Aligns wording around `.conf` files
- Mentionas Connection Manager as used library
- Adds nRF71 as supported series
- Adds section how to build Wi-Fi with TLS
- Makes use of rst anchros in C code instead of copy-pasting the code to .rst files