### PR TITLE
scripts: west_commands: create_board: Update nrf54lc template

### DIFF
--- a/scripts/west_commands/create_board/templates/nrf54lc/board.cmake.jinja2
+++ b/scripts/west_commands/create_board/templates/nrf54lc/board.cmake.jinja2
@@ -1,7 +1,7 @@
 if(CONFIG_SOC_{{ soc | upper }}_CPUAPP)
-  board_runner_args(jlink "--device={{ soc | replace("nrf", "nRF") | replace("lc", "LV") | replace("a", "A") }}_M33" "--speed=4000")
+  board_runner_args(jlink "--device={{ soc | replace("nrf", "nRF") | replace("lc", "LC") | replace("a", "A") }}_M33" "--speed=4000")
 elseif(CONFIG_SOC_{{ soc | upper }}_CPUFLPR)
-  board_runner_args(jlink "--device={{ soc | replace("nrf", "nRF") | replace("lc", "LV") | replace("a", "A")}}_RV32" "--speed=4000")
+  board_runner_args(jlink "--device={{ soc | replace("nrf", "nRF") | replace("lc", "LC") | replace("a", "A")}}_RV32" "--speed=4000")
 endif()
 
 if(CONFIG_TRUSTED_EXECUTION_NONSECURE)


### PR DESCRIPTION
Updates the name used in board.cmake for the JLink runner to use the proper nrf54lc prefix instead of nrf54lv as newer JLink runners have added support for this