### PR TITLE
samples: cellular: Remove thingy91/nrf9160/ns from modem_shell integr…

### DIFF
--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -526,7 +526,6 @@ tests:
     extra_args: modem_shell_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns


### PR DESCRIPTION
…ation

Remove thingy91/nrf9160/ns from
sample.cellular.modem_shell_modem_uart_trace integration list.

This target fails to build as it does not fit the flash.