### PR TITLE
tests: bootloader: adjust integration platforms

### DIFF
--- a/tests/subsys/bootloader/boot_ppi_config_leftovers/testcase.yaml
+++ b/tests/subsys/bootloader/boot_ppi_config_leftovers/testcase.yaml
@@ -10,7 +10,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
-      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - SB_CONFIG_BOOTLOADER_MCUBOOT=y
   bootloader.ppi_config_leftovers.nsib:
@@ -18,7 +18,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
-      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
       - SB_CONFIG_SECURE_BOOT_APPCORE=y
       - SB_CONFIG_SECURE_BOOT_GENERATE_DEFAULT_KMU_KEYFILE=y

--- a/tests/subsys/bootloader/upgrade/ref_smp_svr/testcase.yaml
+++ b/tests/subsys/bootloader/upgrade/ref_smp_svr/testcase.yaml
@@ -95,7 +95,13 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
     integration_platforms:
-      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     harness_config:
       pytest_root:
         - "../pytest/test_serial_recovery.py::test_serial_recovery_after_pin_reset"
@@ -265,7 +271,13 @@ tests:
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lc10dk/nrf54lc10a/cpuapp
     integration_platforms:
-      - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
     tags:
       - encryption
     harness_config:
@@ -291,7 +303,14 @@ tests:
       - nrf54ls05dk/nrf54ls05b/cpuapp
       - nrf54ls05dk/nrf54ls05a/cpuapp
     integration_platforms:
-      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54lv10dk/nrf54lv10a/cpuapp
+      - nrf54lc10dk/nrf54lc10a/cpuapp
+      - nrf54ls05dk/nrf54ls05b/cpuapp
+      - nrf54ls05dk/nrf54ls05a/cpuapp
     tags:
       - encryption
     harness_config:


### PR DESCRIPTION
move legacy platforms to nightly and enable
integration on 54lx platforms