### PR TITLE
nrf_security: cracen: Add support for storing CCM* keys in KMU 

### DIFF
--- a/doc/nrf/app_dev/device_guides/kmu_guides/kmu_psa_crypto_api_prog_model.rst
+++ b/doc/nrf/app_dev/device_guides/kmu_guides/kmu_psa_crypto_api_prog_model.rst
@@ -99,6 +99,7 @@ For each key type, the table lists the supported algorithms and indicates which 
        | - ``PSA_ALG_AES_ECB_NO_PADDING``
        | - ``PSA_ALG_AES_CBC_NO_PADDING``
        | - ``PSA_ALG_AES_CTR``
+       | - ``PSA_ALG_CCM_STAR_NO_TAG``
        | - ``PSA_ALG_CCM``
        | - ``PSA_ALG_GCM``
        | - ``PSA_ALG_CMAC*``
@@ -119,6 +120,7 @@ For each key type, the table lists the supported algorithms and indicates which 
        | - ``PSA_ALG_AES_ECB_NO_PADDING``
        | - ``PSA_ALG_AES_CBC_NO_PADDING``
        | - ``PSA_ALG_AES_CTR``
+       | - ``PSA_ALG_CCM_STAR_NO_TAG``
        | - ``PSA_ALG_CCM``
        | - ``PSA_ALG_GCM``
        | - ``PSA_ALG_CMAC*``

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -153,6 +153,9 @@ Security
     See also :ref:`ug_tfm_logging` for more information.
   * Support for the SHAKE-128 and SHAKE-256 eXtendable Output Functions (XOF) in the CRACEN driver.
   * Support for signature verification with ML-DSA-44, ML-DSA-65, and ML-DSA-87 when using the CRACEN driver.
+  * Support for the AES CCM* no tag cipher mode in the CRACEN driver.
+    The :ref:`Supported cryptographic operations in the nRF Connect SDK <ug_crypto_supported_features_cipher_modes>` page has been updated accordingly.
+  * Support for storing keys used by AES CCM* no tag in the KMU.
 
 * Updated:
 

--- a/scripts/generate_psa_key_attributes.py
+++ b/scripts/generate_psa_key_attributes.py
@@ -147,6 +147,9 @@ class PsaAlgorithm(IntEnum):
     # PSA_ALG_CTR
     CTR = 0x04C01000
 
+    # PSA_ALG_CCM_STAR_NO_TAG
+    CCM_STAR_NO_TAG = 0x04C01300
+
     # PSA_ALG_ECB_NO_PADDING
     ECB = 0x04404400
 
@@ -259,6 +262,7 @@ class PlatformKeyAttributes:
             PsaAlgorithm.CBC,
             PsaAlgorithm.CBC_PKCS7,
             PsaAlgorithm.CTR,
+            PsaAlgorithm.CCM_STAR_NO_TAG,
             PsaAlgorithm.ECB,
             PsaAlgorithm.CCM,
             PsaAlgorithm.GCM,

--- a/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_kmu.c
+++ b/subsys/nrf_security/src/drivers/cracen/cracenpsa/src/cracen_psa_kmu.c
@@ -100,6 +100,7 @@ enum kmu_metadata_algorithm {
 	METADATA_ALG_CHACHA20_POLY1305 = 8,
 	METADATA_ALG_AES_GCM = 12,
 	METADATA_ALG_AES_CCM = 16,
+	METADATA_ALG_AES_CCM_STAR = 17,
 	METADATA_ALG_AES_ECB = 20,
 	METADATA_ALG_AES_CTR = 24,
 	METADATA_ALG_AES_CBC = 28,
@@ -784,6 +785,12 @@ static psa_status_t convert_to_psa_attributes(kmu_metadata *metadata,
 						PSA_ALG_CCM, CRACEN_KMU_MIN_TAG_SIZE_CCM));
 		break;
 #endif /* PSA_NEED_CRACEN_CCM_AES */
+#ifdef PSA_NEED_CRACEN_CCM_STAR_NO_TAG_AES
+	case METADATA_ALG_AES_CCM_STAR:
+		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
+		psa_set_key_algorithm(key_attr, PSA_ALG_CCM_STAR_NO_TAG);
+		break;
+#endif /* PSA_NEED_CRACEN_CCM_STAR_NO_TAG_AES */
 #ifdef PSA_NEED_CRACEN_ECB_NO_PADDING_AES
 	case METADATA_ALG_AES_ECB:
 		psa_set_key_type(key_attr, PSA_KEY_TYPE_AES);
@@ -1006,6 +1013,14 @@ static psa_status_t convert_from_psa_attributes(const psa_key_attributes_t *key_
 		}
 		break;
 #endif /* PSA_NEED_CRACEN_CCM_AES */
+#ifdef PSA_NEED_CRACEN_CCM_STAR_NO_TAG_AES
+	case PSA_ALG_CCM_STAR_NO_TAG:
+		metadata->algorithm = METADATA_ALG_AES_CCM_STAR;
+		if (key_type != PSA_KEY_TYPE_AES) {
+			return PSA_ERROR_NOT_SUPPORTED;
+		}
+		break;
+#endif /* PSA_NEED_CRACEN_CCM_STAR_NO_TAG_AES */
 #ifdef PSA_NEED_CRACEN_ECB_NO_PADDING_AES
 	case PSA_ALG_ECB_NO_PADDING:
 		metadata->algorithm = METADATA_ALG_AES_ECB;


### PR DESCRIPTION
Add METADATA_ALG_AES_CCM_STAR = 17, next to the AES-CCM value, and map
it in both directions in convert_to_psa_attributes() and
convert_from_psa_attributes() so PSA_ALG_CCM_STAR_NO_TAG keys can be
provisioned into and loaded from the KMU.
