### PR TITLE
samples: cellular: reduce integration targets from Twister builds

### DIFF
--- a/samples/cellular/at_client/sample.yaml
+++ b/samples/cellular/at_client/sample.yaml
@@ -28,7 +28,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
@@ -71,7 +70,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/at_client/sample.yaml
+++ b/samples/cellular/at_client/sample.yaml
@@ -8,7 +8,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - nrf9251dk/nrf9251/cpuapp
       - thingy91x/nrf9151/ns
     platform_allow:
@@ -29,7 +28,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
     platform_allow:
@@ -52,7 +50,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - nrf9251dk/nrf9251/cpuapp
       - thingy91x/nrf9151/ns
     platform_allow:
@@ -74,7 +71,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
     platform_allow:

--- a/samples/cellular/at_client/sample.yaml
+++ b/samples/cellular/at_client/sample.yaml
@@ -9,7 +9,6 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9251dk/nrf9251/cpuapp
-      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -28,7 +27,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -50,7 +48,6 @@ tests:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
       - nrf9251dk/nrf9251/cpuapp
-      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -70,7 +67,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/at_monitor/sample.yaml
+++ b/samples/cellular/at_monitor/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/battery/sample.yaml
+++ b/samples/cellular/battery/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/fmfu_smp_svr/sample.yaml
+++ b/samples/cellular/fmfu_smp_svr/sample.yaml
@@ -8,7 +8,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/gnss/sample.yaml
+++ b/samples/cellular/gnss/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - nrf9251dk/nrf9251/cpuapp
     platform_allow:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/http_update/application_update/sample.yaml
+++ b/samples/cellular/http_update/application_update/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -23,7 +22,6 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE=carrier.overlay
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/http_update/modem_delta_update/sample.yaml
+++ b/samples/cellular/http_update/modem_delta_update/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/http_update/modem_full_update/sample.yaml
+++ b/samples/cellular/http_update/modem_full_update/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/location/sample.yaml
+++ b/samples/cellular/location/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/location/sample.yaml
+++ b/samples/cellular/location/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/lwm2m_carrier/sample.yaml
+++ b/samples/cellular/lwm2m_carrier/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/lwm2m_client/sample.yaml
+++ b/samples/cellular/lwm2m_client/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/lwm2m_client/sample.yaml
+++ b/samples/cellular/lwm2m_client/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - thingy91/nrf9160/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/modem_callbacks/sample.yaml
+++ b/samples/cellular/modem_callbacks/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -524,7 +524,6 @@ tests:
     extra_args: modem_shell_SNIPPET="nrf91-modem-trace-uart"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -134,7 +134,6 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE="nrf9161dk_ext_flash.overlay"
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9161dk/nrf9161/ns

--- a/samples/cellular/modem_shell/sample.yaml
+++ b/samples/cellular/modem_shell/sample.yaml
@@ -307,7 +307,6 @@ tests:
     sysbuild: true
     build_only: true
     integration_platforms:
-      - thingy91/nrf9160/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - thingy91/nrf9160/ns

--- a/samples/cellular/modem_trace_backend/sample.yaml
+++ b/samples/cellular/modem_trace_backend/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/modem_trace_flash/sample.yaml
+++ b/samples/cellular/modem_trace_flash/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/nidd/sample.yaml
+++ b/samples/cellular/nidd/sample.yaml
@@ -13,7 +13,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
     tags:
       - ci_build

--- a/samples/cellular/nidd/sample.yaml
+++ b/samples/cellular/nidd/sample.yaml
@@ -13,7 +13,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - thingy91/nrf9160/ns
     tags:
       - ci_build
       - sysbuild

--- a/samples/cellular/nrf_cloud_coap_cell_location/sample.yaml
+++ b/samples/cellular/nrf_cloud_coap_cell_location/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/nrf_cloud_coap_cell_location/sample.yaml
+++ b/samples/cellular/nrf_cloud_coap_cell_location/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/nrf_cloud_coap_device_message/sample.yaml
+++ b/samples/cellular/nrf_cloud_coap_device_message/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/nrf_cloud_coap_device_message/sample.yaml
+++ b/samples/cellular/nrf_cloud_coap_device_message/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/nrf_cloud_coap_fota/sample.yaml
+++ b/samples/cellular/nrf_cloud_coap_fota/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
@@ -24,7 +23,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/nrf_cloud_mqtt_cell_location/sample.yaml
+++ b/samples/cellular/nrf_cloud_mqtt_cell_location/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/nrf_cloud_mqtt_cell_location/sample.yaml
+++ b/samples/cellular/nrf_cloud_mqtt_cell_location/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/nrf_cloud_mqtt_device_message/sample.yaml
+++ b/samples/cellular/nrf_cloud_mqtt_device_message/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/nrf_cloud_mqtt_device_message/sample.yaml
+++ b/samples/cellular/nrf_cloud_mqtt_device_message/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/nrf_cloud_mqtt_fota/sample.yaml
+++ b/samples/cellular/nrf_cloud_mqtt_fota/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
@@ -24,7 +23,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/nrf_device_provisioning/sample.yaml
+++ b/samples/cellular/nrf_device_provisioning/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/nrf_device_provisioning/sample.yaml
+++ b/samples/cellular/nrf_device_provisioning/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/pdn/sample.yaml
+++ b/samples/cellular/pdn/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/sms/sample.yaml
+++ b/samples/cellular/sms/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
@@ -22,7 +21,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/tls_ciphersuites/sample.yaml
+++ b/samples/cellular/tls_ciphersuites/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - nrf9160dk/nrf9160/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/tls_ciphersuites/sample.yaml
+++ b/samples/cellular/tls_ciphersuites/sample.yaml
@@ -7,7 +7,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/udp/sample.yaml
+++ b/samples/cellular/udp/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns

--- a/samples/cellular/udp/sample.yaml
+++ b/samples/cellular/udp/sample.yaml
@@ -6,7 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf9151dk/nrf9151/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91x/nrf9151/ns
     platform_allow:
       - nrf9151dk/nrf9151/ns

--- a/samples/cellular/uicc_lwm2m/sample.yaml
+++ b/samples/cellular/uicc_lwm2m/sample.yaml
@@ -13,7 +13,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - nrf9161dk/nrf9161/ns
       - thingy91/nrf9160/ns
     tags:
       - ci_build

--- a/samples/cellular/uicc_lwm2m/sample.yaml
+++ b/samples/cellular/uicc_lwm2m/sample.yaml
@@ -13,7 +13,6 @@ tests:
     integration_platforms:
       - nrf9151dk/nrf9151/ns
       - nrf9160dk/nrf9160/ns
-      - thingy91/nrf9160/ns
     tags:
       - ci_build
       - sysbuild


### PR DESCRIPTION
Our Twister integration builds have 2450 build targets from which 178 comes from Cellular.
This causes unnecessary long CI build for PR checks.

Drop few integration targets from CI builds while leaving the `platform_allow` lists untouched. This allows targets to build on nightly jobs.

This PR drops 55 integration targets from `samples/cellular` using following rules:

### samples: cellular: Drop redundant nrf9161dk integration targets 

nrf9161dk and nrf9151dk share the same modem core from a software
point of view, so building the same configuration on both wastes CI
time. Drop nrf9161dk and keep nrf9151dk as the representative
target. Boards stay in platform_allow so they remain buildable
on demand.

### samples: cellular: Drop thingy91 where thingy91x already covers it 

Thingy:91 and Thingy:91 X are both nRF9151-family-adjacent boards
(9160 vs 9151 SiP), but when a scenario already builds thingy91x with
an identical configuration, thingy91 adds no new coverage. Drop
thingy91 and keep thingy91x, the newer and better-supported board.
platform_allow is left untouched so thingy91 stays buildable.

### samples: cellular: Drop thingy91/91x from plain modem/network configs 

Thingy:91 and Thingy:91 X carry the same silicon as nrf9160dk and
nrf9151dk respectively. For a configuration that is plain network or
modem functionality with no FOTA/DFU, no bootloader, no flash-map
change, and no board-specific DTS overlay, the DK build already
proves the software works, so the Thingy variant adds no coverage.
Drop thingy91x where nrf9151dk builds the same config, and thingy91
where nrf9160dk does. platform_allow is left untouched.

### samples: cellular: tls_ciphersuites: Build only nrf9151dk in CI 

This sample only exercises the generic socket/TLS stack and has no
modem-specific feature under test, so its behavior does not vary
across nRF91-series boards. One representative target (nrf9151dk)
is enough for CI; platform_allow keeps every board buildable
on demand.
