### PR TITLE
services: throughput: Clarify what throughput numbers represent

### DIFF
--- a/doc/nrf/libraries/bluetooth/services/throughput.rst
+++ b/doc/nrf/libraries/bluetooth/services/throughput.rst
@@ -12,6 +12,10 @@ The GATT Throughput Service is a custom service that receives and writes data an
 To test GATT throughput, the client (central) writes without response to the characteristic on the server (peripheral).
 The client can then read the characteristic to retrieve the metrics.
 
+The service calls the :c:func:`bt_gatt_write_without_response` function to send data to the characteristic.
+This wraps the payload into an ATT_WRITE_CMD PDU in a single L2CAP B-frame.
+Each payload has an overhead of 7 bytes: 3 bytes for the ATT header and 4 bytes for the L2CAP header.
+
 The GATT Throughput Service is used in the :ref:`ble_throughput` sample.
 
 Service UUID
@@ -35,7 +39,7 @@ Read
    The read operation returns 3*4 bytes (12 bytes) that contain the metrics:
 
    * Four bytes unsigned: Number of GATT writes received
-   * Four bytes unsigned: Total bytes received
+   * Four bytes unsigned: Total bytes of ATT payload received
    * Four bytes unsigned: Throughput in bits per second
 
 
@@ -46,3 +50,12 @@ API documentation
 | Source file: :file:`subsys/bluetooth/services/throughput.c`
 
 .. doxygengroup::  bt_throughput
+
+References
+***********
+
+For more information about the protocol layers and ATT operations involved in this sample, see the following chapters in the `Bluetooth Core Specification`_:
+
+   * Volume 3, Part A, Section 3.1: Connection-oriented channels in Basic L2CAP mode
+   * Volume 3, Part F, Section 3.4.5.3: ATT_WRITE_CMD
+   * Volume 3, Part G, Section 4.9.1: Write Without Response

--- a/include/bluetooth/services/throughput.h
+++ b/include/bluetooth/services/throughput.h
@@ -28,10 +28,10 @@ struct bt_throughput_metrics {
         /** Number of GATT writes received. */
 	uint32_t write_count;
 
-        /** Number of bytes received. */
+	/** Number of ATT payload bytes received. */
 	uint32_t write_len;
 
-        /** Transfer speed in bits per second. */
+	/** Transfer speed in ATT payload bits per second. */
 	uint32_t write_rate;
 };
 

--- a/subsys/bluetooth/services/throughput.c
+++ b/subsys/bluetooth/services/throughput.c
@@ -69,7 +69,7 @@ static ssize_t write_callback(struct bt_conn *conn,
 		met_data->write_count++;
 		met_data->write_len += len;
 		met_data->write_rate =
-		    ((uint64_t)met_data->write_len << 3) * 1000000000 / delta;
+		    ((uint64_t)met_data->write_len * BITS_PER_BYTE) * 1000000000 / delta;
 	}
 
 	LOG_DBG("Received data.");


### PR DESCRIPTION
This commit clarifies that the service measures ATT throughput. That may remove some confusion about ATT vs LL throughput.