### PR TITLE
samples: bluetooth: mesh: light_switch: Fix nRF54L15tag LPN power measurement

### DIFF
--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -151,7 +151,7 @@ The following table shows a list of the supported boards for the LPN configurati
    nrf52dk/nrf52832      7.14 mA                   13.69 µA
    nrf52840dk/nrf52840   6.71 mA                   14.63 µA
    nrf52833dk/nrf52833   6.10 mA                   14.43 µA
-   nrf54l15tag/nrf54l15  -                         12.42 µA
+   nrf54l15tag/nrf54l15  --                        15.59 µA
    ====================  ========================  ====================
 
 The following applies to the LPN measurements presented in this table:
@@ -163,6 +163,8 @@ The following applies to the LPN measurements presented in this table:
 * The current consumption is measured using the `Power Profiler Kit II (PPK2)`_.
 
 * The measurements are done on the SoC only (meaning the measurements do not include power consumed by development kit LEDs for example).
+
+  * The nRF54L15 Tag is an exception to this, as it cannot be measured on the SoC only.
 
 .. image:: img/standard_52840ppk.png
    :align: center


### PR DESCRIPTION
The nRF54L15 Tag LPN current consumption measurement was previously taken with an inaccurate methodology, giving 12.42 uA. Replace it with 15.59 uA from a corrected re-measurement.

Also fix the "non-LPN" placeholder for this board to use an en dash consistent with table formatting elsewhere, and add a note stating that, unlike the other boards, the nRF54L15 Tag measurement is not isolated to the SoC only, since the board does not support that.