### PR TITLE
applications: nrf_desktop: Minor doc alignment (params update fail)

### DIFF
--- a/applications/nrf_desktop/doc/ble_latency.rst
+++ b/applications/nrf_desktop/doc/ble_latency.rst
@@ -114,7 +114,7 @@ After the link uses HID SCI, only the connection rate API might be used to adjus
 
 If a HID SCI mode request through the HID Control Point characteristic or Connection Rate Update Request is received before the delayed work runs, the module cancels the scheduled initial connection parameter request and switches to the connection rate API instead.
 If a HID SCI mode request arrives while the initial connection parameter update is already in progress, the requested SCI mode is made pending and applied after that update completes or fails.
-As of |NCS| 3.4.0 (which the current code must be compatible with), no connection parameter update rejection callback was available.
+The connection parameter update rejection callback is not available in the |NCS| long term support (LTS) release v3.4.0 and the subsequent bug fix releases.
 As a workaround, a timeout is scheduled that treats the update as failed if a completion callback is not received within 5 seconds after the update is requested.
 
 Module events

--- a/applications/nrf_desktop/src/modules/ble_latency.c
+++ b/applications/nrf_desktop/src/modules/ble_latency.c
@@ -98,7 +98,7 @@ static void set_init_conn_params(void)
 	if (!err) {
 		latency_state |= CONN_IS_INIT_PARAMS_UPDATE_IN_PROGRESS;
 		/* The conn_params_update_rejected callback was not
-		 * available on NCS 3.4.0 which this code needs to be compatible with.
+		 * available on NCS 3.4.X which this code needs to be compatible with.
 		 * To avoid the CONN_IS_INIT_PARAMS_UPDATE_IN_PROGRESS being set
 		 * permanently locking connection rate updates, treat the update
 		 * as rejected/failed after the INIT_CONN_PARAMS_UPDATE_TIMEOUT_MS


### PR DESCRIPTION
This commit adds a minor alignment to the documentation of the nrf_desktop ble_latency module and the explanation of handling connection parameters update failure.

The mentioned release 3.4.0 was imprecise, as the issue will also occur in bugfix releases - thus, changed it to 3.4.X