### PR TITLE
wifi: nrf71: fix UMAC interface stats decoding on ROM'd FW

### DIFF
--- a/drivers/wifi/nrf71/inc/common/fw_if/nrf71_wifi_debug_stats.h
+++ b/drivers/wifi/nrf71/inc/common/fw_if/nrf71_wifi_debug_stats.h
@@ -327,22 +327,6 @@ struct umac_scan_dbg_params {
 	unsigned int scan_complete_from_lmac_6g;
 	/** Scan-done notifications toward upper layers (cfg80211) */
 	unsigned int scan_done_to_host;
-	/** Display scan: ieee80211_abort_scan when DB is at cap and a stronger new BSS arrives */
-	unsigned int display_scan_abort_bss_limit;
-	/** Host NL80211 abort-scan (rdev_abort_scan / cancel_hw_scan path) */
-	unsigned int scan_abort_req_from_host;
-	/** LMAC_CMD_SCAN_ABORT successfully queued to LMAC */
-	unsigned int scan_abort_cmd_to_lmac;
-	/** LMAC_CMD_SCAN_ABORT not sent (e.g. kmalloc failure in rpu_scan_abort) */
-	unsigned int scan_abort_cmd_alloc_fail;
-	/** wait_for_scan_abort timed out waiting for SCAN_ABORT_DONE */
-	unsigned int scan_abort_wait_timeout;
-	/** LMAC_EVENT_SCAN_ABORT_COMPLETE handled in rpu_scan_complete (IRQ path) */
-	unsigned int scan_abort_complete_lmac_irq;
-	/** cancel_hw_scan: wait succeeded; mac80211 completed from LMAC IRQ */
-	unsigned int scan_abort_cancel_scan_irq_done;
-	/** cancel_hw_scan: forced ieee80211_scan_completed after abort wait timeout */
-	unsigned int scan_abort_cancel_scan_timeout_umac;
 } __NRF_WIFI_PKD;
 
 /**

--- a/drivers/wifi/nrf71/src/system/fmac_event.c
+++ b/drivers/wifi/nrf71/src/system/fmac_event.c
@@ -184,6 +184,8 @@ static enum nrf_wifi_status umac_event_sys_stats_process(
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_sys_umac_event_stats *stats = NULL;
+	unsigned int recvd_len;
+	unsigned int copy_len;
 
 	if (!event) {
 		LOG_ERR("%s: Invalid parameters",
@@ -200,9 +202,28 @@ static enum nrf_wifi_status umac_event_sys_stats_process(
 
 	stats = ((struct nrf_wifi_sys_umac_event_stats *)event);
 
+	if (stats->sys_head.len < sizeof(stats->sys_head)) {
+		LOG_ERR("%s: Malformed stats event, len=%u",
+				      __func__, stats->sys_head.len);
+		goto out;
+	}
+
+	recvd_len = stats->sys_head.len - sizeof(stats->sys_head);
+	copy_len = recvd_len < sizeof(stats->fw) ? recvd_len : sizeof(stats->fw);
+
+	if (copy_len < sizeof(stats->fw)) {
+		/* FW sent fewer stats fields than this driver knows about (e.g.
+		 * older FW without interface_data_stats) - zero the rest instead
+		 * of leaving stale bytes from a previous transfer in fw_stats.
+		 */
+		LOG_DBG("%s: Truncated stats event (recvd=%u, expected=%u)",
+				      __func__, recvd_len, (unsigned int)sizeof(stats->fw));
+		nrf_wifi_mem_set(fmac_dev_ctx->fw_stats, 0, sizeof(stats->fw));
+	}
+
 	nrf_wifi_mem_cpy(fmac_dev_ctx->fw_stats,
 			      &stats->fw,
-			      sizeof(stats->fw));
+			      copy_len);
 
 	fmac_dev_ctx->stats_req = false;
 


### PR DESCRIPTION
## Summary
- `nrf71 util rpu_stats umac` showed bogus values for `UMAC interface stats`
  (e.g. `tx_multicast_pkt_count` in the millions) while the equivalent
  firmware-side counters were genuinely zero.
- `umac_event_sys_stats_process()` always copied `sizeof(stats->fw)` bytes
  out of the `NRF_WIFI_EVENT_STATS` payload regardless of how many bytes the
  firmware actually sent, so any shortfall was filled from stale bytes left
  over in the event buffer instead of zeros.
- The actual shortfall traced back to `struct umac_scan_dbg_params` in
  sdk-nrf's copy of `nrf71_wifi_debug_stats.h` having gained 8 fields
  (32 bytes) that don't exist in the FW mask-ROM'd on this nRF71 silicon
  (`release/nrf71_rom_1.0`) and can't be added via the UMAC patch
  mechanism. Since `scan_dbg_params` sits immediately before
  `interface_data_stats` in `struct rpu_umac_stats`, the size mismatch
  shifted every byte from that point on, so the driver was decoding
  `interface_data_stats` from the wrong offset entirely (e.g. `rx_bytes`
  showing up under `tx_multicast_pkt_count`).
- Fix is two commits:
  1. Clamp the stats-event copy to the number of bytes the firmware
     actually sent, zero-filling anything beyond that, so a size mismatch
     degrades to missing/zero fields instead of an out-of-bounds read.
  2. Drop the 8 `umac_scan_dbg_params` fields sdk-nrf doesn't actually
     have firmware support for on this silicon, restoring correct
     decoding of `interface_data_stats`.

## Test plan
- [x] `west build -b nrf7120dk/nrf7120/cpuapp samples/wifi/shell` (clean build on top of latest `main`)
- [x] Verified on nRF7120 DK hardware: `nrf71 util rpu_stats umac` now reports
      correct, internally-consistent counters instead of bogus values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)