### PR TITLE
doc: software maturity: update ESB support on nRF54LC10A and nRF54LS05A

### DIFF
--- a/doc/nrf/releases_and_maturity/software_maturity.rst
+++ b/doc/nrf/releases_and_maturity/software_maturity.rst
@@ -378,11 +378,11 @@ The following table indicates the software maturity levels of the support for ea
            - Supported
            - Supported
            - Supported
-           - --
+           - Experimental
            - Supported
            - Supported
            - Experimental
-           - --
+           - Experimental
            - Experimental
          * - **LTE**
            - --


### PR DESCRIPTION
Update the Protocol support table in the Software maturity levels page to set experimental ESB support on the nRF54LC10A and nRF54LS05A SoCs.