### PR TITLE
doc: software maturity: update MCUboot/NSIB support for nRF54Lx: LS05A/B & LC10A

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -3346,7 +3346,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Experimental
-              - --
+              - Experimental
               - Experimental
             * - **Updatable MCUboot as part of build**
               - Supported
@@ -3364,7 +3364,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - --
               - Experimental
-              - --
+              - Experimental
               - Experimental
             * - **Hardware cryptography acceleration**
               - Supported
@@ -3382,7 +3382,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Experimental
-              - --
+              - Experimental
               - Experimental
             * - **Image encryption**
               - Experimental
@@ -3391,8 +3391,8 @@ The following table indicates the software maturity levels of the support for ea
               - Experimental
               - Experimental
               - Experimental
-              - --
-              - --
+              - Experimental
+              - Experimental
 
       .. tab:: nRF91 Series
 

--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -2991,6 +2991,7 @@ The lists are organized by device Series and implementation.
              - nRF54L05
              - nRF54L10
              - nRF54L15
+             - nRF54LC10A
              - nRF54LM20A
              - nRF54LM20B
              - nRF54LV10A
@@ -3000,6 +3001,7 @@ The lists are organized by device Series and implementation.
              - Supported
              - Supported
              - Supported
+             - Experimental
              - Supported
              - Supported
              - Experimental
@@ -3334,6 +3336,7 @@ The following table indicates the software maturity levels of the support for ea
               - nRF54L05
               - nRF54L10
               - nRF54L15
+              - nRF54LC10A
               - nRF54LM20A
               - nRF54LM20B
               - nRF54LV10A
@@ -3343,6 +3346,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - Experimental
@@ -3352,6 +3356,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - Experimental
@@ -3361,6 +3366,7 @@ The following table indicates the software maturity levels of the support for ea
               - --
               - Supported
               - Supported
+              - Experimental
               - Supported
               - --
               - Experimental
@@ -3370,6 +3376,7 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - Experimental
@@ -3379,12 +3386,14 @@ The following table indicates the software maturity levels of the support for ea
               - Supported
               - Supported
               - Supported
+              - Experimental
               - Supported
               - Supported
               - Experimental
               - Experimental
               - Experimental
             * - **Image encryption**
+              - Experimental
               - Experimental
               - Experimental
               - Experimental


### PR DESCRIPTION
Mark image encryption as experimental on nRF54LS05B and align nRF54LS05A with the same MCUboot feature maturity levels.

This is for 3.4.1 release and is in synch with https://github.com/nrfconnect/sdk-nrf/pull/31233