### PR TITLE
ci: src-mirror: use tag name as toolchain version on tag push

### DIFF
--- a/.github/workflows/src-mirror.yml
+++ b/.github/workflows/src-mirror.yml
@@ -41,3 +41,6 @@ jobs:
           artifactory-pass: ${{ secrets.COM_NORDICSEMI_FILES_PASSWORD }}
           stable: ${{ env.STABLE }}
           repository-type: 'nrf'
+          # On tag push, use the tag as toolchain version and skip Artifactory index
+          # lookup. promote-bundle adds the alias later; src-mirror must not race it.
+          toolchain-version: ${{ github.event_name == 'push' && github.ref_type == 'tag' && github.ref_name || '' }}


### PR DESCRIPTION
## Summary

- Pass `toolchain-version: ${{ github.ref_name }}` to `action-src-mirror` on tag push events.
- Skips Artifactory toolchain index lookup, which previously raced Jenkins `promote-bundle` and caused src-mirror to fail (e.g. v3.4.1-rc1 with checksum `8285d8ad56`).

## Problem

On tag push, GitHub src-mirror runs immediately and resolves `TOOLCHAIN_VERSION` from the Artifactory toolchain index. Jenkins `promote-bundle` adds the tag alias (`v3.4.1-rc1` → checksum) a few minutes later. When west update finishes quickly, src-mirror fails before the alias exists.

## Fix

On tags, the toolchain version for SDK Manager is the tag name itself — no index lookup needed. Non-tag runs (`workflow_dispatch`) keep the existing checksum-based lookup.

## Follow-up

- Optional upstream in `nrfconnect/action-src-mirror` for other consumers