### PR TITLE
tests: zephyr: drivers: gpio: gpio_nrf: Enable on nrf9251 APP

### DIFF
--- a/tests/zephyr/drivers/gpio/gpio_nrf/testcase.yaml
+++ b/tests/zephyr/drivers/gpio/gpio_nrf/testcase.yaml
@@ -8,7 +8,8 @@ common:
 tests:
   nrf.extended.drivers.gpio.gpio_nrf:
     platform_allow:
-      - nrf9251dk/nrf9251/cpuppr
       - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf9251dk/nrf9251/cpuapp
+      - nrf9251dk/nrf9251/cpuppr
     integration_platforms:
       - nrf9251dk/nrf9251/cpuppr


### PR DESCRIPTION
Add nrf9251dk/nrf9251/cpuapp platform to the platform_allow list.