### PR TITLE
doc: security: downgrade LS05 support

### DIFF
--- a/doc/nrf/app_dev/device_guides/kmu_guides/kmu_cracen_overview.rst
+++ b/doc/nrf/app_dev/device_guides/kmu_guides/kmu_cracen_overview.rst
@@ -37,7 +37,6 @@ The following table shows which devices use KMU and CRACEN peripherals.
        | nRF54LM20A
        | nRF54LM20B
        | nRF54LV10A
-       | nRF54LV10B
      - | nRF54LS05A
        | nRF54LS05B
 

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -2864,8 +2864,8 @@ The lists are organized by device Series and implementation.
               - Supported
               - Supported
               - Supported
-              - Supported
-              - Supported
+              - Experimental
+              - Experimental
             * - :ref:`TF-M Crypto Service <ug_crypto_architecture_implementation_standards_tfm>`
               - --
               - Experimental


### PR DESCRIPTION
Updated security docs to mention LS05 support as Experimental.