### PR TITLE
doc: mesh: fix Light LC Server element placement requirement

### DIFF
--- a/doc/nrf/libraries/bluetooth/mesh/light_ctl_srv.rst
+++ b/doc/nrf/libraries/bluetooth/mesh/light_ctl_srv.rst
@@ -53,6 +53,9 @@ The Lightness and Light Temperature Server callbacks will pass pointers to :c:me
     The Light CTL Server will verify that its internal Light Temperature Server is instantiated on a subsequent element on startup.
     If the Light Temperature Server is missing or instantiated on the same or a preceding element, the Bluetooth® Mesh startup procedure will fail, and the device will not be responsive.
 
+To add automatic light level control to the same light, instantiate a :ref:`bt_mesh_light_ctrl_srv_readme` on an element after the ones listed, and let it control :c:member:`bt_mesh_light_ctl_srv.lightness_srv`.
+See :ref:`bt_mesh_light_ctrl_srv_composition_color` for details.
+
 States
 ======
 

--- a/doc/nrf/libraries/bluetooth/mesh/light_ctrl_srv.rst
+++ b/doc/nrf/libraries/bluetooth/mesh/light_ctrl_srv.rst
@@ -34,9 +34,8 @@ Composition data structure
 ==========================
 
 As both the Light LC Server and the Light Lightness Server extend the Generic OnOff model, the two models cannot be instantiated on the same element.
-
-.. note::
-    Due to implementation limitations, the Light LC Server is instantiated on the next element after the Light Lightness Server it is controlling.
+The Light LC Server must be instantiated on an element with a higher element index than the Light Lightness Server it controls.
+The two elements do not have to be adjacent, which allows other models to occupy the elements in between.
 
 .. figure:: images/bt_mesh_light_ctrl_composition.svg
    :alt: Light Lightness Control Server composition data structure
@@ -58,7 +57,58 @@ In the application, this composition data looks like this:
           BT_MESH_MODEL_NONE),
    };
 
-The Light LC Server will log an error during initialization if the controlled Light Lightness Server is on the same element.
+The Light LC Server will log an error during initialization if the controlled Light Lightness Server is on the same or a subsequent element.
+
+.. _bt_mesh_light_ctrl_srv_composition_color:
+
+Combining the Light LC Server with a color light server
+-------------------------------------------------------
+
+The Light LC Server does not need a Light Lightness Server of its own.
+If the device also implements a :ref:`bt_mesh_light_ctl_srv_readme`, a :ref:`bt_mesh_light_hsl_srv_readme` or a :ref:`bt_mesh_light_xyl_srv_readme`, the Light LC Server controls the same Light Lightness Server that these models extend.
+This matches the model relationship described in the Bluetooth Mesh Model Specification, where a single Light Lightness Server is extended by both the color light server and the Light LC Server.
+
+The placement of the shared Light Lightness Server depends on the color light server:
+
+* The :ref:`bt_mesh_light_ctl_srv_readme` contains its own Light Lightness Server.
+  Pass :c:member:`bt_mesh_light_ctl_srv.lightness_srv` to the Light LC Server initialization macro.
+* The :ref:`bt_mesh_light_hsl_srv_readme` and the :ref:`bt_mesh_light_xyl_srv_readme` reference an externally defined Light Lightness Server on their own element.
+  Pass the same Light Lightness Server to the Light LC Server initialization macro.
+
+The corresponding elements of the color light server, such as the Light CTL Temperature element or the Light Hue and Light Saturation elements, are placed directly after the element holding the Light Lightness Server.
+The Light Control element is placed after them.
+
+The following example combines a Light CTL Server with a Light LC Server:
+
+.. code-block:: c
+
+   static struct bt_mesh_light_ctl_srv light_ctl_srv =
+      BT_MESH_LIGHT_CTL_SRV_INIT(&lightness_handlers, &light_temp_handlers);
+
+   static struct bt_mesh_light_ctrl_srv light_ctrl_srv =
+      BT_MESH_LIGHT_CTRL_SRV_INIT(&light_ctl_srv.lightness_srv);
+
+   static struct bt_mesh_elem elements[] = {
+      /* Light CTL element, holds the shared Light Lightness Server */
+      BT_MESH_ELEM(1,
+          BT_MESH_MODEL_LIST(BT_MESH_MODEL_LIGHT_CTL_SRV(&light_ctl_srv)),
+          BT_MESH_MODEL_NONE),
+      /* Light CTL Temperature element */
+      BT_MESH_ELEM(2,
+          BT_MESH_MODEL_LIST(BT_MESH_MODEL_LIGHT_TEMP_SRV(&light_ctl_srv.temp_srv)),
+          BT_MESH_MODEL_NONE),
+      /* Light Control element */
+      BT_MESH_ELEM(3,
+          BT_MESH_MODEL_LIST(BT_MESH_MODEL_LIGHT_CTRL_SRV(&light_ctrl_srv)),
+          BT_MESH_MODEL_NONE),
+   };
+
+When a Light Lightness Server is controlled by a Light LC Server, the Light LC Server takes over its power-up behavior and its scene store and recall behavior for the Lightness state.
+The color light server stores and recalls only its own states, so recalling a color scene does not disturb the light level set by the controller.
+
+.. note::
+   A Light Lightness Server can be controlled by just one Light LC Server.
+   Instantiating several Light LC Servers with a pointer to the same Light Lightness Server is not supported, as the controllers would compete for the Lightness state.
 
 Relationship with other nodes
 =============================

--- a/doc/nrf/libraries/bluetooth/mesh/light_hsl_srv.rst
+++ b/doc/nrf/libraries/bluetooth/mesh/light_hsl_srv.rst
@@ -74,6 +74,9 @@ In the application code, this would look like this:
    The :c:struct:`bt_mesh_light_hsl_srv` also contains a pointer to the Light Lightness Server model.
    Pointer to this model should be passed to the Light HSL Server initialization macro.
 
+To add automatic light level control to the same light, instantiate a :ref:`bt_mesh_light_ctrl_srv_readme` on an element after the ones listed, and let it control the same Light Lightness Server.
+See :ref:`bt_mesh_light_ctrl_srv_composition_color` for details.
+
 The Light HSL Server does not contain any states on its own, but instead operates on the underlying Light Hue, Saturation and Lightness Server models' states.
 Because of this, the Light HSL Server does not have a message handler structure, but will instead defer its messages to the individual submodels' handler callbacks.
 

--- a/doc/nrf/libraries/bluetooth/mesh/light_xyl_srv.rst
+++ b/doc/nrf/libraries/bluetooth/mesh/light_xyl_srv.rst
@@ -41,6 +41,9 @@ The extended Light Lightness Server shall be instantiated on the same element:
 
 The Light xyL Server structure does not contain a Light Lightness Server instance, so this must be instantiated separately.
 
+To add automatic light level control to the same light, instantiate a :ref:`bt_mesh_light_ctrl_srv_readme` on a subsequent element, and let it control the same Light Lightness Server.
+See :ref:`bt_mesh_light_ctrl_srv_composition_color` for details.
+
 In the application code, this would look like this:
 
 .. code-block:: c


### PR DESCRIPTION
The Light LC Server documentation claimed that the server must be instantiated on the element directly after the Light Lightness Server it controls. The implementation only requires the Light Lightness Server to have a lower element index, and reaches it through the pointer passed to BT_MESH_LIGHT_CTRL_SRV_INIT, so adjacency is never assumed. Replace the note with the actual requirement and add a section on combining the Light LC Server with a Light CTL, Light HSL or Light xyL Server, cross-referenced from those pages.