### PR TITLE
lib_ nrf_modem_lib: update memory allocation failure diagnostics

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -813,6 +813,10 @@ Gazell libraries
 Modem libraries
 ---------------
 
+* :ref:`nrf_modem_lib_readme`:
+
+  * Updated the diagnostic counters of memory allocation failures to depend on the :kconfig:option:`CONFIG_NRF_MODEM_LIB_MEM_DIAG` Kconfig option.
+
 * :ref:`lib_location` library:
 
   * Updated the library to always use the chosen ``zephyr,wifi`` node instead of ``ncs,location-wifi`` to find the used Wi-Fi device.

--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -368,7 +368,7 @@ void *nrf_modem_os_alloc(size_t bytes)
 	extern uint32_t nrf_modem_lib_failed_allocs;
 	void * const addr = k_heap_alloc(&nrf_modem_lib_heap, bytes, K_NO_WAIT);
 
-	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_MEM_DIAG_ALLOC) && !addr) {
+	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_MEM_DIAG) && !addr) {
 		nrf_modem_lib_failed_allocs++;
 	}
 
@@ -392,7 +392,7 @@ void *nrf_modem_os_shm_tx_alloc(size_t bytes)
 	void * const addr = k_heap_alloc(&nrf_modem_lib_shmem_heap, bytes, K_NO_WAIT);
 #endif
 
-	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_MEM_DIAG_ALLOC) && !addr) {
+	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_MEM_DIAG) && !addr) {
 		nrf_modem_lib_shmem_failed_allocs++;
 	}
 


### PR DESCRIPTION
The memory allocation failure diagnostics counters now depend on the CONFIG_NRF_MODEM_LIB_MEM_DIAG Kconfig option. Hence, the statistics returned by the nrf_modem_lib_diag_stats_get() function, and the diagnostics logged when the CONFIG_NRF_MODEM_LIB_MEM_DIAG_DUMP Kconfig option is set, is valid also when the
CONFIG_NRF_MODEM_LIB_MEM_DIAG_ALLOC Kconfig option is not set.