### PR TITLE
applications: nrf_desktop: sci "out-of-spec" state renamed

### DIFF
--- a/applications/nrf_desktop/doc/ble_latency.rst
+++ b/applications/nrf_desktop/doc/ble_latency.rst
@@ -139,7 +139,7 @@ When the :option:`CONFIG_DESKTOP_BLE_LATENCY_PM_EVENTS` Kconfig option is enable
 
 On a :c:struct:`power_down_event`, the module requests the LOW_POWER mode.
 On a :c:struct:`wake_up_event`, the module restores the last SCI mode requested by the host through the HID Control Point characteristic.
-If the connection is in the out-of-spec state described in :ref:`nrf_desktop_ble_latency_sci_host_updates`, the module does not change SCI mode in response to power management events.
+If the connection is in the HID host enforced rate state described in :ref:`nrf_desktop_ble_latency_sci_host_updates`, the module does not change SCI mode in response to power management events.
 
 If the host requests a mode other than LOW_POWER while the device is suspended, the module will save the requested mode but will remain in the LOW_POWER SCI mode.
 On wake up, the module will restore the saved mode.
@@ -184,8 +184,8 @@ If the connected host rejects this request, the module performs the following op
 
 .. _nrf_desktop_ble_latency_sci_host_updates:
 
-Out-of-spec host-initiated transport parameter updates
-------------------------------------------------------
+HID host enforced rate (host-initiated transport parameter updates)
+-------------------------------------------------------------------
 
 The HID over GATT Profile specification defines how HID SCI transport parameters must be negotiated.
 According to `HID Over GATT Profile Specification`_, Section 7.5.2 (*HID Host-initiated transport parameter updates*):
@@ -199,7 +199,7 @@ Section 7.5.1 defines the complementary device-initiated path:
 The nRF Desktop peripheral follows the device-initiated path when it adjusts peripheral latency within the active SCI mode.
 It expects the connected HID host to use the HID Control Point characteristic when requesting an SCI mode change.
 
-If the connected host updates transport parameters directly at the Link Layer (for example, by initiating a connection rate update instead of writing to the HID Control Point characteristic), the peripheral treats this as out-of-spec behavior.
+If the connected host updates transport parameters directly at the Link Layer (for example, by initiating a connection rate update instead of writing to the HID Control Point characteristic), the peripheral enters the **HID host enforced rate** state.
 When a :c:struct:`ble_peer_sci_conn_rate_event` is received without a prior HID SCI mode request, the module:
 
 * Attempts to determine a matching SCI mode for the received parameters, starting from the current mode and then trying modes in the order of FAST, DEFAULT, LOW_POWER, and FULL_RANGE.
@@ -208,14 +208,14 @@ When a :c:struct:`ble_peer_sci_conn_rate_event` is received without a prior HID 
 * The module drops any pending HID SCI mode or latency update requests.
 
 This recovery behavior is application-specific and is not mandated by the specification.
-It allows the peripheral to remain connected and usable with hosts that do not follow the Control Point negotiation procedure.
+It allows the peripheral to remain connected and usable with hosts that enforce connection rate parameters directly at the Link Layer.
 In order to return to the normal operation, the host must:
 
 1. Update the connection rate parameters to a range allowing to support all the HID SCI modes.
 2. Request an HID SCI mode change through the HID Control Point characteristic.
-   As a result, the Bluetooth LE latency module requests a matching connection rate update and clears the out-of-spec host-initiated transport parameter update state if the request succeeds.
-   If the current connection parameters are already valid for the requested mode, the module clears the out-of-spec state but no connection rate update is requested.
+   As a result, the Bluetooth LE latency module requests a matching connection rate update and clears the HID host enforced rate state if the request succeeds.
+   If the current connection parameters are already valid for the requested mode, the module clears the HID host enforced rate state but no connection rate update is requested.
 
    .. note::
       If the peripheral is in suspended/power-down state, the module will save the requested mode and attempt to request LOW_POWER mode parameters.
-      Only if this succeeds, the peripheral will exit the out-of-spec state.
+      Only if this succeeds, the peripheral will exit the HID host enforced rate state.

--- a/applications/nrf_desktop/src/modules/ble_latency.c
+++ b/applications/nrf_desktop/src/modules/ble_latency.c
@@ -51,7 +51,7 @@ enum {
 	CONN_IS_SCI			= BIT(4),
 	CONN_IS_SECURED			= BIT(5),
 	CONN_IS_SCI_PARAM_UPDATE_PENDING = BIT(6),
-	CONN_IS_SCI_OUT_OF_SPEC	= BIT(7),
+	CONN_IS_SCI_HID_HOST_ENFORCED_RATE	= BIT(7),
 	CONN_IS_POWER_DOWN		= BIT(8),
 	CONN_IS_SCI_LOW_POWER_HIGH_INTERVAL_FORBIDDEN = BIT(9),
 	CONN_IS_INIT_PARAMS_UPDATE_IN_PROGRESS = BIT(10),
@@ -223,7 +223,7 @@ static void set_conn_latency_sci(bool low_latency)
 	}
 
 	if ((latency_state & CONN_LOW_LATENCY_LOCKED) ||
-		(latency_state & CONN_IS_SCI_OUT_OF_SPEC)) {
+		(latency_state & CONN_IS_SCI_HID_HOST_ENFORCED_RATE)) {
 		return;
 	}
 
@@ -314,7 +314,7 @@ static bool is_high_latency_supported_for_mode(enum bt_hids_sci_mode_value mode)
 {
 	const struct bt_conn_le_conn_rate_param *mode_params = NULL;
 
-	/* HID SCI mode NONE could only happen if we are in an "out-of-spec" state.
+	/* HID SCI mode NONE could only happen if we are in the HID host enforced rate state.
 	 * No latency updates are supported in this state.
 	 */
 	if (mode != BT_HIDS_SCI_MODE_NONE) {
@@ -330,7 +330,7 @@ static void latency_updated(bool low_latency)
 		latency_state |= CONN_LOW_LATENCY_ENABLED;
 		latency_state &= ~CONN_LOW_LATENCY_REQUIRED;
 		if (!(latency_state & CONN_LOW_LATENCY_LOCKED)
-			&& !(latency_state & CONN_IS_SCI_OUT_OF_SPEC)) {
+			&& !(latency_state & CONN_IS_SCI_HID_HOST_ENFORCED_RATE)) {
 			(void)k_work_reschedule(&low_latency_check,
 						LOW_LATENCY_CHECK_PERIOD_MS);
 		} else {
@@ -357,7 +357,7 @@ static void conn_params_update_finished_sci_conn(void)
 		LOG_WRN("Unexpected non-SCI connection parameters update while SCI is active");
 
 		latency_state &= ~CONN_IS_SCI_PARAM_UPDATE_PENDING;
-		latency_state |= CONN_IS_SCI_OUT_OF_SPEC;
+		latency_state |= CONN_IS_SCI_HID_HOST_ENFORCED_RATE;
 		(void)k_work_cancel_delayable(&low_latency_check);
 	}
 
@@ -452,11 +452,11 @@ static void hid_sci_mode_request(enum bt_hids_sci_mode_value mode)
 		 * Usually in this case the peripheral will already be in the LOW_POWER SCI mode,
 		 * so the code below will result in no connection rate update and no SCI mode change
 		 * notification to the host.
-		 * The notable exception is if the peripheral is operating in an out-of-spec state,
+		 * The notable exception is if the peripheral is in the HID host enforced rate state,
 		 * due to a previous direct connection rate update from the host.
 		 * In this case, the current mode might be different - an attempt will be made to
 		 * switch to the LOW_POWER mode, and only if it succeeds, the peripheral will exit
-		 * the out-of-spec state.
+		 * the HID host enforced rate state.
 		 */
 		mode = BT_HIDS_SCI_MODE_LOW_POWER;
 	}
@@ -488,17 +488,17 @@ static void hid_sci_mode_request(enum bt_hids_sci_mode_value mode)
 
 	if (current_mode != mode) {
 		(void)hid_sci_conn_rate_request(last_requested_latency_is_low, mode);
-	} else if (latency_state & CONN_IS_SCI_OUT_OF_SPEC) {
+	} else if (latency_state & CONN_IS_SCI_HID_HOST_ENFORCED_RATE) {
 		struct bt_conn_info info;
 
-		/* Mode update properly requested after out-of-spec behavior,
+		/* Mode update properly requested after HID host enforced rate,
 		 * but the requested mode matches the current mode (no connection
 		 * rate update is performed).
 		 */
-		latency_state &= ~CONN_IS_SCI_OUT_OF_SPEC;
+		latency_state &= ~CONN_IS_SCI_HID_HOST_ENFORCED_RATE;
 		LOG_INF("The current connection parameters are valid for the requested mode %s",
 			sci_mode_to_string(mode));
-		LOG_INF("Clearing out-of-spec state and returning to normal operation");
+		LOG_INF("Clearing HID host enforced rate state and returning to normal operation");
 		err = bt_conn_get_info(active_conn, &info);
 
 		if (!err) {
@@ -673,7 +673,7 @@ static void conn_rate_update_success_handle(const struct ble_peer_sci_conn_rate_
 	}
 
 	/* Parameters update initiated directly by the host (not via SCI
-	 * mode API) is out-of-spec behavior.
+	 * mode API) puts the connection in the HID host enforced rate state.
 	 * We assume that if the host forces the parameters, it expects the peripheral
 	 * to keep them.
 	 * Thus, lock the possibility of autonomously changing connection latency.
@@ -684,22 +684,22 @@ static void conn_rate_update_success_handle(const struct ble_peer_sci_conn_rate_
 	if (processed_sci_mode == BT_HIDS_SCI_MODE_NONE) {
 		LOG_WRN("Direct SCI connection parameters update from the central");
 		LOG_WRN("(not through HID SCI control point characteristic).");
-		LOG_WRN("This is out-of-spec behavior.");
+		LOG_WRN("Entering HID host enforced rate state.");
 		LOG_WRN("No latency update requests will be performed by the peripheral "
 			"until a SCI mode request is received.");
 		latency_state &= ~CONN_IS_SCI_PARAM_UPDATE_PENDING;
-		latency_state |= CONN_IS_SCI_OUT_OF_SPEC;
+		latency_state |= CONN_IS_SCI_HID_HOST_ENFORCED_RATE;
 		(void)k_work_cancel_delayable(&low_latency_check);
 	} else if (mode == processed_sci_mode) {
 		/* A properly requested SCI mode update has been successfully performed. */
-		if (latency_state & CONN_IS_SCI_OUT_OF_SPEC) {
+		if (latency_state & CONN_IS_SCI_HID_HOST_ENFORCED_RATE) {
 			LOG_INF("Connection rate update successful for the requested mode %s",
 				sci_mode_to_string(mode));
-			LOG_INF("Clearing out-of-spec state and returning to normal operation");
-			latency_state &= ~CONN_IS_SCI_OUT_OF_SPEC;
+			LOG_INF("Clearing HID host enforced rate state and returning to normal operation");
+			latency_state &= ~CONN_IS_SCI_HID_HOST_ENFORCED_RATE;
 		}
 	} else {
-		/* Do nothing, remain in the in-spec/out-of-spec state. */
+		/* Do nothing, remain in the current HID host enforced rate state. */
 	}
 }
 
@@ -772,7 +772,7 @@ static void sci_power_event_handle(void)
 		return;
 	}
 
-	if (latency_state & CONN_IS_SCI_OUT_OF_SPEC) {
+	if (latency_state & CONN_IS_SCI_HID_HOST_ENFORCED_RATE) {
 		return;
 	}
 


### PR DESCRIPTION
Previously, it was assumed that the HID host requesting a direct connection rate update directly (not through HID control point) violates the HID SCI specifivation.

This turned out not to be true - upon more thorough inspection, such a case is present in the flow diagrams.

Refactored the ble_latency module and renamed the
"out-of-spec" state to "HID host enforced rate" state. No functional adjustments were made.