### PR TITLE
ci: src-mirror: apply LTS tag only for stable releases

### DIFF
--- a/.github/workflows/src-mirror.yml
+++ b/.github/workflows/src-mirror.yml
@@ -41,4 +41,4 @@ jobs:
           artifactory-pass: ${{ secrets.COM_NORDICSEMI_FILES_PASSWORD }}
           stable: ${{ env.STABLE }}
           repository-type: 'nrf'
-          tags: 'LTS'
+          tags: ${{ env.STABLE == 'true' && 'LTS' || '' }}


### PR DESCRIPTION
## Summary

- Gate the SDK Manager `LTS` tag on `STABLE=true` in `src-mirror.yml`.
- RC and other non-GA tags keep `unstable` only; GA tags (e.g. `v3.4.1`) still get `LTS`.

## Problem

Commit ead9c3c7834 added unconditional `tags: 'LTS'` on `v3.4-branch`, so RC builds such as `v3.4.1-rc1` were indexed with both `unstable` and `LTS`.

## Fix

```yaml
tags: ${{ env.STABLE == 'true' && 'LTS' || '' }}
```

Uses the existing `STABLE` logic (semver tag without suffix).

## Note

Does not retroactively fix existing index entries; re-run src-mirror on affected tags if needed.