### PR TITLE
subsys: mcumgr: img_mgmt: allow QSPI XIP split image confirm

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -25,6 +25,18 @@ config MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_IMAGE
 	  sysbuild if needed. This enables selecting the correct slot when running a QSPI XIP
 	  split image application in DirectXIP mode.
 
+config MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_COCONFIRM
+	bool "QSPI XIP split image uses application SMP confirm policy"
+	depends on MCUMGR_GRP_IMG
+	default y if MCUBOOT_QSPI_XIP_IMAGE_NUMBER > -1
+	help
+	  When the application is split between internal flash and external QSPI XIP, MCUboot
+	  exposes the external portion as a separate updateable image. MCUmgr normally treats
+	  only the internal image (MCUBOOT_APPLICATION_IMAGE_NUMBER) as the "active" image for
+	  confirm and slot-active policy. Enable this to treat the QSPI XIP image
+	  (MCUBOOT_QSPI_XIP_IMAGE_NUMBER) as part of the running application: allow confirming
+	  its primary slot and include it in hash-less image confirm.
+
 endif # MCUMGR_GRP_IMG_NRF
 
 endmenu

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -90,6 +90,21 @@ static bool img_mgmt_is_running_application_image(int image)
 }
 #endif
 
+#if defined(CONFIG_MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_COCONFIRM)
+static int img_mgmt_qspi_split_co_confirm(void)
+{
+	if (CONFIG_MCUBOOT_QSPI_XIP_IMAGE_NUMBER < 0) {
+		return IMG_MGMT_ERR_OK;
+	}
+
+	if (boot_write_img_confirmed_multi(CONFIG_MCUBOOT_QSPI_XIP_IMAGE_NUMBER) != 0) {
+		return IMG_MGMT_ERR_FLASH_WRITE_FAILED;
+	}
+
+	return IMG_MGMT_ERR_OK;
+}
+#endif
+
 /**
  * Collects information about the specified image slot.
  */
@@ -523,11 +538,9 @@ img_mgmt_state_confirm(void)
 	}
 
 #if defined(CONFIG_MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_COCONFIRM)
-	if (CONFIG_MCUBOOT_QSPI_XIP_IMAGE_NUMBER >= 0) {
-		if (boot_write_img_confirmed_multi(CONFIG_MCUBOOT_QSPI_XIP_IMAGE_NUMBER) != 0) {
-			rc = IMG_MGMT_ERR_FLASH_WRITE_FAILED;
-			goto err;
-		}
+	rc = img_mgmt_qspi_split_co_confirm();
+	if (rc != 0) {
+		goto err;
 	}
 #endif
 
@@ -944,6 +957,16 @@ img_mgmt_state_write(struct smp_streamer *ctxt)
 		ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE, rc);
 		goto end;
 	}
+
+#if defined(CONFIG_MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_COCONFIRM)
+	if (confirm && zhash.len == 0) {
+		rc = img_mgmt_qspi_split_co_confirm();
+		if (rc != 0) {
+			ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE, rc);
+			goto end;
+		}
+	}
+#endif
 
 	/* Send the current image state in the response. */
 	rc = img_mgmt_state_read(ctxt);

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -537,13 +537,6 @@ img_mgmt_state_confirm(void)
 		goto err;
 	}
 
-#if defined(CONFIG_MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_COCONFIRM)
-	rc = img_mgmt_qspi_split_co_confirm();
-	if (rc != 0) {
-		goto err;
-	}
-#endif
-
 #if defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS)
 	if (!rc) {
 		int32_t err_rc;
@@ -952,13 +945,10 @@ img_mgmt_state_write(struct smp_streamer *ctxt)
 		}
 	}
 
-	rc = img_mgmt_set_next_boot_slot(slot, confirm);
-	if (rc != 0) {
-		ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE, rc);
-		goto end;
-	}
-
 #if defined(CONFIG_MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_COCONFIRM)
+	/* Confirm external QSPI half before internal image_ok so a QSPI flash
+	 * failure cannot leave only the internal image confirmed.
+	 */
 	if (confirm && zhash.len == 0) {
 		rc = img_mgmt_qspi_split_co_confirm();
 		if (rc != 0) {
@@ -967,6 +957,12 @@ img_mgmt_state_write(struct smp_streamer *ctxt)
 		}
 	}
 #endif
+
+	rc = img_mgmt_set_next_boot_slot(slot, confirm);
+	if (rc != 0) {
+		ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE, rc);
+		goto end;
+	}
 
 	/* Send the current image state in the response. */
 	rc = img_mgmt_state_read(ctxt);

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr/sys/util_macro.h>
+#include <stdbool.h>
 #include <zephyr/toolchain.h>
 #include <string.h>
 #include <zephyr/logging/log.h>
@@ -67,6 +68,28 @@ LOG_MODULE_DECLARE(mcumgr_img_grp, CONFIG_MCUMGR_GRP_IMG_LOG_LEVEL);
 #warning "MCUmgr img mgmt only supports 1 image"
 #endif
 
+#if defined(CONFIG_MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_COCONFIRM)
+static bool img_mgmt_is_running_application_image(int image)
+{
+	if (image == img_mgmt_active_image()) {
+		return true;
+	}
+
+	if (CONFIG_MCUBOOT_QSPI_XIP_IMAGE_NUMBER >= 0 &&
+	    image == CONFIG_MCUBOOT_QSPI_XIP_IMAGE_NUMBER &&
+	    img_mgmt_active_image() == CONFIG_MCUBOOT_APPLICATION_IMAGE_NUMBER) {
+		return true;
+	}
+
+	return false;
+}
+#else
+static bool img_mgmt_is_running_application_image(int image)
+{
+	return image == img_mgmt_active_image();
+}
+#endif
+
 /**
  * Collects information about the specified image slot.
  */
@@ -117,7 +140,7 @@ img_mgmt_state_flags(int query_slot)
 	}
 
 	/* Only running application is active */
-	if (image == img_mgmt_active_image() && query_slot == active_slot) {
+	if (img_mgmt_is_running_application_image(image) && query_slot == active_slot) {
 		flags |= IMG_MGMT_STATE_F_ACTIVE;
 	}
 
@@ -155,7 +178,7 @@ img_mgmt_state_flags(int query_slot)
 	 * - version in that slot is higher than version of active slot.
 	 * - versions are equal but slot number is lower than the active slot.
 	 */
-	if (image == img_mgmt_active_image() && query_slot == active_slot) {
+	if (img_mgmt_is_running_application_image(image) && query_slot == active_slot) {
 		flags = IMG_MGMT_STATE_F_ACTIVE;
 #ifdef CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
 #ifdef CONFIG_NRF_MCUBOOT_BOOT_REQUEST
@@ -495,6 +518,18 @@ img_mgmt_state_confirm(void)
 	}
 
 	rc = img_mgmt_write_confirmed();
+	if (rc != 0) {
+		goto err;
+	}
+
+#if defined(CONFIG_MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_COCONFIRM)
+	if (CONFIG_MCUBOOT_QSPI_XIP_IMAGE_NUMBER >= 0) {
+		if (boot_write_img_confirmed_multi(CONFIG_MCUBOOT_QSPI_XIP_IMAGE_NUMBER) != 0) {
+			rc = IMG_MGMT_ERR_FLASH_WRITE_FAILED;
+			goto err;
+		}
+	}
+#endif
 
 #if defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS)
 	if (!rc) {
@@ -756,7 +791,7 @@ int img_mgmt_set_next_boot_slot(int slot, bool confirm)
 	 * image. Now the behaviour is controlled via Kconfig options.
 	 */
 #ifndef CONFIG_MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_ANY
-	if (confirm && image != img_mgmt_active_image() &&
+	if (confirm && !img_mgmt_is_running_application_image(image) &&
 	    (!IS_ENABLED(CONFIG_MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_SECONDARY) ||
 	     slot == active_slot)) {
 		LOG_DBG("Not allowed to confirm non-active images");

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -483,10 +483,10 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
         set_config_bool(${DEFAULT_IMAGE} CONFIG_HAVE_CUSTOM_LINKER_SCRIPT y)
         set_config_bool(${DEFAULT_IMAGE} CONFIG_BUILD_NO_GAP_FILL y)
 
-        # Set required options if MCUmgr img mgmt is used
+        # Extended MCUmgr img mgmt for QSPI XIP split (slot selection, confirm policy)
+        set_config_bool(${DEFAULT_IMAGE} CONFIG_MCUMGR_GRP_IMG_NRF y)
         if(SB_CONFIG_MCUBOOT_MODE_DIRECT_XIP)
           set_config_bool(${DEFAULT_IMAGE} CONFIG_MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_IMAGE y)
-          set_config_bool(${DEFAULT_IMAGE} CONFIG_MCUMGR_GRP_IMG_NRF y)
         else()
           set_config_bool(${DEFAULT_IMAGE} CONFIG_MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_IMAGE n)
         endif()


### PR DESCRIPTION
MCUmgr treated only the internal application image as active for SMP confirm policy, so confirming the internal half before the external QSPI image could leave only the internal portion activated. Treat the QSPI XIP updateable image as part of the running application, confirm both halves on hash-less confirm, and enable MCUMGR_GRP_IMG_NRF for all QSPI XIP split sysbuild applications.

Added option `CONFIG_MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_COCONFIRM=y` (sysbuild default for QSPI split), that patch targets exactly the failure mode where internal (image 0) was confirmed first and the external part (image 2) never got a valid confirm, so only the internal part looked “activated.”

It does that by (1) allowing confirm on image 2’s primary under the same application policy as image 0, and (2) making hash-less image confirm "" also call boot_write_img_confirmed_multi() for the QSPI image.

Forcing `CONFIG_MCUMGR_GRP_IMG_NRF==y ` allows the patch to be only downstream. Without it a small patch to the zephyr-rtos would be required.