### PR TITLE
[Backport v3.4-branch] doc: nrf54l: add nRF54LC10A to NFC and FEM maturity tables

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -1782,6 +1782,7 @@ The following table indicates the software maturity levels of the support for ea
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LC10A
               - nRF54LM20A
               - nRF54LM20B
               - nRF54LV10A
@@ -1791,6 +1792,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - --
               - Supported
               - Supported
               - --
@@ -1800,6 +1802,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - --
               - Supported
               - Supported
               - --
@@ -1814,10 +1817,12 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - --
               - --
+              - --
             * - **NFC ISO-DEP protocol (ISO/IEC 14443-4)**
               - Supported
               - Supported
               - Supported
+              - --
               - Supported
               - Supported
               - --
@@ -1827,6 +1832,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - --
               - Supported
               - Supported
               - --
@@ -1836,6 +1842,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - --
               - Supported
               - Supported
               - --
@@ -1845,6 +1852,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - --
               - Supported
               - Supported
               - --
@@ -1854,6 +1862,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported\ :sup:`1`
               - Supported\ :sup:`1`
               - Supported\ :sup:`1`
+              - --
               - Supported\ :sup:`1`
               - Supported\ :sup:`1`
               - --
@@ -3705,6 +3714,7 @@ The following table indicates the software maturity levels of the support for Fr
             - nRF54L05
             - nRF54L10
             - nRF54L15
+            - nRF54LC10A
             - nRF54LM20A
             - nRF54LM20B
             - nRF54LV10A
@@ -3720,11 +3730,13 @@ The following table indicates the software maturity levels of the support for Fr
             - --
             - --
             - --
+            - --
           * - nRF21540
             - nRF21540 GPIO+SPI
             - Supported
             - Supported
             - Supported
+            - --
             - Supported
             - Supported
             - --
@@ -3735,6 +3747,7 @@ The following table indicates the software maturity levels of the support for Fr
             - Supported
             - Supported
             - Supported
+            - --
             - --
             - --
             - --


### PR DESCRIPTION
Backport 3b8c1da7b3a24d96f6fd5dada099fd4816a1f980 from #31165.